### PR TITLE
MH-12678 Fix Video Playback After Tab Switch

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
@@ -48,6 +48,16 @@ angular.module('adminNg.controllers')
             } else if ($scope.tab === "playback") {
               $scope.area   = "metadata";
             }
+
+            // This fixes a problem where video playback breaks after switching tabs. Changing the location seems
+            // to be destructive to the <video> element working together with opencast's external controls.
+            var lastRoute, off;
+            lastRoute = $route.current;
+            off = $scope.$on('$locationChangeSuccess', function () {
+                $route.current = lastRoute;
+                off();
+            });
+
             $scope.navigateTo('/events/' + $scope.resource + '/' + $scope.id + '/tools/' + tab);
         };
 


### PR DESCRIPTION
See JIRA issue for reproduction steps.

This basically re-introduces the code removed by commit [#28e6fc053](https://github.com/opencast/opencast/commit/28e6fc053).

When tabs are switched, the location is updated to end with 'editor' or
'playback', depending on the active tab. However, it turns out that it
is necessary to preserve the route in order to avoid breaking the video
playback when changing the location. Unfortunately, preserving the route
breaks the close button. So the route-restoring code must only be used
when switching tabs, not when closing the video editor/player.

If the route is changed, the <video> element starts to behave odd when
controlled by opencast's external controls. While it still plays audio,
the video image becomes frozen.

This work is sponsored by SWITCH.