### PR TITLE
MH-12786 Undistinguishable Entries in Groups Editor User List

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupController.js
@@ -26,15 +26,19 @@ angular.module('adminNg.controllers')
 
         var reloadSelectedUsers = function () {
             $scope.group.$promise.then(function() {
-                $scope.user.available.$promise.then(function() {
-                    // Now that we have the user users and the available users populate the selected and available
-                    $scope.user.selected = [];
-                    angular.forEach($scope.group.users, function (user) {
-                        $scope.user.selected.push({name: user.name, value: user.username});
+                $scope.user.all.$promise.then(function() {
+                    // Now that we have the user users and the group users populate the selected and available
+                    $scope.user.selected = $scope.user.all.filter(function (user) {
+                        var foundUser = $scope.group.users.find(function (groupUser) {
+                            return groupUser.username === user.value;
+                        });
+                        return foundUser !== undefined;
                     });
-                    // Filter the selected from the available list
-                    $scope.user.available = _.filter($scope.user.available, function(user) {
-                        return !_.findWhere($scope.user.selected, {name: user.name});
+                    $scope.user.available = $scope.user.all.filter(function (user) {
+                        var foundUser = $scope.user.selected.find(function (selectedUser) {
+                            return selectedUser.value === user.value;
+                        });
+                        return foundUser === undefined;
                     });
                 });
             });
@@ -72,7 +76,8 @@ angular.module('adminNg.controllers')
                $scope.orgProperties = current_user.org.properties;
           }
           $scope.user = {
-              available: ResourcesListResource.query({ resource: $scope.orgProperties['adminui.user.listname'] || 'USERS.INVERSE.WITH.USERNAME'}),
+              all: ResourcesListResource.query({ resource: $scope.orgProperties['adminui.user.listname'] || 'USERS.INVERSE.WITH.USERNAME'}),
+              available: [],
               selected:  [],
               i18n: 'USERS.GROUPS.DETAILS.USERS',
               searchable: true

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/selectContainer.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/selectContainer.html
@@ -42,7 +42,7 @@
                     ng-model="markedForRemoval"
                     ng-init="markedForRemoval = []"
                     ng-class="{ disabled: disabled }"
-                    ng-options="item.name|translate group by item[groupBy] for item in resource.selected | filter: customSelectedFilter() | orderBy: 'name' : false"
+                    ng-options="item.name group by item[groupBy] for item in resource.selected | filter: customSelectedFilter() | orderBy: 'name' : false"
                     style="min-height: 11em;"
                     ng-style="getHeight()"
                     ng-dblclick="remove()">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/users.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/users.js
@@ -21,18 +21,29 @@
 'use strict';
 
 angular.module('adminNg.services')
-.factory('NewGroupUsers', ['ResourcesListResource', '$location', function (ResourcesListResource) {
+.factory('NewGroupUsers', ['AuthService', 'ResourcesListResource', '$location', function (AuthService, ResourcesListResource) {
     var Users = function () {
         var me = this;
-        me.users = {
-            available: ResourcesListResource.query({ resource: 'USERS.INVERSE'}),
-            selected:  [],
-            i18n: 'USERS.GROUPS.DETAILS.USERS',
-            searchable: true
-        };
+
+        var listName = AuthService.getUser().$promise.then(function (current_user) {
+            return angular.isDefined(current_user)
+                && angular.isDefined(current_user.org)
+                && angular.isDefined(current_user.org.properties) ?
+                current_user.org.properties['adminui.user.listname'] : undefined;
+        });
 
         this.reset = function () {
+            me.users = {
+                available: [],
+                selected:  [],
+                i18n: 'USERS.GROUPS.DETAILS.USERS',
+                searchable: true
+            };
+            listName.then(function (listName) {
+                me.users.available = ResourcesListResource.query({ resource: listName || 'USERS.INVERSE.WITH.USERNAME'});
+            });
         };
+
         this.reset();
 
         this.isValid = function () {
@@ -49,5 +60,6 @@ angular.module('adminNg.services')
             return list;
         };
     };
+
     return new Users();
 }]);


### PR DESCRIPTION
When two users share the same fore- and surname, they cannot be
distinguished from each other in the following lists:

- Add Group -> users: left and right list (available and selected)
- Edit Group -> users: right list (selected)

This patch fixes the issue by also displaying the username, or whatever
is configured by prop.adminui.user.listname in
org.opencastproject.organization.cfg.

Also, the translation filter is removed from the selectContainer since
it causes problems when displaying email addresses. Translating entries
of the selectContaiener seems to not be used by now.

This work is sponsored by SWITCH.