### PR TITLE
MH-11621 Option to marshal empty values in DublinCore XML catalog. 

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/XMLCatalog.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/XMLCatalog.java
@@ -74,4 +74,12 @@ public interface XMLCatalog {
    */
   void toXml(OutputStream out, boolean format) throws IOException;
 
+  /**
+   * Marshal elements with empty values to support
+   * remove existing values during catalog merge.
+   *
+   * @param includeEmpty
+   */
+  void includeEmpty(boolean includeEmpty);
+
 }

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/XMLCatalogImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/XMLCatalogImpl.java
@@ -106,6 +106,9 @@ public abstract class XMLCatalogImpl extends CatalogImpl implements XMLCatalog {
   /** Namespace prefix for XML schema instance. */
   public static final String XSI_NS_PREFIX = "xsi";
 
+  /** To marshaling empty fields to remove existing values during merge, default is not to marshal empty elements */
+  protected boolean includeEmpty = false;
+
   /**
    * Expanded name of the XSI type attribute.
    * <p>
@@ -251,7 +254,12 @@ public abstract class XMLCatalogImpl extends CatalogImpl implements XMLCatalog {
    *          the element
    */
   private void addElement(CatalogEntry element) {
-    if (element == null || StringUtils.trimToNull(element.getValue()) == null)
+
+    // Option includeEmpty allows marshaling empty elements
+    // for deleting existing values during a catalog merge
+    if (element == null)
+      return;
+    if (StringUtils.trimToNull(element.getValue()) == null && !includeEmpty)
       return;
     List<CatalogEntry> values = data.get(element.getEName());
     if (values == null) {
@@ -500,6 +508,15 @@ public abstract class XMLCatalogImpl extends CatalogImpl implements XMLCatalog {
     } else {
       throw new NamespaceBindingException(format("Namespace URI %s is not bound to a prefix", namespaceURI));
     }
+  }
+
+  /**
+   * @see org.opencastproject.mediapackage.XMLCatalog#includeEmpty(boolean)
+   */
+  @Override
+  public
+  void includeEmpty(boolean includeEmpty) {
+    this.includeEmpty = includeEmpty;
   }
 
   /**

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalog.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalog.java
@@ -371,7 +371,8 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
   }
 
   void add(EName property, String value, String language, @Nullable EName encodingScheme) {
-    if (LANGUAGE_UNDEFINED.equals(language)) {
+    // Ignore empty rootTag element
+    if (LANGUAGE_UNDEFINED.equals(language) && !property.equals(rootTag)) {
       if (encodingScheme == null) {
         addElement(property, value);
       } else {
@@ -462,7 +463,10 @@ public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, Met
 
   // make public
   @Override public void addElement(EName element, String value, Attributes attributes) {
-    super.addElement(element, value, attributes);
+    // Ignore empty root element
+    if (! rootTag.equals(element)) {
+      super.addElement(element, value, attributes);
+    }
   }
 
   // make public

--- a/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreCatalogTest.java
+++ b/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreCatalogTest.java
@@ -24,6 +24,7 @@ package org.opencastproject.metadata.dublincore;
 import static com.entwinemedia.fn.Stream.$;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.opencastproject.util.data.Collections.list;
@@ -42,16 +43,25 @@ import com.entwinemedia.fn.data.Opt;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CyclicBarrier;
 
 import javax.xml.XMLConstants;
 
 public class DublinCoreCatalogTest {
+  private static final String fooId = "197011";
   private static final EName PROPERTY_FOO_ID = new EName("http://foo.org/metadata", "id");
+  private static final EName PROPERTY_FOO_EMPTY = new EName("http://foo.org/metadata", "empty");
+  private static final Logger logger = LoggerFactory.getLogger(DublinCoreCatalogTest.class);
 
   @Rule
   public TemporaryFolder testFolder = new TemporaryFolder();
@@ -81,11 +91,81 @@ public class DublinCoreCatalogTest {
   @Test
   public void testLoadNonOpencastDublinCore() throws Exception {
     final DublinCoreCatalog dc = read("/dublincore-non-oc.xml");
+    for (DublinCoreValue value: dc.getValuesFlat()) {
+      logger.debug("DublinCorevalue " + value.getValue());
+    }
     assertEquals(9, dc.getValuesFlat().size());
     assertEquals(2, dc.get(DublinCore.PROPERTY_TITLE).size());
     assertEquals(
             Opt.some(EName.mk("http://lib.org/metadata-enc", "PlainTitle")),
             dc.get(DublinCore.PROPERTY_TITLE).get(0).getEncodingScheme());
+    for (CatalogEntry entry : dc.getEntriesSorted()) {
+      logger.debug(entry.getEName().toString() + " " + entry.getValue());
+    }
+
+    assertTrue("Property foo:id should be in the list of known properties.",
+            dc.getProperties().contains(PROPERTY_FOO_ID));
+    assertEquals(fooId, dc.getFirstVal(PROPERTY_FOO_ID).getValue());
+  }
+
+  @Test
+  /**
+   *  MH-11621 test optional marshal input XML with intentionally emptied fields
+   * @throws Exception
+   */
+  public void testLoadEmptiedElementsDublinCore() throws Exception {
+    boolean includeEmptiedFields = true;
+    final DublinCoreCatalog dc = read("/dublincore-non-oc.xml", includeEmptiedFields);
+    for (DublinCoreValue value: dc.getValuesFlat()) {
+      logger.debug("DublinCorevalue " + value.getValue());
+    }
+    // additional empty field is part of the count
+    assertEquals(10, dc.getValuesFlat().size());
+    assertEquals(2, dc.get(DublinCore.PROPERTY_TITLE).size());
+    assertEquals(
+            Opt.some(EName.mk("http://lib.org/metadata-enc", "PlainTitle")),
+            dc.get(DublinCore.PROPERTY_TITLE).get(0).getEncodingScheme());
+    for (CatalogEntry entry : dc.getEntriesSorted()) {
+      logger.debug(entry.getEName().toString() + " " + entry.getValue());
+    }
+
+    assertTrue("Property foo:id should be in the list of known properties.",
+            dc.getProperties().contains(PROPERTY_FOO_ID));
+    assertEquals(fooId, dc.getFirstVal(PROPERTY_FOO_ID).getValue());
+    //  verify that catalog only instantiates properties from catalog
+    // and that it instantiates properties with passed in empty values.
+    // Passing empty values is how existing values are deleted during metadata update
+    assertFalse("Non-passed property dc:temporal should *not* be instantiated.",
+            dc.getProperties().contains(DublinCore.PROPERTY_TEMPORAL));
+    assertTrue("Property foo:empty should be in the list of known properties.",
+            dc.getProperties().contains(PROPERTY_FOO_EMPTY));
+    assertEquals("", dc.getFirstVal(PROPERTY_FOO_EMPTY).getValue());
+  }
+
+  @Test
+  /**
+   *  MH-11621 test emptied fields after merge
+   * @throws Exception
+   */
+  public void testMergeEmptiedElementsDublinCore() throws Exception {
+    final DublinCoreCatalog dcOrig = read("/dublincore-non-oc.xml");
+    boolean isMarshalEmptyFields = true;
+    final DublinCoreCatalog dc2 = read("/dublincore-non-oc2.xml", isMarshalEmptyFields);
+    for (DublinCoreValue value: dcOrig.getValuesFlat()) {
+      logger.debug("DublinCorevalue 1 " + value.getValue());
+    }
+    for (DublinCoreValue value: dc2.getValuesFlat()) {
+      logger.debug("DublinCorevalue 2 " + value.getValue());
+    }
+    assertEquals("Original value count", 9, dcOrig.getValuesFlat().size());
+    assertEquals("Merge catalog value count", 6, dc2.getValuesFlat().size());
+
+    DublinCoreCatalog dc3 = DublinCoreXmlFormat.merge(dc2, dcOrig);
+    assertEquals("Merge count (removed 2 values added 1 value)", 8, dc3.getValuesFlat().size());
+    assertEquals("Only one title now exists", 1, dc3.get(DublinCore.PROPERTY_TITLE).size());
+    assertTrue("A changed Modify value", "2018-01-05".equals(dc3.get(DublinCore.PROPERTY_MODIFIED).get(0).getValue()));
+    assertEquals("Not Empty!", dc3.getFirstVal(PROPERTY_FOO_EMPTY).getValue());
+    assertEquals("German title was removed", 0, dc3.get(DublinCore.PROPERTY_TITLE, "de").size());
   }
 
   @Test
@@ -144,8 +224,68 @@ public class DublinCoreCatalogTest {
         IoSupport.loadTxtFromClassPath("/sorting/dublincore2-2.xml", this.getClass()).get().trim());
   }
 
+  @Test
+  /**
+   *  MH-11621 verify that there are no state issues with static read methods
+   */
+  public void testMultiThreadedCatalogRead() throws Exception {
+    ConcurrentMap<Integer, DublinCoreCatalog> map = new ConcurrentHashMap();
+    List<DublinCoreCatalog> list = new ArrayList();
+    List<Thread> threadList = new ArrayList();
+    int count = 100;
+    for (int i = 0; i < count; i++) {
+      DublinCoreCatalog cat = read("/dublincore.xml");
+      cat.set(DublinCore.PROPERTY_TITLE, "title-" + i);
+      list.add(cat);
+    }
+    DublinCoreCatalog cat = read("/dublincore.xml");
+    final CyclicBarrier gate = new CyclicBarrier(count + 1);
+    for (int i = 0; i < count; i++) {
+      final int index = i;
+      cat.set(DublinCore.PROPERTY_TITLE, "title-" + index);
+      final String catString = cat.toXmlString();
+      threadList.add(new Thread(new Runnable() {
+        public void run() {
+          try {
+            // block until all threads are started
+            gate.await();
+            logger.debug("Running with " + index + " in " + Thread.currentThread().getId());
+            DublinCoreCatalog cat = DublinCoreXmlFormat.read(catString);
+            map.put(Integer.valueOf(index), cat);
+          } catch (Exception e) {
+            org.junit.Assert.fail("Should not have failed reading the catalog!");
+          }
+        }
+      }));
+    }
+    for (Thread t: threadList) {
+      t.start();
+    }
+    // Last await is launched to unblock all threads
+    gate.await();
+    int currentCount = 0;
+    while (currentCount < count) {
+      if (map.get(currentCount) != null) {
+        logger.debug("title-" + currentCount + ": " +  map.get(currentCount).getFirst(DublinCore.PROPERTY_TITLE));
+        assertEquals("title-" + currentCount, map.get(currentCount).getFirst(DublinCore.PROPERTY_TITLE));
+        currentCount++;
+      }
+    }
+  }
+
   /** Read from the classpath. */
   private DublinCoreCatalog read(String dcFile) throws Exception {
     return DublinCoreXmlFormat.read(IoSupport.classPathResourceAsFile(dcFile).get());
   }
+
+  /**
+   *  MH-11621
+   * Optional reads that allow instantiating with intentionally passed empty elements
+   * used to remove existing DublinCore catalog values during a merge update.
+   *  Read from the classpath.
+   */
+  private DublinCoreCatalog read(String dcFile, boolean includeEmptiedElements) throws Exception {
+    return DublinCoreXmlFormat.read(IoSupport.classPathResourceAsFile(dcFile).get(), includeEmptiedElements);
+  }
 }
