### PR TITLE
MH-12843, Fix “Add Event” Tab Index

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -228,7 +228,7 @@
                           <td>
                             <select chosen
                                     data-width="'100px'"
-                                    tabindex="7"
+                                    tabindex="9"
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_SINGLE.end.hour" ng-change="wizard.step.onTemporalValueChange('end')"
@@ -239,7 +239,7 @@
                             </select>
                             <select chosen
                                     data-width="'100px'"
-                                    tabindex="8"
+                                    tabindex="10"
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_SINGLE.end.minute" ng-change="wizard.step.onTemporalValueChange('end')"
@@ -258,7 +258,7 @@
                             <td>
                             <select chosen
                                 data-width="'200px'"
-                                tabindex="9"
+                                tabindex="11"
                                 ng-disabled="wizard.step.checkingConflicts"
                                 ng-change="wizard.step.roomChanged(); wizard.step.checkConflicts()"
                                 data-disable-search-threshold="8"
@@ -274,7 +274,10 @@
                             <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.INPUTS' | translate }} <i class="required">*</i></td>
                             <td>
                                 <label ng-repeat="inputMethod in wizard.step.ud.SCHEDULE_SINGLE.device.inputs">
-                                    <input type="checkbox" ng-model="wizard.step.ud.SCHEDULE_SINGLE.device.inputMethods[inputMethod.id]" tabindex="10"> {{ inputMethod.id | translate }}
+                                    <input type="checkbox"
+                                        ng-model="wizard.step.ud.SCHEDULE_SINGLE.device.inputMethods[inputMethod.id]"
+                                        tabindex="12">
+                                    {{ inputMethod.id | translate }}
                                     <br>
                                 </label>
                             </td>
@@ -308,7 +311,9 @@
                             <td>
                                 <div ng-repeat="weekday in wizard.step.sortedWeekdays" class="day-check-container">{{ weekday.translation | translate }}
                                      <br>
-                                    <input type="checkbox" ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.weekdays[weekday.key]"
+                                    <input
+                                        type="checkbox"
+                                        ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.weekdays[weekday.key]"
                                         ng-change="wizard.step.checkConflicts()"
                                      />
                                  </div>
@@ -320,7 +325,7 @@
                             <td>
                                 <select chosen
                                     data-width="'100px'"
-                                    tabindex="15"
+                                    tabindex="7"
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.start.hour"
@@ -332,7 +337,7 @@
                                 </select>
                                 <select chosen
                                     data-width="'100px'"
-                                    tabindex="16"
+                                    tabindex="8"
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.start.minute"
@@ -350,7 +355,7 @@
                                 <select chosen
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-width="'100px'"
-                                    tabindex="17"
+                                    tabindex="9"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.duration.hour"
                                     ng-change="wizard.step.onTemporalValueChange('duration')"
@@ -362,7 +367,7 @@
                                 <select chosen
                                     ng-disabled="wizard.step.checkingConflicts"
                                     data-width="'100px'"
-                                    tabindex="18"
+                                    tabindex="10"
                                     data-disable-search-threshold="8"
                                     ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.duration.minute"
                                     ng-change="wizard.step.onTemporalValueChange('duration')"


### PR DESCRIPTION
This patch fixes the problem that hitting tab in the schedule form of
the “Add Event” wizard will not necessary bring you to the next input
field since the tab index of those fields is broken.

Note that the problem of jumping out of the form when reaching the end
still persists.