### PR TITLE
MH-12706 Stop Zombie Workflows

### DIFF
--- a/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1315,26 +1315,30 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
         }
       }
 
-      // Before we persist this, extract the metadata
-      final MediaPackage updatedMediaPackage = workflowInstance.getMediaPackage();
-      populateMediaPackageMetadata(updatedMediaPackage);
-      String seriesId = updatedMediaPackage.getSeries();
-      if (seriesId != null && workflowInstance.getCurrentOperation() != null) {
-        // If the mediapackage contains a series, find the series ACLs and add the security information to the
-        // mediapackage
-        try {
+      MediaPackage updatedMediaPackage = null;
+      try {
+
+        // Before we persist this, extract the metadata
+        updatedMediaPackage = workflowInstance.getMediaPackage();
+
+        populateMediaPackageMetadata(updatedMediaPackage);
+
+        String seriesId = updatedMediaPackage.getSeries();
+        if (seriesId != null && workflowInstance.getCurrentOperation() != null) {
+          // If the mediapackage contains a series, find the series ACLs and add the security information to the
+          // mediapackage
+
           AccessControlList acl = seriesService.getSeriesAccessControl(seriesId);
-          Option<AccessControlList> activeSeriesAcl = authorizationService.getAcl(updatedMediaPackage,
-                 AclScope.Series);
+          Option<AccessControlList> activeSeriesAcl = authorizationService.getAcl(updatedMediaPackage, AclScope.Series);
           if (activeSeriesAcl.isNone() || !AccessControlUtil.equals(activeSeriesAcl.get(), acl))
             authorizationService.setAcl(updatedMediaPackage, AclScope.Series, acl);
-        } catch (SeriesException e) {
-          throw new WorkflowDatabaseException(e);
-        } catch (NotFoundException e) {
-          logger.warn("Series %s not found, unable to set ACLs", seriesId);
-        } catch (Exception e) {
-          logger.error("Error reading ACL from series {}: {}", seriesId, e);
         }
+      } catch (SeriesException e) {
+        throw new WorkflowDatabaseException(e);
+      } catch (NotFoundException e) {
+        logger.warn("Metadata for mediapackage {} could not be updated because it wasn't found", updatedMediaPackage, e);
+      } catch (Exception e) {
+        logger.error("Metadata for mediapackage {} could not be updated", updatedMediaPackage, e);
       }
 
       // Synchronize the job status with the workflow


### PR DESCRIPTION
When updating workflow instances (for example when stopping or suspending a workflow), handle the case that the metadata for the mediapackage can not be populated because they're no longer in the WFR without failing completely. Otherwise old workflows that have been running forever cannot be stopped.