### PR TITLE
MH-12717 Preserve the mediapackage service owner when creating a new …

### DIFF
--- a/modules/matterhorn-conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
+++ b/modules/matterhorn-conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.event.handler;
 
-import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
 import static org.opencastproject.assetmanager.api.fn.Enrichments.enrich;
 
 import org.opencastproject.assetmanager.api.AssetManager;
@@ -222,7 +221,7 @@ public class AssetManagerUpdatedEventHandler {
 
         try {
           // Update the asset manager with the modified mediapackage
-          assetManager.takeSnapshot(DEFAULT_OWNER, mp);
+          assetManager.takeSnapshot(snapshot.getOwner(), mp);
         } catch (AssetManagerException e) {
           logger.error("Error updating mediapackage {}: {}", mp, e.getMessage());
         }


### PR DESCRIPTION
…snapshot for series metadata updates

A scheduled event must not have a new snapshot owner of 'default' when the previous snapshot is owned by the scheduler, otherwise it disappears from the recording calendar (details in MH-12717).
