### PR TITLE
MH-12826: Make workflow processing settings persistent

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -48,6 +48,7 @@
     <sec:intercept-url pattern="/admin-ng/event/*/asset/publication/*.json" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_ASSETS_VIEW" />
     <sec:intercept-url pattern="/admin-ng/event/catalogAdapters" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_METADATA_VIEW" />
     <sec:intercept-url pattern="/admin-ng/event/events.json" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_VIEW" />
+    <sec:intercept-url pattern="/admin-ng/event/workflowProperties" method="POST" access="ROLE_ADMIN, ROLE_UI_EVENTS_CREATE, ROLE_UI_TASKS_CREATE, ROLE_UI_EVENTS_EDITOR_VIEW" />
     <sec:intercept-url pattern="/admin-ng/event/new/metadata" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_METADATA_VIEW" />
     <sec:intercept-url pattern="/admin-ng/event/new/processing" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_CREATE, ROLE_UI_TASKS_CREATE" />
     <sec:intercept-url pattern="/admin-ng/event/*/attachments.json" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_DETAILS_ATTACHMENTS_VIEW" />

--- a/etc/workflows/publish-after-cutting.xml
+++ b/etc/workflows/publish-after-cutting.xml
@@ -23,17 +23,6 @@
       </configurations>
     </operation>
 
-    <!-- Import properties -->
-    <operation
-        id="import-wf-properties"
-        fail-on-error="true"
-        exception-handler-workflow="partial-error"
-        description="Load processing settings">
-      <configurations>
-      <configuration key="source-flavor">processing/defaults</configuration>
-      </configurations>
-    </operation>
-
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- Remove tag for cutting                                            -->
     <!--                                                                   -->

--- a/etc/workflows/publish.xml
+++ b/etc/workflows/publish.xml
@@ -107,16 +107,6 @@
     <!-- Apply the default workflow configuration -->
 
     <operation
-      id="import-wf-properties"
-      fail-on-error="true"
-      exception-handler-workflow="ng-partial-error"
-      description="Import workflow settings to Java properties file">
-      <configurations>
-        <configuration key="source-flavor">processing/defaults</configuration>
-      </configurations>
-    </operation>
-
-    <operation
       id="defaults"
       description="Applying default configuration values">
       <configurations>

--- a/etc/workflows/schedule-and-upload.xml
+++ b/etc/workflows/schedule-and-upload.xml
@@ -169,16 +169,6 @@
       </configurations>
     </operation>
 
-    <operation
-      id="export-wf-properties"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error"
-      description="Export workflow settings to Java properties file">
-      <configurations>
-        <configuration key="target-flavor">processing/defaults</configuration>
-      </configurations>
-    </operation>
-
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- Prepare asset                                                     -->

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -171,6 +171,7 @@ import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -298,6 +299,47 @@ public abstract class AbstractEventEndpoint {
     }
 
   }
