### PR TITLE
MH-12757, Fix ClassCastException

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalGroupLoader.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalGroupLoader.java
@@ -107,8 +107,6 @@ public class ExternalGroupLoader {
   /**
    * Creates initial groups for external applications per organization
    *
-   * @throws IOException
-   *           if loading of the role and user lists fails
    * @throws IllegalStateException
    *           if a specified role or user list is unavailable
    */
@@ -118,7 +116,11 @@ public class ExternalGroupLoader {
         @Override
         protected void run() {
           try {
-            JpaOrganization org = (JpaOrganization) organizationDirectoryService.getOrganization(organization.getId());
+            Organization testOrg = organizationDirectoryService.getOrganization(organization.getId());
+            if (!(testOrg instanceof JpaOrganization)) {
+              return;
+            }
+            JpaOrganization org = (JpaOrganization) testOrg;
 
             // External Applications
             String externalApplicationsGroupId = org.getId().toUpperCase().concat(EXTERNAL_GROUP_SUFFIX);
@@ -136,13 +138,7 @@ public class ExternalGroupLoader {
                       externalApplicationsGroupDescription, roles, new HashSet<String>());
               groupRoleProvider.addGroup(externalApplicationGroup);
             }
-          } catch (NotFoundException e) {
-            logger.error("Unable to load external API groups because {}", ExceptionUtils.getStackTrace(e));
-          } catch (IllegalStateException e) {
-            logger.error("Unable to load external API groups because {}", ExceptionUtils.getStackTrace(e));
-          } catch (IOException e) {
-            logger.error("Unable to load external API groups because {}", ExceptionUtils.getStackTrace(e));
-          } catch (UnauthorizedException e) {
+          } catch (NotFoundException | IllegalStateException | IOException | UnauthorizedException e) {
             logger.error("Unable to load external API groups because {}", ExceptionUtils.getStackTrace(e));
           }
         }


### PR DESCRIPTION
This fixes the issue but as discussed in chat, I'm unsure about this patch:

- The external API assumes that all Organizations are JPAOrganizations
- Does this not need to work with other organization types?
- Is it ok to just discard them?