### PR TITLE
MH-12764: update license information for admin-ui

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/emailtemplatesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/emailtemplatesController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('EmailtemplatesCtrl', ['$scope', 'Table', 'Notifications', 'EmailTemplatesResource', 'EmailTemplateResource', 'ResourcesFilterResource',
     function ($scope, Table, Notifications, EmailTemplatesResource, EmailTemplateResource, ResourcesFilterResource) {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/themeFormController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/themeFormController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('ThemeFormCtrl', ['$scope', '$timeout', 'FormNavigatorService', 'Notifications', 'ThemeResource', 'NewThemeResource', 'ThemeUsageResource', 'Table',
     function ($scope, $timeout, FormNavigatorService, Notifications, ThemeResource, NewThemeResource, ThemeUsageResource, Table) {
@@ -8,7 +30,7 @@ angular.module('adminNg.controllers')
         $scope.navigateTo = function (targetForm, currentForm, requiredForms) {
             // We have to set the currentForm property here in the controller.
             // The reason for that is that the footer sections in the partial are decorated with ng-if, which
-            // creates a new scope each time they are activated. 
+            // creates a new scope each time they are activated.
             $scope.currentForm = FormNavigatorService.navigateTo(targetForm, currentForm, requiredForms);
         };
 
@@ -101,4 +123,4 @@ angular.module('adminNg.controllers')
         };
 
     }]);
-    
+

--- a/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/themesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/themesController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('ThemesCtrl', ['$scope', 'Table', 'ThemesResource', 'ThemeResource', 'ResourcesFilterResource', 'Notifications',
     function ($scope, Table, ThemesResource, ThemeResource, ResourcesFilterResource, Notifications) {
@@ -17,7 +39,7 @@ angular.module('adminNg.controllers')
                 name:  'creation_date',
                 label: 'CONFIGURATION.THEMES.TABLE.CREATED'
             },
-            /* 
+            /*
              * Temporarily disabled
              *
              *{

--- a/modules/admin-ui/src/main/webapp/scripts/modules/configuration/validators/uniqueThemeName.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/configuration/validators/uniqueThemeName.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.modules.configuration.validators.uniquerThemeName
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/modules/dashboard/controllers/dashboardController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/dashboard/controllers/dashboardController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('DashboardCtrl', ['$scope',
     function ($scope) {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkMessageController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkMessageController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('BulkMessageCtrl', ['$scope', 'BulkMessageStates', 'EmailResource', 'Table', 'Notifications', 'Modal', 'EVENT_TAB_CHANGE',
 function ($scope, BulkMessageStates, EmailResource, Table, Notifications, Modal, EVENT_TAB_CHANGE) {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/validators/notEmptySelectionValidator.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/validators/notEmptySelectionValidator.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.modules.events.validators.taskStartableValidator
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/validators/taskStartableValidator.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/validators/taskStartableValidator.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.modules.events.validators.taskStartable
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/aclsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/aclsController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('AclsCtrl', ['$scope', 'Table', 'AclsResource', 'AclResource', 'ResourcesFilterResource', 'Notifications',
     function ($scope, Table, AclsResource, AclResource, ResourcesFilterResource, Notifications) {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('GroupCtrl', ['$scope', 'AuthService', 'UserRolesResource', 'ResourcesListResource', 'GroupResource', 'GroupsResource', 'Notifications', 'Modal',
     function ($scope, AuthService, UserRolesResource, ResourcesListResource, GroupResource, GroupsResources, Notifications, Modal) {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupsController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('GroupsCtrl', ['$scope', 'Table', 'Modal', 'GroupsResource', 'GroupResource', 'ResourcesFilterResource', 'Notifications',
     function ($scope, Table, Modal, GroupsResource, GroupResource, ResourcesFilterResource, Notifications) {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/newAclController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/newAclController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('NewAclCtrl', ['$scope', 'Table', 'NewAclStates', 'ResourcesListResource', 'AclsResource', 'Notifications', 'Modal',
     function ($scope, Table, NewAclStates, ResourcesListResource, AclsResource, Notifications, Modal) {
@@ -23,7 +45,7 @@ angular.module('adminNg.controllers')
                           'action' : 'write',
                           'allow'  : policy.write,
                           'role'   : policy.role
-                      });   
+                      });
                   }
 
                   angular.forEach(policy.actions.value, function(customAction){

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/newGroupController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/newGroupController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('NewGroupCtrl', ['$scope', '$timeout', 'Table', 'NewGroupStates', 'ResourcesListResource', 'GroupsResource', 'Notifications', 'Modal',
     function ($scope, $timeout, Table, NewGroupStates, ResourcesListResource, GroupsResource, Notifications, Modal) {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('UserCtrl', ['$scope', 'Table', 'UserRolesResource', 'UserResource', 'UsersResource', 'JsHelper', 'Notifications', 'Modal', 'AuthService', 'underscore',
     function ($scope, Table, UserRolesResource, UserResource, UsersResource, JsHelper, Notifications, Modal, AuthService, _) {
@@ -16,7 +38,7 @@ angular.module('adminNg.controllers')
                 $scope.showExternalRoles = user.org.properties[EXTERNAL_ROLE_DISPLAY] === "true";
             }
         });
-        
+
         $scope.role = {
             available: UserRolesResource.query({limit: 0, offset: 0, filter: 'role_target:USER'}), // Load all the internal roles
             external: [],

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userblacklistsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userblacklistsController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('UserblacklistsCtrl', ['$scope', 'Table', 'Notifications', 'UserBlacklistsResource', 'ResourcesFilterResource',
     function ($scope, Table, Notifications, UserBlacklistsResource, ResourcesFilterResource) {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/usersController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/usersController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.controllers')
 .controller('UsersCtrl', ['$scope', 'Table', 'UsersResource', 'UserResource', 'ResourcesFilterResource', 'Notifications', 'Modal',
     function ($scope, Table, UsersResource, UserResource, ResourcesFilterResource, Notifications, Modal) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/controllers/applicationController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/controllers/applicationController.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // The main controller that all other scopes inherit from (except isolated scopes).
 angular.module('adminNg.controllers')
 .controller('ApplicationCtrl', ['$scope', '$rootScope', '$location', '$window', 'AuthService', 'Notifications',

--- a/modules/admin-ui/src/main/webapp/scripts/shared/controllers/controllers.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/controllers/controllers.js
@@ -1,2 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // Controllers registry.
 angular.module('adminNg.controllers', []);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/confirmationModalDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/confirmationModalDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.modal.confirmationModal
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/customIcon.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/customIcon.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
     .directive('customIcon', function() {
     return function($scope, element, attrs) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/datepickerDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/datepickerDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('datepicker', ['Language', function (Language) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/datetimepickerDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/datetimepickerDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('datetimepicker', ['Language', function (Language) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/directives.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/directives.js
@@ -1,2 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // Directive modules registry
 angular.module('adminNg.directives', []);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableBooleanValueDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableBooleanValueDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgEditableBooleanValue', function () {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableDateValueDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableDateValueDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name ng.directive:adminNgEditableDateValue
  *

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgEditable', ['AuthService', 'ResourcesListResource', function (AuthService, ResourcesListResource) {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableMultiSelectDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableMultiSelectDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name ng.directive:adminNgEditableMultiSelect
  *

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableMultiValueDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableMultiValueDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name ng.directive:adminNgEditableMultiValue
  *

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name ng.directive:adminNgEditableSingleSelect
  *

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleValueDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleValueDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name ng.directive:adminNgEditableSingleValue
  *

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/fileDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/fileDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgFileUpload', ['$parse', function ($parse) {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/fileuploadDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/fileuploadDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
     .directive('fileUpload', ['$upload', function ($upload) {
         return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/focushere.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/focushere.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
     .directive('focushere', ['$timeout', function($timeout) {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/hrefRoleDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/hrefRoleDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.directives.adminNgHrefRole
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/loadingScrollerDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/loadingScrollerDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.modal.adminNgLoadingScroller
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/navDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/navDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgNav', ['HotkeysService', function (HotkeysService) {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/notificationDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/notificationDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgNotification', ['Notifications', '$timeout',
 function (Notifications, $timeout) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/notificationsDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/notificationsDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgNotifications', ['Notifications', function (Notifications) {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('oldAdminNgDropdown', function () {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/opencastScrollGlue.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/opencastScrollGlue.js
@@ -1,3 +1,20 @@
+/**
+ * Copyright (C) 2013 Luegg
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ * persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 /* Adapted from:
  * angularjs Scroll Glue
  * version 2.0.6

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/passwordCheckDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/passwordCheckDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.modal.adminNgPwCheck
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/playerDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/playerDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('videoPlayer', ['PlayerAdapter', 'PlayerAdapterRepository', 'VideoService', '$timeout', 'HotkeysService',
     function (PlayerAdapter, PlayerAdapterRepository, VideoService, $timeout, HotkeysService) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/popOverDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/popOverDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module("adminNg.directives")
 .directive("popOver", ["$timeout", function ($timeout) {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/preSelectFromDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/preSelectFromDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('preSelectFrom', [ 'underscore',
 function (_) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/resourceModalDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/resourceModalDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.directives.openModal
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/segmentsDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/segmentsDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgSegments', ['PlayerAdapter', '$document', 'VideoService', '$timeout',
 function (PlayerAdapter, $document, VideoService, $timeout) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/selectBoxDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/selectBoxDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgSelectBox', [function () {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/statsDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/statsDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.directives.adminNgStats
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/tableDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/tableDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.directives.adminNgTable
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/tableFilterDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/tableFilterDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgTableFilter', ['Storage', 'FilterProfiles', 'Language', 'underscore', '$translate', '$timeout', function (Storage, FilterProfiles, Language, _, $translate, $timeout) {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .directive('adminNgTimeline', ['AuthService', 'PlayerAdapter', '$document', 'VideoService', '$timeout',
 function (AuthService, PlayerAdapter, $document, VideoService, $timeout) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/uploadAssetDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/uploadAssetDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // Asset upload html UI directive
 // Used in new event and existing event asset upload
 angular.module('adminNg.directives')

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/withRoleDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/withRoleDirective.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc directive
  * @name adminNg.directives.withRole
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/wizardDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/wizardDirective.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.directives')
 .constant('EVENT_TAB_CHANGE', 'tab_change')
 .directive('adminNgWizard', ['EVENT_TAB_CHANGE', function (EVENT_TAB_CHANGE) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/addLeadingZerosFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/addLeadingZerosFilter.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.filters')
 .filter('addLeadingZeros', [function () {
     return function (input, digitNumber) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/arrayFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/arrayFilter.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.filters')
 .filter('joinBy', [function () {
     return function (input, delimiter) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/filters.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/filters.js
@@ -1,2 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // Filter modules registry
 angular.module('adminNg.filters', []);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/humanByteSizeFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/humanByteSizeFilter.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 /*
  Transforms numbers of bytes into human readable format
  */

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/humanDurationFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/humanDurationFilter.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.filters')
     .filter('humanDuration', [function () {
         return function (durationInMsecValue) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/localizeDateFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/localizeDateFilter.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.filters')
 .filter('localizeDate', ['Language', function (Language) {
     return function (input, type, format) {
@@ -13,7 +35,7 @@ angular.module('adminNg.filters')
             case 'time':
                 if (!angular.isDate(Date.parse(input))) {
                     return input;
-                } 
+                }
 
                 return Language.formatTime(format, input);
             default:

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/presentValue.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/presentValue.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.filters')
 .filter('presentValue', [function () {
     return function (input, delimiter) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/removeQueryParams.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/removeQueryParams.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.filters')
 .filter('removeQueryParams', [function () {
     return function (input) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/trustedResourceUrlFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/trustedResourceUrlFilter.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.filters')
 .filter('trusted', ['$sce', function ($sce) {
     return function(url) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/aclResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/aclResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('AclResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/acl/:id', { id: '@id' }, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/aclsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/aclsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('AclsResource', ['ResourceHelper', '$resource', function (ResourceHelper, $resource) {
     return $resource('/admin-ng/acl/:ext', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/blacklistCountResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/blacklistCountResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('BlacklistCountResource', ['$resource', function ($resource) {
     return $resource('/blacklist/blacklistCount', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/blacklistsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/blacklistsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('BlacklistsResource', ['$resource', '$filter', 'Language', 'JsHelper',
 function ($resource, $filter, Language, JsHelper) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/bulkDeleteResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/bulkDeleteResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('BulkDeleteResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/:resource/:endpoint', {resource: '@resource', endpoint: '@endpoint'}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/captureAgentResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/captureAgentResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('CaptureAgentResource', ['$resource', 'Language', function ($resource, Language) {
     return $resource('/admin-ng/capture-agents/:name', { name: '@name' }, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/captureAgentsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/captureAgentsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('CaptureAgentsResource', ['$resource', 'Language', function ($resource, Language) {
     return $resource('/admin-ng/capture-agents/:target', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/commentResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/commentResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('CommentResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/:resource/:resourceId/:type/:id/:reply', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/conflictCheckResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/conflictCheckResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('ConflictCheckResource', ['$resource', 'JsHelper', function ($resource, JsHelper) {
     var transformRequest = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/emailResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/emailResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('RecipientsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/:category/:resource/recipients');

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/emailTemplateResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/emailTemplateResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EmailTemplatesResource', ['$resource', 'Language', 'ResourceHelper',
 function ($resource, Language, ResourceHelper) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventAccessResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventAccessResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventAccessResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventAssetsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventAssetsResource.js
@@ -1,8 +1,30 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventAssetsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id/asset/assets.json', { id: '@id' }, {
-        get: { 
-            method: 'GET', 
+        get: {
+            method: 'GET',
             isArray: false
         }
     });

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventAttachmentDetailsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventAttachmentDetailsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventAttachmentDetailsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/asset/attachment/:id2.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventAttachmentsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventAttachmentsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventAttachmentsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/asset/attachment/attachments.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventCatalogDetailsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventCatalogDetailsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventCatalogDetailsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/asset/catalog/:id2.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventCatalogsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventCatalogsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventCatalogsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/asset/catalog/catalogs.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventErrorDetailsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventErrorDetailsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventErrorDetailsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/workflows/:id1/errors/:id2.json');

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventErrorsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventErrorsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventErrorsResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventGeneralResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventGeneralResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventGeneralResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id/general.json', { id: '@id' });

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventHasSnapshotsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventHasSnapshotsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventHasSnapshotsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id/hasSnapshots.json', { id: '@id' });

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventMediaDetailsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventMediaDetailsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventMediaDetailsResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventMediaResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventMediaResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventMediaResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventMetadataResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventMetadataResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventMetadataResource', ['JsHelper', '$resource', function (JsHelper, $resource) {
     var transformResponse = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventParticipationResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventParticipationResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventParticipationResource', ['JsHelper', '$resource', function (JsHelper, $resource) {
     var transformResponse = function (data) {
@@ -11,7 +33,7 @@ angular.module('adminNg.resources')
                 } else {
                     metadata.opt_out = 'false';
                 }
-            } 
+            }
         } catch (e) { }
 
         return metadata;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventPublicationDetailsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventPublicationDetailsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventPublicationDetailsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/asset/publication/:id2.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventPublicationsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventPublicationsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventPublicationsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/asset/publication/publications.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventSchedulingResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventSchedulingResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventSchedulingResource', ['$resource', 'JsHelper', function ($resource, JsHelper) {
     var transformResponse = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventTransactionResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventTransactionResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventTransactionResource', ['$resource', function ($resource) {
     var transform = function (data) {
@@ -9,10 +31,10 @@ angular.module('adminNg.resources')
     };
 
     return $resource('/admin-ng/event/:id/hasActiveTransaction', {}, {
-        hasActiveTransaction: { 
+        hasActiveTransaction: {
             method: 'GET',
             responseType: 'text',
-            isArray: false, 
+            isArray: false,
             paramDefaults: { id: '@id'},
             transformResponse: transform
         }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventUploadAssetResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventUploadAssetResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 /** Upload asset resource
  This resource performs the POST communication with the server
  to start the workflow to process the upload files  */

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowActionResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowActionResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventWorkflowActionResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id/workflows/:wfId/action/:action', { id: '@id', wfId: '@wfId', action: '@action' }, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowDetailsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowDetailsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventWorkflowDetailsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/workflows/:id1.json');

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowOperationDetailsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowOperationDetailsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventWorkflowOperationDetailsResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/event/:id0/workflows/:id1/operations/:id2');

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowOperationsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowOperationsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventWorkflowOperationsResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventWorkflowsResource', ['$resource', function ($resource) {
     var transform = function (data) {
@@ -25,12 +47,12 @@ angular.module('adminNg.resources')
           method: 'GET',
           transformResponse: transform
         },
-        save: { 
+        save: {
             method: 'PUT',
             responseType: 'text',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             transformRequest: function (data) {
-                return $.param({configuration: angular.toJson(data.entries)});   
+                return $.param({configuration: angular.toJson(data.entries)});
             }
         }
     });

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('EventsResource', ['$resource', 'Language', '$translate', 'ResourceHelper', function ($resource, Language, $translate, ResourceHelper) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/groupResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/groupResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('GroupResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/groups/:id', { id: '@id' }, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/groupsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/groupsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('GroupsResource', ['$resource', 'ResourceHelper', function ($resource, ResourceHelper) {
     return $resource('/admin-ng/groups/:ext', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/identityResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/identityResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('IdentityResource', ['$resource', function ($resource) {
     return $resource('/info/me.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/jobsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/jobsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('JobsResource', ['$resource', 'Language', function ($resource, Language) {
     return $resource('/admin-ng/job/jobs.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventMetadataResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventMetadataResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('NewEventMetadataResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventProcessingResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventProcessingResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('NewEventProcessingResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('NewEventResource', ['$resource', 'JsHelper', function ($resource, JsHelper) {
     return $resource('/admin-ng/event/new', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newSeriesMetadataResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newSeriesMetadataResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('NewSeriesMetadataResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newSeriesThemeResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newSeriesThemeResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('NewSeriesThemeResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newThemeResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newThemeResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
     .factory('NewThemeResource', ['$resource', function ($resource) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/optoutSingleResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/optoutSingleResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('OptoutSingleResource', ['$resource', function ($resource) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/optoutsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/optoutsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('OptoutsResource', ['$resource', function ($resource) {
     var transformRequest = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/resources.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/resources.js
@@ -1,2 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // Resources registry.
 angular.module('adminNg.resources', []);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/resourcesFilterResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/resourcesFilterResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('ResourcesFilterResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/resources/:resource/filters.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/resourcesListResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/resourcesListResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('ResourcesListResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/resources/:resource.json', {}, {
@@ -16,7 +38,7 @@ angular.module('adminNg.resources')
                     name: key,
                     value: value
                   });
-                  
+
                 });
               }
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesAccessResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesAccessResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('SeriesAccessResource', ['$resource', function ($resource) {
     var seriesResource,

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesEventsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesEventsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('SeriesEventsResource', ['$resource', function ($resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesMetadataResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesMetadataResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('SeriesMetadataResource', ['JsHelper', '$resource', function (JsHelper, $resource) {
     var transform = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesParticipationResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesParticipationResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('SeriesParticipationResource', ['$resource', function ($resource) {
     var transformResponse = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('SeriesResource', ['$resource', 'Language', 'ResourceHelper', function ($resource, Language, ResourceHelper) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesThemeResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesThemeResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('SeriesThemeResource', ['$resource', function ($resource) {
 
@@ -11,7 +33,7 @@ angular.module('adminNg.resources')
                         return data;
                     }
                     d.themeId = data.theme;
-                	return $.param(d);	
+                	return $.param(d);
             	}
             },
             get: {params:{'ext':'.json'}, method: 'GET'},

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/serversResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/serversResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('ServersResource', ['$resource', 'JsHelper', function ($resource, JsHelper) {
     return $resource('/admin-ng/server/servers.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/serviceResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/serviceResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('ServiceResource', ['$resource', function ($resource) {
     return $resource('/services/:resource', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/servicesResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/servicesResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('ServicesResource', ['$resource', 'JsHelper', function ($resource, JsHelper) {
     // Note: This is the productive path

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/signatureResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/signatureResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('SignatureResource', ['$resource', function ($resource) {
     var transformRequest = function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/taskResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/taskResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('TaskResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/tasks/new', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/themesResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/themesResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 
     /**
@@ -43,7 +65,7 @@ angular.module('adminNg.resources')
     .factory('ThemeResource', ['$resource',  'Language', 'ResourceHelper',
         function ($resource) {
             return $resource('/admin-ng/themes/:id:format', {}, {
-        
+
                 /**
                  * Returns a list of themes mainly used by the table implementation.
                  */

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/toolsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/toolsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('ToolsResource', ['$resource', 'JsHelper', function ($resource, JsHelper) {
     return $resource('/admin-ng/tools/:id/:tool.json', { id: '@id' }, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/userResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/userResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('UserResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/users/:username.json', { }, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/userRolesResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/userRolesResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('UserRolesResource', ['$resource', function ($resource) {
     return $resource('/admin-ng/resources/ROLES.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/usersResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/usersResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('UsersResource', ['$resource', 'Language', function ($resource, Language) {
     return $resource('/admin-ng/users/:target', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/versionResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/versionResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('VersionResource', ['$resource', function ($resource) {
     return $resource('/sysinfo/bundles/version?prefix=opencast', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/workflowsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/workflowsResource.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.resources')
 .factory('WorkflowsResource', ['$resource', function ($resource) {
     return $resource('/workflow/definitions.json', {}, {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/authService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/authService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('AuthService', ['IdentityResource', function (IdentityResource) {
     var AuthService = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/confirmationModalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/confirmationModalService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc service
  * @name adminNg.modal.Modal
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/cryptService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/cryptService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('CryptService', ['md5', function (md5) {
     var CryptService = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/decorateWithTableRowSelection.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/decorateWithTableRowSelection.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
     .factory('decorateWithTableRowSelection', function () {
         /**

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/eventHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/eventHelperService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('EventHelperService', function () {
     var EventHelperService = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/filterProfilesService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/filterProfilesService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
 * A service to manage filter profiles.
 *
 * Filter profiles will be stored in the localStorage.

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/formNavigatorService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/formNavigatorService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('FormNavigatorService', function () {
     var FormNavigator = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/hotkeysService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/hotkeysService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('HotkeysService', ['$q', 'IdentityResource', 'hotkeys',
         function ($q, IdentityResource, hotkeys) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/languageService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/languageService.js
@@ -18,7 +18,6 @@
  * the License.
  *
  */
-'use strict';
 
 /**
  * @ngdoc overview

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/languageService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/languageService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc overview
  * @name adminNg.Language
  *

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/modalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/modalService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc service
  * @name adminNg.modal.Modal
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/notificationsService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/notificationsService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .provider('Notifications', function () {
     var notifications = {},

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapter.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .service('PlayerAdapter', [function () {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterFactoryDefault.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterFactoryDefault.js
@@ -18,7 +18,6 @@
  * the License.
  *
  */
-'use strict';
 
 angular.module('adminNg.services')
 .factory('PlayerAdapterFactoryDefault', ['PlayerAdapter', function (PlayerAdapter) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterFactoryDefault.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterFactoryDefault.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('PlayerAdapterFactoryDefault', ['PlayerAdapter', function (PlayerAdapter) {
     var Factory = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterFactoryHtml5.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterFactoryHtml5.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('PlayerAdapterFactoryHTML5', ['PlayerAdapter', 'PlayerAdapterFactoryDefault', function (PlayerAdapter, PlayerAdapterFactoryDefault) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterFactoryVideoJs.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterFactoryVideoJs.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('PlayerAdapterFactoryVIDEOJS', ['PlayerAdapter', 'PlayerAdapterFactoryDefault', function (PlayerAdapter, PlayerAdapterFactoryDefault) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterRepository.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/playerAdapterRepository.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('PlayerAdapterRepository', ['$injector', function ($injector) {
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/regexService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/regexService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .service('RegexService', [function () {
     return {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/resourceHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/resourceHelperService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc service
  * @name adminNg.modal
  * @description
@@ -25,7 +47,7 @@ angular.module('adminNg.services')
                 var result = [], data = {};
 
                 try {
-                    data = JSON.parse(responseBody);     
+                    data = JSON.parse(responseBody);
 
                     // Distinguish between single and multiple values
                     if ($.isArray(data.results)) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/resourceModalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/resourceModalService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * @ngdoc service
  * @name adminNg.modal.Modal
  * @description

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/restServiceMonitor.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('RestServiceMonitor', ['$http', '$location', 'Storage', function($http, $location, Storage) {
     var Monitoring = {};

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('SchedulingHelperService', [function () {
     var SchedulingHelperService = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/services.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/services.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // Service modules registry
 angular.module('adminNg.services', []);
 angular.module('adminNg.services.language', []);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/statsService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/statsService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('Stats', ['$rootScope', '$filter', 'Storage', '$location', '$timeout',
     function ($rootScope, $filter, Storage, $location, $timeout) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/storageService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/storageService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
 * A service to store arbitrary information without use of a backend.
 *
 * Information can either be stored in the localStorage or as a search

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('Table', ['$rootScope', '$filter', 'Storage', '$location', '$timeout', 'decorateWithTableRowSelection',
     function ($rootScope, $filter, Storage, $location, $timeout, decorateWithTableRowSelection) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/underscoreService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/underscoreService.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('underscore', function() {
   return window._; // assumes underscore has already been loaded on the page

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/uploadAssetOptionsService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/uploadAssetOptionsService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * Dynamic Asset Upload Options List Service
  *
  * A service to retrieve and provide a list of available upload options (track, attachment, catalog).

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/videoService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/videoService.js
@@ -1,4 +1,26 @@
 /**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
  * Utility service bridging video and timeline functionality.
  */
 angular.module('adminNg.services')

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/bulk-message/message.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/bulk-message/message.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('BulkMessageMessage', ['EmailPreviewResource', 'EmailVariablesResource', 'EmailTemplatesResource', 'EmailTemplateResource', 'BulkMessageRecipients',
 function (EmailPreviewResource, EmailVariablesResource, EmailTemplatesResource, EmailTemplateResource, BulkMessageRecipients) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/bulk-message/recipients.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/bulk-message/recipients.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('BulkMessageRecipients', ['RecipientsResource', 'Table',
 function (RecipientsResource, Table) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/bulk-message/states.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/bulk-message/states.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('BulkMessageStates', ['BulkMessageRecipients', 'BulkMessageMessage', 'BulkMessageSummary',
         function (BulkMessageRecipients, BulkMessageMessage, BulkMessageSummary) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/bulk-message/summary.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/bulk-message/summary.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('BulkMessageSummary', [function () {
     var Summary = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/emailtemplate/message.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/emailtemplate/message.js
@@ -1,9 +1,31 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
     .factory('EmailtemplateMessage', ['$location', 'ResourcesListResource', 'EmailTemplateDemoResource',
         'EmailVariablesResource', 'Notifications',
         function ($location, ResourcesListResource, EmailTemplateDemoResource, EmailVariablesResource, Notifications) {
             var Message = function () {
-                var me = this, 
+                var me = this,
                     isNameUnique = function () {
                         me.unique = true;
                         angular.forEach(me.names, function (name) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/emailtemplate/states.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/emailtemplate/states.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('EmailtemplateStates', ['EmailtemplateMessage', 'EmailtemplateSummary',
         function (EmailtemplateMessage, EmailtemplateSummary) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/emailtemplate/summary.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/emailtemplate/summary.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('EmailtemplateSummary', [function () {
     var Summary = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/dates.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/dates.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewLocationblacklistDates', ['BlacklistCountResource', 'NewLocationblacklistItems', 'JsHelper',
 function (BlacklistCountResource, NewLocationblacklistItems, JsHelper) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/items.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/items.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewLocationblacklistItems', ['CaptureAgentsResource', function (CaptureAgentsResource) {
     var Locations = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/reason.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/reason.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewLocationblacklistReason', ['ResourcesListResource',
 function (ResourcesListResource) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/states.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/states.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewLocationblacklistStates', ['NewLocationblacklistItems', 'NewLocationblacklistDates', 'NewLocationblacklistReason', 'NewLocationblacklistSummary',
         function (NewLocationblacklistItems, NewLocationblacklistDates, NewLocationblacklistReason, NewLocationblacklistSummary) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/summary.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/locationblacklist/summary.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewLocationblacklistSummary', [function () {
     var Summary = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/access.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/access.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewAclAccess', ['ResourcesListResource', 'UserRolesResource', 'AclResource', function (ResourcesListResource, UserRolesResource, AclResource) {
     var Access = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/metadata.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewAclMetadata', [function () {
     var Metadata = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/states.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/states.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewAclStates', ['NewAclMetadata', 'NewAclAccess', 'NewAclSummary',
         function (NewAclMetadata, NewAclAccess, NewAclSummary) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/summary.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/summary.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewAclSummary', [function () {
     var Summary = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/access.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewEventAccess', ['ResourcesListResource', 'EventAccessResource', 'SeriesAccessResource', 'AuthService', 'UserRolesResource', 'Notifications', '$timeout',
     function (ResourcesListResource, EventAccessResource, SeriesAccessResource, AuthService, UserRolesResource, Notifications, $timeout) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewEventMetadata', ['NewEventMetadataResource', function (NewEventMetadataResource) {
     var Metadata = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadataExtended.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadataExtended.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewEventMetadataExtended', ['NewEventMetadataResource', function (NewEventMetadataResource) {
     var MetadataExtended = function () {
@@ -97,7 +119,7 @@ angular.module('adminNg.services')
             me.metadata = NewEventMetadataResource.get(me.postProcessMetadata);
         };
 
-        this.getFiledCatalogs = function () { 
+        this.getFiledCatalogs = function () {
             var catalogs = [];
 
             angular.forEach(me.ud, function(catalog) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewEventProcessing', ['$sce', 'NewEventProcessingResource', function ($sce, NewEventProcessingResource) {
     var Processing = function (use) {
@@ -40,7 +62,7 @@ angular.module('adminNg.services')
         NewEventProcessingResource.get(queryParams, function (data) {
 
             me.changingWorkflow = true;
-            
+
             me.workflows = data.workflows;
             var default_workflow_id = data.default_workflow_id;
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewEventSource', ['JsHelper', 'CaptureAgentsResource', 'ConflictCheckResource', 'Notifications', 'Language', '$translate', '$filter', 'underscore', '$timeout', 'localStorageService', 'AuthService', 'SchedulingHelperService',
     function (JsHelper, CaptureAgentsResource, ConflictCheckResource, Notifications, Language, $translate, $filter, _, $timeout, localStorageService, AuthService, SchedulingHelperService) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/states.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/states.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewEventStates', ['NewEventMetadata', 'NewEventMetadataExtended', 'NewEventSource', 'NewEventUploadAsset', 'NewEventAccess', 'NewEventProcessing', 'NewEventSummary',
         function (NewEventMetadata, NewEventMetadataExtended, NewEventSource, NewEventUploadAsset, NewEventAccess, NewEventProcessing, NewEventSummary) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/summary.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/summary.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewEventSummary', [function () {
     var Summary = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/uploadAssetNewEvent.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/uploadAssetNewEvent.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // Asset Upload service for New Events (MH-12085)
 // This is used in the new events states wizard directive
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/metadata.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewGroupMetadata', [function () {
     var Metadata = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/roles.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/roles.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewGroupRoles', ['UsersResource', 'UserRolesResource', 'ResourcesListResource', function (UsersResource, UserRolesResource, ResourcesListResource) {
     var Roles = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/states.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/states.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewGroupStates', ['NewGroupMetadata', 'NewGroupRoles', 'NewGroupUsers', 'NewGroupSummary',
         function (NewGroupMetadata, NewGroupRoles, NewGroupUsers, NewGroupSummary) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/summary.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/summary.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewGroupSummary', [function () {
     var Summary = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/users.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/users.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewGroupUsers', ['ResourcesListResource', '$location', function (ResourcesListResource) {
     var Users = function () {
@@ -19,7 +41,7 @@ angular.module('adminNg.services')
 
         this.getUsersList = function () {
             var list = '';
-            
+
             angular.forEach(me.users.selected, function (user, index) {
                 list += user.name + ((index + 1) === me.users.selected.length ? '' : ', ');
             });

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/access.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/access.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewSeriesAccess', ['ResourcesListResource', 'SeriesAccessResource', 'AuthService', 'UserRolesResource', 'Notifications', '$timeout',
     function (ResourcesListResource, SeriesAccessResource, AuthService, UserRolesResource, Notifications, $timeout) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewSeriesMetadata', ['NewSeriesMetadataResource', function (NewSeriesMetadataResource) {
     var Metadata = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadataExtended.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadataExtended.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewSeriesMetadataExtended', ['NewSeriesMetadataResource', function (NewSeriesMetadataResource) {
     var MetadataExtended = function () {
@@ -84,7 +106,7 @@ angular.module('adminNg.services')
             }
         };
 
-        this.getFiledCatalogs = function () { 
+        this.getFiledCatalogs = function () {
             var catalogs = [];
 
             angular.forEach(me.ud, function(catalog) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/states.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/states.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewSeriesStates', ['NewSeriesMetadata', 'NewSeriesMetadataExtended', 'NewSeriesAccess', 'NewSeriesTheme', 'NewSeriesSummary',
         function (NewSeriesMetadata, NewSeriesMetadataExtended, NewSeriesAccess, NewSeriesTheme, NewSeriesSummary) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/summary.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/summary.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewSeriesSummary', [function () {
     var Summary = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/theme.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/theme.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewSeriesTheme', ['NewSeriesThemeResource', function (NewSeriesThemeResource) {
     var Theme = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/dates.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/dates.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewUserblacklistDates', ['BlacklistCountResource', 'NewUserblacklistItems', 'JsHelper',
 function (BlacklistCountResource, NewUserblacklistItems, JsHelper) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/items.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/items.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewUserblacklistItems', ['UsersResource', '$location', function (UsersResource, $location) {
     var Users = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/reason.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/reason.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewUserblacklistReason', ['ResourcesListResource',
 function (ResourcesListResource) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/states.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/states.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewUserblacklistStates', ['NewUserblacklistItems', 'NewUserblacklistDates', 'NewUserblacklistReason', 'NewUserblacklistSummary',
         function (NewUserblacklistItems, NewUserblacklistDates, NewUserblacklistReason, NewUserblacklistSummary) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/summary.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/userblacklist/summary.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 angular.module('adminNg.services')
 .factory('NewUserblacklistSummary', [function () {
     var Summary = function () {

--- a/modules/admin-ui/src/main/webapp/styles/components/data-filter/_filter-profiles.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/data-filter/_filter-profiles.scss
@@ -1,3 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
 @mixin filter-dd-mixin {
     $width: 200px;
     @include filter-dd-content-mixin($width);

--- a/modules/admin-ui/src/main/webapp/styles/views/modals/_action-modal.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/modals/_action-modal.scss
@@ -1,3 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
 #add-email-template-modal {
 
     // Different tabs

--- a/modules/admin-ui/src/main/webapp/styles/views/modals/_group.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/modals/_group.scss
@@ -1,3 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
 .modal#group-modal {
    @extend .medium-modal; //small-modal
 

--- a/modules/admin-ui/src/main/webapp/styles/views/modals/_send-message-modal.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/modals/_send-message-modal.scss
@@ -1,3 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
 #send-message-modal {
 
     // Different tabs

--- a/modules/admin-ui/src/main/webapp/styles/views/modals/_users.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/modals/_users.scss
@@ -1,3 +1,24 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
 .modal#user-modal {
     @extend .medium-modal; //small-modal
 


### PR DESCRIPTION
For all *.js and *.scss files, which are clearly not a vendor library, the copyright header was added.

Signed-off-by: Daniel Ziegenberg <daniel@ziegenberg.at>