### PR TITLE
MH-12684 Make License List Provider More Flexible

### DIFF
--- a/etc/listproviders/licenses.properties
+++ b/etc/listproviders/licenses.properties
@@ -1,10 +1,26 @@
 list.name=LICENSES
+
+# This list provider allows you to configure the licenses shown in event/series wizards of the admin ui. If meta data
+# field type 'ordered_text' is used for the license, the entries are configured with a license=record pair. Records are
+# json records which can have the following fields:
+#
+# - "label" to configure which text is displayed for the license name. This can be a plain text or a translation key.
+# - "order" to configure in which order the entries are displayed. This is a number and the entries are sorted ascending
+#   by their "order" value.
+# - "selectable" to configure whether the entry can still be selected or not. If you set this to false, the entry is
+#   only listed if it matches the current value. So, if it was selectable previously and you have chosen this value, you
+#   will still see it in the list. However, once you change it, the entry becomes hidden and cannot be selected again.
+#   This is a boolean value.
+#
+# Here is a full example:
+# ALLRIGHTS={"label":"EVENTS.LICENSE.ALLRIGHTS", "order":1, "selectable": true}
+
 list.translatable=true
-ALLRIGHTS=EVENTS.LICENSE.ALLRIGHTS
-CC-BY=EVENTS.LICENSE.CCBY
-CC-BY-SA=EVENTS.LICENSE.CCBYSA
-CC-BY-ND=EVENTS.LICENSE.CCBYND
-CC-BY-NC=EVENTS.LICENSE.CCBYNC
-CC-BY-NC-SA=EVENTS.LICENSE.CCBYNCSA
-CC-BY-NC-ND=EVENTS.LICENSE.CCBYNCND
-CC0=EVENTS.LICENSE.CC0
+ALLRIGHTS={"label":"EVENTS.LICENSE.ALLRIGHTS", "order":1, "selectable": true}
+CC-BY={"label":"EVENTS.LICENSE.CCBY", "order":2, "selectable": true}
+CC-BY-SA={"label":"EVENTS.LICENSE.CCBYSA", "order":3, "selectable": true}
+CC-BY-ND={"label":"EVENTS.LICENSE.CCBYND", "order":4, "selectable": true}
+CC-BY-NC={"label":"EVENTS.LICENSE.CCBYNC", "order":5, "selectable": true}
+CC-BY-NC-SA={"label":"EVENTS.LICENSE.CCBYNCSA", "order":6, "selectable": true}
+CC-BY-NC-ND={"label":"EVENTS.LICENSE.CCBYNCND", "order":7, "selectable": true}
+CC0={"label":"EVENTS.LICENSE.CC0", "order":8, "selectable": true}

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -139,7 +139,7 @@ property.rightsHolder.order=4
 # License
 property.license.inputID=license
 property.license.label=EVENTS.EVENTS.DETAILS.METADATA.LICENSE
-property.license.type=text
+property.license.type=ordered_text
 property.license.readOnly=false
 property.license.required=false
 property.license.listprovider=LICENSES

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-series-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-series-common.cfg
@@ -96,7 +96,7 @@ property.rightsHolder.order=4
 # License
 property.license.inputID=license
 property.license.label=EVENTS.SERIES.DETAILS.METADATA.LICENSE
