### PR TITLE
MH-12815 delete series with events option

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -4,7 +4,7 @@ Opencast 6: Release Notes
 New Features and Improvements
 -----------------------------
 
-* **Admin UI** - Deleting Series now warns if series contains events. You can configure if the user is allowed to
+- **Admin UI** - Deleting Series now warns if series contains events. You can configure if the user is allowed to
   delete a series containing events in the series endpoint config file.
 
 

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -4,7 +4,8 @@ Opencast 6: Release Notes
 New Features and Improvements
 -----------------------------
 
-- …
+* **Admin UI** - Deleting Series now warns if series contains events. You can configure if the user is allowed to
+  delete a series containing events in the series endpoint config file.
 
 
 Configuration changes

--- a/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
@@ -1,3 +1,5 @@
 # If false a user will not be able to delete a series containing events in Admin UI
-# Note: Have a look at org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg property.series.required=false
-series.hasEvents.delete.allow=true
+# Note: Have a look at org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+#       property.series.required=false if you want to configure if a event has to have a series
+# Default: true
+# series.hasEvents.delete.allow=true

--- a/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
@@ -1,0 +1,1 @@
+series.hasEvents.delete.allow=true

--- a/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
@@ -1,1 +1,3 @@
+# If false a user will not be able to delete a series containing events in Admin UI
+# Note: Have a look at org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg property.series.required=false
 series.hasEvents.delete.allow=true

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -109,6 +109,7 @@ import com.entwinemedia.fn.data.json.JValue;
 import com.entwinemedia.fn.data.json.Jsons;
 import com.entwinemedia.fn.data.json.Jsons.Functions;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.simple.JSONArray;
@@ -224,7 +225,7 @@ public class SeriesEndpoint implements ManagedService {
 
     Object dictionaryValue = properties.get(SERIES_HASEVENTS_DELETE_ALLOW_KEY);
     if (dictionaryValue != null) {
-      deleteSeriesWithEventsAllowed = Boolean.parseBoolean(dictionaryValue.toString());
+      deleteSeriesWithEventsAllowed = BooleanUtils.toBoolean(dictionaryValue.toString());
     }
   }
 
@@ -1062,7 +1063,7 @@ public class SeriesEndpoint implements ManagedService {
       SearchResult<Event> result = searchIndex.getByQuery(query);
       elementsCount = result.getHitCount();
     } catch (SearchIndexException e) {
-      logger.warn("Could not perform search query: {}", ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not perform search query", e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -1090,9 +1090,9 @@ public class SeriesEndpoint implements ManagedService {
   }
 
   @GET
-  @Path("options.json")
+  @Path("configuration.json")
   @Produces(MediaType.APPLICATION_JSON)
-  @RestQuery(name = "getseriesoptions", description = "Get the series configuration options", returnDescription = "List of configuration keys", reponses = {
+  @RestQuery(name = "getseriesconfiguration", description = "Get the series configuration", returnDescription = "List of configuration keys", reponses = {
     @RestResponse(responseCode = SC_BAD_REQUEST, description = "The required form params were missing in the request."),
     @RestResponse(responseCode = SC_NOT_FOUND, description = "If the series has not been found."),
     @RestResponse(responseCode = SC_OK, description = "The access information ") })

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -223,7 +223,9 @@ public class SeriesEndpoint implements ManagedService {
     }
 
     Object dictionaryValue = properties.get(SERIES_HASEVENTS_DELETE_ALLOW_KEY);
-    deleteSeriesWithEventsAllowed = Boolean.parseBoolean(dictionaryValue.toString());
+    if (dictionaryValue != null) {
+      deleteSeriesWithEventsAllowed = Boolean.parseBoolean(dictionaryValue.toString());
+    }
   }
 
   @GET

--- a/modules/admin-ui/src/main/resources/OSGI-INF/series_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/series_endpoint.xml
@@ -8,6 +8,7 @@
   <property name="opencast.service.path" value="/admin-ng/series" />
   <service>
     <provide interface="org.opencastproject.adminui.endpoint.SeriesEndpoint" />
+    <provide interface="org.osgi.service.cm.ManagedService" />
   </service>
 
    <reference name="AclServiceFactory" interface="org.opencastproject.authorization.xacml.manager.api.AclServiceFactory"

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -67,10 +67,10 @@
        "CONFIRMATION" : "Confirmation"
      },
      "WARNINGS": {
-       "SERIES_HAS_EVENTS": "This series does contain events. Deleting the series will not delete the events"
+       "SERIES_HAS_EVENTS": "This series does contain events. Deleting the series will not delete the events."
      },
      "ERRORS": {
-       "SERIES_HAS_EVENTS": "This series cannot be deleted as it still contains events"
+       "SERIES_HAS_EVENTS": "This series cannot be deleted as it still contains events."
      }
    },
    "MEDIAMODULE": "Media Module",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -52,6 +52,7 @@
          "UNKNOWN"            : "The following element will be deleted",
          "EVENT"              : "The following event will be deleted",
          "SERIES"             : "The following series will be deleted",
