### PR TITLE
MH-12728 Add LAST-MODIFIED to ical event properties

### DIFF
--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/CalendarGenerator.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/CalendarGenerator.java
@@ -40,6 +40,7 @@ import net.fortuna.ical4j.model.parameter.XParameter;
 import net.fortuna.ical4j.model.property.Attach;
 import net.fortuna.ical4j.model.property.CalScale;
 import net.fortuna.ical4j.model.property.Description;
+import net.fortuna.ical4j.model.property.LastModified;
 import net.fortuna.ical4j.model.property.Location;
 import net.fortuna.ical4j.model.property.ProdId;
 import net.fortuna.ical4j.model.property.RelatedTo;
@@ -122,7 +123,7 @@ public class CalendarGenerator {
    * @return true if the event could be added.
    */
   public boolean addEvent(MediaPackage mp, DublinCoreCatalog catalog, String agentId, Date start, Date end,
-          String captureAgentMetadata) {
+          Date lastModified, String captureAgentMetadata) {
     String eventId = mp.getIdentifier().compact();
 
     logger.debug("Creating iCaleandar VEvent from scheduled event '{}'", eventId);
@@ -141,6 +142,10 @@ public class CalendarGenerator {
     VEvent event = new VEvent(startDate, endDate, catalog.getFirst(DublinCore.PROPERTY_TITLE));
     try {
       event.getProperties().add(new Uid(eventId));
+
+      DateTime lastModifiedDate = new DateTime(lastModified);
+      lastModifiedDate.setUtc(true);
+      event.getProperties().add(new LastModified(lastModifiedDate));
 
       if (StringUtils.isNotEmpty(catalog.getFirst(DublinCore.PROPERTY_DESCRIPTION))) {
         event.getProperties().add(new Description(catalog.getFirst(DublinCore.PROPERTY_DESCRIPTION)));

--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1453,10 +1453,11 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         String agentId = record.getProperties().apply(Properties.getString(AGENT_CONFIG));
         Date start = record.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
         Date end = record.getProperties().apply(Properties.getDate(END_DATE_CONFIG));
+        Date lastModified = record.getSnapshot().get().getArchivalDate();
 
         // Add the entry to the calendar, skip it with a warning if adding fails
         try {
-          cal.addEvent(optMp.get(), catalogOpt.get(), agentId, start, end, toPropertyString(caMetadata));
+          cal.addEvent(optMp.get(), catalogOpt.get(), agentId, start, end, lastModified, toPropertyString(caMetadata));
         } catch (Exception e) {
           logger.warn("Error adding event '{}' to calendar, event is not recorded: {}", record.getMediaPackageId(),
                   getStackTrace(e));


### PR DESCRIPTION
Some CAs like Galicaster look to see if an event has changed by comparing a cached copy of the ical
with the ical fetched from the server (if a 200 response is received rather than not-modified).

The CA then wants to know which events have been modified. As metadata could have changed inside one
of the attachments (episode.xml, series.xml, etc.) it is hard for a CA to establish if a previously
known event has been updated - see https://github.com/teltek/Galicaster/issues/586

Adding the standard ical LAST-MODIFIED field can help CAs decide this quickly and efficiently.

LAST-MODIFIED is defined here:

https://www.ietf.org/rfc/rfc2445.txt 4.8.7.3 Last Modified

Purpose: The property specifies the date and time that the
information associated with the calendar component was last revised
in the calendar store.

and we can set this exactly by using the ArchivalDate field of the last version (snapshot) of the event
in the asset manager when we construct the ical calendar.

This is targeted at 4.x rather than 5.0 because it adds a standard iCal field and thus does not change
the API in any way that would present any difficulties to current CAs, and helps to resolve an operational issue.

The LAST-MODIFIED field is informational for the capture agent, and CAs are not required to use it.