### PR TITLE
MH-12755, Fix workflow-workflowoperation dependencies

### DIFF
--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -23,12 +23,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-authorization-manager</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-dublincore</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>


### PR DESCRIPTION
The workflow-workflowoperation bundle declares a dependency to
org.opencastproject:opencast-authorization-manager which is not used at
all and should hence be removed.