### PR TITLE
MH-12655 Ampersand double-escaped in series title shown in metadata and filters

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
@@ -1,5 +1,5 @@
 <div ng-form="innerForm" ng-click="enterEditMode()">
-  &nbsp;<span ng-show="!editMode" ng-click="enterEditMode()">{{ ((params.value === '' || params.value === null || angular.isUndefined(params.value)) ? 'SELECT_NO_OPTIONS' : getLabel(params.value)) | translate }}</span>
+    &nbsp;<span ng-show="!editMode" ng-click="enterEditMode()" translate="{{((params.value === '' || params.value === null || angular.isUndefined(params.value)) ? 'SELECT_NO_OPTIONS' : getLabel(params.value))}}"></span>
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-click="enterEditMode()" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
   <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>


### PR DESCRIPTION
- translate string using directive instead of filter

This is a workaround for the translate filter bug and should not make any functional difference.

This work is sponsored by SWITCH.