### PR TITLE
MH-12609 scheduling tab broken

### DIFF
--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -103,7 +103,7 @@ property.startDate.readOnly=false
 property.startDate.required=false
 property.startDate.order=9
 
-# Capture Agent
+# Location
 property.agent.inputID=spatial
 property.agent.outputID=location
 property.agent.label=EVENTS.EVENTS.DETAILS.METADATA.LOCATION

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -104,13 +104,13 @@ property.startDate.required=false
 property.startDate.order=9
 
 # Location
-property.agent.inputID=spatial
-property.agent.outputID=location
-property.agent.label=EVENTS.EVENTS.DETAILS.METADATA.LOCATION
-property.agent.type=text
-property.agent.readOnly=false
-property.agent.required=false
-property.agent.order=12
+property.location.inputID=spatial
+property.location.outputID=location
+property.location.label=EVENTS.EVENTS.DETAILS.METADATA.LOCATION
+property.location.type=text
+property.location.readOnly=false
+property.location.required=false
+property.location.order=12
 
 # Source
 property.source.inputID=source

--- a/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -439,9 +439,7 @@ public abstract class AbstractEventEndpoint {
 
     try {
       TechnicalMetadata technicalMetadata = getSchedulerService().getTechnicalMetadata(eventId);
-      JObject technicalMetadataJson = technicalMetadataToJson.apply(technicalMetadata);
-      return okJson(obj(f("source", v(getIndexService().getEventSource(optEvent.get()).toString())),
-              f("metadata", technicalMetadataJson)));
+      return okJson(technicalMetadataToJson.apply(technicalMetadata));
     } catch (SchedulerException e) {
       logger.error("Unable to get technical metadata for event with id {}", eventId);
       throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -673,12 +673,12 @@ angular.module('adminNg.controllers')
                 if (angular.isDefined(callback)) {
                     callback();
                 }
-            });
-            // Mark the saved attribute as saved
-            angular.forEach(catalog.fields, function (entry) {
-                if (entry.id === id) {
-                    entry.saved = true;
-                }
+                // Mark the saved attribute as saved
+                angular.forEach(catalog.fields, function (entry) {
+                    if (entry.id === id) {
+                        entry.saved = true;
+                    }
+                });
             });
         };
 

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/editableSingleValue.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/editableSingleValue.html
@@ -1,5 +1,5 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
-    &nbsp;<span ng-show="!editMode" class="preserve-newlines">{{ ( params.id == 'location' ? params.value : (presentableValue | localizeDate:params.type:'short') ) }}</span>
+    &nbsp;<span ng-show="!editMode" class="preserve-newlines">{{ presentableValue | localizeDate:params.type:'short' }}</span>
 
     <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()"
        tabindex="{{ params.tabindex }}" focushere="{{ params.tabindex }}"></i>
@@ -10,7 +10,7 @@
         ng-if="params.type === 'text_long' && editMode" ng-required="params.required" name="{{ params.name }}"/>
 
     <input ng-keyup="keyUp($event)"
-        ng-if="params.id != 'location' && params.type != 'time' && editMode && params.type === 'text'"
+        ng-if="editMode && params.type === 'text'"
         type="{{ (params.type === 'time') ? 'text' : (params.type || 'text') }}"
         ng-model="params.value" ng-blur="submit()" tabindex="{{ params.tabindex }}"
         ng-required="params.required" name="{{ params.id }}"/>
@@ -39,17 +39,4 @@
         data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
         ng-options="m.index as m.value for m in minutes"
     />
-    <select chosen
-        ng-if="params.id == 'location' && editMode "
-        ng-model="params.value"
-        ng-change="submit()"
-        data-width="'250px'"
-        data-disable-search-threshold="5"
-        ng-disabled="!editMode && params.id == 'location'"
-        ng-required="params.required" name="{{ params.id }}"
-        data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION' | translate}}"
-        ng-options="value as label|translate for (label, value) in params.collection"
-    >
-        <option ng-if="params.required && Object.keys(params.collection).length === 0" value="" ng-selected="params.value == '' || !params.collection.hasOwnProperty(params.value) ">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo: 70 }} --</option>
-    </select>
 </div>

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -257,10 +257,6 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td>{{ 'EVENTS.EVENTS.DETAILS.SCHEDULING.PLACEHOLDER.PRESENTERS' | translate }}</td>
-                                <td>{{ source.presenters }}</td>
-                            </tr>
-                            <tr>
                                 <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}</td>
                                 <td ng-if="!checkingConflicts && $root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                 <select chosen pre-select-from="captureAgents"

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -183,10 +183,16 @@
 
     <div class="modal-content" data-modal-tab-content="scheduling">
         <div class="modal-body">
