### PR TITLE
MH-12658, Disable Jasmine for Theodul

### DIFF
--- a/modules/engage-theodul-plugin-controls/pom.xml
+++ b/modules/engage-theodul-plugin-controls/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-custom-mhConnection/pom.xml
+++ b/modules/engage-theodul-plugin-custom-mhConnection/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-custom-notifications/pom.xml
+++ b/modules/engage-theodul-plugin-custom-notifications/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-custom-usertracking/pom.xml
+++ b/modules/engage-theodul-plugin-custom-usertracking/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-description/pom.xml
+++ b/modules/engage-theodul-plugin-description/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-tab-description/pom.xml
+++ b/modules/engage-theodul-plugin-tab-description/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-tab-shortcuts/pom.xml
+++ b/modules/engage-theodul-plugin-tab-shortcuts/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+	 <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-tab-slidetext/pom.xml
+++ b/modules/engage-theodul-plugin-tab-slidetext/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+	 <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-timeline-statistics/pom.xml
+++ b/modules/engage-theodul-plugin-timeline-statistics/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+	 <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-video-videojs/pom.xml
+++ b/modules/engage-theodul-plugin-video-videojs/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+	 <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
As discussed on list, the Theodul Jasmine tests cause random test
failures. To address the issue, this disables the offending tests by
default.