+

--- a/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreTest.java
+++ b/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/DublinCoreTest.java
@@ -222,13 +222,13 @@ public class DublinCoreTest {
     assertNotNull(dcTerms);
 
     JSONArray titleArray = (JSONArray) dcTerms.get("title");
-    assertEquals("Two titles should be present", 2, titleArray.size());
+    assertEquals("Three titles should be present", 3, titleArray.size());
 
     JSONArray subjectArray = (JSONArray) dcTerms.get("subject");
     assertEquals("The subject should be present", 1, subjectArray.size());
 
     DublinCoreCatalog fromJson = DublinCores.read(IOUtils.toInputStream(jsonString));
-    assertEquals(2, fromJson.getLanguages(PROPERTY_TITLE).size());
+    assertEquals(3, fromJson.getLanguages(PROPERTY_TITLE).size());
     assertEquals("video/x-dv", fromJson.getFirst(PROPERTY_FORMAT));
     assertEquals("eng", fromJson.getFirst(PROPERTY_LANGUAGE));
     assertEquals("2007-12-05", fromJson.getFirst(PROPERTY_CREATED));

--- a/modules/dublincore/src/test/resources/dublincore-extended.xml
+++ b/modules/dublincore/src/test/resources/dublincore-extended.xml
@@ -15,6 +15,8 @@
   <dcterms:contributor>Harald Juhnke</dcterms:contributor>
   <dcterms:title>A title</dcterms:title>
   <dcterms:title xml:lang="de">Ein Titel</dcterms:title>
+  <dcterms:title xml:lang="ga"></dcterms:title>
+  <dcterms:spatial>lab2</dcterms:spatial>
   <oc:promoted>true</oc:promoted>
   <foo:id>197011</foo:id>
 </dublincore>

--- a/modules/dublincore/src/test/resources/dublincore-non-oc2.xml
+++ b/modules/dublincore/src/test/resources/dublincore-non-oc2.xml
@@ -9,15 +9,18 @@
           xmlns:lib="http://lib.org/metadata-enc">
   <dcterms:description xml:lang="en">Introduction lecture from the Institute for Atmospheric and Climate Science.
   </dcterms:description>
+  <!--  modifying modified value -->
   <dcterms:modified xsi:type="dcterms:W3CDTF">
-    2007-12-05
+    2018-01-05
   </dcterms:modified>
+  <!--  not sending type, contributor or title fields
   <dcterms:type>MovingImage/LectureRecording</dcterms:type>
   <dcterms:contributor>Harald Juhnke</dcterms:contributor>
   <dcterms:contributor>Loriot</dcterms:contributor>
-  <dcterms:title xsi:type="lib:PlainTitle">A title</dcterms:title>
-  <dcterms:title xml:lang="de">Ein Titel</dcterms:title>
-  <oc:promoted>true</oc:promoted>
+  <dcterms:title xsi:type="lib:PlainTitle">A title</dcterms:title> -->
+  <!-- intentionally emptying out de title and oc:promoted -->
+  <dcterms:title xml:lang="de"></dcterms:title>
+  <oc:promoted></oc:promoted>
   <foo:id>197011</foo:id>
-  <foo:empty></foo:empty>
+  <foo:empty>Not Empty!</foo:empty>
 </metadata>

--- a/modules/dublincore/src/test/resources/dublincore.xml
+++ b/modules/dublincore/src/test/resources/dublincore.xml
@@ -4,6 +4,7 @@
             xmlns:dcterms="http://purl.org/dc/terms/" xmlns:oc="http://www.opencastproject.org/matterhorn/">
   <dcterms:title>Land and Vegetation: Key players on the Climate Scene</dcterms:title>
   <dcterms:title xml:lang="de">Land und Vegetation: Key Player in der Klima-Szene</dcterms:title>
+  <dcterms:title xml:lang="ga">Talamh agus Fásra: Príomh-imreoirí ar an Radharc Aeráide</dcterms:title>
   <dcterms:subject>climate, land, vegetation</dcterms:subject>
   <dcterms:description xml:lang="en">
     Introduction lecture from the Institute for Atmospheric and Climate Science.
@@ -14,6 +15,7 @@
   <dcterms:identifier>
     10.0000/5819
   </dcterms:identifier>
+  <dcterms:spatial></dcterms:spatial>
   <dcterms:created>2007-12-05</dcterms:created>
   <dcterms:language>eng</dcterms:language>
   <dcterms:type>MovingImage/LectureRecording</dcterms:type>


### PR DESCRIPTION
This patch allows an input DublinCore catalog to merge targeted updates, additions, deletions into existing DublinCore catalog. It allows the input catalog to only override specified attributes instead of having to override the whole catalog. 