### PR TITLE
MH-12506 admin ui blocked for minutes with slow backend

### DIFF
--- a/docs/scripts/activemq/activemq.xml
+++ b/docs/scripts/activemq/activemq.xml
@@ -95,6 +95,15 @@
           </virtualDestinationInterceptor>
           <virtualDestinationInterceptor>
             <virtualDestinations>
+              <compositeQueue name="EVENT_STATUS_CHANGE.QUEUE">
+                <forwardTo>
+                  <queue physicalName="EVENT_STATUS_CHANGE.Adminui" />
+                </forwardTo>
+              </compositeQueue>
+            </virtualDestinations>
+          </virtualDestinationInterceptor>
+          <virtualDestinationInterceptor>
+            <virtualDestinations>
               <compositeQueue name="GROUP.QUEUE">
                 <forwardTo>
                   <queue physicalName="GROUP.Adminui" />

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -460,6 +460,7 @@
               OSGI-INF/message-receiver-acl.xml,
               OSGI-INF/message-receiver-assetmanager.xml,
               OSGI-INF/message-receiver-comment.xml,
+              OSGI-INF/message-receiver-event-status-change.xml,
               OSGI-INF/message-receiver-group.xml,
               OSGI-INF/message-receiver-scheduler.xml,
               OSGI-INF/message-receiver-series.xml,

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -31,6 +31,7 @@ import static com.entwinemedia.fn.data.json.Jsons.f;
 import static com.entwinemedia.fn.data.json.Jsons.obj;
 import static com.entwinemedia.fn.data.json.Jsons.v;
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
@@ -98,6 +99,7 @@ import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.VideoStream;
 import org.opencastproject.mediapackage.track.AudioStreamImpl;
 import org.opencastproject.mediapackage.track.VideoStreamImpl;
+import org.opencastproject.message.broker.api.eventstatuschange.EventStatusChangeItem;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.EventCatalogUIAdapter;
 import org.opencastproject.metadata.dublincore.MetadataCollection;
@@ -206,7 +208,7 @@ import javax.ws.rs.core.Response.Status;
               + "<em>This service is for exclusive use by the module admin-ui. Its API might change "
               + "anytime without prior notice. Any dependencies other than the admin UI will be strictly ignored. "
               + "DO NOT use this for integration of third-party applications.<em>"})
