### PR TITLE
MH-12663 Don't search for non-existing WFR files

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
@@ -508,14 +508,20 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
     doc.addField(WORKFLOW_CREATOR_KEY, workflowCreator.getUsername());
     doc.addField(ORG_KEY, instance.getOrganization().getId());
 
-    AccessControlList acl;
-    try {
-      acl = authorizationService.getActiveAcl(mp).getA();
-    } catch (Error e) {
-      logger.error("No security xacml found on media package {}", mp);
-      throw new WorkflowException(e);
+    WorkflowInstance.WorkflowState state = instance.getState();
+    if (!(WorkflowInstance.WorkflowState.SUCCEEDED.equals(state)
+            || WorkflowInstance.WorkflowState.FAILED.equals(state)
+            || WorkflowInstance.WorkflowState.STOPPED.equals(state))) {
+
+      AccessControlList acl;
+      try {
+        acl = authorizationService.getActiveAcl(mp).getA();
+      } catch (Error e) {
+        logger.error("No security xacml found on media package {}", mp);
+        throw new WorkflowException(e);
+      }
+      addAuthorization(doc, acl);
     }
-    addAuthorization(doc, acl);
 
     return doc;
   }
@@ -563,7 +569,6 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
       String fieldName = ACL_KEY_PREFIX + entry.getKey();
       doc.setField(fieldName, entry.getValue());
     }
-
   }
 
   /**


### PR DESCRIPTION
When rebuilding the admin ui index from the workflow service, don't look for ACL's and other metadata files in the working file repository if the corresponding workflow is already finished (workflow state either 'Succeeded', 'Stopped' or 'Failed') since that data should have already been cleaned up.

EDIT: Updated to do the same for the solr index.