### PR TITLE
MH-12879, Default location of paella configuration

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -146,7 +146,10 @@ org.opencastproject.db.ddl.generation=true
 
 ######### Paella player configuration folder #########
 
-org.opencastproject.engage.paella.config.folder=${karaf.etc}/paella
+# Path to the Paella player configuration files. Note that the configuration file for each tenant needs to be in a
+# subfolder with the tenants identifier, e.g. …/etc/mh_default_org/config.json
+# Default: ${karaf.etc}/paella
+#org.opencastproject.engage.paella.config.folder=${karaf.etc}/paella
 
 
 ######### Workspace Cleanup #########

--- a/modules/engage-paella-player/src/main/java/org/opencastproject/engage/paella/PaellaConfigRest.java
+++ b/modules/engage-paella-player/src/main/java/org/opencastproject/engage/paella/PaellaConfigRest.java
@@ -24,13 +24,14 @@ package org.opencastproject.engage.paella;
 import org.opencastproject.rest.RestConstants;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.util.ConfigurationException;
 import org.opencastproject.util.PathSupport;
 import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
-
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,8 +63,11 @@ public class PaellaConfigRest {
 
   private static final Logger logger = LoggerFactory.getLogger(PaellaConfigRest.class);
 
-  /** Configuration properties id */
+  /** Configuration Key for Paella's config folder */
   private static final String PAELLA_CONFIG_FOLDER_PROPERTY = "org.opencastproject.engage.paella.config.folder";
+
+  /** Default configuration location (relative to ${karaf.etc}) */
+  private static final String PAELLA_CONFIG_FOLDER_DEFAULT = "paella";
 
   /**
    * The rest publisher looks for any non-servlet with the 'opencast.service.path' property
@@ -79,9 +83,16 @@ public class PaellaConfigRest {
   }
 
   public void activate(ComponentContext cc) {
-    logger.debug("activate()");
-
     paellaConfigFolder = cc.getBundleContext().getProperty(PAELLA_CONFIG_FOLDER_PROPERTY);
+
+    // Fall back to default location if necessary
+    if (StringUtils.isBlank(paellaConfigFolder)) {
+      paellaConfigFolder = cc.getBundleContext().getProperty("karaf.etc");
+      if (StringUtils.isBlank(paellaConfigFolder)) {
+        throw new ConfigurationException("Paella configuration not set and unable to fall back to default location");
+      }
+      paellaConfigFolder += "/paella";
+    }
     logger.debug("Paella configuration folder is {}", paellaConfigFolder);
   }
 

--- a/modules/engage-paella-player/src/main/java/org/opencastproject/engage/paella/PaellaConfigRest.java
+++ b/modules/engage-paella-player/src/main/java/org/opencastproject/engage/paella/PaellaConfigRest.java
@@ -91,7 +91,7 @@ public class PaellaConfigRest {
       if (StringUtils.isBlank(paellaConfigFolder)) {
         throw new ConfigurationException("Paella configuration not set and unable to fall back to default location");
       }
-      paellaConfigFolder += "/paella";
+      paellaConfigFolder = new File(paellaConfigFolder, "paella").getAbsolutePath();
     }
     logger.debug("Paella configuration folder is {}", paellaConfigFolder);
   }


### PR DESCRIPTION
The paella player lacks any default configuration for the location of
its main configuration files and is thus failing if this key is not
explicitly set, even if the default configuration file is provided.

This patch adds a default to `${karaf.etc}/paella` which is already
being used for the default configuration file.