### PR TITLE
MH-12713: Series cannot be created

### DIFF
--- a/modules/search/pom.xml
+++ b/modules/search/pom.xml
@@ -208,6 +208,7 @@
               !org.antlr.*,
               !org.apache.log4j.*,
               !org.apache.lucene.*,
+              !org.tartarus.snowball*,
               !org.apache.tomcat.*,
               !org.bouncycastle.*,
               !org.codehaus.groovy.*,

--- a/modules/solr/pom.xml
+++ b/modules/solr/pom.xml
@@ -104,6 +104,7 @@
             <Import-Package>
               !junit.framework,
               !org.apache.lucene.*,
+              !org.tartarus.snowball*,
               !org.mortbay.*,
               *
             </Import-Package>


### PR DESCRIPTION
Both of these modules embed these packages as part of Lucene,
and both also export them. Both do not import Lucene, though,
so they are guaranteed to use the embedded Lucene classes.
However, these in turn might end up using an incompatible version
of the snowball packages, depending on the order
in which `solr` and `search` are loaded.

See the [Jira issue](https://opencast.jira.com/browse/MH-12713) for more details.

This is not the nicest solution to this problem, as my comment there already implies, but it is at least consistent with what the bundle configuration of these modules already does (i.e. exclude Lucene (of which the snowball packages are a part in this case, from the `Import-Packages`).

This should fix the problem for now, but I am open to suggestions on how to do this better. I understand a bit more about OSGi and the bundle plugin now, but I am still unclear about a few practices in the Opencast codebase. Why would we want to export `org.tartarus.snowball` in the first place? I guess for sharing, as I already alluded to in my Jira comment, but wouldn't it be better to create an independent wrapper bundle for the Lucene stuff, then?

The other thing I mentioned in the comment---correctly versioning the imports and exports of `org.tartarus.snowball`---is unfortunately also very hard in this case, since Lucene does not seem to "publish" the version of the snowball stemmers they include, somehow. Also some of these packages are atuomatically generated, adding to the confusion.

I think for now this PR represents the best solution; in the long run, someone should overhaul the bundle plugin configuration (and maven dependencies, while they are at it ... :wink:) of all the Opencast modules. Maybe I'll make a Jira ticket for that ... :thinking: 