### PR TITLE
MH-12831, Fixing dependencies

### DIFF
--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -94,6 +94,12 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-distribution-workflowoperation</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-event-comment</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -226,19 +232,9 @@
     </dependency>
     <!-- REST test environment -->
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
+      <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>2.9.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-library</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>uk.co.datumedge</groupId>

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -48,7 +48,6 @@ import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.workflow.api.WorkflowService;
 
 import com.entwinemedia.fn.data.Opt;
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
@@ -67,6 +66,7 @@ import java.io.IOException;
 
 import javax.ws.rs.WebApplicationException;
 
+import io.restassured.http.ContentType;
 import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
 public class AbstractEventEndpointTest {
@@ -675,8 +675,8 @@ public class AbstractEventEndpointTest {
 
   @Test
   public void testGetCatalogAdapters() throws Exception {
-    given().expect().statusCode(HttpStatus.SC_OK).when().contentType(ContentType.JSON).body("", hasSize(2))
-            .body("title", hasItems("name 1", "name 2")).get(rt.host("catalogAdapters"));
+    given().expect().statusCode(HttpStatus.SC_OK).when().get(rt.host("catalogAdapters")).then()
+            .body("title", hasItems("name 1", "name 2")).contentType(ContentType.JSON).body("", hasSize(2));
   }
 
   @Test
@@ -703,7 +703,7 @@ public class AbstractEventEndpointTest {
     String expected = IOUtils.toString(getClass().getResource("/publications.json"));
 
     String result = given().pathParam("eventId", "asdasd").expect().statusCode(HttpStatus.SC_OK).when()
-            .contentType(ContentType.JSON).get(rt.host("{eventId}/asset/publication/publications.json")).asString();
+      .get(rt.host("{eventId}/asset/publication/publications.json")).asString();
 
     assertThat(expected, SameJSONAs.sameJSONAs(result));
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AclEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AclEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
@@ -30,8 +30,6 @@ import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
 import org.opencastproject.rest.NotFoundExceptionMapper;
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.json.simple.JSONObject;
@@ -45,6 +43,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import io.restassured.http.ContentType;
 
 public class AclEndpointTest {
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
@@ -30,8 +30,6 @@ import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -45,6 +43,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import io.restassured.http.ContentType;
 
 public class CaptureAgentsEndpointTest {
   private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestCaptureAgentsEndpoint.class);

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/JobEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/JobEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
@@ -29,8 +29,6 @@ import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
@@ -48,6 +46,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import io.restassured.http.ContentType;
 import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
 public class JobEndpointTest {

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ListProvidersEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ListProvidersEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasValue;
 import static org.junit.Assert.assertEquals;
@@ -29,10 +29,6 @@ import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
-import com.jayway.restassured.response.Response;
-import com.jayway.restassured.response.ResponseBody;
 
 import org.apache.http.HttpStatus;
 import org.json.simple.JSONObject;
@@ -42,6 +38,10 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.response.ResponseBody;
 
 public class ListProvidersEndpointTest {
   private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestListProvidersEndpoint.class);
@@ -79,8 +79,10 @@ public class ListProvidersEndpointTest {
 
   @Test
   public void testGetWithFilters() throws ParseException {
-    Response response = given().log().all().pathParam("id", "SERVERS").parameters("filter", "name=non existing name")
-            .expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON).get(rt.host("/{id}.json"));
+    Response response = given().log().all().pathParam("id", "SERVERS").param("filter", "name=non existing name")
+      .when().get(rt.host("/{id}.json"))
+      .then().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+      .extract().response();
     ResponseBody body = response.getBody();
     String content = body.asString();
     JSONObject json = (JSONObject) parser.parse(content);

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/SeriesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/SeriesEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
@@ -29,8 +29,6 @@ import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 import org.opencastproject.adminui.api.SortType;
 import org.opencastproject.rest.BulkOperationResult;
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
@@ -49,6 +47,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Locale;
+
+import io.restassured.http.ContentType;
 
 public class SeriesEndpointTest {
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServerEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServerEndpointTest.java
@@ -21,15 +21,13 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.json.simple.JSONObject;
@@ -43,6 +41,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import io.restassured.http.ContentType;
 
 public class ServerEndpointTest {
   private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestServerEndpoint.class);

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServicesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServicesEndpointTest.java
@@ -21,15 +21,13 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.json.simple.JSONObject;
@@ -43,6 +41,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import io.restassured.http.ContentType;
 
 /**
  * Services Endpoint unit tests.

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
@@ -21,14 +21,12 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.http.HttpStatus;
 import org.json.simple.JSONArray;
@@ -42,6 +40,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import io.restassured.http.ContentType;
 
 public class TasksEndpointTest {
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ThemesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ThemesEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
@@ -29,8 +29,6 @@ import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.http.HttpStatus;
 import org.json.simple.JSONArray;
@@ -46,6 +44,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+
+import io.restassured.http.ContentType;
 
 public class UsersEndpointTest {
   private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestUsersEndpoint.class);

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersSettingsEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersSettingsEndpointTest.java
@@ -21,15 +21,13 @@
 
 package org.opencastproject.adminui.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.rest.RestServiceTestEnv;
-
-import com.jayway.restassured.http.ContentType;
 
 import org.apache.http.HttpStatus;
 import org.json.simple.JSONArray;
@@ -51,6 +49,8 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Set;
+
+import io.restassured.http.ContentType;
 
 public class UsersSettingsEndpointTest {
   private static final Logger logger = LoggerFactory.getLogger(UsersSettingsEndpointTest.class);

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.mutabilitydetector</groupId>
       <artifactId>MutabilityDetector</artifactId>
-      <version>0.9.2</version>
+      <version>0.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -22,16 +22,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-conductor</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-distribution-service-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-series-service-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -61,6 +51,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workflow-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
     </dependency>
@@ -77,8 +72,12 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -106,6 +105,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
+    </dependency>
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -114,25 +117,34 @@
     </dependency>
     <!-- Testing -->
     <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common-jpa-impl</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-kernel</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -156,29 +168,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.asm</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.antlr</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.mchange</groupId>
-      <artifactId>c3p0</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-distribution-workflowoperation</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/JsonConvTest.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/JsonConvTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.authorization.xacml.manager.endpoint;
 
-import static com.jayway.restassured.path.json.JsonPath.from;
+import static io.restassured.path.json.JsonPath.from;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.security.api.AccessControlUtil.acl;
 import static org.opencastproject.security.api.AccessControlUtil.entry;
@@ -38,8 +38,6 @@ import org.opencastproject.util.data.Collections;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workflow.api.ConfiguredWorkflowRef;
 
-import com.jayway.restassured.path.json.JsonPath;
-
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +45,8 @@ import org.slf4j.LoggerFactory;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+
+import io.restassured.path.json.JsonPath;
 
 public final class JsonConvTest {
   private static final Logger logger = LoggerFactory.getLogger(JsonConvTest.class);

--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpointTest.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpointTest.java
@@ -21,7 +21,7 @@
 
 package org.opencastproject.authorization.xacml.manager.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -625,12 +625,12 @@ public class OsgiAclServiceRestEndpointTest {
     }
   }
 
-  public static Long extractTransitionId(com.jayway.restassured.response.Response r) throws Exception {
+  public static Long extractTransitionId(io.restassured.response.Response r) throws Exception {
     JSONObject json = (JSONObject) new JSONParser().parse(r.asString());
     return (Long) json.get("transitionId");
   }
 
-  public static Long extractAclId(com.jayway.restassured.response.Response r) throws Exception {
+  public static Long extractAclId(io.restassured.response.Response r) throws Exception {
     JSONObject json = (JSONObject) new JSONParser().parse(r.asString());
     return (Long) json.get("id");
   }

--- a/modules/caption-impl/pom.xml
+++ b/modules/caption-impl/pom.xml
@@ -59,6 +59,11 @@
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+    </dependency>
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -15,12 +15,6 @@
     <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>
-    <!-- Opencast -->
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-urlsigning-service-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.entwinemedia.common</groupId>
       <artifactId>functional</artifactId>
@@ -34,6 +28,14 @@
       <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
@@ -42,12 +44,12 @@
       <artifactId>jsr311-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>com.springsource.org.apache.commons.beanutils</artifactId>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
+      <artifactId>httpcore-osgi</artifactId>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
@@ -58,20 +60,12 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
@@ -131,19 +125,14 @@
     </dependency>
     <!-- REST test environment -->
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <version>2.4.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-library</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>xml-path</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>
@@ -163,12 +152,10 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jettison</groupId>
@@ -187,23 +174,19 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
     <!--
     - Parameterized tests for JUnit
     - https://github.com/Pragmatists/JUnitParams
     -->
     <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
-      <version>1.0.4</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/common/src/test/java/org/opencastproject/job/api/JobBarrierTest.java
+++ b/modules/common/src/test/java/org/opencastproject/job/api/JobBarrierTest.java
@@ -31,7 +31,6 @@ import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Function2;
 
 import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,12 +65,9 @@ public class JobBarrierTest {
     logger.info("Waiting for " + jobs.size() + " jobs");
     // create a service registry mock returning those jobs
     final ServiceRegistry sr = createNiceMock(ServiceRegistry.class);
-    EasyMock.expect(sr.getJob(EasyMock.anyLong())).andAnswer(new IAnswer<Job>() {
-      @Override
-      public Job answer() throws Throwable {
-        final long jobId = (Long) (EasyMock.getCurrentArguments()[0]);
-        return jobs.get(jobId);
-      }
+    EasyMock.expect(sr.getJob(EasyMock.anyLong())).andAnswer(() -> {
+      final long jobId = (Long) (EasyMock.getCurrentArguments()[0]);
+      return jobs.get(jobId);
     }).anyTimes();
     EasyMock.replay(sr);
     // wait for all jobs to complete

--- a/modules/common/src/test/java/org/opencastproject/mediapackage/MediaPackageTest.java
+++ b/modules/common/src/test/java/org/opencastproject/mediapackage/MediaPackageTest.java
@@ -22,7 +22,7 @@
 
 package org.opencastproject.mediapackage;
 
-import static com.jayway.restassured.path.xml.XmlPath.from;
+import static io.restassured.path.xml.XmlPath.from;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/modules/common/src/test/java/org/opencastproject/util/JsonsTest.java
+++ b/modules/common/src/test/java/org/opencastproject/util/JsonsTest.java
@@ -37,14 +37,14 @@ import static org.opencastproject.util.Jsons.p;
 import static org.opencastproject.util.Jsons.toJson;
 import static org.opencastproject.util.Jsons.v;
 
-import com.jayway.restassured.path.json.JsonPath;
-
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+
+import io.restassured.path.json.JsonPath;
 
 public class JsonsTest {
   private static final Logger logger = LoggerFactory.getLogger(JsonsTest.class);

--- a/modules/composer-ffmpeg/pom.xml
+++ b/modules/composer-ffmpeg/pom.xml
@@ -31,6 +31,15 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
@@ -57,6 +66,11 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <!-- javax.activation for MimetypesFileTypeMap which can probably be removed: -->
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>
@@ -89,11 +103,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -158,17 +158,6 @@
       <version>1.0-RC1</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.jayway.restassured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <version>2.4.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore-osgi</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/dublincore/pom.xml
+++ b/modules/dublincore/pom.xml
@@ -45,17 +45,38 @@
       <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -35,6 +35,12 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/modules/execute-remote/pom.xml
+++ b/modules/execute-remote/pom.xml
@@ -17,11 +17,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-execute-api</artifactId>
       <version>${project.version}</version>
@@ -30,6 +25,19 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -27,11 +27,6 @@
     <!-- opencast -->
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-message-broker-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -56,12 +51,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-metadata-api</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-series-service-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -80,14 +69,9 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-authorization-manager</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workflow-service-api</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
@@ -101,8 +85,33 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common-jpa-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-urlsigning-service-api</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.json-simple</groupId>
+      <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -115,14 +124,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.groovy</groupId>
-      <artifactId>groovy-all</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -139,71 +140,26 @@
     </dependency>
     <!-- Testing -->
     <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-series-service-impl</artifactId>
+      <artifactId>opencast-distribution-workflowoperation</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.opencastproject</groupId>
-          <artifactId>opencast-solr</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>uk.co.datumedge</groupId>
       <artifactId>hamcrest-json</artifactId>
       <version>0.2</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.xmlmatchers</groupId>
-      <artifactId>xml-matchers</artifactId>
-      <version>1.0-RC1</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>net.sf.saxon</groupId>
-          <artifactId>Saxon-HE</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.xerces</groupId>
-      <artifactId>com.springsource.org.apache.xerces</artifactId>
-      <version>2.9.1</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- REST test environment -->
-    <dependency>
-      <groupId>com.jayway.restassured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <version>2.4.0</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-library</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
@@ -20,7 +20,7 @@
  */
 package org.opencastproject.external.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/EventsEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/EventsEndpointTest.java
@@ -21,7 +21,7 @@
 package org.opencastproject.external.endpoint;
 
 import static com.entwinemedia.fn.data.json.Jsons.arr;
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SecurityEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SecurityEndpointTest.java
@@ -20,7 +20,7 @@
  */
 package org.opencastproject.external.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_ACCEPTABLE;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.Assert.assertEquals;

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SeriesEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SeriesEndpointTest.java
@@ -20,7 +20,7 @@
  */
 package org.opencastproject.external.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;

--- a/modules/hello-world-impl/pom.xml
+++ b/modules/hello-world-impl/pom.xml
@@ -31,6 +31,11 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -138,6 +138,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-distribution-workflowoperation</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -188,6 +194,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.fortuna.ical4j</groupId>
+      <artifactId>ical4j</artifactId>
+    </dependency>
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -219,6 +229,13 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
+    </dependency>
+    <!-- for ical4j: -->
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <scope>test</scope>
+      <version>2.6</version>
     </dependency>
   </dependencies>
   <build>

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
@@ -63,7 +63,7 @@ import org.opencastproject.util.data.Option;
 
 import com.entwinemedia.fn.Fn;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -22,22 +22,12 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-authorization-xacml</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-ingest-service-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workflow-service-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-metadata-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -69,10 +59,6 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-inspection-service-api</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -135,17 +121,16 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.htmlunit</groupId>
-      <artifactId>htmlunit</artifactId>
-      <version>2.6</version>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -52,10 +52,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
@@ -95,16 +91,8 @@
       <artifactId>spring-security-oauth</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-ldap</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.osgi</groupId>
       <artifactId>org.springframework.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>net.sourceforge.nekohtml</groupId>
-      <artifactId>com.springsource.org.cyberneko.html</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -128,22 +116,6 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.ops4j.pax.web</groupId>
-      <artifactId>pax-web-api</artifactId>
-      <version>${pax.web.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.security</groupId>
-      <artifactId>jboss-xacml</artifactId>
-      <version>2.0.5.final</version>
-      <exclusions>
-        <exclusion>
-          <groupId>apache-xerces</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.entwinemedia.common</groupId>
@@ -184,6 +156,10 @@
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>javax.persistence</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -193,19 +169,14 @@
     <!-- Testing -->
     <!-- REST test environment -->
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>2.4.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-library</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -223,6 +194,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.core</artifactId>
       <scope>compile</scope>
@@ -233,23 +214,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.asm</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.antlr</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.mchange</groupId>
-      <artifactId>c3p0</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/modules/kernel/src/test/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpointTest.java
+++ b/modules/kernel/src/test/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpointTest.java
@@ -21,8 +21,8 @@
 
 package org.opencastproject.kernel.bundleinfo;
 
-import static com.jayway.restassured.RestAssured.expect;
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.expect;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.not;
@@ -42,13 +42,13 @@ import org.opencastproject.util.data.Option;
 import org.opencastproject.util.persistence.PersistenceEnv;
 import org.opencastproject.util.persistence.PersistenceEnvs;
 
-import com.jayway.restassured.path.json.JsonPath;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.restassured.path.json.JsonPath;
 
 /**
  * Note that the Jersey implementation serializes number values as strings in JSON so the respective tests test for both

--- a/modules/oaipmh-remote/pom.xml
+++ b/modules/oaipmh-remote/pom.xml
@@ -25,21 +25,13 @@
       <artifactId>opencast-oaipmh-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <!-- Test -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymockclassextension</artifactId>
-      <scope>test</scope>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/oaipmh/pom.xml
+++ b/modules/oaipmh/pom.xml
@@ -29,17 +29,49 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient-osgi</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-dublincore</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-series-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workspace-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -82,9 +114,8 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
+      <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
-      <version>1.3</version>
     </dependency>
     <dependency>
       <groupId>org.xmlmatchers</groupId>
@@ -103,16 +134,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.asm</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.antlr</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>
@@ -120,6 +141,11 @@
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/AbstractOaiPmhServerInfoRestEndpointTest.java
+++ b/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/AbstractOaiPmhServerInfoRestEndpointTest.java
@@ -20,7 +20,7 @@
  */
 package org.opencastproject.oaipmh.server;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;

--- a/modules/publication-service-oaipmh-remote/pom.xml
+++ b/modules/publication-service-oaipmh-remote/pom.xml
@@ -22,8 +22,30 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-urlsigning-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -38,14 +60,6 @@
       <artifactId>jsr311-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -58,18 +72,26 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.compendium</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/publication-service-oaipmh-remote/src/test/java/org/opencastproject/publication/oaipmh/endpoint/OaiPmhPublicationRestServiceTest.java
+++ b/modules/publication-service-oaipmh-remote/src/test/java/org/opencastproject/publication/oaipmh/endpoint/OaiPmhPublicationRestServiceTest.java
@@ -20,7 +20,7 @@
  */
 package org.opencastproject.publication.oaipmh.endpoint;
 
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.rest.RestServiceTestEnv.testEnvForClasses;

--- a/modules/runtime-info/pom.xml
+++ b/modules/runtime-info/pom.xml
@@ -49,25 +49,18 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils-core</artifactId>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -27,11 +27,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-series-service-impl</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-capture-admin-service-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -61,8 +56,30 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workspace-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -107,11 +124,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -183,6 +195,13 @@
       <groupId>com.mysema.querydsl</groupId>
       <artifactId>querydsl-apt</artifactId>
       <scope>test</scope>
+    </dependency>
+    <!-- for ical4j: -->
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <scope>test</scope>
+      <version>2.6</version>
     </dependency>
   </dependencies>
   <build>

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -55,6 +55,26 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -66,11 +86,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/transcription-service-ibm-watson-impl/pom.xml
+++ b/modules/transcription-service-ibm-watson-impl/pom.xml
@@ -27,11 +27,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-caption-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -61,6 +56,14 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
     </dependency>
@@ -87,11 +90,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
@@ -60,7 +60,7 @@ import org.opencastproject.workflow.api.WorkflowService;
 import org.opencastproject.workingfilerepository.api.WorkingFileRepository;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;

--- a/modules/userdirectory-sakai/pom.xml
+++ b/modules/userdirectory-sakai/pom.xml
@@ -64,6 +64,22 @@
       <groupId>org.springframework</groupId>
       <artifactId>org.springframework.transaction</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -71,18 +87,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.7.0</version>
         <configuration>
           <source>${jdk.version}</source>
           <target>${jdk.version}</target>
@@ -741,10 +741,21 @@
         <scope>provided</scope>
       </dependency>
       <!-- JSRs -->
+      <!-- Java 8 = JAX-B Version 2.2.8 -->
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>2.2.12</version>
+        <version>2.2.10</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.2.10</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.2.10</version>
       </dependency>
       <dependency>
         <groupId>javax.activation</groupId>
@@ -1034,6 +1045,11 @@
         <artifactId>com.springsource.org.apache.commons.beanutils</artifactId>
         <version>1.8.3</version>
       </dependency>
+      <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils-core</artifactId>
+        <version>1.8.3</version>
+      </dependency>
       <!-- Querydsl -->
       <dependency>
         <groupId>com.mysema.querydsl</groupId>
@@ -1052,6 +1068,24 @@
         <version>2.9.9</version>
       </dependency>
       <dependency>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>json-path</artifactId>
+        <version>3.0.7</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>xml-path</artifactId>
+        <version>3.0.7</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>rest-assured</artifactId>
+        <version>3.0.7</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.0</version>
@@ -1065,6 +1099,16 @@
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
         <version>2.3.6</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>1.3</version>
       </dependency>
       <!-- testing -->
       <dependency>


### PR DESCRIPTION
This patch is part of getting Opencast getting to not fail with Java 9+.
It fixes a lot of dependency problems I've found when making the
necessary changes for Java 9+ (e.g. explicitly adding java.ee dependencies).

Note that despite the large number of changes the only two non-test,
non-dependency fixes are two places in our code where `commons.lang` was
still used instead of `commons.lang3`.

The main parts of this patch are:

- Explicitly declaring the java.ee dependencies:
  https://stackoverflow.com/a/43574427/2352895
- Fixing obvious dependency problems which popped up due to some modules
  dependencies now being declared more precisely.
- Updating and centralizing the version of `rest-assured` which was
  partly specified incorrectly.

Note that while this patch fixes a lot of the Java 9 problems and nearly
all modules can now be built using Java 9, a few (unfortunately large)
problems still persist:

- The default date format for some languages has changed in Java 9 which
  causes a few tests in the admin interface to fail. I expect this to be
  harmless and think the tests just need adjustment, but I did not want
  to make that change without the ability to test it properly.
- We are on ElasticSearch version 1.7.6. Java 9 is supported starting
  with version 6.2. We had already discussed in the past that upgrading
  this is something we would like to do. Unfortunately, it's a lot of
  work.
- We also need to upgrade to Karaf 4.2.x. At the moment, the assembly
  steps fail due to us using an old Karaf version. Fortunately, we are
  already on 4.0.10 which isn't that far away (compared to ES). Still,
  it's some work.

Hence, consider this a first step. Obviously, I could also not test for
any runtime problems so far. The other problems need to be resolved
first.

Note though, that this does not only fix dependencies for Java 9. Most
of the problems are quite relevant for older Java versions as well.