### PR TITLE
MH-12502, Do Not Leave Files In Workspace

### DIFF
--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestTasksEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestTasksEndpoint.java
@@ -60,6 +60,7 @@ import org.opencastproject.workspace.api.Workspace;
 import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.FileUtils;
+import org.easymock.EasyMock;
 import org.junit.Ignore;
 
 import java.io.ByteArrayInputStream;
@@ -69,6 +70,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.persistence.EntityManagerFactory;
 import javax.ws.rs.Path;
@@ -108,6 +110,11 @@ public class TestTasksEndpoint extends TasksEndpoint {
     Workspace workspace = createNiceMock(Workspace.class);
     expect(workspace.get(anyObject(URI.class)))
             .andReturn(new File(getClass().getResource("/processing-properties.xml").toURI())).anyTimes();
+    expect(workspace.get(anyObject(URI.class), EasyMock.anyBoolean())).andAnswer(() -> {
+        File tmp = new File(baseDir, UUID.randomUUID().toString() + "-processing-properties.xml");
+        FileUtils.copyFile(new File(getClass().getResource("/processing-properties.xml").toURI()), tmp);
+        return tmp;
+      }).anyTimes();
 
     WorkflowService workflowService = createNiceMock(WorkflowService.class);
     expect(workflowService.listAvailableWorkflowDefinitions()).andReturn(Arrays.asList(wfD, wfD2, wfD3)).anyTimes();

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerItemTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerItemTest.java
@@ -54,7 +54,7 @@ public class AssetManagerItemTest {
     EasyMock.expect(workspace.get(EasyMock.anyObject(URI.class)))
             .andReturn(new File(getClass().getResource("/dublincore-a.xml").toURI())).once();
     EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class)))
-            .andReturn(new File(getClass().getResource("/dublincore-a.xml").toURI())).once();
+            .andAnswer(() -> getClass().getResourceAsStream("/dublincore-a.xml")).once();
     EasyMock.replay(workspace);
     final MediaPackage mp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
     mp.add(DublinCores.mkOpencastEpisode().getCatalog());

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerWithMessagingTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerWithMessagingTest.java
@@ -61,7 +61,7 @@ public class AssetManagerWithMessagingTest extends AssetManagerTestBase<AssetMan
     EasyMock.expect(workspace.get(EasyMock.anyObject(URI.class)))
             .andReturn(new File(getClass().getResource("/dublincore-a.xml").toURI())).anyTimes();
     EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class)))
-            .andReturn(new File(getClass().getResource("/dublincore-a.xml").toURI())).anyTimes();
+            .andAnswer(() -> getClass().getResourceAsStream("/dublincore-a.xml")).anyTimes();
     EasyMock.replay(workspace);
     final AuthorizationService authSvc = EasyMock.createNiceMock(AuthorizationService.class);
     final AccessControlList acl = new AccessControlList(new AccessControlEntry("admin", "write", true));

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
@@ -73,7 +73,7 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
     // working file repository. In the very few cases where the file is not in the working file repository,
     // this strategy leads to a minor overhead because the file not only gets downloaded and stored in the file system
     // but also a hard link needs to be created (or if that's not possible, a copy of the file.
-    final File origin = getFileFromWorkspace(source);
+    final File origin = getUniqueFileFromWorkspace(source);
     final File destination = createFile(storagePath, source);
     try {
       mkParent(destination);
@@ -81,12 +81,16 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
     } catch (IOException e) {
       logger.error("Error while linking/copying file {} to {}: {}", origin, destination, getMessage(e));
       throw new AssetStoreException(e);
+    } finally {
+      if (origin != null) {
+        FileUtils.deleteQuietly(origin);
+      }
     }
   }
 
