### PR TITLE
MH-12874 NotFoundException handling for OAI-PMH retract operation with non published event

### DIFF
--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractOaiPmhWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractOaiPmhWorkflowOperationHandler.java
@@ -63,7 +63,7 @@ public class RetractOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
    */
   @Override
@@ -73,7 +73,7 @@ public class RetractOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
 
   /**
    * OSGi declarative service configuration callback.
-   * 
+   *
    * @param publicationService
    *          the publication service
    */
@@ -83,7 +83,7 @@ public class RetractOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @see org.opencastproject.workflow.api.AbstractWorkflowOperationHandler#activate(ComponentContext)
    */
   @Override
@@ -93,7 +93,7 @@ public class RetractOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @see org.opencastproject.workflow.api.WorkflowOperationHandler#start(WorkflowInstance, JobContext)
    */
   @Override
@@ -106,7 +106,7 @@ public class RetractOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
       throw new IllegalArgumentException("No repository has been specified");
 
     try {
-      logger.info("Retracting media package {} from OAI-PMH publication repository", mediaPackage);
+      logger.info("Retracting media package {} publication from OAI-PMH repository {}", mediaPackage, repository);
 
       // Wait for OAI-PMH retraction to finish
       Job retractJob = publicationService.retract(mediaPackage, repository);

--- a/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
+++ b/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
@@ -314,6 +314,9 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
     } catch (OaiPmhDatabaseException e) {
       throw new PublicationException(format("Unable to retract media package %s from OAI-PMH repository %s",
               mpId, repository), e);
+    } catch (NotFoundException e) {
+      logger.debug(format("Skip retracting media package %s from OIA-PMH repository %s as it isn't published.",
+              mpId, repository), e);
     }
 
     if (oaiPmhMp != null && oaiPmhMp.getElements().length > 0) {


### PR DESCRIPTION
As the retract operation should remove all data from repository, it should finish without error, if there is no publication found.