### PR TITLE
MH-12882, Fix org.w3c.dom.smil version

### DIFF
--- a/modules/smil-api/pom.xml
+++ b/modules/smil-api/pom.xml
@@ -63,7 +63,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Export-Package>
-              org.w3c.dom.smil;version=${project.version},
+              org.w3c.dom.smil;version=1.1,
               org.opencastproject.smil.api.*;version=${project.version},
               org.opencastproject.smil.entity.api*;version=${project.version},
               org.opencastproject.smil.entity.media.api.*;version=${project.version},


### PR DESCRIPTION
The smil service API exported an invalid version of the org.w3c.dom.smil
library used in the module. Instead of the version being set to the
library's version, it was set to automatically follow Opencast's
version, causing even Maven to complain during build-time:

    [WARNING] Bundle
    org.opencastproject:opencast-smil-api:bundle:5-SNAPSHOT :
    Version for package org.w3c.dom.smil is set to different values in
    the source (5-SNAPSHOT) and in the manifest (1.1). The version in
    the manifest is not picked up by an other sibling bundles in this
    project or projects that directly depend on this project

This patch fixes that issue and sets the version to the one from
android-mms bundle which provides the library in question.