### PR TITLE
MH-12859, Segmentation parsing error

### DIFF
--- a/modules/matterhorn-videosegmenter-ffmpeg/src/test/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterTest.java
+++ b/modules/matterhorn-videosegmenter-ffmpeg/src/test/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterTest.java
@@ -256,7 +256,6 @@ public class VideoSegmenterTest {
 
     // Is there multimedia content in the mpeg7?
     assertTrue("Audiovisual content was expected", mpeg7.hasVideoContent());
-    assertNotNull("Audiovisual content expected", mpeg7.multimediaContent().next().elements().hasNext());
 
     MultimediaContentType contentType = mpeg7.multimediaContent().next().elements().next();
 


### PR DESCRIPTION
The video segmenter internally uses FFmpeg's select and showinfo filter
to detect scene cuts and then display and parse time information. But
FFmpeg's showinfo filter will print out more information which our code
would then parse and interpret incorrectly leading to invalid
segmentation.

The issue was revealed since FFmpeg 4 by chance now prints a non-time
showinfo statement as last line which caused one of our tests to break.

This patch fixes the problem by skipping all showinfo statements without
time information.