### PR TITLE
MH-12623 Improve workflow dropdown menu

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinition.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinition.java
@@ -30,7 +30,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  * A workflow definition.
  */
 @XmlJavaTypeAdapter(WorkflowDefinitionImpl.Adapter.class)
-public interface WorkflowDefinition {
+public interface WorkflowDefinition extends Comparable<WorkflowDefinition> {
 
   /**
    * The variable in a workflow definition that is to be replaced by the reason for an operation's failure.

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinitionImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinitionImpl.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.workflow.api;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -274,6 +276,18 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
    */
   public static WorkflowDefinitionImpl valueOf(String xmlString) throws Exception {
     return (WorkflowDefinitionImpl) WorkflowParser.parseWorkflowDefinition(xmlString);
+  }
+
+  @Override
+  public int compareTo(WorkflowDefinition workflowDefinition) {
+
+    if (workflowDefinition == null) {
+      throw new NullPointerException("WorkflowDefinition for comparison can't be null");
+    }
+
+    // nullsafe comparison where null is lesser than non-null
+    // workflows with null title probably aren't for displaying anyway
+    return StringUtils.compareIgnoreCase(this.getTitle(), workflowDefinition.getTitle());
   }
 
   static class Adapter extends XmlAdapter<WorkflowDefinitionImpl, WorkflowDefinition> {

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -390,12 +390,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     for (Entry<String, WorkflowDefinition> entry : workflowDefinitionScanner.getWorkflowDefinitions().entrySet()) {
       list.add(entry.getValue());
     }
-    Collections.sort(list, new Comparator<WorkflowDefinition>() {
-      @Override
-      public int compare(WorkflowDefinition o1, WorkflowDefinition o2) {
-        return o1.getId().compareTo(o2.getId());
-      }
-    });
+    Collections.sort(list); //sorts by title
     return list;
   }
 

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -68,6 +68,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -598,8 +599,11 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     HttpGet get = new HttpGet("/definitions.xml");
     HttpResponse response = getResponse(get);
     try {
-      if (response != null)
-        return WorkflowParser.parseWorkflowDefinitions(response.getEntity().getContent());
+      if (response != null) {
+        List<WorkflowDefinition> list = WorkflowParser.parseWorkflowDefinitions(response.getEntity().getContent());
+        Collections.sort(list); //sorts by title
+        return list;
+      }
     } catch (Exception e) {
       throw new IllegalStateException("Unable to parse workflow definitions");
     } finally {


### PR DESCRIPTION
Workflows are sorted by title instead of ID since that makes more sense for the drop-down menu (workflows without a title aren't displayed in the admin ui anyway).

The desired filtering of the drop-down menu already works, but is only enabled when there are >= 8 workflows (see f/MH-12626).