### PR TITLE
MH-12872 event can not be deleted

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
@@ -470,7 +470,7 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
     if (event == null)
       throw new NotFoundException("No event with id " + uid + " found.");
 
-    if (event.getWorkflowId() == workflowId) {
+    if (event.getWorkflowId() != null && event.getWorkflowId().equals(workflowId)) {
       logger.debug("Workflow {} is the current workflow of event {}. Removing it from event.", uid, workflowId);
       event.setWorkflowId(null);
       event.setWorkflowDefinitionId(null);


### PR DESCRIPTION
The '==' operator compare the objects reference of Long instances. What we definitly mean is the value comparison, that should be done with equals().