### PR TITLE
MH-12871 Ability to use user names in to/cc/bcc fields in send-email woh

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -7,12 +7,14 @@ Description
 The EmailWorkflowOperationHandler invokes the SMTP Service to send an email with the parameters provided. It is useful
 to send email notifications when some operation(s) have been completed or some error(s) have occurred in a workflow.
 
-The email body, if not specified by body or body-template-file, will consist of a single line of the form: `<Recording
-Title> (<Mediapackage ID>)`.
+The email body, if not specified by body or body-template-file, will consist of a single line of the form:
+`<Recording Title> (<Mediapackage ID>)`.
 
 Freemarker templates can be used in the following fields to allow replacement with values obtained from the workflow or
-media package: to, subject, and body. If body-template-file is specified, the operation will use a Freemarker template
+media package: to, cc, bcc, subject, and body. If body-template-file is specified, the operation will use a Freemarker template
 file located in `<config_dir>/etc/email` to generate the email body.
+
+User names can be provided in `to`, `cc`, or `bcc` in lieu of email addresses so that the user directory is searched and that user's email address is used (see Example 5).
 
 
 Parameter Table
@@ -20,12 +22,12 @@ Parameter Table
 
 |configuration keys|description|default value|example|
 |------------------|-------|-----------|-------------|
-|body|Email body content.<br>Takes precedence over body-template-file.|```<Recording Title> (<Mediapackage ID>)```|Lecture 1 (4bf316fc-ea78-4903-b00e-9976b0912e4d)|
+|body|Email body content.<br>Takes precedence over body-template-file.|`<Recording Title> (<Mediapackage ID>)`|Lecture 1 (4bf316fc-ea78-4903-b00e-9976b0912e4d)|
 |body-template-file|Name of file that will be used as a template for the content of the email body.|EMPTY|templateName|
-|subject|Specifies the email subject.|EMPTY|Operation has been completed|
-|to|It specifies the field to of the email<br>i.e. the comma separated list of email accounts the email will be sent to.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
-|cc|It specifies the field cc of the email<br>i.e. the comma separated list of email accounts that will receive a carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
-|bcc|It specifies the field bcc of the email<br>i.e. the comma separated list of email accounts that will receive a blind carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
+|subject|Email subject.|EMPTY|Operation has been completed|
+|to|The field `to` of the email<br>i.e. the comma separated list of email accounts the email will be sent to.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
+|cc|The field `cc` of the email<br>i.e. the comma separated list of email accounts that will receive a carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
+|bcc|The field `bcc` of the email<br>i.e. the comma separated list of email accounts that will receive a blind carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 
 **Some other email parameters can be customized in the SMTP Service configuration**
 
@@ -86,7 +88,7 @@ In your email template:
 
 ### Catalog fields
 
-Use ```${catalogs['SUBTYPE']['FIELD']}`
+Use `${catalogs['SUBTYPE']['FIELD']}`
 
 #### Examples
 
@@ -276,4 +278,38 @@ Logged incident of the error looks like this:
     <#list inc.details as dets>${dets.b} </#list>
   </#list>
 </#if>
+```
+
+### Example 5
+
+The user name is stored in the episode dublin core `contributor` field. There's a user `jharvard` with email `jharvard@harvard.edu` defined in the system. The message will be sent to `jharvard@harvard.edu`: 
+
+```xml
+   <operation
+      id="send-email"
+      fail-on-error="false"
+      description="Notify user associated to this recording that it is ready to be trimmed">
+      <configurations>
+        <configuration key="to">${(catalogs['episode']['contributor'])}</configuration>
+        <configuration key="subject">Recording is ready for EDIT</configuration>
+        <configuration key="body-template-file">eventDetails</configuration>
+      </configurations>
+    </operation>
+```
+
+#### Episode Dublin Core
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<dublincore xmlns="http://www.opencastproject.org/xsd/1.0/dublincore/"
+    xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <dcterms:contributor>jharvard</dcterms:contributor>
+    <dcterms:created>2018-05-01T16:14:00Z</dcterms:created>
+    <dcterms:extent xsi:type="dcterms:ISO8601">PT17M1.933S</dcterms:extent>
+    <dcterms:isPartOf>20180229999</dcterms:isPartOf>
+    <dcterms:spatial>classroom-20</dcterms:spatial>
+    <dcterms:temporal>start=2018-05-01T16:14:00Z; end=2018-05-01T16:31:00Z;
+        scheme=W3C-DTF;</dcterms:temporal>
+    <dcterms:title>Test Lecture</dcterms:title>
+</dublincore>
 ```

