### PR TITLE
MH-12657: Users of non-admin groups cannot create events

### DIFF
--- a/modules/matterhorn-authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/matterhorn-authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -124,6 +124,17 @@ public class XACMLAuthorizationService implements AuthorizationService {
     });
   }
 
+  public Tuple<AccessControlList, AclScope> getAclFromInputStream(final InputStream in) {
+    logger.debug("Get ACL from inputstream");
+    return withContextClassLoader(new Function0<Tuple<AccessControlList, AclScope>>() {
+      @Override
+      public Tuple<AccessControlList, AclScope> apply() {
+        Option<AccessControlList> episode = loadAclFromFile(in);
+        return tuple(episode.get(), AclScope.Episode);
+      }
+    });
+  }
+
   private Tuple<AccessControlList, AclScope> getDefaultAcl(final MediaPackage mp) {
     logger.debug("Get default ACL for media package {}", mp.getIdentifier());
     if (StringUtils.isNotBlank(mp.getSeries())) {
@@ -394,6 +405,18 @@ public class XACMLAuthorizationService implements AuthorizationService {
       }
     } else {
       logger.debug("URI {} not found", uri);
+    }
+    return Option.none();
+  }
+
+  private Option<AccessControlList> loadAclFromFile(final InputStream in) {
+    try {
+      AccessControlList acl = XACMLUtils.parseXacml(in);
+      if (acl != null) {
+        return Option.option(acl);
+      }
+    } catch (Exception e) {
+      logger.error("Exception occurred: {}", e);
     }
     return Option.none();
   }

--- a/modules/matterhorn-authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/matterhorn-authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -124,6 +124,7 @@ public class XACMLAuthorizationService implements AuthorizationService {
     });
   }
 
+  /** Returns an ACL based on a given file/inputstream. */
   public Tuple<AccessControlList, AclScope> getAclFromInputStream(final InputStream in) {
     logger.debug("Get ACL from inputstream");
     return withContextClassLoader(new Function0<Tuple<AccessControlList, AclScope>>() {
@@ -409,6 +410,8 @@ public class XACMLAuthorizationService implements AuthorizationService {
     return Option.none();
   }
 
+
+  /** Produces an ACL derived from a given security policy file. */
   private Option<AccessControlList> loadAclFromFile(final InputStream in) {
     try {
       AccessControlList acl = XACMLUtils.parseXacml(in);
@@ -416,7 +419,7 @@ public class XACMLAuthorizationService implements AuthorizationService {
         return Option.option(acl);
       }
     } catch (Exception e) {
-      logger.error("Exception occurred: {}", e);
+      logger.error("Failed to produce Acl when reading file: {}", e);
     }
     return Option.none();
   }

--- a/modules/matterhorn-common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
+++ b/modules/matterhorn-common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
@@ -26,7 +26,9 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.Tuple;
 
+import java.io.InputStream;
 import java.util.List;
+
 
 /**
  * Provides generation and interpretation of policy documents in media packages
@@ -80,6 +82,7 @@ public interface AuthorizationService {
    * @return the set of permissions and explicit denials
    */
   Tuple<AccessControlList, AclScope> getActiveAcl(MediaPackage mp);
+  Tuple<AccessControlList, AclScope> getAclFromInputStream(InputStream in);
 
   /**
    * Gets the permissions by its scope associated with this media package, as specified by its XACML attachment.

--- a/modules/matterhorn-common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
+++ b/modules/matterhorn-common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
@@ -82,6 +82,14 @@ public interface AuthorizationService {
    * @return the set of permissions and explicit denials
    */
   Tuple<AccessControlList, AclScope> getActiveAcl(MediaPackage mp);
+
+  /**
+   * Gets the active permissions as specified by the given XACML attachment.
+   *
+   * @param in
+   *          the XACML attachment used to determine a set of permissions and explicit denials
+   * @return a set of permissions and explicit denials
+   */
   Tuple<AccessControlList, AclScope> getAclFromInputStream(InputStream in);
 
   /**


### PR DESCRIPTION
Definition:
User - A user who does not have the global admin role, nor the tenant admin role.

Issue resolved by this PR:
Access to assets depend on ACLs. ACLs themselves are assets; users thus cannot access
the very asset (ACL) authorizing event creation. This PR retrieves the event ACL from
the asset store, using it to vet access to event assets.

The security policy of an asset now determines whether a user is authorised to it (the asset).
If a user is authorised to perform an action on an asset (e.g. update), and that action
includes a successful snapshot workflow operation, the assets metadata is saved to persistence.
Asset metadata is saved to various tables, the most notable table for this PR being the
`mh_assets_properties` table. The `mh_assets_properties` table would contain, among other properties,
those roles that may read, alter or delete an asset. Note that the `mh_assets_properties` table
only contain those assets that have been successfully snapshot(ted?).

Currently, as far as users are concerned, the security policy for an asset is determined
solely by those roles associated to said asset contained in the `mh_assets_properties` table.
This presents a problem as newly created assets have no reference in
the `mh_assets_properties_table`. Thus, no security policy for newly created assets can be found,
leaving users unable to create new events.

This PR solves this issue by retrieving the actual security policy from the Asset Store, thereby
negating the need for a non-empty result set when querying the `mh_assets_properties` table for
event ACLs.