### PR TITLE
MH-12613 New WorkflowOperationHandler 'create-event'

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
@@ -1,0 +1,48 @@
+Duplicate Event Workflow Operation
+===============================
+
+```Id: duplicate-event```
+
+Description
+-----------
+
+The duplicate event operation can be used to duplicate an event by copying an existing one. The main use case are events,
+which contain a series of different presentations which were all recorded with just one recording. In order to create
+seperate events for each presentation, the original recording can be copied and each copy can be cut to only contain
+one presentation. If the original event was already published, the duplicate won't be published right away. The user will
+have to publish it manually when he is done editing it.
+
+Parameter Table
+---------------
+
+|Configuration Key    |Example                                    |Description                                          |
+|---------------------|-------------------------------------------|-----------------------------------------------------|
+|source-flavors       |`archive`                                  |Copy any mediapackage elements with one of these (comma separated) flavors.|
+|source-tags          |`*/*`                                      |Copy any mediapackage elements with one of these (comma separated) tags.|
+|target-tags          |`+copied`                                  |Apply these (comma separated) tags to any copied media package elements. If a target-tag starts with a '-', it will be removed from preexisting tags, if a target-tag starts with a '+', it will be added to preexisting tags. If there is no prefix, all preexisting tags are removed and replaced by the target-tags.|
+|property-namespaces  |`org.opencastproject.assetmanager.security`|Copy all asset manager properties of these (comma separated) namespaces.|
+|copy-number-prefix   |`copy`                                     |The prefix used for the number of the copy which is appended to the title of the new event.     |
+|number-of-events     |`2`                                        |How many events to create.|
+|max-number-of-events |`1000`                                     |How many events are allowed to be created at maximum.|
+
+
+Operation Example
+-----------------
+
+    <operation
+      id="duplicate-event"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error"
+      description="Duplicate event">
+      <configurations>
+        <configuration key="source-flavors">*/*</configuration>
+        <configuration key="number-of-events">${numberOfEvents}</configuration>
+        <configuration key="max-number-of-events">1000</configuration>
+        <configuration key="target-tags"></configuration>
+        <configuration key="property-namespaces">
+          org.opencastproject.assetmanager.security
+        </configuration>
+        <configuration key="copy-number-prefix">copy</configuration>
+      </configurations>
+    </operation>
+

--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -36,6 +36,7 @@ The following table contains the workflow operations that are available in an ou
 |copy                |Copy media package elements to target directory                |[Documentation](copy-woh.md)|
 |cover-image         |Generate a cover-image containing metadata                     |[Documentation](coverimage-woh.md)|
 |defaults            |Applies default workflow configuration values                  |[Documentation](defaults-woh.md)|
+|duplicate-event     |Create an event by cloning an existing one                     |[Documentation](duplicate-event-woh.md)|
 |editor              |Waiting for user to review, then cut video based on edit-list  |[Documentation](editor-woh.md)|
 |encode              |Encode media files to differents formats in parallel           |[Documentation](encode-woh.md)|
 |error-resolution    |Internal operation to pause a workflow in error                |[Documentation](error-resolution-woh.md)|

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -95,6 +95,7 @@ pages:
    - Copy: 'workflowoperationhandlers/copy-woh.md'
    - Cover Image: 'workflowoperationhandlers/coverimage-woh.md'
    - Defaults: 'workflowoperationhandlers/defaults-woh.md'
+   - Duplicate Event: 'workflowoperationhandlers/duplicate-event-woh.md'
    - Editor: 'workflowoperationhandlers/editor-woh.md'
    - Encode: 'workflowoperationhandlers/encode-woh.md'
    - Error Resolution: 'workflowoperationhandlers/error-resolution-woh.md'   

--- a/etc/workflows/duplicate-event.xml
+++ b/etc/workflows/duplicate-event.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<definition xmlns="http://workflow.opencastproject.org">
+
+  <id>duplicate-event</id>
+  <title>Duplicate Event</title>
+  <tags>
+    <tag>archive</tag>
+  </tags>
+  <description/>
+  <configuration_panel>
+    <![CDATA[
+      <div id="workflow-configuration">
+        <fieldset>
+          <input
+            id="numberOfEvents"
+            name="numberOfEvents"
+            type="number"
+            class="configField"
+            onkeypress="return event.charCode > 47"
+            oninput="checkValueInBounds()"
+            min="1"
+            value="1"
+            max="25"
+            />
+          <label for="numberOfEvents">Number of Events</label>
+        </fieldset>
+      </div>
+
+      <script type="text/javascript">
+        function checkValueInBounds() {
+          var value = $('#numberOfEvents').val();
+          var max = $('#numberOfEvents').attr('max');
+          var min = $('#numberOfEvents').attr('min');
+          if (parseInt(value) < parseInt(min)) $('#numberOfEvents').val(min);
+          if (parseInt(value) > parseInt(max)) $('#numberOfEvents').val(max);
+        }
+      </script>
+    ]]>
+  </configuration_panel>
+
+  <operations>
+
+    <!-- Create the new events -->
+    <operation
+      id="duplicate-event"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error"
+      description="Duplicate Event">
+      <configurations>
+        <configuration key="source-flavors">*/*</configuration>
+        <configuration key="number-of-events">${numberOfEvents}</configuration>
+        <configuration key="target-tags"></configuration>
+        <configuration key="property-namespaces">org.opencastproject.assetmanager.security</configuration>
+        <configuration key="copy-number-prefix">copy</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Cleanup the working file repository -->
+    <operation
+        id="include"
+        description="Remove temporary processing artifacts">
+      <configurations>
+        <configuration key="workflow-id">partial-cleanup</configuration>
+      </configurations>
+    </operation>
+
+  </operations>
+
+</definition>

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-distribution-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workspace-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -60,6 +65,18 @@
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-presets</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-distribution-workflowoperation</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-asset-manager-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -134,6 +151,7 @@
               OSGI-INF/operations/configure-by-dcterm.xml,
               OSGI-INF/operations/copy.xml,
               OSGI-INF/operations/defaults.xml,
