### PR TITLE
Use Matching FontAwesome Icons

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/index.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/index.html
@@ -52,12 +52,12 @@
 
                 <div ng-if="mediaModuleUrl" class="nav-dd" title="{{ 'MEDIAMODULE' | translate}}">
                     <a href="{{mediaModuleUrl}}">
-                        <span class="fa fa-play-circle-o"><!-- Media Module --></span>
+                        <span class="fa fa-play-circle"><!-- Media Module --></span>
                     </a>
                 </div>
 
                 <div class="nav-dd info-dd" id="info-dd" old-admin-ng-dropdown="">
-                  <i class="fa fa-bell-o" aria-hidden="true"></i>
+                  <i class="fa fa-bell" aria-hidden="true"></i>
                       <span id="error-count" class="badge" ng-show="service.error">{{ service.numErr }}</span>
                     <ul class="dropdown-ul">
                       <li><!-- service directive -->


### PR DESCRIPTION
This patch switched to filled style FontAwesome icons for all icons in
the top-right corner of the admin interface to have a more consistent
style.