### PR TITLE
[MH-12782] As an unprivileged user, I only want to see series and events that I have write access to.

### DIFF
--- a/etc/org.opencastproject.adminui.endpoint.OsgiEventEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.OsgiEventEndpoint.cfg
@@ -22,3 +22,8 @@
 # recommended default value.
 #
 preview.subtype=preview
+
+# If this property is true, we only see the series to which we have write access
+# within the new event wizard or event details.
+# Default: false
+# eventModal.onlySeriesWithWriteAccess=false

--- a/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
@@ -1,5 +1,16 @@
+
 # If false a user will not be able to delete a series containing events in Admin UI
 # Note: Have a look at org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
 #       property.series.required=false if you want to configure if a event has to have a series
 # Default: true
 # series.hasEvents.delete.allow=true
+
+# If this property is true, we only see the series to which we have write access
+# to in the series tab.
+# Default: false
+# seriesTab.onlySeriesWithWriteAccess=false
+
+# If this property is true, we only see the series to which we have write access
+# to in the events filter.
+# Default: false
+# eventsFilter.onlySeriesWithWriteAccess=false

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -35,6 +35,7 @@ import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.security.urlsigning.utils.UrlSigningServiceOsgiUtil;
 import org.opencastproject.workflow.api.WorkflowService;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 
@@ -53,6 +54,7 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   private EventCommentService eventCommentService;
   private IndexService indexService;
   private JobEndpoint jobService;
+  private SeriesEndpoint seriesService;
   private SchedulerService schedulerService;
   private SecurityService securityService;
   private UrlSigningService urlSigningService;
@@ -61,6 +63,9 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
 
   private long expireSeconds = UrlSigningServiceOsgiUtil.DEFAULT_URL_SIGNING_EXPIRE_DURATION;
   private Boolean signWithClientIP = UrlSigningServiceOsgiUtil.DEFAULT_SIGN_WITH_CLIENT_IP;
+
+  public static final String EVENTMODAL_ONLYSERIESWITHWRITEACCESS_KEY = "eventModal.onlySeriesWithWriteAccess";
+  private Boolean onlySeriesWithWriteAccessEventModal = false;
 
   @Override
   public AdminUIConfiguration getAdminUIConfiguration() {
@@ -85,6 +90,16 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   @Override
   public JobEndpoint getJobService() {
     return jobService;
+  }
+
+  /** OSGi DI. */
+  public void setSeriesService(SeriesEndpoint seriesService) {
+    this.seriesService = seriesService;
+  }
+
+  @Override
+  public SeriesEndpoint getSeriesService() {
+    return seriesService;
   }
 
   /** OSGi DI. */
@@ -192,6 +207,11 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
     expireSeconds = UrlSigningServiceOsgiUtil.getUpdatedSigningExpiration(properties, this.getClass().getSimpleName());
     signWithClientIP = UrlSigningServiceOsgiUtil.getUpdatedSignWithClientIP(properties,
             this.getClass().getSimpleName());
+
+    Object dictionaryValue = properties.get(EVENTMODAL_ONLYSERIESWITHWRITEACCESS_KEY);
+    if (dictionaryValue != null) {
+      onlySeriesWithWriteAccessEventModal = BooleanUtils.toBoolean(dictionaryValue.toString());
+    }
   }
 
   @Override
@@ -202,6 +222,11 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   @Override
   public Boolean signWithClientIP() {
     return signWithClientIP;
+  }
+
+  @Override
+  public Boolean getOnlySeriesWithWriteAccessEventModal() {
+    return onlySeriesWithWriteAccessEventModal;
   }
 
 }

--- a/modules/admin-ui/src/main/resources/OSGI-INF/event_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/event_endpoint.xml
@@ -27,6 +27,11 @@
              cardinality="1..1"
              policy="static"
              bind="setJobService"/>
+  <reference name="seriesService"
+             interface="org.opencastproject.adminui.endpoint.SeriesEndpoint"
+             cardinality="1..1"
+             policy="static"
+             bind="setSeriesService"/>
   <reference name="AclServiceFactory"
              interface="org.opencastproject.authorization.xacml.manager.api.AclServiceFactory"
              cardinality="1..1"

--- a/modules/admin-ui/src/main/resources/OSGI-INF/list_providers_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/list_providers_endpoint.xml
@@ -15,5 +15,6 @@
              name="ListProvidersService" policy="static"/>
   <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
              cardinality="1..1" policy="static" bind="setSecurityService"/>
-
+  <reference name="seriesService" interface="org.opencastproject.adminui.endpoint.SeriesEndpoint"
+             cardinality="1..1" policy="static" bind="setSeriesEndpoint"/>
 </scr:component>

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -745,6 +745,7 @@ public class AbstractEventEndpointTest {
     private WorkflowService workflowService;
     private AssetManager assetManager;
     private JobEndpoint jobService;
+    private SeriesEndpoint seriesService;
     private AclService aclService;
     private EventCommentService eventCommentService;
     private SecurityService securityService;
@@ -765,6 +766,14 @@ public class AbstractEventEndpointTest {
 
     public JobEndpoint getJobService() {
       return jobService;
+    }
+
+    public void setSeriesService(SeriesEndpoint seriesService) {
+      this.seriesService = seriesService;
+    }
+
+    public SeriesEndpoint getSeriesService() {
+      return seriesService;
     }
 
     public void setWorkflowService(WorkflowService workflowService) {

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -806,6 +806,11 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
   }
 
   @Override
+  public SeriesEndpoint getSeriesService() {
+    return env.getSeriesService();
+  }
+
+  @Override
   public AclService getAclService() {
     return env.getAclService();
   }
@@ -865,4 +870,8 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
     return false;
   }
 
+  @Override
+  public Boolean getOnlySeriesWithWriteAccessEventModal() {
+    return false;
+  }
 }


### PR DESCRIPTION
A new method called _getSeriesWriteAccess()_ has been created in the _SeriesEndpoint_ class to get the series with write access of the logged-in user. This method makes a simple query and returns only the metadata we need in the right format.

This method is called from _getNewMetadata(....)_ in the _AbstractEventEndpoint_ class, so only write-enabled series will be displayed in the event metadata when one of them is created.

In addition, code has been added in the _getSeries(....)_ method of the _AbstractEventEndpoint_ class to display only the writeable series in the series section and in _getEvents(...)_ to see only the writeable events in the events section. 