### PR TITLE
 MH-12610 Switching events in the AdminUI fixed

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -753,6 +753,11 @@ angular.module('adminNg.controllers')
           });
         };
 
+        $scope.accessChanged = function (role) {
+          if (!role) return;
+          $scope.accessSave();
+        };
+
         $scope.accessSave = function () {
             var ace = [],
                 hasRights = false,

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -543,7 +543,7 @@
                                                         data-disable-search-threshold="8"
                                                         data-search_contains="true"
                                                         ng-model="policy.role"
-                                                        ng-change="accessSave(policy)"
+                                                        ng-change="accessChanged(policy.role)"
                                                         ng-options="id as id for (id, type) in roles"
                                                         ng-get-more="getMoreRoles"
                                                         data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ROLES.LABEL' | translate }}"


### PR DESCRIPTION
Switching event with the '<' or '>' buttons in the Admin UI should not trigger an access policy update

Work sponsored by SWITCH