### PR TITLE
MH-12616 Admin UI Flexible Asset Upload override or fallback display text

### DIFF
--- a/docs/guides/admin/docs/configuration/asset-upload-ui/index.md
+++ b/docs/guides/admin/docs/configuration/asset-upload-ui/index.md
@@ -161,11 +161,18 @@ Underbars are allowed. CONFIGURATION values are in JSON object format.
 Attribute    | Example         | Description
 -------------| ----------------| -----------
 id           | track_presenter | One of "attachment" or "catalog" or "track", underbar (_), unique text (no spaces)
-type         | track           | One of "attachment" or "catalog" or "track" to designate asset type
+type         | track           | One of "attachment" or "catalog" or "track" to designate asset type (must match id prefix)
 flavorType   | presentation    | The primary flavor type. Used to reference asset in workflows, player, and media module
 flavorSubType| source          | The sub flavor type. Used to identify the sub flavor of this flavor type
 multiple     | false           | true or false, used by the admin UI to enable single or multiple file input selection
 displayOrder | 32              | Integer number, used by the admin UI to sort the display of upload options in the UI
+displayOverride | 'My New Catalog'    | A short asset title which overrides all translations
+displayFallback | 'My New Catalog'    | A short asset title which displays when no translation is found
+displayOverride.SHORT | 'Video of a Presenter'    | A short source title which overrides all translations
+displayFallback.SHORT | 'Video of a Presenter'    | A short source title which displays when no translation is found
+displayOverride.DETAIL | 'A recording that showing the lecturer speaking' | A longer source description which overrides all translation
+displayFallback.DETAIL | 'A recording that showing the lecturer speaking' | A longer source description which displays when no translation is found
+
 
 The parameter key is internationalized as the display text in the admin UI
 ref: modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -283,6 +283,7 @@
         <script src="scripts/shared/filters/arrayFilter.js"></script>
         <script src="scripts/shared/filters/presentValue.js"></script>
         <script src="scripts/shared/filters/removeQueryParams.js"></script>
+        <script src="scripts/shared/filters/translateOverrideFallbackFilter.js"></script>
         <script src="scripts/shared/filters/trustedResourceUrlFilter.js"></script>
         <script src="scripts/shared/directives/directives.js"></script>
         <script src="scripts/shared/directives/customIcon.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/uploadAssetDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/uploadAssetDirective.js
@@ -42,7 +42,7 @@ angular.module('adminNg.directives')
            }
            // Allows sorting list on traslated title/description/caption
            scope.translatedTitle = function(asset) {
-               return $filter('translate')(asset.title);
+               return $filter('translateOverrideFallback')(asset);
            }
            //The "onexitscope"'s oldValue acts as the callback when the scope of the directive is exited.
            //The callback allow the parent scope to do work (i.e. make a summary map) based on

--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/translateOverrideFallbackFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/translateOverrideFallbackFilter.js
@@ -1,0 +1,63 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.filters')
+    .filter('translateOverrideFallback', ['$filter', function ($filter) {
+
+    // This Filter enables text override, translate, or a fallback display when no translation is availble
+    // Used for customized asset upload options that do not have a built in translation (display fallback)
+    // Or a translation that requires site customization (display override).
+    //
+    // "item" parameter is required, expected to have "title" attribute at minimum
+    // "subtitle" parameter is optional
+    // Example of title from an asset upload item: 'EVENTS.EVENTS.NEW.SOURCE.UPLOAD.FOOBAR'
+    // Example of a subtitle from an assets upload option: 'SHORT' or 'DETAIL'
+    // Example of filter use in template: {{item | translateOverrideFallback: 'DETAIL'}}
+    // Example of a passed in item object:
+    //   {
+    //    "title": "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.AUDIO_ONLY",
+    //    "displayOverride.SHORT": "Audio *ONLY*",
+    //    "displayOverride.DETAIL": "Don't upload anything but an audio file here!"
+    //   }
+
+    return function (item, subtitle) {
+        var result = null;
+        var sub = subtitle == null ? "" : "." + subtitle;
+        var translatable = item['title'] + sub;
+
+        if (item['displayOverride' + sub]) {
+            result = item['displayOverride' + sub];
+
+        } else if ($filter('translate')(translatable) != translatable) {
+            result = $filter('translate')(translatable);
+
+        } else if (item['displayFallback' + sub]) {
+            result = item['displayFallback' + sub];
+
+        } else {
+            // no translate, override, or fallback, use what is given
+            result = translatable;
+        }
+        return result;
+    };
+}]);
+

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/uploadAsset.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/uploadAsset.html
@@ -2,7 +2,7 @@
 <form novalidate name="assetform" id="assetform">
   <table class="main-tbl">
     <tr ng-if="assetoptions" ng-repeat="asset in assetoptions | filter:{type:'!track'} | orderBy: 'displayOrder' track by asset.id"  ng-init="assets=$parent.assets; onassetupdate=$parent.onassetupdate">
