### PR TITLE
MH-12747 Fix the JobProducerHeartbeat

### DIFF
--- a/modules/matterhorn-serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/matterhorn-serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -3231,69 +3231,75 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     @Override
     public void run() {
       logger.debug("Checking for unresponsive services");
-      List<ServiceRegistration> serviceRegistrations = getOnlineServiceRegistrations();
 
-      for (ServiceRegistration service : serviceRegistrations) {
-        hostsStatistics.updateHost(((ServiceRegistrationJpaImpl) service).getHostRegistration());
-        servicesStatistics.updateService(service);
-        if (!service.isJobProducer())
-          continue;
-        if (service.isInMaintenanceMode())
-          continue;
+      try {
+        List<ServiceRegistration> serviceRegistrations = getOnlineServiceRegistrations();
 
-        // We think this service is online and available. Prove it.
-        String serviceUrl = UrlSupport.concat(service.getHost(), service.getPath(), "dispatch");
-        HttpHead options = new HttpHead(serviceUrl);
-        HttpResponse response = null;
-        try {
+        for (ServiceRegistration service : serviceRegistrations) {
+          hostsStatistics.updateHost(((ServiceRegistrationJpaImpl) service).getHostRegistration());
+          servicesStatistics.updateService(service);
+          if (!service.isJobProducer())
+            continue;
+          if (service.isInMaintenanceMode())
+            continue;
+
+          // We think this service is online and available. Prove it.
+          String serviceUrl = UrlSupport.concat(service.getHost(), service.getPath(), "dispatch");
+
+          HttpHead options = new HttpHead(serviceUrl);
+          HttpResponse response = null;
           try {
-            response = client.execute(options);
-            if (response != null) {
-              switch (response.getStatusLine().getStatusCode()) {
-                case HttpStatus.SC_OK:
-                  // this service is reachable, continue checking other services
-                  logger.trace("Service " + service.toString() + " is responsive: " + response.getStatusLine());
-                  if (unresponsive.remove(service)) {
-                    logger.info("Service {} is still online", service);
-                  } else if (!service.isOnline()) {
-                    try {
-                      setOnlineStatus(service.getServiceType(), service.getHost(), service.getPath(), true, true);
-                      logger.info("Service {} is back online", service);
-                    } catch (ServiceRegistryException e) {
-                      logger.warn("Error setting online status for {}", service);
+            try {
+              response = client.execute(options);
+              if (response != null) {
+                switch (response.getStatusLine().getStatusCode()) {
+                  case HttpStatus.SC_OK:
+                    // this service is reachable, continue checking other services
+                    logger.trace("Service " + service.toString() + " is responsive: " + response.getStatusLine());
+                    if (unresponsive.remove(service)) {
+                      logger.info("Service {} is still online", service);
+                    } else if (!service.isOnline()) {
+                      try {
+                        setOnlineStatus(service.getServiceType(), service.getHost(), service.getPath(), true, true);
+                        logger.info("Service {} is back online", service);
+                      } catch (ServiceRegistryException e) {
+                        logger.warn("Error setting online status for {}", service);
+                      }
                     }
-                  }
-                  continue;
-                default:
-                  if (!service.isOnline())
                     continue;
-                  logger.warn("Service {} is not working as expected: {}", service, response.getStatusLine());
+                  default:
+                    if (!service.isOnline())
+                      continue;
+                    logger.warn("Service {} is not working as expected: {}", service, response.getStatusLine());
+                }
+              } else {
+                logger.warn("Service {} does not respond: {}", service.toString());
               }
-            } else {
-              logger.warn("Service {} does not respond: {}", service.toString());
+            } catch (TrustedHttpClientException e) {
+              if (!service.isOnline())
+                continue;
+              logger.warn("Unable to reach {} : {}", service, e);
             }
-          } catch (TrustedHttpClientException e) {
-            if (!service.isOnline())
-              continue;
-            logger.warn("Unable to reach {} : {}", service, e);
-          }
 
-          // If we get here, the service did not respond as expected
-          try {
-            if (unresponsive.contains(service)) {
-              unRegisterService(service.getServiceType(), service.getHost());
-              unresponsive.remove(service);
-              logger.warn("Marking {} as offline", service);
-            } else {
-              unresponsive.add(service);
-              logger.warn("Added {} to the watch list", service);
+            // If we get here, the service did not respond as expected
+            try {
+              if (unresponsive.contains(service)) {
+                unRegisterService(service.getServiceType(), service.getHost());
+                unresponsive.remove(service);
+                logger.warn("Marking {} as offline", service);
+              } else {
+                unresponsive.add(service);
+                logger.warn("Added {} to the watch list", service);
+              }
+            } catch (ServiceRegistryException e) {
+              logger.warn("Unable to unregister unreachable service: {} : {}", service, e);
             }
-          } catch (ServiceRegistryException e) {
-            logger.warn("Unable to unregister unreachable service: {} : {}", service, e);
+          } finally {
+            client.close(response);
           }
-        } finally {
-          client.close(response);
         }
+      } catch (Throwable t) {
+        logger.warn("Error while checking for unresponsive services", t);
       }
 
       logger.debug("Finished checking for unresponsive services");

--- a/modules/matterhorn-urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/AbstractUrlSigningProvider.java
+++ b/modules/matterhorn-urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/AbstractUrlSigningProvider.java
@@ -229,6 +229,12 @@ public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, 
 
   @Override
   public boolean accepts(String baseUrl) {
+
+    // Don't accept URLs without an organization context
+    // (for example from the ServiceRegistry JobProducerHeartbeat)
+    if (securityService.getOrganization() == null)
+      return false;
+
     String orgId = securityService.getOrganization().getId();
     try {
       new URI(baseUrl);


### PR DESCRIPTION
This was failing on first run because of an NPE in AbstractUrlSigningProvider because the
organization context was not set for the URL.

Also add a try/catch block around the code so that errors are reported, and that an error
in one run doesn't prevent it from being invoked in future.