### PR TITLE
MH-12758: Fix skipped AssetManagerDecorators

### DIFF
--- a/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
+++ b/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
@@ -54,7 +54,6 @@ import org.opencastproject.util.Checksum;
 import org.opencastproject.util.ChecksumType;
 import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
-import org.opencastproject.util.RequireUtil;
 import org.opencastproject.workspace.api.Workspace;
 
 import com.entwinemedia.fn.Fn;
@@ -107,7 +106,9 @@ public abstract class AbstractAssetManager implements AssetManager {
   /* ------------------------------------------------------------------------------------------------------------------ */
 
   @Override public Snapshot takeSnapshot(final String owner, final MediaPackage mp) {
-    RequireUtil.notEmpty(owner, "owner");
+    if (owner == null)
+      return takeSnapshot(mp);
+
     return handleException(new P1Lazy<Snapshot>() {
       @Override public Snapshot get1() {
         try {

--- a/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
+++ b/modules/matterhorn-asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
@@ -39,11 +39,11 @@ public class AssetManagerDecorator implements AssetManager {
   }
 
   @Override public Snapshot takeSnapshot(String owner, MediaPackage mp) {
-    return delegate.takeSnapshot(owner, mp);
+    return owner == null ? delegate.takeSnapshot(mp) : delegate.takeSnapshot(owner, mp);
   }
 
   @Override public Snapshot takeSnapshot(MediaPackage mp) {
-    return delegate.takeSnapshot(mp);
+    return takeSnapshot(null, mp);
   }
 
   @Override public Opt<Asset> getAsset(Version version, String mpId, String mpeId) {


### PR DESCRIPTION
PR #103 introduced the new `takeSnapshot(MediaPackage mediaPackage)` method which was not overriden in the `AssetManagerDecorator` sub classes. The decorators were thus effectively skipped completely. This PR adds an override to the two sub decorators.