### PR TITLE
MH-12651: Recurring scheduling efficiency fixes

### DIFF
--- a/modules/matterhorn-index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/matterhorn-index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -1036,7 +1036,7 @@ public class IndexServiceImplTest {
     return String.format("FREQ=WEEKLY;BYDAY=%s;BYHOUR=%d;BYMINUTE=%d", days, hour, minute);
   }
 
-  //NOTE: Do not modify this without making the same modifications to the copy of this method in SchedulerServiceImpl
+  //NOTE: Do not modify this without making the same modifications to the copy of this method in Util in the scheduler service
   //I would have moved this to an abstract class in the scheduler-api bundle, but that would introduce a circular dependency :(
   public List<Period> calculatePeriods(RRule rrule, Date start, Date end, long duration, TimeZone tz) {
     final TimeZone timeZone = TimeZone.getDefault();

--- a/modules/matterhorn-index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/matterhorn-index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -86,6 +86,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.joda.time.DateTimeConstants;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -103,12 +105,14 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Dictionary;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.UUID;
 
 public class IndexServiceImplTest {
 
@@ -625,6 +629,7 @@ public class IndexServiceImplTest {
 
     // Setup mediapackage.
     MediaPackage mediapackage = EasyMock.createMock(MediaPackage.class);
+    EasyMock.expect(mediapackage.clone()).andReturn(mediapackage).anyTimes();
     EasyMock.expect(mediapackage.getSeries()).andReturn(null).anyTimes();
     EasyMock.expect(mediapackage.getCatalogs(EasyMock.anyObject(MediaPackageElementFlavor.class)))
             .andReturn(new Catalog[] { CatalogImpl.fromURI(getClass().getResource("/dublincore.xml").toURI()) });
@@ -648,14 +653,50 @@ public class IndexServiceImplTest {
     CaptureAgentStateService captureAgentStateService = setupCaptureAgentStateService();
 
     // Setup scheduler service
-    Capture<Date> captureStart = EasyMock.newCapture();
-    Capture<Date> captureEnd = EasyMock.newCapture();
+    Capture<Date> recurrenceStart = EasyMock.newCapture();
+    Capture<Date> recurrenceEnd = EasyMock.newCapture();
+    Capture<RRule> rrule = EasyMock.newCapture();
+    Capture duration = EasyMock.newCapture();
+    Capture<TimeZone> tz = EasyMock.newCapture();
+
+    Capture<Date> schedStart = EasyMock.newCapture();
+    Capture<Date> schedEnd = EasyMock.newCapture();
+    Capture<RRule> schedRRule = EasyMock.newCapture();
+    Capture schedDuration = EasyMock.newCapture();
+    Capture<TimeZone> schedTz = EasyMock.newCapture();
+
+    Capture<MediaPackage> mp = EasyMock.newCapture();
     SchedulerService schedulerService = EasyMock.createNiceMock(SchedulerService.class);
-    schedulerService.addEvent(EasyMock.capture(captureStart), EasyMock.capture(captureEnd), EasyMock.anyString(),
-            EasyMock.<Set<String>> anyObject(), EasyMock.anyObject(MediaPackage.class),
-            EasyMock.<Map<String, String>> anyObject(), EasyMock.<Map<String, String>> anyObject(),
-            EasyMock.<Opt<Boolean>> anyObject(), EasyMock.<Opt<String>> anyObject(), EasyMock.anyString());
-    EasyMock.expectLastCall().atLeastOnce();
+    //Look up the expected periods
+    EasyMock.expect(
+            schedulerService.calculatePeriods(EasyMock.capture(rrule), EasyMock.capture(recurrenceStart),
+                    EasyMock.capture(recurrenceEnd), EasyMock.captureLong(duration), EasyMock.capture(tz))).
+            andAnswer(new IAnswer<List<Period>>() {
+              @Override
+              public List<Period> answer() throws Throwable {
+                return calculatePeriods(rrule.getValue(), recurrenceStart.getValue(), recurrenceEnd.getValue(), (Long) duration.getValue(), tz.getValue());
+              }
+            }).anyTimes();
+    //The actual scheduling
+    EasyMock.expect(
+    schedulerService.addMultipleEvents(
+            EasyMock.capture(schedRRule), EasyMock.capture(schedStart), EasyMock.capture(schedEnd),
+            EasyMock.captureLong(schedDuration), EasyMock.capture(schedTz), EasyMock.anyString(),
+            EasyMock.<Set<String>>anyObject(), EasyMock.capture(mp), EasyMock.<Map<String, String>>anyObject(),
+            EasyMock.<Map<String, String>>anyObject(), EasyMock.<Opt<Boolean>>anyObject(),
+            EasyMock.<Opt<String>>anyObject(), EasyMock.anyString())).
+            andAnswer(new IAnswer<Map<String, Period>>() {
+              @Override
+              public Map<String, Period> answer() throws Throwable {
+                List<Period> periods = calculatePeriods(schedRRule.getValue(), schedStart.getValue(), schedEnd.getValue(), (Long) schedDuration.getValue(), schedTz.getValue());
+                Map<String, Period> mapping = new LinkedHashMap<>();
+                int counter = 0;
+                for (Period p : periods) {
+                  mapping.put(new IdImpl(UUID.randomUUID().toString()).compact(), p);
+                }
+                return mapping;
+              }
+            }).anyTimes();
     EasyMock.replay(schedulerService);
 
     // Run Test
@@ -671,7 +712,8 @@ public class IndexServiceImplTest {
     indexServiceImpl.setSchedulerService(schedulerService);
     String scheduledEvents = indexServiceImpl.createEvent(metadataJson, mediapackage);
     String[] ids = StringUtils.split(scheduledEvents, ",");
-    Assert.assertTrue(ids.length > 1);
+    //We should have as many scheduled events as we do periods
+    Assert.assertTrue(ids.length == calculatePeriods(rrule.getValue(), recurrenceStart.getValue(), recurrenceEnd.getValue(), (Long) duration.getValue(), tz.getValue()).size());
 
     assertEquals("The catalog should have been added to the correct mediapackage", mpId.toString(),
             mediapackageIdResult.getValue());
@@ -681,13 +723,25 @@ public class IndexServiceImplTest {
     assertTrue("The mediapackage should have had its title updated", catalogResult.hasCaptured());
     assertEquals("The mediapackage title should have been updated.", expectedTitle, mediapackageTitleResult.getValue());
     assertTrue("The catalog should have been created", catalogResult.hasCaptured());
-    assertTrue(captureStart.hasCaptured());
-    assertTrue(captureEnd.hasCaptured());
-    List<Date> endDates = captureEnd.getValues();
-    int i = 0;
-    for (Date start : captureStart.getValues()) {
-      Assert.assertEquals(new Date(start.getTime() + 60000), endDates.get(i++));
-    }
+    //Assert that the start and end recurrence dates captured, along with the duration and recurrence rule
+    //This is all used by the scheduling calculation, but not the actual scheduling call
+    assertTrue(recurrenceStart.hasCaptured());
+    assertTrue(recurrenceEnd.hasCaptured());
+    assertTrue(duration.hasCaptured());
+    assertTrue(rrule.hasCaptured());
+    //Assert that the scheduling call has its necessary data
+    assertTrue(schedStart.hasCaptured());
+    assertTrue(schedEnd.hasCaptured());
+    assertTrue(schedDuration.hasCaptured());
+    assertTrue(schedRRule.hasCaptured());
+    assertTrue(schedTz.hasCaptured());
+    List<Period> pCheck = calculatePeriods(schedRRule.getValue(), schedStart.getValue(), schedEnd.getValue(), (Long) schedDuration.getValue(), schedTz.getValue());
+    List<Period> pExpected = calculatePeriods(rrule.getValue(), recurrenceStart.getValue(), recurrenceEnd.getValue(), (Long) duration.getValue(), tz.getValue());
+
+    //Assert that the first capture time is the same as the recurrence start
+    assertEquals(pExpected.get(0).getStart(), pCheck.get(0).getStart());
+    //Assert that the end of the last capture time is the same as the recurrence end
+    assertEquals(pExpected.get(pExpected.size() - 1).getEnd(), pCheck.get(pCheck.size() - 1).getEnd());
   }
 
   /**
@@ -975,11 +1029,58 @@ public class IndexServiceImplTest {
     utcDate.setTime(start.getTime());
     RRule rRule = new RRule(generateRule(days, utcDate.get(Calendar.HOUR_OF_DAY), utcDate.get(Calendar.MINUTE)));
     IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
-    return indexServiceImpl.calculatePeriods(start.getTime(), end.getTime(), duration, rRule, tz);
+    return calculatePeriods(rRule, start.getTime(), end.getTime(), duration, tz);
   }
 
   private String generateRule(String days, int hour, int minute) {
     return String.format("FREQ=WEEKLY;BYDAY=%s;BYHOUR=%d;BYMINUTE=%d", days, hour, minute);
   }
 
+  //NOTE: Do not modify this without making the same modifications to the copy of this method in SchedulerServiceImpl
+  //I would have moved this to an abstract class in the scheduler-api bundle, but that would introduce a circular dependency :(
+  public List<Period> calculatePeriods(RRule rrule, Date start, Date end, long duration, TimeZone tz) {
+    final TimeZone timeZone = TimeZone.getDefault();
+    final TimeZone utc = TimeZone.getTimeZone("UTC");
+    TimeZone.setDefault(tz);
+    net.fortuna.ical4j.model.DateTime periodStart = new net.fortuna.ical4j.model.DateTime(start);
+    net.fortuna.ical4j.model.DateTime periodEnd = new net.fortuna.ical4j.model.DateTime();
+
+    Calendar endCalendar = Calendar.getInstance(utc);
+    endCalendar.setTime(end);
+    Calendar calendar = Calendar.getInstance(utc);
+    calendar.setTime(periodStart);
+    calendar.set(Calendar.DAY_OF_MONTH, endCalendar.get(Calendar.DAY_OF_MONTH));
+    calendar.set(Calendar.MONTH, endCalendar.get(Calendar.MONTH));
+    calendar.set(Calendar.YEAR, endCalendar.get(Calendar.YEAR));
+    periodEnd.setTime(calendar.getTime().getTime() + duration);
+    duration = duration % (DateTimeConstants.MILLIS_PER_DAY);
+
+    List<Period> events = new LinkedList<>();
+
+    TimeZone.setDefault(utc);
+    for (Object date : rrule.getRecur().getDates(periodStart, periodEnd, net.fortuna.ical4j.model.parameter.Value.DATE_TIME)) {
+      Date d = (Date) date;
+      Calendar cDate = Calendar.getInstance(utc);
+
+      // Adjust for DST, if start of event
+      if (tz.inDaylightTime(periodStart)) { // Event starts in DST
+        if (!tz.inDaylightTime(d)) { // Date not in DST?
+          d.setTime(d.getTime() + tz.getDSTSavings()); // Adjust for Fall back one hour
+        }
+      } else { // Event doesn't start in DST
+        if (tz.inDaylightTime(d)) {
+          d.setTime(d.getTime() - tz.getDSTSavings()); // Adjust for Spring forward one hour
+        }
+      }
+      cDate.setTime(d);
+
+      TimeZone.setDefault(timeZone);
+      Period p = new Period(new net.fortuna.ical4j.model.DateTime(cDate.getTime()),
+              new net.fortuna.ical4j.model.DateTime(cDate.getTimeInMillis() + duration));
+      events.add(p);
+      TimeZone.setDefault(utc);
+    }
+    TimeZone.setDefault(timeZone);
+    return events;
+  }
 }

--- a/modules/matterhorn-index-service/src/test/resources/events/create-recurring-event.json
+++ b/modules/matterhorn-index-service/src/test/resources/events/create-recurring-event.json
@@ -304,10 +304,10 @@
    "source":{
       "type":"SCHEDULE_MULTIPLE",
       "metadata": {
-        "start":"2008-03-16T14:00:00Z",
-        "end":"2008-04-16T00:00:00Z",
+        "start":"2018-02-04T14:00:00Z",
+        "end":"2018-02-24T00:00:00Z",
         "duration":"60000",
-        "rrule":"FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR;COUNT=15",
+        "rrule":"FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=14;BYMINUTE=0",
         "device":"agent1",
         "inputs":"a,b"
       }

--- a/modules/matterhorn-scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
+++ b/modules/matterhorn-scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
@@ -29,6 +29,7 @@ import org.opencastproject.util.NotFoundException;
 
 import com.entwinemedia.fn.data.Opt;
 
+import net.fortuna.ical4j.model.Period;
 import net.fortuna.ical4j.model.property.RRule;
 
 import java.util.Date;
@@ -244,6 +245,59 @@ public interface SchedulerService {
                   SchedulerConflictException, SchedulerTransactionLockException, SchedulerException;
 
   /**
+   * Creates a group of new event using specified mediapackage, workflow configuration and capture agent configuration.
+   * The mediapackage id is used as the event's identifier.
+   *
+   * Default capture agent properties are created from agentId and DublinCore. Following values are generated:
+   * <ul>
+   * <li>event.title (mapped from dc:title)</li>
+   * <li>event.series (mapped from mediaPackage#getSeries())</li>
+   * <li>event.location (mapped from captureAgentId)</li>
+   * </ul>
+   *
+   * @param rRule
+   *          the {@link RRule} for the events to schedule
+   * @param start
+   *          the start date for the recurrence
+   * @param end
+   *          the end date for the recurrence
+   * @param duration
+   *          the duration of the events
+   * @param tz
+   *          the {@link TimeZone} for the events
+   * @param captureAgentId
+   *          the capture agent id
+   * @param userIds
+   *          the list of user identifiers of speakers/lecturers
+   * @param templateMp
+   *          the mediapackage to base the events on
+   * @param wfProperties
+   *          the workflow configuration
+   * @param caMetadata
+   *          the capture agent configuration
+   * @param optOut
+   *          the optional opt out status
+   * @param schedulingSource
+   *          the optional scheduling source from which the event comes from
+   * @param modificationOrigin
+   *          the origin of the modifier which adds the event
+   * @return A {@link Map>} of mediapackage ID and {@link Period} where the event occurs
+   * @throws UnauthorizedException
+   *           if the caller is not authorized to take this action
+   * @throws SchedulerConflictException
+   *           if there are conflicting events
+   * @throws SchedulerTransactionLockException
+   *           if there is a conflict with an open transaction
+   * @throws SchedulerException
+   *           if creating new events failed
+   */
+  Map<String, Period> addMultipleEvents(RRule rRule, Date start, Date end, Long duration, TimeZone tz,
+          String captureAgentId, Set<String> userIds, MediaPackage templateMp, Map<String,
+          String> wfProperties, Map<String, String> caMetadata, Opt<Boolean> optOut, Opt<String> schedulingSource,
+          String modificationOrigin) throws UnauthorizedException,
+          SchedulerConflictException, SchedulerTransactionLockException, SchedulerException;
+
+  /**
    * Updates event with specified ID.
    *
    * Default capture agent properties are created from DublinCore. Following values are generated:
@@ -432,6 +486,24 @@ public interface SchedulerService {
    */
   ReviewStatus getReviewStatus(String mediaPackageId)
           throws NotFoundException, UnauthorizedException, SchedulerException;
+
+  /**
+   * Returns a list of {@link Period}s which would be scheduled between a start and end date with a given recurrence
+   * rule. Note that this method does not actually schedule anything, merely calculates where things *would* be scheduled.
+   *
+   * @param rrule
+   *          The {@link RRule} defining the recurrence rules
+   * @param start
+   *          The start date and time
+   * @param end
+   *          The end date and time
+   * @param duration
+   *          The duration for each event
+   * @param tz
+   *          The timezone to schedule in
+   * @return The list of Periods which would be scheduled
+   */
+  List<Period> calculatePeriods(RRule rrule, Date start, Date end, long duration, TimeZone tz);
 
   /**
    * Query

--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -40,6 +40,7 @@ import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.Log.getHumanReadableTimeString;
 import static org.opencastproject.util.RequireUtil.notEmpty;
 import static org.opencastproject.util.RequireUtil.notNull;
+import static org.opencastproject.util.RequireUtil.requireTrue;
 import static org.opencastproject.util.data.Monadics.mlist;
 
 import org.opencastproject.assetmanager.api.Asset;
@@ -62,21 +63,30 @@ import org.opencastproject.assetmanager.api.query.PropertyField;
 import org.opencastproject.assetmanager.api.query.PropertySchema;
 import org.opencastproject.authorization.xacml.XACMLUtils;
 import org.opencastproject.index.IndexProducer;
+import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageElements;
+import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.MediaPackageSupport;
+import org.opencastproject.mediapackage.identifier.Id;
+import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.message.broker.api.MessageReceiver;
 import org.opencastproject.message.broker.api.MessageSender;
 import org.opencastproject.message.broker.api.index.AbstractIndexProducer;
 import org.opencastproject.message.broker.api.index.IndexRecreateObject;
 import org.opencastproject.message.broker.api.index.IndexRecreateObject.Service;
 import org.opencastproject.message.broker.api.scheduler.SchedulerItem;
+import org.opencastproject.metadata.dublincore.DCMIPeriod;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreUtil;
+import org.opencastproject.metadata.dublincore.DublinCoreValue;
 import org.opencastproject.metadata.dublincore.DublinCores;
+import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
 import org.opencastproject.metadata.dublincore.EventCatalogUIAdapter;
+import org.opencastproject.metadata.dublincore.Precision;
 import org.opencastproject.scheduler.api.Blacklist;
 import org.opencastproject.scheduler.api.ConflictHandler;
 import org.opencastproject.scheduler.api.ConflictNotifier;
@@ -108,6 +118,8 @@ import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.DateTimeSupport;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.OsgiUtil;
+import org.opencastproject.util.XmlNamespaceBinding;
+import org.opencastproject.util.XmlNamespaceContext;
 import org.opencastproject.util.data.Effect0;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.Tuple;
@@ -121,6 +133,7 @@ import com.entwinemedia.fn.data.Opt;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+import net.fortuna.ical4j.model.Period;
 import net.fortuna.ical4j.model.ValidationException;
 import net.fortuna.ical4j.model.property.RRule;
 
@@ -138,7 +151,9 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -148,6 +163,8 @@ import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -615,6 +632,166 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       throw e;
     } catch (Exception e) {
       logger.error("Failed to create event with id '{}': {}", mediaPackageId, getStackTrace(e));
+      throw new SchedulerException(e);
+    }
+  }
+
+
+  public Map<String, Period> addMultipleEvents(RRule rRule, Date start, Date end, Long duration, TimeZone tz,
+          String captureAgentId, Set<String> userIds, MediaPackage templateMp, Map<String, String> wfProperties,
+          Map<String, String> caMetadata, Opt<Boolean> optOut, Opt<String> schedulingSource, String modificationOrigin)
+          throws UnauthorizedException, SchedulerConflictException, SchedulerTransactionLockException, SchedulerException {
+    List<Period> periods = calculatePeriods(rRule, start, end, duration, tz);
+    return addMultipleEventInternal(periods, captureAgentId, userIds, templateMp, wfProperties, caMetadata,
+            modificationOrigin, optOut, schedulingSource, Opt.<String> none());
+  }
+
+
+  private Map<String, Period> addMultipleEventInternal(List<Period> periods, String captureAgentId,
+          Set<String> userIds, MediaPackage templateMp, Map<String, String> wfProperties,
+          Map<String, String> caMetadata, String modificationOrigin, Opt<Boolean> optOutStatus,
+          Opt<String> schedulingSource, Opt<String> trxId)
+                  throws SchedulerException {
+    notNull(periods, "periods");
+    requireTrue(periods.size() > 0, "periods");
+    notEmpty(captureAgentId, "captureAgentId");
+    notNull(userIds, "userIds");
+    notNull(templateMp, "mediaPackages");
+    notNull(wfProperties, "wfProperties");
+    notNull(caMetadata, "caMetadata");
+    notEmpty(modificationOrigin, "modificationOrigin");
+    notNull(optOutStatus, "optOutStatus");
+    notNull(schedulingSource, "schedulingSource");
+    notNull(trxId, "trxId");
+
+    Map<String, Period> scheduledEvents = new LinkedHashMap<>();
+
+    try {
+      LinkedList<Id> ids = new LinkedList<>();
+      AQueryBuilder qb = assetManager.createQuery();
+      Predicate p = null;
+      //While we don't have a list of IDs equal to the number of periods
+      while (ids.size() <= periods.size()) {
+        //Create a list of IDs equal to the number of periods, along with a set of AM predicates
+        while (ids.size() <= periods.size()) {
+          Id id = new IdImpl(UUID.randomUUID().toString());
+          ids.add(id);
+          Predicate np = qb.mediaPackageId(id.compact());
+          //Haha, p = np jokes with the AM query language. Ha. Haha. Ha.  (Sob...)
+          if (null == p) {
+            p = np;
+          } else {
+            p = p.or(np);
+          }
+        }
+        //Select the list of ids which alread exist.  Hint: this needs to be zero
+        AResult result = qb.select(qb.nothing()).where(withOrganization(qb).and(p).and(qb.version().isLatest())).run();
+        //If there is conflict, clear the list and start over
+        if (result.getTotalSize() > 0) {
+          ids.clear();
+        }
+      }
+
+
+      Opt<String> seriesId = Opt.nul(StringUtils.trimToNull(templateMp.getSeries()));
+      // Get opt out status
+      boolean optOut = getOptOutStatus(seriesId, optOutStatus);
+
+      if (trxId.isNone()) {
+        // Check for locked transactions
+        if (schedulingSource.isSome() && persistence.hasTransaction(schedulingSource.get())) {
+          logger.warn("Unable to add events, source '{}' is currently locked due to an active transaction!",
+                  schedulingSource.get());
+          throw new SchedulerTransactionLockException("Unable to add event, locked source " + schedulingSource.get());
+        }
+
+        // Check for conflicting events if not opted out
+        if (!optOut) {
+          List<MediaPackage> conflictingEvents = findConflictingEvents(periods, captureAgentId, TimeZone.getDefault());
+          if (conflictingEvents.size() > 0) {
+            logger.info("Unable to add events, conflicting events found: {}", conflictingEvents);
+            throw new SchedulerConflictException("Unable to add event, conflicting events found");
+          }
+        }
+      }
+
+      //counter for index into the list of mediapackages
+      int counter = 0;
+      for (Period event : periods) {
+        MediaPackage mediaPackage = (MediaPackage) templateMp.clone();
+        Date startDate = new Date(event.getStart().getTime());
+        Date endDate = new Date(event.getEnd().getTime());
+        Id id = ids.get(counter);
+
+        //Get, or make, the DC catalog
+        DublinCoreCatalog dc;
+        Opt<DublinCoreCatalog> dcOpt = DublinCoreUtil.loadEpisodeDublinCore(workspace,
+                templateMp);
+        if (dcOpt.isSome()) {
+          dc = dcOpt.get();
+          dc = (DublinCoreCatalog) dc.clone();
+          // make sure to bind the OC_PROPERTY namespace
+          dc.addBindings(XmlNamespaceContext
+                  .mk(XmlNamespaceBinding.mk(DublinCores.OC_PROPERTY_NS_PREFIX, DublinCores.OC_PROPERTY_NS_URI)));
+        } else {
+          dc = DublinCores.mkOpencastEpisode().getCatalog();
+        }
+
+        // Set the new media package identifier
+        mediaPackage.setIdentifier(id);
+
+        // Update dublincore title and temporal
+        String newTitle = dc.getFirst(DublinCore.PROPERTY_TITLE) + String.format(" %0" + Integer.toString(periods.size()).length() + "d", ++counter);
+        dc.set(DublinCore.PROPERTY_TITLE, newTitle);
+        DublinCoreValue eventTime = EncodingSchemeUtils.encodePeriod(new DCMIPeriod(startDate, endDate),
+                Precision.Second);
+        dc.set(DublinCore.PROPERTY_TEMPORAL, eventTime);
+        mediaPackage = updateDublincCoreCatalog(mediaPackage, dc);
+        mediaPackage.setTitle(newTitle);
+
+        String mediaPackageId = mediaPackage.getIdentifier().compact();
+        //Converting from iCal4j DateTime objects to plain Date objects to prevent AMQ issues below
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        cal.setTime(event.getStart());
+        Date startDateTime = cal.getTime();
+        cal.setTime(event.getEnd());
+        Date endDateTime = cal.getTime();
+        // Load dublincore and acl for update
+        Opt<DublinCoreCatalog> dublinCore = DublinCoreUtil.loadEpisodeDublinCore(workspace, mediaPackage);
+        Option<AccessControlList> acl = authorizationService.getAcl(mediaPackage, AclScope.Episode);
+
+        // Get updated agent properties
+        Map<String, String> finalCaProperties = getFinalAgentProperties(caMetadata, wfProperties, captureAgentId,
+                seriesId, dublinCore);
+
+        // Persist asset
+        String checksum = calculateChecksum(workspace, getEventCatalogUIAdapterFlavors(), startDateTime, endDateTime,
+                captureAgentId, userIds, mediaPackage, dublinCore, wfProperties, finalCaProperties, optOut, acl.toOpt().getOr(new AccessControlList()));
+        persistEvent(mediaPackageId, modificationOrigin, checksum, Opt.some(startDateTime), Opt.some(endDateTime), Opt.some(captureAgentId), Opt.some(userIds), Opt.some(mediaPackage), Opt.some(wfProperties),
+                Opt.some(finalCaProperties), Opt.some(optOut), schedulingSource, trxId);
+
+        if (trxId.isNone()) {
+          // Send updates
+          sendUpdateAddEvent(mediaPackageId, acl.toOpt(), dublinCore, Opt.some(startDateTime), Opt.some(endDateTime),
+                  Opt.some(userIds), Opt.some(captureAgentId), Opt.some(finalCaProperties), Opt.some(optOut));
+
+          // Update last modified
+          touchLastEntry(captureAgentId);
+        }
+        scheduledEvents.put(mediaPackageId, event);
+        for (MediaPackageElement mediaPackageElement : mediaPackage.getElements()) {
+          try {
+            workspace.delete(mediaPackage.getIdentifier().toString(), mediaPackageElement.getIdentifier());
+          } catch (NotFoundException | IOException e) {
+            logger.warn("Failed to delete media package element", e);
+          }
+        }
+      }
+      return scheduledEvents;
+    } catch (SchedulerException e) {
+      throw e;
+    } catch (Exception e) {
+      logger.error("Failed to create events: {}", getStackTrace(e));
       throw new SchedulerException(e);
     }
   }
@@ -1338,49 +1515,29 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     notNull(end, "end");
     notNull(tz, "timeZone");
 
+    final List<Period> periods = calculatePeriods(rrule, start, end, duration, tz);
+    return findConflictingEvents(periods, captureAgentId, tz);
+  }
+
+    private List<MediaPackage> findConflictingEvents(List<Period> periods, String captureAgentId, TimeZone tz)
+          throws SchedulerException {
+    notEmpty(captureAgentId, "captureAgentId");
+    notNull(periods, "periods");
+    requireTrue(periods.size() > 0, "periods");
+
     try {
       final ARecord[] alreadyScheduledEvents = getScheduledEvents(Opt.some(captureAgentId));
       final TimeZone timeZone = TimeZone.getDefault();
-      final TimeZone utc = TimeZone.getTimeZone("UTC");
-      TimeZone.setDefault(tz);
-      net.fortuna.ical4j.model.DateTime seed = new net.fortuna.ical4j.model.DateTime(start);
-      net.fortuna.ical4j.model.DateTime period = new net.fortuna.ical4j.model.DateTime();
-
-      Calendar endCalendar = Calendar.getInstance(utc);
-      endCalendar.setTime(end);
-      Calendar calendar = Calendar.getInstance(utc);
-      calendar.setTime(seed);
-      calendar.set(Calendar.DAY_OF_MONTH, endCalendar.get(Calendar.DAY_OF_MONTH));
-      calendar.set(Calendar.MONTH, endCalendar.get(Calendar.MONTH));
-      calendar.set(Calendar.YEAR, endCalendar.get(Calendar.YEAR));
-      period.setTime(calendar.getTime().getTime() + duration);
-      duration = duration % (DateTimeConstants.MILLIS_PER_DAY);
+      final TimeZone utc = TimeZone.getTimeZone("utc");
 
       Set<MediaPackage> events = new HashSet<>();
 
-      TimeZone.setDefault(utc);
-      for (Object date : rrule.getRecur().getDates(seed, period, net.fortuna.ical4j.model.parameter.Value.DATE_TIME)) {
-        Date d = (Date) date;
-        Calendar cDate = Calendar.getInstance(utc);
-
-        // Adjust for DST, if start of event
-        if (tz.inDaylightTime(seed)) { // Event starts in DST
-          if (!tz.inDaylightTime(d)) { // Date not in DST?
-            d.setTime(d.getTime() + tz.getDSTSavings()); // Adjust for Fall back one hour
-          }
-        } else { // Event doesn't start in DST
-          if (tz.inDaylightTime(d)) {
-            d.setTime(d.getTime() - tz.getDSTSavings()); // Adjust for Spring forward one hour
-          }
-        }
-        cDate.setTime(d);
-
-        TimeZone.setDefault(timeZone);
-        final Date startDate = cDate.getTime();
-        final Date endDate = new Date(cDate.getTimeInMillis() + duration);
+      for (Period event : periods) {
+        TimeZone.setDefault(utc);
+        final Date startDate = event.getStart();
+        final Date endDate = event.getEnd();
 
         events.addAll(findConflictingEvents(startDate, endDate, alreadyScheduledEvents));
-        TimeZone.setDefault(utc);
       }
 
       TimeZone.setDefault(timeZone);
@@ -1389,6 +1546,55 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       logger.error("Failed to search for conflicting events: {}", getStackTrace(e));
       throw new SchedulerException(e);
     }
+  }
+
+  //NOTE: Do not modify this without making the same modifications to the copy of this method in IndexServiceImplTest, and SchedulerServiceRemoteImpl
+  //I would have moved this to an abstract class in the scheduler-api bundle, but that would introduce a circular dependency :(
+  @Override
+  public List<Period> calculatePeriods(RRule rrule, Date start, Date end, long duration, TimeZone tz) {
+    final TimeZone timeZone = TimeZone.getDefault();
+    final TimeZone utc = TimeZone.getTimeZone("UTC");
+    TimeZone.setDefault(tz);
+    net.fortuna.ical4j.model.DateTime periodStart = new net.fortuna.ical4j.model.DateTime(start);
+    net.fortuna.ical4j.model.DateTime periodEnd = new net.fortuna.ical4j.model.DateTime();
+
+    Calendar endCalendar = Calendar.getInstance(utc);
+    endCalendar.setTime(end);
+    Calendar calendar = Calendar.getInstance(utc);
+    calendar.setTime(periodStart);
+    calendar.set(Calendar.DAY_OF_MONTH, endCalendar.get(Calendar.DAY_OF_MONTH));
+    calendar.set(Calendar.MONTH, endCalendar.get(Calendar.MONTH));
+    calendar.set(Calendar.YEAR, endCalendar.get(Calendar.YEAR));
+    periodEnd.setTime(calendar.getTime().getTime() + duration);
+    duration = duration % (DateTimeConstants.MILLIS_PER_DAY);
+
+    List<Period> events = new LinkedList<>();
+
+    TimeZone.setDefault(utc);
+    for (Object date : rrule.getRecur().getDates(periodStart, periodEnd, net.fortuna.ical4j.model.parameter.Value.DATE_TIME)) {
+      Date d = (Date) date;
+      Calendar cDate = Calendar.getInstance(utc);
+
+      // Adjust for DST, if start of event
+      if (tz.inDaylightTime(periodStart)) { // Event starts in DST
+        if (!tz.inDaylightTime(d)) { // Date not in DST?
+          d.setTime(d.getTime() + tz.getDSTSavings()); // Adjust for Fall back one hour
+        }
+      } else { // Event doesn't start in DST
+        if (tz.inDaylightTime(d)) {
+          d.setTime(d.getTime() - tz.getDSTSavings()); // Adjust for Spring forward one hour
+        }
+      }
+      cDate.setTime(d);
+
+      TimeZone.setDefault(timeZone);
+      Period p = new Period(new net.fortuna.ical4j.model.DateTime(cDate.getTime()),
+              new net.fortuna.ical4j.model.DateTime(cDate.getTimeInMillis() + duration));
+      events.add(p);
+      TimeZone.setDefault(utc);
+    }
+    TimeZone.setDefault(timeZone);
+    return events;
   }
 
   @Override
@@ -1929,6 +2135,36 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       return Opt.none();
 
     return record.bind(recordToMp);
+  }
+
+  /**
+   *
+   * @param mp
+   *          the mediapackage to update
+   * @param dc
+   *          the dublincore metadata to use to update the mediapackage
+   * @return the updated mediapackage
+   * @throws IOException
+   *           Thrown if an IO error occurred adding the dc catalog file
+   * @throws MediaPackageException
+   *           Thrown if an error occurred updating the mediapackage or the mediapackage does not contain a catalog
+   */
+  private MediaPackage updateDublincCoreCatalog(MediaPackage mp, DublinCoreCatalog dc)
+          throws IOException, MediaPackageException {
+    try (InputStream inputStream = IOUtils.toInputStream(dc.toXmlString(), "UTF-8")) {
+      // Update dublincore catalog
+      Catalog[] catalogs = mp.getCatalogs(MediaPackageElements.EPISODE);
+      if (catalogs.length > 0) {
+        Catalog catalog = catalogs[0];
+        URI uri = workspace.put(mp.getIdentifier().toString(), catalog.getIdentifier(), "dublincore.xml", inputStream);
+        catalog.setURI(uri);
+        // setting the URI to a new source so the checksum will most like be invalid
+        catalog.setChecksum(null);
+      } else {
+        throw new MediaPackageException("Unable to find catalog");
+      }
+    }
+    return mp;
   }
 
   private TechnicalMetadata getTechnicalMetadata(ARecord record, Props p) {

--- a/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1680,6 +1680,16 @@ public class SchedulerServiceImplTest {
   }
 
   @Test
+  public void testRecurringRecording() throws Exception {
+    RRule rrule = new RRule("FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA");
+
+    //GDLGDL Needs test
+    /*List<MediaPackage> events = schedSvc.findConflictingEvents("Device A",
+            , start, new Date(start.getTime() + hours(48)),
+            new Long(seconds(36)), TimeZone.getTimeZone("America/Chicago"));*/
+  }
+
+  @Test
   public void testGetArchivedOnly() throws Exception {
     MediaPackage mediaPackage = generateEvent(Opt.some("1"));
     Version version = assetManager.takeSnapshot("test", mediaPackage).getVersion();

--- a/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/UtilTests.java
+++ b/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/UtilTests.java
@@ -22,6 +22,8 @@ package org.opencastproject.scheduler.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import org.opencastproject.scheduler.api.Util;
+
 import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.Period;
 import net.fortuna.ical4j.model.property.RRule;

--- a/modules/matterhorn-scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
+++ b/modules/matterhorn-scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
@@ -53,7 +53,9 @@ import org.opencastproject.util.UrlSupport;
 
 import com.entwinemedia.fn.data.Opt;
 
+import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.Period;
+import net.fortuna.ical4j.model.parameter.Value;
 import net.fortuna.ical4j.model.property.RRule;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -862,8 +864,8 @@ public class SchedulerServiceRemoteImpl extends RemoteBase implements SchedulerS
     final TimeZone timeZone = TimeZone.getDefault();
     final TimeZone utc = TimeZone.getTimeZone("UTC");
     TimeZone.setDefault(tz);
-    net.fortuna.ical4j.model.DateTime periodStart = new net.fortuna.ical4j.model.DateTime(start);
-    net.fortuna.ical4j.model.DateTime periodEnd = new net.fortuna.ical4j.model.DateTime();
+    DateTime periodStart = new DateTime(start);
+    DateTime periodEnd = new DateTime();
 
     Calendar endCalendar = Calendar.getInstance(utc);
     endCalendar.setTime(end);
@@ -878,7 +880,7 @@ public class SchedulerServiceRemoteImpl extends RemoteBase implements SchedulerS
     List<Period> events = new LinkedList<>();
 
     TimeZone.setDefault(utc);
-    for (Object date : rrule.getRecur().getDates(periodStart, periodEnd, net.fortuna.ical4j.model.parameter.Value.DATE_TIME)) {
+    for (Object date : rrule.getRecur().getDates(periodStart, periodEnd, Value.DATE_TIME)) {
       Date d = (Date) date;
       Calendar cDate = Calendar.getInstance(utc);
 
@@ -895,8 +897,8 @@ public class SchedulerServiceRemoteImpl extends RemoteBase implements SchedulerS
       cDate.setTime(d);
 
       TimeZone.setDefault(timeZone);
-      Period p = new Period(new net.fortuna.ical4j.model.DateTime(cDate.getTime()),
-              new net.fortuna.ical4j.model.DateTime(cDate.getTimeInMillis() + duration));
+      Period p = new Period(new DateTime(cDate.getTime()),
+              new DateTime(cDate.getTimeInMillis() + duration));
       events.add(p);
       TimeZone.setDefault(utc);
     }


### PR DESCRIPTION
Per the description in MH-12651, this ticket moves a bunch of the recurring scheduling logic out of the index service(!) and into the scheduler where it belongs.  This also allows us to be much more efficient with our conflict checks, generating a single large check rather than a separate smaller one for each event.

*Work sponsored by UCT*