### PR TITLE
MH-12790, Make LTI respect player configuration

### DIFF
--- a/modules/matterhorn-lti/src/main/resources/tools/player/index.html
+++ b/modules/matterhorn-lti/src/main/resources/tools/player/index.html
@@ -84,34 +84,34 @@
 
     <div id="oc_ie8comments">
       <center>
-	<div class="ie8comments-outer">
+        <div class="ie8comments-outer">
           <div class="ie8comments-inner-up">
             <div class="icon icon-information ie8comments-inner-image">&#160;</div>
             No support for your browser
-	    <div id="ie8comments-close" class="icon-2 icon-close ie8comments-inner-image-2">&#160;</div>
+            <div id="ie8comments-close" class="icon-2 icon-close ie8comments-inner-image-2">&#160;</div>
           </div>
           <div class="ie8comments-inner-down">
-	    The comments feature is not available for Internet Explorer browsers with versions less than version 9.<br />
-	    You have the Internet Explorer <span id="ie8comments-browser-version"></span>, please update it.
+            The comments feature is not available for Internet Explorer browsers with versions less than version 9.<br />
+            You have the Internet Explorer <span id="ie8comments-browser-version"></span>, please update it.
           </div>
-	</div>
+        </div>
       </center>
     </div>
     <!-- END #oc_ie8comments -->
-    
+
     <div id="oc_mobile_redirect">
       <center>
-	<div class="mobile_redirect-outer">
+        <div class="mobile_redirect-outer">
           <div class="mobile_redirect-inner-up">
             <div class="icon icon-information mobile_redirect-inner-image">&#160;</div>
             Mobile experience
-	    <div id="mobile_redirect-close" class="icon-2 icon-close mobile_redirect-inner-image-2">&#160;</div>
+            <div id="mobile_redirect-close" class="icon-2 icon-close mobile_redirect-inner-image-2">&#160;</div>
           </div>
           <div class="mobile_redirect-inner-down">
-	    For a better mobile experience there are also mobile phone apps for nearly every platform available.<br />
-	    <span id="oc_mobile_redirect-url">For more information have a look at <a href="http://opencast.org/matterhorn">http://opencast.org/matterhorn</a></span>
+            For a better mobile experience there are also mobile phone apps for nearly every platform available.<br />
+            <span id="oc_mobile_redirect-url">For more information have a look at <a href="http://opencast.org">http://opencast.org</a></span>
           </div>
-	</div>
+        </div>
       </center>
     </div>
     <!-- END #oc_mobile_redirect -->
@@ -178,7 +178,7 @@
         </center>
       </noscript>
 
-	<div id="oc_slide-comments"></div>
+        <div id="oc_slide-comments"></div>
 
       <div id="oc_flash-player">
         <script type="text/javascript" src="/engage/ui/js/player/player-multi-hybrid-flash.js"></script>
@@ -200,9 +200,9 @@
                 Show Captions
               </label>
             </span>
-	        <div id="oc_comment-control">
-	        	<input id="oc_btn-add-comment" class="oc_btn-add-comment handcursor" type="image" src="/engage/ui/img/misc/space.png" name="Add Comment: Control + Alt + A" alt="Add Comment: Control + Alt + A" title="Add Comment: Control + Alt + A" value="Add Comment: Control + Alt + A" />
-	        </div>
+                <div id="oc_comment-control">
+                        <input id="oc_btn-add-comment" class="oc_btn-add-comment handcursor" type="image" src="/engage/ui/img/misc/space.png" name="Add Comment: Control + Alt + A" alt="Add Comment: Control + Alt + A" title="Add Comment: Control + Alt + A" value="Add Comment: Control + Alt + A" />
+                </div>
           </div>
         </div>
         <!-- END #oc_video-time -->
@@ -211,54 +211,54 @@
             <a name="controls"></a>
             Video Player Controls
           </h2>
