### PR TITLE
MH-12730, Workflow Index Rebuild Performance

### DIFF
--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
@@ -89,6 +89,8 @@ import javax.persistence.Version;
                 + "WHERE j.dispatchable = true AND j.status IN :statuses AND j.id IN :jobids ORDER BY j.dateCreated"),
         @NamedQuery(name = "Job.undispatchable.status", query = "SELECT j FROM Job j where j.dispatchable = false and "
                 + "j.status in :statuses order by j.dateCreated"),
+        @NamedQuery(name = "Job.payload", query = "SELECT j.payload FROM Job j where j.operation = :operation "
+                + "order by j.dateCreated"),
         @NamedQuery(name = "Job.processinghost.status", query = "SELECT j FROM Job j "
                 + "where j.status in :statuses and j.processorServiceRegistration is not null and "
                 + "j.processorServiceRegistration.serviceType = :serviceType and "

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistry.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistry.java
@@ -493,6 +493,17 @@ public interface ServiceRegistry {
   List<Job> getJobs(String serviceType, Status status) throws ServiceRegistryException;
 
   /**
+   * Return the payload of all jobs for a specified operation type.
+   *
+   * @param operation
+   *          Operation type to get payload for
+   * @return Serialized workflows
+   * @throws ServiceRegistryException
+   *          if there is a problem accessing the service registry
+   */
+  List<String> getJobPayloads(String operation) throws ServiceRegistryException;
+
+  /**
    * Get the list of active jobs.
    *
    * @return list of active jobs

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
@@ -707,6 +707,22 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
     return result;
   }
 
+  @Override
+  public List<String> getJobPayloads(String operation) throws ServiceRegistryException {
+    List<String> result = new ArrayList<>();
+    for (String serializedJob : jobs.values()) {
+      try {
+        Job job = JobParser.parseJob(serializedJob);
+        if (operation.equals(job.getOperation())) {
+          result.add(job.getPayload());
+        }
+      } catch (IOException e) {
+        throw new IllegalStateException("Error unmarshaling job", e);
+      }
+    }
+    return result;
+  }
+
   /**
    * {@inheritDoc}
    *

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -1750,6 +1750,20 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
 
   }
 
+  @Override
+  public List<String> getJobPayloads(String operation) throws ServiceRegistryException {
+    EntityManager em = emf.createEntityManager();
+    try {
+      Query query = em.createNativeQuery("SELECT j.payload FROM oc_job j "
+              + "where j.operation = #operation order by j.date_created");
+      query.setParameter("operation", operation);
+      logger.debug("Requesting job payloads using query: {}", query);
+      return (List<String>) query.getResultList();
+    } catch (Exception e) {
+      throw new ServiceRegistryException(e);
+    }
+  }
+
   /**
    * {@inheritDoc}
    *

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -1754,11 +1754,10 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   public List<String> getJobPayloads(String operation) throws ServiceRegistryException {
     EntityManager em = emf.createEntityManager();
     try {
-      Query query = em.createNativeQuery("SELECT j.payload FROM oc_job j "
-              + "where j.operation = #operation order by j.date_created");
+      TypedQuery<String> query = em.createNamedQuery("Job.payload", String.class);
       query.setParameter("operation", operation);
       logger.debug("Requesting job payloads using query: {}", query);
-      return (List<String>) query.getResultList();
+      return query.getResultList();
     } catch (Exception e) {
       throw new ServiceRegistryException(e);
     }

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2394,7 +2394,6 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
     final String destinationId = WorkflowItem.WORKFLOW_QUEUE_PREFIX + indexName.substring(0, 1).toUpperCase()
             + indexName.substring(1);
-    logger.warn("index name: {}", destinationId);
     if (workflows.size() > 0) {
       final int total = workflows.size();
       logger.info("Populating index '{}' with {} workflows", indexName, total);

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -68,11 +68,9 @@ import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.serviceregistry.api.UndispatchableJobException;
-import org.opencastproject.util.JobUtil;
 import org.opencastproject.util.Log;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Effect0;
-import org.opencastproject.util.data.Function0;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.jmx.JmxUtil;
 import org.opencastproject.workflow.api.ResumableWorkflowOperationHandler;
@@ -109,10 +107,8 @@ import com.google.common.util.concurrent.Striped;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.commons.lang3.text.WordUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.framework.ServiceException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
@@ -2394,71 +2390,44 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
   @Override
   public void repopulate(final String indexName) throws Exception {
-    List<Job> jobs = new ArrayList<>();
-    try {
-      for (Job job : serviceRegistry.getJobs(WorkflowService.JOB_TYPE, null)) {
-        if (WorkflowServiceImpl.Operation.START_WORKFLOW.toString().equals(job.getOperation())) {
-          jobs.add(job);
-        }
-      }
-    } catch (ServiceRegistryException e) {
-      logger.error("Unable to load the workflows jobs: {}", e.getMessage());
-      throw new ServiceException(e.getMessage());
-    }
+    List<String> workflows =  serviceRegistry.getJobPayloads(Operation.START_WORKFLOW.toString());
 
-    final String destinationId = WorkflowItem.WORKFLOW_QUEUE_PREFIX + WordUtils.capitalize(indexName);
-    if (jobs.size() > 0) {
-      logger.info("Populating index '{}' with {} workflows", indexName, jobs.size());
-      final int total = jobs.size();
+    final String destinationId = WorkflowItem.WORKFLOW_QUEUE_PREFIX + indexName.substring(0, 1).toUpperCase()
+            + indexName.substring(1);
+    logger.warn("index name: {}", destinationId);
+    if (workflows.size() > 0) {
+      final int total = workflows.size();
+      logger.info("Populating index '{}' with {} workflows", indexName, total);
       final int responseInterval = (total < 100) ? 1 : (total / 100);
-      final int[] errors = new int[1];
-      errors[0] = 0;
-      final int[] current = new int[1];
-      current[0] = 1;
-      for (final Job job : jobs) {
-        if (job.getPayload() == null) {
-          logger.warn("Skipping restoring of workflow {}: Payload is empty", job.getId());
+      int current = 0;
+      for (final String workflow : workflows) {
+        current += 1;
+        if (StringUtils.isEmpty(workflow)) {
+          logger.warn("Skipping restoring of workflow no {}: Payload is empty", current);
           continue;
         }
-        Organization organization = organizationDirectoryService.getOrganization(job.getOrganization());
-        boolean erroneousWorkflowJob = SecurityUtil.runAs(securityService, organization,
-                SecurityUtil.createSystemUser(componentContext, organization), new Function0<Boolean>() {
+        WorkflowInstance instance;
+        try {
+          instance = WorkflowParser.parseWorkflowInstance(workflow);
+        } catch (WorkflowParsingException e) {
+          logger.warn("Skipping restoring of workflow. Error parsing: {}", workflow, e);
+          continue;
+        }
+        Organization organization = instance.getOrganization();
+        SecurityUtil.runAs(securityService, organization,
+                SecurityUtil.createSystemUser(componentContext, organization), new Effect0() {
                   @Override
-                  public Boolean apply() {
-                    WorkflowInstance instance;
-                    try {
-                      instance = WorkflowParser.parseWorkflowInstance(job.getPayload());
-                      messageSender.sendObjectMessage(destinationId, MessageSender.DestinationType.Queue,
-                              WorkflowItem.updateInstance(instance));
-                      if (((current[0] % responseInterval) == 0) || (current[0] == total)) {
-                        messageSender.sendObjectMessage(IndexProducer.RESPONSE_QUEUE,
-                              MessageSender.DestinationType.Queue, IndexRecreateObject.update(indexName,
-                                      IndexRecreateObject.Service.Workflow, total, current[0]));
-                      }
-                      current[0] += 1;
-                      return false;
-                    } catch (WorkflowParsingException e) {
-                      logger.warn("Skipping restoring of workflow job {}: {}", job.getId(),
-                              ExceptionUtils.getMessage(e));
-                      errors[0] += 1;
-                    }
-                    return true;
+                  public void run() {
+                    // Send message to update index item
+                    messageSender.sendObjectMessage(destinationId, MessageSender.DestinationType.Queue,
+                            WorkflowItem.updateInstance(instance));
                   }
                 });
-
-        // Make sure this job is not being dispatched anymore
-        if (erroneousWorkflowJob && JobUtil.isReadyToDispatch(job)) {
-          job.setStatus(Job.Status.CANCELED);
-          try {
-            serviceRegistry.updateJob(job);
-            logger.info("Canceled job {} because unable to restore", job);
-          } catch (Exception e) {
-            logger.error("Error updating erroneous job {}: {}", job.getId(), e.getMessage());
-          }
+        if ((current % responseInterval == 0) || (current == total)) {
+          logger.info("Updating {} workflow index {}/{}: {} percent complete.", indexName, current, total,
+                  current * 100 / total);
         }
       }
-      if (errors[0] > 0)
-        logger.warn("Skipped {} erroneous workflows while populating the index", errors[0]);
     }
     logger.info("Finished populating {} index with workflows", indexName);
     Organization organization = new DefaultOrganization();

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndexTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndexTest.java
@@ -50,6 +50,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -73,7 +74,7 @@ public class WorkflowServiceSolrIndexTest {
     EasyMock.replay(orgDirectroy);
 
     // Create a job with a workflow as its payload
-    List<Job> jobs = new ArrayList<Job>();
+    List<Job> jobs = new ArrayList<>();
     Job job = new JobImpl();
     WorkflowInstanceImpl workflow = new WorkflowInstanceImpl();
     workflow.setId(123);
@@ -81,15 +82,18 @@ public class WorkflowServiceSolrIndexTest {
     workflow.setOrganization(securityService.getOrganization());
     workflow.setState(WorkflowState.INSTANTIATED);
     workflow.setMediaPackage(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());
-    job.setPayload(WorkflowParser.toXml(workflow));
+    String jobPayload = WorkflowParser.toXml(workflow);
+    job.setPayload(jobPayload);
     job.setOrganization(securityService.getOrganization().getId());
     jobs.add(job);
 
     // Mock up the service registry to return the job
-    ServiceRegistry serviceRegistry = EasyMock.createNiceMock(ServiceRegistry.class);
-    EasyMock.expect(serviceRegistry.count(WorkflowService.JOB_TYPE, null)).andReturn(new Long(1));
+    ServiceRegistry serviceRegistry = EasyMock.createMock(ServiceRegistry.class);
+    EasyMock.expect(serviceRegistry.count(WorkflowService.JOB_TYPE, null)).andReturn(1L);
     EasyMock.expect(serviceRegistry.getJobs(WorkflowService.JOB_TYPE, null)).andReturn(jobs);
     EasyMock.expect(serviceRegistry.getJob(123)).andReturn(job);
+    EasyMock.expect(serviceRegistry.getJobPayloads("START_WORKFLOW"))
+            .andReturn(Collections.singletonList(jobPayload));
     EasyMock.replay(serviceRegistry);
 
     MessageSender messageSender = EasyMock.createNiceMock(MessageSender.class);


### PR DESCRIPTION
For a workflow-index rebuild Opencast loads and deserializes far more
data that it actually needs. This may even lead to a system needing
hours before it can actually start the index rebuild or for the process
to fail due to the massive amount of required memory.

This patch tries to improve this behavior by requesting the specific
resources directly from the database and deserializing only what is
necessary.

Additionally, it will also avoid sending those messages via message
broker which would only be used for creating log messages. Instead, the
logging is executed directly.

*Work sponsored by SWITCH*