### PR TITLE
MH-12731, Improve Recreating Series Index

### DIFF
--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
@@ -29,7 +29,7 @@ import org.opencastproject.util.data.Tuple;
 
 import com.entwinemedia.fn.data.Opt;
 
-import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -102,7 +102,7 @@ public interface SeriesServiceDatabase {
    * @throws SeriesServiceDatabaseException
    *           if exception occurs
    */
-  Iterator<Tuple<DublinCoreCatalog, String>> getAllSeries() throws SeriesServiceDatabaseException;
+  List<Tuple<DublinCoreCatalog, String>> getAllSeries() throws SeriesServiceDatabaseException;
 
   /**
    * Retrieves ACL for series with given ID.

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
@@ -24,6 +24,7 @@ package org.opencastproject.series.impl;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.series.impl.persistence.SeriesEntity;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple;
 
@@ -102,7 +103,7 @@ public interface SeriesServiceDatabase {
    * @throws SeriesServiceDatabaseException
    *           if exception occurs
    */
-  List<Tuple<DublinCoreCatalog, String>> getAllSeries() throws SeriesServiceDatabaseException;
+  List<SeriesEntity> getAllSeries() throws SeriesServiceDatabaseException;
 
   /**
    * Retrieves ACL for series with given ID.

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -62,7 +62,6 @@ import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.commons.lang3.text.WordUtils;
 import org.osgi.framework.ServiceException;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
@@ -566,7 +565,8 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
 
   @Override
   public void repopulate(final String indexName) {
-    final String destinationId = SeriesItem.SERIES_QUEUE_PREFIX + WordUtils.capitalize(indexName);
+    final String destinationId = SeriesItem.SERIES_QUEUE_PREFIX + indexName.substring(0, 1).toUpperCase()
+            + indexName.substring(1);
     try {
       final int total = persistence.countSeries();
       logger.info("Re-populating '{}' index with series. There are {} series to add to the index.", indexName, total);
@@ -599,12 +599,12 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
                   }
                 });
         if ((current % responseInterval == 0) || (current == total)) {
-          logger.info("Updating {} series index {}/{}: {} percent complete.", indexName, current, total,
+          logger.info("Initializing {} series index rebuild {}/{}: {} percent", indexName, current, total,
                   current * 100 / total);
         }
         current++;
       }
-      logger.info("Finished populating '{}' index with series.", indexName);
+      logger.info("Finished initializing '{}' index rebuild", indexName);
     } catch (Exception e) {
       logger.warn("Unable to index series instances:", e);
       throw new ServiceException(e.getMessage());

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -36,7 +36,6 @@ import org.opencastproject.security.api.User;
 import org.opencastproject.series.impl.SeriesServiceDatabase;
 import org.opencastproject.series.impl.SeriesServiceDatabaseException;
 import org.opencastproject.util.NotFoundException;
-import org.opencastproject.util.data.Tuple;
 
 import com.entwinemedia.fn.data.Opt;
 
@@ -50,7 +49,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -238,29 +236,17 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
    */
   @SuppressWarnings("unchecked")
   @Override
-  public List<Tuple<DublinCoreCatalog, String>> getAllSeries() throws SeriesServiceDatabaseException {
+  public List<SeriesEntity> getAllSeries() throws SeriesServiceDatabaseException {
     EntityManager em = emf.createEntityManager();
     Query query = em.createNamedQuery("Series.findAll");
-    List<SeriesEntity> seriesEntities;
     try {
-      seriesEntities = query.getResultList();
+      return query.getResultList();
     } catch (Exception e) {
       logger.error("Could not retrieve all series: {}", e.getMessage());
       throw new SeriesServiceDatabaseException(e);
     } finally {
       em.close();
     }
-    List<Tuple<DublinCoreCatalog, String>> seriesList = new ArrayList<>(seriesEntities.size());
-    try {
-      for (SeriesEntity entity : seriesEntities) {
-        DublinCoreCatalog dc = parseDublinCore(entity.getDublinCoreXML());
-        seriesList.add(Tuple.tuple(dc, entity.getOrganization()));
-      }
-    } catch (Exception e) {
-      logger.error("Could not parse series entity: {}", e.getMessage());
-      throw new SeriesServiceDatabaseException(e);
-    }
-    return seriesList;
   }
 
   /*

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -50,8 +50,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -239,10 +238,10 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
    */
   @SuppressWarnings("unchecked")
   @Override
-  public Iterator<Tuple<DublinCoreCatalog, String>> getAllSeries() throws SeriesServiceDatabaseException {
+  public List<Tuple<DublinCoreCatalog, String>> getAllSeries() throws SeriesServiceDatabaseException {
     EntityManager em = emf.createEntityManager();
     Query query = em.createNamedQuery("Series.findAll");
-    List<SeriesEntity> seriesEntities = null;
+    List<SeriesEntity> seriesEntities;
     try {
       seriesEntities = query.getResultList();
     } catch (Exception e) {
@@ -251,7 +250,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } finally {
       em.close();
     }
-    List<Tuple<DublinCoreCatalog, String>> seriesList = new LinkedList<>();
+    List<Tuple<DublinCoreCatalog, String>> seriesList = new ArrayList<>(seriesEntities.size());
     try {
       for (SeriesEntity entity : seriesEntities) {
         DublinCoreCatalog dc = parseDublinCore(entity.getDublinCoreXML());
@@ -261,7 +260,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
       logger.error("Could not parse series entity: {}", e.getMessage());
       throw new SeriesServiceDatabaseException(e);
     }
-    return seriesList.iterator();
+    return seriesList;
   }
 
   /*

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/solr/SeriesServiceSolrIndex.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/solr/SeriesServiceSolrIndex.java
@@ -182,11 +182,8 @@ public class SeriesServiceSolrIndex implements SeriesServiceIndex {
       }
 
       Object syncIndexingConfig = cc.getProperties().get("synchronousIndexing");
-      if ((syncIndexingConfig != null) && ((syncIndexingConfig instanceof Boolean))) {
-        synchronousIndexing = ((Boolean) syncIndexingConfig).booleanValue();
-      } else {
-        synchronousIndexing = true;
-      }
+      synchronousIndexing = (syncIndexingConfig == null) || !(syncIndexingConfig instanceof Boolean)
+              || (Boolean) syncIndexingConfig;
     }
 
     activate();
@@ -210,9 +207,7 @@ public class SeriesServiceSolrIndex implements SeriesServiceIndex {
     } else {
       try {
         setupSolr(new File(solrRoot));
-      } catch (IOException e) {
-        throw new IllegalStateException("Unable to connect to solr at " + solrRoot, e);
-      } catch (SolrServerException e) {
+      } catch (IOException | SolrServerException e) {
         throw new IllegalStateException("Unable to connect to solr at " + solrRoot, e);
       }
     }

--- a/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/persistence/SeriesServicePersistenceTest.java
+++ b/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/persistence/SeriesServicePersistenceTest.java
@@ -41,7 +41,6 @@ import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
 import org.opencastproject.util.NotFoundException;
-import org.opencastproject.util.data.Tuple;
 
 import com.entwinemedia.fn.data.Opt;
 
@@ -117,7 +116,7 @@ public class SeriesServicePersistenceTest {
   public void testRetrieving() throws Exception {
     seriesDatabase.storeSeries(testCatalog);
 
-    List<Tuple<DublinCoreCatalog, String>> series = seriesDatabase.getAllSeries();
+    List series = seriesDatabase.getAllSeries();
     assertTrue("Exactly one series should be returned", series.size() == 1);
     seriesDatabase.deleteSeries(testCatalog.getFirst(DublinCoreCatalog.PROPERTY_IDENTIFIER));
     series = seriesDatabase.getAllSeries();

--- a/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/persistence/SeriesServicePersistenceTest.java
+++ b/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/persistence/SeriesServicePersistenceTest.java
@@ -51,7 +51,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStream;
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -118,11 +117,11 @@ public class SeriesServicePersistenceTest {
   public void testRetrieving() throws Exception {
     seriesDatabase.storeSeries(testCatalog);
 
-    Iterator<Tuple<DublinCoreCatalog, String>> series = seriesDatabase.getAllSeries();
-    assertTrue("Exactly one series should be returned", series.hasNext());
+    List<Tuple<DublinCoreCatalog, String>> series = seriesDatabase.getAllSeries();
+    assertTrue("Exactly one series should be returned", series.size() == 1);
     seriesDatabase.deleteSeries(testCatalog.getFirst(DublinCoreCatalog.PROPERTY_IDENTIFIER));
     series = seriesDatabase.getAllSeries();
-    assertFalse("Exactly zero series should be returned", series.hasNext());
+    assertTrue("Exactly zero series should be returned", series.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
This patch prohibits Opencast from sending out log messages via
ActiveMQ, effectively reducing the overall amount of messages,
introduces a progress logging for the series Solr index and simplifies
the re-indexing code.

*Work sponsored by SWITCH*