### PR TITLE
MH-12709: Replacing broken conflict detection logic

### DIFF
--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1250,13 +1250,12 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       final Date start = r.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
       final Date end = r.getProperties().apply(Properties.getDate(END_DATE_CONFIG));
       /*
-      If the start or end times are identical (.after and .before are strict comparisons) OR
       If the potential event starts during event r OR
       If the potential event ends during event r OR
-      If the potential event begins before, and ends after event r (ie, containment)
+      If the potential event begins before, and ends after event r (ie, containment) OR
+      If the potential event begins or ends within the minimum separation distance of event r
       */
-      if (checkStart.equals(start) || checkEnd.equals(end)
-       || checkStart.after(start) && checkStart.before(end)
+      if (checkStart.after(start) && checkStart.before(end)
        || checkEnd.after(start) && checkEnd.before(end)
        || checkStart.before(start) && checkEnd.after(end)
        || eventWithinMinimumSeparation(checkStart, checkEnd, start, end)) {

--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1211,7 +1211,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    * Returns a list of events which start and/or end within a given date range.  So you could search for things which start
    * on Tuesday between 0900 and 1000, and end between 1500 and 1600, and you could get an event which started at Epoch and
    * ended at 1559 on Tuesday.  This is *NOT* appropriate for conflict checking, and does not check for any edge cases.
-   * sUse checkScheduleConflicts instead.
+   * Use checkScheduleConflicts instead.
    */
   private List<MediaPackage> searchInternal(Opt<Date> startsFrom, Opt<Date> startsTo,
                                             Opt<Date> endFrom, Opt<Date> endTo, ARecord[] records) {

--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1278,10 +1278,10 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    * is within EVENT_MINIMUM_SEPARATION_SECONDS of either the start or end dates.  False otherwise
    */
   private boolean eventWithinMinimumSeparation(Date checkStart, Date checkEnd, Date start, Date end) {
-    if (Math.abs(checkStart.getTime() - start.getTime()) <= EVENT_MINIMUM_SEPARATION_MILLISECONDS
-        || Math.abs(checkStart.getTime() - end.getTime()) <= EVENT_MINIMUM_SEPARATION_MILLISECONDS
-        || Math.abs(checkEnd.getTime() - start.getTime()) <= EVENT_MINIMUM_SEPARATION_MILLISECONDS
-        || Math.abs(checkEnd.getTime() - end.getTime()) <= EVENT_MINIMUM_SEPARATION_MILLISECONDS) {
+    if (Math.abs(checkStart.getTime() - start.getTime()) < EVENT_MINIMUM_SEPARATION_MILLISECONDS
+        || Math.abs(checkStart.getTime() - end.getTime()) < EVENT_MINIMUM_SEPARATION_MILLISECONDS
+        || Math.abs(checkEnd.getTime() - start.getTime()) < EVENT_MINIMUM_SEPARATION_MILLISECONDS
+        || Math.abs(checkEnd.getTime() - end.getTime()) < EVENT_MINIMUM_SEPARATION_MILLISECONDS) {
       return true;
     }
     return false;

--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1207,6 +1207,12 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     return searchInternal(startsFrom, startsTo, endFrom, endTo, alreadyScheduledEvents);
   }
 
+  /*
+   * Returns a list of events which start and/or end within a given date range.  So you could search for things which start
+   * on Tuesday between 0900 and 1000, and end between 1500 and 1600, and you could get an event which started at Epoch and
+   * ended at 1559 on Tuesday.  This is *NOT* appropriate for conflict checking, and does not check for any edge cases.
+   * sUse checkScheduleConflicts instead.
+   */
   private List<MediaPackage> searchInternal(Opt<Date> startsFrom, Opt<Date> startsTo,
                                             Opt<Date> endFrom, Opt<Date> endTo, ARecord[] records) {
     final List<ARecord> result = new ArrayList<>();
@@ -1232,6 +1238,32 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     return Stream.mk(result).bind(recordToMp).toList();
   }
 
+  /*
+   * Returns a list of conflicting mediapackages.  This method checks for containment, starts-during, and ends-during.
+   */
+  private List<MediaPackage> checkScheduleConflicts(Date checkStart, Date checkEnd, ARecord[] records) {
+    final List<ARecord> result = new ArrayList<>();
+    for (final ARecord r : records) {
+      final Date start = r.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
+      final Date end = r.getProperties().apply(Properties.getDate(END_DATE_CONFIG));
+      if (checkStart.equals(start) || checkEnd.equals(end) ||      //If the start or end times are identical (.after and .before are strict comparisons)
+          checkStart.after(start) && checkStart.before(end) ||     //If the potential event starts during event r
+          checkEnd.before(end) && checkEnd.after(start) ||         //If the potential event ends during event r
+          checkStart.before(start) && checkEnd.after(end)) {       //If the potential event begins before, and ends after event r (ie, containment)
+        result.add(r);
+      }
+    }
+    result.sort(new Comparator<ARecord>() {
+      @Override
+      public int compare(ARecord o1, ARecord o2) {
+        Date start1 = o1.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
+        Date start2 = o2.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
+        return start1.compareTo(start2);
+      }
+    });
+    return Stream.mk(result).bind(recordToMp).toList();
+  }
+
   @Override
   public List<MediaPackage> findConflictingEvents(String captureDeviceID, Date startDate, Date endDate)
           throws SchedulerException {
@@ -1241,17 +1273,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
   private List<MediaPackage> findConflictingEvents(Date startDate, Date endDate, ARecord[] alreadyScheduledEvents)
           throws SchedulerException {
-    final List<MediaPackage> events = new ArrayList<>();
-    // overlap
-    events.addAll(searchInternal(Opt.<Date> none(), Opt.some(startDate), Opt.some(endDate),
-            Opt.<Date> none(), alreadyScheduledEvents));
-    // start between
-    events.addAll(searchInternal(Opt.some(startDate), Opt.some(endDate), Opt.<Date> none(),
-            Opt.<Date> none(), alreadyScheduledEvents));
-    // end between
-    events.addAll(searchInternal(Opt.<Date> none(), Opt.<Date> none(), Opt.some(startDate),
-            Opt.some(endDate), alreadyScheduledEvents));
-    return events;
+    return checkScheduleConflicts(startDate, endDate, alreadyScheduledEvents);
   }
 
   private List<String> preCollisionEventCheck(String trxId, String schedulingSource) throws SchedulerException {

--- a/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1895,6 +1895,12 @@ public class SchedulerServiceImplTest {
       //Event A contains event B entirely
       conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(23)), new Date(currentTime + hours(26)));
       assertEquals(1, conflicts.size());
+
+      //Event A ends with less than one minute before event B starts
+      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(23)), new Date(currentTime + hours(24) - seconds(1)));
+
+      //Event A begins than one minute after event B ends
+      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(25) + seconds(1)), new Date(currentTime + hours(27)));
     }
   }
 

