### PR TITLE
MH-12694 "Save" button in the editor now stays on the same page.

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
@@ -72,11 +72,11 @@ angular.module('adminNg.controllers')
                 $scope.submitButton = false;
                 if ($scope.video.workflow) {
                     Notifications.add('success', 'VIDEO_CUT_PROCESSING');
+                    $location.url('/events/' + $scope.resource);
                 } else {
                     Notifications.add('success', 'VIDEO_CUT_SAVED');
                 }
                 $scope.unsavedChanges = false;
-                $location.url('/events/' + $scope.resource);
             }, function () {
                 $scope.submitButton = false;
                 Notifications.add('error', 'VIDEO_CUT_NOT_SAVED', 'video-tools');

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
@@ -42,7 +42,7 @@
                 </div>
             </div>
         </div>
-        <div data-admin-ng-notifications="" type="warning" show="submitButton" context="video-editor-event-access"></div>
+        <div data-admin-ng-notifications=""></div>
         <div class="tab-menu">
             <nav class="view-controller">
                 <a ng-class="{active: tab === 'playback'}"
@@ -224,9 +224,8 @@
 
             <div data-admin-ng-notifications="" type="warning" show="submitButton" context="video-editor-event-access"></div>
             <div class="video-editor-actions-toolbar">
-                <div class="video-nav-controls">
-                    <a class="return-button" ng-click="navigateTo('/events/events')" translate>VIDEO_TOOL.BUTTONS.CLOSE</a>
-                </div>
+
+            <div data-admin-ng-notifications=""></div>
 
                 <div class="video-save-panel" ng-if="tab === 'editor' && player.adapter">
                     <div class="buttons">
@@ -243,9 +242,12 @@
                            translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
                           <!-- Save and Continue -->
                         </a>
+
+                        <a class="return-button" ng-click="navigateTo('/events/events')" translate>VIDEO_TOOL.BUTTONS.CLOSE</a>
                     </div>
                 </div>
             </div>
+
         </div>
     </div>
   </div>

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/subresources/controllers/toolsControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/subresources/controllers/toolsControllerSpec.js
@@ -87,6 +87,7 @@ describe('Tools Edit controller', function () {
             });
 
             it('redirects to the events list', function () {
+                $scope.video.workflow = 'some-workflow';
                 $scope.submit();
                 $httpBackend.flush();
 


### PR DESCRIPTION
"Save and Continue" still navigates to event table.
Added notifications that edit list was saved to the top and bottom of the editor.

Moved Close button to the right, next to Save. As the editor does not close automatically, the Close button is now closer.