### PR TITLE
MH-12633, Fix version of maven-dependency-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The maven-dependency-plugin version specified in the main pom.xml does
not exist which obviously breaks `mvn dependency:analyze`. This patch
sets the version to the latest existing one.