### PR TITLE
MH-12692: update maven bundle plugin for java8

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -28,7 +28,7 @@
     <bundle>mvn:javax.el/javax.el-api/3.0.0</bundle>
     <bundle>mvn:javax.servlet.jsp/javax.servlet.jsp-api/2.3.1</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
-    <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1.1/2.8.0</bundle>
+    <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr339-api-2.0.1/2.6.0</bundle>
 
     <!-- JPA -->
     <feature>jndi</feature>

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -430,6 +430,8 @@
             <Import-Package>
               net.fortuna.ical4j.*,
               org.opencastproject.index.service.message,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Private-Package>

--- a/modules/annotation-impl/pom.xml
+++ b/modules/annotation-impl/pom.xml
@@ -126,6 +126,11 @@
               OSGI-INF/annotation-service.xml,
               OSGI-INF/annotation-service-rest.xml
             </Service-Component>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Meta-Persistence>
               META-INF/persistence.xml
             </Meta-Persistence>

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -205,6 +205,8 @@
               org.eclipse.persistence.internal.weaving,
               org.eclipse.persistence.queries,
               org.eclipse.persistence.sessions,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Export-Package> 

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -195,6 +195,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.authorization.xacml.manager.api;version=${project.version},
               org.opencastproject.authorization.xacml.manager.impl;version=${project.version},

--- a/modules/caption-impl/pom.xml
+++ b/modules/caption-impl/pom.xml
@@ -86,6 +86,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.caption.impl;version=${project.version},
               org.opencastproject.caption.endpoint;version=${project.version},

--- a/modules/capture-admin-service-impl/pom.xml
+++ b/modules/capture-admin-service-impl/pom.xml
@@ -143,6 +143,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package> org.opencastproject.capture.admin.*;version=${project.version} </Export-Package>
             <Service-Component>
               OSGI-INF/capture-admin-service.xml,

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -292,6 +292,9 @@
               !org.mozilla.javascript.*,
               !org.python.*,
               !org.zeroturnaround.javarebel.*,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              javax.ws.rs.ext;version=2.0.1,
               *
             </Import-Package>
             <Embed-Dependency>

--- a/modules/composer-ffmpeg/pom.xml
+++ b/modules/composer-ffmpeg/pom.xml
@@ -114,6 +114,8 @@
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
               !org.codehaus.plexus.*,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Export-Package>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -183,6 +183,8 @@
             <Import-Package>
               com.sun.image.codec.jpeg,
               org.w3c.dom,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Export-Package>