-public abstract class AbstractEventEndpoint {
+public abstract class AbstractEventEndpoint extends AsynchronousEndpoint {
 
   /**
    * Scheduling JSON keys
@@ -369,21 +371,8 @@ public abstract class AbstractEventEndpoint {
       return Response.status(Response.Status.BAD_REQUEST).build();
     }
 
-    BulkOperationResult result = new BulkOperationResult();
-
-    for (Object eventIdObject : eventIdsJsonArray) {
-      String eventId = eventIdObject.toString();
-      try {
-        if (!getIndexService().removeEvent(eventId)) {
-          result.addServerError(eventId);
-        } else {
-          result.addOk(eventId);
-        }
-      } catch (NotFoundException e) {
-        result.addNotFound(eventId);
-      }
-    }
-    return Response.ok(result.toJson()).build();
+    submit(new BulkDeleteRunnable(new ArrayList<String>(eventIdsJsonArray)));
+    return Response.ok(new JSONObject().toJSONString()).build();
   }
 
   @GET
@@ -2363,6 +2352,32 @@ public abstract class AbstractEventEndpoint {
       return forbidden();
     } catch (Exception e) {
       return serverError();
+    }
+  }
+
+  private class BulkDeleteRunnable extends WorkStartingRunnable {
+
+    protected BulkDeleteRunnable(List<String> eventIds) {
+      super(eventIds);
+    }
+
+    @Override
+    protected void doWork() {
+      for (String eventId : eventIds) {
+        try {
+          if (!getIndexService().removeEvent(eventId)) {
+            reportEventStatusChange(
+              EventStatusChangeItem.Type.Failed, "Could not delete event", singletonList(eventId));
+          }
+        } catch (NotFoundException e) {
+          reportEventStatusChange(EventStatusChangeItem.Type.Failed, "Could not delete event: Not found",
+            singletonList(eventId));
+        } catch (UnauthorizedException e) {
+          reportEventStatusChange(
+            EventStatusChangeItem.Type.Failed, "Could not delete event: Unauthorized",
+              singletonList(eventId));
+        }
+      }
     }
   }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AsynchronousEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AsynchronousEndpoint.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.adminui.endpoint;
+
+import org.opencastproject.message.broker.api.MessageSender;
+import org.opencastproject.message.broker.api.eventstatuschange.EventStatusChangeItem;
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.User;
+
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Base Endpoint for endpoints which perform asynchronous work.
+ */
+public abstract class AsynchronousEndpoint {
+
+  private static final Logger logger = LoggerFactory.getLogger(AsynchronousEndpoint.class);
+
+  private ExecutorService executorService;
+  protected SecurityService securityService;
+  private MessageSender messageSender;
+
+  /** OSGi callback to set the security service. */
+  public void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
+  }
+
+  /** OSGi callback to set the message sender. */
+  public void setMessageSender(MessageSender messageSender) {
+    this.messageSender = messageSender;
+  }
+
+  protected void activate(BundleContext bundleContext) {
+    executorService = Executors.newCachedThreadPool(new NamingThreadFactory());
+  }
+
+  protected void deactivate(BundleContext bundleContext) {
+    if (executorService != null) {
+      executorService.shutdown();
+    }
+  }
+
+  /**
+   * @param runnable The runnable to execute in the background
+   */
+  protected void submit(WorkStartingRunnable runnable) {
+    runnable.setOrganization(securityService.getOrganization());
+    runnable.setUser(securityService.getUser());
+    executorService.submit(runnable);
+  }
+
+  protected void reportEventStatusChange(EventStatusChangeItem.Type type, String message, List<String> eventIds) {
+    messageSender.sendObjectMessage(
+      EventStatusChangeItem.EVENT_STATUS_CHANGE_QUEUE,
+      MessageSender.DestinationType.Queue,
+      new EventStatusChangeItem(type, eventIds, message));
+  }
+
+  /**
+   * Runnable which is used to do intensive work in the background.
+   */
+  protected abstract class WorkStartingRunnable implements Runnable {
+
+    private User user;
+    private Organization organization;
+    protected List<String> eventIds;
+
+    /**
+     * @param eventIds
+     *          The id(s) of the event(s) to work on
+     */
+    protected WorkStartingRunnable(List<String> eventIds) {
+      this.eventIds = eventIds;
+    }
+
+    private void setUser(User user) {
+      this.user = user;
+    }
+
+    private void setOrganization(Organization organization) {
+      this.organization = organization;
+    }
+
+    @Override
+    public void run() {
+      securityService.setUser(user);
+      securityService.setOrganization(organization);
+      reportEventStatusChange(EventStatusChangeItem.Type.Starting,"Starting task", eventIds);
+      try {
+        doWork();
+      } catch (Throwable t) {
+        logger.warn("An unhandled error occurred while starting a task asynchronously", t);
+        reportEventStatusChange(EventStatusChangeItem.Type.Failed,"Unhandled error", eventIds);
+      }
+    }
+
+    protected abstract void doWork();
+  }
+
+  private class NamingThreadFactory implements ThreadFactory {
+    private AtomicInteger counter = new AtomicInteger(0);
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+      final Thread result = new Thread(runnable);
+      result.setName(AsynchronousEndpoint.this.getClass().getName() + "-executor-" + counter.getAndIncrement());
+      return result;
+    }
+  }
+}

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -54,7 +54,6 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   private IndexService indexService;
   private JobEndpoint jobService;
   private SchedulerService schedulerService;
-  private SecurityService securityService;
   private UrlSigningService urlSigningService;
   private WorkflowService workflowService;
   private AdminUIConfiguration adminUIConfiguration;
@@ -115,11 +114,6 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   @Override
   public SecurityService getSecurityService() {
     return securityService;
-  }
-
-  /** OSGi DI. */
-  public void setSecurityService(SecurityService securityService) {
-    this.securityService = securityService;
   }
 
   @Override

--- a/modules/admin-ui/src/main/resources/OSGI-INF/event_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/event_endpoint.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
                name="org.opencastproject.adminui.endpoint.OsgiEventEndpoint"
