### PR TITLE
MH-12473, update the mediapackages's seriesTitle from the series service

### DIFF
--- a/modules/matterhorn-index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
+++ b/modules/matterhorn-index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
@@ -137,6 +137,7 @@ public class CatalogUIAdapterFactory implements ManagedServiceFactory {
           }
 
           adapter.setListProvidersService(listProvidersService);
+          adapter.setSeriesService(seriesService);
           adapter.setWorkspace(workspace);
           adapter.updated(properties);
 

--- a/modules/matterhorn-index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/events/ConfigurableEventDCCatalogUIAdapter.java
+++ b/modules/matterhorn-index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/events/ConfigurableEventDCCatalogUIAdapter.java
@@ -42,6 +42,7 @@ import org.opencastproject.metadata.dublincore.DublinCores;
 import org.opencastproject.metadata.dublincore.EventCatalogUIAdapter;
 import org.opencastproject.metadata.dublincore.MetadataCollection;
 import org.opencastproject.metadata.dublincore.MetadataField;
+import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.IoSupport;
 import org.opencastproject.workspace.api.Workspace;
 
@@ -80,6 +81,7 @@ public class ConfigurableEventDCCatalogUIAdapter implements EventCatalogUIAdapte
   private String title;
 
   private ListProvidersService listProvidersService;
+  private SeriesService seriesService;
   private Workspace workspace;
 
   public void updated(@SuppressWarnings("rawtypes") Dictionary properties) throws ConfigurationException {
@@ -221,6 +223,14 @@ public class ConfigurableEventDCCatalogUIAdapter implements EventCatalogUIAdapte
 
   protected ListProvidersService getListProvidersService() {
     return listProvidersService;
+  }
+
+  protected SeriesService getSeriesService() {
+    return seriesService;
+  }
+
+  public void setSeriesService(SeriesService seriesService) {
+    this.seriesService = seriesService;
   }
 
   public void setWorkspace(Workspace workspace) {


### PR DESCRIPTION
The mediapackage is only updated from the eventUI metadata and so is missing the series title. Go get it from the series service. 

(note though the event/{id}metadata is given a collection of series id=>title, this information is not extracted from the json). 