+         "SERIES_WITH_EVENTS" : "The series still contains events",
          "ACL"                : "The following ACL will be deleted",
          "GROUP"              : "The following group will be deleted",
          "USER"               : "The following user will be deleted",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -52,8 +52,6 @@
          "UNKNOWN"            : "The following element will be deleted",
          "EVENT"              : "The following event will be deleted",
          "SERIES"             : "The following series will be deleted",
-         "SERIES_WITH_EVENTS" : "The series still contains events",
-         "SERIES_WITH_EVENTS_DELETE_NOT_ALLOWED" : "Deleting series containing events is not allowed",
          "ACL"                : "The following ACL will be deleted",
          "GROUP"              : "The following group will be deleted",
          "USER"               : "The following user will be deleted",
@@ -66,7 +64,13 @@
        "NAME" : "Name"
      },
      "ACTIONS": {
-       "CONFIRMATION" : "Confirmation required"
+       "CONFIRMATION" : "Confirmation"
+     },
+     "WARNINGS": {
+       "SERIES_HAS_EVENTS": "This series does contain events. Deleting the series will not delete the events"
+     },
+     "ERRORS": {
+       "SERIES_HAS_EVENTS": "This series cannot be deleted as it still contains events"
      }
    },
    "MEDIAMODULE": "Media Module",