-  private File getFileFromWorkspace(Source source) {
+  private File getUniqueFileFromWorkspace(Source source) {
     try {
-      return getWorkspace().get(source.getUri());
+      return getWorkspace().get(source.getUri(), true);
     } catch (NotFoundException e) {
       logger.error("Source file '{}' does not exist", source.getUri());
       throw new AssetStoreException(e);

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreUtil.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreUtil.java
@@ -43,6 +43,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -104,10 +105,12 @@ public final class DublinCoreUtil {
   public static DublinCoreCatalog loadDublinCore(Workspace workspace, MediaPackageElement mpe) {
     InputStream in = null;
     try {
-      in = new FileInputStream(workspace.read(mpe.getURI()));
+      File file = workspace.read(mpe.getURI());
+      logger.debug("Loading {}", file);
+      in = new FileInputStream(file);
       return DublinCores.read(in);
     } catch (Exception e) {
-      logger.error("Unable to load metadata from catalog '{}': {}", mpe, e);
+      logger.error("Unable to load metadata from catalog '{}'", mpe, e);
       return chuck(e);
     } finally {
       IOUtils.closeQuietly(in);

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreUtil.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreUtil.java
@@ -39,13 +39,11 @@ import com.entwinemedia.fn.Stream;
 import com.entwinemedia.fn.data.ImmutableListWrapper;
 import com.entwinemedia.fn.data.Opt;
 
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -103,17 +101,13 @@ public final class DublinCoreUtil {
    * @return the catalog
    */
   public static DublinCoreCatalog loadDublinCore(Workspace workspace, MediaPackageElement mpe) {
-    InputStream in = null;
-    try {
-      File file = workspace.read(mpe.getURI());
-      logger.debug("Loading {}", file);
-      in = new FileInputStream(file);
+    URI uri = mpe.getURI();
+    logger.debug("Loading DC catalog from {}", uri);
+    try (InputStream in = workspace.read(uri)) {
       return DublinCores.read(in);
     } catch (Exception e) {
       logger.error("Unable to load metadata from catalog '{}'", mpe, e);
       return chuck(e);
-    } finally {
-      IOUtils.closeQuietly(in);
     }
   }
 

--- a/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreTest.java
+++ b/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreTest.java
@@ -144,7 +144,7 @@ public class DublinCoreTest {
     EasyMock.expect(workspace.get(EasyMock.anyObject())).andReturn(catalogFile).anyTimes();
     EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.anyBoolean()))
             .andReturn(tmpCatalogFile).andReturn(tmpCatalogFile2);
-    EasyMock.expect(workspace.read(EasyMock.anyObject())).andReturn(catalogFile).anyTimes();
+    EasyMock.expect(workspace.read(EasyMock.anyObject())).andAnswer(() -> new FileInputStream(catalogFile)).anyTimes();
     EasyMock.replay(workspace);
     service = new DublinCoreCatalogService();
     service.setWorkspace(workspace);

--- a/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreTest.java
+++ b/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreTest.java
@@ -78,7 +78,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Date;
@@ -132,14 +131,20 @@ public class DublinCoreTest {
   @Before
   public void setUp() throws Exception {
     catalogFile = new File(this.getClass().getResource(catalogName).toURI());
+    File tmpCatalogFile = testFolder.newFile();
+    FileUtils.copyFile(catalogFile, tmpCatalogFile);
+    File tmpCatalogFile2 = testFolder.newFile();
+    FileUtils.copyFile(catalogFile, tmpCatalogFile2);
     catalogFile2 = new File(this.getClass().getResource(catalogName2).toURI());
     if (!catalogFile.exists() || !catalogFile.canRead())
       throw new Exception("Unable to access test catalog");
     if (!catalogFile2.exists() || !catalogFile2.canRead())
       throw new Exception("Unable to access test catalog 2");
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.get((URI) EasyMock.anyObject())).andReturn(catalogFile).anyTimes();
-    EasyMock.expect(workspace.read((URI) EasyMock.anyObject())).andReturn(catalogFile).anyTimes();
+    EasyMock.expect(workspace.get(EasyMock.anyObject())).andReturn(catalogFile).anyTimes();
+    EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.anyBoolean()))
+            .andReturn(tmpCatalogFile).andReturn(tmpCatalogFile2);
+    EasyMock.expect(workspace.read(EasyMock.anyObject())).andReturn(catalogFile).anyTimes();
     EasyMock.replay(workspace);
     service = new DublinCoreCatalogService();
     service.setWorkspace(workspace);

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/DublinCoreCatalogUIAdapterTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/DublinCoreCatalogUIAdapterTest.java
@@ -156,13 +156,14 @@ public class DublinCoreCatalogUIAdapterTest {
 
     outputCatalog = testFolder.newFile("out.xml");
 
-    Capture<String> mediapackageIDCapture = new Capture<String>();
-    Capture<String> catalogIDCapture = new Capture<String>();
-    Capture<String> filenameCapture = new Capture<String>();
-    writtenCatalog = new Capture<InputStream>();
+    Capture<String> mediapackageIDCapture = EasyMock.newCapture();
+    Capture<String> catalogIDCapture = EasyMock.newCapture();
+    Capture<String> filenameCapture = EasyMock.newCapture();
+    writtenCatalog = EasyMock.newCapture();
 
     workspace = EasyMock.createMock(Workspace.class);
-    EasyMock.expect(workspace.read(eventDublincoreURI)).andReturn(new File(eventDublincoreURI));
+    EasyMock.expect(workspace.read(eventDublincoreURI))
+            .andAnswer(() -> new FileInputStream(new File(eventDublincoreURI)));
     EasyMock.expect(
             workspace.put(EasyMock.capture(mediapackageIDCapture), EasyMock.capture(catalogIDCapture),
                     EasyMock.capture(filenameCapture), EasyMock.capture(writtenCatalog))).andReturn(

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/EventCatalogUIAdapterTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/EventCatalogUIAdapterTest.java
@@ -49,6 +49,7 @@ import org.junit.Test;
 import org.osgi.framework.BundleContext;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -111,7 +112,8 @@ public class EventCatalogUIAdapterTest {
     URI eventDublincoreURI = getClass().getResource("/catalog-adapter/event-dublincore.xml").toURI();
 
     workspace = EasyMock.createMock(Workspace.class);
-    EasyMock.expect(workspace.read(eventDublincoreURI)).andReturn(new File(eventDublincoreURI));
+    EasyMock.expect(workspace.read(eventDublincoreURI))
+            .andAnswer(() -> new FileInputStream(new File(eventDublincoreURI)));
     EasyMock.replay(workspace);
 
     Catalog eventCatalog = EasyMock.createMock(Catalog.class);

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -94,7 +94,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.osgi.service.component.ComponentException;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -617,7 +616,7 @@ public class IndexServiceImplTest {
     EasyMock.expect(workspace.put(EasyMock.capture(mediapackageIdResult), EasyMock.capture(catalogIdResult),
             EasyMock.capture(filenameResult), EasyMock.capture(catalogResult))).andReturn(new URI("catalog.xml"));
     EasyMock.expect(workspace.read(getClass().getResource("/dublincore.xml").toURI()))
-            .andReturn(new File(getClass().getResource("/dublincore.xml").toURI())).anyTimes();
+            .andAnswer(() -> getClass().getResourceAsStream("/dublincore.xml")).anyTimes();
     EasyMock.replay(workspace);
 
     // Create Common Event Catalog UI Adapter

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImplTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertNotNull;
 
 import org.opencastproject.authorization.xacml.manager.api.AclService;
 import org.opencastproject.authorization.xacml.manager.api.AclServiceFactory;
-import org.opencastproject.authorization.xacml.manager.api.ManagedAcl;
 import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilderImpl;
@@ -43,7 +42,6 @@ import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
@@ -58,11 +56,11 @@ public class AssetManagerMessageReceiverImplTest {
   public void setUp() throws Exception {
     workspace = createNiceMock(Workspace.class);
     expect(workspace.read(EasyMock.anyObject(URI.class)))
-            .andReturn(new File(getClass().getResource("/dublincore.xml").toURI())).anyTimes();
+            .andAnswer(() -> getClass().getResourceAsStream("/dublincore.xml")).anyTimes();
     replay(workspace);
 
     AclService aclService = createNiceMock(AclService.class);
-    expect(aclService.getAcls()).andReturn(new ArrayList<ManagedAcl>()).anyTimes();
+    expect(aclService.getAcls()).andReturn(new ArrayList<>()).anyTimes();
     replay(aclService);
 
     DefaultOrganization organization = new DefaultOrganization();

--- a/modules/oaipmh-persistence/src/test/java/org/opencastproject/oaipmh/persistence/impl/OaiPmhPersistenceTest.java
+++ b/modules/oaipmh-persistence/src/test/java/org/opencastproject/oaipmh/persistence/impl/OaiPmhPersistenceTest.java
@@ -79,9 +79,9 @@ public class OaiPmhPersistenceTest {
 
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.read(uri("series-dublincore.xml")))
-            .andReturn(new File(getClass().getResource("/series-dublincore.xml").toURI())).anyTimes();
+            .andAnswer(() -> getClass().getResourceAsStream("/series-dublincore.xml")).anyTimes();
     EasyMock.expect(workspace.read(uri("episode-dublincore.xml")))
-            .andReturn(new File(getClass().getResource("/episode-dublincore.xml").toURI())).anyTimes();
+            .andAnswer(() -> getClass().getResourceAsStream("/episode-dublincore.xml")).anyTimes();
     EasyMock.expect(workspace.get(uri("mpeg7.xml")))
             .andReturn(new File(getClass().getResource("/mpeg7.xml").toURI())).anyTimes();
     EasyMock.expect(workspace.get(uri("series-xacml.xml")))

--- a/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/OaiPmhRepositoryPersistenceTest.java
+++ b/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/OaiPmhRepositoryPersistenceTest.java
@@ -57,11 +57,10 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.IOUtils;
 import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.Test;
 
 import java.io.File;
-import java.net.URI;
+import java.io.FileInputStream;
 import java.util.Date;
 import java.util.List;
 
@@ -264,16 +263,13 @@ public class OaiPmhRepositoryPersistenceTest {
               "/episode-dublincore.xml").toURI());
       final File seriesDublinCore = new File(OaiPmhRepositoryPersistenceTest.class
               .getResource("/series-dublincore.xml").toURI());
-      expect(workspace.read(EasyMock.<URI> anyObject())).andAnswer(new IAnswer<File>() {
-        @Override
-        public File answer() throws Throwable {
-          final String uri = getCurrentArguments()[0].toString();
-          if ("dublincore.xml".equals(uri))
-            return episodeDublinCore;
-          if ("series-dublincore.xml".equals(uri))
-            return seriesDublinCore;
-          throw new Error("Workspace mock does not know about file " + uri);
-        }
+      expect(workspace.read(EasyMock.anyObject())).andAnswer(() -> {
+        final String uri = getCurrentArguments()[0].toString();
+        if ("dublincore.xml".equals(uri))
+          return new FileInputStream(episodeDublinCore);
+        if ("series-dublincore.xml".equals(uri))
+          return new FileInputStream(seriesDublinCore);
+        throw new Error("Workspace mock does not know about file " + uri);
       }).anyTimes();
       EasyMock.replay(workspace);
       // oai-pmh database

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerUtilTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerUtilTest.java
@@ -46,6 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
@@ -67,7 +68,8 @@ public class SchedulerUtilTest {
 
     workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.get(EasyMock.anyObject(URI.class))).andReturn(workspaceFile).anyTimes();
-    EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class))).andReturn(workspaceFile).anyTimes();
+    EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class)))
+            .andAnswer(() -> new FileInputStream(workspaceFile)).anyTimes();
     EasyMock.replay(workspace);
   }
 

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/UnitTestWorkspace.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/UnitTestWorkspace.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.UUID;
 
 /**
  * A {@link Workspace} implementation suitable for unit tests.
@@ -61,7 +62,18 @@ public class UnitTestWorkspace implements Workspace {
 
   @Override
   public File get(URI uri) throws NotFoundException, IOException {
-    return new File(uri);
+    return get(uri, false);
+  }
+
+  @Override
+  public File get(URI uri, boolean uniqueFilename) throws NotFoundException, IOException {
+    File src = new File(uri);
+    if (uniqueFilename) {
+      File target = new File(baseDir, UUID.randomUUID().toString());
+      FileUtils.copyFile(src, target);
+      return target;
+    }
+    return src;
   }
 
   @Override

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/UnitTestWorkspace.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/UnitTestWorkspace.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -77,8 +78,8 @@ public class UnitTestWorkspace implements Workspace {
   }
 
   @Override
-  public File read(URI uri) throws NotFoundException, IOException {
-    return get(uri);
+  public InputStream read(URI uri) throws NotFoundException, IOException {
+    return new FileInputStream(get(uri));
   }
 
   @Override

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -77,6 +77,7 @@ import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workspace.api.Workspace;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServer;
@@ -693,14 +694,18 @@ public class SolrIndexManager {
 
   private Mpeg7Catalog loadMpeg7Catalog(Catalog cat) throws IOException {
     InputStream in = null;
+    File f = null;
     try {
-      File f = workspace.get(cat.getURI());
+      f = workspace.get(cat.getURI(), true);
       in = new FileInputStream(f);
       return mpeg7CatalogService.load(in);
     } catch (NotFoundException e) {
       throw new IOException("Unable to load metadata from mpeg7 catalog " + cat);
     } finally {
       IOUtils.closeQuietly(in);
+      if (f != null) {
+        FileUtils.deleteQuietly(f);
+      }
     }
   }
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -77,8 +77,6 @@ import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -91,8 +89,6 @@ import org.apache.solr.servlet.SolrRequestParsers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -692,20 +688,11 @@ public class SolrIndexManager {
     return b.substring(0, b.length() - sep.length());
   }
 
-  private Mpeg7Catalog loadMpeg7Catalog(Catalog cat) throws IOException {
-    InputStream in = null;
-    File f = null;
-    try {
-      f = workspace.get(cat.getURI(), true);
-      in = new FileInputStream(f);
+  private Mpeg7Catalog loadMpeg7Catalog(Catalog catalog) throws IOException {
+    try (InputStream in = workspace.read(catalog.getURI())) {
       return mpeg7CatalogService.load(in);
     } catch (NotFoundException e) {
-      throw new IOException("Unable to load metadata from mpeg7 catalog " + cat);
-    } finally {
-      IOUtils.closeQuietly(in);
-      if (f != null) {
-        FileUtils.deleteQuietly(f);
-      }
+      throw new IOException("Unable to load metadata from mpeg7 catalog " + catalog);
     }
   }
 

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOHTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOHTest.java
@@ -35,8 +35,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -71,8 +69,8 @@ public class ConfigureByDublinCoreTermWOHTest {
     instance.setMediaPackage(mp);
 
     workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.read((URI) EasyMock.anyObject())).andReturn(
-            new File(this.getClass().getResource("/dublincore.xml").toURI()));
+    EasyMock.expect(workspace.read(EasyMock.anyObject()))
+            .andAnswer(() -> getClass().getResourceAsStream("/dublincore.xml"));
     EasyMock.replay(workspace);
     operationHandler.setWorkspace(workspace);
   }

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandlerTest.java
@@ -96,7 +96,8 @@ public class SeriesWorkflowOperationHandlerTest {
     capturedStream = Capture.newInstance(CaptureType.FIRST);
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.get(EasyMock.anyObject(URI.class))).andReturn(file).anyTimes();
-    EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class))).andReturn(file).anyTimes();
+    EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class)))
+            .andAnswer(() -> getClass().getResourceAsStream("/dublincore.xml")).anyTimes();
     EasyMock.expect(workspace.put(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyString(),
             EasyMock.capture(capturedStream))).andReturn(uri).anyTimes();
     EasyMock.replay(workspace);

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOHTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOHTest.java
@@ -36,8 +36,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -70,8 +68,8 @@ public class TagByDublinCoreTermWOHTest {
     instance.setMediaPackage(mp);
 
     workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.read((URI) EasyMock.anyObject())).andReturn(
-            new File(this.getClass().getResource("/dublincore.xml").toURI()));
+    EasyMock.expect(workspace.read(EasyMock.anyObject()))
+            .andAnswer(() -> getClass().getResourceAsStream("/dublincore.xml"));
     EasyMock.replay(workspace);
     operationHandler.setWorkspace(workspace);
   }

--- a/modules/workspace-api/src/main/java/org/opencastproject/workspace/api/Workspace.java
+++ b/modules/workspace-api/src/main/java/org/opencastproject/workspace/api/Workspace.java
@@ -72,13 +72,14 @@ public interface Workspace extends StorageUsage {
    * If shared storage is not available, then fall back to get(uri).
    *
    * @param uri
+   *        URI identifying the resource to load
    * @return The file
    * @throws NotFoundException
    *           if the file does not exist
    * @throws IOException
    *           if reading the file from the working file repository fails
    */
-  File read(URI uri) throws NotFoundException, IOException;
+  InputStream read(URI uri) throws NotFoundException, IOException;
 
 
   /**

--- a/modules/workspace-api/src/main/java/org/opencastproject/workspace/api/Workspace.java
+++ b/modules/workspace-api/src/main/java/org/opencastproject/workspace/api/Workspace.java
@@ -52,6 +52,22 @@ public interface Workspace extends StorageUsage {
   File get(URI uri) throws NotFoundException, IOException;
 
   /**
+   * Get a locally cached {@link File} for a given URI, optionally ensuring that the file is cached in a unique path
+   * so that it can safely be removed afterwards.
+   *
+   * @param uri
+   *          URI to the resource to get
+   * @param uniqueFilename
+   *          If a unique path should be used
+   * @return The locally cached file
+   * @throws NotFoundException
+   *           if the file does not exist
+   * @throws IOException
+   *           if reading the file from the workspace fails
+   */
+  File get(URI uri, boolean uniqueFilename) throws NotFoundException, IOException;
+
+  /**
    * Get the {@link File} for the given URI directly from the working file repository.
    * If shared storage is not available, then fall back to get(uri).
    *

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -76,6 +76,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Date;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import javax.management.ObjectInstance;
@@ -295,7 +296,18 @@ public final class WorkspaceImpl implements Workspace {
 
   @Override
   public File get(final URI uri) throws NotFoundException, IOException {
-    final File inWs = toWorkspaceFile(uri);
+    return get(uri, false);
+  }
+
+  @Override
+  public File get(final URI uri, final boolean uniqueFilename) throws NotFoundException, IOException {
+    File inWs = toWorkspaceFile(uri);
+
+    if (uniqueFilename) {
+      inWs = new File(FilenameUtils.removeExtension(inWs.getAbsolutePath()) + '-' + UUID.randomUUID() + '.'
+              + FilenameUtils.getExtension(inWs.getName()));
+      logger.debug("Created unique filename: {}", inWs);
+    }
 
     if (pathMappable != null && StringUtils.isNotBlank(pathMappable.getPathPrefix())
             && StringUtils.isNotBlank(pathMappable.getUrlPrefix())) {


### PR DESCRIPTION
- MH-12502, Convert Workspace Read To InputStream

    This patch makes the `workspace.read()` method return an InputStream,
    ensuring that the files content which may be read directly from the
    working file repository (if possible) is not modified.

    In case the files cannot be read directly (e.g. non-local files), the
    files are temporarily copied into the workspace, but will automatically
    be removed once the returned InputStream is closed to not leave any
    files lying around in the workspace.

- MH-12502, Ensure search service does not leave MPEG7 catalogs in workspace

    This patch ensures that MPEG7 catalogs, temporary loaded into the
    workspace for parsing will be removed afterward.

- MH-12502, Ensure OAI-PMH does not leave media package elements in WS/WFR

    This patch ensures that media package elements temporary loaded into the
    workspace for parsing will be removed afterward.

- MH-12502, Ensure Asset Manager Cleans Up Workspace

    This patch ensures that at several places the asset manager will clean
    up files it loads into the workspace.

- MH-12502, Add Options To Get Unique Files From Workspace
    
    This patch adds an optional `uniqueFilename` parameter to
    `workspace.get()`, allowing for the requested file to be stored in a
    unique location which makes it safe to modify the files content as well
    as deleting the file when it is not used anymore.