### PR TITLE
MH-12660 Scheduling Events by Specifying End Time

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -382,6 +382,7 @@
                "START_TIME": "Start time",
                "TIMEZONE": "Time zone",
                "END_DATE": "End date",
+               "END_TIME": "End time",
                "DURATION": "Duration"
            },
            "SCHEDULE_SINGLE": {
@@ -481,7 +482,7 @@
          "PROCESSED": "Finished",
          "RECORDING_FAILURE": "Recording failure",
          "PROCESSING_FAILURE": "Processing failure",
-         "PROCESSING_CANCELED": "Processing canceled"         
+         "PROCESSING_CANCELED": "Processing canceled"
        },
        "DETAILS": {
          "HEADER": "Event details - {{resourceId}}",
@@ -561,6 +562,7 @@
                "START_TIME": "Start time",
                "TIMEZONE": "Time zone",
                "END_DATE": "End date",
+               "END_TIME": "End time",
                "DURATION": "Duration"
            },
            "SCHEDULE_SINGLE": {

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -162,6 +162,7 @@
         <script src="scripts/shared/services/formNavigatorService.js"></script>
         <script src="scripts/shared/services/videoService.js"></script>
         <script src="scripts/shared/services/regexService.js"></script>
+        <script src="scripts/shared/services/schedulingHelperService.js"></script>
         <script src="scripts/shared/services/eventHelperService.js"></script>
         <script src="scripts/shared/services/hotkeysService.js"></script>
         <script src="scripts/shared/services/restServiceMonitor.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -28,12 +28,12 @@ angular.module('adminNg.controllers')
     'ResourcesListResource', 'UserRolesResource', 'EventAccessResource', 'EventGeneralResource',
     'OptoutsResource', 'EventParticipationResource', 'EventSchedulingResource', 'NewEventProcessingResource',
     'OptoutSingleResource', 'CaptureAgentsResource', 'ConflictCheckResource', 'Language', 'JsHelper', '$sce', '$timeout', 'EventHelperService',
-    'UploadAssetOptions', 'EventUploadAssetResource', 'Table',
+    'UploadAssetOptions', 'EventUploadAssetResource', 'Table', 'SchedulingHelperService',
     function ($scope, Notifications, EventTransactionResource, EventMetadataResource, EventAssetsResource, EventCatalogsResource, CommentResource,
         EventWorkflowsResource, EventWorkflowActionResource, ResourcesListResource, UserRolesResource, EventAccessResource, EventGeneralResource,
         OptoutsResource, EventParticipationResource, EventSchedulingResource, NewEventProcessingResource,
         OptoutSingleResource, CaptureAgentsResource, ConflictCheckResource, Language, JsHelper, $sce, $timeout, EventHelperService, UploadAssetOptions,
-        EventUploadAssetResource, Table) {
+        EventUploadAssetResource, Table, SchedulingHelperService) {
 
         var roleSlice = 100;
         var roleOffset = 0;
@@ -452,7 +452,7 @@ angular.module('adminNg.controllers')
         $scope.minutes = JsHelper.initArray(60);
 
         $scope.conflicts = [];
-  
+
         this.readyToPollConflicts = function () {
             var data = $scope.source;
             return angular.isDefined(data) &&
@@ -532,6 +532,11 @@ angular.module('adminNg.controllers')
                 }, me.conflictsDetected);
             }
         };