-property.license.type=text
+property.license.type=ordered_text
 property.license.readOnly=false
 property.license.required=false
 property.license.listprovider=LICENSES

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableDirective.js
@@ -13,6 +13,7 @@ angular.module('adminNg.directives')
         },
         link: function (scope, element) {
             scope.mixed = false;
+            scope.ordered = false;
 
             if (scope.params === undefined || scope.params.type === undefined) {
               console.warn("Illegal parameters for editable field");
@@ -50,6 +51,9 @@ angular.module('adminNg.directives')
                             }
                         } else {
                             if (scope.collection) {
+                                if (scope.params.type === 'ordered_text') {
+                                    scope.ordered = true;
+                                }
                                 scope.mode = 'singleSelect';
                             } else {
                                 scope.mode = 'singleValue';

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
@@ -30,6 +30,7 @@ angular.module('adminNg.directives')
         scope: {
             params:     '=',
             collection: '=',
+            ordered:    '=',
             save:       '='
         },
         link: function (scope, element) {
@@ -48,8 +49,32 @@ angular.module('adminNg.directives')
                 return array;
             }
 
+            var mapToArrayOrdered = function (map) {
+                var array = [];
+
+                angular.forEach(map, function (mapValue, mapKey) {
+                    var entry = JSON.parse(mapKey);
+                    if (entry.selectable || scope.params.value === mapValue) {
+                        array.push({
+                            label: entry,
+                            value: mapValue
+                        });
+                    }
+                });
+                array.sort(function(a, b) {
+                    return a.label.order - b.label.order;
+                });
+                return array.map(function (entry) {
+                    return {
+                        label: entry.label.label,
+                        value: entry.value
+                    };
+                });
+            }
+
+
             //transform map to array so that orderBy can be used
-            scope.collection = mapToArray(scope.collection);
+            scope.collection = scope.ordered ? mapToArrayOrdered(scope.collection) : mapToArray(scope.collection);
 
             scope.submit = function () {
                 // Wait until the change of the value propagated to the parent's

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
@@ -22,7 +22,7 @@
    </doc:example>
  */
 angular.module('adminNg.directives')
-.directive('adminNgEditableSingleSelect', ['$timeout', function ($timeout) {
+.directive('adminNgEditableSingleSelect', ['$timeout', '$filter', function ($timeout, $filter) {
     return {
         restrict: 'A',
         templateUrl: 'shared/partials/editableSingleSelect.html',
@@ -35,21 +35,21 @@ angular.module('adminNg.directives')
         },
         link: function (scope, element) {
 
-            var mapToArray = function (map) {
+            var mapToArray = function (map, translate) {
                 var array = [];
 
                 angular.forEach(map, function (mapValue, mapKey) {
 
                     array.push({
-                        label: mapKey,
+                        label: translate ? $filter('translate')(mapKey) : mapKey,
                         value: mapValue
                     });
                 });
 
-                return array;
+                return $filter('orderBy')(array, 'label');
             }
 
-            var mapToArrayOrdered = function (map) {
+            var mapToArrayOrdered = function (map, translate) {
                 var array = [];
 
                 angular.forEach(map, function (mapValue, mapKey) {
@@ -66,7 +66,7 @@ angular.module('adminNg.directives')
                 });
                 return array.map(function (entry) {
                     return {
-                        label: entry.label.label,
+                        label: translate ? $filter('translate')(entry.label.label) : entry.label.label,
                         value: entry.value
                     };
                 });
@@ -74,7 +74,8 @@ angular.module('adminNg.directives')
 
 
             //transform map to array so that orderBy can be used
-            scope.collection = scope.ordered ? mapToArrayOrdered(scope.collection) : mapToArray(scope.collection);
+            scope.collection = scope.ordered ? mapToArrayOrdered(scope.collection, scope.params.translatable) :
+                mapToArray(scope.collection, scope.params.translatable);
 
             scope.submit = function () {
                 // Wait until the change of the value propagated to the parent's

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editable.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editable.html
@@ -22,7 +22,7 @@
 
 <div ng-if="mode === 'singleSelect'"
     admin-ng-editable-single-select
-    collection="collection" save="save" params="params">
+    collection="collection" save="save" params="params" ordered="ordered">
 </div>
 
 <div ng-if="mode === 'multiSelect'"

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
@@ -8,8 +8,11 @@
 
     <!-- Try to translate drop-down values by default -->
     <div ng-if="params.translatable !== false">
+
+      <!-- Sort options if order is not explicitly defined. -->
       <select chosen pre-select-from="collection"
               ng-model="params.value"
+              ng-if="!ordered"
               name="{{ params.name }}"
               ng-change="submit()"
               ng-blur="leaveEditMode()"
@@ -19,12 +22,30 @@
               ng-options="option.value as option.label|translate for option in collection|orderBy: 'label|translate'">
         <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
       </select>
-    </div>
 
-    <!-- Do not translate if explicitely disables -->
-    <div ng-if="params.translatable === false">
+      <!-- Do not sort options if order is explicitly defined. -->
       <select chosen pre-select-from="collection"
               ng-model="params.value"
+              ng-if="ordered"
+              name="{{ params.name }}"
+              ng-change="submit()"
+              ng-blur="leaveEditMode()"
+              ng-required="params.required"
+              tabindex="{{ params.tabindex }}"
+              data-width="'250px'"
+              ng-options="option.value as option.label|translate for option in collection">
+        <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
+      </select>
+
+    </div>
+
+    <!-- Do not translate if explicitly disabled -->
+    <div ng-if="params.translatable === false">
+
+      <!-- Sort options if order is not explicitly defined. -->
+      <select chosen pre-select-from="collection"
+              ng-model="params.value"
+              ng-if="!ordered"
               name="{{ params.name }}"
               ng-change="submit()"
               ng-blur="leaveEditMode()"
@@ -32,6 +53,20 @@
               tabindex="{{ params.tabindex }}"
               data-width="'250px'"
               ng-options="option.value as option.label for option in collection|orderBy: 'label'">
+        <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
+      </select>
+
+      <!-- Do not sort options if order is explicitly defined. -->
+      <select chosen pre-select-from="collection"
+              ng-model="params.value"
+              ng-if="ordered"
+              name="{{ params.name }}"
+              ng-change="submit()"
+              ng-blur="leaveEditMode()"
+              ng-required="params.required"
+              tabindex="{{ params.tabindex }}"
+              data-width="'250px'"
+              ng-options="option.value as option.label for option in collection">
         <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
       </select>
     </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
@@ -6,70 +6,17 @@
 
   <div class="editable-select" ng-show="editMode">
 
-    <!-- Try to translate drop-down values by default -->
-    <div ng-if="params.translatable !== false">
-
-      <!-- Sort options if order is not explicitly defined. -->
-      <select chosen pre-select-from="collection"
-              ng-model="params.value"
-              ng-if="!ordered"
-              name="{{ params.name }}"
-              ng-change="submit()"
-              ng-blur="leaveEditMode()"
-              ng-required="params.required"
-              tabindex="{{ params.tabindex }}"
-              data-width="'250px'"
-              ng-options="option.value as option.label|translate for option in collection|orderBy: 'label|translate'">
-        <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
-      </select>
-
-      <!-- Do not sort options if order is explicitly defined. -->
-      <select chosen pre-select-from="collection"
-              ng-model="params.value"
-              ng-if="ordered"
-              name="{{ params.name }}"
-              ng-change="submit()"
-              ng-blur="leaveEditMode()"
-              ng-required="params.required"
-              tabindex="{{ params.tabindex }}"
-              data-width="'250px'"
-              ng-options="option.value as option.label|translate for option in collection">
-        <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
-      </select>
-
-    </div>
-
-    <!-- Do not translate if explicitly disabled -->
-    <div ng-if="params.translatable === false">
-
-      <!-- Sort options if order is not explicitly defined. -->
-      <select chosen pre-select-from="collection"
-              ng-model="params.value"
-              ng-if="!ordered"
-              name="{{ params.name }}"
-              ng-change="submit()"
-              ng-blur="leaveEditMode()"
-              ng-required="params.required"
-              tabindex="{{ params.tabindex }}"
-              data-width="'250px'"
-              ng-options="option.value as option.label for option in collection|orderBy: 'label'">
-        <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
-      </select>
-
-      <!-- Do not sort options if order is explicitly defined. -->
-      <select chosen pre-select-from="collection"
-              ng-model="params.value"
-              ng-if="ordered"
-              name="{{ params.name }}"
-              ng-change="submit()"
-              ng-blur="leaveEditMode()"
-              ng-required="params.required"
-              tabindex="{{ params.tabindex }}"
-              data-width="'250px'"
-              ng-options="option.value as option.label for option in collection">
-        <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
-      </select>
-    </div>
+    <select chosen pre-select-from="collection"
+            ng-model="params.value"
+            name="{{ params.name }}"
+            ng-change="submit()"
+            ng-blur="leaveEditMode()"
+            ng-required="params.required"
+            tabindex="{{ params.tabindex }}"
+            data-width="'250px'"
+            ng-options="option.value as option.label for option in collection">
+      <option value="" ng-selected="params.value === ''" ng-if="!params.required">-- {{ 'SELECT_NO_OPTIONS' | translate | limitTo : 70 }} --</option>
+    </select>
   </div>
 </div>
 

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
@@ -108,11 +108,11 @@ public class MetadataField<A> {
    * fields should be formatted (if needed).
    */
   public enum Type {
-    BOOLEAN, DATE, DURATION, ITERABLE_TEXT, MIXED_TEXT, LONG, START_DATE, START_TIME, TEXT, TEXT_LONG
+    BOOLEAN, DATE, DURATION, ITERABLE_TEXT, MIXED_TEXT, ORDERED_TEXT, LONG, START_DATE, START_TIME, TEXT, TEXT_LONG
   }
 
   public enum JsonType {
-    BOOLEAN, DATE, NUMBER, TEXT, MIXED_TEXT, TEXT_LONG, TIME
+    BOOLEAN, DATE, NUMBER, TEXT, MIXED_TEXT, ORDERED_TEXT, TEXT_LONG, TIME
   }
 
   /** The id of a collection to validate values against. */
@@ -419,6 +419,13 @@ public class MetadataField<A> {
                 oldField.getNamespace());
         textLongField.fromJSON(value);
         return textLongField;
+      case ORDERED_TEXT:
+        MetadataField<String> orderedTextField = MetadataField.createOrderedTextMetadataField(oldField.getInputID(),
+            Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
+            oldField.isTranslatable(), oldField.getCollection(), oldField.getCollectionID(), oldField.getOrder(),
+            oldField.getNamespace());
+        orderedTextField.fromJSON(value);
+        return orderedTextField;
       default:
         return newField;
     }
@@ -892,6 +899,42 @@ public class MetadataField<A> {
     return createTextLongMetadataField(inputID, outputID, label, readOnly, required, isTranslatable, collection, collectionId, order,
             JsonType.TEXT, namespace);
   }
+
+  /**
+   * Create a metadata field of type String with a single line in the front end which can be ordered and filtered.
+   *
+   * @param inputID
+   *          The identifier of the new metadata field
+   * @param label
+   *          The label of the new metadata field
+   * @param readOnly
+   *          Define if the new metadata field can be or not edited
+   * @param required
+   *          Define if the new metadata field is or not required
+   * @param isTranslatable
+   *          If the field value is not human readable and should be translated before
+   * @param collection
+   *          If the field has a limited list of possible value, the option should contain this one. Otherwise it should
+   *          be none.
+   * @param order
+   *          The ui order for the new field, 0 at the top and progressively down from there.
+   * @return the new metadata field
+   */
+  public static MetadataField<String> createOrderedTextMetadataField(
+      String inputID,
+      Opt<String> outputID,
+      String label,
+      boolean readOnly,
+      boolean required,
+      Opt<Boolean> isTranslatable,
+      Opt<Map<String, String>> collection,
+      Opt<String> collectionId,
+      Opt<Integer> order,
+      Opt<String> namespace) {
+    return createTextLongMetadataField(inputID, outputID, label, readOnly, required, isTranslatable, collection, collectionId, order,
+        JsonType.ORDERED_TEXT, namespace);
+  }
+
 
   /**
    * Create a metadata field of type String with many lines in the front end.

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -924,7 +924,10 @@ public class EventsEndpoint implements ManagedService {
 
         // API v1 should return a two separate fields for start date and start time. Since those fields were merged in index service, we have to split them up.
         Opt<MetadataCollection> collection = actualList.getMetadataByFlavor("dublincore/episode");
-        if (collection.isSome()) convertStartDateTimeToApiV1(collection.get());
+        if (collection.isSome()) {
+          convertStartDateTimeToApiV1(collection.get());
+          ExternalMetadataUtils.changeTypeOrderedTextToText(collection.get());
+        }
 
         return ApiResponses.Json.ok(ApiVersion.VERSION_1_0_0, actualList.toJSON());
       }
@@ -1028,6 +1031,7 @@ public class EventsEndpoint implements ManagedService {
         ExternalMetadataUtils.changeSubjectToSubjects(collection);
         ExternalMetadataUtils.removeCollectionList(collection);
         convertStartDateTimeToApiV1(collection);
+        ExternalMetadataUtils.changeTypeOrderedTextToText(collection);
         return ApiResponses.Json.ok(ApiVersion.VERSION_1_0_0, collection.toJSON());
       }
       // Try the other catalogs
@@ -1040,6 +1044,7 @@ public class EventsEndpoint implements ManagedService {
             MetadataCollection fields = catalogUIAdapter.getFields(mediaPackage);
             ExternalMetadataUtils.removeCollectionList(fields);
             convertStartDateTimeToApiV1(fields);
+            ExternalMetadataUtils.changeTypeOrderedTextToText(fields);
             return ApiResponses.Json.ok(ApiVersion.VERSION_1_0_0, fields.toJSON());
           }
         }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -369,6 +369,7 @@ public class SeriesEndpoint {
     }
     MetadataCollection collection = getSeriesMetadata(optSeries.get());
     ExternalMetadataUtils.changeSubjectToSubjects(collection);
+    ExternalMetadataUtils.changeTypeOrderedTextToText(collection);
     metadataList.add(indexService.getCommonSeriesCatalogUIAdapter(), collection);
     return okJson(metadataList.toJSON());
   }
@@ -382,6 +383,7 @@ public class SeriesEndpoint {
     if (typeMatchesSeriesCatalogUIAdapter(type, indexService.getCommonSeriesCatalogUIAdapter())) {
       MetadataCollection collection = getSeriesMetadata(optSeries.get());
       ExternalMetadataUtils.changeSubjectToSubjects(collection);
+      ExternalMetadataUtils.changeTypeOrderedTextToText(collection);
       return ApiResponses.Json.ok(ApiVersion.VERSION_1_0_0, collection.toJSON());
     }
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/util/ExternalMetadataUtils.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/util/ExternalMetadataUtils.java
@@ -57,6 +57,25 @@ public final class ExternalMetadataUtils {
   }
 
   /**
+   * Change the type of metadata fields from "ordered_text" to "text". This is necessary because "ordered_text" was
+   * added later on, since it is needed by the admin UI. For the external API, backwards compatibility can be achieved
+   * by just changing it back to the more general type "text". Unfortunately, meta data handling is shared between admin
+   * UI and external api, which makes these conversions necessary.
+   *
+   * @param collection The collection to update.
+   */
+  public static void changeTypeOrderedTextToText(MetadataCollection collection) {
+    for (final MetadataField<?> field : collection.getInputFields().values())  {
+      if (MetadataField.Type.ORDERED_TEXT.equals(field.getType())) {
+        field.setType(MetadataField.Type.TEXT);
+      }
+      if (MetadataField.JsonType.ORDERED_TEXT.equals(field.getJsonType())) {
+        field.setJsonType(MetadataField.JsonType.TEXT);
+      }
+    }
+  }
+
+  /**
    * Remove the collection list from the metadata to reduce to amount of data
    *
    * @param metadata

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
@@ -224,6 +224,17 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
         }
         addField(startDate);
         break;
+      case ORDERED_TEXT:
+        MetadataField<String> orderedTextField = MetadataField.createOrderedTextMetadataField(metadataField.getInputID(),
+            Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
+            metadataField.isRequired(), getCollectionIsTranslatable(metadataField, listProvidersService),
+            getCollection(metadataField, listProvidersService),
+            metadataField.getCollectionID(), metadataField.getOrder(), metadataField.getNamespace());
+        if (StringUtils.isNotBlank(value)) {
+          orderedTextField.setValue(value);
+        }
+        addField(orderedTextField);
+        break;
       default:
         throw new IllegalArgumentException("Unknown metadata type! " + metadataField.getType());
     }


### PR DESCRIPTION
This patch adds a new metadata type 'ordered_text' which allows for
listproviders to configure the order, as well as a "selectable" value
for each entry. This can be used to display e.g. licenses in a
meaningful order as well hiding entries if desired. "Hiding" doesn't
actually mean hiding in this case. If "selectable" is false for an
entry, the entry is hidden as long as it isn't already selected as the
current value.

For licenses, there is the following use case: Previously, Creative
Commons 3.0 was selected by users to publish their recordings. Now,
there is Creative Commons 4.0 added to the list and the list of licenses
grows longer and longer. While it is not feasible to change the license
for old events, for new events only Creative Commons 4.0 should show up
in the list. So we cannot remove Creative Commons 3.0, but can hide it
for new events as well as for old events, which were published under a
different license. This is now possible by setting "selectable" to false
for old licenses.

This work is sponsored by SWITCH.