--- a/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1871,6 +1871,31 @@ public class SchedulerServiceImplTest {
               new Long(seconds(36)), TimeZone.getTimeZone("America/Chicago"));
       assertEquals(2, events.size());
     }
+    {
+      //Event A starts before event B, and ends during event B
+      List<MediaPackage> conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(23) + minutes(30)), new Date(currentTime + hours(24) + minutes(30)));
+      assertEquals(1, conflicts.size());
+
+      //Event A starts during event B, and ends after event B
+      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(24) + minutes(30)), new Date(currentTime + hours(25) + minutes(30)));
+      assertEquals(1, conflicts.size());
+
+      //Event A starts at the same time as event B
+      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(24)), new Date(currentTime + hours(24) + minutes(30)));
+      assertEquals(1, conflicts.size());
+
+      //Event A ends at the same time as event B
+      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(24) + minutes(10)), new Date(currentTime + hours(25)));
+      assertEquals(1, conflicts.size());
+
+      //Event A is contained entirely within event B
+      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(24) + minutes(10)), new Date(currentTime + hours(24) + minutes(50)));
+      assertEquals(1, conflicts.size());
+
+      //Event A contains event B entirely
+      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(23)), new Date(currentTime + hours(26)));
+      assertEquals(1, conflicts.size());
+    }
   }
 
   @Test

--- a/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -2270,8 +2270,8 @@ public class SchedulerServiceImplTest {
     long offset = System.currentTimeMillis();
     for (int i = 0; i < number; i++) {
       MediaPackage mp = generateEvent(Opt.<String> none());
-      Date startDateTime = new Date(offset + 10 * 1000);
-      Date endDateTime = new Date(offset + 3610000);
+      Date startDateTime = new Date(offset + 10 * 1000 + i * SchedulerServiceImpl.EVENT_MINIMUM_SEPARATION_MILLISECONDS);
+      Date endDateTime = new Date(offset + 3610000 + i * SchedulerServiceImpl.EVENT_MINIMUM_SEPARATION_MILLISECONDS);
       offset = endDateTime.getTime();
       final DublinCoreCatalog event = generateEvent(agent, Opt.<String> none(), Opt.some(titlePrefix + "-" + i),
               startDateTime, endDateTime);

--- a/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1898,9 +1898,11 @@ public class SchedulerServiceImplTest {
 
       //Event A ends with less than one minute before event B starts
       conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(23)), new Date(currentTime + hours(24) - seconds(1)));
+      assertEquals(1, conflicts.size());
 
       //Event A begins than one minute after event B ends
       conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(25) + seconds(1)), new Date(currentTime + hours(27)));
+      assertEquals(1, conflicts.size());
     }
   }
 


### PR DESCRIPTION
The previous check searched for events which started or ended in a pair of windows.  This missed several edge cases, and was thus replaced.

*Work sponsored by UCT*