-      <td>{{asset.title | translate }}
+      <td>{{asset | translateOverrideFallback}}
         <span class="ui-helper-hidden">({{asset.type}} "{{asset.flavorType}}/{{asset.flavorSubType}}")</span>
       </td>
       <!-- File upload -->

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -117,11 +117,9 @@
                       <input id="{{asset.id}}" class="blue-btn file-select-btn" admin-ng-file-upload data-ng-file-select data-ng-multiple="asset.multiple"
                         type="file" file="$parent.wizard.step.ud.UPLOAD.tracks.{{asset.id}}" tabindex="" />
                     </div>
-                    <span  translate="{{asset.title + '.SHORT'}}">
-                    </span>
+                    <span>{{asset | translateOverrideFallback: 'SHORT'}}</span>
                     <span class="ui-helper-hidden"> ({{asset.type}} "{{asset.flavorType}}/{{asset.flavorSubType}}")</span>
-                    <p translate="{{asset.title + '.DETAIL'}}">
-                    </p>
+                    <p>{{asset | translateOverrideFallback: 'DETAIL'}}</p>
                  </li>
                 </ul>
               </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -245,7 +245,7 @@ angular.module('adminNg.services')
 
         // Sort source select options by short title
         this.translatedSourceShortTitle = function(asset) {
-            return $filter('translate')(asset.title + '.SHORT');
+            return $filter('translateOverrideFallback')(asset, 'SHORT');
         }
 
         // Create the data array for use in the summary view

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/eventUploadAssetOptions.json
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/eventUploadAssetOptions.json
@@ -1,13 +1,14 @@
 {
   "EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CAPTIONS_DFXP": "{\"id\": \"catalog_captions_dfxp\", \"type\": \"catalog\", \"flavorType\": \"captions\", \"flavorSubType\": \"timedtext\",\"multiple\":false,\"displayOrder\":7}",
   "EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CAPTIONS_WEBVTT": "{\"id\": \"attachment_captions_webvtt\", \"type\": \"attachment\", \"flavorType\": \"text\", \"flavorSubType\": \"webvtt\",\"multiple\":false,\"displayOrder\":3}",
-  "EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CLASS_HANDOUT_NOTES": "{\"id\": \"attachment_class_handout_notes\", \"type\": \"attachment\", \"flavorType\": \"attachment\", \"flavorSubType\": \"notes\",\"multiple\":false,\"displayOrder\":5}",
+  "EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CLASS_HANDOUT_NOTES": "{\"id\": \"attachment_class_handout_notes\", \"type\": \"attachment\", \"flavorType\": \"attachment\", \"flavorSubType\": \"notes\",\"multiple\":false,\"displayOrder\":5, \"displayOverride\":\"Overriding Handout Translation\"}",
   "EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.PREVIEW_IMAGE": "{\"id\": \"attachment_preview_image\",\"type\":\"attachment\", \"flavorType\": \"presenter\",\"flavorSubType\": \"search+preview\",\"multiple\":false,\"displayOrder\":2}",
   "EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.SMIL": "{\"id\": \"catalog_smil\",\"type\":\"catalog\", \"flavorType\": \"smil\",\"flavorSubType\": \"smil\",\"displayOrder\":4}",
   "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.MULTIPLE_PARTS": "{\"id\": \"track_trackpart\",\"type\":\"track\", \"flavorType\": \"trackpart\",\"flavorSubType\": \"*\", \"multiple\":true,\"displayOrder\":12}",
   "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.NON_SEGMENTABLE": "{\"id\": \"track_presenter\",\"type\":\"track\", \"flavorType\": \"presenter\",\"flavorSubType\": \"source\", \"multiple\":false,\"displayOrder\":10}",
   "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.SEGMENTABLE": "{\"id\": \"track_presentation\",\"type\":\"track\", \"flavorType\": \"presentation\",\"flavorSubType\": \"source\", \"multiple\":false,\"displayOrder\":11}",
-  "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.AUDIO_ONLY": "{\"id\": \"track_audio\",\"type\":\"track\", \"flavorType\": \"audio\",\"flavorSubType\": \"source\", \"multiple\":false,\"displayOrder\":6}",
+  "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.UNKNOWN": "{\"id\": \"track_unknown\",\"type\":\"track\", \"flavorType\": \"presentation\",\"flavorSubType\": \"unknown\", \"multiple\":false,\"displayOrder\":11, \"displayOverride.SHORT\":\"Override Text\",  \"displayFallback.DETAIL\":\"Fallback detail text\"}",
+  "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.AUDIO_ONLY": "{\"id\": \"track_audio\",\"type\":\"track\", \"flavorType\": \"audio\",\"flavorSubType\": \"source\", \"multiple\":false,\"displayOrder\":6, \"displayOverride.SHORT\":\"Hi I'm the translate text short override!\", \"displayOverride.DETAIL\":\"Hi I'm the translate text detail override!\"}",
   "EVENTS.EVENTS.NEW.UPLOAD_ASSET.WORKFLOWDEFID": "publish-uploaded-assets"
 }
 