+              OSGI-INF/operations/duplicate-event.xml,
               OSGI-INF/operations/error-resolution.xml,
               OSGI-INF/operations/export-wf-properties.xml,
               OSGI-INF/operations/failing.xml,

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -1,0 +1,421 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import static org.apache.commons.lang3.StringUtils.split;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Property;
+import org.opencastproject.assetmanager.api.PropertyId;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.distribution.api.DistributionService;
+import org.opencastproject.job.api.Job;
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
+import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageElements;
+import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.Publication;
+import org.opencastproject.mediapackage.PublicationImpl;
+import org.opencastproject.mediapackage.selector.SimpleElementSelector;
+import org.opencastproject.metadata.dublincore.DublinCore;
+import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
+import org.opencastproject.metadata.dublincore.DublinCoreUtil;
+import org.opencastproject.util.JobUtil;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+import org.opencastproject.workflow.handler.distribution.InternalPublicationChannel;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+
+/**
+ * This WOH duplicates an input event.
+ */
+public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(DuplicateEventWorkflowOperationHandler.class);
+  private static final String PLUS = "+";
+  private static final String MINUS = "-";
+
+  /** Name of the configuration option that provides the source flavors we are looking for */
+  public static final String SOURCE_FLAVORS_PROPERTY = "source-flavors";
+
+  /** Name of the configuration option that provides the source tags we are looking for */
+  public static final String SOURCE_TAGS_PROPERTY = "source-tags";
+
+  /** Name of the configuration option that provides the target tags we should apply */
+  public static final String TARGET_TAGS_PROPERTY = "target-tags";
+
+  /** Name of the configuration option that provides the number of events to create */
+  public static final String NUMBER_PROPERTY = "number-of-events";
+
+  /** Name of the configuration option that provides the maximum number of events to create */
+  public static final String MAX_NUMBER_PROPERTY = "max-number-of-events";
+
+  /** The default maximum number of events to create. Can be overridden. */
+  public static final int MAX_NUMBER_DEFAULT = 25;
+
+  /** The namespaces of the asset manager properties to copy. */
+  public static final String PROPERTY_NAMESPACES_PROPERTY = "property-namespaces";
+
+  /** The prefix to use for the number which is appended to the original title of the event. */
+  public static final String COPY_NUMBER_PREFIX_PROPERTY = "copy-number-prefix";
+
+  /** AssetManager to use for creating new media packages. */
+  private AssetManager assetManager;
+
+  /** The workspace to use for retrieving and storing files. */
+  protected Workspace workspace;
+
+  /** The distribution service */
+  protected DistributionService distributionService;
+
+  /**
+   * Callback for the OSGi declarative services configuration.
+   *
+   * @param assetManager
+   *          the asset manager
+   */
+  public void setAssetManager(AssetManager assetManager) {
+    this.assetManager = assetManager;
+  }
+
+  /**
+   * Callback for the OSGi declarative services configuration.
+   *
+   * @param workspace
+   *          the workspace
+   */
+  public void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
+  }
+
+  /**
+   * Callback for the OSGi declarative services configuration.
+   *
+   * @param distributionService
+   *          the distributionService to set
+   */
+  public void setDistributionService(DistributionService distributionService) {
+    this.distributionService = distributionService;
+  }
+
+  @Override
+  public WorkflowOperationResult start(final WorkflowInstance workflowInstance, final JobContext context)
+      throws WorkflowOperationException {
+
+    final MediaPackage mediaPackage = workflowInstance.getMediaPackage();
+    final WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
+    final String configuredSourceFlavors = trimToEmpty(operation.getConfiguration(SOURCE_FLAVORS_PROPERTY));
+    final String configuredSourceTags = trimToEmpty(operation.getConfiguration(SOURCE_TAGS_PROPERTY));
+    final String configuredTargetTags = trimToEmpty(operation.getConfiguration(TARGET_TAGS_PROPERTY));
+    final int numberOfEvents = Integer.parseInt(operation.getConfiguration(NUMBER_PROPERTY));
+    final String configuredPropertyNamespaces = trimToEmpty(operation.getConfiguration(PROPERTY_NAMESPACES_PROPERTY));
+    int maxNumberOfEvents = MAX_NUMBER_DEFAULT;
+
+    if (operation.getConfiguration(MAX_NUMBER_PROPERTY) != null) {
+      maxNumberOfEvents = Integer.parseInt(operation.getConfiguration(MAX_NUMBER_PROPERTY));
+    }
+
+    if (numberOfEvents > maxNumberOfEvents) {
+      throw new WorkflowOperationException("Number of events to create exceeds the maximum of "
+          + maxNumberOfEvents + ". Aborting.");
+    }
+
+    logger.info("Creating {} new media packages from media package with id {}.", numberOfEvents,
+        mediaPackage.getIdentifier());
+
+    final String[] sourceTags = split(configuredSourceTags, ",");
+    final String[] targetTags = split(configuredTargetTags, ",");
+    final String[] sourceFlavors = split(configuredSourceFlavors, ",");
+    final String[] propertyNamespaces = split(configuredPropertyNamespaces, ",");
+    final String copyNumberPrefix = trimToEmpty(operation.getConfiguration(COPY_NUMBER_PREFIX_PROPERTY));
+
+    final SimpleElementSelector elementSelector = new SimpleElementSelector();
+    for (String flavor : sourceFlavors) {
+      elementSelector.addFlavor(MediaPackageElementFlavor.parseFlavor(flavor));
+    }
+
+    final List<String> removeTags = new ArrayList<>();
+    final List<String> addTags = new ArrayList<>();
+    final List<String> overrideTags = new ArrayList<>();
+
+    for (String tag : targetTags) {
+      if (tag.startsWith(MINUS)) {
+        removeTags.add(tag);
+      } else if (tag.startsWith(PLUS)) {
+        addTags.add(tag);
+      } else {
+        overrideTags.add(tag);
+      }
+    }
+
+    for (String tag : sourceTags) {
+      elementSelector.addTag(tag);
+    }
+
+    // Filter elements to copy based on input tags and input flavors
+    final Collection<MediaPackageElement> elements = elementSelector.select(mediaPackage, false);
+    final Collection<Publication> internalPublications = new HashSet<>();
+
+    for (MediaPackageElement e : mediaPackage.getElements()) {
+      if (e instanceof Publication && InternalPublicationChannel.CHANNEL_ID.equals(((Publication) e).getChannel())) {
+        internalPublications.add((Publication) e);
+      }
+      if (MediaPackageElements.EPISODE.equals(e.getFlavor())) {
+        // Remove episode DC since we will add a new one (with changed title)
+        elements.remove(e);
+      }
+    }
+
+    final MediaPackageElement[] originalEpisodeDc = mediaPackage.getElementsByFlavor(MediaPackageElements.EPISODE);
+    if (originalEpisodeDc.length != 1) {
+      throw new WorkflowOperationException("Media package " + mediaPackage.getIdentifier() + " has "
+          + originalEpisodeDc.length + " episode dublin cores while it is expected to have exactly 1. Aborting.");
+    }
+
+    for (int i = 0; i < numberOfEvents; i++) {
+      final List<URI> temporaryFiles = new ArrayList<>();
+      MediaPackage newMp = null;
+
+      try {
+        // Clone the media package (without its elements)
+        newMp = copyMediaPackage(mediaPackage, i + 1, copyNumberPrefix);
+
+        // Create and add new episode dublin core with changed title
+        newMp = copyDublinCore(mediaPackage, originalEpisodeDc[0], newMp, removeTags, addTags, overrideTags,
+                temporaryFiles);
+
+        // Clone regular elements
+        for (final MediaPackageElement e : elements) {
+          final MediaPackageElement element = (MediaPackageElement) e.clone();
+          updateTags(element, removeTags, addTags, overrideTags);
+          newMp.add(element);
+        }
+
+        // Clone internal publications
+        for (final Publication originalPub : internalPublications) {
+          copyPublication(originalPub, mediaPackage, newMp, removeTags, addTags, overrideTags, temporaryFiles);
+        }
+
+        assetManager.takeSnapshot(AssetManager.DEFAULT_OWNER, newMp);
+
+        // Clone properties of media package
+        for (String namespace : propertyNamespaces) {
+          copyProperties(namespace, mediaPackage, newMp);
+        }
+      } finally {
+        cleanup(temporaryFiles, Optional.ofNullable(newMp));
+      }
+    }
+    return createResult(mediaPackage, Action.CONTINUE);
+  }
+
+  private void cleanup(List<URI> temporaryFiles, Optional<MediaPackage> newMp) {
+    // Remove temporary files of new media package
+    for (URI temporaryFile : temporaryFiles) {
+      try {
+        workspace.delete(temporaryFile);
+      } catch (NotFoundException e) {
+        logger.debug("{} could not be found in the workspace and hence, cannot be deleted.", temporaryFile);
+      } catch (IOException e) {
+        logger.warn("Failed to delete {} from workspace.", temporaryFile);
+      }
+    }
+    newMp.ifPresent(mp -> {
+      try {
+        workspace.cleanup(mp.getIdentifier());
+      } catch (IOException e) {
+        logger.warn("Failed to cleanup the workspace for media package {}", mp.getIdentifier());
+      }
+    });
+  }
+
+  private void updateTags(
+      MediaPackageElement element,
+      List<String> removeTags,
+      List<String> addTags,
+      List<String> overrideTags) {
+    element.setIdentifier(null);
+
+    if (overrideTags.size() > 0) {
+      element.clearTags();
+      for (String overrideTag : overrideTags) {
+        element.addTag(overrideTag);
+      }
+    } else {
+      for (String removeTag : removeTags) {
+        element.removeTag(removeTag.substring(MINUS.length()));
+      }
+      for (String tag : addTags) {
+        element.addTag(tag.substring(PLUS.length()));
+      }
+    }
+  }
+
+  private MediaPackage copyMediaPackage(
+      MediaPackage source,
+      long copyNumber,
+      String copyNumberPrefix) throws WorkflowOperationException {
+    // We are not using MediaPackage.clone() here, since it does "too much" for us (e.g. copies all the attachments)
+    MediaPackage destination;
+    try {
+      destination = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
+    } catch (MediaPackageException e) {
+      logger.error("Failed to create media package " + e.getLocalizedMessage());
+      throw new WorkflowOperationException(e);
+    }
+    logger.info("Created mediapackage {}", destination);
+    destination.setDate(source.getDate());
+    destination.setSeries(source.getSeries());
+    destination.setSeriesTitle(source.getSeriesTitle());
+    destination.setDuration(source.getDuration());
+    destination.setLanguage(source.getLanguage());
+    destination.setLicense(source.getLicense());
+    destination.setTitle(source.getTitle() + " (" + copyNumberPrefix + " " + copyNumber + ")");
+    return destination;
+  }
+
+  private void copyPublication(
+      Publication sourcePublication,
+      MediaPackage source,
+      MediaPackage destination,
+      List<String> removeTags,
+      List<String> addTags,
+      List<String> overrideTags,
+      List<URI> temporaryFiles) throws WorkflowOperationException {
+    final String newPublicationId = UUID.randomUUID().toString();
+    final Publication newPublication = PublicationImpl.publication(newPublicationId,
+        InternalPublicationChannel.CHANNEL_ID, null, null);
+
+    // re-distribute elements of publication to internal publication channel
+    final Collection<MediaPackageElement> sourcePubElements = new HashSet<>();
+    sourcePubElements.addAll(Arrays.asList(sourcePublication.getAttachments()));
+    sourcePubElements.addAll(Arrays.asList(sourcePublication.getCatalogs()));
+    sourcePubElements.addAll(Arrays.asList(sourcePublication.getTracks()));
+    for (final MediaPackageElement e : sourcePubElements) {
+      try {
+        // We first have to copy the media package element into the workspace
+        final MediaPackageElement element = (MediaPackageElement) e.clone();
+        try (InputStream inputStream = workspace.read(element.getURI())) {
+          final URI tmpUri = workspace.put(destination.getIdentifier().toString(), element.getIdentifier(),
+              FilenameUtils.getName(element.getURI().toString()), inputStream);
+          temporaryFiles.add(tmpUri);
+          element.setIdentifier(null);
+          element.setURI(tmpUri);
+        }
+
+        // Now we can distribute it to the new media package
+        destination.add(element); // Element has to be added before it can be distributed
+        final Job job = distributionService.distribute(InternalPublicationChannel.CHANNEL_ID, destination,
+            element.getIdentifier());
+        final MediaPackageElement distributedElement =
+            JobUtil.payloadAsMediaPackageElement(serviceRegistry).apply(job);
+        destination.remove(element);
+
+        updateTags(distributedElement, removeTags, addTags, overrideTags);
+
+        PublicationImpl.addElementToPublication(newPublication, distributedElement);
+      } catch (Exception exception) {
+        throw new WorkflowOperationException(exception);
+      }
+    }
+
+    // Using an altered copy of the source publication's URI is a bit hacky,
+    // but it works without knowing the URI pattern...
+    String publicationUri = sourcePublication.getURI().toString();
+    publicationUri = publicationUri.replace(source.getIdentifier().toString(), destination.getIdentifier().toString());
+    publicationUri = publicationUri.replace(sourcePublication.getIdentifier(), newPublicationId);
+    newPublication.setURI(URI.create(publicationUri));
+    destination.add(newPublication);
+  }
+
+  private MediaPackage copyDublinCore(
+      MediaPackage source,
+      MediaPackageElement sourceDublinCore,
+      MediaPackage destination,
+      List<String> removeTags,
+      List<String> addTags,
+      List<String> overrideTags,
+      List<URI> temporaryFiles) throws WorkflowOperationException {
+    final DublinCoreCatalog destinationDublinCore = DublinCoreUtil.loadEpisodeDublinCore(workspace, source).get();
+    destinationDublinCore.setIdentifier(null);
+    destinationDublinCore.setURI(sourceDublinCore.getURI());
+    destinationDublinCore.set(DublinCore.PROPERTY_TITLE, destination.getTitle());
+    try (InputStream inputStream = IOUtils.toInputStream(destinationDublinCore.toXmlString(), "UTF-8")) {
+      final String elementId = UUID.randomUUID().toString();
+      final URI newUrl = workspace.put(destination.getIdentifier().compact(), elementId, "dublincore.xml",
+          inputStream);
+      temporaryFiles.add(newUrl);
+      final MediaPackageElement mpe = destination.add(newUrl, MediaPackageElement.Type.Catalog,
+          MediaPackageElements.EPISODE);
+      mpe.setIdentifier(elementId);
+      for (String tag : sourceDublinCore.getTags()) {
+        mpe.addTag(tag);
+      }
+      updateTags(mpe, removeTags, addTags, overrideTags);
+    } catch (IOException e) {
+      throw new WorkflowOperationException(e);
+    }
+    return destination;
+  }
+
+  private void copyProperties(String namespace, MediaPackage source, MediaPackage destination) {
+    final AQueryBuilder q = assetManager.createQuery();
+    final AResult properties = q.select(q.propertiesOf(namespace))
+        .where(q.mediaPackageId(source.getIdentifier().toString())).run();
+    if (properties.getRecords().head().isNone()) {
+      logger.info("No properties to copy for media package {}.", source.getIdentifier(), namespace);
+      return;
+    }
+    for (final Property p : properties.getRecords().head().get().getProperties()) {
+      final PropertyId newPropId = PropertyId.mk(destination.getIdentifier().toString(), namespace, p.getId()
+          .getName());
+      assetManager.setProperty(Property.mk(newPropId, p.getValue()));
+    }
+  }
+}