-               immediate="true" activate="activate">
+               immediate="true" activate="activate" deactivate="deactivate">
   <implementation class="org.opencastproject.adminui.endpoint.OsgiEventEndpoint" />
   <property name="service.description" value="Admin UI - Event facade Endpoint" />
   <property name="opencast.service.type" value="org.opencastproject.adminui.endpoint.event" />
   <property name="opencast.service.path" value="/admin-ng/event" />
-  
+
   <service>
     <!-- expose interface for MH REST publisher! -->
     <provide interface="org.opencastproject.adminui.endpoint.OsgiEventEndpoint" />
@@ -62,14 +62,19 @@
              cardinality="1..1"
              policy="static"
              bind="setIndexService" />
- <reference name="AdminUISearchIndex" 
+  <reference name="AdminUISearchIndex"
              interface="org.opencastproject.adminui.impl.index.AdminUISearchIndex"
-             cardinality="1..1" 
-             policy="static" 
+             cardinality="1..1"
+             policy="static"
              bind="setIndex" />
- <reference name="UrlSigningService" 
+  <reference name="UrlSigningService"
              interface="org.opencastproject.security.urlsigning.service.UrlSigningService"
-             cardinality="1..1" 
-             policy="static" 
+             cardinality="1..1"
+             policy="static"
              bind="setUrlSigningService" />
+  <reference name="messageSender"
+             interface="org.opencastproject.message.broker.api.MessageSender"
+             cardinality="1..1"
+             policy="static"
+             bind="setMessageSender" />
 </scr:component>

--- a/modules/admin-ui/src/main/resources/OSGI-INF/message-receiver-event-status-change.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/message-receiver-event-status-change.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+ name="org.opencastproject.index.service.message.EventStatusChangeMessageReceiverImpl-Adminui"
+  immediate="true" activate="activate" deactivate="deactivate">
+  <implementation
+    class="org.opencastproject.index.service.message.EventStatusChangeMessageReceiverImpl" />
+  <property name="service.description" value="Event Status Change Message Receiver" />
+  <property name="destinationId" value="EVENT_STATUS_CHANGE.Adminui"/>
+  <service>
+    <provide interface="org.opencastproject.index.service.message.EventStatusChangeMessageReceiverImpl" />
+  </service>
+
+    <reference name="message-broker-sender"
+        cardinality="1..1"
+        interface="org.opencastproject.message.broker.api.MessageSender"
+        policy="static"
+        bind="setMessageSender" />
+
+    <reference name="message-broker-receiver"
+        interface="org.opencastproject.message.broker.api.MessageReceiver"
+        cardinality="1..1"
+        policy="static"
+        bind="setMessageReceiver" />
+
+    <reference name="message-receiver-lock-service"
+        cardinality="1..1"
+        interface="org.opencastproject.index.service.message.MessageReceiverLockService"
+        policy="static"
+        bind="setMessageReceiverLockService" />
+
+    <reference name="search-index"
+        interface="org.opencastproject.adminui.impl.index.AdminUISearchIndex"
+        cardinality="1..1"
+        policy="static"
+        bind="setSearchIndex" />
+
+    <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
+        cardinality="1..1" policy="static" bind="setSecurityService" />
+
+</scr:component>

--- a/modules/admin-ui/src/main/resources/OSGI-INF/tasks_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/tasks_endpoint.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
- name="org.opencastproject.adminui.endpoint.TasksEndpoint" immediate="true" activate="activate">
+  name="org.opencastproject.adminui.endpoint.TasksEndpoint" immediate="true" activate="activate"
+  deactivate="deactivate">
   <implementation class="org.opencastproject.adminui.endpoint.TasksEndpoint" />
   <property name="service.description" value="Admin UI - Tasks facade Endpoint" />
-  
+
   <property name="opencast.service.type" value="org.opencastproject.adminui.endpoint.TasksEndpoint" />
   <property name="opencast.service.path" value="/admin-ng/tasks" />
   <service>
@@ -16,4 +17,8 @@
     cardinality="1..1" policy="static" bind="setWorkspace"/>
   <reference name="assetManager" interface="org.opencastproject.assetmanager.api.AssetManager"
     cardinality="1..1" policy="static" bind="setAssetManager" />