--- a/modules/admin-ui/src/test/resources/test/unit/shared/filters/translateOverrideFallbackFilterSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/filters/translateOverrideFallbackFilterSpec.js
@@ -1,0 +1,80 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+describe('adminNg.filters.translateOverrideFallback', function () {
+    var $translate, $translateProvider;
+    var overrideTitle = "My override title",
+    fallbackTitle = "My fallback title",
+    overrideDetail = "My override details text",
+    fallbackDetail = "My fallback details text",
+    audioTranslated = "ήχου";
+
+    var myAssetFallback = {
+        "title": "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.FOOBAR",
+        "displayFallback.SHORT": fallbackTitle,
+        "displayFallback.DETAIL": fallbackDetail
+    };
+    var myAssetOverride = {
+        "title": "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.FOOBAR",
+        "displayOverride.SHORT": overrideTitle,
+        "displayOverride.DETAIL": overrideDetail
+    };
+    var myDontHaveSubTitle = {
+        "title": "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.FOOBAR",
+        "displayOverride": overrideTitle,
+        "displayFallback": fallbackTitle
+    };
+    var myAssetAudio = {
+        "title": "EVENTS.EVENTS.NEW.SOURCE.UPLOAD.AUDIO",
+        "displayFallback.SHORT": fallbackTitle
+    };
+
+    beforeEach(module('adminNg', function ($translateProvider) {
+        $translateProvider.translations('en', {
+            'EVENTS.EVENTS.NEW.SOURCE.UPLOAD.AUDIO': audioTranslated
+        }).preferredLanguage('en');
+    }));
+
+    beforeEach(inject(function (_$translate_) {
+        $translate = _$translate_;
+    }));
+
+    it('has this filter', inject(function ($filter) {
+        expect($filter('translateOverrideFallback')).not.toBeNull();
+    }));
+
+    it('should return the override', inject(function (translateOverrideFallbackFilter) {
+        expect(translateOverrideFallbackFilter(myAssetOverride, 'SHORT')).toEqual(overrideTitle);
+        expect(translateOverrideFallbackFilter(myAssetOverride, 'DETAIL')).toEqual(overrideDetail);
+    }));
+
+    it('should return the fallback', inject(function (translateOverrideFallbackFilter) {
+        expect(translateOverrideFallbackFilter(myAssetFallback, 'SHORT')).toEqual(fallbackTitle);
+        expect(translateOverrideFallbackFilter(myAssetFallback, 'DETAIL')).toEqual(fallbackDetail);
+    }));
+
+    it('should return the override with no type needed', inject(function (translateOverrideFallbackFilter) {
+        expect(translateOverrideFallbackFilter(myDontHaveSubTitle)).toEqual(overrideTitle);
+    }));
+
+    it('should return the translated title', inject(function (translateOverrideFallbackFilter) {
+        expect(translateOverrideFallbackFilter(myAssetAudio)).toEqual(audioTranslated);
+    }));
+});


### PR DESCRIPTION
This patch enables configuring custom fallback Admin UI display text for new, site customized, asset upload options when there are no translations available for that new asset title. It also allows the site to override existing translations for asset upload options when the site needs customized display text.

Reference Discussion: https://groups.google.com/a/opencast.org/forum/#!topic/users/bh_fTdXXxT4