@@ -199,7 +203,8 @@
       "DELETE": {
           "SERIES": {
             "CAPTION": "Delete",
-            "BUTTON": "Delete"
+            "BUTTON": "Delete",
+            "CANNOT_DELETE": "The highlighted series cannot be deleted as they still contain events."
           },
           "EVENTS": {
             "CAPTION": "Delete",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -53,6 +53,7 @@
          "EVENT"              : "The following event will be deleted",
          "SERIES"             : "The following series will be deleted",
          "SERIES_WITH_EVENTS" : "The series still contains events",
+         "SERIES_WITH_EVENTS_DELETE_NOT_ALLOWED" : "Deleting series containing events is not allowed",
          "ACL"                : "The following ACL will be deleted",
          "GROUP"              : "The following group will be deleted",
          "USER"               : "The following user will be deleted",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -980,6 +980,7 @@
        "TABLE": {
          "CAPTION":      "Series",
          "TITLE":        "Series",
+         "HAS_EVENTS":    "Contains events",
          "CREATORS":     "Organizer(s)",
          "CONTRIBUTORS": "Contributor(s)",
          "CREATED":      "Created",

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -178,7 +178,7 @@
         <script src="scripts/shared/resources/seriesParticipationResource.js"></script>
         <script src="scripts/shared/resources/seriesEventsResource.js"></script>
         <script src="scripts/shared/resources/seriesHasEventsResource.js"></script>
-        <script src="scripts/shared/resources/seriesOptionsResource.js"></script>
+        <script src="scripts/shared/resources/seriesConfigurationResource.js"></script>
         <script src="scripts/shared/resources/seriesThemeResource.js"></script>
         <script src="scripts/shared/resources/eventMetadataResource.js"></script>
         <script src="scripts/shared/resources/eventUploadAssetResource.js"></script>

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -178,6 +178,7 @@
         <script src="scripts/shared/resources/seriesParticipationResource.js"></script>
         <script src="scripts/shared/resources/seriesEventsResource.js"></script>
         <script src="scripts/shared/resources/seriesHasEventsResource.js"></script>
+        <script src="scripts/shared/resources/seriesOptionsResource.js"></script>
         <script src="scripts/shared/resources/seriesThemeResource.js"></script>
         <script src="scripts/shared/resources/eventMetadataResource.js"></script>
         <script src="scripts/shared/resources/eventUploadAssetResource.js"></script>

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -177,6 +177,7 @@
         <script src="scripts/shared/resources/seriesMetadataResource.js"></script>
         <script src="scripts/shared/resources/seriesParticipationResource.js"></script>
         <script src="scripts/shared/resources/seriesEventsResource.js"></script>
+        <script src="scripts/shared/resources/seriesHasEventsResource.js"></script>
         <script src="scripts/shared/resources/seriesThemeResource.js"></script>
         <script src="scripts/shared/resources/eventMetadataResource.js"></script>
         <script src="scripts/shared/resources/eventUploadAssetResource.js"></script>
@@ -299,6 +300,7 @@
         <script src="scripts/shared/directives/tableDirective.js"></script>
         <script src="scripts/shared/directives/statsDirective.js"></script>
         <script src="scripts/shared/directives/confirmationModalDirective.js"></script>
+        <script src="scripts/shared/directives/deleteSingleSeriesModalDirective.js"></script>
         <script src="scripts/shared/directives/resourceModalDirective.js"></script>
         <script src="scripts/shared/directives/editableDirective.js"></script>
         <script src="scripts/shared/directives/editableBooleanValueDirective.js"></script>
@@ -325,6 +327,7 @@
         <script src="scripts/shared/directives/uploadAssetDirective.js"></script>
         <script src="scripts/shared/services/resourceModalService.js"></script>
         <script src="scripts/shared/services/confirmationModalService.js"></script>
+        <script src="scripts/shared/services/deleteSingleSeriesModalService.js"></script>
         <script src="scripts/shared/services/uploadAssetOptionsService.js"></script>
         <script src="scripts/shared/controllers/controllers.js"></script>
         <script src="scripts/shared/controllers/navigationController.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
@@ -24,8 +24,9 @@
 angular.module('adminNg.controllers')
 .controller('BulkDeleteCtrl', ['$scope', 'Modal', 'FormNavigatorService', 'Table', 'Notifications',
     'BulkDeleteResource', 'NewEventProcessing', 'TaskResource', 'decorateWithTableRowSelection',
+    'SeriesHasEventsResource', 'SeriesOptionsResource',
         function ($scope, Modal, FormNavigatorService, Table, Notifications, BulkDeleteResource, NewEventProcessing,
-                  TaskResource, decorateWithTableRowSelection) {
+                  TaskResource, decorateWithTableRowSelection, SeriesHasEventsResource, SeriesOptionsResource) {
 
     var hasPublishedElements = function (currentEvent) {
         var publicationCount = 0;
@@ -105,6 +106,18 @@ angular.module('adminNg.controllers')
                 return selectedCount > 0;
             }
         }
+    };
+
+    $scope.allowed = function () {
+        var allowed = true;
+        if (Table.resource.indexOf('series') >= 0 && $scope.deleteSeriesWithEventsAllowed == false) {
+            angular.forEach($scope.rows, function (row) {
+                if (allowed && row.selected && row.hasEvents) {
+                    allowed = false;
+                }
+            });
+        }
+        return allowed;
     };
 
     $scope.submitButton = false;
@@ -200,5 +213,17 @@ angular.module('adminNg.controllers')
         $scope.events.unpublished = {};
         $scope.events.unpublished.has = $scope.unpublished.rows.length > 0;
         $scope.events.unpublished.selected = true;
+    }
+    else {
+        SeriesOptionsResource.get(function (data) {
+            $scope.deleteSeriesWithEventsAllowed = data.deleteSeriesWithEventsAllowed;
+        });
+        var result = [];
+        angular.forEach($scope.rows, function(row) {
+            SeriesHasEventsResource.get({id: row.id}, function (data) {
+                row.hasEvents = data.hasEvents;
+            });
+
+        });
     }
 }]);

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
@@ -24,9 +24,9 @@
 angular.module('adminNg.controllers')
 .controller('BulkDeleteCtrl', ['$scope', 'Modal', 'FormNavigatorService', 'Table', 'Notifications',
     'BulkDeleteResource', 'NewEventProcessing', 'TaskResource', 'decorateWithTableRowSelection',
-    'SeriesHasEventsResource', 'SeriesOptionsResource',
+    'SeriesHasEventsResource', 'SeriesConfigurationResource',
         function ($scope, Modal, FormNavigatorService, Table, Notifications, BulkDeleteResource, NewEventProcessing,
-                  TaskResource, decorateWithTableRowSelection, SeriesHasEventsResource, SeriesOptionsResource) {
+                  TaskResource, decorateWithTableRowSelection, SeriesHasEventsResource, SeriesConfigurationResource) {
 
     var hasPublishedElements = function (currentEvent) {
         var publicationCount = 0;
@@ -215,7 +215,7 @@ angular.module('adminNg.controllers')
         $scope.events.unpublished.selected = true;
     }
     else {
-        SeriesOptionsResource.get(function (data) {
+        SeriesConfigurationResource.get(function (data) {
             $scope.deleteSeriesWithEventsAllowed = data.deleteSeriesWithEventsAllowed;
         });
         var result = [];

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
@@ -110,7 +110,7 @@ angular.module('adminNg.controllers')
 
     $scope.allowed = function () {
         var allowed = true;
-        if (Table.resource.indexOf('series') >= 0 && $scope.deleteSeriesWithEventsAllowed == false) {
+        if (Table.resource.indexOf('series') >= 0 && !$scope.deleteSeriesWithEventsAllowed) {
             angular.forEach($scope.rows, function (row) {
                 if (allowed && row.selected && row.hasEvents) {
                     allowed = false;
@@ -218,7 +218,6 @@ angular.module('adminNg.controllers')
         SeriesConfigurationResource.get(function (data) {
             $scope.deleteSeriesWithEventsAllowed = data.deleteSeriesWithEventsAllowed;
         });
-        var result = [];
         angular.forEach($scope.rows, function(row) {
             SeriesHasEventsResource.get({id: row.id}, function (data) {
                 row.hasEvents = data.hasEvents;

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesActionsCell.html
@@ -6,7 +6,7 @@
 </a>
 
 <a class="remove"
-  data-confirmation-modal="confirm-modal"
+  data-delete-single-series-modal="delete-single-series-modal"
   data-callback="table.delete"
   data-object="row"
   title="{{ 'EVENTS.SERIES.TABLE.TOOLTIP.DELETE' | translate }}"

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/deleteSingleSeriesModalDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/deleteSingleSeriesModalDirective.js
@@ -1,0 +1,49 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name adminNg.modal.deleteSingleSeriesModal
+ * @description
+ * Opens the delete modal for a single series.
+ *
+ * The success callback name- and id defined in the `callback` and `id` data
+ * attributes will be sent to the {@link adminNg.modal.DeleteSingleSeriesModal service's show method}.
+ */
+angular.module('adminNg.directives')
+.directive('deleteSingleSeriesModal', ['DeleteSingleSeriesModal', function (DeleteSingleSeriesModal) {
+    return {
+        scope: {
+            callback: '=',
+            object:   '='
+        },
+        link: function ($scope, element, attr) {
+            element.bind('click', function () {
+                DeleteSingleSeriesModal.show(attr.deleteSingleSeriesModal, $scope.callback, $scope.object);
+            });
+
+            $scope.$on('$destroy', function () {
+                element.unbind('click');
+            });
+        }
+    };
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-series-modal.html
@@ -8,7 +8,7 @@
 
         <div class="modal-body">
 
-            <div class="modal-alert danger">
+            <div class="modal-alert danger obj">
                 <p translate="BULK_ACTIONS.DELETE_SERIES_WARNING_LINE1">
                     <!-- You have chosen to delete a series. Once deleted all metadata will be deleted
                          and can not be retrieved. -->
@@ -18,6 +18,12 @@
                 </p>
             </div>
 
+            <div ng-show="!allowed()" class="alert sticky warning">
+              <p translate="BULK_ACTIONS.DELETE.SERIES.CANNOT_DELETE">
+                <!-- The highlighted series cannot be deleted as they still contain events -->
+              </p>
+            </div>
+
             <div class="full-col">
                 <div class="obj">
                     <header translate="EVENTS.SERIES.TABLE.CAPTION"><!-- Series --></header>
@@ -25,15 +31,19 @@
                         <table class="main-tbl">
                             <thead>
                                 <tr>
-                                    <th class="small"><input type="checkbox" ng-model="allSelected" ng-change="allSelectedChanged()" class="select-all-cbox"></th>
+                                    <th class="small">
+                                      <input type="checkbox" ng-model="allSelected" ng-change="allSelectedChanged()" class="select-all-cbox">
+                                    </th>
                                     <th translate="EVENTS.SERIES.TABLE.TITLE"><!-- Series --></th>
                                     <th translate="EVENTS.SERIES.TABLE.CREATORS"><!-- Organizer(s) --></th>
                                     <th translate="EVENTS.SERIES.TABLE.HAS_EVENTS"><!-- Has events --></th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr ng-repeat="row in rows">
-                                    <td><input type="checkbox" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
+                                <tr ng-repeat="row in rows" ng-class="{error: !deleteSeriesWithEventsAllowed && row.selected && row.hasEvents}">
+                                    <td>
+                                      <input type="checkbox" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox">
+                                    </td>
                                     <td>{{ row.title }}</td>
                                     <td>{{ row.creator }}</td>
                                     <td ng-class="row.hasEvents == true ? 'fa fa-check' : ''"></td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-series-modal.html
@@ -28,6 +28,7 @@
                                     <th class="small"><input type="checkbox" ng-model="allSelected" ng-change="allSelectedChanged()" class="select-all-cbox"></th>
                                     <th translate="EVENTS.SERIES.TABLE.TITLE"><!-- Series --></th>
                                     <th translate="EVENTS.SERIES.TABLE.CREATORS"><!-- Organizer(s) --></th>
+                                    <th translate="EVENTS.SERIES.TABLE.HAS_EVENTS"><!-- Has events --></th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -35,6 +36,7 @@
                                     <td><input type="checkbox" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
                                     <td>{{ row.title }}</td>
                                     <td>{{ row.creator }}</td>
+                                    <td ng-class="row.hasEvents == true ? 'fa fa-check' : ''"></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -46,7 +48,7 @@
     </div>
 
     <footer>
-        <a translate="BULK_ACTIONS.DELETE.SERIES.BUTTON" class="danger" ng-class="{disabled: !valid()}" ng-click="submit()">
+        <a translate="BULK_ACTIONS.DELETE.SERIES.BUTTON" class="danger" ng-class="{disabled: !valid() || !allowed()}" ng-click="submit()">
             <!-- Delete -->
         </a>
         <a translate="CANCEL" ng-click="close()" class="cancel">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
@@ -1,23 +1,44 @@
 <section ng-show="open" ng-keyup="keyUp($event)" tabindex="1" class="modal modal-animation ng-hide" id="delete-single-series-modal">
+   
     <header>
         <a class="fa fa-times close-modal" ng-click="close()"></a>
-        <h2 translate="CONFIRMATIONS.ACTIONS.CONFIRMATION"><!-- Confirm --></h2>
+        <h2 translate="CONFIRMATIONS.ACTIONS.CONFIRMATION"><!-- Confirmation  --></h2>
     </header>
 
-    <div>
-        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES"><!-- The following series will be deleted --></span>:</p>
-        <p class="delete">{{name}}</p>
-    </div>
-    <div ng-if="hasEvents == true">
-        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES_WITH_EVENTS"><!-- The series contains events --></span></p>
-    </div>
     <div ng-if="hasEvents == true && deleteSeriesWithEventsAllowed == false">
-        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES_WITH_EVENTS_DELETE_NOT_ALLOWED"><!-- The series contains events --></span></p>
+      <div class="modal-alert danger">
+        <p translate="CONFIRMATIONS.ERRORS.SERIES_HAS_EVENTS">
+          <!-- The highlighted series cannot be deleted as they still contain events -->
+        </p>
+      </div>
+      <div class="btn-container">
+          <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()">
+            <!--- Cancel -->
+          </a>
+      </div>
     </div>
-    <p translate="CONFIRMATIONS.CONTINUE_ACTION"><!-- Are you sure you want to continue? --></p>
 
-    <div class="btn-container">
-        <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()"><i><!--- Cancel --></i></a>
-        <a ng-if="hasEvents == false || hasEvents == true && deleteSeriesWithEventsAllowed == true" translate="CONFIRM" class="danger-btn" ng-click="confirm()"><i><!-- Confirm --></i></a>
+    <div ng-if="hasEvents == false || deleteSeriesWithEventsAllowed == true">
+
+      <div ng-if="hasEvents == true && deleteSeriesWithEventsAllowed == true" class="modal-alert warning">
+        <p translate="CONFIRMATIONS.WARNINGS.SERIES_HAS_EVENTS">
+          <!-- The highlighted series cannot be deleted as they still contain events -->
+        </p>
+      </div>
+
+      <div>
+          <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES"><!-- The following series will be deleted --></span>:</p>
+          <p class="delete">{{name}}</p>
+      </div>
+      <p translate="CONFIRMATIONS.CONTINUE_ACTION"><!-- Are you sure you want to continue? --></p>
+
+      <div class="btn-container">
+          <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()">
+            <!--- Cancel -->
+          </a>
+          <a translate="CONFIRM" class="danger-btn" ng-click="confirm()">
+            <!-- Confirm -->
+          </a>
+      </div>
     </div>
 </section>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
@@ -1,11 +1,11 @@
 <section ng-show="open" ng-keyup="keyUp($event)" tabindex="1" class="modal modal-animation ng-hide" id="delete-single-series-modal">
-   
+
     <header>
         <a class="fa fa-times close-modal" ng-click="close()"></a>
         <h2 translate="CONFIRMATIONS.ACTIONS.CONFIRMATION"><!-- Confirmation  --></h2>
     </header>
 
-    <div ng-if="hasEvents == true && deleteSeriesWithEventsAllowed == false">
+    <div ng-if="hasEvents && !deleteSeriesWithEventsAllowed">
       <div class="modal-alert danger">
         <p translate="CONFIRMATIONS.ERRORS.SERIES_HAS_EVENTS">
           <!-- The highlighted series cannot be deleted as they still contain events -->
@@ -18,9 +18,9 @@
       </div>
     </div>
 
-    <div ng-if="hasEvents == false || deleteSeriesWithEventsAllowed == true">
+    <div ng-if="!hasEvents || deleteSeriesWithEventsAllowed">
 
-      <div ng-if="hasEvents == true && deleteSeriesWithEventsAllowed == true" class="modal-alert warning">
+      <div ng-if="hasEvents && deleteSeriesWithEventsAllowed" class="modal-alert warning">
         <p translate="CONFIRMATIONS.WARNINGS.SERIES_HAS_EVENTS">
           <!-- The highlighted series cannot be deleted as they still contain events -->
         </p>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
@@ -8,13 +8,16 @@
         <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES"><!-- The following series will be deleted --></span>:</p>
         <p class="delete">{{name}}</p>
     </div>
-    <div ng-if="hasEvents">
+    <div ng-if="hasEvents == true">
         <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES_WITH_EVENTS"><!-- The series contains events --></span></p>
+    </div>
+    <div ng-if="hasEvents == true && deleteSeriesWithEventsAllowed == false">
+        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES_WITH_EVENTS_DELETE_NOT_ALLOWED"><!-- The series contains events --></span></p>
     </div>
     <p translate="CONFIRMATIONS.CONTINUE_ACTION"><!-- Are you sure you want to continue? --></p>
 
     <div class="btn-container">
         <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()"><i><!--- Cancel --></i></a>
-        <a translate="CONFIRM" class="danger-btn" ng-click="confirm()"><i><!-- Confirm --></i></a>
+        <a ng-if="hasEvents == false || hasEvents == true && deleteSeriesWithEventsAllowed == true" translate="CONFIRM" class="danger-btn" ng-click="confirm()"><i><!-- Confirm --></i></a>
     </div>
 </section>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-single-series-modal.html
@@ -1,0 +1,20 @@
+<section ng-show="open" ng-keyup="keyUp($event)" tabindex="1" class="modal modal-animation ng-hide" id="delete-single-series-modal">
+    <header>
+        <a class="fa fa-times close-modal" ng-click="close()"></a>
+        <h2 translate="CONFIRMATIONS.ACTIONS.CONFIRMATION"><!-- Confirm --></h2>
+    </header>
+
+    <div>
+        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES"><!-- The following series will be deleted --></span>:</p>
+        <p class="delete">{{name}}</p>
+    </div>
+    <div ng-if="hasEvents">
+        <p><span translate="CONFIRMATIONS.METADATA.NOTICE.SERIES_WITH_EVENTS"><!-- The series contains events --></span></p>
+    </div>
+    <p translate="CONFIRMATIONS.CONTINUE_ACTION"><!-- Are you sure you want to continue? --></p>
+
+    <div class="btn-container">
+        <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()"><i><!--- Cancel --></i></a>
+        <a translate="CONFIRM" class="danger-btn" ng-click="confirm()"><i><!-- Confirm --></i></a>
+    </div>
+</section>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesConfigurationResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesConfigurationResource.js
@@ -21,8 +21,8 @@
 'use strict';
 
 angular.module('adminNg.resources')
-.factory('SeriesOptionsResource', ['$resource', function ($resource) {
-    return $resource('/admin-ng/series/options.json', { }, {
+.factory('SeriesConfigurationResource', ['$resource', function ($resource) {
+    return $resource('/admin-ng/series/configuration.json', { }, {
         get: { method: 'GET' }
     });
 }]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesHasEventsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesHasEventsResource.js
@@ -1,0 +1,28 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.resources')
+.factory('SeriesHasEventsResource', ['$resource', function ($resource) {
+    return $resource('/admin-ng/series/:id/hasEvents.json', { id: '@id' }, {
+        get: { method: 'GET' }
+    });
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesOptionsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesOptionsResource.js
@@ -1,0 +1,28 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.resources')
+.factory('SeriesOptionsResource', ['$resource', function ($resource) {
+    return $resource('/admin-ng/series/options.json', { }, {
+        get: { method: 'GET' }
+    });
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/deleteSingleSeriesModalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/deleteSingleSeriesModalService.js
@@ -68,7 +68,7 @@ angular.module('adminNg.services.modal')
             //64 picked by random experimentation
             if (me.$scope.name.length > 64) {
                 me.$scope.name = me.$scope.name.substr(0,61);
-                me.$scope.name = me.$scope.name + "...";
+                me.$scope.name = me.$scope.name + "…";
             }
 
             SeriesHasEventsResource.get({id: object.id}, function (data) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/deleteSingleSeriesModalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/deleteSingleSeriesModalService.js
@@ -28,7 +28,7 @@
  * partial.
  */
 angular.module('adminNg.services.modal')
-.factory('DeleteSingleSeriesModal', ['$location', 'Modal', 'SeriesHasEventsResource', 'SeriesOptionsResource', function ($location, Modal, SeriesHasEventsResource, SeriesOptionsResource) {
+.factory('DeleteSingleSeriesModal', ['$location', 'Modal', 'SeriesHasEventsResource', 'SeriesConfigurationResource', function ($location, Modal, SeriesHasEventsResource, SeriesConfigurationResource) {
     var DeleteSingleSeriesModal = function () {
         var me = this;
 
@@ -74,7 +74,7 @@ angular.module('adminNg.services.modal')
             SeriesHasEventsResource.get({id: object.id}, function (data) {
                 me.$scope.hasEvents = data.hasEvents;
             });
-            SeriesOptionsResource.get(function (data) {
+            SeriesConfigurationResource.get(function (data) {
                 me.$scope.deleteSeriesWithEventsAllowed = data.deleteSeriesWithEventsAllowed;
             });
         };

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/deleteSingleSeriesModalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/deleteSingleSeriesModalService.js
@@ -28,7 +28,7 @@
  * partial.
  */
 angular.module('adminNg.services.modal')
-.factory('DeleteSingleSeriesModal', ['$location', 'Modal', 'SeriesHasEventsResource', function ($location, Modal, SeriesHasEventsResource) {
+.factory('DeleteSingleSeriesModal', ['$location', 'Modal', 'SeriesHasEventsResource', 'SeriesOptionsResource', function ($location, Modal, SeriesHasEventsResource, SeriesOptionsResource) {
     var DeleteSingleSeriesModal = function () {
         var me = this;
 
@@ -73,6 +73,9 @@ angular.module('adminNg.services.modal')
 
             SeriesHasEventsResource.get({id: object.id}, function (data) {
                 me.$scope.hasEvents = data.hasEvents;
+            });
+            SeriesOptionsResource.get(function (data) {
+                me.$scope.deleteSeriesWithEventsAllowed = data.deleteSeriesWithEventsAllowed;
             });
         };
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/deleteSingleSeriesModalService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/deleteSingleSeriesModalService.js
@@ -1,0 +1,86 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
+ * @ngdoc service
+ * @name adminNg.modal.Modal
+ * @description
+ * Provides a service for displaying the delete single series confirmation dialog.
+ * partial.
+ */
+angular.module('adminNg.services.modal')
+.factory('DeleteSingleSeriesModal', ['$location', 'Modal', 'SeriesHasEventsResource', function ($location, Modal, SeriesHasEventsResource) {
+    var DeleteSingleSeriesModal = function () {
+        var me = this;
+
+        /**
+         * @ngdoc function
+         * @name Modal.show
+         * @methodOf adminNg.modal.Modal
+         * @description
+         * Displays a modal and its overlay.
+         *
+         * Loads markup via AJAX from 'partials/modals/{{ modalId }}.html'.
+         *
+         * @param {string} modalId Identifier for the modal.
+         * @param {string} callback Name of the function to call when confirmed
+         * @param {string} object Hash for the success callback function
+         */
+        this.show = function (modalId, callback, object) {
+            Modal.show(modalId);
+            me.$scope = Modal.$scope;
+
+            me.$scope.confirm  = me.confirm;
+            me.$scope.callback = callback;
+            me.$scope.object   = object;
+            me.$scope.name = "undefined";
+            me.$scope.type = "UNKNOWN";
+            if (!angular.isUndefined(object)) {
+                me.$scope.id = object.id;
+                if (object.title) {
+                    me.$scope.name = object.title;
+                } else if (object.name) {
+                    me.$scope.name = object.name;
+                }
+                if (object.type) {
+                    me.$scope.type = object.type;
+                }
+            }
+            //64 picked by random experimentation
+            if (me.$scope.name.length > 64) {
+                me.$scope.name = me.$scope.name.substr(0,61);
+                me.$scope.name = me.$scope.name + "...";
+            }
+
+            SeriesHasEventsResource.get({id: object.id}, function (data) {
+                me.$scope.hasEvents = data.hasEvents;
+            });
+        };
+
+        this.confirm = function () {
+            me.$scope.callback(me.$scope.object);
+            me.$scope.close();
+        };
+    };
+
+    return new DeleteSingleSeriesModal();
+}]);

--- a/modules/admin-ui/src/main/webapp/styles/views/modals/_modal-dialog.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/modals/_modal-dialog.scss
@@ -70,4 +70,41 @@
             }
         }
     }
+
+
+    // Delete Single Series Modal View
+    // ----------------------------------------
+
+    &#delete-single-series-modal {
+
+        // Modal Size
+        @extend .extra-small-modal;
+
+        top: 35%;
+
+        p {
+            text-align: center;
+            margin:20px auto 20px;
+        }
+
+        .delete {
+            font-weight: bold;
+        }
+
+        .btn-container {
+            margin: 20px auto;
+            text-align: center;
+
+            a {
+                padding: 12px 30px;
+                height: 39px;
+                display: inline-block;
+                margin: 0 10px;
+
+                i {
+                    margin: 0 !important;
+                }
+            }
+        }
+    }
 }

--- a/modules/admin-ui/src/main/webapp/styles/views/modals/_modal-dialog.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/modals/_modal-dialog.scss
@@ -84,7 +84,7 @@
 
         p {
             text-align: center;
-            margin:20px auto 20px;
+            margin: 20px auto 20px;
         }
 
         .delete {


### PR DESCRIPTION
This PR adds two new features concerning series deletion:

1. Series deletion uses a new request to check if a series contains events and warns about this in the deletion dialog (adminUI delete in series table or bulk delete via start task)
2. SeriesEndpoint now has a config file `etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg` where you can specify if it is allowed to delete a series containing events `series.hasEvents.delete.allow=true`. Admin UI will check for this and prevent deletion. For this a new request was added which passes config values from the config file.

Example usecase: You can configure events to require a series to be set. `etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg: property.series.required=true`. Setting this will not prevent the user from deleting the series.

Here some example screenshots:

**Delete a single series with no events**

![screen shot 2018-05-14 at 17 13 17](https://user-images.githubusercontent.com/1590263/40006398-97fbf536-579a-11e8-8f42-4a97bb89cafd.png)

**Delete a single series with events (default configuration, allowed)**

![screen shot 2018-05-14 at 17 13 31](https://user-images.githubusercontent.com/1590263/40006442-b6f8f1f0-579a-11e8-8fdb-1edfe01fa3e3.png)

The assumption here is that a user would normally not want to delete a series if it contains events - even if she or he is allowed to.

**Delete a single series with events (disallowed by configuration)**

![screen shot 2018-05-14 at 17 16 03](https://user-images.githubusercontent.com/1590263/40006474-c7347f9e-579a-11e8-8ffe-66293e7c7fd9.png)

Admittedly not the best usability - but if the user deletes the series, this can cause problems if Opencast clients rely on it.

**Delete multiple series with or without events (default configuration, allowed)**

![screen shot 2018-05-14 at 17 19 22](https://user-images.githubusercontent.com/1590263/40006574-0628a64e-579b-11e8-8c25-9ae63ef83d09.png)

**Delete multiple series with events (disallowed by configuration)**

![screen shot 2018-05-14 at 17 18 22](https://user-images.githubusercontent.com/1590263/40006593-137d400c-579b-11e8-951a-6d3923435d0a.png)

Background information:

In our environment, Series are mandatory. Events not belonging to any Series will cause problems in surrounding systems (learning management plugins, video portal) that expect Events to belong to Series.
This PR addresses this issue for the most prominent case: A user deletes a Series in the Admin UI - leaving orphaned events which - in our case - present inconsistent data.

A solution we would have preferred was to delete all events when deleting a series. That is, however, out of scope.

The usability could certainly be improved (presenting a button to a user just to tell him he cannot perform the action if he tries), but the primarily goal is to prevent users from creating inconsistent data by performing "legal" actions in the Admin UI.

This work is sponsored by SWITCH