### PR TITLE
MH-12645 Created an option to rebuild index for an specific service

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -131,7 +131,7 @@
     <sec:intercept-url pattern="/admin-ng/event/*/comment/*/reply" method="POST" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_COMMENTS_CREATE" />
     <sec:intercept-url pattern="/admin-ng/event/*/comment/*" method="POST" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_COMMENTS_CREATE" />
     <sec:intercept-url pattern="/admin-ng/groups" method="POST" access="ROLE_ADMIN, ROLE_UI_GROUPS_CREATE" />
-    <sec:intercept-url pattern="/admin-ng/index/recreateIndex" method="POST" access="ROLE_ADMIN" />
+    <sec:intercept-url pattern="/admin-ng/index/*" method="POST" access="ROLE_ADMIN" />
     <sec:intercept-url pattern="/admin-ng/series/deleteSeries" method="POST" access="ROLE_ADMIN, ROLE_UI_SERIES_DELETE" />
     <sec:intercept-url pattern="/admin-ng/series/new" method="POST" access="ROLE_ADMIN, ROLE_UI_SERIES_CREATE" />
     <sec:intercept-url pattern="/admin-ng/series/optOutSeries/*" method="POST" access="ROLE_ADMIN, ROLE_UI_SERIES_STATUS_EDIT" />
@@ -201,7 +201,9 @@
     <sec:intercept-url pattern="/api/events/*/comments" method="POST" access="ROLE_ADMIN, ROLE_API_EVENTS_COMMENTS_EDIT"/>
     <sec:intercept-url pattern="/api/groups" method="POST" access="ROLE_ADMIN, ROLE_API_GROUPS_CREATE"/>
     <sec:intercept-url pattern="/api/groups/*/members/*" method="POST" access="ROLE_ADMIN, ROLE_API_GROUPS_EDIT"/>
+    <sec:intercept-url pattern="/api/clearIndex" method="POST" access="ROLE_ADMIN"/>
     <sec:intercept-url pattern="/api/recreateIndex" method="POST" access="ROLE_ADMIN"/>
+    <sec:intercept-url pattern="/api/recreateIndex/*" method="POST" access="ROLE_ADMIN"/>
     <sec:intercept-url pattern="/api/series" method="POST" access="ROLE_ADMIN, ROLE_API_SERIES_CREATE"/>
     <sec:intercept-url pattern="/api/security/sign" method="POST" access="ROLE_ADMIN, ROLE_API_SECURITY_EDIT"/>
     <!-- External API DELETE Endpoints -->

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/IndexEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/IndexEndpoint.java
@@ -26,11 +26,12 @@ import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.util.SecurityContext;
 import org.opencastproject.util.RestUtil.R;
 import org.opencastproject.util.data.Effect0;
