### PR TITLE
Make Travis check for tabs in pom.xml files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,5 @@ install:
 
 script:
   - (! grep -rq '	' modules assemblies pom.xml --include=pom.xml)
+  - (! grep -rq ' $' modules assemblies pom.xml --include=pom.xml)
   - mvn --batch-mode clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pnone

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ install:
   - true
 
 script:
+  - (! grep -rq '	' modules assemblies pom.xml --include=pom.xml)
   - mvn --batch-mode clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pnone

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -209,7 +209,7 @@
               javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
-            <Export-Package> 
+            <Export-Package>
               org.opencastproject.assetmanager.impl;version=${project.version},
               org.opencastproject.assetmanager.impl.persistence;version=${project.version},
               org.opencastproject.assetmanager.impl.query;version=${project.version},

--- a/modules/asset-manager-util/pom.xml
+++ b/modules/asset-manager-util/pom.xml
@@ -129,7 +129,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> 
+            <Export-Package>
               org.opencastproject.assetmanager.util;version=${project.version}
             </Export-Package>
           </instructions>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-	 <batik.version>1.7</batik.version>
+    <batik.version>1.7</batik.version>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -14,7 +14,7 @@
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.opencastproject</groupId>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-    </dependency>            
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -93,8 +93,8 @@
         </plugins>
       </build>
     </profile>
-  
-  
+
+
     <profile>
       <id>frontend</id>
       <activation>
@@ -156,7 +156,7 @@
       </build>
     </profile>
   </profiles>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -204,7 +204,7 @@
             <Export-Package>org.opencastproject.engage.paella</Export-Package>
             <Service-Component>
               OSGI-INF/paella-config-file.xml
-            </Service-Component>            
+            </Service-Component>
           </instructions>
         </configuration>
         <executions>

--- a/modules/engage-theodul-plugin-tab-shortcuts/pom.xml
+++ b/modules/engage-theodul-plugin-tab-shortcuts/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-	 <skipJasmineTests>true</skipJasmineTests>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-tab-slidetext/pom.xml
+++ b/modules/engage-theodul-plugin-tab-slidetext/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-	 <skipJasmineTests>true</skipJasmineTests>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-timeline-statistics/pom.xml
+++ b/modules/engage-theodul-plugin-timeline-statistics/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-	 <skipJasmineTests>true</skipJasmineTests>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/engage-theodul-plugin-video-videojs/pom.xml
+++ b/modules/engage-theodul-plugin-video-videojs/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-	 <skipJasmineTests>true</skipJasmineTests>
+    <skipJasmineTests>true</skipJasmineTests>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/fileupload/pom.xml
+++ b/modules/fileupload/pom.xml
@@ -85,11 +85,11 @@
               javax.ws.rs.core;version=2.0.1,
               *
             </Import-Package>
-            <Export-Package> 
+            <Export-Package>
               org.opencastproject.fileupload.api;version=${project.version},
               org.opencastproject.fileupload.api.exception;version=${project.version},
               org.opencastproject.fileupload.api.job;version=${project.version},
-              org.opencastproject.fileupload.service;version=${project.version} 
+              org.opencastproject.fileupload.service;version=${project.version}
             </Export-Package>
             <Service-Component>
               OSGI-INF/fileupload-service.xml,

--- a/modules/search-service-api/pom.xml
+++ b/modules/search-service-api/pom.xml
@@ -40,7 +40,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> 
+            <Export-Package>
               org.opencastproject.search.api;version=${project.version},
               org.opencastproject.feed.api;version=${project.version}
             </Export-Package>

--- a/modules/security-cas-client-wrapper/pom.xml
+++ b/modules/security-cas-client-wrapper/pom.xml
@@ -56,7 +56,7 @@
               org.jasig.cas.client.validation;resolution:=optional,
               *
             </Import-Package>
-	    <Export-Package>
+            <Export-Package>
               org.opensaml;version=1.1,
               org.opensaml.provider;version=1.1,
               org.opensaml.artifact;version=1.1,
@@ -67,7 +67,7 @@
               org.jasig.cas.client.session;version=3.1.12,
               org.jasig.cas.client.util;version=3.1.12,
               org.jasig.cas.client.validation;version=3.1.12
-	    </Export-Package>
+            </Export-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/security-cas/pom.xml
+++ b/modules/security-cas/pom.xml
@@ -48,7 +48,7 @@
               org.springframework.security.cas.web.authentication,
               *
             </Import-Package>
-            <Fragment-Host>opencast-kernel</Fragment-Host> 
+            <Fragment-Host>opencast-kernel</Fragment-Host>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/videoeditor-remote/pom.xml
+++ b/modules/videoeditor-remote/pom.xml
@@ -26,7 +26,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package> 
+            <Export-Package>
               org.opencastproject.videoeditor.remote;version=${project.version}
             </Export-Package>
             <Service-Component>


### PR DESCRIPTION
This patch adds a simple test for tab characters in `pom.xml` files,
letting the build fail if tabs are included.