### PR TITLE
MH-12863, Fix default owner in SMIL endpoint

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -33,7 +33,6 @@ import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
-import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
 import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.adminui.impl.AdminUIConfiguration;
@@ -543,11 +542,9 @@ public class ToolsEndpoint implements ManagedService {
     catalog.setChecksum(null);
 
     try {
-      // FIXME SWITCHP-333: Start in new thread
-      assetManager.takeSnapshot(DEFAULT_OWNER, mediaPackage);
+      assetManager.takeSnapshot(mediaPackage);
     } catch (AssetManagerException e) {
-      logger.error("Error while adding the updated media package ({}) to the archive: {}", mediaPackage.getIdentifier(),
-              e.getMessage());
+      logger.error("Error while adding the updated media package ({}) to the archive", mediaPackage.getIdentifier(), e);
       throw new IOException(e);
     }
 


### PR DESCRIPTION
This patch fixes the smil archiving endpoint which would set the
snapshot owner to the default owner regardless of which owner it did
belong to earlier.

*Work sponsored by SWITCH*