-            <div data-admin-ng-notifications="" context="event-scheduling"></div>
-            <div data-admin-ng-notifications="" context="events-access"></div>
             <div class="full-col">
-
+                <div data-admin-ng-notifications="" context="event-scheduling"></div>
+                <div data-admin-ng-notifications="" context="events-access"></div>
+                <table ng-show="conflicts.length > 0" class="main-tbl scheduling-conflict">
+                    <tr ng-repeat="conflict in conflicts">
+                        <td>{{ conflict.title }}</td>
+                        <td>{{ conflict.start }}</td>
+                        <td>{{ conflict.end }}</td>
+                    </tr>
+                </table>
                 <!-- Scheduling configuration -->
                 <div class="obj tbl-details" ng-if="scheduling.hasProperties">
                     <header>
@@ -213,8 +219,9 @@
                             </tr>
                             <tr>
                                 <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.START_TIME' | translate }}</td>
-                                <td ng-if="!checkingConflicts && $root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     <select chosen
+                                        ng-disabled="checkingConflicts"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.start.hour" ng-change="saveScheduling()"
@@ -222,6 +229,7 @@
                                         ng-options="h.index as h.value for h in hours"
                                     />
                                     <select chosen
+                                        ng-disabled="checkingConflicts"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.start.minute" ng-change="saveScheduling()"
@@ -229,14 +237,15 @@
                                         ng-options="m.index as m.value for m in minutes"
                                     />
                                 </td>
-                                <td ng-if="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     {{ source.start.hour | addLeadingZeros : 2 }} : {{ source.start.minute | addLeadingZeros : 2}}
                                 </td>
                             </tr>
                             <tr>
                                 <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.DURATION' | translate }}</td>
-                                <td ng-if="!checkingConflicts && $root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     <select chosen
+                                        ng-disabled="checkingConflicts"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.duration.hour" ng-change="saveScheduling()"
@@ -245,6 +254,7 @@
                                     />
 
                                     <select chosen
+                                        ng-disabled="checkingConflicts"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.duration.minute" ng-change="saveScheduling()"
@@ -252,14 +262,15 @@
                                         ng-options="m.index as m.value for m in minutes"
                                     />
                                 </td>
-                                <td ng-if="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     {{ source.duration.hour | addLeadingZeros : 2 }} : {{ source.duration.minute | addLeadingZeros : 2}}
                                 </td>
                             </tr>
                             <tr>
                                 <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}</td>
-                                <td ng-if="!checkingConflicts && $root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                 <select chosen pre-select-from="captureAgents"
+                                    ng-disabled="checkingConflicts"
                                     data-width="'200px'"
                                     ng-change="roomChanged(); saveScheduling()"
                                     data-disable-search-threshold="8"
@@ -268,7 +279,7 @@
                                     data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}"
                                 />
                                 </td>
-                                <td ng-if="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     {{ source.device.name }}
                                 </td>
                             </tr>

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/resources/conflictCheckResource.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/resources/conflictCheckResource.js
@@ -6,7 +6,7 @@ angular.module('adminNg.resources')
                 device: data.device.id,
                 duration: String(moment.duration(parseInt(data.duration.hour, 10), 'h')
                             .add(parseInt(data.duration.minute, 10), 'm')
-                            .asMilliseconds()),
+                            .asMilliseconds())
             };
 
         if (data.weekdays) {

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/resources/eventSchedulingResource.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/resources/eventSchedulingResource.js
@@ -15,8 +15,8 @@ angular.module('adminNg.resources')
                 return data;
             }
 