+  <reference name="SecurityService" interface="org.opencastproject.security.api.SecurityService"
+    cardinality="1..1" policy="static" bind="setSecurityService" />
+  <reference name="messageSender" interface="org.opencastproject.message.broker.api.MessageSender"
+    cardinality="1..1" policy="static" bind="setMessageSender" />
 </scr:component>

--- a/modules/admin-ui/src/main/resources/OSGI-INF/tools_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/tools_endpoint.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
                name="org.opencastproject.adminui.endpoint.ToolsEndpoint"
-               immediate="true">
-	
+               immediate="true"
+               activate="activate"
+               deactivate="deactivate">
+
   <implementation class="org.opencastproject.adminui.endpoint.ToolsEndpoint" />
-  
+
   <property name="service.description" value="Admin UI - Tools Facade Endpoint" />
   <property name="opencast.service.type" value="org.opencastproject.adminui.endpoint.tools" />
   <property name="opencast.service.path" value="/admin-ng/tools" />
-  
+
   <service>
     <!-- expose interface for MH REST publisher! -->
     <provide interface="org.opencastproject.adminui.endpoint.ToolsEndpoint" />
@@ -60,4 +62,9 @@
              interface="org.opencastproject.workflow.api.WorkflowService"
              name="WorkflowService"
              policy="static" />
+  <reference bind="setMessageSender"
+             cardinality="1..1"
+             interface="org.opencastproject.message.broker.api.MessageSender"
+             name="messageSender"
+             policy="static"/>
 </scr:component>

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
@@ -73,13 +73,9 @@ public class TasksEndpointTest {
     given().formParam("metadata", "{\"workflow\":\"full\", \"configuration\":{}}").expect()
             .statusCode(HttpStatus.SC_BAD_REQUEST).when().post(rt.host("/new"));
 
-    given().formParam("metadata", "{\"workflow\":\"exception\", \"configuration\":{}, \"eventIds\":[\"id1\",\"id2\"]}")
-            .expect().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR).when().post(rt.host("/new"));
-
     String result = given()
             .formParam("metadata", "{\"workflow\":\"full\", \"configuration\":{}, \"eventIds\":[\"id1\",\"id2\"]}")
-            .expect().statusCode(HttpStatus.SC_CREATED).when().post(rt.host("/new")).asString();
-    assertEquals("[5,10]", result);
+            .expect().statusCode(HttpStatus.SC_OK).when().post(rt.host("/new")).asString();
   }
 
   @Before

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/EventStatusChangeMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/EventStatusChangeMessageReceiverImpl.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.index.service.message;
+
+import static org.opencastproject.index.service.impl.index.event.EventIndexUtils.getEvent;
+
+import org.opencastproject.index.service.impl.index.event.Event;
+import org.opencastproject.matterhorn.search.SearchIndexException;
+import org.opencastproject.message.broker.api.MessageSender;
+import org.opencastproject.message.broker.api.eventstatuschange.EventStatusChangeItem;
+import org.opencastproject.message.broker.api.eventstatuschange.EventStatusChangeItem.Type;
+import org.opencastproject.security.api.User;
+import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EventStatusChangeMessageReceiverImpl extends BaseMessageReceiverImpl<EventStatusChangeItem> {
+
+  private static final Logger logger = LoggerFactory.getLogger(EventStatusChangeMessageReceiverImpl.class);
+
+  /**
+   * Creates a new message receiver that is listening to the admin ui destination of the event status change queue.
+   */
+  public EventStatusChangeMessageReceiverImpl() {
+    super(MessageSender.DestinationType.Queue);
+  }
+
+  @Override
+  protected void execute(EventStatusChangeItem eventStatusChangeItem) {
+
+    logger.debug("Received EventStatusChangeItem with type: {} and message: {} for these IDs: {}",
+            eventStatusChangeItem.getType(), eventStatusChangeItem.getMessage(), eventStatusChangeItem.getEventIds());
+
+    final String organization = getSecurityService().getOrganization().getId();
+    final User user = getSecurityService().getUser();
+
+    for (String eventId : eventStatusChangeItem.getEventIds()) {
+      try {
+        // Load the corresponding recording event
+        final Event event = getEvent(eventId, organization, user, getSearchIndex());
+        if (event == null) continue; // Event is not yet created and status cannot be set
+        if (eventStatusChangeItem.getType() != Type.Starting) {
+          logger.info("While creating a task for media package {}, the following error occurred: {}", eventId,
+                  eventStatusChangeItem.getMessage());
+          event.setWorkflowState(WorkflowState.FAILED);
+        } else {
+          event.setWorkflowState(WorkflowState.INSTANTIATED);
+        }
+        getSearchIndex().addOrUpdate(event);
+      } catch (SearchIndexException e) {
+        logger.error("Error retrieving or updating the recording event from/in the search index: {}", e.getMessage());
+      }
+    }
+  }
+}

