### PR TITLE
Be less quiet about errors on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
   - true
 
 script:
-  - (! grep -r '	' modules assemblies pom.xml --include=pom.xml)
-  - (! grep -r ' $' modules assemblies pom.xml --include=pom.xml)
-  - (! grep -r '	' etc)
-  - (! grep -r ' $' etc)
+  - (! grep -rn '	' modules assemblies pom.xml --include=pom.xml)
+  - (! grep -rn ' $' modules assemblies pom.xml --include=pom.xml)
+  - (! grep -rn '	' etc)
+  - (! grep -rn ' $' etc)
   - (cd docs/guides/admin && mkdocs build)
   - (cd docs/guides/developer && mkdocs build)
   - (cd docs/guides/user && mkdocs build)

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ install:
   - true
 
 script:
-  - (! grep -rq '	' modules assemblies pom.xml --include=pom.xml)
-  - (! grep -rq ' $' modules assemblies pom.xml --include=pom.xml)
-  - (! grep -rq '	' etc)
-  - (! grep -rq ' $' etc)
-  - cd docs/guides/admin && mkdocs build && cd -
-  - cd docs/guides/developer && mkdocs build && cd -
-  - cd docs/guides/user && mkdocs build && cd -
+  - (! grep -r '	' modules assemblies pom.xml --include=pom.xml)
+  - (! grep -r ' $' modules assemblies pom.xml --include=pom.xml)
+  - (! grep -r '	' etc)
+  - (! grep -r ' $' etc)
+  - (cd docs/guides/admin && mkdocs build)
+  - (cd docs/guides/developer && mkdocs build)
+  - (cd docs/guides/user && mkdocs build)
   - mvn --batch-mode clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pnone


### PR DESCRIPTION
This patch ensures that Travis will not only fail but also highlight the
offending lines when grepping for tabs and trailing spaces.