### PR TITLE
MH-12836, Fix event-comment dependencies not correctly specified

### DIFF
--- a/modules/event-comment/pom.xml
+++ b/modules/event-comment/pom.xml
@@ -31,24 +31,16 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
@@ -141,13 +133,6 @@
           <artifactId>Saxon-HE</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <!-- for xml matchers equivalence tests -->
-    <dependency>
-      <groupId>xmlunit</groupId>
-      <artifactId>xmlunit</artifactId>
-      <version>1.5</version>
-      <scope>test</scope>
     </dependency>
     <!-- for xml matchers (org.w3c.dom.ElementTraversal) -->
     <dependency>


### PR DESCRIPTION
This patch fixes a few dependencies (not) specified in the
event-comment.