### PR TITLE
MH-12544 Play Deleted Segments in Video Editor

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -469,3 +469,10 @@ prop.admin.shortcut.general.help=?
 # Default: 5
 #
 #prop.admin.notification.duration.warning=5
+
+# If the preview mode in the video editor is enabled per default.
+#
+# Format: Boolean
+# Default: true
+#
+#prop.admin.editor.previewmode.default=true

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1535,6 +1535,7 @@
      "WARNING_UNSAVED": "Warning: Some of your changes were not saved. If you leave the video editor, these changes will get lost. Do you really want to continue?",
      "TIMELINE": "Timeline",
      "ZOOMLEVEL": "Zoom Level",
+     "PREVIEW_MODE": "Preview Mode",
      "ZOOM": "Zoom",
      "BUTTONS": {
        "CLOSE":       "Close",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -481,7 +481,7 @@
          "PROCESSED": "Finished",
          "RECORDING_FAILURE": "Recording failure",
          "PROCESSING_FAILURE": "Processing failure",
-         "PROCESSING_CANCELED": "Processing canceled"         
+         "PROCESSING_CANCELED": "Processing canceled"
        },
        "DETAILS": {
          "HEADER": "Event details - {{resourceId}}",
@@ -1536,6 +1536,7 @@
      "TIMELINE": "Timeline",
      "ZOOMLEVEL": "Zoom Level",
      "PREVIEW_MODE": "Preview Mode",
+     "PREVIEW_MODE_TOOLTIP": "Play selected segments only",
      "ZOOM": "Zoom",
      "BUTTONS": {
        "CLOSE":       "Close",

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
@@ -33,6 +33,8 @@ function (PlayerAdapter, $document, VideoService, $timeout) {
             scope.from = 0;
             scope.to = 0;
 
+            scope.previewMode = false; // in preview mode, deactivated segments are skipped while playing.
+
             scope.wrapperClass = ''; // list of border classes for the segment wrapper.
 
             scope.player.adapter.addListener(PlayerAdapter.EVENTS.DURATION_CHANGE, function () {
@@ -81,8 +83,8 @@ function (PlayerAdapter, $document, VideoService, $timeout) {
                     replaySegment = segment;
                 }
 
-                // Skip deleted segments while playing
-                if (segment.deleted && scope.player.adapter.getStatus() === PlayerAdapter.STATUS.PLAYING) {
+                // When in preview mode, skip deleted segments while playing
+                if (scope.previewMode && segment.deleted && scope.player.adapter.getStatus() === PlayerAdapter.STATUS.PLAYING) {
                     scope.player.adapter.setCurrentTime(segment.end / 1000);
                 }
             });
@@ -986,6 +988,13 @@ function (PlayerAdapter, $document, VideoService, $timeout) {
                 });
                 segment.selected = true;
                 scope.setWrapperClasses();
+            };
+
+            /**
+             * Toggles the preview mode. When preview mode is enabled, deactivated segments are skipped while playing.
+             */
+            scope.togglePreviewMode = function() {
+                scope.previewMode = !scope.previewMode;
             };
 
             /**

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
@@ -1,6 +1,6 @@
 angular.module('adminNg.directives')
-.directive('adminNgTimeline', ['PlayerAdapter', '$document', 'VideoService', '$timeout',
-function (PlayerAdapter, $document, VideoService, $timeout) {
+.directive('adminNgTimeline', ['AuthService', 'PlayerAdapter', '$document', 'VideoService', '$timeout',
+function (AuthService, PlayerAdapter, $document, VideoService, $timeout) {
 
     return {
         templateUrl: 'shared/partials/timeline.html',
@@ -33,7 +33,16 @@ function (PlayerAdapter, $document, VideoService, $timeout) {
             scope.from = 0;
             scope.to = 0;
 
-            scope.previewMode = false; // in preview mode, deactivated segments are skipped while playing.
+            scope.previewMode = true; // in preview mode, deactivated segments are skipped while playing.
+
+            if (AuthService) {
+                var ADMIN_EDITOR_PREVIEWMODE_DEFAULT = 'admin.editor.previewmode.default';
+                AuthService.getUser().$promise.then(function(user) {
+                    if (angular.isDefined(user.org.properties[ADMIN_EDITOR_PREVIEWMODE_DEFAULT])) {
+                        scope.previewMode = user.org.properties[ADMIN_EDITOR_PREVIEWMODE_DEFAULT].toUpperCase() === 'TRUE';
+                    }
+                });
+            }
 
             scope.wrapperClass = ''; // list of border classes for the segment wrapper.
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/timeline.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/timeline.html
@@ -37,6 +37,10 @@
 
                 <div class="track-toolbar">
                     <label>{{ track.flavor }}</label>
+                    <div class="preview-toggle-control">
+                        <input type="checkbox" ng-model="previewMode" ng-change="togglePreviewMode()">
+                        <label translate>VIDEO_TOOL.PREVIEW_MODE</label>
+                    </div>
                     <!--
                     <div class="track-options">
                         <div class="track-options-button">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/timeline.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/timeline.html
@@ -37,7 +37,7 @@
 
                 <div class="track-toolbar">
                     <label>{{ track.flavor }}</label>
-                    <div class="preview-toggle-control">
+                    <div class="preview-toggle-control" title="{{ 'VIDEO_TOOL.PREVIEW_MODE_TOOLTIP' | translate }}">
                         <input type="checkbox" ng-model="previewMode" ng-change="togglePreviewMode()">
                         <label translate>VIDEO_TOOL.PREVIEW_MODE</label>
                     </div>

--- a/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
@@ -149,6 +149,15 @@ $segment-deleted-selected: darken($segment-deleted, 18%);
                 }
             }
 
+            .preview-toggle-control {
+                display: inline;
+                float: right;
+            }
+
+            .preview-toggle-control > * {
+                vertical-align: middle;
+            }
+
             $segment-height: 24px;
             $segment-background: $segment-height;
             $segment-main-height: 60px;

--- a/modules/admin-ui/src/test/resources/test/unit/shared/directives/timelineDirectiveSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/directives/timelineDirectiveSpec.js
@@ -1,5 +1,5 @@
 describe('adminNg.directives.timelineDirective', function () {
-    var $compile, $rootScope, $document, element, spy;
+    var $compile, $httpBackend, $rootScope, $document, element, spy;
 
     beforeEach(module('adminNg'));
     beforeEach(module('shared/partials/timeline.html'));
@@ -10,10 +10,14 @@ describe('adminNg.directives.timelineDirective', function () {
         });
     }));
 
-    beforeEach(inject(function (_$rootScope_, _$compile_, _$document_) {
+    beforeEach(inject(function (_$httpBackend_, _$rootScope_, _$compile_, _$document_) {
         $compile = _$compile_;
+        $httpBackend = _$httpBackend_;
         $rootScope = _$rootScope_;
         $document = _$document_;
+
+        jasmine.getJSONFixtures().fixturesPath = 'base/app/GET';
+        $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
     }));
 
     beforeEach(function () {


### PR DESCRIPTION
This patch sets a new default behavior where the video editor plays all segments - even the ones that are deleted. A new checkbox is introduced where the user can enable "Preview Mode" which brings back the old behavior where deleted segments are skipped while playing:

![preview_mode](https://user-images.githubusercontent.com/1727976/34834261-e575258a-f6f1-11e7-80bb-c182d826c7fd.png)

This work is sponsored by SWITCH.