### PR TITLE
MH-12631 Drop the ORGANIZER field from the ical feed

### DIFF
--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/CalendarGenerator.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/CalendarGenerator.java
@@ -33,7 +33,6 @@ import net.fortuna.ical4j.model.Calendar;
 import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.ParameterList;
 import net.fortuna.ical4j.model.component.VEvent;
-import net.fortuna.ical4j.model.parameter.Cn;
 import net.fortuna.ical4j.model.parameter.Encoding;
 import net.fortuna.ical4j.model.parameter.FmtType;
 import net.fortuna.ical4j.model.parameter.Value;
@@ -42,7 +41,6 @@ import net.fortuna.ical4j.model.property.Attach;
 import net.fortuna.ical4j.model.property.CalScale;
 import net.fortuna.ical4j.model.property.Description;
 import net.fortuna.ical4j.model.property.Location;
-import net.fortuna.ical4j.model.property.Organizer;
 import net.fortuna.ical4j.model.property.ProdId;
 import net.fortuna.ical4j.model.property.RelatedTo;
 import net.fortuna.ical4j.model.property.Uid;
@@ -54,7 +52,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -143,17 +140,8 @@ public class CalendarGenerator {
 
     VEvent event = new VEvent(startDate, endDate, catalog.getFirst(DublinCore.PROPERTY_TITLE));
     try {
-      ParameterList pl = new ParameterList();
-      if (StringUtils.isNotEmpty(catalog.getFirst(DublinCore.PROPERTY_CREATOR))) {
-        pl.add(new Cn(catalog.getFirst(DublinCore.PROPERTY_CREATOR)));
-      }
       event.getProperties().add(new Uid(eventId));
 
-      // TODO Organizer should be URI (email-address?) created fake address
-      if (StringUtils.isNotEmpty(catalog.getFirst(DublinCore.PROPERTY_CREATOR))) {
-        URI organizer = new URI("mailto", catalog.getFirst(DublinCore.PROPERTY_CREATOR) + "@matterhorn.opencast", null);
-        event.getProperties().add(new Organizer(pl, organizer));
-      }
       if (StringUtils.isNotEmpty(catalog.getFirst(DublinCore.PROPERTY_DESCRIPTION))) {
         event.getProperties().add(new Description(catalog.getFirst(DublinCore.PROPERTY_DESCRIPTION)));
       }


### PR DESCRIPTION
Opencast includes ORGANIZER only if there is a Presenter (DC Creator) in the metadata.
So the lack of an ORGANIZER: field is not a problem to any existing CAs because Opencast allows
scheduling events without a presenter name.

Second, Opencast's use of the ORGANIZER field in the ical feed is not standards-compliant.

See Specifically https://www.ietf.org/rfc/rfc2445.txt, 4.8.4.3

From a standards point of view, it makes no sense to identify the presenter as the ical ORGANIZER
because the presenter is not sending a group scheduled event or publishing his/her busy time.

If we think of the CA as the "user" it also doesn't make much sense because we're not using VFREEBUSY.

The fake ORGANIZER format used by Opencast can cause problems with parsing the feed for some CAs,
especially when the presenter name includes quotes e.g.

ORGANIZER;CN="abc,Some "long" presenter name goes here":mailto:abc,Some%20%22long%22%20presenter%20name%20goes%20here@matterhorn.opencast
This both has encoding issues (quotes within quotes) and also a non-compliant overlong line.

So simplest is just to drop ORGANIZER, as it's not meaningful or useful and can cause problems.

CAs that need the presenter info should get this from the attached episode.xml.