+
+        $scope.onTemporalValueChange = function(type) {
+            SchedulingHelperService.applyTemporalValueChange($scope.source, type, true);
+            $scope.saveScheduling();
+        }
 
         /**
          * End Scheduling related resources

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -220,7 +220,7 @@
                                         ng-disabled="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')"
                                         placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.START_DATE' | translate }}"
                                         ng-model="source.start.date"
-                                        ng-change="saveScheduling()" />
+                                        ng-change="onTemporalValueChange('start')" />
                                 </td>
                             </tr>
                             <tr>
@@ -230,7 +230,7 @@
                                         ng-disabled="checkingConflicts"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
-                                        ng-model="source.start.hour" ng-change="saveScheduling()"
+                                        ng-model="source.start.hour" ng-change="onTemporalValueChange('start')"
                                         data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}"
                                         ng-options="h.index as h.value for h in hours"
                                     />
@@ -238,7 +238,7 @@
                                         ng-disabled="checkingConflicts"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
-                                        ng-model="source.start.minute" ng-change="saveScheduling()"
+                                        ng-model="source.start.minute" ng-change="onTemporalValueChange('start')"
                                         data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
                                         ng-options="m.index as m.value for m in minutes"
                                     />
@@ -254,7 +254,7 @@
                                         ng-disabled="checkingConflicts"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
-                                        ng-model="source.duration.hour" ng-change="saveScheduling()"
+                                        ng-model="source.duration.hour" ng-change="onTemporalValueChange('duration')"
                                         data-placeholder="{{ 'WIZARD.DURATION.HOURS' | translate }}"
                                         ng-options="h.index as h.value for h in hours"
                                     />
@@ -263,13 +263,43 @@
                                         ng-disabled="checkingConflicts"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
-                                        ng-model="source.duration.minute" ng-change="saveScheduling()"
+                                        ng-model="source.duration.minute" ng-change="onTemporalValueChange('duration')"
                                         data-placeholder="{{ 'WIZARD.DURATION.MINUTES' | translate }}"
                                         ng-options="m.index as m.value for m in minutes"
                                     />
                                 </td>
                                 <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     {{ source.duration.hour | addLeadingZeros : 2 }} : {{ source.duration.minute | addLeadingZeros : 2}}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.END_TIME' | translate }}</td>
+                                <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                    <select chosen
+                                        ng-disabled="checkingConflicts"
+                                        data-width="'100px'"
+                                        data-disable-search-threshold="8"
+                                        ng-model="source.end.hour" ng-change="onTemporalValueChange('end')"
+                                        data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}"
+                                        ng-options="h.index as h.value for h in hours"
+                                    />
+                                    <select chosen
+                                        ng-disabled="checkingConflicts"
+                                        data-width="'100px'"
+                                        data-disable-search-threshold="8"
+                                        ng-model="source.end.minute" ng-change="onTemporalValueChange('end')"
+                                        data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
+                                        ng-options="m.index as m.value for m in minutes"
+                                    />
+                                    <span ng-bind="source.end.date"
+                                          ng-show="source.end.date !== source.start.date"
+                                    />
+                                </td>
+                                <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                    {{ source.end.hour | addLeadingZeros : 2 }} : {{ source.end.minute | addLeadingZeros : 2}}
+                                    <span ng-bind="source.end.date"
+                                          ng-show="source.end.date !== source.start.date"
+                                    />
                                 </td>
                             </tr>
                             <tr>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -166,7 +166,7 @@
                                     ng-disabled="wizard.step.checkingConflicts"
                                     placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.START_DATE' | translate }}"
                                     ng-model="wizard.step.ud.SCHEDULE_SINGLE.start.date"
-                                    ng-change="wizard.step.checkConflicts()" />
+                                    ng-change="wizard.step.onTemporalValueChange('start')" />
                             </td>
                         </tr>
                         <tr>
@@ -177,7 +177,7 @@
                                     tabindex="5"
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
-                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.start.hour" ng-change="wizard.step.checkConflicts()"
+                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.start.hour" ng-change="wizard.step.onTemporalValueChange('start')"
                                     data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.HOUR' | translate}}"
                                     ng-options="h.index as h.value for h in wizard.step.hours"
                                 >
@@ -188,7 +188,7 @@
                                     tabindex="6"
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
-                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.start.minute" ng-change="wizard.step.checkConflicts()"
+                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.start.minute" ng-change="wizard.step.onTemporalValueChange('start')"
                                     data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
                                     ng-options="m.index as m.value for m in wizard.step.minutes"
                                 >
@@ -204,7 +204,7 @@
                                     tabindex="7"
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
-                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.duration.hour" ng-change="wizard.step.checkConflicts()"
+                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.duration.hour" ng-change="wizard.step.onTemporalValueChange('duration')"
                                     data-placeholder="{{ 'WIZARD.DURATION.HOURS' | translate }}"
                                     ng-options="h.index as h.value for h in wizard.step.hours"
                                 >
@@ -215,13 +215,43 @@
                                     tabindex="8"
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
-                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.duration.minute" ng-change="wizard.step.checkConflicts()"
+                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.duration.minute" ng-change="wizard.step.onTemporalValueChange('duration')"
                                     data-placeholder="{{ 'WIZARD.DURATION.MINUTES' | translate }}"
                                     ng-options="m.index as m.value for m in wizard.step.minutes"
                                 >
                                     <option value=""></option>
                                 </select>
                             </td>
+                        </tr>
+                        <tr>
+                          <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_TIME' | translate }} <i class="required">*</i></td>
+                          <td>
+                            <select chosen
+                                    data-width="'100px'"
+                                    tabindex="7"
+                                    ng-disabled="wizard.step.checkingConflicts"
+                                    data-disable-search-threshold="8"
+                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.end.hour" ng-change="wizard.step.onTemporalValueChange('end')"
+                                    data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.HOUR' | translate}}"
+                                    ng-options="h.index as h.value for h in wizard.step.hours"
+                            >
+                              <option value=""></option>
+                            </select>
+                            <select chosen
+                                    data-width="'100px'"
+                                    tabindex="8"
+                                    ng-disabled="wizard.step.checkingConflicts"
+                                    data-disable-search-threshold="8"
+                                    ng-model="wizard.step.ud.SCHEDULE_SINGLE.end.minute" ng-change="wizard.step.onTemporalValueChange('end')"
+                                    data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
+                                    ng-options="m.index as m.value for m in wizard.step.minutes"
+                            >
+                              <option value=""></option>
+                            </select>
+                            <span ng-bind="wizard.step.ud.SCHEDULE_SINGLE.end.date"
+                                  ng-show="wizard.step.ud.SCHEDULE_SINGLE.end.date !== wizard.step.ud.SCHEDULE_SINGLE.start.date"
+                            />
+                          </td>
                         </tr>
                         <tr>
                             <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION' | translate }} <i class="required">*</i></td>
@@ -264,13 +294,13 @@
                         <tr>
                             <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_DATE' | translate }} <i class="required">*</i></td>
                             <td>
-                                <input type="text" tabindex="4" placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.START_DATE' | translate }}"  datepicker ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.start.date" ng-change="wizard.step.checkConflicts()">
+                                <input type="text" tabindex="4" placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.START_DATE' | translate }}"  datepicker ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.start.date" ng-change="wizard.step.onTemporalValueChange('start')">
                             </td>
                         </tr>
                         <tr>
                             <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_DATE' | translate }} <i class="required">*</i></td>
                             <td>
-                                <input type="text" tabindex="5" placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.END_DATE' | translate }}"  datepicker ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.end" ng-change="wizard.step.checkConflicts()">
+                                <input type="text" tabindex="5" placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.END_DATE' | translate }}"  datepicker ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.end.date" ng-change="wizard.step.onTemporalValueChange('end')">
                             </td>
                         </tr>
                         <tr>
@@ -294,7 +324,7 @@
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.start.hour"
-                                    ng-change="wizard.step.checkConflicts()"
+                                    ng-change="wizard.step.onTemporalValueChange('start')"
                                     data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.HOUR' | translate}}"
                                     ng-options="h.index as h.value for h in wizard.step.hours"
                                 >
@@ -306,7 +336,7 @@
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.start.minute"
-                                    ng-change="wizard.step.checkConflicts()"
+                                    ng-change="wizard.step.onTemporalValueChange('start')"
                                     data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
                                     ng-options="m.index as m.value for m in wizard.step.minutes"
                                 >
@@ -323,7 +353,7 @@
                                     tabindex="17"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.duration.hour"
-                                    ng-change="wizard.step.checkConflicts()"
+                                    ng-change="wizard.step.onTemporalValueChange('duration')"
                                     data-placeholder="{{ 'WIZARD.DURATION.HOURS' | translate }}"
                                     ng-options="h.index as h.value for h in wizard.step.hours"
                                 >
@@ -335,13 +365,42 @@
                                     tabindex="18"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.duration.minute"
-                                    ng-change="wizard.step.checkConflicts()"
+                                    ng-change="wizard.step.onTemporalValueChange('duration')"
                                     data-placeholder="{{ 'WIZARD.DURATION.MINUTES' | translate }}"
                                     ng-options="m.index as m.value for m in wizard.step.minutes"
                                 >
                                     <option value=""></option>
                                 </select>
                             </td>
+                        </tr>
+                        <tr>
+                          <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_TIME' | translate }} <i class="required">*</i></td>
+                          <td>
+                            <select chosen
+                                    data-width="'100px'"
+                                    tabindex="15"
+                                    ng-disabled="wizard.step.checkingConflicts"
+                                    data-disable-search-threshold="8"
+                                    ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.end.hour"
+                                    ng-change="wizard.step.onTemporalValueChange('end')"
+                                    data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.HOUR' | translate}}"
+                                    ng-options="h.index as h.value for h in wizard.step.hours"
+                            >
+                              <option value=""></option>
+                            </select>
+                            <select chosen
+                                    data-width="'100px'"
+                                    tabindex="16"
+                                    ng-disabled="wizard.step.checkingConflicts"
+                                    data-disable-search-threshold="8"
+                                    ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.end.minute"
+                                    ng-change="wizard.step.onTemporalValueChange('end')"
+                                    data-placeholder="{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
+                                    ng-options="m.index as m.value for m in wizard.step.minutes"
+                            >
+                              <option value=""></option>
+                            </select>
+                          </td>
                         </tr>
                         <tr>
                             <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION' | translate }} <i class="required">*</i></td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/conflictCheckResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/conflictCheckResource.js
@@ -11,7 +11,7 @@ angular.module('adminNg.resources')
 
         if (data.weekdays) {
             result.end = JsHelper.toZuluTimeString({
-                date: data.end,
+                date: data.end.date,
                 hour: data.start.hour,
                 minute: data.start.minute
             }, data.duration);
@@ -19,7 +19,7 @@ angular.module('adminNg.resources')
         } else {
             result.end = JsHelper.toZuluTimeString(data.start, data.duration);
         }
-        
+
         if (data.eventId) {
        	    result.id = data.eventId;
         }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
@@ -71,12 +71,7 @@ angular.module('adminNg.resources')
                                                     .add(parseInt(data.source.SCHEDULE_MULTIPLE.duration.minute, 10), 'm')
                                                     .as('ms') + '';
 
-                    var endMomentDate = moment(data.source.SCHEDULE_MULTIPLE.end)
-                                        .hour(data.source.SCHEDULE_MULTIPLE.start.hour)
-                                        .minute(data.source.SCHEDULE_MULTIPLE.start.minute)
-                                        .add(source.metadata.duration, 'ms');
-
-                    source.metadata.end = endMomentDate.toISOString().replace('.000', '');
+                    source.metadata.end = JsHelper.toZuluTimeString(data.source.SCHEDULE_MULTIPLE.end);
 
                     source.metadata.rrule = (function (src) {
                         return JsHelper.assembleRrule(src.SCHEDULE_MULTIPLE);
@@ -86,7 +81,7 @@ angular.module('adminNg.resources')
                 // Remove useless information for the request
                 angular.forEach(data.metadata, function (catalog) {
                     angular.forEach(catalog.fields, function (field) {
-                            delete field.collection;                        
+                            delete field.collection;
                             delete field.label;
                             delete field.presentableValue;
                             delete field.readOnly;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
@@ -1,0 +1,46 @@
+angular.module('adminNg.services')
+.factory('SchedulingHelperService', [function () {
+    var SchedulingHelperService = function () {
+
+        var me = this;
+
+        this.parseDate = function(dateStr, hour, minute) {
+            var dateArray = dateStr.split("-");
+            return new Date(dateArray[0], parseInt(dateArray[1]) - 1, dateArray[2], hour, minute);
+        }
+
+        this.getUpdatedEndDateSingle = function(start, end) {
+            var startDate = me.parseDate(start.date, start.hour, start.minute);
+            if (end.hour < start.hour) {
+                startDate.setHours(24);
+            }
+            return moment(startDate).format('YYYY-MM-DD');
+        };
+
+        this.applyTemporalValueChange = function(temporalValues, change, single){
+            var startMins = temporalValues.start.hour * 60 + temporalValues.start.minute;
+            switch(change) {
+                case "duration":
+                    // Update end time
+                    var durationMins = temporalValues.duration.hour * 60 + temporalValues.duration.minute;
+                    temporalValues.end.hour = (Math.floor((startMins + durationMins) / 60)) % 24;
+                    temporalValues.end.minute = (startMins + durationMins) % 60;
+                    break;
+                case "start":
+                case "end":
+                    // Update duration
+                    var endMins = temporalValues.end.hour * 60 + temporalValues.end.minute;
+                    if (endMins < startMins) endMins += 24 * 60; // end is on the next day
+                    temporalValues.duration.hour = Math.floor((endMins - startMins) / 60);
+                    temporalValues.duration.minute = (endMins - startMins) % 60;
+                    break;
+                default:
+                    return;
+            }
+            if (single) {
+                temporalValues.end.date = me.getUpdatedEndDateSingle(temporalValues.start, temporalValues.end);
+            }
+        };
+    };
+    return new SchedulingHelperService();
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -1,6 +1,6 @@
 angular.module('adminNg.services')
-.factory('NewEventSource', ['JsHelper', 'CaptureAgentsResource', 'ConflictCheckResource', 'Notifications', 'Language', '$translate', '$filter', 'underscore', '$timeout', 'localStorageService', 'AuthService', 'NewEventMetadata',
-    function (JsHelper, CaptureAgentsResource, ConflictCheckResource, Notifications, Language, $translate, $filter, _, $timeout, localStorageService, AuthService, NewEventMetadata) {
+.factory('NewEventSource', ['JsHelper', 'CaptureAgentsResource', 'ConflictCheckResource', 'Notifications', 'Language', '$translate', '$filter', 'underscore', '$timeout', 'localStorageService', 'AuthService', 'NewEventMetadata', 'SchedulingHelperService',
+    function (JsHelper, CaptureAgentsResource, ConflictCheckResource, Notifications, Language, $translate, $filter, _, $timeout, localStorageService, AuthService, NewEventMetadata, SchedulingHelperService) {
 
     // -- constants ------------------------------------------------------------------------------------------------- --
 
@@ -101,17 +101,17 @@ angular.module('adminNg.services')
                   return;
                 }
 
-                var singleKeys = ['duration', 'start', 'device'];                        //Only apply these default fields to SCHEDULE_SINGLE
+                var singleKeys = ['duration', 'start', 'end', 'device']; //Only apply these default fields to SCHEDULE_SINGLE
 
                 for (var key in opts) {
                     if (key === 'type') {
                       continue;
                     }
 
-                    self.ud.SCHEDULE_MULTIPLE[key] = opts[key];
+                    self.ud.SCHEDULE_MULTIPLE[key] = angular.copy(opts[key]);
 
                     if (singleKeys.indexOf(key) > -1) {
-                      self.ud.SCHEDULE_SINGLE[key] = opts[key];
+                      self.ud.SCHEDULE_SINGLE[key] = angular.copy(opts[key]);
                     }
                 }
 
@@ -164,6 +164,9 @@ angular.module('adminNg.services')
              'start.minute',
              'duration.hour',
              'duration.minute',
+             'end.date',
+             'end.hour',
+             'end.minute',
              'device.name'];
 
         var getType = function() { return self.ud.type; };
@@ -214,8 +217,8 @@ angular.module('adminNg.services')
                 isDefined(data.device.id) && data.device.id.length > 0;
 
             if (self.isScheduleMultiple() && result) {
-                return angular.isDefined(data.end) &&
-                    data.end.length > 0 &&
+                return angular.isDefined(data.end.date) &&
+                    data.end.date.length > 0 &&
                     self.atLeastOneRepetitionDayMarked();
             } else {
                 return result;
@@ -306,6 +309,11 @@ angular.module('adminNg.services')
             }
         };
 
+        this.getStartDate = function() {
+            var start = self.ud[getType()].start;
+            return SchedulingHelperService.parseDate(start.date, start.hour, start.minute);
+        };
+
         this.checkValidity = function () {
             var data = self.ud[getType()];
 
@@ -317,8 +325,7 @@ angular.module('adminNg.services')
                 && angular.isDefined(data.start.minute) && angular.isDefined(data.start.date)
                 && angular.isDefined(data.duration) && angular.isDefined(data.duration.hour)
                 && angular.isDefined(data.duration.minute)) {
-                var dateArray = data.start.date.split("-");
-                var startDate = new Date(dateArray[0], parseInt(dateArray[1]) - 1, dateArray[2], data.start.hour, data.start.minute);
+                var startDate = self.getStartDate();
                 var endDate = new Date(startDate.getTime());
                 endDate.setHours(endDate.getHours() + data.duration.hour, endDate.getMinutes() + data.duration.minute, 0, 0);
                 var nowDate = new Date();
@@ -334,9 +341,9 @@ angular.module('adminNg.services')
             }
             // check if end date is before start date
             if (angular.isDefined(data.start) && angular.isDefined(data.start.date)
-                && angular.isDefined(data.end)) {
+                && angular.isDefined(data.end.date)) {
                 var startDate = new Date(data.start.date);
-                var endDate = new Date(data.end);
+                var endDate = new Date(data.end.date);
                 if (endDate < startDate) {
                     self.endBeforeStartNotification = Notifications.add('error', 'CONFLICT_END_BEFORE_START',
                         NOTIFICATION_CONTEXT, -1);
@@ -451,7 +458,7 @@ angular.module('adminNg.services')
                     //Variables needed to determine an event's start time
                     var startTime = orgProperties['admin.event.new.start_time'] || '08:00';
                     var endTime = orgProperties['admin.event.new.end_time'] || '20:00';
-                    var durationMins = parseInt(orgProperties['admin.event.new.duration'] || 55);
+                    var durationMins = parseInt(orgProperties['admin.event.new.duration'] || (12 * 60));
                     var intervalMins = parseInt(orgProperties['admin.event.new.interval'] || 60);
 
                     var chosenSlot = moment( moment().format('YYYY-MM-DD') + ' ' + startTime );
@@ -464,21 +471,27 @@ angular.module('adminNg.services')
                         var multiple = Math.ceil( timeDiff/(intervalMins * 60) );
                         chosenSlot.add(multiple * intervalMins, 'minute');
                         if (chosenSlot.unix() >= endSlot.unix()) {
-                            chosenSlot = moment( moment().format('YYYY-MM-DD') + ' ' + startTime )
-                                             .add(1, 'day');
+                            endSlot = moment( chosenSlot ).add(durationMins, 'minutes');
                         }
+                        durationMins = endSlot.diff(chosenSlot, 'minutes');
                     }
 
                     defaults.start = {
                                          date: chosenSlot.format('YYYY-MM-DD'),
                                          hour: parseInt(chosenSlot.format('H')),
                                          minute: parseInt(chosenSlot.format('mm'))
-                                     }
+                                     };
 
                     defaults.duration = {
                                             hour: parseInt(durationMins / 60),
                                             minute: durationMins % 60
                                         };
+
+                    defaults.end = {
+                                         date: endSlot.format('YYYY-MM-DD'),
+                                         hour: parseInt(endSlot.format('H')),
+                                         minute: parseInt(endSlot.format('mm'))
+                                     };
 
                     defaults.presentableWeekdays = chosenSlot.format('dd');
 
@@ -495,6 +508,11 @@ angular.module('adminNg.services')
                     self.defaultsSet = true;
                 });
         };
+
+        this.onTemporalValueChange = function(type) {
+            SchedulingHelperService.applyTemporalValueChange(self.ud[getType()], type, self.isScheduleSingle() );
+            self.checkConflicts();
+        }
     };
     return new Source();
 }]);

--- a/modules/admin-ui/src/test/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/test/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -351,6 +351,7 @@
                "START_TIME": "Start time",
                "TIMEZONE": "Time zone",
                "END_DATE": "End date",
+               "END_TIME": "End time",
                "DURATION": "Duration"
            },
            "SCHEDULE_SINGLE": {
@@ -694,7 +695,7 @@
           "SCHEDULING": {
             "CAPTION": "Participation status",
             "REVIEW_STATUS": {
-              "CAPTION": "Review status" 
+              "CAPTION": "Review status"
             },
             "OPTEDOUT": {
               "CAPTION": "Opted-out Status",
@@ -892,7 +893,7 @@
             "CAPTION": "Participation status template",
             "WARNING_TEMPLATE": "Series paticipation status will be used as default value for new events that are part of the series.",
             "REVIEW_STATUS": {
-              "CAPTION": "Review status" 
+              "CAPTION": "Review status"
             },
             "OPTEDOUT": {
               "CAPTION": "Opted-out Status",

--- a/modules/admin-ui/src/test/resources/test/unit/fixtures/conflictCheckMultiple.json
+++ b/modules/admin-ui/src/test/resources/test/unit/fixtures/conflictCheckMultiple.json
@@ -30,7 +30,11 @@
         "hour": 17,
         "minute": 0
     },
-    "end": "2014-07-23",
+    "end": {
+        "date": "2014-07-23",
+        "hour": 18,
+        "minute": 0
+    },
     "duration": {
         "hour": 1,
         "minute": 0

--- a/modules/admin-ui/src/test/resources/test/unit/fixtures/conflictCheckSingle.json
+++ b/modules/admin-ui/src/test/resources/test/unit/fixtures/conflictCheckSingle.json
@@ -40,6 +40,11 @@
             "date": "2014-07-16",
             "hour": 8,
             "minute": 0
+        },
+        "end": {
+            "date": "2014-07-16",
+            "hour": 12,
+            "minute": 4
         }
     },
     "type": "SCHEDULE_SINGLE",

--- a/modules/admin-ui/src/test/resources/test/unit/fixtures/newEventMultipleDSTFixture.json
+++ b/modules/admin-ui/src/test/resources/test/unit/fixtures/newEventMultipleDSTFixture.json
@@ -103,12 +103,12 @@
   },
   "source": {
     "upload": {
-      
+
     },
     "SCHEDULE_SINGLE": {
       "device": {
         "inputMethods": {
-          
+
         }
       }
     },
@@ -140,7 +140,11 @@
         "hour"   : "8",
         "minute" : "0"
       },
-      "end": "2016-03-28T06:10:00Z",
+      "end": {
+        "date"   : "2016-03-28T00:00:00Z",
+        "hour"   : "8",
+        "minute" : "10"
+      },
       "duration": {
         "hour"   : "0",
         "minute" : "10"
@@ -772,6 +776,6 @@
     }
   },
   "summary": {
-    
+
   }
 }

--- a/modules/admin-ui/src/test/resources/test/unit/fixtures/newEventMultipleFixture.json
+++ b/modules/admin-ui/src/test/resources/test/unit/fixtures/newEventMultipleFixture.json
@@ -103,12 +103,12 @@
   },
   "source": {
     "upload": {
-      
+
     },
     "SCHEDULE_SINGLE": {
       "device": {
         "inputMethods": {
-          
+
         }
       }
     },
@@ -140,7 +140,11 @@
         "hour": "10",
         "minute": "0"
       },
-      "end": "2014-07-24",
+      "end": {
+        "date": "2014-07-24",
+        "hour": "11",
+        "minute": "45"
+      },
       "duration": {
         "hour": "1",
         "minute": "45"
@@ -772,6 +776,6 @@
     }
   },
   "summary": {
-    
+
   }
 }

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/schedulingHelperServiceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/schedulingHelperServiceSpec.js
@@ -1,0 +1,89 @@
+describe('SchedulingHelperService', function () {
+    var $httpBackend, SchedulingHelperService;
+
+    beforeEach(module('adminNg.services'));
+
+    beforeEach(inject(function (_SchedulingHelperService_) {
+        SchedulingHelperService = _SchedulingHelperService_;
+    }));
+
+    it('parses date strings correctly', function () {
+        expect(SchedulingHelperService.parseDate("2018-01-20", 10, 25)).toEqual(new Date(2018, 0, 20, 10, 25));
+    });
+
+    describe('#applyTemporalValueChange', function () {
+        var temporalValues;
+
+        beforeEach(function () {
+            temporalValues = {
+                start: {
+                    date: "2018-01-20",
+                    hour: 10,
+                    minute: 25
+                },
+                end: {
+                    date: "2018-01-20",
+                    hour: 12,
+                    minute: 40
+                },
+                duration: {
+                    hour: 3,
+                    minute: 2
+                }
+            };
+        });
+
+        it('updates the duration when the start time is changed', function() {
+            var expectedTemporalValues = angular.copy(temporalValues);
+            expectedTemporalValues.duration = {hour: 2, minute: 15};
+            SchedulingHelperService.applyTemporalValueChange(temporalValues, 'start', true);
+            expect(temporalValues).toEqual(expectedTemporalValues);
+        });
+
+        it('updates the duration when the end time is changed', function() {
+            var expectedTemporalValues = angular.copy(temporalValues);
+            expectedTemporalValues.duration = {hour: 2, minute: 15};
+            SchedulingHelperService.applyTemporalValueChange(temporalValues, 'end', true);
+            expect(temporalValues).toEqual(expectedTemporalValues);
+        });
+
+        it('updates the end time when the duration is changed', function() {
+            var expectedTemporalValues = angular.copy(temporalValues);
+            expectedTemporalValues.end.hour = 13;
+            expectedTemporalValues.end.minute = 27;
+            SchedulingHelperService.applyTemporalValueChange(temporalValues, 'duration', true);
+            expect(temporalValues).toEqual(expectedTemporalValues);
+        });
+
+        it('updates the end date when the duration is changed and the recording lasts until the next day', function() {
+            temporalValues.duration.hour = 23;
+            var expectedTemporalValues = angular.copy(temporalValues);
+            expectedTemporalValues.end.date = "2018-01-21";
+            expectedTemporalValues.end.hour = 9;
+            expectedTemporalValues.end.minute = 27;
+            SchedulingHelperService.applyTemporalValueChange(temporalValues, 'duration', true);
+            expect(temporalValues).toEqual(expectedTemporalValues);
+        });
+
+        it('updates the end date when the end time is changed and the recording lasts until the next day', function() {
+            temporalValues.end.hour = 9;
+            var expectedTemporalValues = angular.copy(temporalValues);
+            expectedTemporalValues.end.date = "2018-01-21";
+            expectedTemporalValues.duration = {hour: 23, minute: 15};
+            SchedulingHelperService.applyTemporalValueChange(temporalValues, 'end', true);
+            expect(temporalValues).toEqual(expectedTemporalValues);
+        });
+
+        it('does not touch the end date when scheduling multiple events', function() {
+            temporalValues.duration.hour = 23;
+            var expectedTemporalValues = angular.copy(temporalValues);
+            expectedTemporalValues.end.date = "2018-01-20";
+            expectedTemporalValues.end.hour = 9;
+            expectedTemporalValues.end.minute = 27;
+            SchedulingHelperService.applyTemporalValueChange(temporalValues, 'duration', false);
+            expect(temporalValues).toEqual(expectedTemporalValues);
+        });
+
+    });
+
+});

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-event/sourceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-event/sourceSpec.js
@@ -55,6 +55,9 @@ describe('Source Step in New Event Wizard', function () {
                     ud.SCHEDULE_SINGLE.start.minute    = '02';
                     ud.SCHEDULE_SINGLE.duration.hour   = '01';
                     ud.SCHEDULE_SINGLE.duration.minute = '33';
+                    ud.SCHEDULE_SINGLE.end.date      = new Date();
+                    ud.SCHEDULE_SINGLE.end.hour      = '11';
+                    ud.SCHEDULE_SINGLE.end.minute    = '35';
                     ud.SCHEDULE_SINGLE.device =
                     {
                         'name': '•mock• agent4',
@@ -72,6 +75,7 @@ describe('Source Step in New Event Wizard', function () {
                 ud.SCHEDULE_SINGLE = {
                     start: {},
                     duration: {},
+                    end: {},
                     inputMethods: {},
                     device: {
                         name: 'test device',
@@ -104,6 +108,9 @@ describe('Source Step in New Event Wizard', function () {
                 ud.SCHEDULE_MULTIPLE.start.minute = '09';
                 ud.SCHEDULE_MULTIPLE.duration.hour = '10';
                 ud.SCHEDULE_MULTIPLE.duration.minute = '09';
+                ud.SCHEDULE_MULTIPLE.end.date = new Date();
+                ud.SCHEDULE_MULTIPLE.end.hour = '20';
+                ud.SCHEDULE_MULTIPLE.end.minute = '18';
                 ud.SCHEDULE_MULTIPLE.repetitionOption = 'daily';
                 ud.SCHEDULE_MULTIPLE.device = {};
                 ud.SCHEDULE_MULTIPLE.device.name  = 'test device';
@@ -121,7 +128,7 @@ describe('Source Step in New Event Wizard', function () {
                 expect(NewEventSource.canPollConflicts()).toBeFalsy();
                 ud.SCHEDULE_MULTIPLE.start.date = '2014-07-01';
                 expect(NewEventSource.canPollConflicts()).toBeFalsy();
-                ud.SCHEDULE_MULTIPLE.end = '2014-08-01';
+                ud.SCHEDULE_MULTIPLE.end.date = '2014-08-01';
                 expect(NewEventSource.canPollConflicts()).toBeFalsy();
                 ud.SCHEDULE_MULTIPLE.device = {
                     id: 'an id, no matter which'
@@ -170,6 +177,7 @@ describe('Source Step in New Event Wizard', function () {
             var tomorrow = new Date();
             tomorrow.setDate(new Date().getDate() + 1);
             NewEventSource.ud.SCHEDULE_SINGLE.start.date = tomorrow.toISOString().substring(0, 10);
+            NewEventSource.ud.SCHEDULE_SINGLE.end.date = tomorrow.toISOString().substring(0, 10);
             NewEventSource.checkConflicts();
             $httpBackend.flush();
             expect(NewEventSource.hasConflictingSettings()).toBeFalsy();


### PR DESCRIPTION
This patch adds the possibility to specify the end time when scheduling
events. The behavior is as follows:

- When the start time is changed, the end time is kept and the duration
  is adjusted accordingly.
- When the duration is changed, the start time is kept and the end time
  is adjusted accordingly.
- When the end time is changed, the start time is kept and the duration
  is adjusted accordingly.

The following views are affected by this change:

- Add Event -> Schedule Multiple
- Add Event -> Scheduling Single
- Event Details -> Scheduling

The latter two views have one speciality: When start date + duration
lead to the end date being the next day, the end date is displayed
besides the end time. However, for universities, it should be a rare
use case to schedule events over midnight.

Here are screenshots of the changed views:

![end1](https://user-images.githubusercontent.com/1727976/35184895-b441efdc-fdfb-11e7-895b-0accf26064d7.png)
![end2](https://user-images.githubusercontent.com/1727976/35184896-b459a9c4-fdfb-11e7-8d47-1783865df56b.png)
![end3](https://user-images.githubusercontent.com/1727976/35184897-b47148cc-fdfb-11e7-9809-6a871ef511b6.png)

This work is sponsored by SWITCH.
