### PR TITLE
adapt tracking default options to respect the EU GDPR

### DIFF
--- a/docs/guides/admin/docs/configuration/logging.and.privacy.md
+++ b/docs/guides/admin/docs/configuration/logging.and.privacy.md
@@ -23,9 +23,9 @@ have no effect if logging is turned off.
 
 Key                                           | Data to be logged    | Default value
 ----------------------------------------------|----------------------|--------------
-`org.opencastproject.usertracking.log.ip`     | IP addresses         | `true`
-`org.opencastproject.usertracking.log.user`   | login names of users | `true`
-`org.opencastproject.usertracking.log.session`| Browser session-IDs  | `true`
+`org.opencastproject.usertracking.log.ip`     | IP addresses         | `false`
+`org.opencastproject.usertracking.log.user`   | login names of users | `false`
+`org.opencastproject.usertracking.log.session`| Browser session-IDs  | `false`
 
 If you want to use the footprint feature but do not want to store any user specific data you can turn the logging of IP
 addresses, usernames and session-IDs off.

--- a/etc/org.opencastproject.usertracking.impl.UserTrackingServiceImpl.cfg
+++ b/etc/org.opencastproject.usertracking.impl.UserTrackingServiceImpl.cfg
@@ -1,5 +1,5 @@
 #Setting this key to true enables the user tracking javascript, setting it to false prevents the user tracking data from being sent.
 org.opencastproject.usertracking.detailedtrack=true
-org.opencastproject.usertracking.log.ip=true
-org.opencastproject.usertracking.log.user=true
-org.opencastproject.usertracking.log.session=true
+org.opencastproject.usertracking.log.ip=false
+org.opencastproject.usertracking.log.user=false
+org.opencastproject.usertracking.log.session=false


### PR DESCRIPTION
changed the default tracking options of IP addresses, usernames and session-IDs to 'off' to respect the EU GDPR