-          <input id="oc_btn-skip-backward" 
-		 class="oc_btn-skip-backward" 
-		 type="image" 
-		 role="button" 
-		 src="/engage/ui/img/misc/space.png" 
-		 name="Jump To The Previous Slide" 
-		 alt="Jump To The Previous Slide" 
-		 title="Jump To The Previous Slide" 
-		 value="Jump To The Previous Slide" 
-		 aria-labelledby="Jump To The Previous Slide" />
-          <input id="oc_btn-rewind" 
-		 class="oc_btn-rewind" 
-		 type="image" 
-		 role="button" 
-		 src="/engage/ui/img/misc/space.png" 
-		 name="Jump Back: Control + Alt + R" 
-		 alt="Jump Back: Control + Alt + R" 
-		 title="Jump Back: Control + Alt + R" 
-		 value="Jump Back: Control + Alt + R" 
-		 aria-labelledby="Jump Back: Control + Alt + R" />
-          <input id="oc_btn-play-pause" 
-		 class="oc_btn-play" 
-		 type="image" 
-		 role="button" 
-		 src="/engage/ui/img/misc/space.png" 
-		 name="Play: Control + Alt + P" 
-		 alt="Play: Control + Alt + P" 
-		 title="Play: Control + Alt + P" 
-		 value="Play: Control + Alt + P"
-		 aria-labelledby="Play: Control + Alt + P" />
-          <input id="oc_btn-fast-forward" 
-		 class="oc_btn-fast-forward" 
-		 type="image" 
-		 role="button" 
-		 src="/engage/ui/img/misc/space.png" 
-		 name="Jump Forward: Control + Alt + F" 
-		 alt="Jump Forward: Control + Alt + F" 
-		 title="Jump Forward: Control + Alt + F" 
-		 value="Jump Forward: Control + Alt + F" 
-		 aria-labelledby="Play: Control + Alt + P" />
-          <input id="oc_btn-skip-forward" 
-		 class="oc_btn-skip-forward" 
-		 type="image" src="/engage/ui/img/misc/space.png" 
-		 alt="Jump To The Next Slide" 
-		 title="Jump To The Next Slide" 
-		 value="Jump To The Next Slide" 
-		 role="button" 
-		 aria-labelledby="Jump To The Next Slide" />
+          <input id="oc_btn-skip-backward"
+                 class="oc_btn-skip-backward"
+                 type="image"
+                 role="button"
+                 src="/engage/ui/img/misc/space.png"
+                 name="Jump To The Previous Slide"
+                 alt="Jump To The Previous Slide"
+                 title="Jump To The Previous Slide"
+                 value="Jump To The Previous Slide"
+                 aria-labelledby="Jump To The Previous Slide" />
+          <input id="oc_btn-rewind"
+                 class="oc_btn-rewind"
+                 type="image"
+                 role="button"
+                 src="/engage/ui/img/misc/space.png"
+                 name="Jump Back: Control + Alt + R"
+                 alt="Jump Back: Control + Alt + R"
+                 title="Jump Back: Control + Alt + R"
+                 value="Jump Back: Control + Alt + R"
+                 aria-labelledby="Jump Back: Control + Alt + R" />
+          <input id="oc_btn-play-pause"
+                 class="oc_btn-play"
+                 type="image"
+                 role="button"
+                 src="/engage/ui/img/misc/space.png"
+                 name="Play: Control + Alt + P"
+                 alt="Play: Control + Alt + P"
+                 title="Play: Control + Alt + P"
+                 value="Play: Control + Alt + P"
+                 aria-labelledby="Play: Control + Alt + P" />
+          <input id="oc_btn-fast-forward"
+                 class="oc_btn-fast-forward"
+                 type="image"
+                 role="button"
+                 src="/engage/ui/img/misc/space.png"
+                 name="Jump Forward: Control + Alt + F"
+                 alt="Jump Forward: Control + Alt + F"
+                 title="Jump Forward: Control + Alt + F"
+                 value="Jump Forward: Control + Alt + F"
+                 aria-labelledby="Play: Control + Alt + P" />
+          <input id="oc_btn-skip-forward"
+                 class="oc_btn-skip-forward"
+                 type="image" src="/engage/ui/img/misc/space.png"
+                 alt="Jump To The Next Slide"
+                 title="Jump To The Next Slide"
+                 value="Jump To The Next Slide"
+                 role="button"
+                 aria-labelledby="Jump To The Next Slide" />
         </div>
         <!-- END #oc_video-controls -->
         <div id="oc_sound">