--- a/modules/distribution-service-adaptive-streaming-wowza/pom.xml
+++ b/modules/distribution-service-adaptive-streaming-wowza/pom.xml
@@ -83,7 +83,14 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.distribution.streaming;version=${opencast.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.distribution.streaming;version=${project.version}
+            </Export-Package>
             <Service-Component>
               OSGI-INF/distribution-service-streaming.xml
             </Service-Component>

--- a/modules/distribution-service-aws-s3/pom.xml
+++ b/modules/distribution-service-aws-s3/pom.xml
@@ -112,6 +112,8 @@
               com.amazonaws.auth.*,
               com.amazonaws.regions.*,
               com.amazonaws.services.s3.*,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *;resolution:=optional
             </Import-Package>
             <Service-Component>

--- a/modules/distribution-service-download/pom.xml
+++ b/modules/distribution-service-download/pom.xml
@@ -88,6 +88,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package> org.opencastproject.distribution.download;version=${project.version} </Export-Package>
             <Service-Component>
               OSGI-INF/distribution-service-download.xml

--- a/modules/distribution-service-streaming/pom.xml
+++ b/modules/distribution-service-streaming/pom.xml
@@ -88,6 +88,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package> org.opencastproject.distribution.streaming;version=${project.version} </Export-Package>
             <Service-Component>
               OSGI-INF/distribution-service-streaming.xml

--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -196,7 +196,11 @@
             <Http-Alias>/engage/paella/ui</Http-Alias>
             <Http-Classpath>/ui</Http-Classpath>
             <Http-Welcome>watch.html</Http-Welcome>
-            
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>org.opencastproject.engage.paella</Export-Package>
             <Service-Component>
               OSGI-INF/paella-config-file.xml

--- a/modules/engage-theodul-core/pom.xml
+++ b/modules/engage-theodul-core/pom.xml
@@ -78,6 +78,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>org.opencastproject.engage.theodul.manager.impl</Export-Package>
             <Private-Package>ui.*</Private-Package>
             <Service-Component>

--- a/modules/engage-theodul-plugin-controls/pom.xml
+++ b/modules/engage-theodul-plugin-controls/pom.xml
@@ -73,10 +73,14 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package> org.opencastproject.engage.theodul.plugin.controls;version=${project.version} </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-theodul-plugin-custom-mhConnection/pom.xml
+++ b/modules/engage-theodul-plugin-custom-mhConnection/pom.xml
@@ -73,10 +73,16 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.engage.theodul.plugin.custom.mhConnection;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.engage.theodul.plugin.custom.mhConnection;version=${project.version}
+            </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-theodul-plugin-custom-notifications/pom.xml
+++ b/modules/engage-theodul-plugin-custom-notifications/pom.xml
@@ -73,10 +73,16 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.engage.theodul.plugin.custom.notifications;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.engage.theodul.plugin.custom.notifications;version=${project.version}
+            </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-theodul-plugin-description/pom.xml
+++ b/modules/engage-theodul-plugin-description/pom.xml
@@ -73,10 +73,16 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.engage.theodul.plugin.description;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.engage.theodul.plugin.description;version=${project.version}
+            </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-theodul-plugin-tab-description/pom.xml
+++ b/modules/engage-theodul-plugin-tab-description/pom.xml
@@ -73,10 +73,16 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.engage.theodul.plugin.tab.description;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.engage.theodul.plugin.tab.description;version=${project.version}
+            </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-theodul-plugin-tab-shortcuts/pom.xml
+++ b/modules/engage-theodul-plugin-tab-shortcuts/pom.xml
@@ -74,10 +74,16 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.engage.theodul.plugin.tab.shortcuts;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.engage.theodul.plugin.tab.shortcuts;version=${project.version}
+            </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-theodul-plugin-tab-slidetext/pom.xml
+++ b/modules/engage-theodul-plugin-tab-slidetext/pom.xml
@@ -74,10 +74,16 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.engage.theodul.plugin.tab.slidetext;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.engage.theodul.plugin.tab.slidetext;version=${project.version}
+            </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-theodul-plugin-timeline-statistics/pom.xml
+++ b/modules/engage-theodul-plugin-timeline-statistics/pom.xml
@@ -74,10 +74,16 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.engage.theodul.plugin.timeline.statistics;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.engage.theodul.plugin.timeline.statistics;version=${project.version}
+            </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-theodul-plugin-video-videojs/pom.xml
+++ b/modules/engage-theodul-plugin-video-videojs/pom.xml
@@ -74,10 +74,16 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.engage.theodul.plugin.video.videojs;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.engage.theodul.plugin.video.videojs;version=${project.version}
+            </Export-Package>
             <Service-Component>
-                            OSGI-INF/engage-plugin.xml
-                        </Service-Component>
+              OSGI-INF/engage-plugin.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/execute-impl/pom.xml
+++ b/modules/execute-impl/pom.xml
@@ -89,6 +89,10 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.execute.impl.*;version=${project.version}
             </Export-Package>

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -231,13 +231,14 @@
               org.opencastproject.util,
               javax.servlet,
               javax.servlet.http,
-              javax.ws.rs,
               org.apache.commons.lang3,
               org.osgi.service.component,
               org.json.simple,
               org.json.simple.parser,
               org.osgi.framework,
               org.slf4j,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Private-Package>

--- a/modules/fileupload/pom.xml
+++ b/modules/fileupload/pom.xml
@@ -80,6 +80,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package> 
               org.opencastproject.fileupload.api;version=${project.version},
               org.opencastproject.fileupload.api.exception;version=${project.version},

--- a/modules/hello-world-impl/pom.xml
+++ b/modules/hello-world-impl/pom.xml
@@ -47,6 +47,11 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.helloworld.impl;version=${project.version},
               org.opencastproject.helloworld.impl.endpoint;version=${project.version}

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -24,6 +24,10 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+    </dependency>
     <!-- Opencast -->
     <dependency>
       <groupId>org.opencastproject</groupId>
@@ -229,6 +233,8 @@
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
               net.fortuna.ical4j.*,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Export-Package>

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -199,6 +199,8 @@
               !org.apache.tools.tar,
               !org.bouncycastle.crypto.*,
               org.w3c.dom;version=0,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Private-Package>

--- a/modules/inspection-service-ffmpeg/pom.xml
+++ b/modules/inspection-service-ffmpeg/pom.xml
@@ -103,7 +103,14 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package>org.opencastproject.inspection.ffmpeg.*;version=${project.version}</Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.inspection.ffmpeg.*;version=${project.version}
+            </Export-Package>
             <Service-Component>
               OSGI-INF/inspection-service.xml
             </Service-Component>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -297,6 +297,9 @@
               org.springframework.security.ldap.search,
               org.springframework.security.ldap.userdetails,
               org.xml.sax;version=0,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              javax.ws.rs.ext;version=2.0.1,
               *
             </Import-Package>
             <Export-Package>

--- a/modules/lti/pom.xml
+++ b/modules/lti/pom.xml
@@ -243,6 +243,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.lti;version=${project.version}
             </Export-Package>

--- a/modules/message-broker-impl/pom.xml
+++ b/modules/message-broker-impl/pom.xml
@@ -138,6 +138,8 @@
               org.opencastproject.message.broker.api.theme,
               org.opencastproject.message.broker.api.workflow,
               org.springframework.beans.factory.xml,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Embed-Dependency>

--- a/modules/oaipmh/pom.xml
+++ b/modules/oaipmh/pom.xml
@@ -137,6 +137,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.oaipmh;version=${project.version},
               org.opencastproject.oaipmh.harvester;version=${project.version},

--- a/modules/publication-service-oaipmh/pom.xml
+++ b/modules/publication-service-oaipmh/pom.xml
@@ -108,7 +108,14 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> org.opencastproject.publication.oaipmh;version=${project.version} </Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.publication.oaipmh;version=${project.version}
+            </Export-Package>
             <Service-Component>
               OSGI-INF/publication-service-oaipmh.xml
             </Service-Component>

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -164,6 +164,8 @@
               !oracle.xml.parser.*,
               !org.jaxen.*,
               !sun.security.util,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Embed-Dependency>

--- a/modules/runtime-info/pom.xml
+++ b/modules/runtime-info/pom.xml
@@ -85,7 +85,14 @@
             <Private-Package>
               org.opencastproject.runtimeinfo.rest
             </Private-Package>
-            <Export-Package>org.opencastproject.runtimeinfo</Export-Package>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+              org.opencastproject.runtimeinfo
+            </Export-Package>
             <Service-Component>
               OSGI-INF/info.xml
             </Service-Component>

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -212,6 +212,9 @@
             <Import-Package>
               net.fortuna.ical4j.*,
               org.w3c.dom;version=0,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              javax.ws.rs.ext;version=2.0.1,
               *
             </Import-Package>
             <Service-Component>

--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -172,6 +172,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.feed.impl.*;version=${project.version},
               org.opencastproject.search.impl.*;version=${project.version},

--- a/modules/series-service-impl/pom.xml
+++ b/modules/series-service-impl/pom.xml
@@ -151,6 +151,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.series.impl.solr;version=${project.version},
               org.opencastproject.series.impl.persistence;version=${project.version},

--- a/modules/series-service-remote/pom.xml
+++ b/modules/series-service-remote/pom.xml
@@ -64,6 +64,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.series.remote;version=${project.version}
             </Export-Package>

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -127,6 +127,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.serviceregistry.command;version=${project.version},
               org.opencastproject.serviceregistry.impl;version=${project.version},

--- a/modules/silencedetection-impl/pom.xml
+++ b/modules/silencedetection-impl/pom.xml
@@ -25,6 +25,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.silencedetection.impl.*;version=${project.version},
               org.opencastproject.silencedetection.endpoint.*;version=${project.version},

--- a/modules/smil-impl/pom.xml
+++ b/modules/smil-impl/pom.xml
@@ -94,6 +94,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               com.android.mms.dom;version=${project.version},
               com.android.mms.dom.events;version=${project.version},

--- a/modules/sox-impl/pom.xml
+++ b/modules/sox-impl/pom.xml
@@ -111,6 +111,8 @@
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
               !org.apache.ws.commons.*,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Private-Package>org.apache.xmlrpc.*</Private-Package>

--- a/modules/static-file-service-api/pom.xml
+++ b/modules/static-file-service-api/pom.xml
@@ -68,6 +68,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.staticfiles.api;version=${project.version},
               org.opencastproject.staticfiles.endpoint;version=${project.version}

--- a/modules/textanalyzer-impl/pom.xml
+++ b/modules/textanalyzer-impl/pom.xml
@@ -93,6 +93,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.textanalyzer.impl;version=${project.version}
               org.opencastproject.textanalyzer.impl.endpoint;version=${project.version}

--- a/modules/timelinepreviews-ffmpeg/pom.xml
+++ b/modules/timelinepreviews-ffmpeg/pom.xml
@@ -82,6 +82,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.timelinepreviews.ffmpeg;version=${project.version},
               org.opencastproject.timelinepreviews.ffmpeg.endpoint;version=${project.version}

--- a/modules/transcription-service-ibm-watson-impl/pom.xml
+++ b/modules/transcription-service-ibm-watson-impl/pom.xml
@@ -81,6 +81,10 @@
       <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
@@ -151,6 +155,11 @@
               OSGI-INF/ibm-watson-transcription-rest.xml,
               OSGI-INF/ibm-watson-transcription-service.xml
             </Service-Component>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Meta-Persistence>
               META-INF/persistence.xml
             </Meta-Persistence>

--- a/modules/urlsigning-service-impl/pom.xml
+++ b/modules/urlsigning-service-impl/pom.xml
@@ -77,6 +77,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.security.urlsigning,
               org.opencastproject.security.urlsigning.provider.impl,

--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -125,6 +125,8 @@
             <Import-Package>
               javax.servlet,
               javax.servlet.http,
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
             <Export-Package>

--- a/modules/usertracking-impl/pom.xml
+++ b/modules/usertracking-impl/pom.xml
@@ -123,6 +123,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package> org.opencastproject.usertracking.*;version=${project.version} </Export-Package>
             <Service-Component>
               OSGI-INF/usertracking-service.xml,

--- a/modules/videoeditor-ffmpeg-impl/pom.xml
+++ b/modules/videoeditor-ffmpeg-impl/pom.xml
@@ -25,6 +25,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.videoeditor.endpoint;version=${project.version},
               org.opencastproject.videoeditor.ffmpeg;version=${project.version},

--- a/modules/videosegmenter-ffmpeg/pom.xml
+++ b/modules/videosegmenter-ffmpeg/pom.xml
@@ -83,6 +83,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.videosegmenter.ffmpeg;version=${project.version},
               org.opencastproject.videosegmenter.ffmpeg.endpoint;version=${project.version}

--- a/modules/waveform-ffmpeg/pom.xml
+++ b/modules/waveform-ffmpeg/pom.xml
@@ -77,6 +77,11 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
             <Export-Package>
               org.opencastproject.waveform.ffmpeg;version=${project.version},
               org.opencastproject.waveform.endpoint;version=${project.version}

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -179,6 +179,8 @@
               org.opencastproject.mediapackage;version=${project.version},
               org.opencastproject.message.broker.api.index;version=${project.version},
               org.opencastproject.workspace.api;version=${project.version},
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *;resolution:=optional
             </Import-Package>
             <Export-Package>

--- a/modules/working-file-repository-service-impl/pom.xml
+++ b/modules/working-file-repository-service-impl/pom.xml
@@ -106,6 +106,8 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
               *;resolution:=optional
             </Import-Package>
             <Export-Package> org.opencastproject.workingfilerepository.impl;version=${project.version} </Export-Package>

--- a/modules/workspace-impl/pom.xml
+++ b/modules/workspace-impl/pom.xml
@@ -94,6 +94,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              javax.ws.rs.core;version=2.0.1,
               *;resolution:=optional
             </Import-Package>
             <Private-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.0.1</version>
+          <version>3.5.0</version>
           <inherited>true</inherited>
           <configuration>
             <instructions>


### PR DESCRIPTION
This commit updates the maven-bundle-plugin to 3.x, which updates the
“bnd” utility used to resolve osgi dependencies.

By upgrading the plugin, it fixes a bug (a known bug triggering an
`ArrayOutOfBoundsException`) which prevented Java 8 from being used in
production code. However, it also introduced an ambiguity. Both
“jsr311” and “jsr339” provide the Java package
“javax.rs.ws” (apparently, JSR-331 is JAX-RS 1.1 and JSR-339 is
version 2.0). This lead to an ambiguous import chain, for example in
`matterhorn-admin-ui-ng`.

The solution employed here is to force OSGI to use version 2 of the
“javax.rs.ws” package (and replacing a dependency in the
feature.xml). All the code using JAX-RS still compiles and runs.

This also fixes a bug in the pom of wowza, where using
`${opencast.version}` lead to a `NumberFormatException`.

Also, I couldn’t resist my OCD and fixed one or two indentation
mishaps in the vicinity of the bundle-plugin directives I was
changing.

This work is sponsored by plapadoo.