### PR TITLE
MH-12091: Implement per-tenant digest user for capture agents

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -68,6 +68,13 @@ admin_role=ROLE_ADMIN
 #
 anonymous_role=ROLE_ANONYMOUS
 
+# The username and password for capture agents.
+#prop.org.opencastproject.security.capture_agent.user=opencast_ca
+#prop.org.opencastproject.security.capture_agent.pass=CHANGE_ME
+
+# Optional extra roles for the capture agent user. These roles may be used to manage which series are visible to the capture agent.
+#prop.org.opencastproject.security.capture_agent.roles=ROLE_ONE, ROLE_TWO, ROLE_THREE
+
 
 # The base URL of the file server. When using a shared filesystem between servers, set all servers to use the same URL.
 # Only then will hard linking between the working file repository and the workspace be enabled to prevent downloads.

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -249,7 +249,7 @@
     <sec:intercept-url pattern="/export/**" method="GET" access="ROLE_ANONYMOUS" />
 
     <!-- Enable anonymous access to the annotation and the series endpoints -->
-    <sec:intercept-url pattern="/series/**" method="GET" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/series/**" method="GET" access="ROLE_ANONYMOUS, ROLE_CAPTURE_AGENT" />
     <sec:intercept-url pattern="/annotation/**" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/annotation/**" method="PUT" access="ROLE_ANONYMOUS" />
 
@@ -264,10 +264,16 @@
     <sec:intercept-url pattern="/feeds/**" method="GET" access="ROLE_ANONYMOUS" />
 
     <!-- Secure the system management URLs for admins only -->
-    <sec:intercept-url pattern="/services/*" access="ROLE_ADMIN" />
+    <sec:intercept-url pattern="/services/available.*" method="GET" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
+    <sec:intercept-url pattern="/services/**" access="ROLE_ADMIN"/>
     <sec:intercept-url pattern="/signing/**" access="ROLE_ADMIN" />
     <sec:intercept-url pattern="/system/**" access="ROLE_ADMIN" />
     <sec:intercept-url pattern="/config/**" access="ROLE_ADMIN" />
+
+    <!-- Enable capture agent updates and ingest -->
+    <sec:intercept-url pattern="/capture-admin/**" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
+    <sec:intercept-url pattern="/recordings/**" method="GET" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
+    <sec:intercept-url pattern="/ingest/**" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
 
     <!-- Secure the user management URLs for admins only -->
     <sec:intercept-url pattern="/users/**" access="ROLE_ADMIN" />

--- a/modules/common/src/main/java/org/opencastproject/security/api/SecurityConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/SecurityConstants.java
@@ -47,6 +47,9 @@ public interface SecurityConstants {
   /** Name of the Opencast admin role */
   String GLOBAL_ADMIN_ROLE = "ROLE_ADMIN";
 
+  /** Name of the Opencast capture agent role */
+  String GLOBAL_CAPTURE_AGENT_ROLE = "ROLE_CAPTURE_AGENT";
+
   /** Name of the Opencast global sudo role */
   String GLOBAL_SUDO_ROLE = "ROLE_SUDO";
 
@@ -55,5 +58,8 @@ public interface SecurityConstants {
 
   /** The roles associated with the Opencast system account */
   String[] GLOBAL_SYSTEM_ROLES = new String[] { GLOBAL_ADMIN_ROLE, GLOBAL_SUDO_ROLE };
+
+  /** The roles associated with the Opencast capture agent account */
+  String[] GLOBAL_CAPTURE_AGENT_ROLES = new String[] { GLOBAL_CAPTURE_AGENT_ROLE };
 
 }

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -22,6 +22,7 @@
 package org.opencastproject.ingest.impl;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 import static org.opencastproject.util.JobUtil.waitForJob;
 import static org.opencastproject.util.data.Monadics.mlist;
 import static org.opencastproject.util.data.Option.none;
@@ -1281,7 +1282,8 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     if (activeAcl.getEntries().size() == 0) {
       String anonymousRole = securityService.getOrganization().getAnonymousRole();
       activeAcl = new AccessControlList(
-              new AccessControlEntry(anonymousRole, Permissions.Action.READ.toString(), true));
+              new AccessControlEntry(anonymousRole, Permissions.Action.READ.toString(), true),
+              new AccessControlEntry(GLOBAL_CAPTURE_AGENT_ROLE, Permissions.Action.WRITE.toString(), true));
       authorizationService.setAcl(mp, AclScope.Series, activeAcl);
     }
   }


### PR DESCRIPTION
This PR adds a new in-memory per-tenant user and a new role `ROLE_CAPTURE_AGENT` for capture agents. It builds upon work by @smarquard and @lkiesow, see the [bitbucket PR](https://bitbucket.org/opencast-community/opencast/pull-requests/1542).

The new user is able to digest-auth in order to ingest recordings and thus has to be an in-memory user with clear-text password. Restricting the user's rights turned out to be rather tricky because of a "somewhat circular" dependency between `AssetManagerWithMessaging` and `AssetManagerWithSecurity`.

I tried to preserve the older commits in order to see who introduced which feature.

This work is sponsored by SWITCH.