@@ -319,7 +319,7 @@
           <span id="annotation" class="annotation">Annotation..</span>
           <!-- table class="segments" id="segmentstable1" -->
             <!-- data comes here -->
-          <!-- /table -->         
+          <!-- /table -->
         </div>
         <div id="segments_ui_slider_data1"></div>
         <div id="segments_ui_slider_data2"></div>
@@ -398,14 +398,14 @@
         </ul>
       </div>
       <!-- END #oc_tabs -->
-      
+
       <!-- Description tab content -->
       <div id="oc_description" class="fl-fix">
         <div id="description-loading" class="loadingImage"></div>
         <div id="oc-description"></div>
       </div>
       <!-- END #oc_description -->
-      
+
       <!-- Slides tab content -->
       <div id="oc_slides" class="oc_DisplayBlock">
         <div id="segments-holder" class="oc-segments-holder">
@@ -425,7 +425,7 @@
         </div>
       </div>
       <!-- END #oc_slides -->
-	
+
       <!-- Slide text tab content -->
       <div id="oc_slidetext" class="fl-fix">
         <div id="segments_text-loading" class="loadingImage"></div>
@@ -436,40 +436,40 @@
         <div id="oc-search-result"></div>
       </div>
       <!-- END #oc_slidetext -->
-      
+
       <!-- Comment tab content -->
       <div id="oc_comments" class="fl-fix">
-	<div id="oc_comments-list-loading" class="loadingImage"></div>
-	<div id="oc-comments-list-add-form">
-	  <p class="oc-comments-list-headingtext">
-	    Add A New Comment
-	  </p>
-	  <p class="oc-comments-list-text">
-	    Use the comment checkbox to show/add timed and slide comments.
-	  </p>
-	  <div id="oc-comments-list-addbox">
-	    <div>
-	      <input id="oc-comments-list-namebox" name="Name" type="text" />
-	      <textarea id="oc-comments-list-textbox" rows="4" colums="30"></textarea>
-	      <input id="oc-comments-list-submit" value="Add comment" role="button" type="button" />
-	      <input id="oc-comments-list-submit-timed" value="Add comment at 00:00:00" role="button" type="button" />
-	    </div>
-	  </div>
-	  <div id="oc-comments-list-header">
-	    <p id="oc-comments-list-header-top" class="oc-comments-list-headingtext"></p>
-	    <p id="oc-comments-list-header-bottom" class="oc-comments-list-boldtext"></p>
-	  </div>
-	  <div id="oc-comments-list">
-	  </div>
-	</div>
+        <div id="oc_comments-list-loading" class="loadingImage"></div>
+        <div id="oc-comments-list-add-form">
+          <p class="oc-comments-list-headingtext">
+            Add A New Comment
+          </p>
+          <p class="oc-comments-list-text">
+            Use the comment checkbox to show/add timed and slide comments.
+          </p>
+          <div id="oc-comments-list-addbox">
+            <div>
+              <input id="oc-comments-list-namebox" name="Name" type="text" />
+              <textarea id="oc-comments-list-textbox" rows="4" colums="30"></textarea>
+              <input id="oc-comments-list-submit" value="Add comment" role="button" type="button" />
+              <input id="oc-comments-list-submit-timed" value="Add comment at 00:00:00" role="button" type="button" />
+            </div>
+          </div>
+          <div id="oc-comments-list-header">
+            <p id="oc-comments-list-header-top" class="oc-comments-list-headingtext"></p>
+            <p id="oc-comments-list-header-bottom" class="oc-comments-list-boldtext"></p>
+          </div>
+          <div id="oc-comments-list">
+          </div>
+        </div>
       </div>
       <!-- END #oc_comments-list-wrapper -->
