### PR TITLE
MH-12695 Improve performance during synchronization

### DIFF
--- a/modules/matterhorn-index-service/src/main/java/org/opencastproject/index/service/message/MessageReceiverLockService.java
+++ b/modules/matterhorn-index-service/src/main/java/org/opencastproject/index/service/message/MessageReceiverLockService.java
@@ -32,7 +32,7 @@ public class MessageReceiverLockService {
 
   private static final Logger logger = LoggerFactory.getLogger(MessageReceiverLockService.class);
 
-  private final Striped<Lock> lock = Striped.lazyWeakLock(1);
+  private final Striped<Lock> lock = Striped.lazyWeakLock(1024);
 
   public <K, A> A synchronize(K resource, Fn<K, A> function) {
     final Lock lock = this.lock.get(resource);

--- a/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
+++ b/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
@@ -134,6 +134,7 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
   public static final String DESCENDING_SUFFIX = "_DESC";
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(WorkflowRestService.class);
+
   /** The default server URL */
   protected String serverUrl = UrlSupport.DEFAULT_BASE_URL;
   /** The default service URL */
@@ -146,7 +147,7 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
   private Workspace workspace;
 
   /** Resource lock */
-  private final Striped<Lock> lock = Striped.lazyWeakLock(1);
+  private final Striped<Lock> lock = Striped.lazyWeakLock(1024);
 
   /**
    * Callback from the OSGi declarative services to set the service registry.

--- a/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -259,9 +259,9 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   private final List<Long> delayedWorkflows = new ArrayList<Long>();
 
   /** Striped locks for synchronization */
-  private final Striped<Lock> lock = Striped.lazyWeakLock(1);
-  private final Striped<Lock> updateLock = Striped.lazyWeakLock(1);
-  private final Striped<Lock> mediaPackageLocks = Striped.lazyWeakLock(1);
+  private final Striped<Lock> lock = Striped.lazyWeakLock(1024);
+  private final Striped<Lock> updateLock = Striped.lazyWeakLock(1024);
+  private final Striped<Lock> mediaPackageLocks = Striped.lazyWeakLock(1024);
 
   static {
     YES = new HashSet<String>(Arrays.asList(new String[] { "yes", "true", "on" }));
@@ -613,6 +613,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     // We have to synchronize per media package to avoid starting multiple simultaneous workflows for one media package.
     final Lock lock = mediaPackageLocks.get(sourceMediaPackage.getIdentifier().toString());
     lock.lock();
+
     try {
       logger.startUnitOfWork();
       if (workflowDefinition == null)
@@ -1299,6 +1300,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   public void update(final WorkflowInstance workflowInstance) throws WorkflowException, UnauthorizedException {
     final Lock lock = updateLock.get(workflowInstance.getId());
     lock.lock();
+
     try {
       WorkflowInstance originalWorkflowInstance = null;
       try {


### PR DESCRIPTION
Ensure that there is a minimum of 1024 different locks for synchronization when using Striped for synchronization so that there is no unnecessary waiting on lock.lock() because the same lock is always returned even for different resources.
Improves the performance of Actions -> Start Task (locally from 105s to 19s).

Sponsored by SWITCH.

EDIT: Switched base to r/4.x since it's only a small patch that will noticeably improve performance.