### PR TITLE
MH-12576 start task failing

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/TasksEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/TasksEndpoint.java
@@ -152,6 +152,8 @@ public class TasksEndpoint {
     return okJson(arr(actions));
   }
 
+  //TODO change to only accept one event?
+
   @POST
   @Path("/new")
   @RestQuery(name = "createNewTask", description = "Creates a new task by the given metadata as JSON",
@@ -217,9 +219,9 @@ public class TasksEndpoint {
 
     final Workflows workflowsX = new Workflows(assetManager, workspace, workflowService);
     for (Object eventId : eventIds) {
-      Iterable<Snapshot> snapshots = workflowsX.getLatestVersion((String)eventId);
-      for (Snapshot s : snapshots) {
-        MediaPackage mp = workflowsX.putInWorkspace(s);
+      Snapshot snapshot = workflowsX.getLatestVersion((String)eventId);
+      if(snapshot != null){
+        MediaPackage mp = workflowsX.putInWorkspace(snapshot);
 
         try {
           WorkflowInstance wfInstance = workflowService.start(

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -74,6 +74,11 @@
      "DOCUMENTATION": "Documentation",
      "REST_DOC": "REST API Docs"
    },
+   "ERRORS": {
+     "WORKFLOW_NOT_PERSISTED": "Unable to make workflow persistent.",
+     "WORKFLOW_NOT_PARSED": "Workflow could not be parsed.",
+     "ANOTHER_WORKFLOW_ACTIVE": "Another workflow is currently active."
+   },
    "NOTIFICATIONS": {
      "ACL_ADDED":           "The access policy has been created",
      "ACL_NOT_SAVED":       "The access policy could not be saved",
@@ -184,6 +189,22 @@
           "READY_FOR_RECORDING": "Ready for recording",
           "OPTED_OUT": "Opted-out"
       },
+     "START_STATE": {
+       "CAPTION": "Start state",
+       "INSTRUCTION": "This window displays which tasks were successfully started and which failed to start. It can be safely closed at any time, successfully started tasks will continue in the background.",
+       "TABLE": {
+         "EVENTS": "Events",
+         "SERIES": "Series",
+         "STATE": "State",
+         "ERROR":  "Error"
+       },
+       "STATE": {
+         "START_SUCCESS": "Started successfully",
+         "START_FAIL": "Failed to start",
+         "START_PENDING": "Pending"
+       },
+       "SOME_FAILED": "Some tasks failed to start"
+     },
       "DELETE": {
           "SERIES": {
             "CAPTION": "Delete",
@@ -481,7 +502,7 @@
          "PROCESSED": "Finished",
          "RECORDING_FAILURE": "Recording failure",
          "PROCESSING_FAILURE": "Processing failure",
-         "PROCESSING_CANCELED": "Processing canceled"         
+         "PROCESSING_CANCELED": "Processing canceled"
        },
        "DETAILS": {
          "HEADER": "Event details - {{resourceId}}",

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -341,6 +341,7 @@
         <script src="scripts/modules/events/controllers/bulkDeleteController.js"></script>
         <script src="scripts/modules/events/controllers/retractEventController.js"></script>
         <script src="scripts/modules/events/controllers/scheduleTaskController.js"></script>
+        <script src="scripts/modules/events/controllers/startStateController.js"></script>
         <script src="scripts/modules/events/subresources/controllers/toolsController.js"></script>
         <script src="scripts/modules/events/subresources/controllers/video/editController.js"></script>
         <script src="scripts/modules/events/validators/taskStartableValidator.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/scheduleTaskController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/scheduleTaskController.js
@@ -23,8 +23,8 @@
 // Controller for all single series screens.
 angular.module('adminNg.controllers')
 .controller('ScheduleTaskCtrl', ['$scope', 'Table', 'NewEventProcessing', 'TaskResource',
-    'Notifications', 'decorateWithTableRowSelection',
-function ($scope, Table, NewEventProcessing, TaskResource, Notifications, decorateWithTableRowSelection) {
+    'Notifications', 'decorateWithTableRowSelection', 'Modal',
+function ($scope, Table, NewEventProcessing, TaskResource, Notifications, decorateWithTableRowSelection, Modal) {
     $scope.rows = Table.copySelected();
     $scope.allSelected = true; // by default, all rows are selected
     $scope.test = false;
@@ -35,30 +35,33 @@ function ($scope, Table, NewEventProcessing, TaskResource, Notifications, decora
         return $scope.getSelectedIds().length > 0;
     };
 
-    var onSuccess = function () {
-        $scope.submitButton = false;
-        $scope.close();
-        Notifications.add('success', 'TASK_CREATED');
-        Table.deselectAll();
-    };
-
-    var onFailure = function () {
-        $scope.submitButton = false;
-        $scope.close();
-        Notifications.add('error', 'TASK_NOT_CREATED', 'global', -1);
-    };
-
     $scope.submitButton = false;
     $scope.submit = function () {
+
         $scope.submitButton = true;
+
         if ($scope.valid()) {
-            var eventIds = $scope.getSelectedIds(), payload;
-            payload = {
+
+            var eventIds = $scope.getSelectedIds();
+
+            var payload = {
                 workflow: $scope.processing.ud.workflow.id,
                 configuration: $scope.processing.getWorkflowConfig(),
                 eventIds: eventIds
             };
-            TaskResource.save(payload, onSuccess, onFailure);
+
+            var answer = TaskResource.save(payload);
+
+            var params = {
+                rows: $scope.getSelected(),
+                promise: answer.$promise
+            }
+
+            Modal.show('start-state-modal', params);
+
+            $scope.submitButton = false;
+            $scope.close();
+            Table.deselectAll();
         }
     };
     decorateWithTableRowSelection($scope);

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/startStateController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/startStateController.js
@@ -1,0 +1,76 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.controllers')
+.controller('StartStateCtrl', ['$scope', function ($scope) {
+
+    $scope.loading = true;
+
+    var showSuccessfulResults = function () {
+
+        $scope.someFailed = false;
+
+        for (var i = 0; i < $scope.events.length; i++){
+            var id = $scope.events[i].id;
+
+            $scope.events[i].status = 'BULK_ACTIONS.START_STATE.STATE.START_SUCCESS';
+        }
+
+        $scope.loading = false;
+    }
+
+    var showSomeFailedResults = function (response) {
+
+        var data = response.data;
+
+        $scope.someFailed = true;
+
+        for (var i = 0; i < $scope.events.length; i++){
+            var id = $scope.events[i].id;
+
+            if (data[id].successful) {
+                $scope.events[i].status = 'BULK_ACTIONS.START_STATE.STATE.START_SUCCESS';
+            }
+            else {
+                $scope.events[i].status = 'BULK_ACTIONS.START_STATE.STATE.START_FAIL';
+                $scope.events[i].error = data[id].message;
+            }
+        }
+        $scope.loading = false;
+    }
+
+    $scope.events = [];
+
+    for (var i = 0; i < $scope.params.rows.length; i++) {
+
+        var event = {
+            id: $scope.params.rows[i].id,
+            title: $scope.params.rows[i].title,
+            series: $scope.params.rows[i].series_name,
+            status: 'BULK_ACTIONS.START_STATE.STATE.START_PENDING'
+        }
+        $scope.events[i] = event;
+    }
+
+    $scope.someFailed = false;
+    $scope.params.promise.then(showSuccessfulResults, showSomeFailedResults);
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/start-state-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/start-state-modal.html
@@ -1,0 +1,66 @@
+<section ng-show="open" ng-keyup="keyUp($event)" tabindex="1" class="modal modal-animation ng-hide" ng-controller="StartStateCtrl">
+  <header>
+    <a class="fa fa-times close-modal" ng-click="close()"></a>
+    <h2 translate="BULK_ACTIONS.START_STATE.CAPTION"><!-- Template --></h2>
+  </header>
+  <div class="modal-content active">
+    <div class="modal-body">
+      <div class="row">
+        <div ng-show="open">
+          <p translate="BULK_ACTIONS.START_STATE.INSTRUCTION">
+            <!-- Cannot start -->
+          </p>
+        </div>
+      </div>
+
+      <div class="row">
+        <div ng-if="someFailed" class="alert sticky warning">
+          <p translate="BULK_ACTIONS.START_STATE.SOME_FAILED">
+            <!-- Cannot start -->
+          </p>
+        </div>
+        <div data-notifications="start-state"/>
+      </div>
+
+      <div class="full-col">
+        <div class="obj tbl-list">
+          <header translate="BULK_ACTIONS.START_STATE.CAPTION"><!-- Progress --></header>
+          <div class="obj-container">
+
+            <table class="main-tbl">
+              <thead>
+              <tr ng-if="loading === false">
+                <th class="full-width" translate="BULK_ACTIONS.START_STATE.TABLE.EVENTS">
+                  <!-- Title -->
+                </th>
+                <th class="full-width" translate="BULK_ACTIONS.START_STATE.TABLE.SERIES">
+                  <!-- Series -->
+                </th>
+                <th class="full-width" translate="BULK_ACTIONS.START_STATE.TABLE.STATE">
+                  <!-- Status -->
+                </th>
+                <th class="full-width" translate="BULK_ACTIONS.START_STATE.TABLE.ERROR">
+                  <!-- Error -->
+                </th>
+              </tr>
+              <tr ng-if="loading === true">
+                <td colspan="3" style="text-align:center"><i class="fa fa-spinner fa-spin fa-2x fa-fw"></i></td>
+              </tr>
+              </thead>
+              <tbody>
+              <tr ng-if="loading === false" ng-repeat="event in events" ng-class="{error: event.error}">
+                <td>{{ event.title }}</td>
+                <td>{{ event.series }}</td>
+                <td>{{ event.status | translate }}</td>
+                <td>{{ event.error | translate }}</td> <!--TODO or empty? -->
+              </tr>
+              </tbody>
+            </table>
+            </form>
+          </div><!-- obj-container -->
+        </div>
+      </div>
+
+    </div>
+  </div><!-- modal-content [progress] -->
+</section>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/taskResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/taskResource.js
@@ -9,7 +9,7 @@ angular.module('adminNg.resources')
                     metadata: JSON.stringify(data)
                 });
             },
-            isArray: true
+            isArray: false
         }
     });
 }]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/modalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/modalService.js
@@ -22,7 +22,7 @@ angular.module('adminNg.services.modal')
          * @param {string} modalId Identifier for the modal.
          * @returns {HttpPromise} a promise object for the template HTTP request
          */
-        this.show = function (modalId) {
+        this.show = function (modalId, params) {
             var $scope, http, params;
 
             // When opening a modal from another modal, remove the latter from the DOM
@@ -38,6 +38,10 @@ angular.module('adminNg.services.modal')
             }
             $scope = $rootScope.$new();
             this.$scope = $scope;
+
+            if (params) {
+                $scope.params = params;
+            }
 
             /**
              * @ngdoc function

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/resourceModalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/resourceModalService.js
@@ -301,6 +301,8 @@ angular.module('adminNg.services.modal')
             $scope.resourceId = resourceId;
             $scope.action = action;
 
+            //Is this all maybe not even necessary?
+
             http.then(function () {
                 params = $location.search();
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
@@ -79,7 +79,7 @@ public class TasksEndpointTest {
     String result = given()
             .formParam("metadata", "{\"workflow\":\"full\", \"configuration\":{}, \"eventIds\":[\"id1\",\"id2\"]}")
             .expect().statusCode(HttpStatus.SC_CREATED).when().post(rt.host("/new")).asString();
-    assertEquals("[5,10]", result);
+    assertEquals("[[5,10]]", result);
   }
 
   @Before

--- a/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/Workflows.java
+++ b/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/Workflows.java
@@ -204,4 +204,9 @@ public class Workflows {
       return enrich(q.select(q.snapshot()).where(q.mediaPackageId(mpId).and(q.version().isLatest())).run()).getSnapshots();
     }
   };
+
+  public Iterable<Snapshot> getLatestVersion(String mpId) {
+    return $(mpId).bind(findLatest);
+  }
+
 }

--- a/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/Workflows.java
+++ b/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/Workflows.java
@@ -205,8 +205,17 @@ public class Workflows {
     }
   };
 
-  public Iterable<Snapshot> getLatestVersion(String mpId) {
-    return $(mpId).bind(findLatest);
+  /**
+   * Returns the last snapshot of a media package or null if none exist
+   * @param mpId
+   * @return last snapshot of media package or null
+   */
+  public Snapshot getLatestVersion(String mpId) {
+    Iterable<Snapshot> snapshots = findLatest.apply(mpId);
+    if(snapshots.iterator().hasNext()){
+      return snapshots.iterator().next();
+    }
+    return null;
   }
 
 }


### PR DESCRIPTION
This patch changes the behavior of the submit button in the Actions -> Start Task dialog: Instead of waiting for the response of the TasksEndpoint before closing the dialog (which could freeze the ui), this is handed over to a new window and the dialog is closed. The new window can be closed at any time if the user does not want to wait for the backend response. If he does want to wait, then upon response the window displays for each event if the workflow could be started successfully and the error message if it couldn't.

As this patch provides a partial workaround for the ui-freezing-issue, it conflicts with pullrequest #27 which provides another workaround. For easier comparison and discussion this pullrequest was created prematurely, it should not be merged since affected test are not updated yet.

EDIT: This PR builds upon the changes introduced in Christian's PR at Bitbucket which can be found here: https://bitbucket.org/opencast-community/opencast/pull-requests/1845/mh-12576-start-tasks-will-fail-if-start-of/diff