-      
+
     </div>
     <!-- END #oc_ui_tabs -->
-    
+
     <div class="clear"></div>
-    
+
     <div id="segment-tooltip" class="segment-tooltip"></div>
 
     <!-- Shortcut dialog -->
@@ -544,22 +544,22 @@
         <label for="oc_embed-costum-width-textinput" class="handcursor">
           Width:
         </label>
-	&#160;
+        &#160;
         <input id="oc_embed-costum-width-textinput" maxlength="4" type="text" name="Costum width min 300px" alt="Costum width min 300px" title="Costum width min 300px" value="" />
         <div class="clear"></div>
         <label for="oc_embed-costum-height-textinput" class="handcursor">
           Height:
         </label>
-	&#160;
+        &#160;
         <input id="oc_embed-costum-height-textinput" maxlength="4" type="text" name="" alt="" title="" value="" />
 
         <div class="clear"></div>
         <label for="oc_embed-costum-hide-controls-checkbox" class="handcursor">
           Controls:
         </label>
-		&#160;
+                &#160;
         <input id="oc_embed-costum-hide-controls-checkbox" type="checkbox" name="Display controls" alt="Display controls" title="Display controls" value="" />
-	<br />
+        <br />
         <label for="oc_embed-costum-hide-controls-checkbox" class="handcursor"/>
 
         <a href="javascript:;" onclick="$('#oc_embed').dialog('close');" class="handcursor ui-helper-hidden-accessible oc_btn-leave-session-time" title="Leave embed dialog" role="button">
@@ -579,10 +579,10 @@
     <div id="oc_share-time" title="Video at current time">
       <div id="oc_share-time-text"></div>
       <div>
-	<textarea id="oc_share-time-textfield" class="oc_embed-textarea" rows="1" cols="1"></textarea>
+        <textarea id="oc_share-time-textfield" class="oc_embed-textarea" rows="1" cols="1"></textarea>
       </div>
       <div id="oc_share-time-tip">
-	Press the pause button in the player to get the exact time.
+        Press the pause button in the player to get the exact time.
       </div>
     </div>
     <!-- END #oc_share-time -->
@@ -590,12 +590,12 @@
     <!-- Series dialog -->
     <div id="oc_series" class="ui-widget ui-widget-content ui-corner-all oc_popuplayer ui-state-hover" title="see more of this series" tabindex="-1" role="dialog" aria-hidden="true"></div>
 
-    <!--  Comment dialogs -->       
+    <!--  Comment dialogs -->
     <div id="comment-Info" class="oc-comment-Info">
        <div id="cm-info-box" class="oc-comment-box">
             <div id="oc-comment-info-header" class="oc-comment-header">
                 <span class="ui-icon ui-icon-closethick oc-comment-exit" unselectable="on" style="float:right;-moz-user-select: none;">X</span>
-                <div id="oc-comment-info-header-text" class="oc-comment-header-text"></div>                   
+                <div id="oc-comment-info-header-text" class="oc-comment-header-text"></div>
             </div>
             <div id="oc-comment-info-value-wrapper">
 
@@ -603,18 +603,18 @@
             <div id="oc-comment-info-footer" class="oc-comment-footer">
             </div>
        </div>
-        
+
         <div class="oc-comment-arrow-down"></div>
-        
+
     </div>
-    
-	<div id="oc_dbclick-info">
-		<div id="oc_dblick-info-arrow"></div>
-		<p id="oc_dbclick-info-text">
-			double click to add comment
-		</p>
-	</div>        
+
+        <div id="oc_dbclick-info">
+                <div id="oc_dblick-info-arrow"></div>
+                <p id="oc_dbclick-info-text">
+                        double click to add comment
+                </p>
+        </div>
     <!--  END Comment dialogs -->