+
+  /* As the list of event ids can grow large, we use a POST request to avoid problems with too large query strings */
+  @POST
+  @Path("workflowProperties")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RestQuery(name = "workflowProperties", description = "Returns workflow properties for the specified events",
+             returnDescription = "The workflow properties for every event as JSON", restParameters = {
+                @RestParameter(name = "eventIds", description = "A JSON array of ids of the events", isRequired = true, type = RestParameter.Type.STRING)},
+             reponses = {
+                @RestResponse(description = "Returns the workflow properties for the events as JSON", responseCode = HttpServletResponse.SC_OK),
+                @RestResponse(description = "The list of ids could not be parsed into a json list.", responseCode = HttpServletResponse.SC_BAD_REQUEST)
+              })
+  public Response getEventWorkflowProperties(@FormParam("eventIds") String eventIds) throws UnauthorizedException {
+    if (StringUtils.isBlank(eventIds)) {
+      return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+
+    JSONParser parser = new JSONParser();
+    List<String> ids;
+    try {
+      ids = (List<String>) parser.parse(eventIds);
+    } catch (org.json.simple.parser.ParseException e) {
+      logger.error("Unable to parse '{}'", eventIds, e);
+      return Response.status(Response.Status.BAD_REQUEST).build();
+    } catch (ClassCastException e) {
+      logger.error("Unable to cast '{}'", eventIds, e);
+      return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+
+    final Map<String, Map<String, String>> eventWithProperties = getIndexService().getEventWorkflowProperties(ids);
+    final Map<String, Field> jsonEvents = new HashMap<>();
+    for (Entry<String, Map<String, String>> event : eventWithProperties.entrySet()) {
+      final Collection<Field> jsonProperties = new ArrayList<>();
+      for (Entry<String, String> property : event.getValue().entrySet()) {
+        jsonProperties.add(f(property.getKey(),property.getValue()));
+      }
+      jsonEvents.put(event.getKey(), f(event.getKey(), obj(jsonProperties)));
+    }
+    return okJson(obj(jsonEvents));
+  }
+
 
   @GET
   @Path("catalogAdapters")

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -39,6 +39,7 @@ import org.opencastproject.adminui.impl.AdminUIConfiguration;
 import org.opencastproject.adminui.impl.index.AdminUISearchIndex;
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.AssetManagerException;
+import org.opencastproject.assetmanager.util.WorkflowPropertiesUtil;
 import org.opencastproject.assetmanager.util.Workflows;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.api.IndexService.Source;
@@ -114,6 +115,7 @@ import java.util.Dictionary;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -427,9 +429,12 @@ public class ToolsEndpoint implements ManagedService {
       if (editingInfo.getPostProcessingWorkflow().isSome()) {
         final String workflowId = editingInfo.getPostProcessingWorkflow().get();
         try {
+          final Map<String, String> workflowParameters = WorkflowPropertiesUtil
+            .getLatestWorkflowProperties(assetManager, mediaPackage.getIdentifier().compact());
           final Workflows workflows = new Workflows(assetManager, workspace, workflowService);
           workflows.applyWorkflowToLatestVersion($(mediaPackage.getIdentifier().toString()),
-                  ConfiguredWorkflow.workflow(workflowService.getWorkflowDefinitionById(workflowId))).run();
+            ConfiguredWorkflow.workflow(workflowService.getWorkflowDefinitionById(workflowId), workflowParameters))
+            .run();
         } catch (AssetManagerException e) {
           logger.warn("Unable to start workflow '{}' on archived media package '{}': {}",
                   workflowId, mediaPackage, getStackTrace(e));

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -199,6 +199,7 @@
         <script src="scripts/shared/resources/eventAssetPublicationsResource.js"></script>
         <script src="scripts/shared/resources/eventSchedulingResource.js"></script>
         <script src="scripts/shared/resources/eventsSchedulingResource.js"></script>
+        <script src="scripts/shared/resources/eventWorkflowPropertiesResource.js"></script>
         <script src="scripts/shared/resources/eventWorkflowsResource.js"></script>
         <script src="scripts/shared/resources/eventTransactionResource.js"></script>
         <script src="scripts/shared/resources/eventErrorsResource.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
@@ -161,10 +161,16 @@ angular.module('adminNg.controllers')
                 });
                 if (retractEventIds.length > 0) {
                     resetSubmitButton = false;
+                    var configuration = $scope.processing.ud.workflow.selection.configuration;
+                    var finalConfiguration = {};
+                    // We have to duplicate the configuration for each event, since the "bulk start task"
+                    // event wants per-event configuration since MH-12826.
+                    for (var i = 0; i < retractEventIds.length; i++) {
+                        finalConfiguration[retractEventIds[i]] = configuration;
+                    }
                     payload = {
                         workflow: $scope.processing.ud.workflow.id,
-                        configuration: $scope.processing.ud.workflow.selection.configuration,
-                        eventIds: retractEventIds
+                        configuration: finalConfiguration
                     };
                     TaskResource.save(payload, $scope.onSuccess, $scope.onFailure);
                 }

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/retractEventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/retractEventController.js
@@ -52,12 +52,12 @@ function ($scope, NewEventProcessing, TaskResource, Notifications) {
     $scope.submitButton = false;
     $scope.submit = function () {
         $scope.submitButton = true;
-        var eventIds = [], payload;
-        eventIds.push($scope.$parent.resourceId);
-        payload = {
+        var finalConfiguration = {};
+        var eventId = $scope.$parent.resourceId;
+        finalConfiguration[eventId] = $scope.processing.ud.workflow.selection.configuration;
+        var payload = {
             workflow: $scope.processing.ud.workflow.id,
-            configuration: $scope.processing.ud.workflow.selection.configuration,
-            eventIds: eventIds
+            configuration: finalConfiguration
         };
         TaskResource.save(payload, onSuccess, onFailure);
     };

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
@@ -59,7 +59,8 @@
             </div><!-- modal-content [general] -->
 
             <footer>
-                <a wz-next class="submit"
+                <a class="submit"
+                   ng-click="clearWorkflowFormAndContinue()"
                    ng-class="{active: scheduleTaskForm.generalForm.$valid, disabled: scheduleTaskForm.generalForm.$invalid}">
                     {{ 'WIZARD.NEXT_STEP' | translate }}
                 </a>
@@ -78,7 +79,7 @@
                             <div class="obj-container">
                                 <select chosen
                                         data-width="'100%'"
-                                        ng-change="processing.changeWorkflow()"
+                                        ng-change="processing.changeWorkflow(workflowProperties, getSelectedIds())"
                                         data-disable-search-threshold="8"
                                         not-empty-selection
                                         ng-model="processing.ud.workflow"

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowPropertiesResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventWorkflowPropertiesResource.js
@@ -1,0 +1,38 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.resources')
+.factory('EventWorkflowPropertiesResource', ['$resource', function ($resource) {
+    return $resource('/admin-ng/event/workflowProperties', {}, {
+        get: {
+          method: 'POST',
+          responseType: 'json',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          isArray: false,
+          transformRequest: function (data) {
+            return $.param({
+              eventIds : JSON.stringify(data)
+            });
+          }
+        }
+    });
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
@@ -21,7 +21,7 @@
 'use strict';
 
 angular.module('adminNg.services')
-.factory('NewEventProcessing', ['$sce', 'NewEventProcessingResource', function ($sce, NewEventProcessingResource) {
+.factory('NewEventProcessing', ['$sce', '$timeout', 'NewEventProcessingResource', function ($sce, $timeout, NewEventProcessingResource) {
     var Processing = function (use) {
         // Update the content of the configuration panel with the given HTML
         var me = this, queryParams,
@@ -35,7 +35,8 @@ angular.module('adminNg.services')
                 return angular.isDefined(me.ud.workflow) && angular.isDefined(me.ud.workflow.id);
             },
             idConfigElement = '#new-event-workflow-configuration',
-            workflowConfigEl = angular.element(idConfigElement);
+            workflowConfigEl = angular.element(idConfigElement),
+            originalValues = {};
 
         this.isProcessingState = true;
         this.ud = {};
@@ -64,28 +65,228 @@ angular.module('adminNg.services')
             me.changingWorkflow = true;
 
             me.workflows = data.workflows;
-            var default_workflow_id = data.default_workflow_id;
+            me.default_workflow_id = data.default_workflow_id;
 
+            me.changingWorkflow = false;
+
+        });
+
+        // Execute function for each input HTML element that has an ID
+        // (so is used in the workflow configuration form).
+        function forEachHtmlFormElement(htmlElement, f) {
+            htmlElement.each(function (idx, domElement) {
+                var angularElement = angular.element(domElement);
+                var idAttr = angularElement.attr('id');
+
+                // Ignore input fields that don't have an ID
+                if (angular.isDefined(idAttr)) {
+                    f(idAttr, angularElement);
+                }
+            });
+        }
+
+        // Collect all radio elements (which are linked by their name
+        // attribute) into a dictionary:
+        // id: array of other radio ids.
+        function gatherRadios(htmlElement) {
+            var result = {};
+            forEachHtmlFormElement(htmlElement, function(id, angularElement) {
+                if (angularElement.is('[type=radio]')) {
+                    var radioName = angularElement.attr('name');
+                    var radios = angular.element(document).find('input[name='+radioName+']');
+                    result[id] = [];
+                    radios.each(function(ridx, radio) {
+                        result[id].push(angular.element(radio).attr('id'));
+                   });
+                }
+            });
+            return result;
+        }
+
+        // Determine if all elements of an array are the same (returns
+        // true for empty arrays).
+        function allTheSame(a) {
+            if (a.length === 0) {
+                return true;
+            }
+            var first = a[0];
+            for(var i = 0; i < a.length; i++) {
+                if (a[i] !== first) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Take a dictionary collected by gatherHtmlFormElements and
+        // nullify all radio elements that are ambiguous (i.e. are all
+        // unchecked).
+        function determineIndeterminateRadios(htmlFields, radios) {
+            for(var radioId in radios) {
+                if (htmlFields[radioId] === null) {
+                    continue;
+                }
+                var radioValues = [];
+                for (var i = 0; i < radios[radioId].length; i++) {
+                    radioValues.push(htmlFields[radios[radioId][i]]);
+                }
+                if (allTheSame(radioValues)) {
+                    for (var j = 0; j < radios[radioId].length; j++) {
+                        htmlFields[radios[radioId][j]] = null;
+                    }
+                }
+            }
+        }
+
+        // Most of the stuff we do here with input elements doesn't distinguish between
+        // input type="text" and input type="number", so we need this getter a few times.
+        function elementIsTextual(angularElement) {
+            return angularElement.is("[type=text]") || angularElement.is("[type=number]");
+        }
+
+        // Gather all input elements used in the workflow configuration HTML into a dictionary:
+        // id: value or null if it's indeterminate
+        function gatherHtmlFormElements(htmlElement) {
+            var result = {};
+            forEachHtmlFormElement(htmlElement, function(id, angularElement) {
+                if (elementIsTextual(angularElement)) {
+                    if (angularElement.val() === '') {
+                        result[id] = null;
+                    } else {
+                        result[id] = angularElement.val();
+                    }
+                } else if (angularElement.is('[type=checkbox]') || angularElement.is('[type=radio]')) {
+                    if (angularElement.prop('indeterminate')) {
+                        result[id] = null;
+                    } else {
+                        if (angularElement.is(':checked')) {
+                            result[id] = "true";
+                        }
+                        else {
+                            result[id] = "false";
+                        }
+                    }
+                }
+            });
+            return result;
+        }
+
+        // Take a dictionary of event properties and extract all
+        // values of a single property into an array.
+        function eventValuesForField(events, searchProp) {
+            var result = [];
+            for(var eid in events) {
+                for (var evProp in events[eid]) {
+                    if (evProp === searchProp) {
+                        result.push(events[eid][evProp]);
+                    }
+                }
+            }
+            return result;
+        }
+
+        // Filter original workflow properties and make proper
+        // dictionaries out of them so they can be iterated over easily.
+        function filterEventProperties(workflowProperties, selectedIds) {
+          var result = {};
+          for (var workflowProp in workflowProperties) {
+            if (workflowProp.indexOf("$") !== 0 && workflowProperties.hasOwnProperty(workflowProp)) {
+              if (selectedIds.indexOf(workflowProp) >= 0) {
+                  result[workflowProp] = workflowProperties[workflowProp];
+              }
+            }
+          }
+          return result;
+        }
+
+        // Set a HTML form value (abstracts over "set checked" or "set
+        // value" for checkboxes and text fields, respectively)
+        function setHtmlFormValue(angularElement, value) {
+            if (elementIsTextual(angularElement)) {
+                angularElement.val(value);
+            } else if (angularElement.is("[type=checkbox]") || angularElement.is("[type=radio]")) {
+                if (value === "true") {
+                    angularElement.attr("checked", true);
+                } else {
+                    angularElement.attr("checked", false);
+                }
+            }
+        }
+
+        // Set an indeterminate HTML form value (depends on the type
+        // of the form element)
+        function setIndeterminateHtmlFormValue(angularElement) {
+            if (elementIsTextual(angularElement)) {
+                angularElement.val("");
+            } else if (angularElement.is("[type=checkbox]")) {
+                angularElement.prop("indeterminate", true);
+            } else if (angularElement.is("[type=radio]")) {
+                angularElement.attr("checked", false);
+            }
+        }
+
+        this.applyWorkflowProperties = function(workflowProperties, selectedIds) {
+            // Timeout because manipulating the just assigned HTML doesn't work otherwise.
+            $timeout(function() {
+                var element, isRendered = workflowConfigEl.find('.configField').length > 0;
+                if (!isRendered) {
+                    element = angular.element(me.ud.workflow.configuration_panel).find('.configField');
+                } else {
+                    element = workflowConfigEl.find('.configField');
+                }
+
+                var htmlFields = gatherHtmlFormElements(element);
+                me.currentEvents = filterEventProperties(workflowProperties, selectedIds);
+
+		// Set event properties that are in the HTML form, but not in the event, yet.
+                for(var eventId in me.currentEvents) {
+                    var eventProps = me.currentEvents[eventId];
+                    for(var htmlField in htmlFields) {
+                        if (!(htmlField in eventProps)) {
+                            eventProps[htmlField] = htmlFields[htmlField];
+                        }
+                    }
+                }
+                // Only manipulate HTML elements if events are present
+                // (not the case for "Add event")
+                if (selectedIds !== undefined && selectedIds.length > 0) {
+                    forEachHtmlFormElement(element, function(id, angularElement) {
+                        var valuesForId = eventValuesForField(me.currentEvents, id);
+
+                        if(allTheSame(valuesForId)) {
+                            setHtmlFormValue(angularElement, valuesForId[0]);
+                        } else {
+                            setIndeterminateHtmlFormValue(angularElement);
+                        }
+                    });
+                }
+            });
+        };
+
+        this.initWorkflowConfig = function (workflowProperties, selectedIds) {
             // set default workflow as selected
-            if(angular.isDefined(default_workflow_id)){
+            if(angular.isDefined(me.default_workflow_id)){
 
                 for(var i = 0; i < me.workflows.length; i += 1){
                     var workflow = me.workflows[i];
 
-                    if (workflow.id === default_workflow_id){
-                      me.ud.workflow = workflow;
-                      updateConfigurationPanel(me.ud.workflow.configuration_panel);
-                      me.save();
-                      break;
+                    if (workflow.id === me.default_workflow_id){
+                        me.ud.workflow = workflow;
+                        updateConfigurationPanel(me.ud.workflow.configuration_panel);
+                        this.applyWorkflowProperties(workflowProperties, selectedIds);
+                        me.save();
+                        break;
                     }
                 }
+            } else {
+                me.ud.workflow = {};
+                delete me.workflowConfiguration;
             }
-          me.changingWorkflow = false;
-
-        });
+        };
 
         // Listener for the workflow selection
-        this.changeWorkflow = function () {
+        this.changeWorkflow = function (workflowProperties, selectedIds) {
+            originalValues = {};
             me.changingWorkflow = true;
             workflowConfigEl = angular.element(idConfigElement);
             if (angular.isDefined(me.ud.workflow)) {
@@ -93,11 +294,41 @@ angular.module('adminNg.services')
             } else {
                 updateConfigurationPanel();
             }
+            this.applyWorkflowProperties(workflowProperties, selectedIds);
+
             me.save();
             me.changingWorkflow = false;
         };
 
-        // Get the workflow configuration
+        // This is used for the new task post request
+        this.getWorkflowConfigs = function () {
+            var workflowConfigs = {}, element, isRendered = workflowConfigEl.find('.configField').length > 0;
+
+            if (!isRendered) {
+                element = angular.element(me.ud.workflow.configuration_panel).find('.configField');
+            } else {
+                element = workflowConfigEl.find('.configField');
+            }
+
+            var radios = gatherRadios(element);
+            var htmlFields = gatherHtmlFormElements(element);
+            determineIndeterminateRadios(htmlFields, radios);
+
+            for(var eventId in me.currentEvents) {
+                var eventProps = me.currentEvents[eventId];
+                for(var htmlField in htmlFields) {
+                    var htmlValue = htmlFields[htmlField];
+                    if (htmlValue !== null) {
+                        eventProps[htmlField] = htmlValue;
+                    }
+                }
+                workflowConfigs[eventId] = eventProps;
+            }
+
+            return workflowConfigs;
+        };
+
+        // Get the workflow configuration (used for the final value table in the wizard)
         this.getWorkflowConfig = function () {
             var workflowConfig = {}, element, isRendered = workflowConfigEl.find('.configField').length > 0;
 
@@ -107,18 +338,17 @@ angular.module('adminNg.services')
                 element = workflowConfigEl.find('.configField');
             }
 
-            element.each(function (idx, el) {
-                var element = angular.element(el);
-
-                if (angular.isDefined(element.attr('id'))) {
-                    if (element.is('[type=checkbox]') || element.is('[type=radio]')) {
-                        workflowConfig[element.attr('id')] = element.is(':checked') ? 'true' : 'false';
-                    } else {
-                        workflowConfig[element.attr('id')] = element.val();
-                    }
+            var radios = gatherRadios(element);
+            var htmlFields = gatherHtmlFormElements(element);
+            determineIndeterminateRadios(htmlFields, radios);
+            for (var fieldId in htmlFields) {
+                var htmlField = htmlFields[fieldId];
+                if (htmlField === null) {
+                    workflowConfig[fieldId] = "*";
+                } else {
+                    workflowConfig[fieldId] = htmlField;
                 }
-            });
-
+            }
             return workflowConfig;
         };
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
@@ -67,17 +67,20 @@ public class TasksEndpointTest {
 
     given().formParam("metadata", "empty").expect().statusCode(HttpStatus.SC_BAD_REQUEST).when().post(rt.host("/new"));
 
-    given().formParam("metadata", "{\"configuration\":{}, \"eventIds\":[]}").expect()
+    // configuration missing
+    given().formParam("metadata", "{\"workflow\":\"full\"}").expect()
             .statusCode(HttpStatus.SC_BAD_REQUEST).when().post(rt.host("/new"));
 
-    given().formParam("metadata", "{\"workflow\":\"full\", \"configuration\":{}}").expect()
+    // workflow missing
+    given().formParam("metadata", "{\"configuration\":{}}").expect()
             .statusCode(HttpStatus.SC_BAD_REQUEST).when().post(rt.host("/new"));
 
-    given().formParam("metadata", "{\"workflow\":\"exception\", \"configuration\":{}, \"eventIds\":[\"id1\",\"id2\"]}")
+    // invalid workflow id
+    given().formParam("metadata", "{\"workflow\":\"exception\", \"configuration\":{}}")
             .expect().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR).when().post(rt.host("/new"));
 
     String result = given()
-            .formParam("metadata", "{\"workflow\":\"full\", \"configuration\":{}, \"eventIds\":[\"id1\",\"id2\"]}")
+            .formParam("metadata", "{\"workflow\":\"full\", \"configuration\":{\"id1\": {\"foo\": \"bar\"},\"id2\": {\"baz\": \"qux\"}}}")
             .expect().statusCode(HttpStatus.SC_CREATED).when().post(rt.host("/new")).asString();
     assertEquals("[5,10]", result);
   }

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/scheduleTaskControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/scheduleTaskControllerSpec.js
@@ -38,6 +38,7 @@ describe('Schedule Task Controller', function () {
         $controller('ScheduleTaskCtrl', {$scope: $scope});
         jasmine.getJSONFixtures().fixturesPath = 'base/app/GET';
         $httpBackend.whenGET('/admin-ng/event/new/processing?tags=archive').respond(JSON.stringify(getJSONFixture('admin-ng/event/new/processing')));
+        $httpBackend.whenPOST('/admin-ng/event/workflowProperties').respond("{}");
     });
 
     describe('basic functionality', function () {

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-event/proccessingSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-event/proccessingSpec.js
@@ -97,7 +97,7 @@ describe('Processing Step in New Event Wizard', function () {
         describe('without a checkbox', function () {
             beforeEach(function () {
                 $('#new-event-workflow-configuration')
-                    .append('<input class="configField" id="testID" value="testvalueA">');
+                    .append('<input type="text" class="configField" id="testID" value="testvalueA">');
             });
 
             it('returns the field value', function () {

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/AQueryBuilder.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/AQueryBuilder.java
@@ -66,6 +66,9 @@ public interface AQueryBuilder {
   // direct predicate constructors
   //
 
+  /* -- */
+  Predicate mediaPackageIds(String... mpIds);
+
   /** Create a predicate to match an snapshot's media package ID. */
   Predicate mediaPackageId(String mpId);
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AQueryBuilderDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AQueryBuilderDecorator.java
@@ -53,6 +53,11 @@ public class AQueryBuilderDecorator implements AQueryBuilder {
     return delegate.delete(owner, target);
   }
 
+  @Override
+  public Predicate mediaPackageIds(String... mpIds) {
+    return this.delegate.mediaPackageIds(mpIds);
+  }
+
   @Override public Predicate mediaPackageId(String mpId) {
     return delegate.mediaPackageId(mpId);
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
@@ -105,6 +105,28 @@ public final class AQueryBuilderImpl implements AQueryBuilder, EntityPaths {
   }
 
   /* -- */
+  @Override public Predicate mediaPackageIds(final String... mpIds) {
+    return new AbstractPredicate() {
+      /* SELECT */
+      @Override public SelectQueryContribution contributeSelect(JPAQueryFactory f) {
+        return SelectQueryContribution.mk().from(FROM_SNAPSHOT).where(Q_SNAPSHOT.mediaPackageId.in(mpIds));
+      }
+
+      /* DELETE */
+      @Override public DeleteQueryContribution contributeDelete(String owner) {
+        return DeleteQueryContribution.mk().where(new Where() {
+          @Override public BooleanExpression fromSnapshot(@Nonnull QSnapshotDto e) {
+            return e.mediaPackageId.in(mpIds);
+          }
+
+          @Override public BooleanExpression fromProperty(@Nonnull QPropertyDto p) {
+            return p.mediaPackageId.in(mpIds);
+          }
+        });
+      }
+
+    };
+  }
 
   @Override public Predicate mediaPackageId(final String mpId) {
     return new AbstractPredicate() {

--- a/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/WorkflowPropertiesUtil.java
+++ b/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/WorkflowPropertiesUtil.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.assetmanager.util;
+
+import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
+import static org.opencastproject.systems.OpencastConstants.WORKFLOW_PROPERTIES_NAMESPACE;
+
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Property;
+import org.opencastproject.assetmanager.api.PropertyId;
+import org.opencastproject.assetmanager.api.Value;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.mediapackage.MediaPackage;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class to store and retrieve Workflow Properties (which are stored in specially prefixed Asset Manager
+ * properties)
+ */
+public final class WorkflowPropertiesUtil {
+  private WorkflowPropertiesUtil() {
+  }
+
+  /**
+   * Retrieve latest properties for a set of event ids
+   * @param assetManager The Asset Manager to use
+   * @param eventIds Collection of event IDs (can be a set, but doesn't have to be)
+   * @return A map mapping event IDs to key value pairs (which are themselves maps) representing the properties
+   */
+  public static Map<String, Map<String, String>> getLatestWorkflowPropertiesForEvents(final AssetManager assetManager,
+          final Collection<String> eventIds) {
+    final AQueryBuilder query = assetManager.createQuery();
+    final AResult result = query.select(query.snapshot(), query.propertiesOf(WORKFLOW_PROPERTIES_NAMESPACE))
+            .where(query.mediaPackageIds(eventIds.toArray(new String[0])).and(query.version().isLatest())).run();
+    final Map<String, Map<String, String>> workflowProperties = new HashMap<>(eventIds.size());
+    for (final ARecord record : result.getRecords().toList()) {
+      final List<Property> recordProps = record.getProperties().toList();
+      final Map<String, String> eventMap = new HashMap<>(recordProps.size());
+      for (final Property property : recordProps) {
+        eventMap.put(property.getId().getName(), property.getValue().get(Value.STRING));
+      }
+      final String eventId = record.getMediaPackageId();
+      workflowProperties.put(eventId, eventMap);
+    }
+    return workflowProperties;
+  }
+
+  /**
+   * Retrieve the latest properties for a single media package
+   * @param assetManager The Asset Manager to use
+   * @param mediaPackageId The media package to query
+   * @return A list of properties represented by a Map
+   */
+  public static Map<String, String> getLatestWorkflowProperties(final AssetManager assetManager,
+          final String mediaPackageId) {
+    final AQueryBuilder query = assetManager.createQuery();
+    final List<ARecord> queryResults = query.select(query.snapshot(), query.propertiesOf(WORKFLOW_PROPERTIES_NAMESPACE))
+            .where(query.mediaPackageId(mediaPackageId).and(query.version().isLatest())).run()
+            .getRecords().toList();
+    final Map<String, String> workflowParameters = new HashMap<>(0);
+    if (!queryResults.isEmpty()) {
+      for (final Property property : queryResults.get(0).getProperties()) {
+        workflowParameters.put(property.getId().getName(), property.getValue().get(Value.STRING));
+      }
+    }
+    return workflowParameters;
+  }
+
+  /**
+   * Store selected properties for a media package
+   * @param assetManager The Asset Manager to use
+   * @param mediaPackage The media package to store properties relative to
+   * @param properties A list of properties represented by a Map
+   */
+  public static void storeProperties(final AssetManager assetManager, final MediaPackage mediaPackage,
+          final Map<String, String> properties) {
+    assetManager.takeSnapshot(DEFAULT_OWNER,mediaPackage);
+    for (final Map.Entry<String, String> entry : properties.entrySet()) {
+      final PropertyId propertyId = PropertyId
+              .mk(mediaPackage.getIdentifier().compact(), WORKFLOW_PROPERTIES_NAMESPACE, entry.getKey());
+      final Property property = Property.mk(propertyId, Value.mk(entry.getValue()));
+      assetManager.setProperty(property);
+    }
+  }
+}

--- a/modules/common/src/main/java/org/opencastproject/systems/OpencastConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/systems/OpencastConstants.java
@@ -50,4 +50,5 @@ public interface OpencastConstants {
   /** The property key for the Working File Repository URL defined in the organization properties */
   String WFR_URL_ORG_PROPERTY = "org.opencastproject.file.repo.url";
 
+  String WORKFLOW_PROPERTIES_NAMESPACE = "org.opencastproject.workflow.configuration";
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
@@ -58,7 +58,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
 public interface IndexService {
-
   enum Source {
     ARCHIVE, WORKFLOW, SCHEDULE
   };
@@ -572,5 +571,7 @@ public interface IndexService {
    * @return <code>true</code> if the event has snapshots, <code>false</code> otherwise
    */
   boolean hasSnapshots(String eventId);
+
+  Map<String,Map<String,String>> getEventWorkflowProperties(List<String> eventIds);
 
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -31,6 +31,7 @@ import org.opencastproject.assetmanager.api.AssetManagerException;
 import org.opencastproject.assetmanager.api.query.AQueryBuilder;
 import org.opencastproject.assetmanager.api.query.AResult;
 import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.util.WorkflowPropertiesUtil;
 import org.opencastproject.assetmanager.util.Workflows;
 import org.opencastproject.authorization.xacml.manager.api.AclService;
 import org.opencastproject.authorization.xacml.manager.api.AclServiceFactory;
@@ -925,6 +926,7 @@ public class IndexServiceImpl implements IndexService {
     Map<String, String> configuration = new HashMap<>();
     if (eventHttpServletRequest.getProcessing().get().get("configuration") != null) {
       configuration = new HashMap<>((JSONObject) eventHttpServletRequest.getProcessing().get().get("configuration"));
+
     }
     for (Entry<String, String> entry : configuration.entrySet()) {
       caProperties.put(WORKFLOW_CONFIG_PREFIX.concat(entry.getKey()), entry.getValue());
@@ -1367,6 +1369,11 @@ public class IndexServiceImpl implements IndexService {
   public boolean hasSnapshots(String eventId) {
     AQueryBuilder q = assetManager.createQuery();
     return !enrich(q.select(q.snapshot()).where(q.mediaPackageId(eventId).and(q.version().isLatest())).run()).getSnapshots().isEmpty();
+  }
+
+  @Override
+  public Map<String, Map<String, String>> getEventWorkflowProperties(final List<String> eventIds) {
+    return WorkflowPropertiesUtil.getLatestWorkflowPropertiesForEvents(assetManager, eventIds);
   }
 
   @Override

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -24,6 +24,8 @@ package org.opencastproject.index.service.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Property;
 import org.opencastproject.capture.admin.api.CaptureAgentStateService;
 import org.opencastproject.index.service.catalog.adapter.DublinCoreMetadataCollection;
 import org.opencastproject.index.service.catalog.adapter.MetadataList;
@@ -362,6 +364,8 @@ public class IndexServiceImplTest {
     EasyMock.expectLastCall();
     EasyMock.replay(mediapackage);
 
+    AssetManager assetManager = EasyMock.createMock(AssetManager.class);
+
     IngestService ingestService = setupIngestService(mediapackage, Capture.<InputStream> newInstance());
 
     // Setup Authorization Service
@@ -380,6 +384,7 @@ public class IndexServiceImplTest {
     indexServiceImpl.setUserDirectoryService(noUsersUserDirectoryService);
     indexServiceImpl.setSecurityService(securityService);
     indexServiceImpl.setWorkspace(workspace);
+    indexServiceImpl.setAssetManager(assetManager);
     indexServiceImpl.createEvent(metadataJson, mediapackage);
 
     assertTrue("The catalog must be added to the mediapackage", result.hasCaptured());
@@ -450,6 +455,13 @@ public class IndexServiceImplTest {
             EasyMock.anyObject(AclScope.class), EasyMock.anyObject(AccessControlList.class))).andReturn(returnValue);
     EasyMock.replay(authorizationService);
 
+    AssetManager assetManager = EasyMock.createMock(AssetManager.class);
+    EasyMock.expect(
+            assetManager.takeSnapshot(EasyMock.eq(AssetManager.DEFAULT_OWNER), EasyMock.anyObject(MediaPackage.class)))
+            .andReturn(null);
+    EasyMock.expect(assetManager.setProperty(EasyMock.anyObject(Property.class))).andReturn(true).anyTimes();
+    EasyMock.replay(assetManager);
+
     // Run Test
     IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
     indexServiceImpl.setAuthorizationService(setupAuthorizationService(mediapackage));
@@ -459,6 +471,7 @@ public class IndexServiceImplTest {
     indexServiceImpl.setUserDirectoryService(noUsersUserDirectoryService);
     indexServiceImpl.setSecurityService(securityService);
     indexServiceImpl.setWorkspace(workspace);
+    indexServiceImpl.setAssetManager(assetManager);
     indexServiceImpl.createEvent(metadataJson, mediapackage);
 
     assertTrue("The catalog must be added to the mediapackage", result.hasCaptured());

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -27,6 +27,16 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-asset-manager-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-asset-manager-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-serviceregistry</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -32,6 +32,8 @@ import static org.opencastproject.workflow.api.WorkflowInstance.WorkflowState.RU
 import static org.opencastproject.workflow.api.WorkflowInstance.WorkflowState.STOPPED;
 import static org.opencastproject.workflow.api.WorkflowInstance.WorkflowState.SUCCEEDED;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.util.WorkflowPropertiesUtil;
 import org.opencastproject.index.IndexProducer;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.Job.Status;
@@ -241,6 +243,9 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
   /** The series service */
   protected SeriesService seriesService;
+
+  /** The asset manager */
+  protected AssetManager assetManager = null;
 
   /** The message broker receiver service */
   protected MessageReceiver messageReceiver;
@@ -599,10 +604,21 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    */
   @Override
   public WorkflowInstance start(WorkflowDefinition workflowDefinition, MediaPackage sourceMediaPackage,
-          Long parentWorkflowId, Map<String, String> properties) throws WorkflowDatabaseException,
+          Long parentWorkflowId, Map<String, String> originalProperties) throws WorkflowDatabaseException,
           WorkflowParsingException, NotFoundException {
+    final String mediaPackageId = sourceMediaPackage.getIdentifier().compact();
+
+    final Map<String, String> properties;
+    // Currently, the only place where the asset manager isn't involved is in the tests. But it might change.
+    if (assetManager != null) {
+      WorkflowPropertiesUtil.storeProperties(assetManager, sourceMediaPackage, originalProperties);
+      properties = WorkflowPropertiesUtil.getLatestWorkflowProperties(assetManager, mediaPackageId);
+    } else {
+      properties = originalProperties;
+    }
+
     // We have to synchronize per media package to avoid starting multiple simultaneous workflows for one media package.
-    final Lock lock = mediaPackageLocks.get(sourceMediaPackage.getIdentifier().toString());
+    final Lock lock = mediaPackageLocks.get(mediaPackageId);
     lock.lock();
 
     try {
@@ -2133,6 +2149,16 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    */
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
+  }
+
+  /**
+   * Sets the asset manager
+   *
+   * @param assetManager
+   *          the assetManager to set
+   */
+  public void setAssetManager(AssetManager assetManager) {
+    this.assetManager = assetManager;
   }
 
   /**

--- a/modules/workflow-service-impl/src/main/resources/OSGI-INF/workflow-service.xml
+++ b/modules/workflow-service-impl/src/main/resources/OSGI-INF/workflow-service.xml
@@ -27,6 +27,8 @@
              cardinality="1..1" policy="static" bind="setAuthorizationService"/>
   <reference name="series" interface="org.opencastproject.series.api.SeriesService"
              cardinality="1..1" policy="static" bind="setSeriesService"/>
+  <reference name="assetManager" interface="org.opencastproject.assetmanager.api.AssetManager"
+             cardinality="1..1" policy="static" bind="setAssetManager"/>
   <reference name="orgDirectory" interface="org.opencastproject.security.api.OrganizationDirectoryService"
              cardinality="1..1" policy="static" bind="setOrganizationDirectoryService"/>
   <reference name="scanner" interface="org.opencastproject.workflow.impl.WorkflowDefinitionScanner"


### PR DESCRIPTION
This PR adds “workflow properties” to events, as described here:

https://opencast.jira.com/browse/MH-12826

The idea is to store the last workflow instance’s properties using
asset manager properties and load them when the user invokes “Actions
-> Start Task”. This, of course, has to work when multiple events are
selected, which makes the code a lot more difficult.

For example, if two events are selected, both have the (boolean,
checkbox) workflow property “publish to X”, but with different
values. Then the gui now displays an indeterminate checkbox. In a
similar fashion, radio buttons are all deselected for ambiguous
values, and text fields are blanked.

The “Schedule Task” wizard also has a table at the end listing all the
selected properties. This table was changed to display an asterisk for
properties that are different for each event. When hitting the submit
button, the corresponding workflow properties are resolved for each
event separately.

There’s a new endpoint to retrieve these properties in bulk for
multiple events (for performance reasons). To accomplish that, the
`AssetManager` query language had to be extended.

This work is sponsored by SWITCH.