### PR TITLE
MH-12677 Be less technical about displaying the version number

### DIFF
--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -108,9 +108,8 @@
 
         <footer id="main-footer" ng-controller="NavCtrl">
             <div class="default-footer">
-                <div ng-if="version.version" class="meta">
-                    Opencast (v.{{ version.version }}<span ng-if=version.buildNumber> -
-                        build: {{ version.buildNumber }}</span>)
+                <div ng-if="version.version" class="meta" title="Build: {{ version.buildNumber || 'undefined' }}">
+                    Opencast {{ version.version }}
                 </div>
                 <div ng-if="feedbackUrl" class="feedback-btn" id="feedback-btn">
                     <a href="javascript:;">Feedback</a>

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -108,8 +108,9 @@
 
         <footer id="main-footer" ng-controller="NavCtrl">
             <div class="default-footer">
-                <div ng-if="version.version" class="meta" title="Build: {{ version.buildNumber || 'undefined' }}">
+                <div ng-if="version.version" class="meta">
                     Opencast {{ version.version }}
+                    <span with-role="ROLE_ADMIN"> - {{ version.buildNumber || 'undefined' }}</span>
                 </div>
                 <div ng-if="feedbackUrl" class="feedback-btn" id="feedback-btn">
                     <a href="javascript:;">Feedback</a>

--- a/modules/admin-ui/src/main/webapp/login.html
+++ b/modules/admin-ui/src/main/webapp/login.html
@@ -18,10 +18,6 @@
                         <div class="row">
                             <p>
                                 <span translate='LOGIN.WELCOME'><!-- Welcome --></span><br />
-                                <span class="subtle-text" ng-if="version.version">
-                                    Opencast (v.{{ version.version }}<span ng-if=version.buildNumber> -
-                                        build: {{ version.buildNumber }}</span>)
-                                </span>
                             </p>
                         </div>
 


### PR DESCRIPTION
- Removed version number from login screen
- Use simpler visual representation on admin UI status bar

New:
![screen shot 2018-01-25 at 16 47 11](https://user-images.githubusercontent.com/1590263/35398378-ffceab76-01f1-11e8-9258-9e3d7edf20f2.png)

Old:
![screen shot 2018-01-25 at 16 47 25](https://user-images.githubusercontent.com/1590263/35398381-02d36514-01f2-11e8-8cb3-ae30fdf0f56e.png)

New (no ROLE_ADMIN):
![screen shot 2018-01-26 at 08 48 46](https://user-images.githubusercontent.com/1590263/35429825-0222aef2-0276-11e8-8d9a-94a19975307d.png)

New (ROLE_ADMIN):
![screen shot 2018-01-26 at 08 48 19](https://user-images.githubusercontent.com/1590263/35429835-0ad49a1a-0276-11e8-9f59-a4027c179c83.png)

Note that I've omitted the word "build" by intention as it would need to be localised.

Old:
![screen shot 2018-01-25 at 16 58 15](https://user-images.githubusercontent.com/1590263/35398400-0cf4fdd2-01f2-11e8-8790-ed5337bc988b.png)


