### PR TITLE
MH-12702 Special characters double-escaped in add user to group dialog

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/selectContainer.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/selectContainer.html
@@ -17,7 +17,7 @@
                     ng-disabled="disabled"
                     ng-init="markedForAddition = []"
                     ng-class="{ disabled: disabled , scrollable: 'true'}"
-                    ng-options="item.name|translate group by item[groupBy] for item in resource.available | filter: customFilter() | orderBy: 'name' : false"
+                    ng-options="item.name group by item[groupBy] for item in resource.available | filter: customFilter() | orderBy: 'name' : false"
                     loading-scroller="loadMore()"
                     style="min-height: 11em;"
                     ng-style="getHeight()"


### PR DESCRIPTION
- remove translate filter for option items

This removes all option item translation from 'adminNgSelectBox' to work around a translate filter bug. At the moment the component is not used in a context where translation are needed.

This work is sponsored by SWITCH.