### PR TITLE
MH-12833 Consistently use External API as name

### DIFF
--- a/docs/guides/developer/docs/api/authentication.md
+++ b/docs/guides/developer/docs/api/authentication.md
@@ -3,18 +3,18 @@
 
 # Introduction
 
-The Application API’s security layer is designed to support a multitude of mechanisms for authentication such as api
+The External API’s security layer is designed to support a multitude of mechanisms for authentication such as API
 keys, digest authentication and others. While the current implementation only supports basic authentication, further
 authentication mechanisms may be added in the future.
 
 # Basic Authentication
-The Application API is protected by basic authentication, requiring a user and a password be sent in the form of the
+The External API is protected by basic authentication, requiring a user and a password be sent in the form of the
 standard HTTP `Authorization` header. (see [Figure 2](#figure_2)). In the header, the username and password are sent
 encoded in Base64 format. The incoming requests are matched against an existing user whose password needs to match with
 the one that is found in the Authorization request header.
 
 NOTE: Basic authentication is not activated by default, please activate it in the security settings
-(`etc/security/mh_default_org.xml`) before using the Application API.
+(`etc/security/mh_default_org.xml`) before using the External API.
 
 <center>
 ![][figure_2]
@@ -23,10 +23,10 @@ NOTE: Basic authentication is not activated by default, please activate it in th
 
 ## Protection of authentication data
 Since Base64 is by no means regarded as encryption in the sense of security, it is strongly recommended to only offer
-access to the Application API over HTTPS rather than over HTTP in order to avoid unprotected transmission of the
+access to the External API over HTTPS rather than over HTTP in order to avoid unprotected transmission of the
 username and password via the Authorization header.
 
 
 ## Validation criteria
-When initiating the connection, the Application API analyzes the header and extracts the username to match against an
+When initiating the connection, the External API analyzes the header and extracts the username to match against an
 existing API user. If that user is found, the connection is authenticated, otherwise it’s rejected.

--- a/docs/guides/developer/docs/api/authorization.md
+++ b/docs/guides/developer/docs/api/authorization.md
@@ -1,9 +1,9 @@
 
-# Application API
+# External API
 
 ## Introduction
 
-The Application API can be accessed in two different ways: Either using a single dedicated user with access to
+The External API can be accessed in two different ways: Either using a single dedicated user with access to
 everything (“super user”) or by implementing more fine grained access through user and role switching upon every request
 (“user switching” or “sudo” execution mode), where the request is executed in the name and using the roles of the
 specified user.
@@ -15,10 +15,10 @@ to implement but leads a much improved control and assessment of security.
 
 ## Delegation of Authorization
 
-In situations where the provider of the API offers a super user who is allowed “sudo” requests that are executed on
-behalf of another user, the API is actually delegating authorization to the client application. In this cause
-authorization is performed upon login of the super user, but then the super user can switch to any other user or any set
-of roles (with a few exceptions for security reasons).
+In situations where the provider of the External API offers a super user who is allowed “sudo” requests that are
+executed on behalf of another user, the External API is actually delegating authorization to the client application. In
+this cause authorization is performed upon login of the super user, but then the super user can switch to any other user
+or any set of roles (with a few exceptions for security reasons).
 
 Note that in order to allow for user switching, a specific role needs to be assigned to the super user, and that role
 cannot be obtained by manipulating the role set (see [Role switching](#role-switching)).
@@ -53,9 +53,9 @@ Response code             | Comment
 ### Role switching
 
 Rather than specifying an execution user, the client might choose to specify a set of roles that should be used when
-executing the request. This technique is recommended in cases where the users are not managed by the API. By specifying
-a set of roles, the corresponding request will be executed using the API’s anonymous user but equipped with the
-specified set of roles.
+executing the request. This technique is recommended in cases where the users are not managed by the External API. By
+specifying a set of roles, the corresponding request will be executed using the API’s anonymous user but equipped
+with the specified set of roles.
 
 The execution user’s roles can be specified by setting the `X-RUN-WITH-ROLES` request header with the set of roles as
 its value and with individual roles separated by comma, as seen in this sample request:
@@ -78,15 +78,15 @@ Response code             | Comment
 
 ### One user per external application
 
-As a best practice, the API provider should create one super user per external application and tenant, so that access
-through that super user can be controlled, limited and turned off individually for each external application and tenant.
-
+As a best practice, the External API provider should create one super user per external application and tenant, so that
+access through that super user can be controlled, limited and turned off individually for each external application and
+tenant.
 
 ### Preference for user and role switching
 
-Client implementations accessing the API through a super user are urged to implement and enforce user and role switching
-as much as possible, since it allows for auditing of user activity on the API and introduces less risk by running
-requests with a limited set of privileges.
+Client implementations accessing the External API through a super user are urged to implement and enforce user and role
+switching as much as possible, since it allows for auditing of user activity on the External API and introduces less
+risk by running requests with a limited set of privileges.
 
 Obviously, if all requests are executed using the super user directly, it is not possible to track which user initiated
 a given action.

--- a/docs/guides/developer/docs/api/base-api.md
+++ b/docs/guides/developer/docs/api/base-api.md
@@ -2,12 +2,12 @@
 
 # Information
 
-In order to assess key characteristics of the API and to test general connectivity, the API’s root url is not protected
-through authentication:
+In order to assess key characteristics of the External API and to test general connectivity, the External API’s root
+url is not protected through authentication:
 
 ### GET /api
 
-Returns key characteristics of the API such as the Application API base URL and the default version.
+Returns key characteristics of the External API such as the API base URL and the default version.
 
 __Response__
 

--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -466,16 +466,16 @@ __Response__
 
 # Metadata
 
-This section describes how to use the Application API to work with metadata catalogs associated to events.
+This section describes how to use the External API to work with metadata catalogs associated to events.
 
 Opencast manages the bibliographic metadata of series using metadata catalogs which are identified by flavors.
 The default metadata catalog for Opencast events has the flavor `dublincore/episode`. Opencast additionally supports
 extended metadata catalogs for series that can be configured.
 
-The Application API supports both the default event metadata catalog and events extended metadata catalogs.
+The External API supports both the default event metadata catalog and events extended metadata catalogs.
 For the default event metadata catalog, the metadata is directly returned in the responses.
 
-Since the metadata catalogs can be configured, the Application API provides a facility to retrieve the catalog
+Since the metadata catalogs can be configured, the External API provides a facility to retrieve the catalog
 configuration of series metadata catalogs. For more details about this mechanism, please refer to
 ["Metadata Catalogs"](types.md#metadata-catalogs).
 

--- a/docs/guides/developer/docs/api/glossary.md
+++ b/docs/guides/developer/docs/api/glossary.md
@@ -4,7 +4,7 @@
 
 ### Client
 
-A system that is using this API, making requests and consuming responses.
+A system that is using the External API, making requests and consuming responses.
 
 
 ## Data
@@ -12,7 +12,8 @@ A system that is using this API, making requests and consuming responses.
 ### Event
 
 A recording that is either going to take place, has been recorded using Opencast scheduling or has been uploaded either
-using this API or the Opencast administrative user interface. A collection of events may be grouped using a series.
+using the External API or the Opencast administrative user interface. A collection of events may be grouped using a
+series.
 
 ### Series
 
@@ -22,12 +23,12 @@ A collection of events.
 
 ### User
 
-A person accessing data provided by the API.
+A person accessing data provided by the External API.
 
 ### Producer
 
-A user that is managing individual recordings or groups of recordings. The producer uses the API to create, curate,
-publish, retract recordings.
+A user that is managing individual recordings or groups of recordings. The producer uses the External API to create,
+curate, publish, retract recordings.
 
 ### Spectator
 

--- a/docs/guides/developer/docs/api/index.md
+++ b/docs/guides/developer/docs/api/index.md
@@ -8,30 +8,30 @@
 [figure_1]:media/img/figure_1.png "Figure 1: Architectural overview"
 
 
-# Opencast API
+# External API
 
 ## Introduction
 
 In order to allow for robust technical integration of applications like learning management systems or mobile
-applications, Opencast offers an Application API (AAPI) to allow those applications to provide access
+applications, Opencast offers the External API to allow those applications to provide access
 to and management of resources exposed through the API.
-The API has been designed and implemented to support large numbers of clients, each with considerable
+The External API has been designed and implemented to support large numbers of clients, each with considerable
 amounts of requests per time interval. In addition, security has been a focus to ensure protection of the
 managed data and to support use cases promoting differing views on the managed data.
 
 
 ## Architectural Overview
 
-The Application API has been implemented as an abstraction layer to multiple internal APIs that the underlying
+The External API has been implemented as an abstraction layer to multiple internal APIs that the underlying
 application (Opencast) offers for the manipulation of resources like series, events or users (see [Figure
 1: Architectural overview](#figure_1)).
 
 ### Authentication and Authorization
-The API features a dedicated security layer that is in charge of providing support for a variety of authentication and
-authorization mechanisms. Additionally, the security layer provides means for delegation of authorization to the client
-application in cases where the API client needs to manage its own set of assets with implicit access control. These
-concepts are documented in greater detail in the following [Authentication](authentication.md) and
-[Authorization](authorization.md) chapters.
+The External API features a dedicated security layer that is in charge of providing support for a variety of
+authentication and authorization mechanisms. Additionally, the security layer provides means for delegation of
+authorization to the client application in cases where the API client needs to manage its own set of assets with
+implicit access control. These concepts are documented in greater detail in the following
+[Authentication](authentication.md) and [Authorization](authorization.md) chapters.
 
 
 ### Requests for data
@@ -42,9 +42,9 @@ processed per time interval.
 The corresponding requests along with the potential responses are defined later on in the [API](usage.md) chapter.
 
 ### Processing of updates
-Whenever a client sends updated information to the Application API, it will forward that information to the
+Whenever a client sends updated information to the External API, it will forward that information to the
 corresponding Opencast services (3), which in turn will process the data and send messages to the
-message bus accordingly (4). The messages are consumed by the Application API’s data store and can be
+message bus accordingly (4). The messages are consumed by the External API’s data store and can be
 served to its clients from then on.
 The corresponding requests along with the data structures and potential responses are defined later on in
 the [API](usage.md) chapter.
@@ -60,29 +60,29 @@ infrastructure (4), (5).
 
 
 ### Access
-The Application API has been implemented using the [Restful State Transfer][5] paradigm to expose resources of the
+The External API has been implemented using the [Restful State Transfer][5] paradigm to expose resources of the
 underlying system in the URL space that are then accessible using the HTTP protocol and verbs `GET`, `POST`, `PUT` and
 `DELETE`.
 
-Since as part of the communication, the API is used to transfer potentially sensitive data between the client and the
-server including the username and password as part of the Basic Authentication protocol, the API will usually only be
-available over a secure HTTPS connection only.
+Since as part of the communication, the External API is used to transfer potentially sensitive data between the client
+and the server including the username and password as part of the Basic Authentication protocol, the API will usually 
+only be available over a secure HTTPS connection only.
 
 
 ### Url Space
-The API is located at the `/api` namespace on the Opencast admin node. This results in all requests to the Application
-API starting with `https://<hostname>/api`, where the hostname is depending on the installation and tenant (see “Multi
-Tenancy”).
+The External API is located at the `/api` namespace on the Opencast admin node. This results in all requests to the
+External API starting with `https://<hostname>/api`, where the hostname is depending on the installation and tenant
+(see “Multi Tenancy”).
 
 
 ### Versioning
-The API is versioned so that applications developed against one version of the API won’t break with enhancements or
-replacements of existing versions as long as they stay on the same major version. The set of currently supported
-versions as well as the current version are exposed through REST methods as part of the meta API.
+The External API is versioned so that applications developed against one version of the API won’t break with
+enhancements or replacements of existing versions as long as they stay on the same major version. The set of
+currently supported versions as well as the current version are exposed through REST methods as part of the meta API.
 
 
 #### Version scheme
-The application API is following the [semantic versioning standard][4], which is suggesting the use of versions of the
+The External API is following the [semantic versioning standard][4], which is suggesting the use of versions of the
 form `x.z.y` where `x` is the major version, `y` is the minor version and `z` is the patch level.
 
 Part         | Comment
@@ -93,10 +93,10 @@ Patch        | Bugfixes applied in a backwards-compatible manner.
 
 
 #### Backwards Compatibility
-As a consequence, the API is expected to be backwards compatible between minor version upgrades, including the patch
-level. This means that a client that has been developed against version 1.0.0 of the api will work with version 1.1.3 as
-well. This however may not be true going from version 1.1.0 to 2.0.0
+As a consequence, the External API is expected to be backwards compatible between minor version upgrades, including the
+patch level. This means that a client that has been developed against version 1.0.0 of the api will work with version
+1.1.3 as well. This however may not be true going from version 1.1.0 to 2.0.0
 
 ### Multi tenancy
-With Opencast being a multi tenant application, the application API reflects that characteristics as well. Requests are
+With Opencast being a multi tenant application, the External API reflects that characteristics as well. Requests are
 mapped to individual tenants by matching the requests’s target hostname against the list of tenant hostnames.

--- a/docs/guides/developer/docs/api/index.md
+++ b/docs/guides/developer/docs/api/index.md
@@ -65,7 +65,7 @@ underlying system in the URL space that are then accessible using the HTTP proto
 `DELETE`.
 
 Since as part of the communication, the External API is used to transfer potentially sensitive data between the client
-and the server including the username and password as part of the Basic Authentication protocol, the API will usually 
+and the server including the username and password as part of the Basic Authentication protocol, the API will usually
 only be available over a secure HTTPS connection only.
 
 

--- a/docs/guides/developer/docs/api/security-api.md
+++ b/docs/guides/developer/docs/api/security-api.md
@@ -9,14 +9,14 @@ representations - only authorized users are able to consume it.
 This is achieved by handing signed URLs to end users which are validated by the distribution servers and become invalid
 after a given period of time (usually 1 hour, depending on the server configuration).
 
-As a consequence, users of the API who are presenting URLs to distributed media for playback will need to make sure that
-those urls are signed, otherwise the distribution servers will refuse to deliver the content and respond with a `401 NOT
-AUTHORIZED` status.
+As a consequence, users of the External API who are presenting URLs to distributed media for playback will need to make
+sure that those urls are signed, otherwise the distribution servers will refuse to deliver the content and respond with
+a `401 NOT AUTHORIZED` status.
 
 ### Best practices
 
-The use of signed URLs requires a set of best practices to be followed when clients interact with the API, most notably
-in the area of performance and caching.
+The use of signed URLs requires a set of best practices to be followed when clients interact with the External API,
+most notably in the area of performance and caching.
 
 #### Performance
 

--- a/docs/guides/developer/docs/api/series-api.md
+++ b/docs/guides/developer/docs/api/series-api.md
@@ -247,16 +247,16 @@ __Response__
 
 ## Metadata
 
-This section describes how to use the Application API to work with metadata catalogs associated to series.
+This section describes how to use the External API to work with metadata catalogs associated to series.
 
 Opencast manages the bibliographic metadata of series using metadata catalogs which are identified by flavors.
 The default metadata catalog for Opencast series has the flavor `dublincore/series`. Opencast additionally supports
 extended metadata catalogs for series that can be configured.
 
-The Application API supports both the default series metadata catalog and series extended metadata catalogs.
+The External API supports both the default series metadata catalog and series extended metadata catalogs.
 For the default series metadata catalog, the metadata is directly returned in the responses.
 
-Since the metadata catalogs can be configured, the Application API provides a facility to retrieve the catalog
+Since the metadata catalogs can be configured, the External API provides a facility to retrieve the catalog
 configuration of series metadata catalogs. For more details about this mechanism, please refer to
 ["Metadata Catalogs"](types.md#metadata-catalogs).
 

--- a/docs/guides/developer/docs/api/types.md
+++ b/docs/guides/developer/docs/api/types.md
@@ -1,13 +1,13 @@
 # Data Types
 
-This page defines data types that are commonly used by many Application API requests. The page is divided in several
+This page defines data types that are commonly used by many External API requests. The page is divided in several
 sections that start with general information about how the types are supposed to work.
 
 [TOC]
 
 ## Basic
 
-This section defines basic data types used in the Application API specification.
+This section defines basic data types used in the External API specification.
 
 Type                | Description
 :-------------------|:-----------
@@ -17,11 +17,11 @@ Type                | Description
 
 ## Extended
 
-This section describes extended data types used in the Application API specification.
+This section describes extended data types used in the External API specification.
 
 ### array
 
-The Application API makes use of JSON arrays often. We indicate the element type in the brackets, e.g.
+The External API makes use of JSON arrays often. We indicate the element type in the brackets, e.g.
 [`array[string]`](#array).
 
 The empty array [] is allowed.
@@ -55,7 +55,7 @@ dublincore/episode
 
 ### property
 
-Opencast often uses sets of key-value pairs to associate properties to objects. The Application API uses
+Opencast often uses sets of key-value pairs to associate properties to objects. The External API uses
 JSON objects to represent those properties. Both the name of the JSON object field and its value are of type `string`.
 
 __Example__
@@ -92,7 +92,7 @@ __Examples__
 
 ## Metadata Catalogs
 
-The Application API is designed to take full advantage of the powerful metadata facilities of Opencast.
+The External API is designed to take full advantage of the powerful metadata facilities of Opencast.
 
 Opencast distinguishes between bibliographic metadata and technical metadata:
 
@@ -109,7 +109,7 @@ catalogs:
 While the extended metadata can be fully configured, the default metadata catalogs are supposed to hold a minimum
 set of defined metadata fields.
 
-As the metadata catalogs are configurable, the Application API provides means of gathering the metadata catalog
+As the metadata catalogs are configurable, the External API provides means of gathering the metadata catalog
 configuration.
 
 This is done by ["/api/events/{event_id}/metadata"](events-api.md#metadata) and

--- a/docs/guides/developer/docs/api/usage.md
+++ b/docs/guides/developer/docs/api/usage.md
@@ -5,8 +5,8 @@
 
 # Version
 
-Since the API is versioned, it supports specification of a version identifier as part of the standard `Accept` HTTP
-request header:
+Since the External API is versioned, it supports specification of a version identifier as part of the standard `Accept`
+HTTP request header:
 
 
 Header   | Type                       | Description
@@ -15,7 +15,7 @@ Header   | Type                       | Description
 
 Notes:
 
-- The API currently only supports the format [JSON][3]
+- The External API currently only supports the format [JSON][3]
 
 __Example__
 
@@ -35,8 +35,8 @@ Versions should be specified as obtained from the [Base API](base-api.md#version
 
 ## Authentication
 
-The API is using basic authentication. In order to make calls to the API, the following standard request headers need to
-be sent with every request:
+The External API is using basic authentication. In order to make calls to the API, the following standard request
+headers need to be sent with every request:
 
 Header          | Type                       | Description
 :---------------|:---------------------------|:-----------
@@ -46,7 +46,7 @@ Header          | Type                       | Description
 # Authorization
 
 There are multiple ways to authorize a request - see the [authorization section](authorization.md) for more details. In
-short, the Application API either supports specifying the execution user, the execution user’s roles or a combination of
+short, the External API either supports specifying the execution user, the execution user’s roles or a combination of
 the two in which case the execution roles will be added to the execution user’s existing roles.
 
 If no user is specified, Opencast’s `anonymous` user is used to execute the request, potentially enriched by the roles
@@ -62,7 +62,7 @@ Header            | Type                       | Description
 
 ## Content Type
 
-The Application API currently supports [JSON][3] format only.
+The External API currently supports [JSON][3] format only.
 
 Header   | Type                       | Description
 :--------|:---------------------------|:-----------
@@ -70,7 +70,7 @@ Header   | Type                       | Description
 
 If that header is not specified, the `Content-Type` will be `application/<version>+json`.
 
-> Note that the same header should be used to specify the version of the api that is expected to return the response. In
+> Note that the same header should be used to specify the version of the API that is expected to return the response. In
 > this case, the header looks like this: `application/v1+json`. See the [versioning chapter of the general
 > section](index.md#versioning) for more details.
 
@@ -123,7 +123,7 @@ Arrays   | []       | Non-existing list of literals or objects
 
 # Sorting
 
-Sorting of result sets is supported by a set of well-defined fields per request, one at a time. Each api request
+Sorting of result sets is supported by a set of well-defined fields per request, one at a time. Each API request
 explicitly defines the fields that support sorting.
 
 ## Sort field
@@ -159,7 +159,7 @@ GET /api/events?sort=title&order=asc
 Filtering of result sets is supported by a set of well-defined fields per request. Multiple filter criteria can be
 defined by specifying the `filter` parameter more than once. In this case, the criteria are applied using logical `and`.
 
-Each api request explicitly defines the fields that support filtering.
+Each API request explicitly defines the fields that support filtering.
 
 Parameter | Description
 :---------|:-----------

--- a/docs/guides/developer/mkdocs.yml
+++ b/docs/guides/developer/mkdocs.yml
@@ -74,7 +74,7 @@ pages:
    - Overview: 'infrastructure/index.md'
    - Notes: 'infrastructure/notes.md'
    - Maven Repository: 'infrastructure/maven-repository.md'
-- API:
+- External API:
    - Introduction: 'api/index.md'
    - Usage: 'api/usage.md'
    - Authentication: 'api/authentication.md'


### PR DESCRIPTION
Ensure that the External API specification uses the name "External API" consistently