### PR TITLE
MH-12665 Sort table on startup

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
@@ -186,6 +186,17 @@ angular.module('adminNg.services')
                 me.predicate = me.sorters[0].name;
                 me.reverse = me.sorters[0].order === DESC;
             }
+            // if no entry in local storage, sort by first sortable column
+            else {
+                for (var i = 0; i < me.columns.length; i++) {
+                    var column = me.columns[i];
+
+                    if (!column.dontSort) {
+                        me.sortBy(column);
+                        break;
+                    }
+                }
+            }
         };
 
         this.saveSortingCriteria = function (sorterCriteria) {
@@ -257,7 +268,6 @@ angular.module('adminNg.services')
             if (me.sorters.length > 0) {
                 sorters.push(me.sorters[0].name + ':' + me.sorters[0].order);
             }
-
 
             query.limit = me.pagination.limit;
             query.offset = me.pagination.offset * me.pagination.limit;

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/eventsControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/eventsControllerSpec.js
@@ -34,7 +34,7 @@ describe('Events controller', function () {
             $httpBackend.expectGET('/admin-ng/resources/events/filters.json').respond('[]');
             $httpBackend.expectGET('/admin-ng/resources/PUBLICATION.CHANNELS.json').respond('{}');
             $httpBackend.expectDELETE('/admin-ng/event/12').respond('12');
-            $httpBackend.expectGET('/admin-ng/event/events.json?limit=10&offset=0').respond(JSON.stringify(getJSONFixture('admin-ng/event/events.json')));
+            $httpBackend.expectGET('/admin-ng/event/events.json?limit=10&offset=0&sort=title:ASC').respond(JSON.stringify(getJSONFixture('admin-ng/event/events.json')));
 
             $scope.table.delete({'id': 12});
 

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/seriesControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/seriesControllerSpec.js
@@ -34,7 +34,7 @@ describe('Series controller', function () {
         it('reloads series after deletion', function () {
             $httpBackend.expectGET('/admin-ng/resources/series/filters.json').respond('[]');
             $httpBackend.expectDELETE('/admin-ng/series/12').respond('12');
-            $httpBackend.expectGET('/admin-ng/series/series.json?limit=10&offset=0').respond(JSON.stringify(getJSONFixture('admin-ng/series/series.json')));
+            $httpBackend.expectGET('/admin-ng/series/series.json?limit=10&offset=0&sort=title:ASC').respond(JSON.stringify(getJSONFixture('admin-ng/series/series.json')));
 
             $scope.table.delete({'id': 12});
 

--- a/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/aclsControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/aclsControllerSpec.js
@@ -34,7 +34,7 @@ describe('ACL controller', function () {
         it('reloads acls after deletion', function () {
             $httpBackend.expectGET('/admin-ng/resources/acls/filters.json').respond('[]');
             $httpBackend.expectDELETE('/admin-ng/acl/454').respond();
-            $httpBackend.expectGET('/admin-ng/acl/acls.json?limit=10&offset=0').respond(JSON.stringify(getJSONFixture('admin-ng/acl/acls.json')));
+            $httpBackend.expectGET('/admin-ng/acl/acls.json?limit=10&offset=0&sort=name:ASC').respond(JSON.stringify(getJSONFixture('admin-ng/acl/acls.json')));
 
             $scope.table.delete({'id': 454});
 

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/tableServiceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/tableServiceSpec.js
@@ -30,6 +30,7 @@ describe('Table', function () {
     });
 
     describe('#configure', function () {
+
         var params = {
             columns: [{
                 name: 'name',
@@ -40,14 +41,15 @@ describe('Table', function () {
             category: 'furniture',
             apiService: {
                 query: function () {
-                    var rows = [];
-                    rows.push({test: ''});
-
+                    var data = {
+                        rows: []
+                    };
+                    data.rows.push({test: 'chair'});
 
                     return {
                         $promise: {
                             then: function (fn) {
-                                fn(rows);
+                                fn(data);
                             }
                         }
                     };
@@ -63,7 +65,7 @@ describe('Table', function () {
 
         it('sets default sort parameters', function () {
             Table.configure(params);
-            expect(Table.predicate).toEqual('');
+            expect(Table.predicate).toEqual('name');
             expect(Table.reverse).toBe(false);
         });
 


### PR DESCRIPTION
This patch sorts the admin ui table by the first sortable column if there is no entry in local storage (if opencast is opened in a browser for the first time or if local storage was emptied) so that we're not relying on the order the entries are returned in by the backend. This way the table is never unsorted.

This work is sponsored by SWITCH.