### PR TITLE
MH-12707 urlsigning less strict

### DIFF
--- a/modules/matterhorn-urlsigning-common/src/main/java/org/opencastproject/urlsigning/utils/ResourceRequestUtil.java
+++ b/modules/matterhorn-urlsigning-common/src/main/java/org/opencastproject/urlsigning/utils/ResourceRequestUtil.java
@@ -284,7 +284,7 @@ public final class ResourceRequestUtil {
       try {
         String requestedPath = new URI(resourceUri).getPath();
         String policyPath = new URI(policy.getResource()).getPath();
-        if (!policyPath.equals(requestedPath)) {
+        if (!policyPath.endsWith(requestedPath)) {
           resourceRequest.setStatus(Status.Forbidden);
           resourceRequest.setRejectionReason(String.format(
                   "Forbidden because resource trying to be accessed '%s' doesn't match policy resource '%s'", resourceUri,


### PR DESCRIPTION
I tried to fix problems in the Wowza Stream security module. There I found a problem in URL verification. 

I am not even sure if this method is used in Opencast. I used it as a binding for the Wowoza stream security module.