### PR TITLE
MH-12675 Send default startdate to backend also if it hasn't been changed.

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/datetimepickerDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/datetimepickerDirective.js
@@ -28,7 +28,6 @@ angular.module('adminNg.directives')
                 dateValue = new Date(scope.$parent.params.value);
             }
 
-
             if (ngModel) {
 
                 var updateModel = function (date) {
@@ -44,7 +43,6 @@ angular.module('adminNg.directives')
                 optionsObj.timeInput = true;
                 optionsObj.showButtonPanel = true;
                 optionsObj.onClose = function () {
-                    console.log('onClose');
                     var newDate = element.datetimepicker('getDate');
                     setTimeout(function(){
                         updateModel(newDate);
@@ -62,6 +60,7 @@ angular.module('adminNg.directives')
 
                 element.datetimepicker(optionsObj);
                 element.datetimepicker('setDate', dateValue);
+                ngModel.$setViewValue(dateValue.toISOString());
             }
 
             scope.$on('$destroy', function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -115,7 +115,7 @@
                   <li  ng-repeat="asset in wizard.sharedData.uploadAssetOptions | filter:{type:'track'}| orderBy: 'displayOrder' track by asset.id">
                     <div class="file-upload">
                       <input id="{{asset.id}}" class="blue-btn file-select-btn" admin-ng-file-upload data-ng-file-select data-ng-multiple="asset.multiple"
-                        type="file" file="$parent.wizard.step.ud.upload.{{asset.id}}" tabindex="" />
+                        type="file" file="$parent.wizard.step.ud.UPLOAD.tracks.{{asset.id}}" tabindex="" />
                     </div>
                     <span  translate="{{asset.title + '.SHORT'}}">
                     </span>
@@ -133,7 +133,7 @@
                 <div class="obj-container">
                     <form novalidate name="outerForm">
                         <table class="main-tbl">
-                            <tr ng-repeat="row in wizard.step.metadata">
+                            <tr ng-repeat="row in wizard.step.ud.UPLOAD.metadata">
                                 <td>
                                     <span translate="{{ row.label }}"></span>
                                     <i ng-show="row.required" class="required">*</i>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
@@ -16,6 +16,9 @@ angular.module('adminNg.resources')
             transformResponse: [],
 
             transformRequest: function (data) {
+
+                console.log(JSON.stringify(data));
+
                 if (angular.isUndefined(data)) {
                     return data = [];
                 }
@@ -78,25 +81,18 @@ angular.module('adminNg.resources')
                     })(data.source);
                 }
 
-                // Remove useless information for the request
-                angular.forEach(data.metadata, function (catalog) {
-                    angular.forEach(catalog.fields, function (field) {
-                            delete field.collection;
-                            delete field.label;
-                            delete field.presentableValue;
-                            delete field.readOnly;
-                            delete field.required;
-                    });
-                });
-
                 // Dynamic source config and multiple source per type allowed
                 if (sourceType === 'UPLOAD') {
-                    if (data.source.upload) {
-                       angular.forEach(data.source.upload, function(files, name) {
+                    if (data.source.UPLOAD.tracks) {
+                       angular.forEach(data.source.UPLOAD.tracks, function(files, name) {
                           angular.forEach(files, function (file, index) {
                              fd.append(name + "." + index, file);
                           });
                        });
+                    }
+
+                    if (data.source.UPLOAD.metadata.start) {
+                        data.metadata[0].fields.push(data.source.UPLOAD.metadata.start);
                     }
                 }
 
@@ -123,6 +119,17 @@ angular.module('adminNg.resources')
                     data.processing.workflow.selection.configuration["downloadSourceflavorsExist"] = "true";
                     data.processing.workflow.selection.configuration["download-source-flavors"] = flavorList.join(", ");
                 }
+
+                // Remove useless information for the request
+                angular.forEach(data.metadata, function (catalog) {
+                    angular.forEach(catalog.fields, function (field) {
+                        delete field.collection;
+                        delete field.label;
+                        delete field.presentableValue;
+                        delete field.readOnly;
+                        delete field.required;
+                    });
+                });
 
                // Add metadata form field
                 fd.append('metadata', JSON.stringify({

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -1,6 +1,6 @@
 angular.module('adminNg.services')
-.factory('NewEventSource', ['JsHelper', 'CaptureAgentsResource', 'ConflictCheckResource', 'Notifications', 'Language', '$translate', '$filter', 'underscore', '$timeout', 'localStorageService', 'AuthService', 'NewEventMetadata', 'SchedulingHelperService',
-    function (JsHelper, CaptureAgentsResource, ConflictCheckResource, Notifications, Language, $translate, $filter, _, $timeout, localStorageService, AuthService, NewEventMetadata, SchedulingHelperService) {
+.factory('NewEventSource', ['JsHelper', 'CaptureAgentsResource', 'ConflictCheckResource', 'Notifications', 'Language', '$translate', '$filter', 'underscore', '$timeout', 'localStorageService', 'AuthService', 'SchedulingHelperService',
+    function (JsHelper, CaptureAgentsResource, ConflictCheckResource, Notifications, Language, $translate, $filter, _, $timeout, localStorageService, AuthService, SchedulingHelperService) {
 
     // -- constants ------------------------------------------------------------------------------------------------- --
 
@@ -26,29 +26,20 @@ angular.module('adminNg.services')
         var self = this;
 
         this.save = function () {
-          if (self.startDate.index) {
-            NewEventMetadata.ud['dublincore/episode'].fields[self.startDate.index] = self.startDate;
-          } else {
-            self.startDate.index = NewEventMetadata.ud['dublincore/episode'].fields.length;
-            NewEventMetadata.ud['dublincore/episode'].fields.push(self.startDate);
-          }
+            self.ud.UPLOAD.metadata['start'] = self.startDate;
         };
 
         this.createStartDate = function () {
-          self.startDate = {
-            "id": "startDate",
-            "label": "EVENTS.EVENTS.DETAILS.METADATA.START_DATE",
-            "value": new Date(Date.now()).toISOString(),
-            "type": "date",
-            "readOnly": false,
-            "required": false,
-            "tabindex": 7
-          };
-          self.metadata = new Array();
-          self.metadata.push(self.startDate);
+            self.startDate = {
+                "id": "startDate",
+                "label": "EVENTS.EVENTS.DETAILS.METADATA.START_DATE",
+                "value": new Date(Date.now()).toISOString(),
+                "type": "date",
+                "readOnly": false,
+                "required": false,
+                "tabindex": 7
+            };
         };
-
-        this.createStartDate();
 
         self.isSourceState = true;
 
@@ -73,11 +64,16 @@ angular.module('adminNg.services')
         this.loadCaptureAgents();
 
         this.reset = function (opts) {
+
             self.createStartDate();
             self.weekdays = _.clone(WEEKDAYS);
             self.ud = {
-                upload: {},
-
+                UPLOAD: {
+                    tracks: {},
+                    metadata: {
+                        start: self.startDate
+                    }
+                },
                 SCHEDULE_SINGLE: {
                     device: {
                         inputMethods: {}
@@ -175,7 +171,7 @@ angular.module('adminNg.services')
             later: function() { return true; },
             UPLOAD: function() {
                 // test for any type of upload source (MH-12085)
-                return Object.keys(self.ud.upload).length > 0;
+                return Object.keys(self.ud.UPLOAD.tracks).length > 0;
             },
             SCHEDULE_SINGLE: function () {
                 return !self.hasConflicts && _.every(fields, function(field) {
@@ -234,7 +230,7 @@ angular.module('adminNg.services')
         this.updateUploadTracksForSummary =  function () {
             self.ud.trackuploadlistforsummary = [];
             var namemap = self.wizard.sharedData.uploadNameMap;
-            angular.forEach(self.ud.upload, function ( value, key) {
+            angular.forEach(self.ud.UPLOAD.tracks, function ( value, key) {
                 var item = {};
                 var fileNames = [];
                 item.id = key;
@@ -431,7 +427,7 @@ angular.module('adminNg.services')
         this.onExitStep = function () {
             // update summary of selections
             this.updateUploadTracksForSummary();
-        }
+        };
 
         this.isValid = function () {
             var validator = getValidatorByType();

--- a/modules/admin-ui/src/test/resources/test/unit/fixtures/newEventUploadFixture.json
+++ b/modules/admin-ui/src/test/resources/test/unit/fixtures/newEventUploadFixture.json
@@ -1,52 +1,67 @@
 {
   "access": {
-    "access": {
-      "acl": "1601"
+    "acl":{
+      "ace":[
+        {
+          "action":"read",
+          "allow":true,
+          "role":"ROLE_USER_ADMIN"
+        },
+        {
+          "action":"write",
+          "allow":true,
+          "role":"ROLE_USER_ADMIN"
+        }
+      ]
     }
   },
-  "metadata": {
-    "metadata": {
-      "presenters": {
-        "$$hashKey": "026",
-        "collection": "users",
-        "id": "presenters",
-        "label": "EVENTS.EVENTS.DETAILS.METADATA.PRESENTER",
-        "presentableValue": [
-          "chuck.norris"
-        ],
-        "readOnly": false,
-        "required": "true",
-        "type": "text",
-        "value": [
-          "chuck.norris"
-        ]
-      },
-      "subject": {
-        "$$hashKey": "029",
-        "id": "subject",
-        "label": "EVENTS.EVENTS.DETAILS.METADATA.SUBJECT",
-        "presentableValue": [
-          "grunz"
-        ],
-        "readOnly": false,
-        "required": "true",
-        "type": "text",
-        "value": [
-          "grunz"
-        ]
-      },
-      "title": {
-        "$$hashKey": "025",
-        "id": "title",
-        "label": "EVENTS.EVENTS.DETAILS.METADATA.TITLE",
-        "presentableValue": "test",
-        "readOnly": false,
-        "required": "true",
-        "type": "text",
-        "value": "test"
-      }
+  "metadata": [
+    {
+      "flavor": "dublincore/episode",
+      "title": "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
+      "fields": [
+        {
+          "$$hashKey": "026",
+          "collection": "users",
+          "id": "presenters",
+          "label": "EVENTS.EVENTS.DETAILS.METADATA.PRESENTER",
+          "presentableValue": [
+            "chuck.norris"
+          ],
+          "readOnly": false,
+          "required": "true",
+          "type": "text",
+          "value": [
+            "chuck.norris"
+          ]
+        },
+        {
+          "$$hashKey": "029",
+          "id": "subject",
+          "label": "EVENTS.EVENTS.DETAILS.METADATA.SUBJECT",
+          "presentableValue": [
+            "grunz"
+          ],
+          "readOnly": false,
+          "required": "true",
+          "type": "text",
+          "value": [
+            "grunz"
+          ]
+        },
+        {
+          "$$hashKey": "025",
+          "id": "title",
+          "label": "EVENTS.EVENTS.DETAILS.METADATA.TITLE",
+          "presentableValue": "test",
+          "readOnly": false,
+          "required": "true",
+          "type": "text",
+          "value": "test"
+        }
+      ]
     }
-  },
+  ],
   "processing": {
     "workflow": {
       "description": "A workflow that puts mediapackages on hold",
@@ -70,10 +85,24 @@
     }
   },
   "source": {
-    "type": "UPLOAD",
-    "upload": {
-      "audioOnly": {}
-    }
+    "UPLOAD": {
+      "tracks": {
+        "audioOnly": {
+        }
+      },
+      "metadata": {
+        "start": {
+          "id": "startDate",
+          "label": "EVENTS.EVENTS.DETAILS.METADATA.START_DATE",
+          "value": "2018-01-29T10:19:37.943Z",
+          "type": "date",
+          "readOnly": false,
+          "required": false,
+          "tabindex": 7
+        }
+      }
+    },
+    "type": "UPLOAD"
   },
   "summary": {
   }

--- a/modules/admin-ui/src/test/resources/test/unit/shared/resources/newEventResourceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/resources/newEventResourceSpec.js
@@ -31,19 +31,19 @@ describe('New Event API Resource', function () {
             date: '2014-07-17',
             hour:  '10',
             minute: '0'
-        });           
+        });
 
         startDateDST = JsHelper.toZuluTimeString({
             date   : '2016-03-25',
             hour   : '8',
             minute : '0'
-        });         
+        });
 
         endDateDST = JsHelper.toZuluTimeString({
             date   : '2016-03-28',
             hour   : '8',
             minute : '10'
-        });   
+        });
 
         endDate = JsHelper.toZuluTimeString({
             date: '2014-07-24',
@@ -52,7 +52,7 @@ describe('New Event API Resource', function () {
         }, {
             hour: '1',
             minute: '45'
-        });        
+        });
 
         expectedSourceMultiple = {
             'type': 'SCHEDULE_MULTIPLE',
@@ -64,7 +64,7 @@ describe('New Event API Resource', function () {
                 'device'  : '•mock• agent3',
                 'inputs'  : 'TRANSLATION.PATH.VIDEO'
             }
-        };        
+        };
 
         dateDST = moment(startDateDST);
         dateDST.utc();
@@ -86,7 +86,7 @@ describe('New Event API Resource', function () {
             date: '2014-07-16',
             hour:  '02',
             minute: '06'
-        });   
+        });
 
         endDate = JsHelper.toZuluTimeString({
             date: '2014-07-16',
@@ -233,8 +233,8 @@ describe('New Event API Resource', function () {
         });
 
         it('assembles the metadata for segmentable video', function () {
-            delete uploadTestData.source.upload.audioOnly;
-            uploadTestData.source.upload.segmentable = {};
+            delete uploadTestData.source.UPLOAD.tracks.audioOnly;
+            uploadTestData.source.UPLOAD.tracks.segmentable = {};
 
             NewEventResource.save(uploadTestData);
             $httpBackend.flush();
@@ -244,8 +244,8 @@ describe('New Event API Resource', function () {
         });
 
         it('assembles the metadata for non-segmentable video', function () {
-            delete uploadTestData.source.upload.segmentable;
-            uploadTestData.source.upload.nonSegmentable = {};
+            delete uploadTestData.source.UPLOAD.tracks.segmentable;
+            uploadTestData.source.UPLOAD.tracks.nonSegmentable = {};
 
             NewEventResource.save(uploadTestData);
             $httpBackend.flush();
@@ -255,7 +255,7 @@ describe('New Event API Resource', function () {
         });
 
         it('handles empty video format gracefully', function () {
-            delete uploadTestData.source.upload.nonSegmentable;
+            delete uploadTestData.source.UPLOAD.tracks.nonSegmentable;
 
             NewEventResource.save(uploadTestData);
             $httpBackend.flush();


### PR DESCRIPTION
When creating a new event within the modal dialog in the admin ui, the start date in the recording meta data at the bottom of the source tab (only visible when selecting 'UPLOAD') should also be sent to the backend if it hasn't been changed (default is current date and time) instead of leaving that metadata field blank.

This patch also fixes the bug where an additional row will appear at the end of the metadata tab if
the start date was changed in the source tab because of shared data between the tabs. Additionally it fixes a bug where the date value is sometimes an ISO string and sometimes a date object.