### PR TITLE
MH-12765: Fix switching series in the Admin UI bug

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/controllers/serieController.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/controllers/serieController.js
@@ -279,6 +279,11 @@ angular.module('adminNg.controllers')
         });
     };
 
+    $scope.accessChanged = function (role) {
+      if (!role) return;
+      $scope.accessSave();
+    };
+
     $scope.accessSave = function () {
             var ace = [],
                 hasRights = false,

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/series-details.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/modals/series-details.html
@@ -248,7 +248,7 @@
                                                         data-disable-search-threshold="8"
                                                         data-search_contains="true"
                                                         ng-model="policy.role"
-                                                        ng-change="accessSave(policy)"
+                                                        ng-change="accessChanged(policy.role)"
                                                         ng-options="id as id for (id, type) in roles"
                                                         ng-get-more="getMoreRoles"
                                                         data-placeholder="{{ 'EVENTS.SERIES.DETAILS.ACCESS.ROLES.LABEL' | translate }}"


### PR DESCRIPTION
When switching series in the Admin UI, multiple ACL update requests are issued. This PR fixes that. This is exactly the same fix as #13 (MH-12610), but only for series. I'm not sure how severe MH-12610 has been, but this bug leads to data corruption. When navigating between series, the Admin UI sends the updated ACLs with the roles set to null. Because of MH-12715, the ACLs get accepted up to a certain point, i.e. they get persisted in the DB series table but not in the admin index. This data corruption causes that series ACLs can no longer be edited in the Admin UI.