### PR TITLE
MH-12817 scheduler index rebuild not working on multi tenant

### DIFF
--- a/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/matterhorn-scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -113,6 +113,7 @@ import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.security.api.User;
 import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
@@ -2747,82 +2748,94 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     notEmpty(indexName, "indexName");
 
     final String destinationId = SchedulerItem.SCHEDULER_QUEUE_PREFIX + WordUtils.capitalize(indexName);
-    Organization organization = new DefaultOrganization();
-    SecurityUtil.runAs(securityService, organization, SecurityUtil.createSystemUser(systemUserName, organization),
-            new Effect0() {
-              @Override
-              protected void run() {
-                int current = 1;
+    final Organization organization = new DefaultOrganization();
+    final User user = SecurityUtil.createSystemUser(systemUserName, organization);
+    SecurityUtil.runAs(securityService, organization, user, new Effect0() {
+      @Override
+      protected void run() {
+        int current = 0;
 
-                AQueryBuilder query = assetManager.createQuery();
-                Props p = new Props(query);
-                AResult result = query
-                        .select(query.snapshot(), p.agent().target(), p.start().target(), p.end().target(),
-                                p.optOut().target(), p.presenters().target(), p.reviewDate().target(),
-                                p.reviewStatus().target(), p.recordingStatus().target(),
-                                p.recordingLastHeard().target(), query.propertiesOf(CA_NAMESPACE))
-                        .where(withOrganization(query).and(query.hasPropertiesOf(p.namespace()))
-                                .and(withVersion(query)))
-                        .run();
-                final int total = (int) Math.min(result.getSize(), Integer.MAX_VALUE);
-                logger.info(
-                        "Re-populating '{}' index with scheduled events. There are {} scheduled events to add to the index.",
-                        indexName, total);
-                final int responseInterval = (total < 100) ? 1 : (total / 100);
-                try {
-                  for (ARecord record : result.getRecords()) {
-                    String agentId = record.getProperties().apply(Properties.getString(AGENT_CONFIG));
-                    boolean optOut = record.getProperties().apply(Properties.getBoolean(OPTOUT_CONFIG));
-                    Date start = record.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
-                    Date end = record.getProperties().apply(Properties.getDate(END_DATE_CONFIG));
-                    Set<String> presenters = getPresenters(
-                        record.getProperties().apply(getStringOpt(PRESENTERS_CONFIG)).getOr(""));
-                    boolean blacklisted = isBlacklisted(record.getMediaPackageId(), start, end, agentId, presenters);
-                    Map<String, String> caMetadata = record.getProperties().filter(filterByNamespace._2(CA_NAMESPACE))
-                            .group(toKey, toValue);
-                    ReviewStatus reviewStatus = record.getProperties()
-                        .apply(getStringOpt(REVIEW_STATUS_CONFIG)).map(toReviewStatus).getOr(UNSENT);
-                    Date reviewDate = record.getProperties().apply(Properties.getDateOpt(REVIEW_DATE_CONFIG)).orNull();
-                    Opt<String> recordingStatus = record.getProperties()
-                            .apply(Properties.getStringOpt(RECORDING_STATE_CONFIG));
-                    Opt<Long> lastHeard = record.getProperties()
-                            .apply(Properties.getLongOpt(RECORDING_LAST_HEARD_CONFIG));
+        AQueryBuilder query = assetManager.createQuery();
+        Props p = new Props(query);
+        AResult result = query
+                .select(query.snapshot(), p.agent().target(), p.start().target(), p.end().target(),
+                        p.optOut().target(), p.presenters().target(), p.reviewDate().target(),
+                        p.reviewStatus().target(), p.recordingStatus().target(),
+                        p.recordingLastHeard().target(), query.propertiesOf(CA_NAMESPACE))
+                .where(query.hasPropertiesOf(p.namespace()).and(withVersion(query)))
+                .run();
+        final int total = (int) Math.min(result.getSize(), Integer.MAX_VALUE);
+        logger.info(
+                "Re-populating '{}' index with scheduled events. There are {} scheduled events to add to the index.",
+                indexName, total);
+        final int responseInterval = (total < 100) ? 1 : (total / 100);
+        try {
+          for (ARecord record : result.getRecords()) {
+            current++;
+            if (record.getSnapshot().isNone()) {
+              logger.warn("Doesn't found a media package for an scheuled event {}", record.getMediaPackageId());
+              continue;
+            }
+            try {
+              Snapshot snapshot = record.getSnapshot().get();
+              Organization org = orgDirectoryService.getOrganization(snapshot.getOrganizationId());
+              User orgSystemUser = SecurityUtil.createSystemUser(systemUserName, org);
+              securityService.setOrganization(org);
+              securityService.setUser(orgSystemUser);
 
-                    Opt<AccessControlList> acl = loadEpisodeAclFromAsset(record.getSnapshot().get());
-                    Opt<DublinCoreCatalog> dublinCore = loadEpisodeDublinCoreFromAsset(record.getSnapshot().get());
+              String agentId = record.getProperties().apply(Properties.getString(AGENT_CONFIG));
+              boolean optOut = record.getProperties().apply(Properties.getBoolean(OPTOUT_CONFIG));
+              Date start = record.getProperties().apply(Properties.getDate(START_DATE_CONFIG));
+              Date end = record.getProperties().apply(Properties.getDate(END_DATE_CONFIG));
+              Set<String> presenters = getPresenters(
+                  record.getProperties().apply(getStringOpt(PRESENTERS_CONFIG)).getOr(""));
+              boolean blacklisted = isBlacklisted(record.getMediaPackageId(), start, end, agentId, presenters);
+              Map<String, String> caMetadata = record.getProperties().filter(filterByNamespace._2(CA_NAMESPACE))
+                      .group(toKey, toValue);
+              ReviewStatus reviewStatus = record.getProperties()
+                  .apply(getStringOpt(REVIEW_STATUS_CONFIG)).map(toReviewStatus).getOr(UNSENT);
+              Date reviewDate = record.getProperties().apply(Properties.getDateOpt(REVIEW_DATE_CONFIG)).orNull();
+              Opt<String> recordingStatus = record.getProperties()
+                      .apply(Properties.getStringOpt(RECORDING_STATE_CONFIG));
+              Opt<Long> lastHeard = record.getProperties()
+                      .apply(Properties.getLongOpt(RECORDING_LAST_HEARD_CONFIG));
 
-                    sendUpdateAddEvent(record.getMediaPackageId(), acl, dublinCore, Opt.some(start), Opt.some(end),
-                            Opt.some(presenters), Opt.some(agentId), Opt.some(caMetadata), Opt.some(optOut));
+              Opt<AccessControlList> acl = loadEpisodeAclFromAsset(snapshot);
+              Opt<DublinCoreCatalog> dublinCore = loadEpisodeDublinCoreFromAsset(snapshot);
 
-                    messageSender.sendObjectMessage(destinationId, MessageSender.DestinationType.Queue,
-                            SchedulerItem.updateBlacklist(record.getMediaPackageId(), blacklisted));
-                    messageSender.sendObjectMessage(destinationId, MessageSender.DestinationType.Queue,
-                            SchedulerItem.updateReviewStatus(record.getMediaPackageId(), reviewStatus, reviewDate));
-                    if (((current % responseInterval) == 0) || (current == total)) {
-                      messageSender.sendObjectMessage(IndexProducer.RESPONSE_QUEUE, MessageSender.DestinationType.Queue,
-                              IndexRecreateObject
-                                      .update(indexName, IndexRecreateObject.Service.Scheduler, total, current));
-                    }
-                    if (recordingStatus.isSome() && lastHeard.isSome())
-                      sendRecordingUpdate(
-                              new RecordingImpl(record.getMediaPackageId(), recordingStatus.get(), lastHeard.get()));
-                    current++;
-                  }
-                } catch (Exception e) {
-                  logger.warn("Unable to index scheduled instances: {}", e);
-                  throw new ServiceException(e.getMessage());
-                }
-              }
-            });
+              sendUpdateAddEvent(record.getMediaPackageId(), acl, dublinCore, Opt.some(start), Opt.some(end),
+                      Opt.some(presenters), Opt.some(agentId), Opt.some(caMetadata), Opt.some(optOut));
 
-    SecurityUtil.runAs(securityService, organization, SecurityUtil.createSystemUser(systemUserName, organization),
-            new Effect0() {
-              @Override
-              protected void run() {
-                messageSender.sendObjectMessage(IndexProducer.RESPONSE_QUEUE, MessageSender.DestinationType.Queue,
-                        IndexRecreateObject.end(indexName, IndexRecreateObject.Service.Scheduler));
-              }
-            });
+              messageSender.sendObjectMessage(destinationId, MessageSender.DestinationType.Queue,
+                      SchedulerItem.updateBlacklist(record.getMediaPackageId(), blacklisted));
+              messageSender.sendObjectMessage(destinationId, MessageSender.DestinationType.Queue,
+                      SchedulerItem.updateReviewStatus(record.getMediaPackageId(), reviewStatus, reviewDate));
+              if (recordingStatus.isSome() && lastHeard.isSome())
+                sendRecordingUpdate(
+                        new RecordingImpl(record.getMediaPackageId(), recordingStatus.get(), lastHeard.get()));
+            } finally {
+              securityService.setOrganization(organization);
+              securityService.setUser(user);
+            }
+            if (((current % responseInterval) == 0) || (current == total)) {
+              messageSender.sendObjectMessage(IndexProducer.RESPONSE_QUEUE, MessageSender.DestinationType.Queue,
+                      IndexRecreateObject.update(indexName, IndexRecreateObject.Service.Scheduler, total, current));
+            }
+          }
+        } catch (Exception e) {
+          logger.warn("Unable to index scheduled instances:", e);
+          throw new ServiceException(e.getMessage());
+        }
+      }
+    });
+
+    SecurityUtil.runAs(securityService, organization, user, new Effect0() {
+      @Override
+      protected void run() {
+        messageSender.sendObjectMessage(IndexProducer.RESPONSE_QUEUE, MessageSender.DestinationType.Queue,
+                IndexRecreateObject.end(indexName, IndexRecreateObject.Service.Scheduler));
+      }
+    });
   }
 
   @Override

