### PR TITLE
MH-12746, Update Jackson

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -80,9 +80,9 @@
     <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/${json-simple.version}</bundle>
 
     <!-- AWS Bits -->
-    <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/2.6.0</bundle>
-    <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/2.6.6</bundle>
-    <bundle>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/2.6.6</bundle>
+    <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson.version}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson.version}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-cbor/${jackson.version}</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk/${aws.version}</bundle>
 
     <!-- Spring Framework / Security -->

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -71,7 +71,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.2.3</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <karaf.version>4.0.10</karaf.version>
     <pax.web.version>4.3.4</pax.web.version>
     <cxf.version>3.1.12</cxf.version>
-    <jackson.version>2.7.0</jackson.version>
+    <jackson.version>2.9.4</jackson.version>
     <functional.version>1.4.2</functional.version>
     <jdk.version>1.8</jdk.version>
   </properties>
@@ -1102,22 +1102,22 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.6.0</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.6.6</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.6.6</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.dataformat</groupId>
         <artifactId>jackson-dataformat-cbor</artifactId>
-        <version>2.6.6</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>


### PR DESCRIPTION
This patch updates jackson to the latest release version and uses the
`jackson.version* variable for all jackson dependencies.