--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -14,7 +14,7 @@ Freemarker templates can be used in the following fields to allow replacement wi
 media package: to, cc, bcc, subject, and body. If body-template-file is specified, the operation will use a Freemarker template
 file located in `<config_dir>/etc/email` to generate the email body.
 
-User names can be provided in `to`, `cc`, or `bcc` in lieu of email addresses so that the user directory is searched 
+User names can be provided in `to`, `cc`, or `bcc` in lieu of email addresses so that the user directory is searched
 and that user's email address is used (see Example 5).
 
 
@@ -283,7 +283,7 @@ Logged incident of the error looks like this:
 
 ### Example 5
 
-The user name is stored in the episode dublin core `contributor` field. There's a user `jharvard` with email 
+The user name is stored in the episode dublin core `contributor` field. There's a user `jharvard` with email
 `jharvard@harvard.edu` defined in the system. The message will be sent to `jharvard@harvard.edu`:
 
 ```xml

--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -14,7 +14,8 @@ Freemarker templates can be used in the following fields to allow replacement wi
 media package: to, cc, bcc, subject, and body. If body-template-file is specified, the operation will use a Freemarker template
 file located in `<config_dir>/etc/email` to generate the email body.
 
-User names can be provided in `to`, `cc`, or `bcc` in lieu of email addresses so that the user directory is searched and that user's email address is used (see Example 5).
+User names can be provided in `to`, `cc`, or `bcc` in lieu of email addresses so that the user directory is searched 
+and that user's email address is used (see Example 5).
 
 
 Parameter Table
@@ -282,7 +283,8 @@ Logged incident of the error looks like this:
 
 ### Example 5
 
-The user name is stored in the episode dublin core `contributor` field. There's a user `jharvard` with email `jharvard@harvard.edu` defined in the system. The message will be sent to `jharvard@harvard.edu`: 
+The user name is stored in the episode dublin core `contributor` field. There's a user `jharvard` with email 
+`jharvard@harvard.edu` defined in the system. The message will be sent to `jharvard@harvard.edu`:
 
 ```xml
    <operation

--- a/modules/notification-workflowoperation/pom.xml
+++ b/modules/notification-workflowoperation/pom.xml
@@ -37,6 +37,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-userdirectory</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-email-template-service-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/notification-workflowoperation/src/main/resources/OSGI-INF/operations/email.xml
+++ b/modules/notification-workflowoperation/src/main/resources/OSGI-INF/operations/email.xml
@@ -11,4 +11,6 @@
   <reference name="EmailTemplateService" interface="org.opencastproject.email.template.api.EmailTemplateService" policy="static" cardinality="1..1" bind="setEmailTemplateService" />
   <reference name="ServiceRegistry" cardinality="1..1" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
     policy="static" bind="setServiceRegistry" />
+  <reference name="userDIrectoryService" cardinality="1..1" interface="org.opencastproject.security.api.UserDirectoryService"
+    policy="static" bind="setUserDirectoryService" />
 </scr:component>

--- a/modules/notification-workflowoperation/src/main/resources/OSGI-INF/operations/email.xml
+++ b/modules/notification-workflowoperation/src/main/resources/OSGI-INF/operations/email.xml
@@ -11,6 +11,6 @@
   <reference name="EmailTemplateService" interface="org.opencastproject.email.template.api.EmailTemplateService" policy="static" cardinality="1..1" bind="setEmailTemplateService" />
   <reference name="ServiceRegistry" cardinality="1..1" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
     policy="static" bind="setServiceRegistry" />