--- a/modules/message-broker-api/pom.xml
+++ b/modules/message-broker-api/pom.xml
@@ -71,6 +71,7 @@
               org.opencastproject.message.broker.api.acl;version=${project.version},
               org.opencastproject.message.broker.api.assetmanager;version=${project.version},
               org.opencastproject.message.broker.api.comments;version=${project.version},
+              org.opencastproject.message.broker.api.eventstatuschange;version=${project.version},
               org.opencastproject.message.broker.api.group;version=${project.version},
               org.opencastproject.message.broker.api.index;version=${project.version},
               org.opencastproject.message.broker.api.scheduler;version=${project.version},

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/eventstatuschange/EventStatusChangeItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/eventstatuschange/EventStatusChangeItem.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.message.broker.api.eventstatuschange;
+
+import org.opencastproject.message.broker.api.MessageItem;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * {@link Serializable} class that represents all of the possible messages sent through an event status change queue.
+ */
+public class EventStatusChangeItem implements MessageItem, Serializable {
+
+  private static final long serialVersionUID = -89800732905682262L;
+
+  public static final String EVENT_STATUS_CHANGE_QUEUE_PREFIX = "EVENT_STATUS_CHANGE.";
+  public static final String EVENT_STATUS_CHANGE_QUEUE = EVENT_STATUS_CHANGE_QUEUE_PREFIX + "QUEUE";
+
+  public enum Type {
+    Starting, Failed
+  };
+
+  private Type type;
+  private List<String> eventIds;
+  private String message;
+  private String id;
+
+  /**
+   * @param type
+   *          the new status for the event(s)
+   * @param eventIds
+   *          the id(s) of the event(s) to change the status for
+   * @param message
+   *          the message which describes why the status changes
+   */
+  public EventStatusChangeItem(Type type, List<String> eventIds, String message) {
+    this.id = UUID.randomUUID().toString();
+    this.type = type;
+    this.eventIds = eventIds;
+    this.message = message;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  public List<String> getEventIds() {
+    return this.eventIds;
+  }
+
+  public String getMessage() {
+    return this.message;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+}

--- a/modules/message-broker-impl/pom.xml
+++ b/modules/message-broker-impl/pom.xml
@@ -131,6 +131,7 @@
               org.opencastproject.message.broker.api.acl,
               org.opencastproject.message.broker.api.assetmanager,
               org.opencastproject.message.broker.api.comments,
+              org.opencastproject.message.broker.api.eventstatuschange,
               org.opencastproject.message.broker.api.group,
               org.opencastproject.message.broker.api.index,
               org.opencastproject.message.broker.api.scheduler,


### PR DESCRIPTION
When the admin ui sends requests to endpoints which do a lot of file I/O or database work before sending the response, the UI gets frozen for up to several minutes, depending on the performance and load of the backend.

Especially, the following endpoints show this behavior:
- **POST tasks/new** (When starting tasks via recordings -> actions -> start task)
- **POST tools/{mediapackageid}/editor.json** (When exiting the video editor by choosing the "publish" workflow and hitting "save & continue")
- **POST event/deleteevents** (When deleting events via recordings -> actions -> delete)

This patch changes the behavior of these endpoints. Instead of waiting for the heavy work to be completed and responding afterwards, an immediate response is issued while the work is being executed in the background. Feedback about pending operations or errors is given by setting the workflow state of the corresponding recordings to "PENDING" or "FAILED".

This way, the UI responds immediately and the user can go on working on other events.

This work is sponsored by SWITCH.