### PR TITLE
MH-12643, Allow worspace to directly read files from asset manager

### DIFF
--- a/modules/workspace-impl/src/main/resources/OSGI-INF/workspace.xml
+++ b/modules/workspace-impl/src/main/resources/OSGI-INF/workspace.xml
@@ -7,7 +7,9 @@
     <provide interface="org.opencastproject.workspace.api.Workspace" />
   </service>
   <reference name="REPO" interface="org.opencastproject.workingfilerepository.api.WorkingFileRepository"
-    cardinality="1..1" policy="static" bind="setRepository" />
+             bind="setRepository" />
   <reference name="trustedHttpClient" interface="org.opencastproject.security.api.TrustedHttpClient"
-    cardinality="1..1" policy="static" bind="setTrustedHttpClient" />
+             bind="setTrustedHttpClient" />
+  <reference name="securityService" interface="org.opencastproject.security.api.SecurityService"
+             bind="setSecurityService" />
 </scr:component>


### PR DESCRIPTION
The workspace will get all files from the asset manager via HTTP, even
    if the files are accessible locally on the filesystem. While this will
    ensure the data's integrity as no one is able to accidentally write to
    files in the asset manager, this protection is unnecessary for a
    read-only access as we have for example with `Workspace.read(…)`.
    
This patch now tests if the asset manager storage is accessible via
    filesystem and if it is, will try to read files from there directly. If
    it fails to access the file, it will still fall back to the old method
    of using `Workspace.get(…)` and download the files.
    
Note that the existence test for the local asset manager may fail the
    first time Opencast starts (the first time ever!) due to the directory
    being created by Opencast itself. However, the worst case is that the
    fallback to the current state is used and the direct access is used only
    after a restart of Opencast.
    
Also note that this patch makes the workspace access assets directly via
    file system and it is not necessary to have the asset manager running on
    the same node. This means, that this will also work for example on
    worker or presentation nodes.

- *Based on pull request #7 *
- *Work sponsored by SWITCH*