-    
+
   </body>
 </html>

--- a/modules/matterhorn-lti/src/main/resources/tools/series/index.html
+++ b/modules/matterhorn-lti/src/main/resources/tools/series/index.html
@@ -18,8 +18,6 @@
     </script>
     <script type="text/javascript" src="../shared/js/oc-pager.js">
     </script>
-    <script type="text/javascript" src="../shared/js/engage-ui.js">
-    </script>
     <script type="text/javascript">
     var urlParams = {};
     (function () {
@@ -55,7 +53,8 @@
 
         }
 
-        //check whether a user is logged in and show logout link
+        // get configuration
+        var defaultPlayer = '/engage/theodul/ui/core.html';
         $.ajax({
           url: '/info/me.json',
           type: 'GET',
@@ -66,76 +65,81 @@
             {
                 $('#logout').show();
             }
-          }
-        });
+            defaultPlayer = data.org.properties.player;
 
-        restEndpoint = restEndpoint + "limit=10";
+            restEndpoint = restEndpoint + "limit=10";
 
-        restEndpoint = restEndpoint + "&offset=" + (page - 1) * 10;
+            restEndpoint = restEndpoint + "&offset=" + (page - 1) * 10;
 
-        restEndpoint = restEndpoint + "&_=" + new Date().getTime(); // workaround for IE ajax caching problem
-        $('#stage').xslt(restEndpoint, "xsl/episodes.xsl", function(){
-          Opencast.pager.renderPager();
+            restEndpoint = restEndpoint + "&_=" + new Date().getTime(); // workaround for IE ajax caching problem
+            $('#stage').xslt(restEndpoint, "xsl/episodes.xsl", function(){
+              Opencast.pager.renderPager();
 
-          var total = $('#oc-episodes-total').html();
-          var toIndex = parseInt($('#oc-episodes-limit').html()) + (page - 1) * 10;
-          var fromIndex = Math.min(parseInt($('#oc-episodes-offset').html()) + 1, toIndex);
+              var total = $('#oc-episodes-total').html();
+              var toIndex = parseInt($('#oc-episodes-limit').html()) + (page - 1) * 10;
+              var fromIndex = Math.min(parseInt($('#oc-episodes-offset').html()) + 1, toIndex);
 
-          if (total > 0) {
-            $('.title').text("Results " + fromIndex + "-" + toIndex + " of " + total + keywordString).html();
+              if (total > 0) {
+                $('.title').text("Results " + fromIndex + "-" + toIndex + " of " + total + keywordString).html();
 
-            $('.timeDate').each(function(){
-              var timeDate = $(this).text();
-              if (timeDate) {
-                //JavaScript parseInt(string, radix)
-                var sd = new Date();
-                sd.setFullYear(parseInt(timeDate.substring(0, 4), 10));
-                sd.setMonth(parseInt(timeDate.substring(5, 7), 10) - 1);
-                sd.setDate(parseInt(timeDate.substring(8, 10), 10));
-                sd.setHours(parseInt(timeDate.substring(11, 13), 10));
-                sd.setMinutes(parseInt(timeDate.substring(14, 16), 10));
-                sd.setSeconds(parseInt(timeDate.substring(17, 19), 10));
-                $(this).html(sd.toLocaleString());
+                $('.timeDate').each(function(){
+                  var timeDate = $(this).text();
+                  if (timeDate) {
+                    //JavaScript parseInt(string, radix)
+                    var sd = new Date();
+                    sd.setFullYear(parseInt(timeDate.substring(0, 4), 10));
+                    sd.setMonth(parseInt(timeDate.substring(5, 7), 10) - 1);
+                    sd.setDate(parseInt(timeDate.substring(8, 10), 10));
+                    sd.setHours(parseInt(timeDate.substring(11, 13), 10));
+                    sd.setMinutes(parseInt(timeDate.substring(14, 16), 10));
+                    sd.setSeconds(parseInt(timeDate.substring(17, 19), 10));
+                    $(this).html(sd.toLocaleString());
+                  }
+                  else {
+                    $(this).html("n.a.");
+                  }
+                });
+                $(".thumb").each(function(index){
+                  var src = $(this).attr("src");
+                  if (src === undefined || src === "") {
+                    $(this).attr("src", "img/thumbnail.png");
+                  }
+                });
+                $("a.player").each(function(index){
+                  var href = $(this).attr('href');
+                  $(this).attr('href', defaultPlayer + href);
+                });
+                $(".search-item").each(function(index){
+                  if (index % 2 == 1) {
+                    $(this).css('background-color', '#F7FBFC');
+                  }
+                  else {
+                    $(this).css('background-color', '#EFF7F9');
+                  }
+                });
               }
               else {
-                $(this).html("n.a.");
+                if (Opencast.pager.getCurrentSearchQuery() != null) {
+                  $('.title').text('No recordings found for : "' + searchQuery + '"');
+                }
+                else {
+                  $('.title').text("No recordings published yet.");
+
+                }
               }
+
             });
-            $(".thumb").each(function(index){
-              var src = $(this).attr("src");
-              if (src === undefined || src === "") {
-                $(this).attr("src", "img/thumbnail.png");
-              }
-            });
-            $(".search-item").each(function(index){
-              if (index % 2 == 1) {
-                $(this).css('background-color', '#F7FBFC');
-              }
-              else {
-                $(this).css('background-color', '#EFF7F9');
-              }
-            });
-          }
-          else {
-            if (Opencast.pager.getCurrentSearchQuery() != null) {
-              $('.title').text('No recordings found for : "' + searchQuery + '"');
+
+            if (searchQuery != null && searchQuery != "") {
+              $('#rsslink').attr("href", "/feeds/rss/2.0/custom/" + searchQuery);
+              $('#atomlink').attr("href", "/feeds/atom/0.3/custom/" + searchQuery);
             }
             else {
-              $('.title').text("No recordings published yet.");
-
+              $('#rsslink').attr("href", "/feeds/rss/2.0/latest");
+              $('#atomlink').attr("href", "/feeds/atom/0.3/latest");
             }
           }
-
         });
-
-        if (searchQuery != null && searchQuery != "") {
-          $('#rsslink').attr("href", "/feeds/rss/2.0/custom/" + searchQuery);
-          $('#atomlink').attr("href", "/feeds/atom/0.3/custom/" + searchQuery);
-        }
-        else {
-          $('#rsslink').attr("href", "/feeds/rss/2.0/latest");
-          $('#atomlink').attr("href", "/feeds/atom/0.3/latest");
-        }
       });
     </script>
   </head>

--- a/modules/matterhorn-lti/src/main/resources/tools/series/index.html
+++ b/modules/matterhorn-lti/src/main/resources/tools/series/index.html
@@ -34,28 +34,28 @@
     })();
 
 
