### PR TITLE
MH-12743, Don't republish OAIPMH to Amazon S3

### DIFF
--- a/modules/matterhorn-distribution-workflowoperation/src/main/resources/OSGI-INF/operations/republish-oaipmh.xml
+++ b/modules/matterhorn-distribution-workflowoperation/src/main/resources/OSGI-INF/operations/republish-oaipmh.xml
@@ -18,6 +18,7 @@
              interface="org.opencastproject.distribution.api.DownloadDistributionService"
              cardinality="1..1"
              policy="static"
+             target="(distribution.channel=download)"
              bind="setDistributionService" />
   <reference name="serviceRegistry"
              interface="org.opencastproject.serviceregistry.api.ServiceRegistry"


### PR DESCRIPTION
Add target distribution.channel=download to republish-OAIPMH workflow operation so that he doesn't try to use the AWS3DistributionService instead. (Similar to issue MH-12137).

This work is sponsored by SWITCH.