--- a/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/duplicate-event.xml
+++ b/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/duplicate-event.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+ name="org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler" immediate="true">
+  <implementation class="org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler" />
+  <property name="service.description" value="Duplicate Event Workflow Handler" />
+  <property name="workflow.operation" value="duplicate-event" />
+  <service>
+    <provide interface="org.opencastproject.workflow.api.WorkflowOperationHandler" />
+  </service>
+  <reference cardinality="1..1" interface="org.opencastproject.workspace.api.Workspace" name="Workspace"
+             policy="static" bind="setWorkspace" />
+  <reference name="ServiceRegistry" cardinality="1..1" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
+    policy="static" bind="setServiceRegistry" />
+  <reference name="asset-manager" interface="org.opencastproject.assetmanager.api.AssetManager"
+    cardinality="1..1" policy="static" bind="setAssetManager" />
+  <reference name="distributionService" target="(distribution.channel=download)" interface="org.opencastproject.distribution.api.DistributionService"
+    cardinality="1..1" policy="static" bind="setDistributionService"/>
+</scr:component>

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandlerTest.java
@@ -1,0 +1,299 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler
+    .COPY_NUMBER_PREFIX_PROPERTY;
+import static org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler
+    .MAX_NUMBER_PROPERTY;
+import static org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler
+    .NUMBER_PROPERTY;
+import static org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler
+    .PROPERTY_NAMESPACES_PROPERTY;
+import static org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler
+    .SOURCE_FLAVORS_PROPERTY;
+import static org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler
+    .SOURCE_TAGS_PROPERTY;
+import static org.opencastproject.workflow.handler.workflow.DuplicateEventWorkflowOperationHandler
+    .TARGET_TAGS_PROPERTY;
+
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Snapshot;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.distribution.api.DistributionService;
+import org.opencastproject.job.api.Job;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilder;
+import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
+import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.mediapackage.MediaPackageElementParser;
+import org.opencastproject.mediapackage.Publication;
+import org.opencastproject.mediapackage.Track;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
+import org.opencastproject.workflow.api.WorkflowInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationInstance.OperationState;
+import org.opencastproject.workflow.api.WorkflowOperationInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+import org.opencastproject.workflow.handler.distribution.InternalPublicationChannel;
+import org.opencastproject.workspace.api.Workspace;
+
+import com.entwinemedia.fn.Stream;
+
+import org.easymock.Capture;
+import org.easymock.CaptureType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DuplicateEventWorkflowOperationHandlerTest {
+
+  private DuplicateEventWorkflowOperationHandler operationHandler;
+
+  // local resources
+  private MediaPackage mp;
+
+  // mock workspace
+  private Workspace workspace = null;
+
+  // mock asset manager
+  private AssetManager assetManager = null;
+
+  // mock service registry
+  private ServiceRegistry serviceRegistry = null;
+
+  // mock distribution service
+  private DistributionService distributionService = null;
+
+  private Capture<MediaPackage> clonedMediaPackages = null;
+
+  @Before
+  public void setUp() throws Exception {
+    operationHandler = new DuplicateEventWorkflowOperationHandler();
+
+    MediaPackageBuilder builder = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder();
+
+    // test resources
+    URI uriMP = getClass().getResource("/duplicate-event_mediapackage.xml").toURI();
+    mp = builder.loadFromXml(uriMP.toURL().openStream());
+
+    workspace = createNiceMock(Workspace.class);
+    assetManager = createNiceMock(AssetManager.class);
+    distributionService = createNiceMock(DistributionService.class);
+    serviceRegistry = createNiceMock(ServiceRegistry.class);
+
+    operationHandler.setWorkspace(workspace);
+    operationHandler.setAssetManager(assetManager);
+    operationHandler.setDistributionService(distributionService);
+    operationHandler.setServiceRegistry(serviceRegistry);
+  }
+
+  @Test
+  public void testSuccessfulCreate() throws Exception {
+
+    final int numCopies = 2;
+
+    mockDependencies(numCopies);
+
+    // operation configuration
+    Map<String, String> configurations = new HashMap<>();
+    configurations.put(SOURCE_FLAVORS_PROPERTY, "*/*");
+    configurations.put(SOURCE_TAGS_PROPERTY, "archive");
+    configurations.put(TARGET_TAGS_PROPERTY, "");
+    configurations.put(NUMBER_PROPERTY, "" + numCopies);
+    configurations.put(MAX_NUMBER_PROPERTY, "" + 10);
+    configurations.put(PROPERTY_NAMESPACES_PROPERTY, "org.opencastproject.assetmanager.security");
+    configurations.put(COPY_NUMBER_PREFIX_PROPERTY, "copy");
+
+    // run the operation handler
+    WorkflowOperationResult result = getWorkflowOperationResult(mp, configurations);
+
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+    Assert.assertEquals(numCopies, clonedMediaPackages.getValues().size());
+    for (int i = 1; i <= numCopies; i++) {
+      final String expectedTitle = mp.getTitle()
+          + " (" + configurations.get(COPY_NUMBER_PREFIX_PROPERTY) + " " + i + ")";
+      Assert.assertEquals(expectedTitle, clonedMediaPackages.getValues().get(i - 1).getTitle());
+    }
+  }
+
+  @Test
+  public void testOverrideTags() throws Exception {
+
+    mockDependencies(1);
+
+    // operation configuration
+    Map<String, String> configurations = new HashMap<>();
+    configurations.put(SOURCE_FLAVORS_PROPERTY, "presenter/source");
+    configurations.put(SOURCE_TAGS_PROPERTY, "archive");
+    configurations.put(TARGET_TAGS_PROPERTY, "tag1,tag2");
+    configurations.put(NUMBER_PROPERTY, "" + 1);
+    configurations.put(MAX_NUMBER_PROPERTY, "" + 10);
+    configurations.put(PROPERTY_NAMESPACES_PROPERTY, "org.opencastproject.assetmanager.security");
+    configurations.put(COPY_NUMBER_PREFIX_PROPERTY, "copy");
+
+    // run the operation handler
+    WorkflowOperationResult result = getWorkflowOperationResult(mp, configurations);
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    Track track = clonedMediaPackages.getValue().getTracksByTag("tag1")[0];
+    Assert.assertEquals("tag1", track.getTags()[0]);
+    Assert.assertEquals("tag2", track.getTags()[1]);
+  }
+
+  @Test
+  public void testRemoveAndAddTags() throws Exception {
+    mockDependencies(1);
+    Map<String, String> configurations = new HashMap<>();
+    configurations.put(SOURCE_FLAVORS_PROPERTY, "*/*");
+    configurations.put(SOURCE_TAGS_PROPERTY, "part1");
+    configurations.put(TARGET_TAGS_PROPERTY, "-part1,+tag3");
+    configurations.put(NUMBER_PROPERTY, "" + 1);
+    configurations.put(MAX_NUMBER_PROPERTY, "" + 10);
+    configurations.put(PROPERTY_NAMESPACES_PROPERTY, "org.opencastproject.assetmanager.security");
+    configurations.put(COPY_NUMBER_PREFIX_PROPERTY, "copy");
+
+    // run the operation handler
+    WorkflowOperationResult result = getWorkflowOperationResult(mp, configurations);
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    Track track = clonedMediaPackages.getValue().getTracksByTag("tag3")[0];
+    final List<String> newTags = Arrays.asList(track.getTags());
+    final List<String> originalTags = Arrays.asList(mp.getTracksByTag("part1")[0].getTags());
+    Assert.assertEquals(originalTags.size(), newTags.size());
+    Assert.assertTrue(newTags.contains("tag3"));
+    Assert.assertFalse(newTags.contains("part1"));
+  }
+
+  private WorkflowOperationResult getWorkflowOperationResult(MediaPackage mp, Map<String, String> configurations)
+      throws WorkflowOperationException {
+    // Add the mediapackage to a workflow instance
+    WorkflowInstanceImpl workflowInstance = new WorkflowInstanceImpl();
+    workflowInstance.setId(1);
+    workflowInstance.setState(WorkflowState.RUNNING);
+    workflowInstance.setMediaPackage(mp);
+    WorkflowOperationInstanceImpl operation = new WorkflowOperationInstanceImpl("op", OperationState.RUNNING);
+    operation.setTemplate("create-event");
+    operation.setState(OperationState.RUNNING);
+    for (String key : configurations.keySet()) {
+      operation.setConfiguration(key, configurations.get(key));
+    }
+
+    List<WorkflowOperationInstance> operationsList = new ArrayList<>();
+    operationsList.add(operation);
+    workflowInstance.setOperations(operationsList);
+
+    // Run the media package through the operation handler
+    return operationHandler.start(workflowInstance, null);
+  }
+
+  private void mockDependencies(int numberOfCopies) throws Exception {
+    clonedMediaPackages = Capture.newInstance(CaptureType.ALL);
+    reset(workspace, assetManager, distributionService);
+
+    URI uriDc = getClass().getResource("/dublincore.xml").toURI();
+    for (int i = 0; i < numberOfCopies; i++) {
+      expect(workspace.read(eq(URI.create("dublincore.xml")))).andReturn(new FileInputStream(new File(uriDc)))
+              .times(1);
+    }
+    expect(workspace.get(anyObject())).andReturn(new File(getClass().getResource("/av.mov").toURI())).anyTimes();
+    expect(workspace.put(anyString(), anyString(), eq("dublincore.xml"), anyObject()))
+        .andReturn(uriDc).times(numberOfCopies);
+    replay(workspace);
+
+    final AResult qResult = createNiceMock(AResult.class);
+    expect(qResult.getRecords()).andReturn(Stream.empty()).anyTimes();
+    replay(qResult);
+    final ASelectQuery qSelect = createNiceMock(ASelectQuery.class);
+    expect(qSelect.where(anyObject())).andReturn(qSelect).anyTimes();
+    expect(qSelect.run()).andReturn(qResult).anyTimes();
+    replay(qSelect);
+    final AQueryBuilder qBuilder = createNiceMock(AQueryBuilder.class);
+    expect(qBuilder.select(anyObject())).andReturn(qSelect).anyTimes();
+    replay(qBuilder);
+    expect(assetManager.createQuery()).andReturn(qBuilder).anyTimes();
+    expect(assetManager.takeSnapshot(eq(AssetManager.DEFAULT_OWNER), capture(clonedMediaPackages)))
+        .andReturn(createNiceMock(Snapshot.class)).times(numberOfCopies);
+    replay(assetManager);
+
+    final Job distributionJob = createNiceMock(Job.class);
+    final Publication internalPub = (Publication) mp.getElementById("pub-int");
+    final List<MediaPackageElement> internalPubElements = new ArrayList<>();
+    Collections.addAll(internalPubElements, (internalPub.getAttachments()));
+    Collections.addAll(internalPubElements, (internalPub.getCatalogs()));
+    Collections.addAll(internalPubElements, (internalPub.getTracks()));
+    expect(distributionJob.getStatus()).andReturn(Job.Status.FINISHED).anyTimes();
+    for (MediaPackageElement e : internalPubElements) {
+      expect(distributionJob.getPayload()).andReturn(MediaPackageElementParser.getAsXml(e)).times(numberOfCopies);
+    }
+    replay(distributionJob);
+    expect(distributionService.distribute(eq(InternalPublicationChannel.CHANNEL_ID), anyObject(), anyString()))
+        .andReturn(distributionJob).anyTimes();
+    replay(distributionService);
+  }
+
+  @Test(expected = WorkflowOperationException.class)
+  public void testCreateMoreThanMaximum() throws Exception {
+
+    final int numCopies = 2;
+    final int maxCopies = 1;
+
+    mockDependencies(numCopies);
+
+    // operation configuration
+    Map<String, String> configurations = new HashMap<>();
+    configurations.put(SOURCE_FLAVORS_PROPERTY, "*/*");
+    configurations.put(SOURCE_TAGS_PROPERTY, "archive");
+    configurations.put(TARGET_TAGS_PROPERTY, "");
+    configurations.put(NUMBER_PROPERTY, "" + numCopies);
+    configurations.put(MAX_NUMBER_PROPERTY, "" + maxCopies);
+    configurations.put(PROPERTY_NAMESPACES_PROPERTY, "org.opencastproject.assetmanager.security");
+    configurations.put(COPY_NUMBER_PREFIX_PROPERTY, "copy");
+
+    // run the operation handler
+    getWorkflowOperationResult(mp, configurations);
+  }
+
+}

