### PR TITLE
MH-12476 Add a delay of 60s before starting to dispatch jobs on startup

### DIFF
--- a/modules/matterhorn-serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/matterhorn-serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -190,6 +190,9 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** Default delay between job dispatching attempts, in milliseconds */
   static final long DEFAULT_DISPATCH_INTERVAL = 5000;
 
+  /** Default delay before starting job dispatching, in milliseconds */
+  static final long DEFAULT_DISPATCH_START_DELAY = 60000;
+
   /** Default jobs limit during dispatching
    * (larger value will fetch more entries from the database at the same time and increase RAM usage) */
   static final int DEFAULT_DISPATCH_JOBS_LIMIT = 100;
@@ -798,9 +801,12 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       }
     }
 
+    long dispatchDelay = DEFAULT_DISPATCH_START_DELAY;
+
     // Stop the current scheduled executors so we can configure new ones
     if (scheduledExecutor != null) {
       scheduledExecutor.shutdown();
+      dispatchDelay = dispatchInterval;
     }
 
     scheduledExecutor = Executors.newScheduledThreadPool(2);
@@ -815,7 +821,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     // Schedule the job dispatching.
     if (dispatchInterval > 0) {
       logger.debug("Starting job dispatching at a custom interval of {}s", dispatchInterval / 1000);
-      scheduledExecutor.scheduleWithFixedDelay(new JobDispatcher(), dispatchInterval, dispatchInterval,
+      scheduledExecutor.scheduleWithFixedDelay(new JobDispatcher(), dispatchDelay, dispatchInterval,
               TimeUnit.MILLISECONDS);
     }
   }


### PR DESCRIPTION
There are some cases where job dispatching too close to startup can cause operation failures.

One situation is where admin node is behind a proxy (a common configuration),
so the admin node itself is on http://server.domain:8080/ but the proxy public
URL is http://server.domain/

If Opencast restarts, the proxy (e.g. apache) can mark the service as offline
and requests get a service-not-available 503 error for a short time even after
the service has come back, because the proxy has a timeout, as described for
the retry parameter here:

https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass

So Opencast checks for available services on http://server.domain/ and gets
back nothing available even though it's up.

So it is safer to add a delay before starting to dispatch jobs on startup.
This is most significant for scenarios where Opencast admin node is restarted
while workflows are running (usually for unplanned reasons), and avoids
workflows failing because no services are available.

The 60s delay value is the default value of ProxyTimeout for apache's mod_proxy.