### PR TITLE
MH-12638 Migration bundle needs to have a higher runlevel

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -213,7 +213,7 @@
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-lti/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-messages/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-metadata/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
+    <bundle start-level="85">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-oaipmh/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-oaipmh-api/${project.version}</bundle>
@@ -319,7 +319,7 @@
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-lti/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-messages/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-metadata/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
+    <bundle start-level="85">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-oaipmh-persistence/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-presets/${project.version}</bundle>
@@ -436,7 +436,7 @@
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-lti/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-messages/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-metadata/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
+    <bundle start-level="85">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-oaipmh/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-oaipmh-api/${project.version}</bundle>
@@ -601,7 +601,7 @@
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-lti/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-messages/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-metadata/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
+    <bundle start-level="85">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-oaipmh-persistence/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-presets/${project.version}</bundle>
@@ -709,7 +709,7 @@
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-scheduler-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-series-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/matterhorn-solr/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
+    <bundle start-level="85">mvn:org.opencastproject/matterhorn-migration/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-security-cas" version="0.0.0">


### PR DESCRIPTION
The migration bundle can start up before the REST handler for the asset manager
is registered in some cases:

(RestPublisher:333) - Registered REST endpoint at /assets

This will cause a migration failure because /assets URLs will get a 404.

The runlevel of the migration bundle needs to be higher than other bundles.