### PR TITLE
MH-12822 Remove old OCv2x security context fix artifacts

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -515,8 +515,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-runtime-info-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-series-service-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-workflow-service-remote/${project.version}</bundle>
-    <!-- Fixes MH-11263 - add LTI dependency to the kernel bundle for shared opencast.httpcontext -->
-    <bundle start-level="82">mvn:org.opencastproject/opencast-lti/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-worker">
@@ -558,8 +556,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-waveform-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-waveform-ffmpeg/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-workflow-service-remote/${project.version}</bundle>
-    <!-- Fixes MH-11263 - add LTI dependency to the kernel bundle for shared opencast.httpcontext -->
-    <bundle start-level="82">mvn:org.opencastproject/opencast-lti/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-adminworker">


### PR DESCRIPTION
Karaf security context issue was resolved in Karaf 4.0.6 upgrade MH-11797. 
The opencast-kernel is not directly linked to opencast-lti module since the MH-11797 Karaf upgrade. There is no other reason for the worker or ingest node to supply the LTI service.
