### PR TITLE
MH-12870: allow series acl update to complete even if mediapackage exceptions are raised at the mediapackage level

### DIFF
--- a/modules/matterhorn-authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
+++ b/modules/matterhorn-authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
@@ -243,8 +243,12 @@ public final class AclServiceImpl implements AclService {
 
         for (MediaPackage mp : mediaPackages) {
           // remove episode xacml and update in archive service
-          if (assetManager != null)
-            assetManager.takeSnapshot(authorizationService.removeAcl(mp, AclScope.Episode));
+          try {
+            if (assetManager != null)
+              assetManager.takeSnapshot(authorizationService.removeAcl(mp, AclScope.Episode));
+          } catch (Exception e) {
+            logger.info("Error applying series ACL to mediapackage {}", mp.getIdentifier().toString());
+          }
         }
       }
       // update in series service

--- a/modules/matterhorn-authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
+++ b/modules/matterhorn-authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
@@ -247,7 +247,7 @@ public final class AclServiceImpl implements AclService {
             if (assetManager != null)
               assetManager.takeSnapshot(authorizationService.removeAcl(mp, AclScope.Episode));
           } catch (Exception e) {
-            logger.info("Error applying series ACL to mediapackage {}", mp.getIdentifier().toString());
+            logger.error("Error applying series ACL to mediapackage {}", e);
           }
         }
       }


### PR DESCRIPTION
Suppose a series has a mediapackage which, for some reason, cannot be snapshotted. Lets call this mediapackage _corrupted_.

If an ACL update is applied to the series (e.g. to share series content with another series), the update consequently fails at the corrupted mediapackage as it cannot be snapshotted. All those sibling mediapackages which have been snapshotted prior to the attempt against the corrupted mediapackage will have the update applied to them; on the other hand, all mediapackages subsequent to the corrupted mediapackage remain unchanged.

We now have mediapackages in a series where ACLs are not applied consistently.

This PR puts forward a best attempt approach, whereby those mediapackges which can be updated _are_ updated (exceptions at the mediapackage level do not stop the update); those that can not are logged for administrators to deal with.