-  <reference name="userDIrectoryService" cardinality="1..1" interface="org.opencastproject.security.api.UserDirectoryService"
+  <reference name="userDirectoryService" cardinality="1..1" interface="org.opencastproject.security.api.UserDirectoryService"
     policy="static" bind="setUserDirectoryService" />
 </scr:component>

--- a/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
+++ b/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
@@ -29,6 +29,7 @@ import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationException;
 import org.opencastproject.workflow.api.WorkflowOperationInstance;
 import org.opencastproject.workflow.api.WorkflowOperationInstance.OperationState;
 import org.opencastproject.workflow.api.WorkflowOperationInstanceImpl;
@@ -53,11 +54,13 @@ public class EmailWorkflowOperationHandlerTest {
   private URI uriMP;
   // private MimeMessage message;
 
-  private static final String DEFAULT_TO = "somebody@hotmail.com";
+  private static final String DEFAULT_TO = "somebody@testemail.com";
   private static final String DEFAULT_CC = "carboncopy@testemail.com";
   private static final String DEFAULT_BCC = "blindcarboncopy@testemail.com";
   private static final String DEFAULT_SUBJECT = "This is a subject";
   private static final String USER_NAME = "username";
+  private static final String USER_NAME_EMAIL = "username@testemail.com";
+  private static final String USER_NAME_NO_EMAIL = "username_no_email";
 
   private Capture<String> capturedTo;
   private Capture<String> capturedCC;
@@ -99,9 +102,15 @@ public class EmailWorkflowOperationHandlerTest {
 
     User user = EasyMock.createNiceMock(User.class);
     EasyMock.expect(user.getEmail()).andReturn(DEFAULT_TO).anyTimes();
+    User emailUser = EasyMock.createNiceMock(User.class);
+    EasyMock.expect(emailUser.getEmail()).andReturn(DEFAULT_TO).anyTimes();
+    User noEmailUser = EasyMock.createNiceMock(User.class);
+    EasyMock.expect(noEmailUser.getEmail()).andReturn(null).anyTimes();
     UserDirectoryService userDirectoryService = EasyMock.createNiceMock(UserDirectoryService.class);
     EasyMock.expect(userDirectoryService.loadUser(USER_NAME)).andReturn(user).anyTimes();
-    EasyMock.replay(user, userDirectoryService);
+    EasyMock.expect(userDirectoryService.loadUser(USER_NAME_EMAIL)).andReturn(emailUser).anyTimes();
+    EasyMock.expect(userDirectoryService.loadUser(USER_NAME_NO_EMAIL)).andReturn(noEmailUser).anyTimes();
+    EasyMock.replay(user, emailUser, noEmailUser, userDirectoryService);
     operationHandler.setUserDirectoryService(userDirectoryService);
 
     workflowInstance.setId(1);
@@ -124,7 +133,6 @@ public class EmailWorkflowOperationHandlerTest {
 
   @Test
   public void testDefaultBody() throws Exception {
-    workflowInstance.setTitle("testDefaultBody");
     operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY, DEFAULT_TO);
     operation.setConfiguration(EmailWorkflowOperationHandler.CC_PROPERTY, DEFAULT_CC);
     operation.setConfiguration(EmailWorkflowOperationHandler.BCC_PROPERTY, DEFAULT_BCC);
@@ -142,7 +150,6 @@ public class EmailWorkflowOperationHandlerTest {
 
   @Test
   public void testTemplateInBody() throws Exception {
-    workflowInstance.setTitle("testTemplateInBody");
     operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY, DEFAULT_TO);
     operation.setConfiguration(EmailWorkflowOperationHandler.CC_PROPERTY, DEFAULT_CC);
     operation.setConfiguration(EmailWorkflowOperationHandler.BCC_PROPERTY, DEFAULT_BCC);
@@ -162,7 +169,6 @@ public class EmailWorkflowOperationHandlerTest {
 
   @Test
   public void testTemplateInFile() throws Exception {
-    workflowInstance.setTitle("testTemplateInFile");
     operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY, DEFAULT_TO);
     operation.setConfiguration(EmailWorkflowOperationHandler.CC_PROPERTY, DEFAULT_CC);
     operation.setConfiguration(EmailWorkflowOperationHandler.BCC_PROPERTY, DEFAULT_BCC);
@@ -181,7 +187,6 @@ public class EmailWorkflowOperationHandlerTest {
 
   @Test
   public void testTemplateNotFound() throws Exception {
-    workflowInstance.setTitle("testErrorInTemplate");
     operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY, DEFAULT_TO);
     operation.setConfiguration(EmailWorkflowOperationHandler.CC_PROPERTY, DEFAULT_CC);
     operation.setConfiguration(EmailWorkflowOperationHandler.BCC_PROPERTY, DEFAULT_BCC);
@@ -199,7 +204,6 @@ public class EmailWorkflowOperationHandlerTest {
 
   @Test
   public void testDestinationAsUserName() throws Exception {
-    workflowInstance.setTitle("testDestinationAsUserName");
     operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY, USER_NAME);
     operation.setConfiguration(EmailWorkflowOperationHandler.CC_PROPERTY, USER_NAME);
     operation.setConfiguration(EmailWorkflowOperationHandler.BCC_PROPERTY, USER_NAME);
@@ -219,7 +223,6 @@ public class EmailWorkflowOperationHandlerTest {
 
   @Test
   public void testManyDestinationEmails() throws Exception {
-    workflowInstance.setTitle("testManyDestinationEmails");
     operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY,
             USER_NAME + "," + DEFAULT_BCC + " " + DEFAULT_CC);
     operation.setConfiguration(EmailWorkflowOperationHandler.CC_PROPERTY, null);
@@ -237,4 +240,43 @@ public class EmailWorkflowOperationHandlerTest {
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
     Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
   }
+
+  @Test
+  public void testUserNameIsAnEmail() throws Exception {
+    operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY, USER_NAME_EMAIL);
+    operation.setConfiguration(EmailWorkflowOperationHandler.CC_PROPERTY, USER_NAME_EMAIL);
+    operation.setConfiguration(EmailWorkflowOperationHandler.BCC_PROPERTY, USER_NAME_EMAIL);
+    operation.setConfiguration(EmailWorkflowOperationHandler.SUBJECT_PROPERTY, DEFAULT_SUBJECT);
+    operation.setConfiguration(EmailWorkflowOperationHandler.BODY_PROPERTY,
+            "This is the media package: ${mediaPackage.identifier}");
+
+    WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
+
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+    Assert.assertEquals(DEFAULT_TO, capturedTo.getValue());
+    Assert.assertEquals(DEFAULT_TO, capturedCC.getValue());
+    Assert.assertEquals(DEFAULT_TO, capturedBCC.getValue());
+    Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
+    Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
+  }
+
+  @Test(expected = WorkflowOperationException.class)
+  public void testUserNoEmail() throws Exception {
+    operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY, USER_NAME_NO_EMAIL);
+    operation.setConfiguration(EmailWorkflowOperationHandler.CC_PROPERTY, USER_NAME_NO_EMAIL);
+    operation.setConfiguration(EmailWorkflowOperationHandler.BCC_PROPERTY, USER_NAME_NO_EMAIL);
+    operation.setConfiguration(EmailWorkflowOperationHandler.SUBJECT_PROPERTY, DEFAULT_SUBJECT);
+    operation.setConfiguration(EmailWorkflowOperationHandler.BODY_PROPERTY,
+            "This is the media package: ${mediaPackage.identifier}");
+
+    WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
+
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+    Assert.assertEquals(DEFAULT_TO, capturedTo.getValue());
+    Assert.assertEquals(DEFAULT_TO, capturedCC.getValue());
+    Assert.assertEquals(DEFAULT_TO, capturedBCC.getValue());
+    Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
+    Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
+  }
+
 }


### PR DESCRIPTION
Send-email WOH will look for a user in the user directory and use the user's email address if cc/to/bcc don't have a valid email address.