### PR TITLE
MH-12837 external series API ACL is required

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -751,6 +751,9 @@ public class SeriesEndpoint {
     if (isBlank(metadataParam))
       return R.badRequest("Required parameter 'metadata' is missing or invalid");
 
+    if (isBlank(aclParam))
+      return R.badRequest("Required parameter 'acl' is missing or invalid");
+
     MetadataList metadataList;
     try {
       metadataList = deserializeMetadataList(metadataParam);

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -740,7 +740,7 @@ public class SeriesEndpoint {
   @Produces({ "application/json", "application/v1.0.0+json" })
   @RestQuery(name = "createseries", description = "Creates a series.", returnDescription = "", restParameters = {
           @RestParameter(name = "metadata", isRequired = true, description = "Series metadata", type = STRING),
-          @RestParameter(name = "acl", description = "A collection of roles with their possible action", isRequired = false, type = STRING),
+          @RestParameter(name = "acl", description = "A collection of roles with their possible action", isRequired = true, type = STRING),
           @RestParameter(name = "theme", description = "The theme ID to be applied to the series", isRequired = false, type = STRING) }, reponses = {
                   @RestResponse(description = "A new series is created and its identifier is returned in the Location header.", responseCode = HttpServletResponse.SC_CREATED),
                   @RestResponse(description = "The request is invalid or inconsistent..", responseCode = HttpServletResponse.SC_BAD_REQUEST),


### PR DESCRIPTION
Sets ACL param value to required (which is then reflected in auto-generated docs)
Adds a check to ensure there is an ACL param value present