### PR TITLE
MH-12279 Fix Visualization of Audio Track

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/base/_variables.scss
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/base/_variables.scss
@@ -100,7 +100,8 @@ $primary-color-green-dark-3: darken($primary-color-green, 20%);     // #20724b
 $main-border-color:            #c9d0d3;
 $light-border-color:           #cfd3d5;
 $main-border-radius:           4px;
-$thin-border-stroke:           1px solid;
+$thin-border:                  1px;
+$thin-border-stroke:           $thin-border solid;
 $mid-border-stroke:            2px solid;
 
 $dark-bg-border-color: #0e1b25;

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/components/video/_video-editor.scss
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/components/video/_video-editor.scss
@@ -148,16 +148,16 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
             }
 
             $segment-height: 24px;
-            $segment-background: $segment-height;
+            $segment-background: ($segment-height - $thin-border * 2);
             $segment-main-height: 60px;
-            $segment-main-background: $segment-main-height;
+            $segment-main-background: ($segment-main-height - $thin-border * 2);
 
             .segments {
                 // background image set inline
                 overflow: hidden;
                 background-repeat: no-repeat;
                 background-size: 100% $segment-background;
-                background-position: bottom left;
+                background-position: center left;
                 height: $segment-height;
 
                 // needed for zoom offset
@@ -275,6 +275,7 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
                 .segments {
                     background-size: 100% $segment-main-background;
                     height: $segment-main-height;
+                    background-position: center left;
 
                     .segment-container {
                         height: $segment-main-height;

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/components/video/_video-editor.scss
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/components/video/_video-editor.scss
@@ -148,7 +148,7 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
             }
 
             $segment-height: 24px;
-            $segment-background: ($segment-height - $thin-border * 2);
+            $segment-background: $segment-height;
             $segment-main-height: 60px;
             $segment-main-background: ($segment-main-height - $thin-border * 2);
 
@@ -157,7 +157,7 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
                 overflow: hidden;
                 background-repeat: no-repeat;
                 background-size: 100% $segment-background;
-                background-position: center left;
+                background-position: bottom left;
                 height: $segment-height;
 
                 // needed for zoom offset
@@ -508,8 +508,8 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
               height: 100%;
               opacity: .18;
               z-index: -1;
-              background-size: 100% 25px;
-              background-position: top left;
+              background-size: 100% 24px;
+              background-position: center left;
               background-repeat: no-repeat;
             }
 

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/components/video/_video-editor.scss
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/components/video/_video-editor.scss
@@ -150,7 +150,7 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
             $segment-height: 24px;
             $segment-background: $segment-height;
             $segment-main-height: 60px;
-            $segment-main-background: ($segment-main-height - 10);
+            $segment-main-background: $segment-main-height;
 
             .segments {
                 // background image set inline


### PR DESCRIPTION
This fixes the audio track visualization being miss-leading due to a scaling issue. The problem is shown in the following screenshot, where a video with the highest possible volume (0dB) is used.
![sine_1hz_0db_videoeditor](https://user-images.githubusercontent.com/1727976/27791151-f1eb5108-5ff3-11e7-9c1c-7afda0400237.png)
Users expect the waveform to completely span over the vertical space available.

You can download the video I used for testing [here](http://michael.virtuos.uni-osnabrueck.de/data/opencast/640x480-timestamp-maxaudio.mp4).

This work is sponsored by SWITCH.