### PR TITLE
MH-12622, Surefire Versions Should Not Diverge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.20</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1517,7 +1517,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.20</version>
         <configuration>
           <aggregate>true</aggregate>
         </configuration>


### PR DESCRIPTION
There are different versions of the Maven's surefire plugin specified in
the main `pom.xml`. This patch updates all versions to the newest
version specified.