### PR TITLE
MH-12692 Update maven bundle plugin for java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.0.1</version>
+          <version>3.5.0</version>
           <inherited>true</inherited>
           <configuration>
             <instructions>


### PR DESCRIPTION
This commit updates the maven-bundle-plugin version so Java 8 can be safely used (you get a weird ArrayOutOfBoundsException with the old plugin version). See the corresponding JIRA ticket here:

https://issues.apache.org/jira/browse/FELIX-4556

Note that the change only pertains to the parent `pom.xml`, so it should be easily portable to `develop`, too.

This work is sponsored by plapadoo.