### PR TITLE
MH-12682, TimelinePreview Concurrency Problem

### DIFF
--- a/modules/matterhorn-timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/ffmpeg/TimelinePreviewsServiceImpl.java
+++ b/modules/matterhorn-timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/ffmpeg/TimelinePreviewsServiceImpl.java
@@ -64,6 +64,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Media analysis plugin that takes a video stream and generates preview images that can be shown on the timeline.
@@ -378,7 +379,7 @@ TimelinePreviewsService, ManagedService {
           "Error reading the media file in the workspace", e);
     }
 
-    String imageFilePath = FilenameUtils.removeExtension(mediaFile.getAbsolutePath())
+    String imageFilePath = FilenameUtils.removeExtension(mediaFile.getAbsolutePath()) + '_' + UUID.randomUUID()
                            + "_timelinepreviews" + outputFormat;
     int exitCode = 1;
     String[] command = new String[] {


### PR DESCRIPTION
The timeline preview generation uses non-unique files with filenames
based on the input file name. If several operations run at the same
time, they will overwrite and possibly delete each other's output data.

This patch ensures all operations use unique file names.