### PR TITLE
MH-12788, UTF-8 encoding settings in OAI-PMH publication service remote

### DIFF
--- a/modules/publication-service-oaipmh-remote/src/main/java/org/opencastproject/publication/oaipmh/remote/OaiPmhPublicationServiceRemoteImpl.java
+++ b/modules/publication-service-oaipmh-remote/src/main/java/org/opencastproject/publication/oaipmh/remote/OaiPmhPublicationServiceRemoteImpl.java
@@ -69,7 +69,9 @@ public class OaiPmhPublicationServiceRemoteImpl extends RemoteBase implements Oa
     final HttpPost post = new HttpPost();
     HttpResponse response = null;
     try {
-      post.setEntity(new UrlEncodedFormEntity(params, UTF_8));
+      final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, UTF_8);
+      entity.setContentEncoding(UTF_8.toString());
+      post.setEntity(entity);
       response = getResponse(post);
       if (response != null) {
         logger.info("Publishing media package {} to OAI-PMH channel {} using a remote publication service",
@@ -100,7 +102,9 @@ public class OaiPmhPublicationServiceRemoteImpl extends RemoteBase implements Oa
     params.add(new BasicNameValuePair("channel", repository));
     HttpPost post = new HttpPost("/retract");
     HttpResponse response = null;
-    post.setEntity(new UrlEncodedFormEntity(params, UTF_8));
+    UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, UTF_8);
+    entity.setContentEncoding(UTF_8.toString());
+    post.setEntity(entity);
     try {
       response = getResponse(post);
       Job receipt = null;


### PR DESCRIPTION
Patch to ensure UTF-8 encoding is used by the OAI-PMH remote publication
service.

Signed-off-by: Lars Kiesow <lkiesow@uos.de>