--- a/modules/workflow-workflowoperation/src/test/resources/duplicate-event_mediapackage.xml
+++ b/modules/workflow-workflowoperation/src/test/resources/duplicate-event_mediapackage.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:mediapackage xmlns:ns2="http://mediapackage.opencastproject.org" start="2010-05-19T09:27:46"
+                  id="d51f9d4e-b5e7-41e0-8640-0d1f43b2fed0" duration="65649">
+  <ns2:title>duplicate-event workflow operation handler test</ns2:title>
+  <ns2:media>
+    <ns2:track type="presentation/source" id="duplicate-event-workflow-operation-test-source-part-0">
+      <ns2:mimetype>video/msvideo</ns2:mimetype>
+      <ns2:tags>
+        <ns2:tag>first</ns2:tag>
+        <ns2:tag>archive</ns2:tag>
+      </ns2:tags>
+      <ns2:url>av.mov</ns2:url>
+      <ns2:checksum type="md5">322293948673e98459becf5b7ad82585</ns2:checksum>
+      <ns2:duration>65649</ns2:duration>
+      <ns2:audio id="duplicate-event-workflow-operation-test-source-audio-part-0">
+        <ns2:device/>
+        <ns2:encoder type="MPEG Audio"/>
+        <ns2:bitdepth>16</ns2:bitdepth>
+        <ns2:channels>2</ns2:channels>
+        <ns2:samplingrate>48000</ns2:samplingrate>
+        <ns2:bitrate>128000.0</ns2:bitrate>
+      </ns2:audio>
+      <ns2:video id="duplicate-event-workflow-operation-test-source-video-part-0">
+        <ns2:device/>
+        <ns2:encoder type="MPEG-4 Visual"/>
+        <ns2:bitrate>1340065.0</ns2:bitrate>
+        <ns2:framerate>23.976</ns2:framerate>
+        <ns2:resolution>624x352</ns2:resolution>
+        <ns2:scantype type="Progressive"/>
+      </ns2:video>
+    </ns2:track>
+    <ns2:track type="presenter/source" id="duplicate-event-workflow-operation-test-source-part-1">
+      <ns2:mimetype>video/msvideo</ns2:mimetype>
+      <ns2:tags>
+        <ns2:tag>part1</ns2:tag>
+        <ns2:tag>second</ns2:tag>
+        <ns2:tag>archive</ns2:tag>
+      </ns2:tags>
+      <ns2:url>av.mov</ns2:url>
+      <ns2:checksum type="md5">322293948673e98459becf5b7ad82585</ns2:checksum>
+      <ns2:duration>65649</ns2:duration>
+      <ns2:audio id="duplicate-event-workflow-operation-test-source-audio-part-1">
+        <ns2:device/>
+        <ns2:encoder type="MPEG Audio"/>
+        <ns2:bitdepth>16</ns2:bitdepth>
+        <ns2:channels>2</ns2:channels>
+        <ns2:samplingrate>48000</ns2:samplingrate>
+        <ns2:bitrate>128000.0</ns2:bitrate>
+      </ns2:audio>
+      <ns2:video id="duplicate-event-workflow-operation-test-source-video-part-1">
+        <ns2:device/>
+        <ns2:encoder type="MPEG-4 Visual"/>
+        <ns2:bitrate>1340065.0</ns2:bitrate>
+        <ns2:framerate>23.976</ns2:framerate>
+        <ns2:resolution>624x352</ns2:resolution>
+        <ns2:scantype type="Progressive"/>
+      </ns2:video>
+    </ns2:track>
+  </ns2:media>
+  <ns2:metadata>
+    <ns2:catalog type="dublincore/episode" id="9a9eb5dd-e0e1-4321-b46b-66a1feb5bac7">
+      <ns2:mimetype>text/xml</ns2:mimetype>
+      <ns2:tags/>
+      <ns2:url>dublincore.xml</ns2:url>
+    </ns2:catalog>
+    <ns2:catalog ref="track:91bec596-cc93-4315-96c5-9c790c4db875" type="mpeg-7/segments" id="catalog-2">
+      <ns2:mimetype>text/xml</ns2:mimetype>
+      <ns2:tags/>
+      <ns2:url>fooMPEG7.xml</ns2:url>
+    </ns2:catalog>
+  </ns2:metadata>
+  <ns2:attachments/>
+  <ns2:publications>
+    <ns2:publication id="pub-int" channel="internal">
+      <ns2:tags/>
+      <ns2:url>playback</ns2:url>
+      <ns2:media>
+        <ns2:track id="track-int-1" type="presenter/preview"
+                   ref="track:int-dunno">
+          <ns2:mimetype>video/mp4</ns2:mimetype>
+          <ns2:tags>
+            <ns2:tag>preview</ns2:tag>
+          </ns2:tags>
+          <ns2:url>av.mov</ns2:url>
+          <ns2:duration>10000</ns2:duration>
+          <ns2:audio id="audio-1">
+            <ns2:device/>
+            <ns2:encoder type="AAC (Advanced Audio Coding)"/>
+            <ns2:framecount>215</ns2:framecount>
+            <ns2:channels>2</ns2:channels>
+            <ns2:samplingrate>22050</ns2:samplingrate>
+            <ns2:bitrate>63904.0</ns2:bitrate>
+          </ns2:audio>
+          <ns2:video id="video-1">
+            <ns2:device/>
+            <ns2:encoder type="H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10"/>
+            <ns2:framecount>300</ns2:framecount>
+            <ns2:bitrate>49848.0</ns2:bitrate>
+            <ns2:framerate>30.0</ns2:framerate>
+            <ns2:resolution>480x360</ns2:resolution>
+          </ns2:video>
+        </ns2:track>
+      </ns2:media>
+      <ns2:attachments>
+        <ns2:attachment id="pub-int-2" type="presenter/waveform">
+          <ns2:mimetype>image/png</ns2:mimetype>
+          <ns2:tags>
+            <ns2:tag>preview</ns2:tag>
+          </ns2:tags>
+          <ns2:url>waveform.png</ns2:url>
+          <ns2:size>0</ns2:size>
+        </ns2:attachment>
+      </ns2:attachments>
+      <ns2:metadata/>
+    </ns2:publication>
+  </ns2:publications>
+</ns2:mediapackage>

--- a/modules/workflow-workflowoperation/src/test/resources/waveform.png
+++ b/modules/workflow-workflowoperation/src/test/resources/waveform.png
@@ -1,0 +1,1 @@
+just a dummy


### PR DESCRIPTION
This patch adds a new WOH to create new events from an existing one. This is useful when you have a recording with - let's say 3 - different presentations and you want to create 3 events where each event only includes one presentation. With this WOH, you would copy the original event 2 times and cut each of the 3 events differently to only include one presentation, each.

It would be nice to have this functionality in the video editor, but as a first approach, this WOH is a good trade-off between effort and usability. Also, this WOH is useful for creating test data.

This WOH also provides the possibility to select the media package elements to be copied by tags and flavors. Tags can be changed for the newly created media package elements using a "+" and "-" syntax.

A workflow to use/test the WOH is included. It allows you to specify how many copies you would like to create.

This work is sponsored by SWITCH.