### PR TITLE
MH-12685 Don't translate values of filters that must not be translated

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/directives/tableFilterDirective.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/directives/tableFilterDirective.js
@@ -36,7 +36,7 @@ angular.module('adminNg.directives')
                         options: {},
                         type: scope.filters.filters[key].type,
                         label: scope.filters.filters[key].label,
-                        translate: scope.filters.filters[key].translate
+                        translatable: scope.filters.filters[key].translatable
                     };
                     var options = scope.filters.filters[key].options;
                     angular.forEach(options, function(option) {

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/directives/tableFilterDirective.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/directives/tableFilterDirective.js
@@ -35,7 +35,8 @@ angular.module('adminNg.directives')
                     scope.filters.map[key] = {
                         options: {},
                         type: scope.filters.filters[key].type,
-                        label: scope.filters.filters[key].label
+                        label: scope.filters.filters[key].label,
+                        translate: scope.filters.filters[key].translate
                     };
                     var options = scope.filters.filters[key].options;
                     angular.forEach(options, function(option) {

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/tableFilters.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/tableFilters.html
@@ -28,7 +28,7 @@
             <div ng-show="selectedFilter"
                 ng-switch on="selectedFilter.type">
                 <div ng-switch-when="select">
-                    <select 
+                    <select ng-if="selectedFilter.translatable"
                         chosen
                         class="second-filter"
                         placeholder-text-single="'{{'TABLE_FILTERS.FILTER_VALUE_SELECTION.PLACEHOLDER' | translate}}'"
@@ -38,6 +38,19 @@
                         ng-model="filterValue"
                         ng-change="selectFilterSelectValue(filterValue)"
                         ng-options="option as option.label | translate | limitTo : 70 for option in selectedFilter.options track by option.value"
+                        >
+                        <option value=""></option>
+                    </select>
+                    <select ng-if="!selectedFilter.translatable"
+                        chosen
+                        class="second-filter"
+                        placeholder-text-single="'{{'TABLE_FILTERS.FILTER_VALUE_SELECTION.PLACEHOLDER' | translate}}'"
+                        no-results-text="'{{'TABLE_FILTERS.FILTER_VALUE_SELECTION.NO_OPTIONS' | translate}}'"
+                        disable_search_threshold="10"
+                        search_contains="true"
+                        ng-model="filterValue"
+                        ng-change="selectFilterSelectValue(filterValue)"
+                        ng-options="option as option.label | limitTo : 70 for option in selectedFilter.options track by option.value"
                         >
                         <option value=""></option>
                     </select>
@@ -55,7 +68,13 @@
                 class="ng-multi-value" ng-show="filter.value">
                 <span ng-switch on="filter.type">
                     <span ng-switch-when="select">
-                        {{ filter.label | translate | limitTo : 70 }}: {{ filter.options[filter.value] | translate | limitTo : 70 }}
+                      {{ filter.label | translate | limitTo : 70 }}:
+                      <span ng-if="filter.translatable">
+                        {{ filter.options[filter.value] | translate | limitTo : 70 }}
+                      </span>
+                      <span ng-if="!filter.translatable">
+                        {{ filter.options[filter.value] | limitTo : 70 }}
+                      </span>
                     </span>
                     <span ng-switch-when="period">
                         {{ filter.label | translate }}: {{ formatDateRange('short', filter.value) }}

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/acls/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/acls/filters.json
@@ -1,0 +1,12 @@
+{
+  "Name":{
+    "translatable":false,
+    "options":{
+      "authenticated":"authenticated",
+      "private":"private",
+      "public":"public"
+    },
+    "label":"FILTERS.ACLS.NAME.LABEL",
+    "type":"select"
+  }
+}

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/events/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/events/filters.json
@@ -1,37 +1,81 @@
 {
-  "location": {
-    "label": "FILTERS.EVENTS.LOCATION.LABEL",
-    "type": "select",
-    "options": {
-      "location_1": "FILTERS.EVENTS.LOCATION.LOCATION1",
-      "location_2": "FILTERS.EVENTS.LOCATION.LOCATION2",
-      "location_3": "FILTERS.EVENTS.LOCATION.LOCATION3"
-    }
+  "presentersBibliographic":{
+    "translatable":false,
+    "options":{
+      "Opencast Project Administrator":"Opencast Project Administrator",
+      "System User":"System User"
+    },
+    "label":"FILTERS.EVENTS.PRESENTERS_BIBLIOGRAPHIC.LABEL",
+    "type":"select"
   },
-  "source": {
-    "label": "FILTERS.EVENTS.SOURCE.LABEL",
-    "type": "select",
-    "options": {
-      "twitter":  "FILTERS.EVENTS.SOURCE.TWITTER",
-      "github":   "FILTERS.EVENTS.SOURCE.GITHUB",
-      "facebook": "FILTERS.EVENTS.SOURCE.FACEBOOK"
-    }
+  "presentersTechnical":{
+    "translatable":false,
+    "options":{
+      "opencast_system_account":"System User",
+      "admin":"Opencast Project Administrator"
+    },
+    "label":"FILTERS.EVENTS.PRESENTERS_TECHNICAL.LABEL",
+    "type":"select"
   },
-  "status": {
-    "label": "FILTERS.EVENTS.STATUS.LABEL",
-    "type": "select",
-    "options": {
-      "FILTERS.EVENTS.STATUS.SCHEDULED": "scheduled",
-      "FILTERS.EVENTS.STATUS.RECORDING": "recording",
-      "FILTERS.EVENTS.STATUS.INGESTING": "ingesting",
-      "FILTERS.EVENTS.STATUS.PROCESSING": "processing",
-      "FILTERS.EVENTS.STATUS.ARCHIVE": "archive",
-      "FILTERS.EVENTS.STATUS.UPLOAD": "upload",
-      "FILTERS.EVENTS.STATUS.ONHOLD": "on_hold"
-    }
+  "agent":{
+    "translatable":false,
+    "label":"FILTERS.EVENTS.AGENT_ID.LABEL",
+    "type":"select"
   },
-  "period": {
-    "label": "FILTERS.EVENTS.PERIOD.LABEL",
-    "type": "period"
+  "comments":{
+    "translatable":false,
+    "options":{
+      "RESOLVED":"RESOLVED",
+      "NONE":"NONE",
+      "OPEN":"OPEN"
+    },
+    "label":"FILTERS.EVENTS.COMMENTS.LABEL",
+    "type":"select"
+  },
+  "series":{
+    "translatable":false,
+    "options":{
+      "2c06b745-2c5b-4f9c-b856-ad0cd5b575ca":"< & >"
+    },
+    "label":"FILTERS.EVENTS.SERIES.LABEL",
+    "type":"select"
+  },
+  "location":{
+    "translatable":false,
+    "label":"FILTERS.EVENTS.LOCATION.LABEL",
+    "type":"select"
+  },
+  "contributors":{
+    "translatable":false,
+    "options":{
+      "Opencast Project Administrator":"Opencast Project Administrator",
+      "System User":"System User"
+    },
+    "label":"FILTERS.EVENTS.CONTRIBUTORS.LABEL",
+    "type":"select"
+  },
+  "startDate":{
+    "translatable":false,
+    "label":"FILTERS.EVENTS.START_DATE.LABEL",
+    "type":"period"
+  },
+  "status":{
+    "translatable":true,
+    "options":{
+      "EVENTS.EVENTS.STATUS.RECORDING_FAILURE":"EVENTS.EVENTS.STATUS.RECORDING_FAILURE",
+      "EVENTS.EVENTS.STATUS.OPTEDOUT":"EVENTS.EVENTS.STATUS.OPTEDOUT",
+      "EVENTS.EVENTS.STATUS.PENDING":"EVENTS.EVENTS.STATUS.PENDING",
+      "EVENTS.EVENTS.STATUS.RECORDING":"EVENTS.EVENTS.STATUS.RECORDING",
+      "EVENTS.EVENTS.STATUS.PAUSED":"EVENTS.EVENTS.STATUS.PAUSED",
+      "EVENTS.EVENTS.STATUS.INGESTING":"EVENTS.EVENTS.STATUS.INGESTING",
+      "EVENTS.EVENTS.STATUS.PROCESSING_FAILURE":"EVENTS.EVENTS.STATUS.PROCESSING_FAILURE",
+      "EVENTS.EVENTS.STATUS.SCHEDULED":"EVENTS.EVENTS.STATUS.SCHEDULED",
+      "EVENTS.EVENTS.STATUS.BLACKLISTED":"EVENTS.EVENTS.STATUS.BLACKLISTED",
+      "EVENTS.EVENTS.STATUS.PROCESSING":"EVENTS.EVENTS.STATUS.PROCESSING",
+      "EVENTS.EVENTS.STATUS.PROCESSING_CANCELED":"EVENTS.EVENTS.STATUS.PROCESSING_CANCELED",
+      "EVENTS.EVENTS.STATUS.PROCESSED":"EVENTS.EVENTS.STATUS.PROCESSED"
+    },
+    "label":"FILTERS.EVENTS.STATUS.LABEL",
+    "type":"select"
   }
 }

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/groups/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/groups/filters.json
@@ -1,0 +1,11 @@
+{
+  "Name":{
+    "translatable":false,
+    "options":{
+      "Opencast Project External Applications":"Opencast Project External Applications",
+      "Opencast Project System Administrators":"Opencast Project System Administrators"
+    },
+    "label":"FILTERS.USERS.NAME.LABEL",
+    "type":"select"
+  }
+}

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/jobs/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/jobs/filters.json
@@ -1,20 +1,21 @@
 {
-    "hostname": {
-        "options": {
-            "admin.opencast.org": "admin.opencast.org",
-            "worker01.opencast.org": "worker01.opencast.org"
-        },
-        "label": "FILTERS.JOBS.HOSTNAME.LABEL",
-        "type": "select"
+  "hostname":{
+    "translatable":false,
+    "options":{
+      "http:\/\/localhost:8080":"http:\/\/localhost:8080"
     },
-    "status": {
-        "options": {
-            "PAUSED": "FILTERS.JOBS.STATUS.PAUSED",
-            "QUEUED": "FILTERS.JOBS.STATUS.QUEUED",
-            "RUNNING": "FILTERS.JOBS.STATUS.RUNNING",
-            "WAITING": "FILTERS.JOBS.STATUS.WAITING"
-        },
-        "label": "FILTERS.JOBS.STATUS.LABEL",
-        "type": "select"
-    }
+    "label":"FILTERS.JOBS.HOSTNAME.LABEL",
+    "type":"select"
+  },
+  "status":{
+    "translatable":true,
+    "options":{
+      "PAUSED":"FILTERS.JOBS.STATUS.PAUSED",
+      "QUEUED":"FILTERS.JOBS.STATUS.QUEUED",
+      "RUNNING":"FILTERS.JOBS.STATUS.RUNNING",
+      "WAITING":"FILTERS.JOBS.STATUS.WAITING"
+    },
+    "label":"FILTERS.JOBS.STATUS.LABEL",
+    "type":"select"
+  }
 }

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/recordings/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/recordings/filters.json
@@ -1,0 +1,21 @@
+{
+  "Status":{
+    "translatable":true,
+    "options":{
+      "offline":"offline",
+      "shutting_down":"shutting_down",
+      "idle":"idle",
+      "capturing":"capturing",
+      "uploading":"uploading",
+      "error":"error",
+      "unknown":"unknown"
+    },
+    "label":"FILTERS.AGENTS.STATUS.LABEL",
+    "type":"select"
+  },
+  "Name":{
+    "translatable":false,
+    "label":"FILTERS.AGENTS.NAME.LABEL",
+    "type":"select"
+  }
+}

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/series/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/series/filters.json
@@ -1,0 +1,25 @@
+{
+  "CreationDate":{
+    "translatable":false,
+    "label":"FILTERS.SERIES.CREATION_DATE.LABEL",
+    "type":"period"
+  },
+  "organizers":{
+    "translatable":false,
+    "options":{
+      "Opencast Project Administrator":"Opencast Project Administrator",
+      "System User":"System User"
+    },
+    "label":"FILTERS.SERIES.ORGANIZERS.LABEL",
+    "type":"select"
+  },
+  "contributors":{
+    "translatable":false,
+    "options":{
+      "Opencast Project Administrator":"Opencast Project Administrator",
+      "System User":"System User"
+    },
+    "label":"FILTERS.SERIES.CONTRIBUTORS.LABEL",
+    "type":"select"
+  }
+}

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/servers/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/servers/filters.json
@@ -1,21 +1,20 @@
 {
-    "hostname": {
-        "options": {
-            "http:\/\/mh-allinone.localdomain": "http:\/\/mh-allinone.localdomain",
-            "http:\/\/mh-engage.localdomain": "http:\/\/mh-engage.localdomain",
-            "http:\/\/mh-worker1.localdomain": "http:\/\/mh-worker1.localdomain",
-            "http:\/\/mh-worker2.localdomain": "http:\/\/mh-worker2.localdomain"
-        },
-        "label": "FILTERS.SERVERS.HOSTNAME.LABEL",
-        "type": "select"
+  "hostname":{
+    "translatable":false,
+    "options":{
+      "http:\/\/localhost:8080":"http:\/\/localhost:8080"
     },
-    "status": {
-        "options": {
-            "offline": "FILTERS.SERVERS.STATUS.OFFLINE",
-            "online": "FILTERS.SERVERS.STATUS.ONLINE",
-            "maintenance": "FILTERS.SERVERS.STATUS.MAINTENANCE"
-        },
-        "label": "FILTERS.SERVERS.STATUS.LABEL",
-        "type": "select"
-    }
+    "label":"FILTERS.SERVERS.HOSTNAME.LABEL",
+    "type":"select"
+  },
+  "status":{
+    "translatable":true,
+    "options":{
+      "offline":"FILTERS.SERVERS.STATUS.OFFLINE",
+      "online":"FILTERS.SERVERS.STATUS.ONLINE",
+      "maintenance":"FILTERS.SERVERS.STATUS.MAINTENANCE"
+    },
+    "label":"FILTERS.SERVERS.STATUS.LABEL",
+    "type":"select"
+  }
 }

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/services/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/services/filters.json
@@ -1,73 +1,103 @@
 {
-    "name": {
-        "options": {
-            "•mock• ch.entwine.annotations": "•mock• ch.entwine.annotations",
-            "•mock• org.opencastproject.adminui.endpoint.JobEndpoint": "•mock• org.opencastproject.adminui.endpoint.JobEndpoint",
-            "•mock• org.opencastproject.adminui.endpoint.ListProvidersEndpoint": "•mock• org.opencastproject.adminui.endpoint.ListProvidersEndpoint",
-            "•mock• org.opencastproject.adminui.endpoint.ServicesEndpoint": "•mock• org.opencastproject.adminui.endpoint.ServicesEndpoint",
-            "•mock• org.opencastproject.adminui.endpoint.autocomplete": "•mock• org.opencastproject.adminui.endpoint.autocomplete",
-            "•mock• org.opencastproject.adminui.endpoint.seriesdetails": "•mock• org.opencastproject.adminui.endpoint.seriesdetails",
-            "•mock• org.opencastproject.adminui.i18n": "•mock• org.opencastproject.adminui.i18n",
-            "•mock• org.opencastproject.analytics": "•mock• org.opencastproject.analytics",
-            "•mock• org.opencastproject.annotation": "•mock• org.opencastproject.annotation",
-            "•mock• org.opencastproject.authorization.xacml.manager": "•mock• org.opencastproject.authorization.xacml.manager",
-            "•mock• org.opencastproject.caption": "•mock• org.opencastproject.caption",
-            "•mock• org.opencastproject.capture.admin": "•mock• org.opencastproject.capture.admin",
-            "•mock• org.opencastproject.composer": "•mock• org.opencastproject.composer",
-            "•mock• org.opencastproject.coverimage": "•mock• org.opencastproject.coverimage",
-            "•mock• org.opencastproject.distribution.acl": "•mock• org.opencastproject.distribution.acl",
-            "•mock• org.opencastproject.distribution.download": "•mock• org.opencastproject.distribution.download",
-            "•mock• org.opencastproject.distribution.streaming": "•mock• org.opencastproject.distribution.streaming",
-            "•mock• org.opencastproject.episode": "•mock• org.opencastproject.episode",
-            "•mock• org.opencastproject.files": "•mock• org.opencastproject.files",
-            "•mock• org.opencastproject.fileupload": "•mock• org.opencastproject.fileupload",
-            "•mock• org.opencastproject.groups": "•mock• org.opencastproject.groups",
-            "•mock• org.opencastproject.info": "•mock• org.opencastproject.info",
-            "•mock• org.opencastproject.ingest": "•mock• org.opencastproject.ingest",
-            "•mock• org.opencastproject.inspection": "•mock• org.opencastproject.inspection",
-            "•mock• org.opencastproject.kernel.bundleinfo": "•mock• org.opencastproject.kernel.bundleinfo",
-            "•mock• org.opencastproject.manipulator": "•mock• org.opencastproject.manipulator",
-            "•mock• org.opencastproject.oaipmhinfo": "•mock• org.opencastproject.oaipmhinfo",
-            "•mock• org.opencastproject.organization": "•mock• org.opencastproject.organization",
-            "•mock• org.opencastproject.publication.oaipmh": "•mock• org.opencastproject.publication.oaipmh",
-            "•mock• org.opencastproject.publication.youtube": "•mock• org.opencastproject.publication.youtube",
-            "•mock• org.opencastproject.scheduler": "•mock• org.opencastproject.scheduler",
-            "•mock• org.opencastproject.search": "•mock• org.opencastproject.search",
-            "•mock• org.opencastproject.series": "•mock• org.opencastproject.series",
-            "•mock• org.opencastproject.serviceregistry": "•mock• org.opencastproject.serviceregistry",
-            "•mock• org.opencastproject.sox": "•mock• org.opencastproject.sox",
-            "•mock• org.opencastproject.textanalyzer": "•mock• org.opencastproject.textanalyzer",
-            "•mock• org.opencastproject.userdirectory.roles": "•mock• org.opencastproject.userdirectory.roles",
-            "•mock• org.opencastproject.userdirectory.users": "•mock• org.opencastproject.userdirectory.users",
-            "•mock• org.opencastproject.usertracking": "•mock• org.opencastproject.usertracking",
-            "•mock• org.opencastproject.videosegmenter": "•mock• org.opencastproject.videosegmenter",
-            "•mock• org.opencastproject.workflow": "•mock• org.opencastproject.workflow"
-        },
-        "label": "FILTERS.SERVICES.NAME.LABEL",
-        "type": "select"
+  "hostname":{
+    "translatable":false,
+    "options":{
+      "http:\/\/localhost:8080":"http:\/\/localhost:8080"
     },
-    "hostname": {
-        "options": {
-            "http:\/\/mh-allinone.localdomain": "http:\/\/mh-allinone.localdomain "
-        },
-        "label": "FILTERS.SERVICES.HOSTNAME.LABEL",
-        "type": "select"
+    "label":"FILTERS.SERVICES.HOSTNAME.LABEL",
+    "type":"select"
+  },
+  "name":{
+    "translatable":false,
+    "options":{
+      "org.opencastproject.adminui.endpoint.ServicesEndpoint":"org.opencastproject.adminui.endpoint.ServicesEndpoint",
+      "org.opencastproject.kernel.bundleinfo":"org.opencastproject.kernel.bundleinfo",
+      "org.opencastproject.composer":"org.opencastproject.composer",
+      "org.opencastproject.userdirectory.endpoint.UserEndpoint":"org.opencastproject.userdirectory.endpoint.UserEndpoint",
+      "org.opencastproject.coverimage":"org.opencastproject.coverimage",
+      "org.opencastproject.external.events":"org.opencastproject.external.events",
+      "org.opencastproject.files":"org.opencastproject.files",
+      "org.opencastproject.adminui.endpoint.AclEndpoint":"org.opencastproject.adminui.endpoint.AclEndpoint",
+      "org.opencastproject.usertracking":"org.opencastproject.usertracking",
+      "org.opencastproject.info":"org.opencastproject.info",
+      "org.opencastproject.publication.oaipmh":"org.opencastproject.publication.oaipmh",
+      "org.opencastproject.adminui.endpoint.tools":"org.opencastproject.adminui.endpoint.tools",
+      "org.opencastproject.series":"org.opencastproject.series",
+      "org.opencastproject.message.broker.endpoint":"org.opencastproject.message.broker.endpoint",
+      "org.opencastproject.feed.impl.FeedServiceImpl":"org.opencastproject.feed.impl.FeedServiceImpl",
+      "org.opencastproject.adminui.endpoint.GroupsEndpoint":"org.opencastproject.adminui.endpoint.GroupsEndpoint",
+      "org.opencastproject.external.groups":"org.opencastproject.external.groups",
+      "org.opencastproject.userdirectory.roles":"org.opencastproject.userdirectory.roles",
+      "org.opencastproject.caption":"org.opencastproject.caption",
+      "org.opencastproject.assetmanager":"org.opencastproject.assetmanager",
+      "org.opencastproject.adminui.endpoint.ServerEndpoint":"org.opencastproject.adminui.endpoint.ServerEndpoint",
+      "org.opencastproject.oaipmhinfo":"org.opencastproject.oaipmhinfo",
+      "org.opencastproject.capture.admin":"org.opencastproject.capture.admin",
+      "org.opencastproject.adminui.endpoint.event":"org.opencastproject.adminui.endpoint.event",
+      "org.opencastproject.adminui.endpoint.index":"org.opencastproject.adminui.endpoint.index",
+      "org.opencastproject.annotation":"org.opencastproject.annotation",
+      "org.opencastproject.silencedetection":"org.opencastproject.silencedetection",
+      "org.opencastproject.distribution.acl":"org.opencastproject.distribution.acl",
+      "org.opencastproject.videoeditor":"org.opencastproject.videoeditor",
+      "org.opencastproject.publication.youtube":"org.opencastproject.publication.youtube",
+      "org.opencastproject.waveform":"org.opencastproject.waveform",
+      "org.opencastproject.smil":"org.opencastproject.smil",
+      "org.opencastproject.serviceregistry":"org.opencastproject.serviceregistry",
+      "org.opencastproject.sox":"org.opencastproject.sox",
+      "org.opencastproject.videosegmenter":"org.opencastproject.videosegmenter",
+      "org.opencastproject.external":"org.opencastproject.external",
+      "org.opencastproject.adminui.endpoint.ListProvidersEndpoint":"org.opencastproject.adminui.endpoint.ListProvidersEndpoint",
+      "org.opencastproject.scheduler":"org.opencastproject.scheduler",
+      "org.opencastproject.ingest":"org.opencastproject.ingest",
+      "org.opencastproject.adminui.endpoint.SeriesEndpoint":"org.opencastproject.adminui.endpoint.SeriesEndpoint",
+      "org.opencastproject.timelinepreviews":"org.opencastproject.timelinepreviews",
+      "org.opencastproject.distribution.download":"org.opencastproject.distribution.download",
+      "org.opencastproject.execute":"org.opencastproject.execute",
+      "org.opencastproject.workflow":"org.opencastproject.workflow",
+      "org.opencastproject.inspection":"org.opencastproject.inspection",
+      "org.opencastproject.adminui.i18n":"org.opencastproject.adminui.i18n",
+      "org.opencastproject.textanalyzer":"org.opencastproject.textanalyzer",
+      "org.opencastproject.incident":"org.opencastproject.incident",
+      "org.opencastproject.adminui.endpoint.UsersEndpoint":"org.opencastproject.adminui.endpoint.UsersEndpoint",
+      "org.opencastproject.search":"org.opencastproject.search",
+      "org.opencastproject.distribution.aws.s3":"org.opencastproject.distribution.aws.s3",
+      "org.opencastproject.distribution.streaming":"org.opencastproject.distribution.streaming",
+      "org.opencastproject.adminui.endpoint.TasksEndpoint":"org.opencastproject.adminui.endpoint.TasksEndpoint",
+      "org.opencastproject.authorization.xacml.manager":"org.opencastproject.authorization.xacml.manager",
+      "org.opencastproject.engage.plugin.manager":"org.opencastproject.engage.plugin.manager",
+      "org.opencastproject.userdirectory.users":"org.opencastproject.userdirectory.users",
+      "org.opencastproject.adminui.endpoint.JobEndpoint":"org.opencastproject.adminui.endpoint.JobEndpoint",
+      "org.opencastproject.external.security":"org.opencastproject.external.security",
+      "org.opencastproject.adminui.endpoint.UserSettingsEndpoint":"org.opencastproject.adminui.endpoint.UserSettingsEndpoint",
+      "org.opencastproject.adminui.endpoint.PresetsEndpoint":"org.opencastproject.adminui.endpoint.PresetsEndpoint",
+      "org.opencastproject.transcription.ibmwatson":"org.opencastproject.transcription.ibmwatson",
+      "org.opencastproject.staticfiles":"org.opencastproject.staticfiles",
+      "org.opencastproject.organization":"org.opencastproject.organization",
+      "org.opencastproject.adminui.endpoint.ThemesEndpoint":"org.opencastproject.adminui.endpoint.ThemesEndpoint",
+      "org.opencastproject.groups":"org.opencastproject.groups",
+      "org.opencastproject.nop":"org.opencastproject.nop",
+      "org.opencastproject.fileupload":"org.opencastproject.fileupload"
     },
-    "actions": {
-        "options": {
-            "true": "YES",
-            "false": "NO"
-        },
-        "label": "FILTERS.SERVICES.ACTIONS.LABEL",
-        "type": "select"
+    "label":"FILTERS.SERVICES.NAME.LABEL",
+    "type":"select"
+  },
+  "actions":{
+    "translatable":true,
+    "options":{
+      "true":"YES",
+      "false":"NO"
     },
-    "status": {
-        "options": {
-            "ERROR": "FILTERS.SERVICES.STATUS.ERROR",
-            "WARNING": "FILTERS.SERVICES.STATUS.WARNING",
-            "NORMAL": "FILTERS.SERVICES.STATUS.NORMAL"
-        },
-        "label": "FILTERS.SERVICES.STATUS.LABEL",
-        "type": "select"
-    }
+    "label":"FILTERS.SERVICES.ACTIONS.LABEL",
+    "type":"select"
+  },
+  "status":{
+    "translatable":true,
+    "options":{
+      "ERROR":"FILTERS.SERVICES.STATUS.ERROR",
+      "WARNING":"FILTERS.SERVICES.STATUS.WARNING",
+      "NORMAL":"FILTERS.SERVICES.STATUS.NORMAL"
+    },
+    "label":"FILTERS.SERVICES.STATUS.LABEL",
+    "type":"select"
+  }
 }

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/themes/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/themes/filters.json
@@ -1,33 +1,11 @@
 {
-  "name": {
-    "label": "FILTERS.THEMES.NAME.LABEL",
-    "type": "select",
-    "options": {"Entwine Private":"Entwine Private", "Entwine Public": "Entwine Public"}
-  },
-  "description": {
-    "label": "FILTERS.THEMES.DESCRIPTION.LABEL",
-    "type": "select",
-    "options": {
-      "Private Theme of Entwine":"Private Theme of Entwine",
-      "Public Theme of Entwine":"Public Theme of Entwine"
-    }
-  },
-  "creator": {
-    "label": "FILTERS.THEMES.CREATOR.LABEL",
-    "type": "select",
-    "options": {
-      "Digest User": "Digest User",
-      "User1 Name": "User1 Name",
-      "tesst": "tesst",
-      "Test Producer": "Test Producer",
-      "adminui": "adminui",
-      "Admin User": "Admin User",
-      "Guest User": "Guest User"
-    }
-  },
-  "creationDate": {
-    "label": "FILTERS.THEMES.CREATION_DATE.LABEL",
-    "type": "period",
-    "options": {}
+  "Creator":{
+    "translatable":false,
+    "options":{
+      "Opencast Project Administrator":"Opencast Project Administrator",
+      "System User":"System User"
+    },
+    "label":"FILTERS.THEMES.CREATOR.LABEL",
+    "type":"select"
   }
 }

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/users/filters.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/app/GET/admin-ng/resources/users/filters.json
@@ -1,17 +1,30 @@
 {
-  "FILTERS.USERS.ROLES.LABEL": {
-    "ROLE_ADMIN": "FILTERS.USERS.ROLES.ROLE_ADMIN",
-    "ROLE_ANONYMOUS": "FILTERS.USERS.ROLES.ROLE_ANONYMOUS"
+  "Role":{
+    "translatable":false,
+    "options":{
+      "ROLE_OAUTH_USER":"ROLE_OAUTH_USER",
+      "ROLE_SUDO":"ROLE_SUDO",
+      "ROLE_ADMIN":"ROLE_ADMIN"
+    },
+    "label":"FILTERS.USERS.ROLE.LABEL",
+    "type":"select"
   },
-  "FILTERS.USERS.USERNAME.LABEL": {
-    "admin": "admin",
-    "matterhorn_system_account": "matterhorn_system_account"
+  "Name":{
+    "translatable":false,
+    "options":{
+      "Opencast Project Administrator":"Opencast Project Administrator",
+      "System User":"System User"
+    },
+    "label":"FILTERS.USERS.NAME.LABEL",
+    "type":"select"
   },
-  "FILTERS.USERS.NAME.LABEL": {
-    "Digest User": "Digest User",
-    "Admin User": "Admin User"
-  },
-  "FILTERS.USERS.USER_DIRECTORY.LABEL": {
-    "matterhorn-in-memory": "matterhorn-in-memory"
+  "Provider":{
+    "translatable":false,
+    "options":{
+      "system":"system",
+      "opencast":"opencast"
+    },
+    "label":"FILTERS.USERS.PROVIDER.LABEL",
+    "type":"select"
   }
 }

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/test/unit/shared/directives/tableFilterDirectiveSpec.js
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/test/unit/shared/directives/tableFilterDirectiveSpec.js
@@ -38,7 +38,8 @@ describe('adminNg.directives.adminNgTableFilter', function () {
                     'brown': 'BROWN',
                     'white': 'WHITE',
                     'black': 'BLACK'
-                }
+                },
+                translatable: true
             },
             type: {
                 label: 'TYPE',
@@ -46,7 +47,8 @@ describe('adminNg.directives.adminNgTableFilter', function () {
                 options: {
                     'chair': 'CHAIR',
                     'table': 'TABLE'
-                }
+                },
+                translatable: true
             }
         }));
 

--- a/modules/matterhorn-index-service/src/main/java/org/opencastproject/index/service/util/JSONUtils.java
+++ b/modules/matterhorn-index-service/src/main/java/org/opencastproject/index/service/util/JSONUtils.java
@@ -174,11 +174,14 @@ public final class JSONUtils {
 
       if (listProviderName.isSome()) {
         Map<String, String> values = null;
+        boolean translatable = false;
 
-        if (!listProvidersService.hasProvider(listProviderName.get()))
+        if (!listProvidersService.hasProvider(listProviderName.get())) {
           values = new HashMap<String, String>();
-        else
+        } else {
           values = listProvidersService.getList(listProviderName.get(), query, org, false);
+          translatable = listProvidersService.isTranslatable(listProviderName.get());
+        }
 
         List<Field> valuesJSON = new ArrayList<Field>();
         for (Entry<String, String> entry : values.entrySet()) {
@@ -186,6 +189,7 @@ public final class JSONUtils {
         }
 
         fields.add(f("options", obj(valuesJSON)));
+        fields.add(f("translatable", translatable));
       }
 
       filtersJSON.add(f(f.getName(), obj(fields)));

--- a/modules/matterhorn-index-service/src/test/resources/filters.json
+++ b/modules/matterhorn-index-service/src/test/resources/filters.json
@@ -6,6 +6,7 @@
             "contributor2": "My second contributor",
             "contributor3": "My third contributor"
         },
+        "translatable": false,
         "type": "select"
     },
     "textFilter": {


### PR DESCRIPTION
This patch ensures that the isTranslatable setting of list providers is respected in the visual representation of the filters which establishes correctness (translating a non-translatable string is an error) and improves performance.