-            startDate = new Date(parsedData.metadata.start);
-            endDate = new Date(parsedData.metadata.end);
+            startDate = new Date(parsedData.start);
+            endDate = new Date(parsedData.end);
             duration = (endDate - startDate) / 1000;
             durationHours = (duration - (duration % 3600)) / 3600;
             durationMinutes = (duration % 3600) / 60;   

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/views/modals/_event-series.scss
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/styles/views/modals/_event-series.scss
@@ -186,5 +186,10 @@
                 margin-top: 10px;
             }
         }
+
+        .scheduling-conflict {
+          @include alert-variant($state-danger-bg, $state-danger-border, $state-danger-text);
+          margin-bottom: 15px;
+        }
     }
 }

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/eventScheduling.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/eventScheduling.json
@@ -1,18 +1,15 @@
 {
-   "metadata":{
-      "eventId":"asdasd",
-      "optOut":false,
-      "agentId":"demo",
-      "agentConfiguration":{
-         "test":"true",
-         "clear":"all"
-      },
-      "presenters":[
-         "user1",
-         "user2"
-      ],
-      "start":"2017-01-27T10:00:37Z",
-      "end":"2017-01-27T10:10:37Z"
-   },
-   "source":"SCHEDULE"
+  "eventId":"asdasd",
+  "optOut":false,
+  "agentId":"demo",
+  "agentConfiguration":{
+    "test":"true",
+    "clear":"all"
+  },
+  "presenters":[
+    "user1",
+    "user2"
+  ],
+  "start":"2017-01-27T10:00:37Z",
+  "end":"2017-01-27T10:10:37Z"
 }

--- a/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1869,7 +1869,7 @@ public class SchedulerServiceImplTest {
       List<MediaPackage> events = schedSvc.findConflictingEvents("Device A",
               new RRule("FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA"), start, new Date(start.getTime() + hours(48)),
               new Long(seconds(36)), TimeZone.getTimeZone("America/Chicago"));
-      assertEquals(1, events.size());
+      assertEquals(2, events.size());
     }
   }
 


### PR DESCRIPTION
#See https://bitbucket.org/opencast-community/opencast/pull-requests/1885/mh-12609-as-a-user-i-expect-scheduling-of/diff

    The bad news: Found a release blocker in 4.0.

    The good news: Had a working solution before merging 4.x into our codebase, so it was easy to fix the problem.

    Some background:

    Opencast 2.x - 3.x suffer some shortcomings considering mixing up bibliographic metadata (describing the event) and technical metadata (used by application logic).

    Example:

    If Univerity of Nowhere wants to record a lecture that starts at 12.12.2017 3pm, has a duration of 45 minutes and takes place in Room YX-32 in the main building.

    The technical metadata needed to control the capture agents are the start time, duration (or end time) and the capture agent ID. For practical purposes, recording might start 5 minutes earlier and stop 5 minutes later.

    The bibliographic metadata of the event, however, might want to have the start and end time of the lecture as found in the lecture schedule. Also, in your video portal, for example, you wouldn't want the technical identifier of your capture agent but rather something like "University of Nowhere, Room XZ-21" or maybe even a postal address.

    -> Bibliographic metadata serves different purposes than technical metadata.

    The mixup also had some weird consequences:

    "Event Details"->Metadata mixes up bibliographic metadata and technical metadata, i.e. some of the fields are actually controlling capture agents whether others are of descriptive nature. This has a lot of subtle issues, e.g. what does it mean if you select a "capture agent" for an existing uploaded event and set the start date to tomorrow... will this now trigger a recording?

    Opencast 4.x aims at improving the situation by separating the bibliographic metadata from the technical metadata.

        dublincore/episode is bibliographic metadata not used to control capture agents
        "Event Details"->Metadata is bibliographic metadata only - changing the location or start date there has no effect on scheduling
        "Event Details"->Planning is technical metadata only (well, I would suggest to remove "Presenters" there or at least make it read-only. Here, you can control your capture agents

    There is still room for improvements, in particular mixing up "Location", "Capture Agent", "Capture Agent ID" and "Room" is confusing. Probably it would make sense to use the term "Location" for bibliographic metadata and the term "Capture Agent" for technical metadata, but that's not what this PR is about.

    Note that this PR addresses incorrect integration of the new Scheduler into Opencast 4.x.