--- a/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/matterhorn-scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -22,6 +22,8 @@
 package org.opencastproject.scheduler.impl;
 
 import static net.fortuna.ical4j.model.Component.VEVENT;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.eq;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -86,6 +88,7 @@ import org.opencastproject.mediapackage.identifier.UUIDIdBuilderImpl;
 import org.opencastproject.message.broker.api.BaseMessage;
 import org.opencastproject.message.broker.api.MessageReceiver;
 import org.opencastproject.message.broker.api.MessageSender;
+import org.opencastproject.message.broker.api.scheduler.SchedulerItem;
 import org.opencastproject.metadata.dublincore.DCMIPeriod;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogList;
@@ -119,8 +122,10 @@ import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
+import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.security.api.User;
 import org.opencastproject.series.api.SeriesQuery;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.FileSupport;
@@ -153,6 +158,8 @@ import net.fortuna.ical4j.model.property.RRule;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
@@ -187,6 +194,7 @@ import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
+import java.util.stream.Collectors;
 
 import javax.persistence.EntityManagerFactory;
 import javax.servlet.http.HttpServletRequest;
@@ -199,6 +207,10 @@ public class SchedulerServiceImplTest {
   private SeriesService seriesService;
   private static UnitTestWorkspace workspace;
   private AssetManager assetManager;
+  private static OrganizationDirectoryService orgDirectoryService;
+
+  private User currentUser = null;
+  private Organization currentOrg = null;
 
   private static SchedulerServiceImpl schedSvc;
 
@@ -286,7 +298,7 @@ public class SchedulerServiceImplTest {
             authorizationService.getAcl(EasyMock.anyObject(MediaPackage.class), EasyMock.anyObject(AclScope.class)))
             .andReturn(Option.some(acl)).anyTimes();
 
-    OrganizationDirectoryService orgDirectoryService = EasyMock.createNiceMock(OrganizationDirectoryService.class);
+    orgDirectoryService = EasyMock.createNiceMock(OrganizationDirectoryService.class);
     EasyMock.expect(orgDirectoryService.getOrganizations())
             .andReturn(Arrays.asList((Organization) new DefaultOrganization())).anyTimes();
 
@@ -2219,6 +2231,72 @@ public class SchedulerServiceImplTest {
     }
   }
 
