### PR TITLE
MH-12725, ACL update causes schedule to disappear from CA calendar

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -100,7 +100,6 @@ import org.opencastproject.util.doc.rest.RestParameter.Type;
 import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
-import org.opencastproject.workflow.api.ConfiguredWorkflowRef;
 import org.opencastproject.workflow.api.WorkflowInstance;
 
 import com.entwinemedia.fn.data.Opt;
@@ -980,8 +979,7 @@ public class SeriesEndpoint {
     }
 
     try {
-      if (getAclService()
-              .applyAclToSeries(seriesId, accessControlList, override, Option.<ConfiguredWorkflowRef> none()))
+      if (getAclService().applyAclToSeries(seriesId, accessControlList, override, Option.none()))
         return ok();
       else {
         logger.warn("Unable to find series '{}' to apply the ACL.", seriesId);

--- a/modules/matterhorn-asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
+++ b/modules/matterhorn-asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
@@ -62,6 +62,16 @@ public interface AssetManager {
   Snapshot takeSnapshot(String owner, MediaPackage mp);
 
   /**
+   * Take a versioned snapshot of a media package using the owner of the last snapshot or the default owner if it
+   * does not exist.
+   *
+   * @param mediaPackage
+   *          The media package to snapshot
+   * @return A new snapshot
+   */
+  Snapshot takeSnapshot(MediaPackage mediaPackage);
+
+  /**
    * Get the asset that is uniquely identified by the triple {version, media package ID, media package element ID}.
    *
    * @param version the version

--- a/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
+++ b/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
@@ -42,6 +42,10 @@ public class AssetManagerDecorator implements AssetManager {
     return delegate.takeSnapshot(owner, mp);
   }
 
+  @Override public Snapshot takeSnapshot(MediaPackage mp) {
+    return delegate.takeSnapshot(mp);
+  }
+
   @Override public Opt<Asset> getAsset(Version version, String mpId, String mpeId) {
     return delegate.getAsset(version, mpId, mpeId);
   }

--- a/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
+++ b/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
@@ -140,6 +140,11 @@ public class OsgiAssetManager implements AssetManager {
   }
 
   @Override
+  public Snapshot takeSnapshot(MediaPackage mp) {
+    return delegate.takeSnapshot(mp);
+  }
+
+  @Override
   public Opt<Asset> getAsset(Version version, String mpId, String mpeId) {
     return delegate.getAsset(version, mpId, mpeId);
   }

--- a/modules/matterhorn-authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
+++ b/modules/matterhorn-authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
@@ -22,7 +22,6 @@
 package org.opencastproject.authorization.xacml.manager.impl;
 
 import static com.entwinemedia.fn.Stream.$;
-import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
 import static org.opencastproject.assetmanager.api.fn.Enrichments.enrich;
 import static org.opencastproject.authorization.xacml.manager.impl.Util.toAcl;
 import static org.opencastproject.util.data.Collections.list;
@@ -181,7 +180,7 @@ public final class AclServiceImpl implements AclService {
             // update in episode service
             MediaPackage mp = authorizationService.setAcl(episodeSvcMp, AclScope.Episode, acl).getA();
             if (assetManager != null)
-              assetManager.takeSnapshot(DEFAULT_OWNER, mp);
+              assetManager.takeSnapshot(mp);
           }
 
           // if none EpisodeACLTransition#isDelete returns true so delete the episode ACL
@@ -190,7 +189,7 @@ public final class AclServiceImpl implements AclService {
             // update in episode service
             MediaPackage mp = authorizationService.removeAcl(episodeSvcMp, AclScope.Episode);
             if (assetManager != null)
-              assetManager.takeSnapshot(DEFAULT_OWNER, mp);
+              assetManager.takeSnapshot(mp);
           }
 
         });
@@ -245,7 +244,7 @@ public final class AclServiceImpl implements AclService {
         for (MediaPackage mp : mediaPackages) {
           // remove episode xacml and update in archive service
           if (assetManager != null)
-            assetManager.takeSnapshot(DEFAULT_OWNER, authorizationService.removeAcl(mp, AclScope.Episode));
+            assetManager.takeSnapshot(authorizationService.removeAcl(mp, AclScope.Episode));
         }
       }
       // update in series service


### PR DESCRIPTION
This fixes the owner set for the newly updated snapshots in the asset
manager.

*Work sponsored by SWITCH*