### PR TITLE
MH-12797, Explain UI Actions

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -465,7 +465,7 @@
          "PREVIOUS": "Previous",
          "NOCONTENT": "No data available",
          "PUBLISHED": "Published",
-         "HOVER": {
+         "TOOLTIP": {
            "START": "Filter for this start date",
            "SERIES": "Filter for this series",
            "STATUS": "Filter for this event status",
@@ -927,7 +927,7 @@
          "MANAGED_ACL":  "Access policy",
          "EVENTS":       "Events",
          "ACTION":       "Actions",
-         "HOVER": {
+         "TOOLTIP": {
            "SERIES": "Filter events for this series",
            "DETAILS": "Series details",
            "DELETE": "Delete"
@@ -1036,7 +1036,7 @@
          "BLACKLIST_FROM": "Blacklisted from",
          "BLACKLIST_TO":   "Blacklisted until",
          "ACTION":    "Actions",
-         "HOVER": {
+         "TOOLTIP": {
            "NAME": "Filter events for this location",
            "DETAILS": "Location details",
            "DELETE": "Delete location (unregister capture agent)"

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -68,6 +68,8 @@
      }
    },
    "MEDIAMODULE": "Media Module",
+   "SYSTEM_NOTIFICATIONS": "System warnings and notifications",
+   "LANGUAGE": "Select language",
    "HELP":{
      "HELP": "Help",
      "USERS_GUIDE": "User's Guide",
@@ -924,7 +926,12 @@
          "CREATED":      "Created",
          "MANAGED_ACL":  "Access policy",
          "EVENTS":       "Events",
-         "ACTION":       "Actions"
+         "ACTION":       "Actions",
+         "HOVER": {
+           "SERIES": "Filter events for this series",
+           "DETAILS": "Series details",
+           "DELETE": "Delete"
+         }
        },
        "DETAILS": {
           "HEADER": "Series details - {{resourceId}}",
@@ -1028,7 +1035,12 @@
          "VERSION":   "Version",
          "BLACKLIST_FROM": "Blacklisted from",
          "BLACKLIST_TO":   "Blacklisted until",
-         "ACTION":    "Actions"
+         "ACTION":    "Actions",
+         "HOVER": {
+           "NAME": "Filter events for this location",
+           "DETAILS": "Location details",
+           "DELETE": "Delete location (unregister capture agent)"
+         }
        },
        "DETAILS": {
           "HEADER": "Location details - {{resourceId}}",
@@ -1621,6 +1633,8 @@
      "PLACEHOLDER": "Search…",
      "PROFILES": {
        "FILTERS_HEADER":          "Saved filter sets",
+       "EDIT":                    "Edit filter set",
+       "REMOVE":                  "Remove saved filter",
        "EMPTY":                   "No saved filters yet",
        "SAVE_FILTERS":            "Save",
        "FILTER_HEADER":           "Save filter set",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -462,7 +462,19 @@
          "REVIEW_STATUS": "Review status",
          "PREVIOUS": "Previous",
          "NOCONTENT": "No data available",
-         "PUBLISHED": "Published"
+         "PUBLISHED": "Published",
+         "HOVER": {
+           "START": "Filter for this start date",
+           "SERIES": "Filter for this series",
+           "STATUS": "Filter for this event status",
+           "LOCATION": "Filter for this location",
+           "DETAILS": "Event details",
+           "DELETE": "Delete",
+           "PREVIEW": "Open preview player",
+           "EDITOR": "Open video Editor",
+           "COMMENTS": "View comments",
+           "PAUSED_WORKFLOW": "View paused workflow"
+         }
        },
        "SCHEDULING_STATUS": {
          "READY_FOR_RECORDING": "Ready for recording",

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -39,7 +39,7 @@
             </div>
             <nav class="header-nav nav-dd-container" id="nav-dd-container">
                 <div class="nav-dd lang-dd" id="lang-dd" old-admin-ng-dropdown="">
-                    <div class="lang" ng-class="currentLanguageCode">
+                    <div class="lang" ng-class="currentLanguageCode" title="{{ 'LANGUAGE' | translate}}">
                         <img ng-attr-src="img/lang/{{ currentLanguageCode }}.svg"
                             ng-attr-alt="{{ currentLanguageCode }}" />
                     </div>
@@ -59,7 +59,7 @@
                     </a>
                 </div>
 
-                <div class="nav-dd info-dd" id="info-dd" old-admin-ng-dropdown="" with-role="ROLE_ADMIN">
+                <div class="nav-dd info-dd" id="info-dd" title="{{ 'SYSTEM_NOTIFICATIONS' | translate}}" old-admin-ng-dropdown="" with-role="ROLE_ADMIN">
                   <i class="fa fa-bell" aria-hidden="true"></i>
                     <span id="error-count" class="badge" ng-show="services.error">{{ services.numErr }}</span>
                     <ul class="dropdown-ul">

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
@@ -1,26 +1,26 @@
 <a data-open-modal="event-details"
   data-resource-id="{{ row.id }}"
   class="more"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.DETAILS' | translate }}"
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.DETAILS' | translate }}"
   with-role="ROLE_UI_EVENTS_DETAILS_VIEW">
 </a>
 
 <!-- Remove button for published events. -->
 <a class="remove"
   ng-click="row.checkedDelete()"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.DELETE' | translate }}"
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.DELETE' | translate }}"
   with-role="ROLE_UI_EVENTS_DELETE">
 </a>
 
 <a ng-if="row.has_preview && row.needs_cutting" href="#/events/events/{{row.id}}/tools/editor"
   class="fa fa-scissors"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.EDITOR' | translate }}"
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.EDITOR' | translate }}"
   with-role="ROLE_UI_EVENTS_EDITOR_VIEW">
 </a>
 
 <a ng-if="row.has_preview && !row.needs_cutting" href="#/events/events/{{row.id}}/tools/playback"
   class="preview"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.PREVIEW' | translate }}"
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.PREVIEW' | translate }}"
   with-role="ROLE_UI_EVENTS_EDITOR_VIEW">
 </a>
 
@@ -28,7 +28,7 @@
   data-open-modal="event-details"
   data-resource-id="{{ row.id }}"
   data-tab="comments"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.COMMENTS' | translate }}"
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS' | translate }}"
   class="fa fa-comment-o">
 </a>
 
@@ -36,7 +36,7 @@
   data-open-modal="event-details"
   data-resource-id="{{ row.id }}"
   data-tab="comments"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.COMMENTS' | translate }}"
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS' | translate }}"
   class="fa fa-comment">
 </a>
 
@@ -45,6 +45,6 @@
   data-resource-id="{{ row.id }}"
   data-tab="workflows"
   with-role="ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.PAUSED_WORKFLOW' | translate }}"
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.PAUSED_WORKFLOW' | translate }}"
   class="fa fa-warning">
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
@@ -1,44 +1,50 @@
-<!--
-<a class="play" ng-class="{ on: row.publications.Engage }"></a>
--->
 <a data-open-modal="event-details"
-	data-resource-id="{{ row.id }}"
-	class="more"
-	with-role="ROLE_UI_EVENTS_DETAILS_VIEW">
+  data-resource-id="{{ row.id }}"
+  class="more"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.DETAILS' | translate }}"
+  with-role="ROLE_UI_EVENTS_DETAILS_VIEW">
 </a>
 
 <!-- Remove button for published events. -->
-<a class="remove" ng-click="row.checkedDelete()" with-role="ROLE_UI_EVENTS_DELETE"></a>
+<a class="remove"
+  ng-click="row.checkedDelete()"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.DELETE' | translate }}"
+  with-role="ROLE_UI_EVENTS_DELETE">
+</a>
 
 <a ng-if="row.has_preview && row.needs_cutting" href="#/events/events/{{row.id}}/tools/editor"
   class="fa fa-scissors"
-	with-role="ROLE_UI_EVENTS_EDITOR_VIEW">
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.EDITOR' | translate }}"
+  with-role="ROLE_UI_EVENTS_EDITOR_VIEW">
 </a>
 
 <a ng-if="row.has_preview && !row.needs_cutting" href="#/events/events/{{row.id}}/tools/playback"
-	class="preview"
-	with-role="ROLE_UI_EVENTS_EDITOR_VIEW">
+  class="preview"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.PREVIEW' | translate }}"
+  with-role="ROLE_UI_EVENTS_EDITOR_VIEW">
 </a>
 
 <a ng-if="row.has_comments && !row.has_open_comments"
-	data-open-modal="event-details"
-	data-resource-id="{{ row.id }}"
-	data-tab="comments"
-	class="fa fa-comment-o">
-  <!-- <i class="notification"></i> -->
+  data-open-modal="event-details"
+  data-resource-id="{{ row.id }}"
+  data-tab="comments"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.COMMENTS' | translate }}"
+  class="fa fa-comment-o">
 </a>
 
 <a ng-if="row.has_comments && row.has_open_comments"
-	data-open-modal="event-details"
-	data-resource-id="{{ row.id }}"
-	data-tab="comments"
-	class="fa fa-comment">
+  data-open-modal="event-details"
+  data-resource-id="{{ row.id }}"
+  data-tab="comments"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.COMMENTS' | translate }}"
+  class="fa fa-comment">
 </a>
 
 <a ng-if="row.workflow_state == 'PAUSED'"
-	data-open-modal="event-details"
-	data-resource-id="{{ row.id }}"
-	data-tab="workflows"
-	with-role="ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT"
-	class="fa fa-warning">
+  data-open-modal="event-details"
+  data-resource-id="{{ row.id }}"
+  data-tab="workflows"
+  with-role="ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.PAUSED_WORKFLOW' | translate }}"
+  class="fa fa-warning">
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsLocationCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsLocationCell.html
@@ -1,5 +1,5 @@
 <a class="crosslink"
   ng-click="table.addFilterToStorage('location', row.location)"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.LOCATION' | translate }}">
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.LOCATION' | translate }}">
   {{row.location}}
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsLocationCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsLocationCell.html
@@ -1,1 +1,5 @@
-<a class="crosslink" ng-click="table.addFilterToStorage('location', row.location)">{{row.location}}</a>
+<a class="crosslink"
+  ng-click="table.addFilterToStorage('location', row.location)"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.LOCATION' | translate }}">
+  {{row.location}}
+</a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsSeriesCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsSeriesCell.html
@@ -1,5 +1,5 @@
 <a class="crosslink"
   ng-click="table.addFilterToStorage('series', row.series_id)"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.SERIES' | translate }}">
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.SERIES' | translate }}">
   {{row.series_name}}
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsSeriesCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsSeriesCell.html
@@ -1,1 +1,5 @@
-<a class="crosslink" ng-click="table.addFilterToStorage('series', row.series_id)">{{row.series_name}}</a>
+<a class="crosslink"
+  ng-click="table.addFilterToStorage('series', row.series_id)"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.SERIES' | translate }}">
+  {{row.series_name}}
+</a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsStatusCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsStatusCell.html
@@ -1,5 +1,5 @@
 <a class="crosslink"
   ng-click="table.addFilterToStorage('status', row.event_status_raw)"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.STATUS' | translate }}">
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.STATUS' | translate }}">
   {{row.event_status}}
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsStatusCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsStatusCell.html
@@ -1,1 +1,5 @@
-<a class="crosslink" ng-click="table.addFilterToStorage('status', row.event_status_raw)">{{row.event_status}}</a>
+<a class="crosslink"
+  ng-click="table.addFilterToStorage('status', row.event_status_raw)"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.STATUS' | translate }}">
+  {{row.event_status}}
+</a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsTechnicalDateCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsTechnicalDateCell.html
@@ -1,1 +1,5 @@
-<a class="crosslink" ng-click="table.addFilterToStorage('startDate', table.dateToFilterValue(row.technical_date_raw))">{{row.technical_date}}</a>
+<a class="crosslink"
+  ng-click="table.addFilterToStorage('startDate', table.dateToFilterValue(row.technical_date_raw))"
+  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.START' | translate }}">
+  {{row.technical_date}}
+</a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsTechnicalDateCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsTechnicalDateCell.html
@@ -1,5 +1,5 @@
 <a class="crosslink"
   ng-click="table.addFilterToStorage('startDate', table.dateToFilterValue(row.technical_date_raw))"
-  title="{{ 'EVENTS.EVENTS.TABLE.HOVER.START' | translate }}">
+  title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.START' | translate }}">
   {{row.technical_date}}
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesActionsCell.html
@@ -1,7 +1,7 @@
 <a data-open-modal="series-details" 
   data-resource-id="{{ row.id }}" 
   class="more"
-  title="{{ 'EVENTS.SERIES.TABLE.HOVER.DETAILS' | translate }}"
+  title="{{ 'EVENTS.SERIES.TABLE.TOOLTIP.DETAILS' | translate }}"
   with-role="ROLE_UI_SERIES_DETAILS_VIEW">
 </a>
 
@@ -9,6 +9,6 @@
   data-confirmation-modal="confirm-modal"
   data-callback="table.delete"
   data-object="row"
-  title="{{ 'EVENTS.SERIES.TABLE.HOVER.DELETE' | translate }}"
+  title="{{ 'EVENTS.SERIES.TABLE.TOOLTIP.DELETE' | translate }}"
   with-role="ROLE_UI_SERIES_DELETE">
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesActionsCell.html
@@ -1,13 +1,14 @@
 <a data-open-modal="series-details" 
-	data-resource-id="{{ row.id }}" 
-	class="more"
-	with-role="ROLE_UI_SERIES_DETAILS_VIEW">
+  data-resource-id="{{ row.id }}" 
+  class="more"
+  title="{{ 'EVENTS.SERIES.TABLE.HOVER.DETAILS' | translate }}"
+  with-role="ROLE_UI_SERIES_DETAILS_VIEW">
 </a>
 
 <a class="remove"
-    data-confirmation-modal="confirm-modal"
-    data-callback="table.delete"
-    data-object="row"
-    with-role="ROLE_UI_SERIES_DELETE"
-></a>
-
+  data-confirmation-modal="confirm-modal"
+  data-callback="table.delete"
+  data-object="row"
+  title="{{ 'EVENTS.SERIES.TABLE.HOVER.DELETE' | translate }}"
+  with-role="ROLE_UI_SERIES_DELETE">
+</a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesTitleCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesTitleCell.html
@@ -1,1 +1,5 @@
-<a class="crosslink" ng-click="table.addFilterToStorageForResource('events', 'series', row.id);table.gotoRoute('/events/events')">{{row.title}}</a>
+<a class="crosslink"
+  ng-click="table.addFilterToStorageForResource('events', 'series', row.id);table.gotoRoute('/events/events')"
+  title="{{ 'EVENTS.SERIES.TABLE.HOVER.SERIES' | translate }}">
+  {{row.title}}
+</a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesTitleCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesTitleCell.html
@@ -1,5 +1,5 @@
 <a class="crosslink"
   ng-click="table.addFilterToStorageForResource('events', 'series', row.id);table.gotoRoute('/events/events')"
-  title="{{ 'EVENTS.SERIES.TABLE.HOVER.SERIES' | translate }}">
+  title="{{ 'EVENTS.SERIES.TABLE.TOOLTIP.SERIES' | translate }}">
   {{row.title}}
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingActionsCell.html
@@ -1,12 +1,14 @@
 <a data-open-modal="recording-details"
-   data-resource-id="{{ row.id }}"
-   class="more"
-   with-role="ROLE_UI_LOCATIONS_DETAILS_VIEW">
+  data-resource-id="{{ row.id }}"
+  class="more"
+  title="{{ 'RECORDINGS.RECORDINGS.TABLE.HOVER.DETAILS' | translate }}"
+  with-role="ROLE_UI_LOCATIONS_DETAILS_VIEW">
 </a>
 <a data-confirmation-modal="confirm-modal"
-   data-callback="table.delete"
-   data-object="row"
-   ng-if="row.removable"
-   class="remove"
-   with-role="ROLE_UI_LOCATIONS_DELETE">
+  data-callback="table.delete"
+  data-object="row"
+  ng-if="row.removable"
+  class="remove"
+  title="{{ 'RECORDINGS.RECORDINGS.TABLE.HOVER.DELETE' | translate }}"
+  with-role="ROLE_UI_LOCATIONS_DELETE">
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingActionsCell.html
@@ -1,7 +1,7 @@
 <a data-open-modal="recording-details"
   data-resource-id="{{ row.id }}"
   class="more"
-  title="{{ 'RECORDINGS.RECORDINGS.TABLE.HOVER.DETAILS' | translate }}"
+  title="{{ 'RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DETAILS' | translate }}"
   with-role="ROLE_UI_LOCATIONS_DETAILS_VIEW">
 </a>
 <a data-confirmation-modal="confirm-modal"
@@ -9,6 +9,6 @@
   data-object="row"
   ng-if="row.removable"
   class="remove"
-  title="{{ 'RECORDINGS.RECORDINGS.TABLE.HOVER.DELETE' | translate }}"
+  title="{{ 'RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DELETE' | translate }}"
   with-role="ROLE_UI_LOCATIONS_DELETE">
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingsNameCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingsNameCell.html
@@ -1,1 +1,5 @@
-<a class="crosslink" ng-click="table.addFilterToStorageForResource('events', 'location', row.name);table.gotoRoute('/events/events')">{{row.name}}</a>
+<a class="crosslink"
+  ng-click="table.addFilterToStorageForResource('events', 'location', row.name);table.gotoRoute('/events/events')"
+  title="{{ 'RECORDINGS.RECORDINGS.TABLE.HOVER.NAME' | translate }}">
+  {{row.name}}
+</a>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingsNameCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingsNameCell.html
@@ -1,5 +1,5 @@
 <a class="crosslink"
   ng-click="table.addFilterToStorageForResource('events', 'location', row.name);table.gotoRoute('/events/events')"
-  title="{{ 'RECORDINGS.RECORDINGS.TABLE.HOVER.NAME' | translate }}">
+  title="{{ 'RECORDINGS.RECORDINGS.TABLE.TOOLTIP.NAME' | translate }}">
   {{row.name}}
 </a>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/tableFilters.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/tableFilters.html
@@ -8,7 +8,7 @@
         <div class="filters">
             <i title="{{ 'TABLE_FILTERS.ADD' | translate }}"
                 ng-click="displayFilterSelector()" class="fa fa-filter"></i>
-            
+
             <div ng-show="showFilterSelector">
                 <select
                     chosen
@@ -90,7 +90,9 @@
             title="{{ 'TABLE_FILTERS.CLEAR' | translate }}"
             class="clear fa fa-times"></i>
 
-        <i ng-click="toggleFilterSettings()" class="settings fa fa-cog fa-times"></i>
+        <i ng-click="toggleFilterSettings()"
+            title="{{ 'TABLE_FILTERS.PROFILES.FILTERS_HEADER' | translate }}"
+            class="settings fa fa-cog fa-times"></i>
 
         <div class="btn-dd filter-settings-dd df-profile-filters">
             <div ng-show="mode == 1" class="filters-list">
@@ -105,8 +107,12 @@
                             ng-class="{ active: $index === activeProfile }">
                             {{ profile.name | limitTo : 70 }}
                         </a>
-                        <a ng-click="editFilterProfile($index)" class="icon edit"></a>
-                        <a ng-click="removeFilterProfile($index)" class="icon remove"></a>
+                        <a ng-click="editFilterProfile($index)"
+                            title="{{ 'TABLE_FILTERS.PROFILES.EDIT' | translate }}"
+                            class="icon edit"></a>
+                        <a ng-click="removeFilterProfile($index)"
+                            title="{{ 'TABLE_FILTERS.PROFILES.REMOVE' | translate }}"
+                            class="icon remove"></a>
                     </li>
                     <li ng-show="profiles.length == 0"
                     translate="TABLE_FILTERS.PROFILES.EMPTY"><!-- No saved filters yet --></li>


### PR DESCRIPTION
The events table contains several quick filters and actions. For
example, clicking on a series will automatically add a filter for that
particular series which can be very useful. However, the functionality
of these actions is explained nowhere and users are left to figure that
out by their own.

This patch adds title tags to all undescribed icons and links giving a
very short explanation about the functionality when users hover over
them.

Example:
![screenshot from 2018-03-28 20-20-14](https://user-images.githubusercontent.com/1008395/38048874-fa25b5d8-32c6-11e8-907b-c1d92508e22b.png)
