### PR TITLE
Fix tabs and trailing spaces in docs

### DIFF
--- a/docs/guides/Gruntfile.js
+++ b/docs/guides/Gruntfile.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
             MD007: { // unordered list indentation
               indent: 4 // python-markdown requires 4 spaces of indentation. see https://python-markdown.github.io/#differences
             },
+            MD009: true, // prevent trailing spaces
             MD013: { // line-length
               line_length: 120,
               code_blocks: false,

--- a/docs/guides/Gruntfile.js
+++ b/docs/guides/Gruntfile.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
               indent: 4 // python-markdown requires 4 spaces of indentation. see https://python-markdown.github.io/#differences
             },
             MD009: true, // prevent trailing spaces
+            MD010: true, // prevent the usage of tabs
             MD013: { // line-length
               line_length: 120,
               code_blocks: false,

--- a/docs/guides/admin/docs/configuration/asset-manager.md
+++ b/docs/guides/admin/docs/configuration/asset-manager.md
@@ -8,11 +8,11 @@ Config Options
 
 Configure the file system based asset store in custom.properties.
 
-- `org.opencastproject.episode.rootdir`  
+- `org.opencastproject.episode.rootdir`
    The path where the file system based asset store of the default implementation stores the assets. This key is optional.
-- `org.opencastproject.storage.dir`  
-  This is Opencast’s general config key to configure the base path of everything storage related. 
-  If no storage directory is configured explicitely, the file system based asset store will use 
+- `org.opencastproject.storage.dir`
+  This is Opencast’s general config key to configure the base path of everything storage related.
+  If no storage directory is configured explicitely, the file system based asset store will use
   `${org.opencastproject.storage.dir}/archive` as its base path.
 
 Deployment
@@ -32,5 +32,5 @@ Replace the `asset-manager-storage-fs` bundle with another bundle that exports a
 
 ### How can I use a totally different AssetManager implementation?
 
-Replace both `asset-manager-impl` and `asset-manager-storage-fs` bundles 
+Replace both `asset-manager-impl` and `asset-manager-storage-fs` bundles
 with a bundle that exports an implementation of the `asset-manager-api`.

--- a/docs/guides/admin/docs/configuration/database.md
+++ b/docs/guides/admin/docs/configuration/database.md
@@ -54,7 +54,7 @@ following commands:
     service mariadb start
     chkconfig --level 345 mariadb on
 
-Now you have a MariaDB server running, but without a properly configured root account (no password, etc.) which might 
+Now you have a MariaDB server running, but without a properly configured root account (no password, etc.) which might
 pose a security risk. MariaDB includes a useful tool to secure your database server (it is also included in MySQL).
 You can launch this tool by executing (yes, it is still called mysql_…):
 
@@ -104,11 +104,11 @@ or, if you have a systemd based system:
 
 ### Step 2: Set up the Database Structure
 
-To set up the database structure you can (and should!) use the Opencast ddl scripts. You can find them in the 
+To set up the database structure you can (and should!) use the Opencast ddl scripts. You can find them in the
 installation document folder `.../docs/scripts/ddl/mysql5.sql`. You can also download the script from GitHub.
 
-To import the database structure using the MariaDB/MySQL client, switch to the directory that contains the `mysql5.sql` 
-file and run the MariaDB/MySQL client with the user you created in the previous step (`-u opencast`) and switch to 
+To import the database structure using the MariaDB/MySQL client, switch to the directory that contains the `mysql5.sql`
+file and run the MariaDB/MySQL client with the user you created in the previous step (`-u opencast`) and switch to
 the database you want to use (`opencast`):
 
     mysql -u opencast -p opencast
@@ -121,7 +121,7 @@ Alternatively, you can import the script directly from the command line:
 
     mysql -u opencast -p opencast < .../docs/scripts/ddl/mysql5.sql
 
-Instead of using the MariaDB/MySQL Client, you can also use other methods for executing SQL code like phpMyAdmin or 
+Instead of using the MariaDB/MySQL Client, you can also use other methods for executing SQL code like phpMyAdmin or
 MySQL-Workbench.
 
 ### Step 3: Configure Opencast

--- a/docs/guides/admin/docs/configuration/external-api.md
+++ b/docs/guides/admin/docs/configuration/external-api.md
@@ -6,7 +6,7 @@ External API, you need to configure a user that is authorized to do so.
 
 Perform the following steps to get the External API running:
 
-1. Enable basic authentication (see section Authentication) 
+1. Enable basic authentication (see section Authentication)
 2. Create a new user or choose an existing user (administrative user interface)
 3. Authorize the user to access the External API (see section Authorization)
 4. Test whether access works (see section Testing)

--- a/docs/guides/admin/docs/configuration/load.md
+++ b/docs/guides/admin/docs/configuration/load.md
@@ -45,13 +45,13 @@ management system, and be applied on a cluster level to ensure consistency acros
 Step 2: Setting the load values for system jobs
 -----------------------------------------------
 
-Each Opencast instance has its own maximum load.  By default this is set to the number of CPU cores present in the 
-system.  If you wish to change this, set the `org.opencastproject.server.maxload` key in config.properties to the 
+Each Opencast instance has its own maximum load.  By default this is set to the number of CPU cores present in the
+system.  If you wish to change this, set the `org.opencastproject.server.maxload` key in config.properties to the
 maximum load you want this node to accept.  Keep in mind that exceeding the number of CPU cores present in the system is
 not recommended.
 
-The load values for the non-encoding jobs are set in the etc/services files.  Look for files containing the prefix 
-`job.load`.  These configuration keys control the load for each job type.  For example, the 
+The load values for the non-encoding jobs are set in the etc/services files.  Look for files containing the prefix
+`job.load`.  These configuration keys control the load for each job type.  For example, the
 `job.load.download.distribute` configuration key controls the load placed on the system when a download distribution job
 is running.  The current files with relevant configuration keys are:
 

--- a/docs/guides/admin/docs/configuration/metadata.md
+++ b/docs/guides/admin/docs/configuration/metadata.md
@@ -11,7 +11,7 @@ This document provides an overview over Opencast's metadata capabilities and its
 ## Standard Metadata
 
 For both events and series, a common set of metadata is supported by Opencast out-of-the box. Since metadata catalogs
-are referenced from within media package, flavors can be used to identify a specific metadata catalog. The following 
+are referenced from within media package, flavors can be used to identify a specific metadata catalog. The following
 flavors are treated by Opencast as standard metadata in means of Opencast expects them to be present:
 
 * `dublincore/episode` holds the standard metadata of an event
@@ -32,7 +32,7 @@ described in the next section.
 
 ## Extended Metadata
 
-For both events and series, Opencast support an arbitrary number of customized metadata catalogs. 
+For both events and series, Opencast support an arbitrary number of customized metadata catalogs.
 
 To add extended metadata catalogs, create a configuration file with a valid filename of the form
 `org.opencastproject.ui.metadata.CatalogUIAdapterFactory-<name>.cfg` in `/opt/opencast/etc.` on the admin node.
@@ -56,7 +56,7 @@ The metadata configuration file format can be logically split up into different 
 |organization     |mh_default_org           |A custom catalog definition is mapped 1:1 to an organization and is available to this one organization only.|
 |flavor           |mycompany/episode        |The catalog must be of a certain flavor. For a events catalog, the flavor consists of the form type/subtype whereas for series you only need to define the subtype. Attention: For series catalogs, the type (the part before the slash '/') is used as element type.|
 |title            |My Personal Catalog Name |This is the title that is displayed in the UI. It should be something that is readable by humans.|
- 
+
 ### Part 2: XML serialization information
 
 The only supported serialization of catalogs is currently the XML file format. The file follows the recommendation of
@@ -99,7 +99,7 @@ output id to make it easy to find.
 \* Mandatory field attribute
 
 \** See https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
- 
+
 **Field types**
 
 |Type          |Description                     |Example value in catalog  |Example value in UI  |JSON response example|
@@ -112,13 +112,13 @@ output id to make it easy to find.
 |start_date   |The start date portion of a Dublin Core Catalog Period. |start=2014-11-04T19:00:00Z; end=2014-11-05T20:00:00Z; scheme=W3C-DTF; |2014-11-04| |
 |start_time   |The start time portion of a Dublin Core Catalog Period. |start=2014-11-04T19:00:00Z; end=2014-11-05T20:00:00Z; scheme=W3C-DTF; |19:00:00 | |
 |duration     |The duration of the event portion of a Dublin Core Catalog Period.|start=2014-11-04T19:00:00Z; end=2014-11-05T20:00:00Z; scheme=W3C-DTF; |01:00:00 | |
- 
+
 **Workflow Configuration**
 
 Since the extended metadata don't have the `dublincore/*` flavor, a tagging operation for the archive has to be added
-for the extended catalogs. 
+for the extended catalogs.
 In our examples below, we use ext/episode as a flavor, so the following operation should be added to the workflows
- 
+
     <!-- Tag the extended metadata catalogs for publishing -->
     <operation
         id="tag"
@@ -128,11 +128,11 @@ In our examples below, we use ext/episode as a flavor, so the following operatio
             <configuration key="target-tags">+archive</configuration>
         </configurations>
     </operation>
- 
- 
+
+
 If you want the extended metadata to be published the same way as the standard metadata, you can update the existing
 tagging operation for dublincore metadata the following way
- 
+
     <!-- Tag the incoming metadata catalogs for publishing -->
     <operation
       id="tag"

--- a/docs/guides/admin/docs/configuration/oaipmh.md
+++ b/docs/guides/admin/docs/configuration/oaipmh.md
@@ -32,7 +32,7 @@ Step 3: Configure the OAI-PMH default repository
 
 In case the repository is not included in the URL, the OAI-PMH default repository will be selected.
 
-The property to configure the OAI-PMH default repository can be found in 
+The property to configure the OAI-PMH default repository can be found in
 `etc/org.opencastproject.oaipmh.server.OaiPmhServer.cfg`
 
     default-repository=default

--- a/docs/guides/admin/docs/configuration/security.aai.md
+++ b/docs/guides/admin/docs/configuration/security.aai.md
@@ -112,7 +112,7 @@ respective name of the Shibboleth attribute you use in your Shibboleth Federatio
 
     <bean id="preauthAuthProvider"
           class="org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationProvider">
-  	  <property name="preAuthenticatedUserDetailsService">
+      <property name="preAuthenticatedUserDetailsService">
         <bean id="userDetailsServiceWrapper"
               class="org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper">
           <property name="userDetailsService" ref="userDetailsService"/>

--- a/docs/guides/admin/docs/configuration/security.ldap.md
+++ b/docs/guides/admin/docs/configuration/security.ldap.md
@@ -247,7 +247,7 @@ at the bottom of the file. Please see the example below:
       <!-- Defines how the user attributes are converted to authorities (roles) -->
       <!-- PLEASE NOTE: the ref below must match the corresponding authoritiesPopulator -->
       <constructor-arg ref="authoritiesPopulator2" />
-	</bean>
+    </bean>
 
     <!-- [ ... SKIPPED LINES ... ] -->
 

--- a/docs/guides/admin/docs/configuration/security.user.sakai.md
+++ b/docs/guides/admin/docs/configuration/security.user.sakai.md
@@ -1,7 +1,7 @@
 ### What it does
 
 The [Sakai](https://www.sakaiproject.org/) User Provider enriches Opencast users
-with a set of roles made up of the user's membership in Sakai sites, of the form 
+with a set of roles made up of the user's membership in Sakai sites, of the form
 SITEID_Role. For example, an Opencast user who is also a Sakai user and a member
 of the Sakai site `mysiteid` with the Sakai role `Student` will be granted the
 Opencast role `mysiteid_Learner`. Note that by default, Sakai site IDs are opaque
@@ -18,13 +18,13 @@ Series ACL to grant access to the Series to members of the `mysiteid` site in Sa
 
 ### Requirements
 
-The Sakai User Provider requires Sakai 11.0 or later, and an admin-equivalent 
+The Sakai User Provider requires Sakai 11.0 or later, and an admin-equivalent
 account on the Sakai instance.
 
 ### Step 1
 
-To enable the Sakai User Provider, copy and rename the bundled configuration template from 
-`OPENCAST/etc/org.opencastproject.userdirectory.sakai-default.cfg.template` to 
+To enable the Sakai User Provider, copy and rename the bundled configuration template from
+`OPENCAST/etc/org.opencastproject.userdirectory.sakai-default.cfg.template` to
 `OPENCAST/etc/org.opencastproject.userdirectory.sakai-default.cfg`
 
 Edit the configuration file to set your Sakai URL, and the username and password of

--- a/docs/guides/admin/docs/configuration/stream-security.md
+++ b/docs/guides/admin/docs/configuration/stream-security.md
@@ -95,7 +95,7 @@ provider to have one key for any URL that begins with one scheme, such as http, 
 signed with a single key. Or it could be configured so that each different scheme and hostname pair would have a
 different keys protecting each host’s URLs separately etc. Having the timing configurations separate from the key
 configuration allows the different types of URLs to be signed differently depending on the needs of the users without
-needing to configure this timing for all of the different keys. 
+needing to configure this timing for all of the different keys.
 
 ### Signing for Opencast-internal access
 

--- a/docs/guides/admin/docs/installation/source-macosx.md
+++ b/docs/guides/admin/docs/installation/source-macosx.md
@@ -101,7 +101,7 @@ Building Opencast
 Switch to the opencast folder. If you downloaded the tarball, this is the folder you just unpacked (called something
 like `opencast-community-opencast-[…]`). If you chose to download via git, use `cd opencast`. You can proceed by
 building opencast (depending on the folder permissions, you might need to start the command with `sudo`):
-       
+
     mvn clean install
 
 > *Please be patient, as building Opencast for the first time will take quite long.*

--- a/docs/guides/admin/docs/modules/adaptivestreaming-wowza.md
+++ b/docs/guides/admin/docs/modules/adaptivestreaming-wowza.md
@@ -150,7 +150,7 @@ All this can be configured in the "Options" section of the Wowza application:
 3. Click the "Edit" button
 4. Add the following Properties
 
-    |Path                           |Name	                                    |Type    |Value |
+    |Path                           |Name                                     |Type    |Value |
     |-------------------------------|-----------------------------------------|--------|------|
     |/Root/Application/HTTPStreamer |cupertinoUserHTTPHeaders                 |String  | \*\* |
     |/Root/Application/HTTPStreamer |mpegdashUserHTTPHeaders                  |String  | \*\* |

--- a/docs/guides/admin/docs/modules/awss3distribution.md
+++ b/docs/guides/admin/docs/modules/awss3distribution.md
@@ -76,12 +76,12 @@ workflow operation is *last* in the workflow will be the final publication.
 Using this handler in custom workflows
 --------------------------------------
 
-If your workflow contains both `publish-engage` and `publish-aws`, in that order, and without a 
+If your workflow contains both `publish-engage` and `publish-aws`, in that order, and without a
 [conditional](../configuration/workflow.md) you would have publication files stored both locally *and* in AWS.  This is
 likely not what you want, so protect your workflow operations appropriately.  If you really do need these files stored
-in both places (for example, in cases where you need to make the files available immediately, and only push to AWS in 
+in both places (for example, in cases where you need to make the files available immediately, and only push to AWS in
 some cases) then remember to add a [retract-engage](../workflowoperationhandlers/retract-engage-woh.md) in between the
-publication operations.  Note that if this step is omitted the files will remain available locally, but will not be 
+publication operations.  Note that if this step is omitted the files will remain available locally, but will not be
 used.  Of further note, if you retract after publication to AWS then your workflow *will not be available* to users.
 To summarize, this table presents a subset of the various situations that are possible
 

--- a/docs/guides/admin/docs/modules/execute.md
+++ b/docs/guides/admin/docs/modules/execute.md
@@ -25,7 +25,7 @@ job.load.execute = 1.0
 # The list of commands, separated by spaces, which may be run by the Execute Service.
 # A value of * means any command is allowed.
 # Default: empty (no commands allowed)
-#commands.allowed = 
+#commands.allowed =
 ````
 
 If `commands.allowed` is empty or undefined (the default), the service won't be able to run any commands.
@@ -61,11 +61,11 @@ For instance, suppose you use the Execute Service with the following arguments:
 
     "John Doe" xyz #{my.property}
 
-the command run will receive that argument list as-is, because my.property is not a valid placeholder, nor 
+the command run will receive that argument list as-is, because my.property is not a valid placeholder, nor
 is it defined in the Execute Service's configuration file or `custom.properties`.
 
 However, if you define my.property in `custom.properties`:
-  
+
     my.property = foo
 
 then the command will get the following argument list:
@@ -74,7 +74,7 @@ then the command will get the following argument list:
 
 If you define the same variable in the Execute Service's configuration file (regardless of whether the variable
 is defined in `custom.properties` or not):
- 
+
     my.property = bar
 
 then the actual argument list will be:

--- a/docs/guides/admin/docs/modules/liveschedule.md
+++ b/docs/guides/admin/docs/modules/liveschedule.md
@@ -32,7 +32,7 @@ Configuration
 Edit  _etc/org.opencastproject.liveschedule.impl.LiveScheduleServiceImpl.cfg_.
 
 If your capture agent does not register a _capture.device.live.resolution.WIDTHxHEIGHT_ property, it's mandatory to
-configure the _live.streamingUrl_. 
+configure the _live.streamingUrl_.
 
 The _live.streamingUrl_ should be set to your streaming server url (or the subscriber url specified by your CDN).
 
@@ -78,12 +78,12 @@ live.distributionService=download
 
 ### Step 2: Configure the capture agent
 
-#### Capture agent does not register the _capture.device.live.resolution.WIDTHxHEIGHT_ property 
+#### Capture agent does not register the _capture.device.live.resolution.WIDTHxHEIGHT_ property
 
 Configure the capture agent to stream to your streaming server (or the publisher url specified by your CDN), using the
 same stream name specified in live.streamName.
 
-#### Capture agent registers the _capture.device.live.resolution.WIDTHxHEIGHT_ property 
+#### Capture agent registers the _capture.device.live.resolution.WIDTHxHEIGHT_ property
 
 If your capture agent supports configuring custom capture agent properties, instead of configuring the
 live.streamingUrl, live.resolution, live.streamName, you can update the capture agent firmware to pass the following
@@ -98,7 +98,7 @@ urls, using 'presenter/delivery' (or the flavor configured, but only one flavor 
 If a property capture.device.live.resolution.WIDTHxHEIGHT was registered, it will take precedence over the
 LiveScheduleService configuration.
 
-#### Example 1: 
+#### Example 1:
 
 #### Capture agent does not register with capture.device.live.resolution.WIDTHxHEIGHT
 
@@ -117,7 +117,7 @@ _live.streamingUrl_ may be very different from the url the capture agent streams
 used by the player will be something like live.streamingUrl=rtmp://xyz.live.edgefcs.net/live/ and the capture agent's
 publish url something like rtmp://a.bcd.e.akamaientrypoint.net/EntryPoint. The stream name should always match.
 
-#### Example 2: 
+#### Example 2:
 
 #### Capture agent registers with capture.device.live.resolution.WIDTHxHEIGHT
 
@@ -152,7 +152,7 @@ If not using the sample Opencast workflows, add to the `<configuration_panel>`:
               <label for="publishLive">Add live event to Opencast Media Module</label>
             </li>
           </ul>
-        </fieldset>        
+        </fieldset>
 ```
 
 And to the _defaults_ operation:
@@ -166,7 +166,7 @@ And to the _defaults_ operation:
         <configuration key="publishToMediaModule">true</configuration>
         <configuration key="publishToOaiPmh">true</configuration>
         <configuration key="uploadedSearchPreview">false</configuration>
-        <configuration key="publishLive">false</configuration>        
+        <configuration key="publishLive">false</configuration>
       </configurations>
     </operation>
 ```

--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -7,18 +7,18 @@ What it does
 The Opencast LTI module provides an easy way to integrate Opencast into a Learning Management System (LMS),
 or any other system which supports the LTI standard as an LTI _tool consumer_.
 
-Typically, students enrolled in a course access Opencast through an LTI tool in the LMS course site, 
-and can play back videos in an Opencast series set up for the course. 
+Typically, students enrolled in a course access Opencast through an LTI tool in the LMS course site,
+and can play back videos in an Opencast series set up for the course.
 
-More information about the LTI specifications is available at 
+More information about the LTI specifications is available at
 [IMS Learning Tools Interoperability](http://www.imsglobal.org/activity/learning-tools-interoperability).
 
-Configure Opencast 
+Configure Opencast
 ------------------------
 
 To enable LTI authentication in Opencast, edit `OPENCAST/etc/security/mh_default_org.xml`
 
-* In the Authentication Filters section, uncomment the oAuthProtectedResourceFilter: 
+* In the Authentication Filters section, uncomment the oAuthProtectedResourceFilter:
 ````
     <!-- 2-legged OAuth is used by trusted 3rd party applications, including LTI. -->
     <!-- Uncomment the line below to support LTI or other OAuth clients.          -->
@@ -42,7 +42,7 @@ To enable LTI authentication in Opencast, edit `OPENCAST/etc/security/mh_default
     </bean>
 ````
 
-* To give LMS users the same username in Opencast as the LMS username, uncomment the constructor arguments 
+* To give LMS users the same username in Opencast as the LMS username, uncomment the constructor arguments
 below and update CONSUMERKEY to the same key used above:
 
 ````
@@ -68,24 +68,24 @@ Configure an LTI tool in the LMS with these values:
 
 In a clustered Opencast system, choose the URL of the presentation server where the media module and player are available.
 
-Access the LTI tool configured for Opencast in the LMS. The Opencast LTI Welcome page should appear. Click on the links 
+Access the LTI tool configured for Opencast in the LMS. The Opencast LTI Welcome page should appear. Click on the links
 provided to `OPENCAST-URL/lti` and `OPENCAST-URL/info/me.json` to verify the LTI parameters provided to Opencast by the LMS,
 and the list of roles which the LTI user has in Opencast.
 
 LTI roles
 ----------
 
-LTI users will only see Opencast series and videos which are public, or those to which they have access 
+LTI users will only see Opencast series and videos which are public, or those to which they have access
 because of the Opencast roles which they have. The Opencast LTI module grants an LTI user the role(s) formed
 from the LTI parameters `context_id` and `roles`.
 
 The LTI context is typically the LMS course ID, and the default LTI role for a student in a course is `Learner`.
 The Opencast role granted would therefore be `SITEID_Learner`.
 
-To make a series or video visible to students who access Opencast through LTI in an LMS course, 
-add the role `SITEID_Learner` to the Series or Event Access Control List (ACL). 
+To make a series or video visible to students who access Opencast through LTI in an LMS course,
+add the role `SITEID_Learner` to the Series or Event Access Control List (ACL).
 
-LTI users may also have additional roles if the LTI user is created as an Opencast user in the Admin UI and 
+LTI users may also have additional roles if the LTI user is created as an Opencast user in the Admin UI and
 given additional roles, or if one or more Opencast User Providers or Role Providers are configured.
 
 Customize the LTI tool in the LMS

--- a/docs/guides/admin/docs/modules/player.matomo.tracking.md
+++ b/docs/guides/admin/docs/modules/player.matomo.tracking.md
@@ -27,7 +27,7 @@ Configuration
 ### prop.player.matomo.server
 
 The plugin shows a notification about the tracking to the user. This can be disabled with this option. (Default: true)
-Before you disable the notification, make sure that you do not violate any local regulations. 
+Before you disable the notification, make sure that you do not violate any local regulations.
 
 ### prop.player.matomo.server
 

--- a/docs/guides/admin/docs/modules/textextraction.md
+++ b/docs/guides/admin/docs/modules/textextraction.md
@@ -79,7 +79,7 @@ For this, edit the `/etc/opencast/encoding/opencast-images.properties` and modif
 extraction:
 
     profile.text-analysis.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
-	    -filter:v boxblur=1:1,curves=all=0.4/0#{space}0.6/1 \
+      -filter:v boxblur=1:1,curves=all=0.4/0#{space}0.6/1 \
       -frames:v 1 -pix_fmt:v gray -r 1 #{out.dir}/#{out.name}#{out.suffix}
 
 This profile will create a gray, high contrast image. The additional light blur will reduce or remove noise and thicken

--- a/docs/guides/admin/docs/modules/watsontranscripts.md
+++ b/docs/guides/admin/docs/modules/watsontranscripts.md
@@ -42,21 +42,21 @@ Edit  _etc/org.opencastproject.transcription.ibmwatson.IBMWatsonTranscriptionSer
 * Set _enabled_=true
 * Use service credentials obtained above to set _ibm.watson.user_ and _ibm.watson.psw_
 * Enter the appropriate language model in _ibm.watson.model_, if not using the default (_en-US_BroadbandModel_)
-* In _workflow_, enter the workflow definition id of the workflow to be used to attach the generated 
+* In _workflow_, enter the workflow definition id of the workflow to be used to attach the generated
 transcripts/captions
-* Enter a _notification.email_ to get job failure notifications. If not entered, the email in 
+* Enter a _notification.email_ to get job failure notifications. If not entered, the email in
 etc/custom.properties (org.opencastproject.admin.email) will be used. Configure the SmtpService.
 If no email address specified in either _notification.email_ or _org.opencastproject.admin.email_,
-email notifications will be disabled. 
+email notifications will be disabled.
 
 ```
-# Change enabled to true to enable this service. 
+# Change enabled to true to enable this service.
 enabled=true
 
-# User obtained when registering with the IBM Watson Speech-to_text service 
+# User obtained when registering with the IBM Watson Speech-to_text service
 ibm.watson.user=<SERVICE_USER>
 
-# Password obtained when registering with the IBM Watson Speech-to_text service 
+# Password obtained when registering with the IBM Watson Speech-to_text service
 ibm.watson.password=<SERVICE_PSW>
 
 # Language model to be used. See the IBM Watson Speech-to-Text service documentation
@@ -65,19 +65,19 @@ ibm.watson.password=<SERVICE_PSW>
 
 # Workflow to be executed when results are ready to be attached to media package.
 #workflow=attach-watson-transcription
-  
+
 # Interval the workflow dispatcher runs to start workflows to attach transcripts to the media package
 # after the transcription job is completed.
 # (in seconds) Default is 1 minute.
 #workflow.dispatch.interval=60
- 
+
 # How long it should wait to check jobs after their start date + track duration has passed.
 # The default is 10 minutes. This is only used if we didn't get a callback from the
 # ibm watson speech-to-text service.
 # (in seconds)
 #completion.check.buffer=600
 
-# How long to wait after a transcription is supposed to finish before marking the job as 
+# How long to wait after a transcription is supposed to finish before marking the job as
 # canceled in the database. Default is 2 hours.
 # (in seconds)
 #max.processing.time=7200
@@ -93,7 +93,7 @@ ibm.watson.password=<SERVICE_PSW>
 
 ### Step 3: Add encoding profile for extracting audio
 
-The IBM Watson Speech-to-Text service has limitations on audio file size. Try using the encoding profile suggested in 
+The IBM Watson Speech-to-Text service has limitations on audio file size. Try using the encoding profile suggested in
 etc/encoding/watson-audio.properties.
 
 ### Step 4: Add workflow operations and create new workflow
@@ -101,7 +101,7 @@ etc/encoding/watson-audio.properties.
 Add the following operations to your workflow. We suggest adding them after the media package is
 published so that users can watch videos without having to wait for the transcription to finish, but it
 depends on your use case. The only requirement is to take a snapshot of the media package so that
-the second workflow can retrieve it from the Asset Manager to attach the caption/transcripts.  
+the second workflow can retrieve it from the Asset Manager to attach the caption/transcripts.
 
 ``` xml
 <!-- Extract audio from one of the presenter videos -->

--- a/docs/guides/admin/docs/workflowoperationhandlers/analyzeaudio-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/analyzeaudio-woh.md
@@ -19,47 +19,50 @@ otherwise nothing happens. Here are the internal steps done by the different inp
 
 Example result track:
 
-    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <track type="presentation/audio" id="audio">
-        <mimetype>video/x-flac</mimetype>
-        <tags />
-        <url>fooVideo.flac</url>
-        <checksum type="md5">46cb2e9df2e73756b0d96c33b1aaf055</checksum>
-        <duration>65680</duration>
-        <audio id="audio-1">
-            <device />
-            <encoder type="ADPCM" />
-            <bitdepth>16</bitdepth>
-            <channels>2</channels>
-            <bitrate>62500.0</bitrate>
-            <peakleveldb>-30</peakleveldb> <!-- NEW -->
-            <rmsleveldb>-20</rmsleveldb> <!-- NEW -->
-            <rmspeakdb>-10</rmspeakdb> <!-- NEW -->
-        </audio>
-    </track>
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<track type="presentation/audio" id="audio">
+  <mimetype>video/x-flac</mimetype>
+  <tags />
+  <url>fooVideo.flac</url>
+  <checksum type="md5">46cb2e9df2e73756b0d96c33b1aaf055</checksum>
+  <duration>65680</duration>
+  <audio id="audio-1">
+    <device />
+    <encoder type="ADPCM" />
+    <bitdepth>16</bitdepth>
+    <channels>2</channels>
+    <bitrate>62500.0</bitrate>
+    <peakleveldb>-30</peakleveldb> <!-- NEW -->
+    <rmsleveldb>-20</rmsleveldb> <!-- NEW -->
+    <rmspeakdb>-10</rmspeakdb> <!-- NEW -->
+  </audio>
+</track>
+```
 
 ## Parameter Table
 
 
-|configuration keys	|example				|description|default value|
-|-----------------------|---------------------------------------|-----------|-------------|
-|source-flavors		|"presentation/work,presenter/work"	|The "flavors" of the track to use as a source input	|EMPTY|
-|source-flavor		|"presentation/work"			|The "flavor" of the track to use as a source input	|EMPTY|
-|source-tags		|"engage,atom,rss"			|The "tag" of the track to use as a source input	|EMPTY|
-|force-transcode		|"true" or "false"			|Whether to force transcoding the audio stream
-(This is needed when trying to strip an audio stream from an audio only video container, because SoX can not handle video formats, so it must be encoded to an audio format)	|FALSE|
+|configuration keys|example                           |description|default value|
+|------------------|----------------------------------|-----------|-------------|
+|source-flavors    |"presentation/work,presenter/work"|The "flavors" of the track to use as a source input|EMPTY|
+|source-flavor     |"presentation/work"               |The "flavor" of the track to use as a source input|EMPTY|
+|source-tags       |"engage,atom,rss"                 |The "tag" of the track to use as a source input|EMPTY|
+|force-transcode   |"true" or "false"                 |Whether to force transcoding the audio stream
+(This is needed when trying to strip an audio stream from an audio only video container, because SoX can not handle video formats, so it must be encoded to an audio format)|FALSE|
 
 
 ## Operation Example
 
-    <operation
-      id="analyze-audio"
-      fail-on-error="true"
-      exception-handler-workflow="error"
-      description="Analyze audio stream">
-      <configurations>
-        <configuration key="source-flavor">*/work</configuration>
-        <configuration key="force-transcode">true</configuration>
-      </configurations>
-    </operation>
-
+```xml
+<operation
+  id="analyze-audio"
+  fail-on-error="true"
+  exception-handler-workflow="error"
+  description="Analyze audio stream">
+  <configurations>
+    <configuration key="source-flavor">*/work</configuration>
+    <configuration key="force-transcode">true</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/attach-watson-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/attach-watson-transcription-woh.md
@@ -34,7 +34,7 @@ Example
     <configuration key="target-tag">archive</configuration>
     <!-- Caption generated will have the default flavor based on the target-caption-format and language e.g. captions/vtt+en -->
     <configuration key="target-caption-format">vtt</configuration>
-    <configuration key="target-tag">engage-download</configuration>    
+    <configuration key="target-tag">engage-download</configuration>
   </configurations>
 </operation>
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/compose-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/compose-woh.md
@@ -13,8 +13,8 @@ The ComposeWorkflowHandler is used to encode media files to different formats us
 |target-tags       | sometag            | Specifies the tags of the new media                                           |
 |encoding-profile  | webm-hd            | Specifies the encoding profile to use                                         |
 |tags-and-flavors  | true               | When false (default), the operation selects input elements that have EITHER any of the source tags OR the source flavor. When true, the operation selects input elements that have BOTH the source-flavor AND any of the source tags |
-	 
- 
+
+
 ## Operation Example
 
     <operation

--- a/docs/guides/admin/docs/workflowoperationhandlers/composite-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/composite-woh.md
@@ -22,22 +22,22 @@ Tags and flavors can be used in combination.
 
 |configuration keys|value type (EBNF)|example|description|default value|
 |------------------|-----------------|-------|-----------|-------------|
-|source-tags-upper|String , { "," , String }	|comp,rss|The "tag" of the upper track to use as a source input.|EMPTY|
-|source-flavor-upper|MediaPackageElementFlavor	|presenter/trimmed|The "flavor" of the upper track to use as a source input.|EMPTY|
-|source-tags-lower|String , { "," , String }	|comp,rss|The "tag" of the lower track to use as a source input.|EMPTY|
-|source-flavor-lower|MediaPackageElementFlavor	|presenter/trimmed|The "flavor" of the lower track to use as a source input.|EMPTY|
-|source-tags-watermark|String , { "," , String }	|branding|The "tag" of the attachment image to use as a source input.|EMPTY|
-|source-flavor-watermark|MediaPackageElementFlavor	|image/work|The "flavor" of the attachment image to use as a source input.|EMPTY|
-|source-url-watermark|URL	|file:///Users/me/logo.jpg|The "URL" of the fallback image to use as a source input.|EMPTY|
-|target-tags|String , { "," , String }	|composite,rss,atom,archive|The tags to apply to the compound video track.|EMPTY|
-|\* **target-flavor**|MediaPackageElementFlavor|	composite/delivery	|The flavor to apply to the compound video track.|EMPTY|
-|\* **encoding-profile**|String|	composite	|The encoding profile to use.|EMPTY|
+|source-tags-upper|String , { "," , String }    |comp,rss|The "tag" of the upper track to use as a source input.|EMPTY|
+|source-flavor-upper|MediaPackageElementFlavor    |presenter/trimmed|The "flavor" of the upper track to use as a source input.|EMPTY|
+|source-tags-lower|String , { "," , String }    |comp,rss|The "tag" of the lower track to use as a source input.|EMPTY|
+|source-flavor-lower|MediaPackageElementFlavor    |presenter/trimmed|The "flavor" of the lower track to use as a source input.|EMPTY|
+|source-tags-watermark|String , { "," , String }    |branding|The "tag" of the attachment image to use as a source input.|EMPTY|
+|source-flavor-watermark|MediaPackageElementFlavor    |image/work|The "flavor" of the attachment image to use as a source input.|EMPTY|
+|source-url-watermark|URL    |file:///Users/me/logo.jpg|The "URL" of the fallback image to use as a source input.|EMPTY|
+|target-tags|String , { "," , String }    |composite,rss,atom,archive|The tags to apply to the compound video track.|EMPTY|
+|\* **target-flavor**|MediaPackageElementFlavor|    composite/delivery    |The flavor to apply to the compound video track.|EMPTY|
+|\* **encoding-profile**|String|    composite    |The encoding profile to use.|EMPTY|
 |\* **output-resolution**|width , "x" , height &#124; lower &#124; higher|1920x1080|The resulting resolution of the compound video e.g. 1920x1080.|EMPTY|
-|output-background|String	|red|The resulting background color of the compound video http://www.ffmpeg.org/ffmpeg-utils.html#Color.|black|
+|output-background|String    |red|The resulting background color of the compound video http://www.ffmpeg.org/ffmpeg-utils.html#Color.|black|
 |layout|name | Json , ";" , Json , [ ";" , Json ]|The layout name to use or a semi-colon separated JSON layout definition (lower video, upper video, optional watermark). If a layout name is given than the corresponding layout-{name} key must be defined.|EMPTY|
 |layout-single|name | Json , ";" , Json , [ ";" , Json ]|Layout to be used in case of one input video track (see *layout*)|EMPTY|
 |layout-dual|name | Json , ";" , Json , [ ";" , Json ]|Layout to be used in case of two input video tracks (see *layout*). Defaults to value of *layout* if not set.|EMPTY|
-|layout-{name}|Json , ";" , Json , [ ";" , Json ]	 	|Define semi-colon separated JSON layouts (lower video, upper video, optional watermark) to provide by name.|EMPTY|
+|layout-{name}|Json , ";" , Json , [ ";" , Json ]         |Define semi-colon separated JSON layouts (lower video, upper video, optional watermark) to provide by name.|EMPTY|
 
 
 \* **mandatory**

--- a/docs/guides/admin/docs/workflowoperationhandlers/configure-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/configure-by-dcterm-woh.md
@@ -23,26 +23,26 @@ Tags and flavors can be used in combination.
 The type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
 
 ### dcterm
-The name of the Dublin Core term to look for in the `dccatalog`. This could be one of the terms set by Opencast or an 
+The name of the Dublin Core term to look for in the `dccatalog`. This could be one of the terms set by Opencast or an
 additional term adding to the catalog.
- 
+
 ### match-value
 The value of the `dcterm` which to match against. The comparison is case sensitive.
 
 ### default-value
-If `default-value` is used when the `dcterm` is not found in the catalog. If not specified the operation will treat the 
-match as false and not configure anything. If `default-value` is specified the operation will compare the `match-value` 
-to the `default-value` and set the workflow property if they match. This allows an implied value to be explicitly and 
-clearly defined. For example if you have mediapackages that were created before additional metadata was added to the 
+If `default-value` is used when the `dcterm` is not found in the catalog. If not specified the operation will treat the
+match as false and not configure anything. If `default-value` is specified the operation will compare the `match-value`
+to the `default-value` and set the workflow property if they match. This allows an implied value to be explicitly and
+clearly defined. For example if you have mediapackages that were created before additional metadata was added to the
 episode catalog you may want to imply that the `audience` term has a value of `all-enrolled`.
 
 ### "configProperty"
-Specifies as the key the name of a new workflow configuration property and the boolean value to which it will be set if 
-the Dublin Core term matches the specified value. 
+Specifies as the key the name of a new workflow configuration property and the boolean value to which it will be set if
+the Dublin Core term matches the specified value.
 
-Due to the way a workflow evaluates operation `if` conditions as configuration properties are created, only new 
-configuration properties can be used to modify the execution of subsequent operations. Also since an undefined property 
-will be evaluted as `false` in practice the only useful value which can set is `true`.  However operation `if` 
+Due to the way a workflow evaluates operation `if` conditions as configuration properties are created, only new
+configuration properties can be used to modify the execution of subsequent operations. Also since an undefined property
+will be evaluted as `false` in practice the only useful value which can set is `true`.  However operation `if`
 conditions can be negated though so it is possible to skip subsequent operations on matched `dcterm`  value.
 
 ## Operation Example
@@ -64,7 +64,7 @@ conditions can be negated though so it is possible to skip subsequent operations
        id="publish-engage"
        if="${publishPrivate}"
        description="Publish to internal audience only">
-       ... 
+       ...
     </operation>
 
 
@@ -72,5 +72,5 @@ conditions can be negated though so it is possible to skip subsequent operations
        id="publish-youtube"
        if="NOT ${publishPrivate}"
        description="Publish to global audience">
-       ... 
+       ...
     </operation>

--- a/docs/guides/admin/docs/workflowoperationhandlers/coverimage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/coverimage-woh.md
@@ -95,7 +95,7 @@ Later on, you can use methods of those classes as shown in the following example
       <xsl:value-of select="opencast:XsltHelper.split(metadata/title, 30, 1, false())" />
     </tspan>
 
-Note: In XSLT, use `true()` and `false()` for boolean literals (`true` and `false` won't work since those are not 
+Note: In XSLT, use `true()` and `false()` for boolean literals (`true` and `false` won't work since those are not
 keywords in XSLT)
 
 The following classes are provided by the org.opencastproject.coverimage.impl.xsl package:

--- a/docs/guides/admin/docs/workflowoperationhandlers/execute-once-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/execute-once-woh.md
@@ -6,7 +6,7 @@ may be used to create a new mediapackage element, or to add configuration proper
 
 To run a command for each element in a MediaPackage, use the [Execute Many](execute-many-woh.md) operation.
 
-Commands run by this operation handler must first be included in the `commands.allowed` list in the 
+Commands run by this operation handler must first be included in the `commands.allowed` list in the
 [Execute Service](../modules/execute.md#service-configuration) configuration.
 
 ### Parameter table

--- a/docs/guides/admin/docs/workflowoperationhandlers/extracttext-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/extracttext-woh.md
@@ -23,4 +23,4 @@ The ExtractTextWorkflowOperation will try to extract test from a video using Tes
                 <configuration key="target-tags">engage,archive</configuration>
           </configurations>
     </operation>
- 
+

--- a/docs/guides/admin/docs/workflowoperationhandlers/extracttext-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/extracttext-woh.md
@@ -1,26 +1,29 @@
 # ExtractTextWorkflowOperation
 
 ## Description
+
 The ExtractTextWorkflowOperation will try to extract test from a video using Tesseract OCR.
+
 ## Parameter Table
 
-|configuration keys|example|description|
-|------------------|-------|-----------|
-|source-flavor|presentation/work|Specifies which media should be processed.|
-|source-tags	|text	 |Specifies which media should be processed.	 |
-|target-tags 	|engage  |Specifies the tags for the produces media. 	 |
+|configuration keys|example          |description|
+|------------------|-----------------|-----------|
+|source-flavor     |presentation/work|Specifies which media should be processed|
+|source-tags       |text             |Specifies which media should be processed|
+|target-tags       |engage           |Specifies the tags for the produces media|
 
 ## Operation Example
 
-    <operation
-          id="extract-text"
-          fail-on-error="false"
-          exception-handler-workflow="error"
-          description="Extracting text from presentation segments">
-          <configurations>
-                <configuration key="source-flavor">presentation/trimmed</configuration>
-                <configuration key="source-tags"></configuration>
-                <configuration key="target-tags">engage,archive</configuration>
-          </configurations>
-    </operation>
-
+```xml
+<operation
+  id="extract-text"
+  fail-on-error="false"
+  exception-handler-workflow="error"
+  description="Extracting text from presentation segments">
+  <configurations>
+    <configuration key="source-flavor">presentation/trimmed</configuration>
+    <configuration key="source-tags"></configuration>
+    <configuration key="target-tags">engage,archive</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/image-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/image-woh.md
@@ -7,7 +7,7 @@ Both absolute and relative positions can be used.
 ## Parameter Table
 
 |configuration keys|example|description|
-|------------------|-------|-----------| 
+|------------------|-------|-----------|
 |source-flavor|presenter/source|Specifies which media should be processed.|
 |source-flavors|presenter/source, presentation/source|Specifies a list of media which should be processed. In case a flavor has been specified in *source-flavor*, it will be added to this list.|
 |source-tags	|engage	|Specifies which media should be processed.|

--- a/docs/guides/admin/docs/workflowoperationhandlers/image-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/image-woh.md
@@ -10,11 +10,11 @@ Both absolute and relative positions can be used.
 |------------------|-------|-----------|
 |source-flavor|presenter/source|Specifies which media should be processed.|
 |source-flavors|presenter/source, presentation/source|Specifies a list of media which should be processed. In case a flavor has been specified in *source-flavor*, it will be added to this list.|
-|source-tags	|engage	|Specifies which media should be processed.|
+|source-tags    |engage    |Specifies which media should be processed.|
 |target-flavor|presenter/work|Specifies the flavor the new files will get.|
-|target-tags	|engage	|Specifies the tags the new files will get.	 |
-|encoding-profile	|search-cover.http	|Comma-separated list of encoding profiles to use.	 |
-|time	|1	|Comma-separated list of time (in seconds or relative to source track duration) where the image should be taken.	 |
+|target-tags    |engage    |Specifies the tags the new files will get.     |
+|encoding-profile    |search-cover.http    |Comma-separated list of encoding profiles to use.     |
+|time    |1    |Comma-separated list of time (in seconds or relative to source track duration) where the image should be taken.     |
 |target-base-name-format-second|thumbnail_%.0f%s|Used to control the target filenames for images extracted at absolute times. Mainly helpful when integrating third-party applications that prefer to use filename to distinguish individual images|
 |target-base-name-format-percent|thumbnail_%.3f%s|Used to control the target filenames for images extracted at relative times. Mainly helpful when integrating third-party applications that prefer to use filename to distinguish individual images|
 |end-margin|500|Safety margin at the end of the track. Sometimes, image extraction is critical at the end of the file. Using *end-margin* ensures, that no images are being extracted near the end of the video file to avoid problems with defective inputs.</br>(Default: 100)|

--- a/docs/guides/admin/docs/workflowoperationhandlers/imagetovideo-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/imagetovideo-woh.md
@@ -1,19 +1,21 @@
 # ImageToVideo Workflow Operation Handler
 
 ## Description
+
 The ImageToVideo Workflow Operation Handler allows to create a video track from a source image.
 
 ## Parameters table
+
 Tags and flavors can be used in combination. But combined they should match one image.
 
-|configuration keys|example|description|default value|
-|------------------|-------|-----------|-------------|
-|**source-tags**\* |intro  |A comma separated list of tags of the input image|EMPTY|
-|**source-flavor**\*|intro/source|The "flavor" of the image to use as a source input|EMPTY|
-|target-tags|composite,rss,atom,archive|The tags to apply to the output video track|EMPTY|
-|target-flavor|intro/work	|The flavor to apply to the output video track|EMPTY|
-|**duration**\*|5	|The length of the output video in seconds.|EMPTY|
-|**profile**\*|image-movie|Define the encoding-profile to use to create the output video. See example of profile below.|EMPTY|
+|configuration keys |example                   |description|default value|
+|-------------------|--------------------------|-----------|-------------|
+|**source-tags**\*  |intro                     |A comma separated list of tags of the input image|EMPTY|
+|**source-flavor**\*|intro/source              |The "flavor" of the image to use as a source input|EMPTY|
+|target-tags        |composite,rss,atom,archive|The tags to apply to the output video track|EMPTY|
+|target-flavor      |intro/work                |The flavor to apply to the output video track|EMPTY|
+|**duration**\*     |5                         |The length of the output video in seconds.|EMPTY|
+|**profile**\*      |image-movie               |Define the encoding-profile to use to create the output video. See example of profile below.|EMPTY|
 
 \* **mandatory**
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/incident-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/incident-woh.md
@@ -1,27 +1,31 @@
 # IncidentCreatorWorkflowOperationHandler
 
 ## Description
+
 The IncidentCreatorWorkflowOperationHandler creates an incident on a dummy job used for integration testing.
 
 ## Parameter Table
-|configuration keys|example|description|default value|
-|------------------|-------|-----------|-------------|
-|code|2|The code number of the incident to produce.|1|
-|severity|WARNING	|The severity. See Incident.Severity enum.|INFO|
-|details	|"tagged,+rss" / "-rss,+tagged"| Some details: title=content;title=content;...|EMPTY|
-|params|"presentation/tagged"|Some params: key=value;key=value;...|EMPTY|
+
+|configuration keys|example                       |description                                  |default value|
+|------------------|------------------------------|---------------------------------------------|-------------|
+|code              |2                             |The code number of the incident to produce.  |1|
+|severity          |WARNING                       |The severity. See Incident.Severity enum.    |INFO|
+|details           |"tagged,+rss" / "-rss,+tagged"|Some details: title=content;title=content;...|EMPTY|
+|params            |"presentation/tagged"         |Some params: key=value;key=value;...         |EMPTY|
 
 ## Operation Example
 
-    <operation
-      id="incident"
-      fail-on-error="true"
-      exception-handler-workflow="error"
-      description="Provoke a job incident">
-      <configurations>
-        <configuration key="code">3</configuration>
-        <configuration key="severity">INFO</configuration>
-        <configuration key="details">exception=content;id=325</configuration>
-        <configuration key="params">track=track-1;profile=full</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+  id="incident"
+  fail-on-error="true"
+  exception-handler-workflow="error"
+  description="Provoke a job incident">
+  <configurations>
+    <configuration key="code">3</configuration>
+    <configuration key="severity">INFO</configuration>
+    <configuration key="details">exception=content;id=325</configuration>
+    <configuration key="params">track=track-1;profile=full</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/normalizeaudio-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/normalizeaudio-woh.md
@@ -69,13 +69,13 @@ Parameter Table
 
 |configuration keys|example|description|default value|
 |------------------|-------|-----------|-------------|
-|source-flavors |"presentation/work,presenter/work"	|The "flavors" of the track to use as a source input	|EMPTY|
-|source-flavor  |"presentation/work"	|The "flavor" of the track to use as a source input	|EMPTY|
-|source-tags    |"engage,atom,rss"	|The "tag" of the track to use as a source input	|EMPTY|
-|target-flavor  |"presentation/normalized"	|The flavor to apply to the normalized file	|EMPTY|
-|target-tags    |"norm"	|The tags to apply to the normalized file	|EMPTY|
-|**target-decibel**\*|-30.4	|The target RMS Level Decibel	|EMPTY|
-|force-transcode	|"true" or "false"	|Whether to force transcoding the audio stream (This is needed when trying to strip an audio stream from an audio only video container, because SoX can not handle video formats, so it must be encoded to an audio format)	|FALSE|
+|source-flavors      |"presentation/work,presenter/work"    |The "flavors" of the track to use as a source input    |EMPTY|
+|source-flavor       |"presentation/work"    |The "flavor" of the track to use as a source input    |EMPTY|
+|source-tags         |"engage,atom,rss"    |The "tag" of the track to use as a source input    |EMPTY|
+|target-flavor       |"presentation/normalized"    |The flavor to apply to the normalized file    |EMPTY|
+|target-tags         |"norm"    |The tags to apply to the normalized file    |EMPTY|
+|**target-decibel**\*|-30.4    |The target RMS Level Decibel    |EMPTY|
+|force-transcode     |"true" or "false"    |Whether to force transcoding the audio stream (This is needed when trying to strip an audio stream from an audio only video container, because SoX can not handle video formats, so it must be encoded to an audio format)    |FALSE|
 
 \* **required keys**
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/partial-import-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/partial-import-woh.md
@@ -10,7 +10,7 @@ When using the PartialImportWorkflowOperation, it is recommended to perform a me
 InspectWorkflowOperation with the option `accurate-frame-count` set to `true`. This ensures that
 the PartialImportWorkflowOperation works correctly in case of media files with incorrect framecount in their header.
 Note that the use of `accurate-frame-count` will force the InspectWorkflowOperation to decode the complete video
-stream which makes the operation more expensive in terms of load. 
+stream which makes the operation more expensive in terms of load.
 
 ## Parameter Table
 
@@ -108,7 +108,7 @@ in the SMIL file:
     </operation>
 
 In our example, the PartialImportWorkflowOperation will create the target flavors presenter/standard and
-presentation/standard as depicted below: 
+presentation/standard as depicted below:
 
 ![Figure 2](./partial-import-woh-figure-2.jpg)
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/prepareav-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/prepareav-woh.md
@@ -20,12 +20,12 @@ in the pipeline (encoding to flash, mjpeg etc.).
 |------------------|-------|-----------|
 |source-flavor|presenter/source|Specifies which media should be processed.|
 |target-flavor|presenter/work|Specifies the flavor the new files will get.|
-|mux-encoding-profile	|mux-av.work	|The encoding profile to use for media that needs to be muxed (default is 'mux-av.work')|
-|audio-video-encoding-profile	|av.work	|The encoding profile to use for media that is audio-video already and needs to be re-encodend (default is av.work)	 |
-|video-encoding-profile	|video-only.work	|The encoding profile to use for media that is only video and needs to be re-encodend (default is video-only.work)	 |
-|audio-encoding-profile	|audio-only.work	|The encoding profile to use for media that is only audio and needs to be re-encodend (default is audio-only.work)	 |
-|rewrite	|true	|Should files be rewritten	 |
-|audio-muxing-source-flavors|presentation/source,presentation/\*,\*/\*	|If there is no matching flavor to mux, search for a track with audio that can be muxed by going from left to right through this comma-separated list of source flavors|
+|mux-encoding-profile    |mux-av.work    |The encoding profile to use for media that needs to be muxed (default is 'mux-av.work')|
+|audio-video-encoding-profile    |av.work    |The encoding profile to use for media that is audio-video already and needs to be re-encodend (default is av.work)     |
+|video-encoding-profile    |video-only.work    |The encoding profile to use for media that is only video and needs to be re-encodend (default is video-only.work)     |
+|audio-encoding-profile    |audio-only.work    |The encoding profile to use for media that is only audio and needs to be re-encodend (default is audio-only.work)     |
+|rewrite    |true    |Should files be rewritten     |
+|audio-muxing-source-flavors|presentation/source,presentation/\*,\*/\*    |If there is no matching flavor to mux, search for a track with audio that can be muxed by going from left to right through this comma-separated list of source flavors|
 
 
 ## Operation Example

--- a/docs/guides/admin/docs/workflowoperationhandlers/prepareav-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/prepareav-woh.md
@@ -1,18 +1,18 @@
 # PrepareAVWorkflowOperation
 
 ## Description
-The PrepareAVWorkflowOperation works is like this: 
+The PrepareAVWorkflowOperation works is like this:
 
 If there are two tracks with the same flavor, and one of them contains a video stream only, while the other contains an
 audio stream only, the implementation will call the composer's "mux" method, with the result that the audio will be
-muxed with the video, using the video's movie container. 
+muxed with the video, using the video's movie container.
 
 If it there is one track with a certain flavor, the "encode" method is called which will rewrite (vs. encode) the file
 using the same container and codec (-vcodec copy, -a codec copy), while the container format is determined by ffmpeg via
 the file's extension. The reason for doing this is that many media files are in a poor state with regard to their
 compatibility (most often, the stream's codec contains differing information from the container), so we are basically
 asking ffmepg to rewrite the whole thing, which will in many cases eliminate problems that would otherwhise occur later
-in the pipeline (encoding to flash, mjpeg etc.). 
+in the pipeline (encoding to flash, mjpeg etc.).
 
 ## Parameter Table
 
@@ -26,8 +26,8 @@ in the pipeline (encoding to flash, mjpeg etc.).
 |audio-encoding-profile	|audio-only.work	|The encoding profile to use for media that is only audio and needs to be re-encodend (default is audio-only.work)	 |
 |rewrite	|true	|Should files be rewritten	 |
 |audio-muxing-source-flavors|presentation/source,presentation/\*,\*/\*	|If there is no matching flavor to mux, search for a track with audio that can be muxed by going from left to right through this comma-separated list of source flavors|
- 	 	 	 
- 
+
+
 ## Operation Example
 
     <operation

--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-youtube-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-youtube-woh.md
@@ -5,10 +5,10 @@ PublishYoutubeWorkflowOperation
 Description
 -----------
 
-The PublishYoutubeWorkflowOperation publishes a single stream to YouTube.  This stream must meet YouTube's format 
+The PublishYoutubeWorkflowOperation publishes a single stream to YouTube.  This stream must meet YouTube's format
 requirements, and may consist of audio and/or video.  If you want to publish both your presenter and presentation
 streams we suggest using the [Composite](composite-woh.md) workflow operation handler to prepare a composite file
-with both streams inside of it.  The default Opencast workflow prepares a video using this method. 
+with both streams inside of it.  The default Opencast workflow prepares a video using this method.
 
 
 Parameter Table

--- a/docs/guides/admin/docs/workflowoperationhandlers/retract-configure-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/retract-configure-woh.md
@@ -9,7 +9,7 @@ If the elements have been added to the Publication using "with-published-element
 api, they haven't actually been published so it is unnecessary to have a retract-configuration. Adding a retraction
 won't cause any errors, it will just skip those elements.
 
-There is only one configuration key "channel-id". This is the channel to remove the published elements from. 
+There is only one configuration key "channel-id". This is the channel to remove the published elements from.
 
 ## Operation Examples
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/segmentpreviews-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/segmentpreviews-woh.md
@@ -10,11 +10,11 @@ previous discovered segments.
 |------------------|-------|-----------|
 |source-flavor|presenter/source|Specifies which media should be processed.|
 |target-flavor|presenter/work|Specifies the flavor the new files will get.|
-|source-tags	|engage	|Specifies which media should be processed.	 |
-|target-tags	|engage	|Specifies the tags the new files will get.	 |
-|encoding-profile	|search-cover.http	|The encoding profile to use.	 |
-|reference-flavor	|presentation/work	|Flavor of the segments to use.	 |
-|reference-tags	|engage	|Tags of the segments to use.	 |
+|source-tags    |engage    |Specifies which media should be processed.     |
+|target-tags    |engage    |Specifies the tags the new files will get.     |
+|encoding-profile    |search-cover.http    |The encoding profile to use.     |
+|reference-flavor    |presentation/work    |Flavor of the segments to use.     |
+|reference-tags    |engage    |Tags of the segments to use.     |
 
 ## Operation Example
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/segmentpreviews-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/segmentpreviews-woh.md
@@ -7,7 +7,7 @@ previous discovered segments.
 ## Parameter Table
 
 |configuration keys|example|description|
-|------------------|-------|-----------| 
+|------------------|-------|-----------|
 |source-flavor|presenter/source|Specifies which media should be processed.|
 |target-flavor|presenter/work|Specifies the flavor the new files will get.|
 |source-tags	|engage	|Specifies which media should be processed.	 |
@@ -15,7 +15,7 @@ previous discovered segments.
 |encoding-profile	|search-cover.http	|The encoding profile to use.	 |
 |reference-flavor	|presentation/work	|Flavor of the segments to use.	 |
 |reference-tags	|engage	|Tags of the segments to use.	 |
- 
+
 ## Operation Example
 
     <operation

--- a/docs/guides/admin/docs/workflowoperationhandlers/segmentvideo-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/segmentvideo-woh.md
@@ -10,7 +10,7 @@ slides which were shown change.
 |configuration keys|example|description|
 |------------------|-------|-----------|
 |source-flavor |presentation/trimmed|Specifies which media should be processed.|
- 	 	 	 
+
 ## Operation Example
 
     <operation

--- a/docs/guides/admin/docs/workflowoperationhandlers/start-watson-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/start-watson-transcription-woh.md
@@ -1,7 +1,7 @@
 # Start Watson Transcription
 ## Description
 
-The Start Watson Transcription invokes the IBM Watson Speech-to-Text service, passing an audio file to be translated to 
+The Start Watson Transcription invokes the IBM Watson Speech-to-Text service, passing an audio file to be translated to
 text.
 
 ## Parameter Table

--- a/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
@@ -1,14 +1,14 @@
 # TagByDCTermWorkflowOperationHandler
 
 ## Description
-With the TagByDCTermWorkflowOperationHandler it's possible to select various media package elements and then modify 
+With the TagByDCTermWorkflowOperationHandler it's possible to select various media package elements and then modify
 their tag set and / or set their flavor according to whether a Dublin Core term in a catalog has a specific value.
 
-So for example it's possible to pick elements like the Dublin Core catalogs that have been added to the media package 
-at the beginning of the workflow and tag them, so they can be picked up by operations later on or even an application 
+So for example it's possible to pick elements like the Dublin Core catalogs that have been added to the media package
+at the beginning of the workflow and tag them, so they can be picked up by operations later on or even an application
 that harvests the mediapackage from a publication channel.
 
-In combination with [ConfigureByDCTermWorkflowOperationHandler](configure-by-dcterm-woh.md) workflows can be controlled 
+In combination with [ConfigureByDCTermWorkflowOperationHandler](configure-by-dcterm-woh.md) workflows can be controlled
 by the metadata contained within the Dublin core catalogs.
 
 ## Parameter Table
@@ -25,24 +25,24 @@ Tags and flavors can be used in combination.
 |target-tags       |"tagged,+rss" / "-rss,+tagged"|Apply these (comma separated) tags to any media package elements. If a target-tag starts with a '-', it will be removed from preexisting tags, if a target-tag starts with a '+', it will be added to preexisting tags. If there is no prefix, all preexisting tags are removed and replaced by the target-tags.|EMPTY|
 |target-flavor     |"presentation/tagged"     |Apply these flavor to any media package elements|EMPTY|
 |copy              |"true" or "false"         |Indicates if matching elements will be cloned before tagging is applied or whether tagging is applied to the original element. Set to "true" to create a copy first, "false" otherwise.|FALSE|
- 
+
 Note: see [TagWorkflowOperationHandler](tag-woh.md) for further explanation of the source/target-flavour/tags
 
 ### dccatalog
 The type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
 
 ### dcterm
-The name of the Dublin Core term to look for in the `dccatalog`. This could be one of the terms set by Opencast or an 
+The name of the Dublin Core term to look for in the `dccatalog`. This could be one of the terms set by Opencast or an
 additional term adding to the catalog.
- 
+
 ### match-value
 The value of the `dcterm` which to match against. The comparison is case sensitive.
 
 ### default-value
-If `default-value` is used when the `dcterm` is not found in the catalog. If not specified the operation will treat the 
-match as false and not tag anything. If `default-value` is specified the operation will compare the `match-value` to 
-the `default-value` and apply the tags if they match. This allows an implied value to be explicitly and clearly 
-defined. For example if you have mediapackages that were created before additional metadata was added to the episode 
+If `default-value` is used when the `dcterm` is not found in the catalog. If not specified the operation will treat the
+match as false and not tag anything. If `default-value` is specified the operation will compare the `match-value` to
+the `default-value` and apply the tags if they match. This allows an implied value to be explicitly and clearly
+defined. For example if you have mediapackages that were created before additional metadata was added to the episode
 catalog you may want to imply that the `audience` term has a value of `all-enrolled`.
 
 ## Operation Example

--- a/docs/guides/admin/docs/workflowoperationhandlers/theme-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/theme-woh.md
@@ -1,7 +1,7 @@
 # ThemeWorkflowOperationHandler
 
 ## Description
-The ThemeWorkflowOperation loads workflow properties and adds elements to the media package if available. 
+The ThemeWorkflowOperation loads workflow properties and adds elements to the media package if available.
 This information can be used within workflow definitions to actually implement themes.
 
 **Bumpers**

--- a/docs/guides/admin/docs/workflowoperationhandlers/watermark-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/watermark-woh.md
@@ -1,7 +1,7 @@
 ## WatermarkWorkflowOperationHandler
 
 ## Description
-The WatermarkWorkflowOperationHandler adds a custom image (usually a small one) to the source video. 
+The WatermarkWorkflowOperationHandler adds a custom image (usually a small one) to the source video.
 
 The operation needs a source video and a custom image file to create a watermarked video.
 

--- a/docs/guides/developer/docs/api/types.md
+++ b/docs/guides/developer/docs/api/types.md
@@ -123,7 +123,7 @@ The following sections define data types that are used to manage metadata catalo
 
 ### fields
 
-Each metadata catalogs has a list of metadata fields that is described as array of JSON objects with the following 
+Each metadata catalogs has a list of metadata fields that is described as array of JSON objects with the following
 fields:
 
 Field          | Optional | Type                | Description
@@ -310,7 +310,7 @@ ACE field  | Required | Type                | Description
 
 __Example__
 
-``` 
+```
   {
     "allow": true,
     "action": "write",

--- a/docs/guides/developer/docs/api/usage.md
+++ b/docs/guides/developer/docs/api/usage.md
@@ -145,7 +145,7 @@ GET /api/events?sort=title
 Parameter | Encoding      | Description
 :---------|:--------------|:-----------
 `order`   | `asc`, `desc` | The sort order. Default value is `asc`.
-                  
+
 __Example__
 
 Ordering the list of events by title in ascending order:

--- a/docs/guides/developer/docs/asset-manager.md
+++ b/docs/guides/developer/docs/asset-manager.md
@@ -8,15 +8,15 @@ Architecture
 
 The AssetManager consists of the following modules:
 
-* `asset-manager-api`  
+* `asset-manager-api`
 An API module defining the core AssetManager functions, properties and the query language.
-* `asset-manager-impl`  
+* `asset-manager-impl`
 The default implementation of the AssetManager as an OSGi service, containing the storage API for pluggable asset stores.
-* `asset-manager-storage-fs`  
+* `asset-manager-storage-fs`
 The default  implementation of the AssetStore. Depends on asset-manager-impl.
-* `asset-manager-util`  
+* `asset-manager-util`
 Additional functionality for the AssetManager providing utilities such as starting workflows on archived snapshots, etc.
-* `asset-manager-workflowoperation`  
+* `asset-manager-workflowoperation`
 A workflow operation handler to take media package snapshots of a media package from inside a running workflow.
 
 ### High Level View
@@ -46,14 +46,14 @@ Assets are stored in the following directory structure.
 
 The asset manager uses four tables
 
-* `mh_assets_snapshot`  
+* `mh_assets_snapshot`
   Manages snapshots. Each snapshot may be linked to zero or more assets.
-* `mh_assets_asset`  
+* `mh_assets_asset`
   Manages the assets of a snapshot.
-* `mh_assets_properties`  
-  Manages the properties. This table is indirectly linked to the snapshot table via column `mediapackage_id`. 
-* `mh_assets_version_claim`  
-  Manages the next free version number per episode. 
+* `mh_assets_properties`
+  Manages the properties. This table is indirectly linked to the snapshot table via column `mediapackage_id`.
+* `mh_assets_version_claim`
+  Manages the next free version number per episode.
 
 ### Security
 
@@ -86,7 +86,7 @@ am referring to the AssetManager and mp the media package id of type String of t
     am.setProperty(Property.mk(PropertyId.mk(
       mp, "org.opencastproject.approval", "approval"),
       Value.mk(true)));
-      
+
 It is recommended to use namespace names after the service's package name, in the example:
 `org.opencastproject.approval`. This code looks overly verbose. Also you need to deal with namespace names and property
 names directly. That's cumbersome and error prone even though you might intoduce constants for them. To help remedy this
@@ -97,20 +97,20 @@ it goes.
      public ApprovalProps(AQueryBuilder q) {
        super(q, "org.opencastproject.approval");
      }
-    
+
      public PropertyField<Boolean> approved() {
        return booleanProp("approved");
      }
-    
+
      public PropertyField<String> comment() {
        return stringProp("comment");
      }
-    
+
      public PropertyField<Date> date() {
        return dateProp("date");
      }
     }
-    
+
 Now you can set properties like this.
 
     am.setProperty(p.approved().mk(mp, false));
@@ -136,7 +136,7 @@ properties need to be selected in order to fetch them.
 
     q.select(q.snapshot(), q.properties())
       .where(p.approved().eq(true).and(q.version().isLatest())
-      .run(); 
+      .run();
 
 Here we go. Now we can access all properties stored with the returned snapshots. Now, let's assume other services make
 heavy use of properties too. This may cause serious database IO if we always select all properties like we did using the
@@ -144,7 +144,7 @@ q.properties() target. Let's do better.
 
     q.select(q.snapshot(), q.propertiesOf("org.opencastproject.approval"))
       .where(p.approved().eq(true).and(q.version().isLatest())
-      .run(); 
+      .run();
 
 This will return only the properties of our service's namespace. But do we have to deal with namespace strings again?
 No.
@@ -192,11 +192,11 @@ The following type are available for properties:
 * String
 * Date
 * Boolean
-* Version  
+* Version
   Version is the AssetManager type that abstracts a snapshot version.
 
 #### Decomposing properties
-Since properties are type safe they cannot be accessed directly. 
+Since properties are type safe they cannot be accessed directly.
 If you know the type of the property you can access its value using a type evidence constant.
 
     String string = p.getValue().get(Value.STRING);
@@ -215,7 +215,7 @@ type `Fn` taking the raw value as input and returning a String.
         handleDateFn,
         handleLongFn,
         handleBooleanFn,
-        handleVersionFn);		
+        handleVersionFn);
       System.out.println(f);
     }
 
@@ -280,7 +280,7 @@ the result in an enrichment.
 
 ### Deleting Snapshots
 
-This works exactly like deleting properties, except that you need to specify snapshots instead of properties. 
+This works exactly like deleting properties, except that you need to specify snapshots instead of properties.
 Please note that it's also possible to specify snapshots and properties simultanously.
 
     q.delete("owner", q.snapshot()).where(q.version().isLatest().not()).run();

--- a/docs/guides/developer/docs/committer.md
+++ b/docs/guides/developer/docs/committer.md
@@ -3,9 +3,9 @@ Committers and Contributors
 
 What is a committer, and how does that differ from a contributor?
 -----------------------------------------------------------------
-The Opencast project welcomes all those who are interested in contributing in concrete ways. Contributions can take 
-many forms, and there are various mechanisms by which one can contribute (signing up for the mailing list or 
-browsing our issue tracker are both great places to start). Anyone can become a contributor, and there is no 
+The Opencast project welcomes all those who are interested in contributing in concrete ways. Contributions can take
+many forms, and there are various mechanisms by which one can contribute (signing up for the mailing list or
+browsing our issue tracker are both great places to start). Anyone can become a contributor, and there is no
 expectation of future commitment to the project, no specific skill requirements, and no selection process. Some of the
 contributions individuals have given in the past include:
 
@@ -19,7 +19,7 @@ contributions individuals have given in the past include:
 * Assisting in translation of both documentation and the system itself
 * Performing Quality Assurance tasks as needed as part of the QA process prior to release
 
-As contributors gain experience and familiarity with the project they generally find that making such contributions 
+As contributors gain experience and familiarity with the project they generally find that making such contributions
 becomes easier. With a sufficient level of participation and commitment to the project, contributors may be nominated
 by existing committers to join the committer body. While similar in day-to-day activities as contributors, committers
 have shown a dedicated interest in supporting the project over the longer term. Committership allows individuals to
@@ -43,8 +43,8 @@ activities such as:
 * Knowing when a change is beyond your ability and asking for help.
 * Keeping informed of project governance and direction.
 * Fostering a collegial environment between the group of committers.
-* Ensuring that incoming code adheres to our [license](license.md) requirements. Minor patches can be accepted 
-  without concern, but the main reviewer *must* ensure that a CLA (and CCLA) is in place prior to merging in the 
+* Ensuring that incoming code adheres to our [license](license.md) requirements. Minor patches can be accepted
+  without concern, but the main reviewer *must* ensure that a CLA (and CCLA) is in place prior to merging in the
   contribution.
 * 20% of the time a committer invests to the project is to be allocated for general purposes, i.e. work not directly
   associated with the committer's individual or institutional concerns.
@@ -67,10 +67,10 @@ What happens if I stop contributing?
 Committer status can be lost through any of the methods below:
 
 * *Committer Emeritus*: By being absent or inactive for a period of six months or more, or by request, a committer
-  enters emeritus status. No vote is required to enter this state, and committer status can be restored just by 
-  making an inquiry to the project infrastructure group. While in emeritus, committers lose access to project 
+  enters emeritus status. No vote is required to enter this state, and committer status can be restored just by
+  making an inquiry to the project infrastructure group. While in emeritus, committers lose access to project
   resources (e.g. git write access), as well as lose the ability to vote and engage in discussion on the committers
   mailing list.
 * *Revocation of Commit Privileges*: A committer may make a proposal to remove an individual from the committer body.
-  Discussion and voting happen on the confidential committers mailing list, and the committer in question is not 
+  Discussion and voting happen on the confidential committers mailing list, and the committer in question is not
   entitled to a vote (though they do get to participate in the discussion).

--- a/docs/guides/developer/docs/infrastructure/notes.md
+++ b/docs/guides/developer/docs/infrastructure/notes.md
@@ -20,7 +20,7 @@ Harvard DCE
 ETH
 ---
 
-### opencast-nexus.ethz.ch 
+### opencast-nexus.ethz.ch
 
 - Unattended upgrade
 - RHEL 7.x
@@ -40,7 +40,7 @@ SWITCH
 - Rebuilt weekly via cron + shell, manual branch selection
 
 
-University of Osnabrück 
+University of Osnabrück
 -----------------------
 
 ### Common Configuration Choices

--- a/docs/guides/developer/docs/modules/admin-ui/style/buttons.md
+++ b/docs/guides/developer/docs/modules/admin-ui/style/buttons.md
@@ -80,7 +80,7 @@ Modal Buttons
           <span class="hljs-attribute">background-image</span>
           <span class="hljs-rule">:</span>
           <span class="hljs-value"> linear-gradient(
-            <span class="hljs-hexcolor">#39c985</span>, 
+            <span class="hljs-hexcolor">#39c985</span>,
             <span class="hljs-hexcolor">#2d9b67</span>)
           </span>
         </span>
@@ -131,12 +131,12 @@ placed in a specific hierarchical order for consistency.
   <img src="../../../../img/more-icon_2x.png" alt="More Information"/>
   <img src="../../../../img/edit-icon_2x.png" alt="Edit"/>
   <img src="../../../../img/time-icon_2x.png" alt="Time"/>
-  <img src="../../../../img/preview-icon_2x.png" alt="Preview"/>  
+  <img src="../../../../img/preview-icon_2x.png" alt="Preview"/>
   <img src="../../../../img/plus-icon_2x.png" alt="Plus"/>
   <img src="../../../../img/play-icon_2x.png" alt="Play"/>
   <img src="../../../../img/play-icon-on_2x.png" alt="Play Active"/>
   <i class="fa fa-comment fa-2x"></i>
-  <i class="fa fa-comment-o fa-2x"></i>  
+  <i class="fa fa-comment-o fa-2x"></i>
   <img src="../../../../img/remove-icon_2x.png" alt="Remove"/>
 </div>
 <br/>

--- a/docs/guides/developer/docs/modules/admin-ui/style/color-palette.md
+++ b/docs/guides/developer/docs/modules/admin-ui/style/color-palette.md
@@ -30,7 +30,7 @@ professional environment for users. Percentage tints can be used of any of these
         <a class="dark">#5bd099</a>
       </li><li style="background-color:#6fd6a5;">
         <a class="dark">#6fd6a5</a>
-      </li>										
+      </li>
     </ul>
   </div>
 </div>
@@ -57,7 +57,7 @@ professional environment for users. Percentage tints can be used of any of these
       </li>
       <li style="background-color:#3a6993;">
         <a>#3a6993</a>
-      </li>										
+      </li>
     </ul>
   </div>
 </div>
@@ -97,7 +97,7 @@ endless palette to choose from.
             </span>
           </li>
         </ul>
-    </li>    
+    </li>
     <li>
         <ul>
           <li style="background-color:#fa1919;">
@@ -125,7 +125,7 @@ endless palette to choose from.
             </span>
           </li>
         </ul>
-      </li>    
+      </li>
       <li>
         <ul>
           <li style="background-color:#e45253;">
@@ -153,7 +153,7 @@ endless palette to choose from.
             </span>
           </li>
         </ul>
-      </li>    
+      </li>
       <li>
         <ul>
           <li style="background-color:#e4d12e;">
@@ -213,10 +213,10 @@ A selection of grayscale colors for background, border or text color use.
       </li>
       <li style="background-color:#e1e1e1;">
         <a class="dark">#e1e1e1</a>
-      </li>      
+      </li>
       <li style="background-color:#fafafa;">
         <a class="dark">#fafafa</a>
-      </li>										
+      </li>
     </ul>
   </div>
 </div>

--- a/docs/guides/developer/docs/modules/admin-ui/style/forms.md
+++ b/docs/guides/developer/docs/modules/admin-ui/style/forms.md
@@ -1,4 +1,5 @@
 ## Forms
+
 There are currently **2** form conventions used in the system and they are
 closely associated with the modal type that the form is displayed in.
 
@@ -83,7 +84,7 @@ span.editable, td.editable span {
   font-size: 14px;
   font-weight: 400;
   color: #666;
-  line-height	14px
+  line-height: 14px;
 }
 
 .form-container input {

--- a/docs/guides/developer/docs/modules/admin-ui/style/forms.md
+++ b/docs/guides/developer/docs/modules/admin-ui/style/forms.md
@@ -13,7 +13,7 @@ closely associated with the modal type that the form is displayed in.
     The form inputs are read-only on initial display and if editable will activate when the user
     clicks on the value (underlined text) or on the edit button located on the right side of the form field.
     <br/><br/>
-    Dropdown selection boxes will appear on editing/interaction of the field, if the field is so defined.    
+    Dropdown selection boxes will appear on editing/interaction of the field, if the field is so defined.
   </dd>
 </dl>
 
@@ -53,7 +53,7 @@ span.editable, td.editable span {
 .chosen-container {
   /* Drop down selector */
   font-size: 13px;
-  font-weight: 400;    
+  font-weight: 400;
   width: 250px;
 }
 
@@ -66,7 +66,7 @@ span.editable, td.editable span {
 }
 ```
 
-<dl>  
+<dl>
   <dt>Tabbed</dt>
   <dd>
     The tabbed modal is normally a much smaller modal and the fields required to complete the action fewer and more

--- a/docs/guides/developer/docs/modules/admin-ui/style/index.md
+++ b/docs/guides/developer/docs/modules/admin-ui/style/index.md
@@ -4,7 +4,7 @@ Administrative User Interface: Style Guide
 - [Color Palette](color-palette.md)
 - [Typeface](typeface.md)
 - [View Structure](view-structure.md)
-- [Logo](spacing.md)        
+- [Logo](spacing.md)
 - [Navigation](navigation.md)
 - [Modals](modals.md)
 - [Forms](forms.md)

--- a/docs/guides/developer/docs/modules/admin-ui/style/navigation.md
+++ b/docs/guides/developer/docs/modules/admin-ui/style/navigation.md
@@ -8,7 +8,7 @@ for a user to easily access other sections of the Admin UI.
   <p>
     By default the main menu is hidden to allow for the maximum viewing area and to have a clean navigation area
     displaying the current important location.
-    <br/><br/>    
+    <br/><br/>
     Clicking on the main menu button displays the menu bar with all of the appropriate menu icons (Shown below).
   </p>
 </div>

--- a/docs/guides/developer/docs/modules/admin-ui/style/typeface.md
+++ b/docs/guides/developer/docs/modules/admin-ui/style/typeface.md
@@ -47,7 +47,7 @@ Please see [References - Open Sans](/modules/admin-ui/style/references/#open-san
           <span class="hljs-value"> italic</span>
         </span>;
       </code>
-    </pre>    
+    </pre>
   </div>
 
   <div>
@@ -132,7 +132,7 @@ Please see [References - Open Sans](/modules/admin-ui/style/references/#open-san
         </span>;
       </code>
     </pre>
-  </div>     
+  </div>
 
   <div class="bold">
     <div class="header">Bold</div>
@@ -174,7 +174,7 @@ Please see [References - Open Sans](/modules/admin-ui/style/references/#open-san
         </span>;
       </code>
     </pre>
-  </div>     
+  </div>
 
   <div class="extrabold"><!-- style="height: 150px;" -->
     <div class="header">Extrabold</div>
@@ -216,7 +216,7 @@ Please see [References - Open Sans](/modules/admin-ui/style/references/#open-san
       </span>;
     </code>
     </pre>
-  </div>  
+  </div>
 </div>
 <br/>
 

--- a/docs/guides/developer/docs/modules/player/architecture.md
+++ b/docs/guides/developer/docs/modules/player/architecture.md
@@ -90,12 +90,12 @@ possible:
 
 |Plugin Type|Description|Characteristics|Module Name|JS Plugin Type Name|Maven Plugin Type Name|
 |-----------|-----------|---------------|-----------|-------------------|----------------------|
-|Controls	|Implements the main controls of the top of the player	|Only one plugin per player possible.	|engage-theodul-plugin-controls	|engage_controls	|controls|
-|Timeline	|Timeline information below the main controls.|Good for processing time-based data like user tracking, slide previews or annotations.|Optional plugin, more than one possible.	engage-theodul-plugin-timeline-<pluginName>	|engage_timeline	|timeline|
-|Videodisplay	|Implementation of the video display.	|Currently only one plugin per player possible, but in the future more video displays should be possible.|engage-theodul-plugin-video-<pluginName>	|engage_video	|video|
-|Description/Label	|A plugin below the video display, good to show simple information about the video, like a title and the creator.	|Only one plugin per player possible.	|engage-theodul-plugin-description	|engage_description	|description|
-|Tab	|Shows a tab in the tab view at the bottom of the player.	|Optional plugin, more than one possible.	|engage-theodul-plugin-tab-<pluginName>	|engage_tab	|tab|
-|Custom	|A custom plugin without a relationship to an UI element.|Good for a custom REST endpoint, global data representation or to load custom JS code or libraries.|Optional plugin, more than one possible.|No connection to a preserved UI element.|engage-theodul-plugin-custom-<pluginName>	|engage_custom	|custom|
+|Controls    |Implements the main controls of the top of the player    |Only one plugin per player possible.    |engage-theodul-plugin-controls    |engage_controls    |controls|
+|Timeline    |Timeline information below the main controls.|Good for processing time-based data like user tracking, slide previews or annotations.|Optional plugin, more than one possible.    engage-theodul-plugin-timeline-<pluginName>    |engage_timeline    |timeline|
+|Videodisplay    |Implementation of the video display.    |Currently only one plugin per player possible, but in the future more video displays should be possible.|engage-theodul-plugin-video-<pluginName>    |engage_video    |video|
+|Description/Label    |A plugin below the video display, good to show simple information about the video, like a title and the creator.    |Only one plugin per player possible.    |engage-theodul-plugin-description    |engage_description    |description|
+|Tab    |Shows a tab in the tab view at the bottom of the player.    |Optional plugin, more than one possible.    |engage-theodul-plugin-tab-<pluginName>    |engage_tab    |tab|
+|Custom    |A custom plugin without a relationship to an UI element.|Good for a custom REST endpoint, global data representation or to load custom JS code or libraries.|Optional plugin, more than one possible.|No connection to a preserved UI element.|engage-theodul-plugin-custom-<pluginName>    |engage_custom    |custom|
 
 The following listing shows the directory structure of a plugin module:
 

--- a/docs/guides/developer/docs/modules/player/core.reference.md
+++ b/docs/guides/developer/docs/modules/player/core.reference.md
@@ -43,7 +43,7 @@ plugin, which has a reference to the EngageModel.
 |pluginsInfo	|Backbone Model	|Contains Information's of each plugin|
 |pluginModels	|Backbone Collection	|Contains the plugin models|
 |urlParameters	|Object	|Contains the data of the URL parameters.|
- 
+
 ## Plugin Object
 
 Each plugin **must** create and return a object with some properties which are set by the plugin itself. It is recommend

--- a/docs/guides/developer/docs/modules/player/core.reference.md
+++ b/docs/guides/developer/docs/modules/player/core.reference.md
@@ -11,22 +11,22 @@ Added object functions and properties:
 
 |Name|Parameters|Type|Description|
 |----|----------|----|-----------|
-|log(value):void	|value:String	|function	|function to log via the core cross browser|
-|Event:EngageEvent|none	|property	|Returns the EngageEvent object prototype, the see EngageEvent Object for more information|
-|trigger(event):void	|event:EngageEvent	|function	|triggers an EngageEvent|
-|on(event, handler, context):void	|event:EngageEvent, handler:function, context:object|function	|install an event handler on a EngageEvent|
-|model:EngageModel	|none	|property	|Returns the singleton engage model for this session, see EngageModel for more information's|
-|getPluginPath(pluginName):String	|pluginName:String	|function	|Returns the absolute path of a plugin by name.|
+|log(value):void    |value:String    |function    |function to log via the core cross browser|
+|Event:EngageEvent|none    |property    |Returns the EngageEvent object prototype, the see EngageEvent Object for more information|
+|trigger(event):void    |event:EngageEvent    |function    |triggers an EngageEvent|
+|on(event, handler, context):void    |event:EngageEvent, handler:function, context:object|function    |install an event handler on a EngageEvent|
+|model:EngageModel    |none    |property    |Returns the singleton engage model for this session, see EngageModel for more information's|
+|getPluginPath(pluginName):String    |pluginName:String    |function    |Returns the absolute path of a plugin by name.|
 
 ## EngageEvent Object
 
 |Name|Paramters|Type|Description|
 |----|---------|----|-----------|
-|EngageEvent(name, description, type)	|name:String, description:String, type:String | constructor	|Create a new unbound EngageEvent, with a name, description and a type. For Example: var myEvent = new EngageEvent('play', 'plays the video', 'trigger')|
-|getName:String	|none	|function	|Gets the name|
-|getDescription:String	|none	|function	|Gets the description|
-|getType:String	|none	|function	|Gets the Type, can be a "handler", "trigger" or "both"|
-|toString:String	|none	|function	|Build a string that describes the event|
+|EngageEvent(name, description, type)    |name:String, description:String, type:String | constructor    |Create a new unbound EngageEvent, with a name, description and a type. For Example: var myEvent = new EngageEvent('play', 'plays the video', 'trigger')|
+|getName:String    |none    |function    |Gets the name|
+|getDescription:String    |none    |function    |Gets the description|
+|getType:String    |none    |function    |Gets the Type, can be a "handler", "trigger" or "both"|
+|toString:String    |none    |function    |Build a string that describes the event|
 
 ## Engage Model
 
@@ -40,9 +40,9 @@ plugin, which has a reference to the EngageModel.
 
 |Property Name|Type|Description|
 |-------------|----|-----------|
-|pluginsInfo	|Backbone Model	|Contains Information's of each plugin|
-|pluginModels	|Backbone Collection	|Contains the plugin models|
-|urlParameters	|Object	|Contains the data of the URL parameters.|
+|pluginsInfo    |Backbone Model    |Contains Information's of each plugin|
+|pluginModels    |Backbone Collection    |Contains the plugin models|
+|urlParameters    |Object    |Contains the data of the URL parameters.|
 
 ## Plugin Object
 
@@ -51,12 +51,12 @@ to keep a reference to the object because some properties are set by the core af
 
 |Property Name|Type|Description|
 |-------------|----|-----------|
-|name	|String	|Name of the plugin, e.g. "Engage Controls". **This property is set by the plugin.**|
-|type	|String |Type of the plugin, e.g. "engage_controls", see the plugin table in Architecture for the other plugin types. **This property is set by the plugin.**|
-|version	|String	|Version of plugin. **This property is set by the plugin.**|
-|styles	|Array of Strings	|Array of the paths of css files relative to the static folder of each plugin . **This property is set by the plugin.**|
-|template	|String	|Before the plugin object is returned by the plugin logic, the template property contains the path to the template relative to the static folder. **The path property is set first by the plugin**. After the plugin object is returned and the Theodul core processed the plugin, the template property is filled with the real template data and can be used to re-render the view.|
-|container	|String	|Contains the ID of the HTML div container, which contains the rendered template. This can be used to re-render the view. **This property is set by the core.**|
-|pluginPath	|String	|Contains the absolute path of the plugin.  **This property is set by the core.**|
-|events	|Object	|Contains all events which are used of this plugin. Each handled and each triggered event.|
+|name    |String    |Name of the plugin, e.g. "Engage Controls". **This property is set by the plugin.**|
+|type    |String |Type of the plugin, e.g. "engage_controls", see the plugin table in Architecture for the other plugin types. **This property is set by the plugin.**|
+|version    |String    |Version of plugin. **This property is set by the plugin.**|
+|styles    |Array of Strings    |Array of the paths of css files relative to the static folder of each plugin . **This property is set by the plugin.**|
+|template    |String    |Before the plugin object is returned by the plugin logic, the template property contains the path to the template relative to the static folder. **The path property is set first by the plugin**. After the plugin object is returned and the Theodul core processed the plugin, the template property is filled with the real template data and can be used to re-render the view.|
+|container    |String    |Contains the ID of the HTML div container, which contains the rendered template. This can be used to re-render the view. **This property is set by the core.**|
+|pluginPath    |String    |Contains the absolute path of the plugin.  **This property is set by the core.**|
+|events    |Object    |Contains all events which are used of this plugin. Each handled and each triggered event.|
 

--- a/docs/guides/developer/docs/modules/player/events.md
+++ b/docs/guides/developer/docs/modules/player/events.md
@@ -17,7 +17,7 @@ An event can be triggered via
 and can be subscribed to via
 
     Engage.on(plugin.events.NAME.getName(), function () {});
- 
+
 The following list contains all events of the Core + of all official plugins, sorted alphabetically after "Event name"
 for version 1.0 of Feb 12, 2015.
 
@@ -33,12 +33,12 @@ Currently official plugins are
 * Shortcuts (Tab)
 * Timeline statistics
 * Videodisplay
- 
+
 |Name | Event name | Additional parameters|Description|Triggered in|Handled in|
 |-----|------------|----------------------|-----------|------------|----------|
 |coreInit	|Core:init	 	 	| | |Core| |
 |plugin_load_done	|Core:plugin_load_done	 	 	| | |Core|Core, Controls, MHConnection, Notifications, Usertracking, Description, Description (Tab), Slide text (Tab), Shortcuts (Tab), Timeline statistics, Videodisplay|
-|timelineplugin_closed	|Engage:timelineplugin_closed	|*Note: No "Engage Event", just use as string, example: Engage.on("Engage:timelineplugin_closed", function() {});*| when the timeline plugin container closed	|Core| | 
+|timelineplugin_closed	|Engage:timelineplugin_closed	|*Note: No "Engage Event", just use as string, example: Engage.on("Engage:timelineplugin_closed", function() {});*| when the timeline plugin container closed	|Core| |
 |timelineplugin_opened	|Engage:timelineplugin_opened	|*Note: No "Engage Event", just use as string, example: Engage.on("Engage:timelineplugin_opened", function() {});* |when the timeline plugin container opened	|Core|Timeline statistics|
 |getMediaInfo	|MhConnection:getMediaInfo|	| |	 	 	|MHConnection|
 |getMediaPackage	|MhConnection:getMediaPackage|	| |	 	 	|MHConnection|
@@ -49,10 +49,10 @@ Currently official plugins are
 |customSuccess	|Notification:customSuccess	|msg: The message to display	|a custom success message	|Core, Controls| Notifications|
 |segmentMouseout	|Segment:mouseOut	|no: Segment number	|the mouse is off a segment	|Controls, Slide text (Tab)| Controls, Slide text (Tab)|
 |segmentMouseover	|Segment:mouseOver	|no: Segment number	|the mouse is over a segment	|Controls, Slide text (Tab)| Controls, Slide text (Tab)|
-|sliderMousein	|Slider:mouseIn	 |	|the mouse entered the slider	|Controls| | 
+|sliderMousein	|Slider:mouseIn	 |	|the mouse entered the slider	|Controls| |
 |sliderMouseout	|Slider:mouseOut	| 	|the mouse is off the slider	|Controls | |
 |sliderMousemove	|Slider:mouseMoved	|timeInMs: The time on the hovered position in ms	|the mouse is moving over the slider	| Controls | |
-|sliderStart	|Slider:start	 |	|slider started	|Controls| | 
+|sliderStart	|Slider:start	 |	|slider started	|Controls| |
 |sliderStop	|Slider:stop	|time: The time the slider stopped at	| slider stopped	|Controls|Videodisplay|
 |aspectRatioSet	|Video:aspectRatioSet	|as: (array) as[0] = width, as[1] = height, as[2] = aspect ratio in %|the aspect ratio has been calculated	|Videodisplay|Controls|
 |audioCodecNotSupported	|Video:audioCodecNotSupported	 |	|when the audio codec seems not to be supported by the browser	| Videodisplay |Notifications|
@@ -70,11 +70,11 @@ Currently official plugins are
 |muteToggle	|Video:muteToggle	 |	|toggle mute and unmute	| Core|Videodisplay|
 |nextChapter	|Video:nextChapter	| | Core | |
 |numberOfVideodisplaysSet	|Video:numberOfVideodisplaysSet	|no: Number of videodisplays	|the number of videodisplays has been set	|Videodisplay| |
-|pause	|Video:pause	|triggeredByMaster: Whether or not the event has been triggered by master	|pauses the video	
+|pause	|Video:pause	|triggeredByMaster: Whether or not the event has been triggered by master	|pauses the video
 |Core, Controls, Videodisplay| Controls, Videodisplay|
 |play	|Video:play	|triggeredByMaster: Whether or not the event has been triggered by master	|plays the video	|Core, Controls, Videodisplay| Controls,Videodisplay |
 |playPause	|Video:playPause	 |	 |	|Core|Videodisplay|
-|previousChapter	|Video:previousChapter	 	 | | |Core| | 
+|previousChapter	|Video:previousChapter	 	 | | |Core| |
 |playbackRateChanged	|Video:playbackRateChanged	|rate: The video playback rate (0.0-x, default: 1.0)	|The video playback rate changed	|Controls| Controls, Videodisplay|
 |playbackRateIncrease	|Video:playbackRateIncrease	 | | |Core|Videodisplay|
 |playbackRateDecrease	|Video:playbackRateDecrease	 | | |Core|Videodisplay|

--- a/docs/guides/developer/docs/modules/player/events.md
+++ b/docs/guides/developer/docs/modules/player/events.md
@@ -36,61 +36,61 @@ Currently official plugins are
 
 |Name | Event name | Additional parameters|Description|Triggered in|Handled in|
 |-----|------------|----------------------|-----------|------------|----------|
-|coreInit	|Core:init	 	 	| | |Core| |
-|plugin_load_done	|Core:plugin_load_done	 	 	| | |Core|Core, Controls, MHConnection, Notifications, Usertracking, Description, Description (Tab), Slide text (Tab), Shortcuts (Tab), Timeline statistics, Videodisplay|
-|timelineplugin_closed	|Engage:timelineplugin_closed	|*Note: No "Engage Event", just use as string, example: Engage.on("Engage:timelineplugin_closed", function() {});*| when the timeline plugin container closed	|Core| |
-|timelineplugin_opened	|Engage:timelineplugin_opened	|*Note: No "Engage Event", just use as string, example: Engage.on("Engage:timelineplugin_opened", function() {});* |when the timeline plugin container opened	|Core|Timeline statistics|
-|getMediaInfo	|MhConnection:getMediaInfo|	| |	 	 	|MHConnection|
-|getMediaPackage	|MhConnection:getMediaPackage|	| |	 	 	|MHConnection|
-|mediaPackageModelError	|MhConnection:mediaPackageModelError	 |	 |	|MHConnection| Core, Controls, Notifications, Usertracking, Description, Description (Tab), Slide text (Tab), Shortcuts (Tab), Timeline statistics, Videodisplay|
-|customError	|Notification:customError	|msg: The message to display	|an error occurred	| Core, Controls, Videodisplay| Notifications|
-|customNotification	|Notification:customNotification	|msg: The message to display	|a custom message	| Videodisplay| Notifications|
-|customOKMessage	|Notification:customOKMessage	| msg: The message to display	| a custom message with an OK button	|Controls | Notifications |
-|customSuccess	|Notification:customSuccess	|msg: The message to display	|a custom success message	|Core, Controls| Notifications|
-|segmentMouseout	|Segment:mouseOut	|no: Segment number	|the mouse is off a segment	|Controls, Slide text (Tab)| Controls, Slide text (Tab)|
-|segmentMouseover	|Segment:mouseOver	|no: Segment number	|the mouse is over a segment	|Controls, Slide text (Tab)| Controls, Slide text (Tab)|
-|sliderMousein	|Slider:mouseIn	 |	|the mouse entered the slider	|Controls| |
-|sliderMouseout	|Slider:mouseOut	| 	|the mouse is off the slider	|Controls | |
-|sliderMousemove	|Slider:mouseMoved	|timeInMs: The time on the hovered position in ms	|the mouse is moving over the slider	| Controls | |
-|sliderStart	|Slider:start	 |	|slider started	|Controls| |
-|sliderStop	|Slider:stop	|time: The time the slider stopped at	| slider stopped	|Controls|Videodisplay|
-|aspectRatioSet	|Video:aspectRatioSet	|as: (array) as[0] = width, as[1] = height, as[2] = aspect ratio in %|the aspect ratio has been calculated	|Videodisplay|Controls|
-|audioCodecNotSupported	|Video:audioCodecNotSupported	 |	|when the audio codec seems not to be supported by the browser	| Videodisplay |Notifications|
-|autoplay	|Video:autoplay	 |	|autoplay the video	|Core| Videodisplay|
-|bufferedAndAutoplaying	|Video:bufferedAndAutoplaying	 |	|buffering successful, was playing, autoplaying now	|Videodisplay |Notifications|
-|bufferedButNotAutoplaying	|Video:bufferedButNotAutoplaying	 |	|buffering successful, was not playing, not autoplaying now	|Videodisplay |Notifications|
-|buffering	|Video:buffering	 |	|video is buffering	|Videodisplay|Notifications|
-|ended	|Video:ended	|triggeredByMaster: Whether or not the event has been triggered by master	|video ended	|Videodisplay|Controls|
-|fullscreenCancel	|Video:fullscreenCancel	 |	|cancel fullscreen	|Controls, Videodisplay|Videodisplay|
-|fullscreenChange	|Video:fullscreenChange	 |	|a fullscreen change happened	|Videodisplay|Controls|
-|fullscreenEnable	|Video:fullscreenEnable	 |	|enable fullscreen	|Controls, Core| Controls, Videodisplay|
-|isAudioOnly	|Video:isAudioOnly	|audio: true if audio only, false else	|whether it's audio only or not	| Videodisplay|Controls, Notifications|
-|initialSeek	|Video:initialSeek	|time: The time to seek to	|Seeks initially after all plugins have been loaded after a short delay	| Core| Videodisplay|
-|mute	|Video:mute	 |	|mute	|Videodisplay|Videodisplay|
-|muteToggle	|Video:muteToggle	 |	|toggle mute and unmute	| Core|Videodisplay|
-|nextChapter	|Video:nextChapter	| | Core | |
-|numberOfVideodisplaysSet	|Video:numberOfVideodisplaysSet	|no: Number of videodisplays	|the number of videodisplays has been set	|Videodisplay| |
-|pause	|Video:pause	|triggeredByMaster: Whether or not the event has been triggered by master	|pauses the video
+|coreInit    |Core:init              | | |Core| |
+|plugin_load_done    |Core:plugin_load_done              | | |Core|Core, Controls, MHConnection, Notifications, Usertracking, Description, Description (Tab), Slide text (Tab), Shortcuts (Tab), Timeline statistics, Videodisplay|
+|timelineplugin_closed    |Engage:timelineplugin_closed    |*Note: No "Engage Event", just use as string, example: Engage.on("Engage:timelineplugin_closed", function() {});*| when the timeline plugin container closed    |Core| |
+|timelineplugin_opened    |Engage:timelineplugin_opened    |*Note: No "Engage Event", just use as string, example: Engage.on("Engage:timelineplugin_opened", function() {});* |when the timeline plugin container opened    |Core|Timeline statistics|
+|getMediaInfo    |MhConnection:getMediaInfo|    | |              |MHConnection|
+|getMediaPackage    |MhConnection:getMediaPackage|    | |              |MHConnection|
+|mediaPackageModelError    |MhConnection:mediaPackageModelError     |     |    |MHConnection| Core, Controls, Notifications, Usertracking, Description, Description (Tab), Slide text (Tab), Shortcuts (Tab), Timeline statistics, Videodisplay|
+|customError    |Notification:customError    |msg: The message to display    |an error occurred    | Core, Controls, Videodisplay| Notifications|
+|customNotification    |Notification:customNotification    |msg: The message to display    |a custom message    | Videodisplay| Notifications|
+|customOKMessage    |Notification:customOKMessage    | msg: The message to display    | a custom message with an OK button    |Controls | Notifications |
+|customSuccess    |Notification:customSuccess    |msg: The message to display    |a custom success message    |Core, Controls| Notifications|
+|segmentMouseout    |Segment:mouseOut    |no: Segment number    |the mouse is off a segment    |Controls, Slide text (Tab)| Controls, Slide text (Tab)|
+|segmentMouseover    |Segment:mouseOver    |no: Segment number    |the mouse is over a segment    |Controls, Slide text (Tab)| Controls, Slide text (Tab)|
+|sliderMousein    |Slider:mouseIn     |    |the mouse entered the slider    |Controls| |
+|sliderMouseout    |Slider:mouseOut    |     |the mouse is off the slider    |Controls | |
+|sliderMousemove    |Slider:mouseMoved    |timeInMs: The time on the hovered position in ms    |the mouse is moving over the slider    | Controls | |
+|sliderStart    |Slider:start     |    |slider started    |Controls| |
+|sliderStop    |Slider:stop    |time: The time the slider stopped at    | slider stopped    |Controls|Videodisplay|
+|aspectRatioSet    |Video:aspectRatioSet    |as: (array) as[0] = width, as[1] = height, as[2] = aspect ratio in %|the aspect ratio has been calculated    |Videodisplay|Controls|
+|audioCodecNotSupported    |Video:audioCodecNotSupported     |    |when the audio codec seems not to be supported by the browser    | Videodisplay |Notifications|
+|autoplay    |Video:autoplay     |    |autoplay the video    |Core| Videodisplay|
+|bufferedAndAutoplaying    |Video:bufferedAndAutoplaying     |    |buffering successful, was playing, autoplaying now    |Videodisplay |Notifications|
+|bufferedButNotAutoplaying    |Video:bufferedButNotAutoplaying     |    |buffering successful, was not playing, not autoplaying now    |Videodisplay |Notifications|
+|buffering    |Video:buffering     |    |video is buffering    |Videodisplay|Notifications|
+|ended    |Video:ended    |triggeredByMaster: Whether or not the event has been triggered by master    |video ended    |Videodisplay|Controls|
+|fullscreenCancel    |Video:fullscreenCancel     |    |cancel fullscreen    |Controls, Videodisplay|Videodisplay|
+|fullscreenChange    |Video:fullscreenChange     |    |a fullscreen change happened    |Videodisplay|Controls|
+|fullscreenEnable    |Video:fullscreenEnable     |    |enable fullscreen    |Controls, Core| Controls, Videodisplay|
+|isAudioOnly    |Video:isAudioOnly    |audio: true if audio only, false else    |whether it's audio only or not    | Videodisplay|Controls, Notifications|
+|initialSeek    |Video:initialSeek    |time: The time to seek to    |Seeks initially after all plugins have been loaded after a short delay    | Core| Videodisplay|
+|mute    |Video:mute     |    |mute    |Videodisplay|Videodisplay|
+|muteToggle    |Video:muteToggle     |    |toggle mute and unmute    | Core|Videodisplay|
+|nextChapter    |Video:nextChapter    | | Core | |
+|numberOfVideodisplaysSet    |Video:numberOfVideodisplaysSet    |no: Number of videodisplays    |the number of videodisplays has been set    |Videodisplay| |
+|pause    |Video:pause    |triggeredByMaster: Whether or not the event has been triggered by master    |pauses the video
 |Core, Controls, Videodisplay| Controls, Videodisplay|
-|play	|Video:play	|triggeredByMaster: Whether or not the event has been triggered by master	|plays the video	|Core, Controls, Videodisplay| Controls,Videodisplay |
-|playPause	|Video:playPause	 |	 |	|Core|Videodisplay|
-|previousChapter	|Video:previousChapter	 	 | | |Core| |
-|playbackRateChanged	|Video:playbackRateChanged	|rate: The video playback rate (0.0-x, default: 1.0)	|The video playback rate changed	|Controls| Controls, Videodisplay|
-|playbackRateIncrease	|Video:playbackRateIncrease	 | | |Core|Videodisplay|
-|playbackRateDecrease	|Video:playbackRateDecrease	 | | |Core|Videodisplay|
-|playerLoaded	|Video:playerLoaded	 | | player loaded successfully	|Videodisplay| |
-|ready	|Video:ready	 |	|all videos loaded successfully	|Videodisplay| Controls, Notifications|
-|seek	|Video:seek	|time: Current time in seconds	seek video to a given position in seconds	|Core, Controls, Slide text (Tab)|Videodisplay |
-|seekLeft	|Video:seekLeft	 |	| 	|Core|Videodisplay|
-|seekRight	|Video:seekRight |	| 	|Core|Videodisplay|
-|synchronizing	|Video:synchronizing	| 	|synchronizing videos with the master video	|Videodisplay| |
-|timeupdate	|Video:timeupdate	|time: Current time in seconds, triggeredByMaster: Whether or not the event has been triggered by master|a timeupdate happened	|Videodisplay| Controls, Usertracking|
-|qualitySet	|Video:qualitySet	|quality: the quality that has been set	a video quality has been set	|Controls|Videodisplay|
-|unmute	|Video:unmute	 |	|unmute	|Controls|Controls|
-|usingFlash	|Video:usingFlash	|flash: true if flash is being used, false else	|flash is being used	|Videodisplay|Controls|
-|videoFormatsFound	|Video:videoFormatsFound	|format: array of video formats	if different video formats (qualities) have been found	|Videodisplay|Controls|
-|volumechange	|Video:volumechange	|vol: Current volume (0 is off (muted), 1.0 is all the way up, 0.5 is half way)	| a volume change happened	|Videodisplay| |
-|volumeDown	|Video:volumeDown	 	| |	|Core|Controls|
-|volumeGet	|Video:volumeGet	|callback: A callback function with the current volume as a parameter	|get the volume	 	| Videodisplay|
-|volumeSet	|Video:volumeSet	|percentAsDecimal: Volume to set (0 is off (muted), 1.0 is all the way up, 0.5 is half way)	|set the volume	|Controls|Controls, Videodisplay|
-|volumeUp	|Video:volumeUp	 	| |	|Core|Controls|
+|play    |Video:play    |triggeredByMaster: Whether or not the event has been triggered by master    |plays the video    |Core, Controls, Videodisplay| Controls,Videodisplay |
+|playPause    |Video:playPause     |     |    |Core|Videodisplay|
+|previousChapter    |Video:previousChapter          | | |Core| |
+|playbackRateChanged    |Video:playbackRateChanged    |rate: The video playback rate (0.0-x, default: 1.0)    |The video playback rate changed    |Controls| Controls, Videodisplay|
+|playbackRateIncrease    |Video:playbackRateIncrease     | | |Core|Videodisplay|
+|playbackRateDecrease    |Video:playbackRateDecrease     | | |Core|Videodisplay|
+|playerLoaded    |Video:playerLoaded     | | player loaded successfully    |Videodisplay| |
+|ready    |Video:ready     |    |all videos loaded successfully    |Videodisplay| Controls, Notifications|
+|seek    |Video:seek    |time: Current time in seconds    seek video to a given position in seconds    |Core, Controls, Slide text (Tab)|Videodisplay |
+|seekLeft    |Video:seekLeft     |    |     |Core|Videodisplay|
+|seekRight    |Video:seekRight |    |     |Core|Videodisplay|
+|synchronizing    |Video:synchronizing    |     |synchronizing videos with the master video    |Videodisplay| |
+|timeupdate    |Video:timeupdate    |time: Current time in seconds, triggeredByMaster: Whether or not the event has been triggered by master|a timeupdate happened    |Videodisplay| Controls, Usertracking|
+|qualitySet    |Video:qualitySet    |quality: the quality that has been set    a video quality has been set    |Controls|Videodisplay|
+|unmute    |Video:unmute     |    |unmute    |Controls|Controls|
+|usingFlash    |Video:usingFlash    |flash: true if flash is being used, false else    |flash is being used    |Videodisplay|Controls|
+|videoFormatsFound    |Video:videoFormatsFound    |format: array of video formats    if different video formats (qualities) have been found    |Videodisplay|Controls|
+|volumechange    |Video:volumechange    |vol: Current volume (0 is off (muted), 1.0 is all the way up, 0.5 is half way)    | a volume change happened    |Videodisplay| |
+|volumeDown    |Video:volumeDown         | |    |Core|Controls|
+|volumeGet    |Video:volumeGet    |callback: A callback function with the current volume as a parameter    |get the volume         | Videodisplay|
+|volumeSet    |Video:volumeSet    |percentAsDecimal: Volume to set (0 is off (muted), 1.0 is all the way up, 0.5 is half way)    |set the volume    |Controls|Controls, Videodisplay|
+|volumeUp    |Video:volumeUp         | |    |Core|Controls|

--- a/docs/guides/developer/docs/modules/player/plugin.development.md
+++ b/docs/guides/developer/docs/modules/player/plugin.development.md
@@ -35,7 +35,7 @@ Provided the archetype is installed maven will now ask you for the properties co
     Define value for property 'version': 1.0-SNAPSHOT: : 1.5-SNAPSHOT
     Define value for property 'package': org.opencastproject: : org.opencastproject.engage.theodul.plugin.custom.test
     Define value for property 'plugin_description': : A test plugin
-    Define value for property 'plugin_name': : testName 
+    Define value for property 'plugin_name': : testName
     Define value for property 'plugin_type': : custom
     Define value for property 'plugin_version': : 0.1
     Define value for property 'plugin_rest': : false

--- a/docs/guides/developer/docs/modules/stream-security.md
+++ b/docs/guides/developer/docs/modules/stream-security.md
@@ -6,7 +6,7 @@ Admin Guide.
 ## Opencast Signing Protocol
 
 The Signing Providers as well as the verification components that are developed by the Opencast community implement the
-policy and signature specified in the Opencast Signing Protocol. 
+policy and signature specified in the Opencast Signing Protocol.
 
 ### Policy
 The policy is a Base64 encoded JSON document. A human-readable version of the JSON document looks like this:
@@ -62,7 +62,7 @@ identifier, e.g. ‘key1’. In this example, the following key has been used:
 
 Key ID: demoKeyOne Secret Key: 6EDB5EDDCF994B7432C371D7C274F
 
-The HMAC for the signature from the previous section calculated based on the *demoKey1* is 
+The HMAC for the signature from the previous section calculated based on the *demoKey1* is
 
     c8712284aabc843f76a132a3a7c8997670414b2f89cb96b367d5f35d0f62a2e4
 
@@ -71,7 +71,7 @@ would now look like this:
 
     http://opencast.org/engage/resource.mp4?policy=eyJTdGF0ZW1lbnQiOnsiUmVzb3VyY2UiOiJodHRwOlwvXC9vcGVuY2FzdC5vcmdcL2VuZ2FnZVwvcmVzb3VyY2UubXA0IiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6MTQyNTE3MDc3NzAwMCwiRGF0ZUdyZWF0ZXJUaGFuIjoxNDI1MDg0Mzc5MDAwLCJJcEFkZHJlc3MiOiIxMC4wLjAuMSJ9fX0&signature=c8712284aabc843f76a132a3a7c8997670414b2f89cb96b367d5f35d0f62a2e4
 
-The same is true for the key id, which needs to be included to determine which key was used to create the signature. 
+The same is true for the key id, which needs to be included to determine which key was used to create the signature.
 
     http://opencast.org/engage/resource.mp4?policy=eyJTdGF0ZW1lbnQiOnsiUmVzb3VyY2UiOiJodHRwOlwvXC9vcGVuY2FzdC5vcmdcL2VuZ2FnZVwvcmVzb3VyY2UubXA0IiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6MTQyNTE3MDc3NzAwMCwiRGF0ZUdyZWF0ZXJUaGFuIjoxNDI1MDg0Mzc5MDAwLCJJcEFkZHJlc3MiOiIxMC4wLjAuMSJ9fX0&signature=c8712284aabc843f76a132a3a7c8997670414b2f89cb96b367d5f35d0f62a2e4&keyId=demoKeyOne
 
@@ -99,7 +99,7 @@ void setUrlSigningService(UrlSigningService service) {
   this.urlSigningService = service;
 }
 
-… 
+…
 
 String urlToSign = “http://my.custom.url/with/path.mp4”;
 long signedUrlExpiresDuration = 60;

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -134,7 +134,7 @@ Please create a single post on the Opencast Users list:
     Your Opencast <VERSION> Release Manager
 
     [1] Opencast project on Crowdin, https://crowdin.com/project/opencast-community
-    [2] Inclusion and Exclusion of Translations, https://docs.opencast.org/develop/developer/... 
+    [2] Inclusion and Exclusion of Translations, https://docs.opencast.org/develop/developer/...
 
 In case endangered languages have been identified, this needs to be communicated immediately to the Opencast community.
 Please create a post for each endangered translation on the Opencast Users list:
@@ -165,7 +165,7 @@ Please create a post for each endangered translation on the Opencast Users list:
 
 The [Opencast pull request filter](http://pullrequests.opencast.org) links the versions currently in development. The
 merge ticket identifier needs to be added to that filter. To do this, create a ticket with a title in the format of
-`Merge the result of the current peer review to <VERSION>`. The ticket will be automatically detected by the pull 
+`Merge the result of the current peer review to <VERSION>`. The ticket will be automatically detected by the pull
 request filter and will appear shortly.
 
 

--- a/docs/guides/user/docs/advanced/role-based-visibility.md
+++ b/docs/guides/user/docs/advanced/role-based-visibility.md
@@ -13,7 +13,7 @@ roles that allow the users to access specific parts of the UI.
 
 Please consult the [Groups section](../groups.md) for information about adding new groups.
 
-There is a set of so-called user interface roles, each of them providing access to a specific part of the 
+There is a set of so-called user interface roles, each of them providing access to a specific part of the
 administrative user interface. Those roles can be easily identified by their name prefix *ROLE_UI*.
 
 **Important** *ROLE_ADMIN* implicitly provides full access to the user interface. When working with role-based

--- a/docs/guides/user/docs/asset-manager.md
+++ b/docs/guides/user/docs/asset-manager.md
@@ -3,22 +3,22 @@ Overview
 The AssetManager is the successor of the Archive. The AssetManager resolves some of the shortcomings of the Archive,
 such as
 
-- **Complexity**  
+- **Complexity**
   The Archive architecture, with its implementation specific metadata schemas, turned out to be too complex and not used
   in practice
-- **Offline storage**  
+- **Offline storage**
   Adopters requested the need to move assets offline which cannot be handled with the Archive. The AssetManager lays the
   ground for this, with futher improvements and features to follow.
-- **Properties**   
+- **Properties**
   Services often need to store some properties along with a media package to accomplish their tasks. This leads to
   services creating their own persistence layer which increases the overall complexity of the system. The AssetManager
   provides a simple yet powerful annotation API to set key/value properties on media packages.
-- **Queries**  
+- **Queries**
   The Archive only provided a very simple query interface supporting boolean AND operations. The AssetManager, equipped
   with a comprehensive query language, supporting complex SQL-like queries.
-- **Bandwidth**  
+- **Bandwidth**
   To reduce database IO, the AssetManager’s query language supports the selection of only parts of a media package.
-- **Name**  
+- **Name**
   The name Archive did not properly describe its purpose. It has been used as an archive but also as a hub for starting
   workflows and managing assets. This may have caused confusion here and there which should be replaced by the new name
   AssetManager.
@@ -31,21 +31,21 @@ Before we move on to the list of features let’s clarify some terms. Media pack
 structure within Opencast that refers to  a collection of different types of elements, e.g. video tracks, metadata
 catalogs, attachments that belong together. See also ⇒episode.
 
-- **Media package element**   
+- **Media package element**
   Each element contained in a media package, like video tracks and metadata catalogs, are referred to as a media package
   element.
-- **Asset**  
+- **Asset**
   This is a media package element under the control of the AssetManager. This implies that each asset, unlike a raw
   media package element, has a version.
-- **Property**   
+- **Property**
   Key/value metadata stored with an ⇒episode.
-- **Snapshot**   
+- **Snapshot**
   A snapshot is the immutable, versioned “copy” that the AssetManager takes of a media package.
-- **Episode**   
+- **Episode**
   An episode is the complete history of snapshots of a media package. It can be associated with ⇒properties.
-- **Availability**    
+- **Availability**
   A flag that indicates if an ⇒asset is online or offline. Availability is managed per ⇒episode.
-- **Target**    
+- **Target**
   A target defines the data that should be fetched from the database and is used to reduce database IO by fetching only
   what’s actually needed.
 
@@ -55,31 +55,31 @@ Features
 ### General
 This section describes the features defined by the AssetManager API.
 
-- **Versioned storage of media packages**  
+- **Versioned storage of media packages**
   Media package snapshots are stored in an immutable, versioned manner. Each snapshot operation creates a new single
   version of the media package and all of its assets.
-- **Properties**  
+- **Properties**
   Properties of various data types can be saved along with an episode. This frees services from implementing their own
   persistence layer if they need to store metadata along with an episode. Properties are a key/value store. The key is a
   tuple consisting of a namespace name and the key name, which allows properties to be grouped.
-- **Query language**  
+- **Query language**
   SQL-like query language.
 
 ### Default Implementation
 Find below the features of the default implementation.
 
-- **Asset store API**  
+- **Asset store API**
   This is an API for pluggable storage backends, supporting operations to store, retrieve and delete assets. The default
   implementation of the store saves assets in the file system leveraging the Workspace service in order to reduce data
   transfers.
-- **REST endpoint**  
+- **REST endpoint**
   Provides support for the most basic operations of the AssetManager.
-- **Disc space management**  
+- **Disc space management**
   If an asset has not been modified between two snapshots, the AssetManager is able to save disk space by creating hard
   links. The underlying file system needs to support this feature.
-- **HttpAssetProvider API**  
+- **HttpAssetProvider API**
   The central transport protocol of Opencast is HTTP, with media package elements accessible via URLs. When a saved
   media package is being delivered, the HttpAssetProvider rewrite the URLs of media package elements to point to a valid
   HTTP endpoint. The bundled REST endpoint implements this interface.
-- **Security**  
+- **Security**
   Access to the AssetManager is secured based on the organization, user roles and media package ACLs.

--- a/docs/guides/user/docs/events.md
+++ b/docs/guides/user/docs/events.md
@@ -32,7 +32,7 @@ allows it. You can access the Events page from the **Main Menu > Recordings > Ev
 
 ## How to create an Event
 
-An Event can either be a single, standalone Event or one of many Events that belong to a single Series.  
+An Event can either be a single, standalone Event or one of many Events that belong to a single Series.
 
 1. Click the Add Event button and a Create New Event modal will open
 1. On the Source tab you will need to select whether the event(s) are being scheduled or uploaded.

--- a/docs/guides/user/docs/glossary.md
+++ b/docs/guides/user/docs/glossary.md
@@ -54,7 +54,7 @@ audio and video (VGA/DVI), and, depending on software and hardware support, vari
 
 ## Tasks
 Tasks are utilized by Opencast to define production processes. They contains a series of operations (also called Jobs)
-that instructs the Opencast system on how video is captured, encoded, archived, and distributed.  
+that instructs the Opencast system on how video is captured, encoded, archived, and distributed.
 
 ## Themes
 Enable an administrator to brand recordings using intro video, title slides, and watermarks. Themes can be applied on a

--- a/docs/guides/user/docs/login.md
+++ b/docs/guides/user/docs/login.md
@@ -16,4 +16,4 @@ other languages, you can find more information here in the [i18n section](i18n.m
 > Note:  There is no self-registration functionality in the Opencast administrative interface. However, if you just
 > finished the initial setup of your Opencast instance, you will have noticed the administrative username and password
 > in the configuration section. This user can be used to log in with administrator rights and create less privileged
-> users.  
+> users.

--- a/docs/guides/user/docs/searchandfilter.md
+++ b/docs/guides/user/docs/searchandfilter.md
@@ -35,7 +35,7 @@ required operator, while the prohibit operator `-` is used to exlude items match
 
 For example, `hello +world` matches *hello world* but not *hello again*, whereas `hello -world` matches *hello* but not
 *hello world*.
-  
+
 The NOT operator `!` can be used to negate a term, so `!hello` matches all items **not** matching *hello*. The AND
 operator `&&` can be used to override the default term conjunction which is OR.
 

--- a/docs/guides/user/docs/series.md
+++ b/docs/guides/user/docs/series.md
@@ -18,7 +18,7 @@ across a defined period of time. Here is an example of a Series which consists o
 You can access the Series page from the **Main Menu > Recordings > Series**
 
 ## How to create a Series
-A Series contains multiple events that occur across a defined period of time.  
+A Series contains multiple events that occur across a defined period of time.
 
 1. Click the Add Series button and a Create New Series wizard will be displayed
 1. At minimum you must enter a Title for the creation of a Series. All other fields on the Metadata screen are optional.


### PR DESCRIPTION
These patches enforce the absence of tabs and trailing spaces in the markdown documentation files.

@ziegenberg, this extends your markdown linting work. Maybe, you can also take a look at this? Though the rules are very simple I guess :-)