### PR TITLE
MH-12880, Remove redundant OSGI declarations

### DIFF
--- a/modules/engage-paella-player/src/main/java/org/opencastproject/engage/paella/PaellaConfigRest.java
+++ b/modules/engage-paella-player/src/main/java/org/opencastproject/engage/paella/PaellaConfigRest.java
@@ -85,11 +85,6 @@ public class PaellaConfigRest {
     logger.debug("Paella configuration folder is {}", paellaConfigFolder);
   }
 
-  public void deactivate() {
-    // Nothing to do
-    logger.debug("deactivate()");
-  }
-
   @GET
   @Path("config.json")
   @Produces(MediaType.APPLICATION_JSON)

--- a/modules/engage-paella-player/src/main/resources/OSGI-INF/paella-config-file.xml
+++ b/modules/engage-paella-player/src/main/resources/OSGI-INF/paella-config-file.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
- name="org.opencastproject.engage.paella.PaellaConfigRest" immediate="true" activate="activate" deactivate="deactivate">
+               name="org.opencastproject.engage.paella.PaellaConfigRest" immediate="true">
   <implementation class="org.opencastproject.engage.paella.PaellaConfigRest" />
   <property name="service.description" value="Paella config REST Endpoint" />
 
@@ -11,5 +11,5 @@
     <provide interface="org.opencastproject.engage.paella.PaellaConfigRest" />
   </service>
   <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
-    cardinality="1..1" policy="static" bind="setSecurityService" />
+             bind="setSecurityService" />
 </scr:component>


### PR DESCRIPTION
This patch removes some redundant OSGI declarations and unused OSGI
methods from the Paella player module.