+import org.opencastproject.util.data.Function0;
+import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ import java.util.concurrent.Executors;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
 /**
@@ -89,8 +91,73 @@ public class IndexEndpoint {
   }
 
   @POST
+  @Path("clearIndex")
+  @RestQuery(name = "clearIndex", description = "Clear the Admin UI index",
+    returnDescription = "OK if index is cleared", reponses = {
+    @RestResponse(description = "Index is cleared", responseCode = HttpServletResponse.SC_OK),
+    @RestResponse(description = "Unable to clear index", responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR) })
+  public Response clearIndex() {
+    final SecurityContext securityContext = new SecurityContext(securityService, securityService.getOrganization(),
+      securityService.getUser());
+    return securityContext.runInContext(new Function0<Response>() {
+      @Override
+      public Response apply() {
+        try {
+          logger.info("Clear the Admin UI index");
+          adminUISearchIndex.clear();
+          return R.ok();
+        } catch (Throwable t) {
+          logger.error("Clearing the Admin UI index failed", t);
+          return R.serverError();
+        }
+      }
+    });
+  }
+
+  @POST
+  @Path("recreateIndex/{service}")
+  @RestQuery(name = "recreateIndexFromService",
+    description = "Repopulates the Admin UI Index from an specific service",
+    returnDescription = "OK if repopulation has started", pathParameters = {
+      @RestParameter(name = "service", isRequired = true, description = "The service to recreate index from. "
+        + "The available services are: Groups, Acl, Themes, Series, Scheduler, Workflow, AssetManager and Comments. "
+        + "The service order (see above) is very important! Make sure, you do not run index rebuild for more than one "
+        + "service at a time!",
+        type = RestParameter.Type.STRING) }, reponses = {
+      @RestResponse(description = "OK if repopulation has started", responseCode = HttpServletResponse.SC_OK) })
+  public Response recreateIndexFromService(@PathParam("service") final String service) {
+    final SecurityContext securityContext = new SecurityContext(securityService, securityService.getOrganization(),
+      securityService.getUser());
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        securityContext.runInContext(new Effect0() {
+          @Override
+          protected void run() {
+            try {
+              logger.info("Starting to repopulate the index from service {}", service);
+              adminUISearchIndex.recreateIndex(service);
+            } catch (InterruptedException e) {
+              logger.error("Repopulating the index was interrupted", e);
+            } catch (CancellationException e) {
+              logger.trace("Listening for index messages has been cancelled.");
+            } catch (ExecutionException e) {
+              logger.error("Repopulating the index failed to execute", e);
+            } catch (Throwable t) {
+              logger.error("Repopulating the index failed", t);
+            }
+          }
+        });
+      }
+    });
+    return R.ok();
+  }
+
+  @POST
   @Path("recreateIndex")
-  @RestQuery(name = "recreateIndex", description = "Repopulates the Admin UI Index directly from the Services", returnDescription = "OK if repopulation has started", reponses = { @RestResponse(description = "OK if repopulation has started", responseCode = HttpServletResponse.SC_OK) })
+  @RestQuery(name = "recreateIndex", description = "Clear and repopulates the Admin UI Index directly from the Services",
+    returnDescription = "OK if repopulation has started", reponses = {
+    @RestResponse(description = "OK if repopulation has started", responseCode = HttpServletResponse.SC_OK) })
   public Response recreateIndex() {
     final SecurityContext securityContext = new SecurityContext(securityService, securityService.getOrganization(),
             securityService.getUser());
@@ -103,15 +170,14 @@ public class IndexEndpoint {
             try {
               logger.info("Starting to repopulate the index");
               adminUISearchIndex.recreateIndex();
-              logger.info("Finished repopulating the index");
             } catch (InterruptedException e) {
-              logger.error("Repopulating the index was interrupted {}", ExceptionUtils.getStackTrace(e));
+              logger.error("Repopulating the index was interrupted", e);
             } catch (CancellationException e) {
               logger.trace("Listening for index messages has been cancelled.");
             } catch (ExecutionException e) {
-              logger.error("Repopulating the index failed to execute because {}", ExceptionUtils.getStackTrace(e));
+              logger.error("Repopulating the index failed to execute", e);
             } catch (Throwable t) {
-              logger.error("Repopulating the index failed because {}", ExceptionUtils.getStackTrace(t));
+              logger.error("Repopulating the index failed", t);
             }
           }
         });
@@ -119,5 +185,4 @@ public class IndexEndpoint {
     });
     return R.ok();
   }
-
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
@@ -63,6 +63,7 @@ import org.opencastproject.util.data.Option;
 
 import com.entwinemedia.fn.Fn;
 
+import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
@@ -138,6 +139,44 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
     recreateService(IndexRecreateObject.Service.Workflow);
     recreateService(IndexRecreateObject.Service.AssetManager);
     recreateService(IndexRecreateObject.Service.Comments);
+  }
+
+  /**
+   * Recreate the index from a specific service that provide data.
+   *
+   * @param service
+   *           The service name. The available services are:
+   *           Groups, Acl, Themes, Series, Scheduler, Workflow, AssetManager, Comments
+   *
+   * @throws IllegalArgumentException
+   *           Thrown if the service name is invalid
+   * @throws InterruptedException
+   *           Thrown if the process is interupted.
+   * @throws ExecutionException
+   *           Thrown if there is a problem executing the process.
+   * @throws IndexServiceException
+   *           Thrown if there was a problem adding some of the data back into the index.
+   */
+  public synchronized void recreateIndex(String service)
+          throws IllegalArgumentException, InterruptedException, ExecutionException, IndexServiceException {
+    if (StringUtils.equalsIgnoreCase("Groups", StringUtils.trim(service)))
+      recreateService(IndexRecreateObject.Service.Groups);
+    else if (StringUtils.equalsIgnoreCase("Acl", StringUtils.trim(service)))
+      recreateService(IndexRecreateObject.Service.Acl);
+    else if (StringUtils.equalsIgnoreCase("Themes", StringUtils.trim(service)))
+      recreateService(IndexRecreateObject.Service.Themes);
+    else if (StringUtils.equalsIgnoreCase("Series", StringUtils.trim(service)))
+      recreateService(IndexRecreateObject.Service.Series);
+    else if (StringUtils.equalsIgnoreCase("Scheduler", StringUtils.trim(service)))
+      recreateService(IndexRecreateObject.Service.Scheduler);
+    else if (StringUtils.equalsIgnoreCase("Workflow", StringUtils.trim(service)))
+      recreateService(IndexRecreateObject.Service.Workflow);
+    else if (StringUtils.equalsIgnoreCase("AssetManager", StringUtils.trim(service)))
+      recreateService(IndexRecreateObject.Service.AssetManager);
+    else if (StringUtils.equalsIgnoreCase("Comments", StringUtils.trim(service)))
+      recreateService(IndexRecreateObject.Service.Comments);
+    else
+      throw new IllegalArgumentException("Unknown service " + service);
   }
 
   /**


### PR DESCRIPTION
Added an endpoint to recreate the AdminUI or ExternalAPI index from a specific service.

As some services update the same index data, the execution order may be important. 
With this endpoints you can ensure the index rebuild is executed in the right order.