### PR TITLE
MH-12628, MH-12629, MH-12630, Minor database fixes

### DIFF
--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -539,8 +539,12 @@ CREATE TABLE mh_user_settings (
   username varchar(128) NOT NULL,
   organization varchar(128) NOT NULL,
   PRIMARY KEY (id),
-  CONSTRAINT UNQ_mh_user_settings UNIQUE (username, organization)
+  CONSTRAINT UNQ_mh_user_settings UNIQUE (username, organization),
+  CONSTRAINT `FK_mh_user_setting_organization` FOREIGN KEY (`organization`) REFERENCES `mh_user` (`organization`),
+  CONSTRAINT `FK_mh_user_setting_username` FOREIGN KEY (`username`) REFERENCES `mh_user` (`username`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE INDEX IX_mh_user_setting_organization ON mh_user_settings (organization);
 
 CREATE TABLE mh_email_configuration (
   id BIGINT(20) NOT NULL,

--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -528,7 +528,6 @@ CREATE TABLE mh_user_ref_role (
   user_id bigint(20) NOT NULL,
   role_id bigint(20) NOT NULL,
   PRIMARY KEY (user_id, role_id),
-  CONSTRAINT UNQ_mh_user_ref_role UNIQUE (user_id, role_id),
   CONSTRAINT FK_mh_user_ref_role_role_id FOREIGN KEY (role_id) REFERENCES mh_role (id),
   CONSTRAINT FK_mh_user_ref_role_user_id FOREIGN KEY (user_id) REFERENCES mh_user_ref (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -620,7 +620,7 @@ CREATE TABLE mh_event_comment_reply (
   text TEXT(65535) NOT NULL,
   modification_date DATETIME NOT NULL,
   PRIMARY KEY (id),
-  CONSTRAINT FK_mh_event_comment_reply_mh_event_comment FOREIGN KEY (event_comment_id) REFERENCES mh_event_comment (id)
+  CONSTRAINT FK_mh_event_comment_reply_mh_event_comment FOREIGN KEY (event_comment_id) REFERENCES mh_event_comment (id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE mh_series_elements (

--- a/docs/upgrade/4_to_5/update-4-to-5.sql
+++ b/docs/upgrade/4_to_5/update-4-to-5.sql
@@ -1,0 +1,2 @@
+-- Remove duplicated index
+DROP INDEX IF EXISTS UNQ_mh_user_ref_role ON mh_user_ref_role;

--- a/docs/upgrade/4_to_5/update-4-to-5.sql
+++ b/docs/upgrade/4_to_5/update-4-to-5.sql
@@ -11,3 +11,12 @@ ALTER TABLE mh_user_settings
   FOREIGN KEY (`username`)
   REFERENCES `mh_user` (`username`);
 CREATE INDEX IX_mh_user_setting_organization ON mh_user_settings (organization);
+
+-- Ensure replies to comments are deleted if the comments are deleted
+ALTER TABLE mh_event_comment_reply
+  DROP FOREIGN KEY `FK_mh_event_comment_reply_mh_event_comment`;
+ALTER TABLE mh_event_comment_reply
+  ADD CONSTRAINT `FK_mh_event_comment_reply_mh_event_comment`
+  FOREIGN KEY (`event_comment_id`)
+  REFERENCES `mh_event_comment` (`id`)
+  ON DELETE CASCADE;

--- a/docs/upgrade/4_to_5/update-4-to-5.sql
+++ b/docs/upgrade/4_to_5/update-4-to-5.sql
@@ -1,2 +1,13 @@
 -- Remove duplicated index
 DROP INDEX IF EXISTS UNQ_mh_user_ref_role ON mh_user_ref_role;
+
+-- Add missing foreign keys
+ALTER TABLE mh_user_settings
+  ADD CONSTRAINT `FK_mh_user_setting_organization`
+  FOREIGN KEY (`organization`)
+  REFERENCES `mh_user` (`organization`);
+ALTER TABLE mh_user_settings
+  ADD CONSTRAINT `FK_mh_user_setting_username`
+  FOREIGN KEY (`username`)
+  REFERENCES `mh_user` (`username`);
+CREATE INDEX IX_mh_user_setting_organization ON mh_user_settings (organization);


### PR DESCRIPTION
- MH-12629, Missing foreign keys on mh_user_settings
    
    The table `mh_user_settings` references users and organizations which
    are not marked as foreign keys. Hence, the existence and correctness of
    these connections is not ensured.

- MH-12628, Index duplication on mh_user_ref_role
    
    `UNQ_mh_user_ref_role` defines a unique constraint which is already
    defined as primary key and hence by definition unique. This patch
    removes the duplicated definition.

*Work sponsored by SWITCH*

- MH-12630, Ensure replies to comments are deleted if the comments are deleted
    
    This patch adds `ON DELETE CASCADE` to ensure database entries connected
    to comments are deleted if the comments are deleted.

*Work sponsored by ETH*