-    
+
       $(document).ready(function(){
-            
+
         var page = Opencast.pager.getCurrentPageID();
         var searchQuery = urlParams["series"];
         var restEndpoint = "../../search/episode.xml?";
-                
+
         var keywordString = "";
-                
+
         if (searchQuery != null && searchQuery != "") {
           restEndpoint = restEndpoint + "q=" + searchQuery + "&";
-                    
+
           // replace all occurences of + by a space
           searchQuery = searchQuery.replace(/\+/g, " ");
-                    
+
           keywordString = " for “" + unescape(searchQuery) + "”";
-          
+
           $('#searchField').attr("value", unescape(searchQuery));
-                    
+
         }
-        
-        //check whether a user is logged in and show logout link 
+
+        //check whether a user is logged in and show logout link
         $.ajax({
           url: '/info/me.json',
           type: 'GET',
@@ -68,11 +68,11 @@
             }
           }
         });
-                
+
         restEndpoint = restEndpoint + "limit=10";
-                
+
         restEndpoint = restEndpoint + "&offset=" + (page - 1) * 10;
-                
+
         restEndpoint = restEndpoint + "&_=" + new Date().getTime(); // workaround for IE ajax caching problem
         $('#stage').xslt(restEndpoint, "xsl/episodes.xsl", function(){
           Opencast.pager.renderPager();
@@ -80,10 +80,10 @@
           var total = $('#oc-episodes-total').html();
           var toIndex = parseInt($('#oc-episodes-limit').html()) + (page - 1) * 10;
           var fromIndex = Math.min(parseInt($('#oc-episodes-offset').html()) + 1, toIndex);
-                    
+
           if (total > 0) {
             $('.title').text("Results " + fromIndex + "-" + toIndex + " of " + total + keywordString).html();
-                        
+
             $('.timeDate').each(function(){
               var timeDate = $(this).text();
               if (timeDate) {
@@ -122,12 +122,12 @@
             }
             else {
               $('.title').text("No recordings published yet.");
-                            
+
             }
           }
-                    
+
         });
-                
+
         if (searchQuery != null && searchQuery != "") {
           $('#rsslink').attr("href", "/feeds/rss/2.0/custom/" + searchQuery);
           $('#atomlink').attr("href", "/feeds/atom/0.3/custom/" + searchQuery);

--- a/modules/matterhorn-lti/src/main/resources/tools/series/xsl/episodes.xsl
+++ b/modules/matterhorn-lti/src/main/resources/tools/series/xsl/episodes.xsl
@@ -8,8 +8,8 @@
         <xsl:for-each select="ns2:search-results/ns2:result">
             <tr class="search-item">
                     <td style="vertical-align: middle; text-align: center; width: 180px; height: 140px;">
-                        <a class="itemtitle">
-                            <xsl:attribute name="href">/engage/theodul/ui/core.html?id=<xsl:value-of
+                        <a class="itemtitle player">
+                            <xsl:attribute name="href">?id=<xsl:value-of
                                 select="mp:mediapackage/@id" /></xsl:attribute>
                                 <img class="thumb" alt="">
                                     <xsl:for-each select="mp:mediapackage/mp:attachments/mp:attachment">
@@ -30,8 +30,8 @@
                             <xsl:choose>
                                  <xsl:when test="mp:mediapackage/mp:media/mp:track/mp:mimetype[.='video/x-flv'] or mp:mediapackage/mp:media/mp:track/mp:mimetype[.='video/mp4'] or mp:mediapackage/mp:media/mp:track/mp:mimetype[.='audio/x-adpcm']">
                                     <b>
-                                        <a class="itemtitle">
-                                            <xsl:attribute name="href">/engage/theodul/ui/core.html?id=<xsl:value-of
+                                        <a class="itemtitle player">
+                                            <xsl:attribute name="href">?id=<xsl:value-of
                                                 select="mp:mediapackage/@id" /></xsl:attribute>
                                             <xsl:value-of select='substring(ns2:dcTitle, 0, 80)' />
                                             <xsl:if test='string-length(ns2:dcTitle)>80'>


### PR DESCRIPTION
This patch fixes that the LTI series tool always linked to `/engage/theodul/ui/core.html` despite actually loading the configuration file specifying the default player.

This patch also fixes a few minor issues like for example that the code tried to load non-existing JavaScript files. In the long run, LTI needs some polishing, but the basics should work like this.

Note that this also includes pull request #158 which is already merged on `develop` which fixes the usage of tabs and trailing spaces. While not strictly necessary for this patch, it makes merging a lot easier and it's cosmetics anyway.

For testing this patch, you do not need a working LTI integration. Instead, just log in and head to:

> http://localhost:8080/ltitools/series/index.html?series=7ef45764-84bb-45c8-8bae-5395e70c1111

…with `7ef45764-84bb-45c8-8bae-5395e70c1111` being a valid series identifier.