### PR TITLE
MH-12641 Asset manager conflict checks are very slow

### DIFF
--- a/modules/matterhorn-asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/AQueryBuilder.java
+++ b/modules/matterhorn-asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/AQueryBuilder.java
@@ -82,6 +82,9 @@ public interface AQueryBuilder {
   /** Get the snapshot's "organizationId" field. Use it to create a predicate. */
   Field<String> organizationId();
 
+  /** Get the snapshot's "owner" field. Use it to create a predicate. */
+  Field<String> owner();
+
   Predicate availability(Availability availability);
 
   /** Get the snapshots's "availability" field. Use it to create a predicate. */

--- a/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AQueryBuilderDecorator.java
+++ b/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AQueryBuilderDecorator.java
@@ -69,6 +69,10 @@ public class AQueryBuilderDecorator implements AQueryBuilder {
     return delegate.organizationId();
   }
 
+  @Override public Field<String> owner() {
+    return delegate.owner();
+  }
+
   @Override public Predicate availability(Availability availability) {
     return delegate.availability(availability);
   }

--- a/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
+++ b/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
@@ -170,6 +170,10 @@ public final class AQueryBuilderImpl implements AQueryBuilder, EntityPaths {
     return new SimpleSnapshotField<>(Q_SNAPSHOT.organizationId);
   }
 
+  @Override public Field<String> owner() {
+    return new SimpleSnapshotField<>(Q_SNAPSHOT.owner);
+  }
+
   @Override public Predicate availability(final Availability availability) {
     return new SnapshotBasedPredicate() {
       @Override protected BooleanExpression mkSnapshotFieldPredicate(QSnapshotDto e) {

--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1397,7 +1397,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     try {
       AQueryBuilder query = assetManager.createQuery();
       Props p = new Props(query);
-      Predicate predicate = withOrganization(query).and(query.hasPropertiesOf(p.namespace())).and(p.optOut().eq(false))
+      Predicate predicate = withOrganization(query).and(withOwner(query)).and(query.hasPropertiesOf(p.namespace())).and(p.optOut().eq(false))
               .and(withVersion(query)).and(p.end().ge(DateTime.now().minusHours(1).toDate()));
       for (String agentId : captureAgentId) {
         predicate = predicate.and(p.agent().eq(agentId));

--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1184,63 +1184,74 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     }
   }
 
+  /*
+   * FIXME: This query is unsafe since it may fetch many many rows. It would be better to do conflict checking directly
+   * in the database instead of fetching all scheduled events for the capture agent and then doing the checks in memory.
+   * Unfortunately, the current database schema is not suitable to do this in an efficient manner. Especially the generic
+   * concept of 'properties' would lead to many nested queries.
+   */
+  private ARecord[] getScheduledEvents(Opt<String> captureAgentId) {
+    AQueryBuilder query = assetManager.createQuery();
+    Props p = new Props(query);
+    Predicate predicate = withOrganization(query).and(query.hasPropertiesOf(p.namespace())).and(withVersion(query));
+    for (String agentId : captureAgentId) {
+      predicate = predicate.and(p.agent().eq(agentId));
+    }
+    return query.select(query.snapshot(), p.start().target(), p.end().target()).where(predicate).run().getRecords().toList().toArray(new ARecord[0]);
+  }
+
   @Override
   public List<MediaPackage> search(Opt<String> captureAgentId, Opt<Date> startsFrom, Opt<Date> startsTo,
           Opt<Date> endFrom, Opt<Date> endTo) throws SchedulerException {
-    return searchInternal(captureAgentId, startsFrom, startsTo, endFrom, endTo).bind(recordToMp).toList();
+    final ARecord[] alreadyScheduledEvents = getScheduledEvents(captureAgentId);
+    return searchInternal(startsFrom, startsTo, endFrom, endTo, alreadyScheduledEvents);
   }
 
-  private Stream<ARecord> searchInternal(Opt<String> captureAgentId, Opt<Date> startsFrom, Opt<Date> startsTo,
-          Opt<Date> endFrom, Opt<Date> endTo) throws SchedulerException {
-    try {
-      AQueryBuilder query = assetManager.createQuery();
-      Props p = new Props(query);
-      Predicate predicate = withOrganization(query).and(query.hasPropertiesOf(p.namespace())).and(withVersion(query));
-      for (String agentId : captureAgentId) {
-        predicate = predicate.and(p.agent().eq(agentId));
+  private List<MediaPackage> searchInternal(Opt<Date> startsFrom, Opt<Date> startsTo,
+                                            Opt<Date> endFrom, Opt<Date> endTo, ARecord[] records) {
+    final List<ARecord> result = new ArrayList<>();
+    for (final ARecord r : records) {
+      final Date start = r.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
+      final Date end = r.getProperties().apply(Properties.getDate(END_DATE_CONFIG));
+      if (startsFrom.isSome() && start.before(startsFrom.get())
+              || startsTo.isSome() && start.after(startsTo.get())
+              || endFrom.isSome() && end.before(endFrom.get())
+              || endTo.isSome() && end.after(endTo.get())) {
+        continue;
       }
-      for (Date d : startsFrom) {
-        predicate = predicate.and(p.start().ge(d));
-      }
-      for (Date d : startsTo) {
-        predicate = predicate.and(p.start().le(d));
-      }
-      for (Date d : endFrom) {
-        predicate = predicate.and(p.end().ge(d));
-      }
-      for (Date d : endTo) {
-        predicate = predicate.and(p.end().le(d));
-      }
-      // TODO Replace comparator with date.orderBy(p.start().asc()); and remove p.start().target()
-      ASelectQuery select = query.select(query.snapshot(), p.start().target(), p.optOut().target()).where(predicate);
-      return select.run().getRecords().sort(new Comparator<ARecord>() {
-        @Override
-        public int compare(ARecord o1, ARecord o2) {
-          Date start1 = o1.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
-          Date start2 = o2.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
-          return start1.compareTo(start2);
-        }
-      });
-    } catch (Exception e) {
-      logger.error("Failed to search for events: {}", getStackTrace(e));
-      throw new SchedulerException(e);
+      result.add(r);
     }
+    result.sort(new Comparator<ARecord>() {
+      @Override
+      public int compare(ARecord o1, ARecord o2) {
+        Date start1 = o1.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
+        Date start2 = o2.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
+        return start1.compareTo(start2);
+      }
+    });
+    return Stream.mk(result).bind(recordToMp).toList();
   }
 
   @Override
   public List<MediaPackage> findConflictingEvents(String captureDeviceID, Date startDate, Date endDate)
           throws SchedulerException {
-    Set<MediaPackage> events = new HashSet<MediaPackage>();
+    final ARecord[] alreadyScheduledEvents = getScheduledEvents(Opt.some(captureDeviceID));
+    return findConflictingEvents(startDate, endDate, alreadyScheduledEvents);
+  }
+
+  private List<MediaPackage> findConflictingEvents(Date startDate, Date endDate, ARecord[] alreadyScheduledEvents)
+          throws SchedulerException {
+    final List<MediaPackage> events = new ArrayList<>();
     // overlap
-    events.addAll(search(Opt.some(captureDeviceID), Opt.<Date> none(), Opt.some(startDate), Opt.some(endDate),
-            Opt.<Date> none()));
+    events.addAll(searchInternal(Opt.<Date> none(), Opt.some(startDate), Opt.some(endDate),
+            Opt.<Date> none(), alreadyScheduledEvents));
     // start between
-    events.addAll(search(Opt.some(captureDeviceID), Opt.some(startDate), Opt.some(endDate), Opt.<Date> none(),
-            Opt.<Date> none()));
+    events.addAll(searchInternal(Opt.some(startDate), Opt.some(endDate), Opt.<Date> none(),
+            Opt.<Date> none(), alreadyScheduledEvents));
     // end between
-    events.addAll(search(Opt.some(captureDeviceID), Opt.<Date> none(), Opt.<Date> none(), Opt.some(startDate),
-           Opt.some(endDate)));
-    return new ArrayList<MediaPackage>(events);
+    events.addAll(searchInternal(Opt.<Date> none(), Opt.<Date> none(), Opt.some(startDate),
+            Opt.some(endDate), alreadyScheduledEvents));
+    return events;
   }
 
   private List<String> preCollisionEventCheck(String trxId, String schedulingSource) throws SchedulerException {
@@ -1328,6 +1339,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     notNull(tz, "timeZone");
 
     try {
+      final ARecord[] alreadyScheduledEvents = getScheduledEvents(Opt.some(captureAgentId));
       final TimeZone timeZone = TimeZone.getDefault();
       final TimeZone utc = TimeZone.getTimeZone("UTC");
       TimeZone.setDefault(tz);
@@ -1364,8 +1376,10 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         cDate.setTime(d);
 
         TimeZone.setDefault(timeZone);
-        events.addAll(
-                findConflictingEvents(captureAgentId, cDate.getTime(), new Date(cDate.getTimeInMillis() + duration)));
+        final Date startDate = cDate.getTime();
+        final Date endDate = new Date(cDate.getTimeInMillis() + duration);
+
+        events.addAll(findConflictingEvents(startDate, endDate, alreadyScheduledEvents));
         TimeZone.setDefault(utc);
       }
 
@@ -1974,8 +1988,6 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   }
 
   /**
-   * @param organization
-   *          The organization to filter the results with.
    * @return A {@link List} of {@link MediaPackageElementFlavor} that provide the extended metadata to the front end.
    */
   private List<MediaPackageElementFlavor> getEventCatalogUIAdapterFlavors() {

--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1193,7 +1193,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   private ARecord[] getScheduledEvents(Opt<String> captureAgentId) {
     AQueryBuilder query = assetManager.createQuery();
     Props p = new Props(query);
-    Predicate predicate = withOrganization(query).and(query.hasPropertiesOf(p.namespace())).and(withVersion(query));
+    Predicate predicate = withOrganization(query).and(withOwner(query)).and(query.hasPropertiesOf(p.namespace())).and(withVersion(query));
     for (String agentId : captureAgentId) {
       predicate = predicate.and(p.agent().eq(agentId));
     }
@@ -1965,6 +1965,10 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
   private Predicate withOrganization(AQueryBuilder query) {
     return query.organizationId().eq(securityService.getOrganization().getId());
+  }
+
+  private Predicate withOwner(AQueryBuilder query) {
+    return query.owner().eq(SNAPSHOT_OWNER);
   }
 
   private Predicate withVersion(AQueryBuilder query) {


### PR DESCRIPTION
When scheduling new events for a certain capture agent, the
scheduler service checks for conflicts with existing events already
scheduled on that capture agent.

For this check, queries are created using the asset manager's query
builder. Unfortunately, due to the nature of the underlying database
schema, the resulting SQL queries contain many nested queries and hence,
are very slow if there already is a higher number of scheduled events.

The best approach to solve this would be to change the database schema.
The problem is mainly caused by the concept of generic 'properties'
which are related to snapshots and are managed by the asset manager.
However, changing the schema would mean that we need a database
migration and it would yield architectural issues since the separation
between asset manager and scheduler service would break.

Since there currently is not enough time to change the database schema,
this patch chooses a different approach. The measurements include:

- Don't do three queries for each event to schedule, but only one query
  for all the events to schedule. When scheduling 50 events, we now use
  one query instead of 150 queries.
- Use a simpler query with less nested queries.

This is achieved by reading all events for the capture agent in
question and then doing the conflict checks in memory. Of course, there
may be lots of events and performance issues can still arise when
reading so many rows from the database. Also, no limit is used which
generally is bad practice. In the worst case, opencast could run out of
memory or reading all the rows from the database could take forever.
However, productive systems are expected to have a moderate number of
scheduled recordings per capture agent which should not cause the
problems mentioned.

Disclaimer: This solution is not optimal since it utilizes an anti
pattern, but it solves the performance issue for now. It should be
considered as a temporary workaround which as well has its problems.

To test this, you first have to schedule some events and then try to schedule additional events which may or may not cause conflicts.

This work is sponsored by SWITCH.