+  @Test
+  public void testRepopulateIndexMultitenant() throws Exception {
+    List<Organization> orgList = Arrays.asList(
+            (Organization) new DefaultOrganization(),
+            createOrganization("org1", "Org 1"),
+            createOrganization("org2", "Org 2"));
+
+    List<User> usersList = Arrays.asList(
+            createUser(orgList.get(0), "user1", Arrays.asList(orgList.get(0).getAdminRole())),
+            createUser(orgList.get(1), "user2", Arrays.asList(orgList.get(1).getAdminRole())),
+            createUser(orgList.get(2), "user3", Arrays.asList(orgList.get(2).getAdminRole())));
+
+    currentUser = usersList.get(0);
+    currentOrg = currentUser.getOrganization();
+
+    EventCatalogUIAdapter episodeAdapter = EasyMock.createMock(EventCatalogUIAdapter.class);
+    EasyMock.expect(episodeAdapter.getFlavor()).andReturn(MediaPackageElements.EPISODE).anyTimes();
+    EasyMock.expect(episodeAdapter.getOrganization()).andAnswer(() -> { return currentOrg.getId(); }).anyTimes();
+    EasyMock.replay(episodeAdapter);
+    schedSvc.addCatalogUIAdapter(episodeAdapter);
+
+    EasyMock.reset(orgDirectoryService);
+    EasyMock.expect(orgDirectoryService.getOrganizations()).andReturn(orgList).anyTimes();
+    EasyMock.expect(orgDirectoryService.getOrganization(EasyMock.anyString())).andAnswer(() -> {
+      String orgId = (String) EasyMock.getCurrentArguments()[0];
+      return orgList.stream().filter(org -> org.getId().equalsIgnoreCase(orgId)).findFirst().orElse(null);
+    }).anyTimes();
+
+    SecurityService securityService = schedSvc.getSecurityService();
+    EasyMock.reset(securityService);
+    EasyMock.expect(securityService.getUser()).andAnswer(() -> currentUser).anyTimes();
+    EasyMock.expect(securityService.getOrganization()).andAnswer(() -> currentOrg).anyTimes();
+    securityService.setUser(EasyMock.anyObject(User.class));
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.replay(orgDirectoryService, securityService);
+
+    MessageSender messageSender = schedSvc.getMessageSender();
+    EasyMock.reset(messageSender);
+    Capture<SchedulerItem> schedulerItemsCapture = Capture.newInstance(CaptureType.ALL);
+    messageSender.sendObjectMessage(eq(SchedulerItem.SCHEDULER_QUEUE), eq(MessageSender.DestinationType.Queue),
+            capture(schedulerItemsCapture));
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.replay(messageSender);
+
+    // create test events for each organization
+    for (User user : usersList) {
+      currentUser = user;
+      currentOrg = user.getOrganization();
+      createEvents("Event", "ca_" + currentOrg.getId(), 1, schedSvc, false, false);
+    }
+    currentUser = usersList.get(0);
+    currentOrg = currentUser.getOrganization();
+    schedulerItemsCapture.reset();
+
+    schedSvc.repopulate("adminui");
+    assertTrue(schedulerItemsCapture.hasCaptured());
+    List<DublinCoreCatalog> dublincoreCatalogs = new ArrayList<>();
+    for (SchedulerItem schedulerItem : schedulerItemsCapture.getValues()) {
+      if (schedulerItem.getType() == SchedulerItem.Type.UpdateCatalog) {
+        DublinCoreCatalog snapshotDC = schedulerItem.getEvent();
+        dublincoreCatalogs.add(snapshotDC);
+      }
+    }
+    assertEquals(orgList.size(), dublincoreCatalogs.size());
+  }
+
   private String addDublinCore(Opt<String> id, MediaPackage mediaPackage, final DublinCoreCatalog initalEvent)
           throws URISyntaxException, IOException {
     String catalogId = UUID.randomUUID().toString();
@@ -2528,5 +2606,52 @@ public class SchedulerServiceImplTest {
                     tuple("eclipselink.ddl-generation.output-mode", "database"),
                     tuple("eclipselink.logging.level.sql", "FINE"), tuple("eclipselink.logging.parameters", "true")),
             PersistenceUtil.mkTestPersistenceProvider());
