### PR TITLE
MH-12727: Fixing some OptimisticLockException

### DIFF
--- a/modules/matterhorn-common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
+++ b/modules/matterhorn-common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
@@ -170,6 +170,10 @@ public class JpaJob {
   @Temporal(TemporalType.TIMESTAMP)
   private Date dateCreated;
 
+  public Date getDateStarted() {
+    return dateStarted;
+  }
+
   @Column(name = "date_started")
   @Temporal(TemporalType.TIMESTAMP)
   private Date dateStarted;
@@ -190,6 +194,19 @@ public class JpaJob {
 
   @Column(name = "job_load")
   private Float jobLoad;
+
+  public String getBlockedJobIds() {
+    StringBuffer sb = new StringBuffer();
+    for (Long id : blockedJobIds) {
+      sb.append(id);
+      sb.append(" ");
+    }
+    return sb.toString();
+  }
+
+  public Long getBlockingJobId() {
+    return blockingJobId;
+  }
 
   /** The list of job IDs that are blocking this job from continuing. */
   @Column(name = "blocking_job_list")
@@ -440,6 +457,15 @@ public class JpaJob {
 
   public List<JpaJob> getChildJobs() {
     return childJobs;
+  }
+
+  public String getChildJobsString() {
+    StringBuilder sb = new StringBuilder();
+    for (JpaJob job : getChildJobs()) {
+      sb.append(job.getId());
+      sb.append(" ");
+    }
+    return sb.toString();
   }
 
   public FailureReason getFailureReason() {

--- a/modules/matterhorn-common/src/main/java/org/opencastproject/job/api/JobBarrier.java
+++ b/modules/matterhorn-common/src/main/java/org/opencastproject/job/api/JobBarrier.java
@@ -39,6 +39,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import javax.persistence.OptimisticLockException;
+
 /**
  * This class is a utility implementation that will wait for all given jobs to change their status to either one of:
  * <ul>
@@ -153,11 +155,17 @@ public final class JobBarrier {
         waiter.setStatus(Job.Status.WAITING);
         List<Long> blockedForJobs = new LinkedList<Long>();
         for (Job j : jobs) {
-          Job blockerJob = this.serviceRegistry.getJob(j.getId());
-          blockedForJobs.add(blockerJob.getId());
-          blockerJob.setBlockingJobId(waiter.getId());
-          // FYI not updating local j in jobs collection
-          this.serviceRegistry.updateJob(blockerJob);
+          try {
+            if (setBlockerJob(j, waiter)) {
+              blockedForJobs.add(j.getId());
+            }
+          } catch (OptimisticLockException e) {
+            // Try again, this happens if the job finishes before we get here
+            // If the same exception happens again then we're in a very weird state
+            if (setBlockerJob(j, waiter)) {
+              blockedForJobs.add(j.getId());
+            }
+          }
         }
         waiter.setBlockedJobIds(blockedForJobs);
         this.serviceRegistry.updateJob(waiter);
@@ -168,6 +176,29 @@ public final class JobBarrier {
       }
     } else {
       logger.debug("No waiting job set, unable to put waiting job into waiting state");
+    }
+  }
+
+  /**
+   * Sets j's blocking job ID (ie, the job which it is blocking) to waiter's ID
+   * @param j
+   *   The job doing the blocking
+   * @param waiter
+   *   The job blocking, waiting for its child to finish
+   * @return
+   *   True if j is an active job and has been successfully updated, false if it is not an active job
+   * @throws ServiceRegistryException
+   * @throws NotFoundException
+   */
+  private boolean setBlockerJob(Job j, Job waiter) throws ServiceRegistryException, NotFoundException {
+    Job blockerJob = this.serviceRegistry.getJob(j.getId());
+    if (j.getStatus().isActive()) {
+      blockerJob.setBlockingJobId(waiter.getId());
+      // FYI not updating local j in jobs collection
+      this.serviceRegistry.updateJob(blockerJob);
+      return true;
+    } else {
+      return false;
     }
   }
 


### PR DESCRIPTION
This code resolves an OptimisticLockException in the JobBarrier which causes deadlocks for workflow which encounter it.  This issue is caused by the child job being updated prior to the job barrier being able to update it, and then getting stuck in an inconsistent state.  Resolution involves restarting(!) the affected worker, which is less than idea in a high volume production system.

This PR also includes additional logging code which logs the job state when the same issue is encountered inside of the service registry.  This code does nothing but log, and could easily be removed if it is inappropriate for the upstream codebase - however debugging this issue is much harder without some more detailed information.

*Work sponsored by UCT*