### PR TITLE
MH-12662 Special characters in modal window titles are double-escaped

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -2,8 +2,7 @@
 
     <header>
         <a class="fa fa-times close-modal" ng-click="close()"></a>
-        <h2>
-            {{ 'EVENTS.EVENTS.DETAILS.HEADER' | translate:titleParams }}
+        <h2 translate="EVENTS.EVENTS.DETAILS.HEADER" translate-values="{{titleParams}}">
             <!-- Event details - {{resourceId}} -->
         </h2>
     </header>

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/series-details.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/series-details.html
@@ -1,8 +1,7 @@
 <section ng-show="open" ng-keyup="keyUp($event)" tabindex="1" class="modal modal-animation ng-hide" id="series-details-modal" ng-controller="SerieCtrl">
     <header>
         <a class="fa fa-times close-modal" ng-click="close()"></a>
-        <h2>
-            {{'EVENTS.SERIES.DETAILS.HEADER' | translate:titleParams}}
+        <h2 translate="EVENTS.SERIES.DETAILS.HEADER" translate-values="{{titleParams}}">
             <!-- Series details - {{resourceId}} -->
         </h2>
     </header>


### PR DESCRIPTION
As the angular-translate documentation encourages the use of directives over filters, the problem could be mitigated by using directives which are not affected