### PR TITLE
[MH-12782] As an unprivileged user, I only want to see series and events that I have write access to.

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -232,6 +232,8 @@ public abstract class AbstractEventEndpoint {
 
   public abstract JobEndpoint getJobService();
 
+  public abstract SeriesEndpoint getSeriesService();
+
   public abstract AclService getAclService();
 
   public abstract EventCommentService getEventCommentService();
@@ -1730,6 +1732,11 @@ public abstract class AbstractEventEndpoint {
         collection.removeField(collection.getOutputFields().get("startTime"));
       if (collection.getOutputFields().containsKey("location"))
         collection.removeField(collection.getOutputFields().get("location"));
+
+      Map swaMap = getSeriesService().getSeriesWriteAccess();
+      Opt<Map<String, String>> map = Opt.some(swaMap);
+      collection.getOutputFields().get(DublinCore.PROPERTY_IS_PART_OF.getLocalName()).setCollection(map);
+
       metadataList.add(getIndexService().getCommonEventCatalogUIAdapter(), collection);
     }
     return okJson(metadataList.toJSON());

--- a/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -111,6 +111,7 @@ import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
+import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
@@ -2033,6 +2034,10 @@ public abstract class AbstractEventEndpoint {
       query.withLimit(optLimit.get());
     if (optOffset.isSome())
       query.withOffset(offset);
+
+    //We search for write actions
+    query.withoutActions();
+    query.withAction(Permissions.Action.WRITE);
     // TODO: Add other filters to the query
 
     SearchResult<Event> results = null;

--- a/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -53,6 +53,7 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   private EventCommentService eventCommentService;
   private IndexService indexService;
   private JobEndpoint jobService;
+  private SeriesEndpoint seriesService;
   private SchedulerService schedulerService;
   private SecurityService securityService;
   private UrlSigningService urlSigningService;
@@ -85,6 +86,16 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   @Override
   public JobEndpoint getJobService() {
     return jobService;
+  }
+
+  /** OSGi DI. */
+  public void setSeriesService(SeriesEndpoint seriesService) {
+    this.seriesService = seriesService;
+  }
+
+  @Override
+  public SeriesEndpoint getSeriesService() {
+    return seriesService;
   }
 
   /** OSGi DI. */

--- a/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -85,6 +85,7 @@ import org.opencastproject.rest.BulkOperationResult;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.AclScope;
+import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.series.api.SeriesException;
@@ -684,6 +685,10 @@ public class SeriesEndpoint {
           }
         }
       }
+
+      //We search for write actions
+      query.withoutActions();
+      query.withAction(Permissions.Action.WRITE);
 
       logger.trace("Using Query: " + query.toString());
 

--- a/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -121,6 +121,7 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -734,6 +735,28 @@ public class SeriesEndpoint {
       logger.warn("Could not perform search query: {}", ExceptionUtils.getStackTrace(e));
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  public HashMap<String, String> getSeriesWriteAccess() {
+      try {
+          SeriesSearchQuery query = new SeriesSearchQuery(
+                  securityService.getOrganization().getId(), securityService.getUser());
+          query.withLimit(DEFAULT_LIMIT);
+          query.withoutActions();
+          query.withAction(Permissions.Action.WRITE);
+
+          SearchResult<Series> result = searchIndex.getByQuery(query);
+          HashMap<String, String> m = new HashMap<String, String>();
+          for (SearchResultItem<Series> item : result.getItems()) {
+            Series s = item.getSource();
+            m.put(s.getTitle(), s.getIdentifier());
+          }
+
+          return m;
+      } catch (SearchIndexException e) {
+          logger.warn("Could not perform search query: {}", ExceptionUtils.getStackTrace(e));
+          throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
+      }
   }
 
   @SuppressWarnings("unchecked")

--- a/modules/matterhorn-admin-ui-ng/src/main/resources/OSGI-INF/event_endpoint.xml
+++ b/modules/matterhorn-admin-ui-ng/src/main/resources/OSGI-INF/event_endpoint.xml
@@ -6,7 +6,7 @@
   <property name="service.description" value="Admin UI - Event facade Endpoint" />
   <property name="opencast.service.type" value="org.opencastproject.adminui.endpoint.event" />
   <property name="opencast.service.path" value="/admin-ng/event" />
-  
+
   <service>
     <!-- expose interface for MH REST publisher! -->
     <provide interface="org.opencastproject.adminui.endpoint.OsgiEventEndpoint" />
@@ -27,6 +27,11 @@
              cardinality="1..1"
              policy="static"
              bind="setJobService" />
+  <reference name="seriesService"
+             interface="org.opencastproject.adminui.endpoint.SeriesEndpoint"
+             cardinality="1..1"
+             policy="static"
+             bind="setSeriesService" />
   <reference name="AclServiceFactory"
              interface="org.opencastproject.authorization.xacml.manager.api.AclServiceFactory"
              cardinality="1..1"
@@ -62,14 +67,14 @@
              cardinality="1..1"
              policy="static"
              bind="setIndexService" />
- <reference name="AdminUISearchIndex" 
+ <reference name="AdminUISearchIndex"
              interface="org.opencastproject.adminui.impl.index.AdminUISearchIndex"
-             cardinality="1..1" 
-             policy="static" 
+             cardinality="1..1"
+             policy="static"
              bind="setIndex" />
- <reference name="UrlSigningService" 
+ <reference name="UrlSigningService"
              interface="org.opencastproject.security.urlsigning.service.UrlSigningService"
-             cardinality="1..1" 
-             policy="static" 
+             cardinality="1..1"
+             policy="static"
              bind="setUrlSigningService" />
 </scr:component>

--- a/modules/matterhorn-admin-ui-ng/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/matterhorn-admin-ui-ng/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -724,6 +724,7 @@ public class AbstractEventEndpointTest {
     private WorkflowService workflowService;
     private AssetManager assetManager;
     private JobEndpoint jobService;
+    private SeriesEndpoint seriesService;
     private AclService aclService;
     private EventCommentService eventCommentService;
     private SecurityService securityService;
@@ -744,6 +745,14 @@ public class AbstractEventEndpointTest {
 
     public JobEndpoint getJobService() {
       return jobService;
+    }
+
+    public void setSeriesService(SeriesEndpoint seriesService) {
+      this.seriesService = seriesService;
+    }
+
+    public SeriesEndpoint getSeriesService() {
+      return seriesService;
     }
 
     public void setWorkflowService(WorkflowService workflowService) {

--- a/modules/matterhorn-admin-ui-ng/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -801,6 +801,11 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
   }
 
   @Override
+  public SeriesEndpoint getSeriesService() {
+    return env.getSeriesService();
+  }
+
+  @Override
   public AclService getAclService() {
     return env.getAclService();
   }


### PR DESCRIPTION
A new method called _getSeriesWriteAccess()_ has been created in the _SeriesEndpoint_ class to get the series with write access of the logged-in user. This method makes a simple query and returns only the metadata we need in the right format.

This method is called from _getNewMetadata(....)_ in the _AbstractEventEndpoint_ class, so only write-enabled series will be displayed in the event metadata when one of them is created.

In addition, code has been added in the _getSeries(....)_ method of the _AbstractEventEndpoint_ class to display only the writeable series in the series section and in _getEvents(...)_ to see only the writeable events in the events section. 