### PR TITLE
MH-12711 improve xacml parser

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -2054,7 +2054,7 @@ public abstract class AbstractEventEndpoint {
     try {
       results = getIndex().getByQuery(query);
     } catch (SearchIndexException e) {
-      logger.error("The admin UI Search Index was not able to get the events list: {}", e);
+      logger.error("The admin UI Search Index was not able to get the events list:", e);
       return RestUtil.R.serverError();
     }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ThemesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ThemesEndpoint.java
@@ -237,7 +237,7 @@ public class ThemesEndpoint {
     try {
       results = searchIndex.getByQuery(query);
     } catch (SearchIndexException e) {
-      logger.error("The admin UI Search Index was not able to get the themes list: {}", e);
+      logger.error("The admin UI Search Index was not able to get the themes list:", e);
       return RestUtil.R.serverError();
     }
 

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/AbstractAclServiceRestEndpoint.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/AbstractAclServiceRestEndpoint.java
@@ -165,7 +165,7 @@ public abstract class AbstractAclServiceRestEndpoint {
       logger.info("Managed acl with id '{}' could not be found", managedAclId);
       throw new WebApplicationException(Status.BAD_REQUEST);
     } catch (AclServiceException e) {
-      logger.warn("Error updating series transition: {}", e);
+      logger.warn("Error updating series transition:", e);
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
     } catch (NotFoundException e) {
       throw e;
@@ -196,7 +196,7 @@ public abstract class AbstractAclServiceRestEndpoint {
               workflow);
       return JsonConv.full(t).toJson();
     } catch (AclServiceException e) {
-      logger.warn("Error updating episode transition: {}", e);
+      logger.warn("Error updating episode transition:", e);
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
     } catch (NotFoundException e) {
       throw e;
@@ -236,7 +236,7 @@ public abstract class AbstractAclServiceRestEndpoint {
       logger.info("Error adding series transition: transition with date {} already exists", applicationDate);
       throw new WebApplicationException(Status.CONFLICT);
     } catch (AclServiceException e) {
-      logger.warn("Error adding series transition: {}", e);
+      logger.warn("Error adding series transition:", e);
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
     } catch (Exception e) {
       logger.warn("Unable to parse the application date");
@@ -269,7 +269,7 @@ public abstract class AbstractAclServiceRestEndpoint {
       logger.info("Error adding episode transition: transition with date {} already exists", applicationDate);
       throw new WebApplicationException(Status.CONFLICT);
     } catch (AclServiceException e) {
-      logger.warn("Error adding episode transition: {}", e);
+      logger.warn("Error adding episode transition:", e);
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
     } catch (Exception e) {
       logger.warn("Unable to parse the application date");

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclScanner.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclScanner.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.authorization.xacml.manager.impl;
 
+import org.opencastproject.authorization.xacml.XACMLParsingException;
 import org.opencastproject.authorization.xacml.XACMLUtils;
 import org.opencastproject.authorization.xacml.manager.api.AclService;
 import org.opencastproject.authorization.xacml.manager.api.AclServiceException;
@@ -120,7 +121,7 @@ public class AclScanner implements ArtifactInstaller {
    * @throws IOException
    * @throws JAXBException
    */
-  private void addAcl(File artifact) throws IOException, JAXBException {
+  private void addAcl(File artifact) throws IOException, XACMLParsingException {
     List<Organization> organizations = organizationDirectoryService.getOrganizations();
 
     logger.debug("Adding Acl {}", artifact.getAbsolutePath());
@@ -163,7 +164,7 @@ public class AclScanner implements ArtifactInstaller {
    * @throws IOException
    * @throws JAXBException
    */
-  private void updateAcl(File artifact) throws IOException, JAXBException {
+  private void updateAcl(File artifact) throws IOException, XACMLParsingException {
     List<Organization> organizations = organizationDirectoryService.getOrganizations();
 
     logger.debug("Updating Acl {}", artifact.getAbsolutePath());
@@ -243,7 +244,7 @@ public class AclScanner implements ArtifactInstaller {
    * @throws FileNotFoundException
    * @throws JAXBException
    */
-  private AccessControlList parseToAcl(File artifact) throws FileNotFoundException, JAXBException {
+  private AccessControlList parseToAcl(File artifact) throws FileNotFoundException, XACMLParsingException {
     FileInputStream in = null;
     AccessControlList acl = null;
 

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/persistence/OsgiJpaAclTransitionDb.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/persistence/OsgiJpaAclTransitionDb.java
@@ -272,7 +272,7 @@ public final class OsgiJpaAclTransitionDb implements AclTransitionDb {
       em = emf.createEntityManager();
       return Misc.<EpisodeACLTransition> widen(getEpisodeEntities(episodeId, org.getId(), em));
     } catch (Exception e) {
-      logger.warn("Error parsing episode ACL: {}", e);
+      logger.warn("Error parsing episode ACL:", e);
       throw new AclTransitionDbException(e);
     } finally {
       if (em != null)
@@ -288,7 +288,7 @@ public final class OsgiJpaAclTransitionDb implements AclTransitionDb {
       em = emf.createEntityManager();
       return Misc.<SeriesACLTransition> widen(getSeriesEntities(seriesId, org.getId(), em));
     } catch (Exception e) {
-      logger.warn("Error parsing episode ACL: {}", e);
+      logger.warn("Error parsing episode ACL:", e);
       throw new AclTransitionDbException(e);
     } finally {
       if (em != null)
@@ -388,7 +388,7 @@ public final class OsgiJpaAclTransitionDb implements AclTransitionDb {
         return new TransitionResultImpl(Misc.<EpisodeACLTransition> widen(option(
                 getEpisodeEntity(transitionId, orgId, em)).list()), Collections.<SeriesACLTransition> nil());
       } catch (Exception e) {
-        logger.warn("Error parsing episode ACL: {}", e);
+        logger.warn("Error parsing episode ACL:", e);
         throw new AclTransitionDbException(e);
       } finally {
         if (em != null)
@@ -450,7 +450,7 @@ public final class OsgiJpaAclTransitionDb implements AclTransitionDb {
         return new TransitionResultImpl(Collections.<EpisodeACLTransition> nil(),
                 Misc.<SeriesACLTransition> widen(option(getSeriesEntity(transitionId, orgId, em)).list()));
       } catch (Exception e) {
-        logger.warn("Error parsing episode ACL: {}", e);
+        logger.warn("Error parsing episode ACL:", e);
         throw new AclTransitionDbException(e);
       } finally {
         if (em != null)

--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/impl/AclScannerTest.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/impl/AclScannerTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.opencastproject.authorization.xacml.XACMLParsingException;
 import org.opencastproject.authorization.xacml.manager.api.AclService;
 import org.opencastproject.authorization.xacml.manager.api.AclServiceFactory;
 import org.opencastproject.authorization.xacml.manager.api.EpisodeACLTransition;
@@ -53,7 +54,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.xml.bind.JAXBException;
 import javax.xml.bind.UnmarshalException;
 
 public class AclScannerTest {
@@ -170,8 +170,8 @@ public class AclScannerTest {
     try {
       aclScanner.install(file);
       fail("Should not be parsed.");
-    } catch (JAXBException e) {
-      assertTrue("The file can not be parsed.", e instanceof UnmarshalException);
+    } catch (XACMLParsingException e) {
+      assertTrue("The file can not be parsed.", e.getCause() instanceof UnmarshalException);
     }
   }
 
@@ -221,8 +221,8 @@ public class AclScannerTest {
     try {
       aclScanner.update(file);
       fail("Should not be parsed.");
-    } catch (JAXBException e) {
-      assertTrue("The file can not be parsed.", e instanceof UnmarshalException);
+    } catch (XACMLParsingException e) {
+      assertTrue("The file can not be parsed.", e.getCause() instanceof UnmarshalException);
     }
   }
 

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -383,7 +383,7 @@ public class XACMLAuthorizationService implements AuthorizationService {
       try {
         workspace.delete(a.getURI());
       } catch (Exception e) {
-        logger.warn("Unable to delete XACML file: {}", e);
+        logger.warn("Unable to delete XACML file:", e);
       }
       mp.remove(a);
     }
@@ -402,7 +402,7 @@ public class XACMLAuthorizationService implements AuthorizationService {
           return Option.option(acl);
         }
       } catch (Exception e) {
-        logger.error("Exception occured: {}", e);
+        logger.error("Exception occured:", e);
       }
     } else {
       logger.debug("URI {} not found", uri);
@@ -419,7 +419,7 @@ public class XACMLAuthorizationService implements AuthorizationService {
         return Option.option(acl);
       }
     } catch (Exception e) {
-      logger.error("Failed to produce Acl when reading file: {}", e);
+      logger.error("Failed to produce Acl when reading file:", e);
     }
     return Option.none();
   }

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLParsingException.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLParsingException.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.authorization.xacml;
+
+/**
+ * This exception may be thrown during parsing of a XACML.
+ */
+public class XACMLParsingException extends Exception {
+
+  /**
+   * Creates a new xacml parsing exception with the given error message.
+   *
+   * @param message
+   *          the error message
+   */
+  public XACMLParsingException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates a new xacml parsing exception with the given error message, caused by the given exception.
+   *
+   * @param message
+   *          the error message
+   * @param cause
+   *          the error cause
+   */
+  public XACMLParsingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Creates a new xacml parsing exception, caused by the given exception.
+   *
+   * @param cause
+   *          the error cause
+   */
+  public XACMLParsingException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
+++ b/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
@@ -56,10 +56,10 @@ import de.schlichtherle.io.FileOutputStream;
 /**
  * Tests XACML features of the security service
  */
-public class XacmlSecurityTest {
+public class XACMLSecurityTest {
 
   /** The logger */
-  protected static final Logger logger = LoggerFactory.getLogger(XacmlSecurityTest.class);
+  protected static final Logger logger = LoggerFactory.getLogger(XACMLSecurityTest.class);
 
   /** The username to use with the security service */
   protected final String currentUser = "me";

--- a/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/AbstractCoverImageService.java
+++ b/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/AbstractCoverImageService.java
@@ -263,7 +263,7 @@ public abstract class AbstractCoverImageService extends AbstractJobProducer impl
       tempFile = File.createTempFile(COVERIMAGE_WORKSPACE_COLLECTION, Long.toString(job.getId()) + "_" + suffix);
       log.debug("Created temporary file {}", tempFile);
     } catch (IOException e) {
-      log.warn("Error creating temporary file: {}", e);
+      log.warn("Error creating temporary file:", e);
       throw new CoverImageException("Error creating temporary file", e);
     }
     return tempFile;

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
@@ -595,7 +595,7 @@ public class MetadataField<A> {
           try {
             array = (JSONArray) parser.parse((String) arrayIn);
           } catch (ParseException e) {
-            throw new IllegalArgumentException("Unable to parse Mixed Iterable value into a JSONArray: {}", e);
+            throw new IllegalArgumentException("Unable to parse Mixed Iterable value into a JSONArray:", e);
           }
         } else {
           array = (JSONArray) arrayIn;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/WorkflowsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/WorkflowsListProvider.java
@@ -78,7 +78,7 @@ public class WorkflowsListProvider implements ResourceListProvider {
     try {
       workflowInstances = workflowService.getWorkflowInstances(q).getItems();
     } catch (WorkflowDatabaseException e) {
-      logger.error("Error by querying the workflow instances from the DB:  {}", e);
+      logger.error("Error by querying the workflow instances from the DB: ", e);
       throw new ListProviderException(e.getMessage(), e.getCause());
     }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/AccessInformationUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/AccessInformationUtil.java
@@ -82,7 +82,7 @@ public final class AccessInformationUtil {
       systemAclJson.put("name", managedAcl.getName());
     } catch (JSONException e) {
       // This should never happen, because the key is never null
-      logger.error("An unexpected error occured: {}", e);
+      logger.error("An unexpected error occured:", e);
     }
 
     return systemAclJson;
@@ -119,7 +119,7 @@ public final class AccessInformationUtil {
       transJson.put("done", trans.isDone());
     } catch (JSONException e) {
       // This should never happen, because the key is never null
-      logger.error("An unexpected error occured: {}", e);
+      logger.error("An unexpected error occured:", e);
       throw new IllegalStateException(e);
     }
 
@@ -154,7 +154,7 @@ public final class AccessInformationUtil {
       transJson.put("override_episodes", trans.isOverride());
     } catch (JSONException e) {
       // This should never happen, because the key is never null
-      logger.error("An unexpected error occured: {}", e);
+      logger.error("An unexpected error occured:", e);
       throw new IllegalStateException(e);
     }
 
@@ -189,7 +189,7 @@ public final class AccessInformationUtil {
       transJson.put("is_deleted", trans.isDelete());
     } catch (JSONException e) {
       // This should never happen, because the key is never null
-      logger.error("An unexpected error occured: {}", e);
+      logger.error("An unexpected error occured:", e);
       throw new IllegalStateException(e);
     }
 
@@ -235,7 +235,7 @@ public final class AccessInformationUtil {
         rolePrivileges.put(entry.getAction(), entry.isAllow());
       } catch (JSONException e) {
         // This should never happen, because the key is never null
-        logger.error("An unexpected error occured: {}", e);
+        logger.error("An unexpected error occured:", e);
       }
     }
 
@@ -245,7 +245,7 @@ public final class AccessInformationUtil {
         privilegesJson.put(privilege.getKey(), privilege.getValue());
       } catch (JSONException e) {
         // This should never happen, because the key is never null
-        logger.error("An unexpected error occured: {}", e);
+        logger.error("An unexpected error occured:", e);
       }
     }
     return privilegesJson;

--- a/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageBaseFacility.java
+++ b/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageBaseFacility.java
@@ -170,7 +170,7 @@ public class MessageBaseFacility {
         }
       } catch (JMSException e) {
         if (verbose) {
-          logger.error("Error while trying to close producer: {}", e);
+          logger.error("Error while trying to close producer:", e);
         }
       }
       producer = null;
@@ -181,7 +181,7 @@ public class MessageBaseFacility {
         }
       } catch (JMSException e) {
         if (verbose) {
-          logger.error("Error while trying to close session: {}", e);
+          logger.error("Error while trying to close session:", e);
         }
       }
       session = null;
@@ -192,7 +192,7 @@ public class MessageBaseFacility {
         }
       } catch (JMSException e) {
         if (verbose) {
-          logger.error("Error while trying to close session: {}", e);
+          logger.error("Error while trying to close session:", e);
         }
       }
       connection = null;

--- a/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageReceiverImpl.java
+++ b/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageReceiverImpl.java
@@ -97,7 +97,7 @@ public class MessageReceiverImpl extends MessageBaseFacility implements MessageR
           return consumer.receive();
     } catch (JMSException e) {
       if (e.getCause() instanceof InterruptedIOException || e.getCause() instanceof InterruptedException) {
-        logger.trace("Exception due to message receiver shutdown: {}", e);
+        logger.trace("Exception due to message receiver shutdown:", e);
       } else if (isConnected()) {
         logger.error("Unable to receive messages", e);
       }

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/HttpNotificationWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/HttpNotificationWorkflowOperationHandler.java
@@ -189,7 +189,7 @@ public class HttpNotificationWorkflowOperationHandler extends AbstractWorkflowOp
       request.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (UnsupportedEncodingException e) {
       throw new WorkflowOperationException(
-              "Error happened during the encoding of the event parameter as form parameter: {}", e);
+              "Error happened during the encoding of the event parameter as form parameter:", e);
     }
 
     // Execute the request

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
@@ -1292,7 +1292,7 @@ public class SchedulerRestService {
     try {
       mediaPackage = MediaPackageParser.getFromXml(mediaPackageXml);
     } catch (Exception e) {
-      logger.info("Could not parse media package: {}", e);
+      logger.info("Could not parse media package:", e);
       return Response.status(Status.BAD_REQUEST).build();
     }
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -2571,7 +2571,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
                     current++;
                   }
                 } catch (Exception e) {
-                  logger.warn("Unable to index scheduled instances: {}", e);
+                  logger.warn("Unable to index scheduled instances:", e);
                   throw new ServiceException(e.getMessage());
                 }
               }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
@@ -538,7 +538,7 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
 
           indexManager.add(mediaPackage.getA(), acl, deletionDate, modificationDate);
         } catch (Exception e) {
-          logger.error("Unable to index search instances: {}", e);
+          logger.error("Unable to index search instances:", e);
           if (retryToPopulateIndex(systemUserName)) {
             logger.warn("Trying to re-index search index later. Aborting for now.");
             return;

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -179,7 +179,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
           logger.info("Finished populating series search index");
         }
       } catch (Exception e) {
-        logger.warn("Unable to index series instances: {}", e);
+        logger.warn("Unable to index series instances:", e);
         throw new ServiceException(e.getMessage());
       } finally {
         securityService.setOrganization(null);
@@ -599,7 +599,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       }
       logger.info("Finished populating '{}' index with series.", indexName);
     } catch (Exception e) {
-      logger.warn("Unable to index series instances: {}", e);
+      logger.warn("Unable to index series instances:", e);
       throw new ServiceException(e.getMessage());
     }
 

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/solr/SeriesServiceSolrIndex.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/solr/SeriesServiceSolrIndex.java
@@ -978,7 +978,7 @@ public class SeriesServiceSolrIndex implements SeriesServiceIndex {
       try {
         dc = parseDublinCore(dcXML);
       } catch (IOException e) {
-        logger.error("Could not parse Dublin core: {}", e);
+        logger.error("Could not parse Dublin core:", e);
         throw new SeriesServiceDatabaseException(e);
       }
       return dc;
@@ -1046,7 +1046,7 @@ public class SeriesServiceSolrIndex implements SeriesServiceIndex {
         return response.getResults().get(0);
       }
     } catch (SolrServerException e) {
-      logger.error("Could not perform series retrieval: {}", e);
+      logger.error("Could not perform series retrieval:", e);
       throw new SeriesServiceDatabaseException(e);
     }
   }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -302,7 +302,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       jmxBeans.add(JmxUtil.registerMXBean(servicesStatistics, JMX_SERVICES_STATISTICS_TYPE));
       jmxBeans.add(JmxUtil.registerMXBean(jobsStatistics, JMX_JOBS_STATISTICS_TYPE));
     } catch (ServiceRegistryException e) {
-      logger.error("Error registering JMX statistic beans {}", e);
+      logger.error("Error registering JMX statistic beans", e);
     }
 
     // Find the jobs URL
@@ -342,7 +342,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         tracker = new RestServiceTracker(cc.getBundleContext());
         tracker.open(true);
       } catch (InvalidSyntaxException e) {
-        logger.error("Invalid filter syntax: {}", e);
+        logger.error("Invalid filter syntax:", e);
         throw new IllegalStateException(e);
       }
     }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/IncidentServiceEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/IncidentServiceEndpoint.java
@@ -284,7 +284,7 @@ public class IncidentServiceEndpoint {
       json.put("description", localization.getDescription());
       return Response.ok(json.toJSONString()).build();
     } catch (IncidentServiceException e) {
-      logger.warn("Unable to get job localization of jo incident: {}", e);
+      logger.warn("Unable to get job localization of jo incident:", e);
       throw new WebApplicationException(INTERNAL_SERVER_ERROR);
     }
   }

--- a/modules/static/src/main/java/org/opencastproject/fsresources/ResourceServlet.java
+++ b/modules/static/src/main/java/org/opencastproject/fsresources/ResourceServlet.java
@@ -246,7 +246,7 @@ public class ResourceServlet extends HttpServlet {
         logger.warn("Invalid XML in file " + aclFile.getAbsolutePath() + ", denying access by default");
       }
     } catch (XPathExpressionException e) {
-      logger.error("Wrong xPath expression: {}", e);
+      logger.error("Wrong xPath expression:", e);
     }
     return allowed;
   }

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowCleanupScanner.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowCleanupScanner.java
@@ -165,7 +165,7 @@ public class WorkflowCleanupScanner extends AbstractWorkflowBufferScanner implem
       try {
         getWorkflowService().cleanupWorkflowInstances(bufferForFailedJobs, WorkflowInstance.WorkflowState.FAILED);
       } catch (WorkflowDatabaseException e) {
-        logger.error("Unable to cleanup failed jobs: {}", e);
+        logger.error("Unable to cleanup failed jobs:", e);
       } catch (UnauthorizedException e) {
         logger.error("Workflow cleanup job doesn't have right to delete jobs!");
         throw new IllegalStateException(e);
@@ -176,7 +176,7 @@ public class WorkflowCleanupScanner extends AbstractWorkflowBufferScanner implem
       try {
         getWorkflowService().cleanupWorkflowInstances(bufferForSuccessfulJobs, WorkflowInstance.WorkflowState.SUCCEEDED);
       } catch (WorkflowDatabaseException e) {
-        logger.error("Unable to cleanup successful jobs: {}", e);
+        logger.error("Unable to cleanup successful jobs:", e);
       } catch (UnauthorizedException e) {
         logger.error("Workflow cleanup job doesn't have right to delete jobs!");
         throw new IllegalStateException(e);
@@ -187,7 +187,7 @@ public class WorkflowCleanupScanner extends AbstractWorkflowBufferScanner implem
       try {
         getWorkflowService().cleanupWorkflowInstances(bufferForStoppedJobs, WorkflowInstance.WorkflowState.STOPPED);
       } catch (WorkflowDatabaseException e) {
-        logger.error("Unable to cleanup stopped jobs: {}", e);
+        logger.error("Unable to cleanup stopped jobs:", e);
       } catch (UnauthorizedException e) {
         logger.error("Workflow cleanup job doesn't have right to delete jobs!");
         throw new IllegalStateException(e);


### PR DESCRIPTION
This patch introduces a new exception for when the parsing of an XACML fails, providing as much details about the cause of the failure as possible.

This issue was originally investigated because it was thought to be the cause for some actions in the admin ui (e.g. viewing event details) being no longer possible if the ACL of a series is broken (e.g. role missing) because the XACML parsing fails (see issue description), however it turned out that the parser was most likely not responsible for that since all exceptions are caught and dealt with pretty early on.

But by then I had written this, so here it is anyway!

Additionally this patch removes the unnecessary {} when logging some exceptions.

This work is sponsored by SWITCH.