### PR TITLE
MH-12637 Remove event id from episode DC catalog

### DIFF
--- a/modules/matterhorn-migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
+++ b/modules/matterhorn-migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
@@ -285,6 +285,7 @@ public class SchedulerMigrationService {
         DublinCoreCatalog dc = readDublinCoreSilent(resultSet.getString(5));
         dc.setIdentifier(UUID.randomUUID().toString());
         dc.setFlavor(MediaPackageElements.EPISODE);
+        dc.remove(DublinCore.PROPERTY_IDENTIFIER);
         Properties properties = parseProperties(resultSet.getString(4));
         AccessControlList acl = resultSet.getString(2) != null
                 ? AccessControlParser.parseAclSilent(resultSet.getString(2)) : null;


### PR DESCRIPTION
The DC catalog for events in mh_scheduled_event from OC 3.x systems
includes an identifier in the DC catalog that is the numeric event ID
rather than the mediapackage ID, e.g.

    <dcterms:identifier>1188074069566068736</dcterms:identifier>

This is kept in the event DC catalog during the migration process,
although this identifier is no longer in use. When the event is provided
to the CA in an ical calendar after migration, this identifier is still
there in episode.xml and causes problems for Galicaster and possibly other CAs.

So we remove this attribute during migration.