+  }
+
+  /**
+   * Create a mocked organization.
+   * @param id the organization identifier
+   * @param name the organization name
+   * @return a mocked organization
+   */
+  static Organization createOrganization(String id, String name) {
+    Organization org = EasyMock.createNiceMock(Organization.class);
+    EasyMock.expect(org.getId()).andReturn(id).anyTimes();
+    EasyMock.expect(org.getName()).andReturn(name).anyTimes();
+    EasyMock.expect(org.getAdminRole()).andReturn("ROLE_ADMIN_" + id.toUpperCase().replaceAll(" ", "_")).anyTimes();
+    EasyMock.expect(org.getProperties()).andReturn(Collections.EMPTY_MAP).anyTimes();
+    EasyMock.expect(org.getServers()).andReturn(Collections.EMPTY_MAP).anyTimes();
+    EasyMock.replay(org);
+    return org;
+  }
+
+  /**
+   * Create a mocked user.
+   * @param org the organization the user belongs to
+   * @param username the username
+   * @param roles the users role names
+   * @return a mocked user
+   */
+  static User createUser(Organization org, String username, List<String> roles) {
+    Set<Role> rolesList = roles.stream().map(roleName -> {
+      Role r = EasyMock.createNiceMock(Role.class);
+      EasyMock.expect(r.getName()).andReturn(roleName).anyTimes();
+      EasyMock.expect(r.getOrganization()).andReturn(org).anyTimes();
+      EasyMock.replay(r);
+      return r;
+    }).collect(Collectors.toSet());
+
+    User user = EasyMock.createNiceMock(User.class);
+    EasyMock.expect(user.getName()).andReturn(username).anyTimes();
+    EasyMock.expect(user.getUsername()).andReturn(username).anyTimes();
+    EasyMock.expect(user.getOrganization()).andReturn(org).anyTimes();
+    EasyMock.expect(user.getRoles()).andReturn(rolesList).anyTimes();
+    EasyMock.expect(user.hasRole(EasyMock.anyString())).andAnswer(() -> {
+      String role = (String) EasyMock.getCurrentArguments()[0];
+      return roles.contains(role);
+    }).anyTimes();
+
+    EasyMock.replay(user);
+    return user;
   }
 }


### PR DESCRIPTION
The scheduler index rebuild only update events for the default organization. Events of other organizations aren't updated with schedule metadata at all. This misbehaviour should be fixed by this PR.

For testing you need to configure two or more organizations in opencast, schedule some events and rebuild the index (e.g. adminui index). 

Work sponsored by SWITCH