### PR TITLE
MH-12625: Fix references to the source code repository in the docs

### DIFF
--- a/docs/guides/admin/docs/configuration/database.md
+++ b/docs/guides/admin/docs/configuration/database.md
@@ -108,7 +108,7 @@ or, if you have a systemd based system:
 ### Step 2: Set up the Database Structure
 
 To set up the database structure you can (and should!) use the Opencast ddl scripts. You can find them in the 
-installation document folder `.../docs/scripts/ddl/mysql5.sql`. You can also download the script from BitBucket.
+installation document folder `.../docs/scripts/ddl/mysql5.sql`. You can also download the script from GitHub.
 
 To import the database structure using the MariaDB/MySQL client, switch to the directory that contains the `mysql5.sql` 
 file and run the MariaDB/MySQL client with the user you created in the previous step (`-u opencast`) and switch to 

--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -18,17 +18,17 @@ prior option, the tarball download, needs less tools and you do not have to down
 
 Using the tarball:
 
-Select the tarball for the version you want to install from the [BitBucket downloads section
-](https://bitbucket.org/opencast-community/opencast/downloads).
+Select the tarball for the version you want to install
+from the [GitHub releases section](https://github.com/opencast/opencast/releases).
 
     # Download desired tarball
-    curl -O https://bitbucket.org/opencast-community/opencast/...
-    tar xf ....tar.gz
-    cd opencast-community-...
+    curl -OL https://github.com/opencast/opencast/archive/[...].tar.gz
+    tar xf [...].tar.gz
+    cd opencast--[...]
 
 Cloning the Git repository:
 
-    git clone https://bitbucket.org/opencast-community/opencast.git
+    git clone https://github.com/opencast/opencast.git
     cd opencast
     git tag   <-  List all available versions
     git checkout TAG   <-  Switch to desired version

--- a/docs/guides/admin/docs/installation/source-macosx.md
+++ b/docs/guides/admin/docs/installation/source-macosx.md
@@ -21,19 +21,19 @@ prior option, the tarball download, needs less tools and you don't have to downl
 
 Cloning the Git repository:
 
-    git clone https://bitbucket.org/opencast-community/opencast.git
+    git clone https://github.com/opencast/opencast.git
     cd opencast
     git tag   <-  List all available versions
     git checkout TAG   <-  Switch to desired version
 
 Using the tarball:
 
-Select the tarball for the version you want to install from the [BitBucket downloads section
-](https://bitbucket.org/opencast-community/opencast/downloads) under the "Tags" tab and download it directly from there
-or with the curl command specified below.
+Select the tarball for the version you want to install
+from the [GitHub releases section](https://github.com/opencast/opencast/releases) under the "Tags" tab and download it
+directly from there or with the curl command specified below.
 
     # Download desired tarball, replace [...] with the desired version
-    curl -O https://bitbucket.org/opencast-community/opencast/get/[...].tar.gz
+    curl -OL https://github.com/opencast/opencast/archive/[...].tar.gz
     tar xf [...].tar.gz
 
 

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Opencast - Administration Guide
-repo_url: https://bitbucket.org/opencast-community/opencast/src/develop/docs/guides/admin/docs
+repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/admin/docs
 
 # Default theme used is readthedocs
 theme: readthedocs

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -14,20 +14,21 @@ contributed, how they are merged and how releases are done.
 Contributing Code
 -----------------
 
-Opencast sources can be found on [BitBucket](http://bitbucket.org/opencast-community). The easiest way to contribute
-code to the project is by creating a pull request against the project's official repository. More details about the
-structure of this repository are explained later in this guide.
+Opencast sources can be found on [GitHub](https://github.com/opencast) and some of its ancillary projects
+on [BitBucket](https://bitbucket.org/opencast-community/). The easiest way to contribute code to the project
+is by creating a pull request against the project's official repository. More details about the structure
+of this repository are explained later in this guide.
 
-### Jira and BitBucket
+### Jira and GitHub
 
  - Opencast uses [Jira](https://opencast.jira.com) for tracking issues. Each pull request should be accompanied by a
    ticket in Jira. The issue identifier should also be used in the title of the pull request and the commits. E.g.:
    `MH-12345, Fixing Something Somewhere`. Creating a Jira ticket is usually the first step when fixing something.
 
- - Opencast uses [BitBucket](http://bitbucket.org/opencast-community) for code hosting. Please
-   [fork](https://confluence.atlassian.com/bitbucket/forking-a-repository-221449527.html) the official
-   repository on BitBucket to [create pull
-   requests](https://confluence.atlassian.com/bitbucket/work-with-pull-requests-223220593.html) from your repository
+ - Opencast uses [GitHub](https://github.com/opencast) for code hosting.
+   Please [fork](https://help.github.com/articles/fork-a-repo/)
+   the [official repository](https://github.com/opencast/opencast) on GitHub
+   to [create pull requests](https://help.github.com/articles/creating-a-pull-request/) from your repository
    which will show up on the project's list of open pull requests.
 
  - All open pull requests are listed on the [Opencast Pull Request Filter](http://pullrequests.opencast.org). It might
@@ -50,7 +51,7 @@ Opencast distinguishes between bug fix and feature pull requests.
 Before a patch is merged, it needs to be reviewed by a committer. The reviewer makes sure that the patch merges
 without conflicts, that it works as expected and that it does not break anything else.
 
-If the reviewer discovers any kind of issue, he should comment on the pull request in BitBucket, so that the author can
+If the reviewer discovers any kind of issue, he should comment on the pull request in GitHub, so that the author can
 fix the problem.
 
 For more details about the review and merge process, have a look at [Reviewing, Merging and Declining Pull

--- a/docs/guides/developer/docs/infrastructure/index.md
+++ b/docs/guides/developer/docs/infrastructure/index.md
@@ -60,10 +60,9 @@ An administrator is someone within the Opencast community who has administrative
 tools.  These tools are
 
  - JIRA
- - BitBucket
+ - GitHub
  - Google Groups
  - Crowdin
- - Github
 
 While many of our administrators are committers, an administrator is _not_ a committer by necessity.  Administrators
 have important responsibilities within the community, but mainly work behind the scenes.  These responsibilities
@@ -81,10 +80,9 @@ from the appropriate groups across all of our hosted products.  Administrators a
 groups in multiple places when a change is necessary.  These changes are
 
  - Modifying the [JIRA committers group](https://opencast.jira.com/admin/groups/view?groupname=committers-matterhorn)
- - Modifying the [BitBucket committers group](https://bitbucket.org/account/user/opencast-community/groups/opencast-committers/)
+ - Modifying the [GitHub committers group](https://github.com/orgs/opencast/teams/committers/members) upon request
  - Modifying the [Google committers group](https://admin.google.com/opencast.org/AdminHome?hl=de&pli=1&fral=1&groupId=committers@opencast.org&chromeless=1#OGX:Group?hl=de)
  - Modifying the [Crowdin commiters group](https://crowdin.com/project/opencast-community/settings#members)
- - Modifying the [GitHub committers group](https://github.com/orgs/opencast/teams/committers/members) upon request
 
 Current Administrators
 ----------------------
@@ -96,28 +94,6 @@ order:
  - Greg Logan
  - Lars Kiesow
  - Olaf Schulte
-
-Account Management
-------------------
-
-The following additional people have administrative access to the following services as well
-
-- opencast.jira.com
-    - Stephen Marquard
-	 - Global administrators
-- bitbucket.org/opencast-community
-	 - Global administrators
-- github.com/opencast
-	 - Global administrators
-- twitter.com/openmatter
-    - Lars Kiesow
-- facebook.com/opencast
-    - Rüdiger Rolf
-- youtube.com/opencast
-    - Rüdiger Rolf
-- crowdin.com/project/opencast-community
-    - Sven Stauber
-
 
 Video Conferencing
 ------------------

--- a/docs/guides/developer/docs/infrastructure/notes.md
+++ b/docs/guides/developer/docs/infrastructure/notes.md
@@ -52,10 +52,6 @@ University of Osnabrück
 
 - Builds are triggered by cron, manual branch selection
 
-### docs.opencast.org
-
-- Rebuild every 5 minutes via bitbucket webhook, nightly rebuild
-
 ### nexus.opencast.org, nexus.virtuos.uos.de
 
 - GeoIP based redirect for all Nexus servers

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -122,8 +122,8 @@ are unable to do that, please contact one of the JIRA administrators so we can c
 ### Release Documentation
 
 The [Opencast release documentation](http://docs.opencast.org) will be built automatically from available release tags.
-However, new branches need to be included.  As release manager, please talk to the [administrator
-](https://bitbucket.org/opencast-community/opencast-infrastructure) of that
+However, new branches need to be included.  As release manager, please talk to
+the [administrator](https://docs.opencast.org/develop/developer/infrastructure/#administrators) of that
 tool to ensure the ticket is added.
 
 
@@ -220,7 +220,7 @@ At this point the developer community should then be notified. Consider using th
 
     Hi everyone,
     I am pleased to announce that Opencast <VERSION> is now available for
-    testing. Please download the source from BitBucket [1] or use git to check
+    testing. Please download the source from GitHub [1] or use git to check
     out the tag.
 
     Issue Count:
@@ -233,7 +233,7 @@ At this point the developer community should then be notified. Consider using th
     Please test this release as thoroughly as
     possible.
 
-    [1] https://bitbucket.org/opencast-community/opencast/downloads
+    [1] https://github.com/opencast/opencast/releases
 
 If the version is a release candidate, you probably want to highlight that there are no *Blockers* left at the moment
 and *#propose* this to become the final release.
@@ -296,8 +296,8 @@ assume the final release should be based on `3.0-rc2`.
 12. Push the built artifacts to Maven. Bug the QA Coordinator to do this so that he remembers to set this up from the CI
     servers.
 
-13. Push the built artifacts back to BitBucket. Please review the following commands carefully before executing them. If
-    in doubt, use the [graphical user interface](https://bitbucket.org/opencast-community/opencast/downloads/) to upload
+13. Push the built artifacts back to GitHub. Please review the following commands carefully before executing them. If
+    in doubt, use the [graphical user interface](https://github.com/opencast/opencast/releases) to upload
     the distribution tarballs manually.
 
         # Get Opencast version, BitBucket username and password
@@ -344,7 +344,7 @@ list, please ask to be given permission. For the message, you may use the follow
     Subject: Opencast <VERSION> Released
     Hi all,
     it is my pleasure to announce that Opencast <VERSION> has been released and
-    can be downloaded from BitBucket [1] or checked out via git.
+    can be downloaded from GitHub [1] or checked out via git.
 
     The documentation for this release can be found at [http://docs.opencast.org].
 
@@ -355,7 +355,7 @@ list, please ask to be given permission. For the message, you may use the follow
     This could not have happened without you and I am glad we were able to work
     together and get this release out.
 
-    [1] https://bitbucket.org/opencast-community/opencast/downloads
+    [1] https://github.com/opencast/opencast/releases
 
 
 ### Appointment of Next Release Manager

--- a/docs/guides/developer/docs/reviewing-and-merging.md
+++ b/docs/guides/developer/docs/reviewing-and-merging.md
@@ -5,7 +5,7 @@ Before a patch is merged into an official branch, it needs to be reviewed by a c
 review, the reviewer tries to make sure that the patch merges without conflicts, that it works as expected and that
 it does not break anything else.
 
-If the reviewer discovers any kind of issue, he should leave a comment in the pull request view of BitBucket and let the
+If the reviewer discovers any kind of issue, he should leave a comment in the pull request view of GitHub and let the
 contributor fix the problem. Reviewer and contributor should work together to fix any problem with the pull requests
 before it is ready to go into the codebase.
 
@@ -14,9 +14,6 @@ Reviewing Rules
 
  - Reviews and merges need to be done by committers.
  - Reviewers should come from a different institution than the contributor.
- - To assign yourself as a reviewer, add a comment to the BitBucket pull request like “`I will //review// this`”. The
-   use of `//review//` will make the [pull request filter](http://pullrequests.opencast.org) pick up the author of this
-   comment as reviewer.
  - Pull requests for bug fixes or documentation may be reviewed and merged out of order.
  - Feature pull requests have to be merged in order unless their contributor or reviewer decide to temporarily skip it.
    Such a decision has to be justified by the existence of unresolved issues in that particular pull request.

--- a/docs/guides/developer/docs/security.md
+++ b/docs/guides/developer/docs/security.md
@@ -16,9 +16,9 @@ What to do if you find a security issue
 Report it to `security@opencast.org`! Please include a complete description of the issue, including which version(s) it
 affects, as well as any steps required to reproduce it. This email will be sent privately to the full list of
 committers for the project. You should receive an email acknowledging the issue from the QA coordinator, or release
-manager(s) within 3 business days. At this point, depending on the issue, you may be asked for your JIRA and BitBucket
+manager(s) within 3 business days. At this point, depending on the issue, you may be asked for your Attlassian and GitHub
 logins. It is enouraged to have one, since internal discussion on JIRA will be restricted to committers and the
-reporter. Likewise, all code reviews will be done on in an internal BitBucket repository.
+reporter. Likewise, all code reviews will be done on in an internal GitHub repository.
 
 What to do once you have reported your security issue
 -----------------------------------------------------

--- a/docs/guides/developer/mkdocs.yml
+++ b/docs/guides/developer/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Opencast - Developer Guide
-repo_url: https://bitbucket.org/opencast-community/opencast/src/develop/docs/guides/developer/docs
+repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/developer/docs
 
 # Default theme used is readthedocs
 theme: readthedocs

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -147,7 +147,7 @@
         <div class="col-md-4">
           <h4>Code</h4>
           <p>You can find the codebase of Opencast in the Git repository hosted at
-          <a href="https://bitbucket.org/opencast-community/opencast/src">Bitbucket</a>.</p>
+          <a href="https://github.com/opencast/opencast">GitHub</a>.</p>
         </div>
         <div class="col-md-4">
           <h4>Pull requests</h4>

--- a/docs/guides/user/README.md
+++ b/docs/guides/user/README.md
@@ -5,7 +5,7 @@ This guide is the official Opencast user's manual for the open-source video capt
 # Setup
 
 ### Git Repository
-The source documentation is hosted on this Git repository: https://bitbucket.org/opencast-community/opencast
+The source documentation is hosted on this Git repository: https://github.com/opencast/opencast
 
 ### Building Locally
 The documentation is written in standard markdown. The tool that is used to build the documentation is

--- a/docs/guides/user/docs/index.md
+++ b/docs/guides/user/docs/index.md
@@ -57,6 +57,6 @@ website](http://www.opencast.org/community).
 ## Licenses
 
 Opencast Projects, including source code, are licensed under [Educational Community License
-2.0](https://bitbucket.org/opencast-community/opencast/src/develop/LICENSE) Except where otherwise noted,
+2.0](https://github.com/opencast/opencast/blob/develop/LICENSE) Except where otherwise noted,
 documentation on this site is licensed under a [Creative Commons Attribution 4.0 International
 license](http://creativecommons.org/licenses/by/4.0/deed.en_US)

--- a/docs/guides/user/mkdocs.yml
+++ b/docs/guides/user/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Opencast - Users Guide
-repo_url: https://bitbucket.org/opencast-community/opencast/src/develop/docs/guides/user/docs
+repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/user/docs
 
 # Default theme used is readthedocs
 theme: readthedocs


### PR DESCRIPTION
This only covers some places where I knew what to do, though. ;P
It also reformats some lines in the Markdown files for better plain text readability.