### PR TITLE
MH-12877: Add new modal to edit multiple scheduled events at once

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/util/BulkUpdateUtil.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/util/BulkUpdateUtil.java
@@ -1,0 +1,331 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.adminui.util;
+
+import static org.opencastproject.adminui.endpoint.AbstractEventEndpoint.SCHEDULING_AGENT_ID_KEY;
+import static org.opencastproject.adminui.endpoint.AbstractEventEndpoint.SCHEDULING_END_KEY;
+import static org.opencastproject.adminui.endpoint.AbstractEventEndpoint.SCHEDULING_START_KEY;
+
+import org.opencastproject.adminui.impl.index.AdminUISearchIndex;
+import org.opencastproject.index.service.api.IndexService;
+import org.opencastproject.index.service.catalog.adapter.events.CommonEventCatalogUIAdapter;
+import org.opencastproject.index.service.impl.index.event.Event;
+import org.opencastproject.matterhorn.search.SearchIndexException;
+import org.opencastproject.mediapackage.MediaPackageElements;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+
+/**
+ * This class holds utility functions which are related to the bulk update feature for events.
+ */
+public final class BulkUpdateUtil {
+
+  private static final JSONParser parser = new JSONParser();
+
+  private BulkUpdateUtil() {
+  }
+
+  /**
+   * Wraps the IndexService.getEvent() method to convert SearchIndexExceptions into RuntimeExceptions. Useful when
+   * using Java's functional programming features.
+   *
+   * @param indexSvc The IndexService instance.
+   * @param index The index to get the event from.
+   * @param id The id of the event to get.
+   * @return An optional holding the event or nothing, if not found.
+   */
+  public static Optional<Event> getEvent(
+    final IndexService indexSvc,
+    final AdminUISearchIndex index,
+    final String id) {
+    try {
+      final Event event = indexSvc.getEvent(id, index).orNull();
+      return Optional.ofNullable(event);
+    } catch (SearchIndexException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Takes the given scheduling information and completes the event start and end dates as well as the duration for the
+   * given event. If the weekday shall be changed, the start and end dates are adjusted accordingly.
+   *
+   * @param event The event to complete the scheduling information for.
+   * @param scheduling The (yet incomplete) scheduling information to complete.
+   * @return The completed scheduling information, adjusted for the given event.
+   */
+  @SuppressWarnings("unchecked")
+  public static JSONObject addSchedulingDates(final Event event, final JSONObject scheduling) {
+    final JSONObject result = deepCopy(scheduling);
+    ZonedDateTime startDate = ZonedDateTime.parse(event.getRecordingStartDate());
+    ZonedDateTime endDate = ZonedDateTime.parse(event.getRecordingEndDate());
+    final InternalDuration oldDuration = InternalDuration.of(startDate.toInstant(), endDate.toInstant());
+    final ZoneId timezone = ZoneId.of((String) result.get("timezone"));
+
+    // The client only sends start time hours and/or minutes. We have to apply this to each event to get a full date.
+    if (result.containsKey(SCHEDULING_START_KEY)) {
+      startDate = adjustedSchedulingDate(result, SCHEDULING_START_KEY, startDate, timezone);
+    }
+    // The client only sends end time hours and/or minutes. We have to apply this to each event to get a full date.
+    if (result.containsKey(SCHEDULING_END_KEY)) {
+      endDate = adjustedSchedulingDate(result, SCHEDULING_END_KEY, endDate, timezone);
+    }
+    if (endDate.isBefore(startDate)) {
+      endDate = endDate.plusDays(1);
+    }
+
+    // If duration is set, we have to adjust the end or start date.
+    if (result.containsKey("duration")) {
+      final JSONObject time = (JSONObject) result.get("duration");
+      final InternalDuration newDuration = new InternalDuration(oldDuration);
+      if (time.containsKey("hour")) {
+        newDuration.hours = (Long) time.get("hour");
+      }
+      if (time.containsKey("minute")) {
+        newDuration.minutes = (Long) time.get("minute");
+      }
+      if (time.containsKey("second")) {
+        newDuration.seconds = (Long) time.get("second");
+      }
+      if (result.containsKey(SCHEDULING_END_KEY)) {
+        startDate = endDate.minusHours(newDuration.hours)
+          .minusMinutes(newDuration.minutes)
+          .minusSeconds(newDuration.seconds);
+      } else {
+        endDate = startDate.plusHours(newDuration.hours)
+          .plusMinutes(newDuration.minutes)
+          .plusSeconds(newDuration.seconds);
+      }
+    }
+
+    // Setting the weekday means that the event should be moved to the new weekday within the same week
+    if (result.containsKey("weekday")) {
+      final String weekdayAbbrev = ((String) result.get("weekday"));
+      if (weekdayAbbrev != null) {
+        final DayOfWeek newWeekDay = Arrays.stream(DayOfWeek.values())
+          .filter(d -> d.name().startsWith(weekdayAbbrev.toUpperCase()))
+          .findAny()
+          .orElseThrow(() -> new IllegalArgumentException("Cannot parse weekday: " + weekdayAbbrev));
+        final int daysDiff = newWeekDay.getValue() - startDate.getDayOfWeek().getValue();
+        startDate = startDate.plusDays(daysDiff);
+        endDate = endDate.plusDays(daysDiff);
+      }
+    }
+
+    result.put(SCHEDULING_START_KEY, startDate.format(DateTimeFormatter.ISO_INSTANT));
+    result.put(SCHEDULING_END_KEY, endDate.format(DateTimeFormatter.ISO_INSTANT));
+    return result;
+  }
+
+  /**
+   * Creates a json object containing meta data based on the given scheduling information.
+   *
+   * @param scheduling The scheduling information to extract meta data from.
+   * @return The meta data, consisting of location, startDate, and duration.
+   */
+  @SuppressWarnings("unchecked")
+  public static JSONObject toNonTechnicalMetadataJson(final JSONObject scheduling) {
+    final List<JSONObject> fields = new ArrayList<>();
+    if (scheduling.containsKey(SCHEDULING_AGENT_ID_KEY)) {
+      final JSONObject locationJson = new JSONObject();
+      locationJson.put("id", "location");
+      locationJson.put("value", scheduling.get(SCHEDULING_AGENT_ID_KEY));
+      fields.add(locationJson);
+    }
+    if (scheduling.containsKey(SCHEDULING_START_KEY) && scheduling.containsKey(SCHEDULING_END_KEY)) {
+      final JSONObject startDateJson = new JSONObject();
+      startDateJson.put("id", "startDate");
+      final String startDate = Instant.parse((String) scheduling.get(SCHEDULING_START_KEY))
+        .atOffset(ZoneOffset.UTC)
+        .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) + ".000Z";
+      startDateJson.put("value", startDate);
+      fields.add(startDateJson);
+
+      final JSONObject durationJson = new JSONObject();
+      durationJson.put("id", "duration");
+      final Instant start = Instant.parse((String) scheduling.get(SCHEDULING_START_KEY));
+      final Instant end = Instant.parse((String) scheduling.get(SCHEDULING_END_KEY));
+      final InternalDuration duration = InternalDuration.of(start, end);
+      durationJson.put("value", duration.toString());
+      fields.add(durationJson);
+    }
+
+    final JSONObject result = new JSONObject();
+    result.put("flavor", MediaPackageElements.EPISODE.toString());
+    result.put("title", CommonEventCatalogUIAdapter.EPISODE_TITLE);
+    result.put("fields", fields);
+    return result;
+  }
+
+  /**
+   * Merges all fields of the given meta data json objects into one object.
+   *
+   * @param first The first meta data json object.
+   * @param second The second meta data json object.
+   * @return A new json meta data object, containing the field of both input objects.
+   */
+  @SuppressWarnings("unchecked")
+  public static JSONObject mergeMetadataFields(final JSONObject first, final JSONObject second) {
+    if (first == null) {
+      return second;
+    }
+    if (second == null) {
+      return first;
+    }
+    final JSONObject result = deepCopy(first);
+    final Collection fields = (Collection) result.get("fields");
+    fields.addAll((Collection) second.get("fields"));
+    return result;
+  }
+
+  private static JSONObject deepCopy(final JSONObject o) {
+    try {
+      return (JSONObject) parser.parse(o.toJSONString());
+    } catch (ParseException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  private static class InternalDuration {
+    private long hours;
+    private long minutes;
+    private long seconds;
+
+    InternalDuration() {
+    }
+
+    InternalDuration(final InternalDuration other) {
+      this.hours = other.hours;
+      this.minutes = other.minutes;
+      this.seconds = other.seconds;
+    }
+
+    public static InternalDuration of(final Instant start, final Instant end) {
+      final InternalDuration result = new InternalDuration();
+      final Duration duration = Duration.between(start, end);
+      result.hours = duration.toHours();
+      result.minutes = duration.minusHours(result.hours).toMinutes();
+      result.seconds = duration.minusHours(result.hours).minusMinutes(result.minutes).getSeconds();
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+    }
+  }
+
+  private static ZonedDateTime adjustedSchedulingDate(
+    final JSONObject scheduling,
+    final String dateKey,
+    final ZonedDateTime date,
+    final ZoneId timezone) {
+    final JSONObject time = (JSONObject) scheduling.get(dateKey);
+    ZonedDateTime result = date.withZoneSameInstant(timezone);
+    if (time.containsKey("hour")) {
+      final int hour = Math.toIntExact((Long) time.get("hour"));
+      result = result.withHour(hour);
+    }
+    if (time.containsKey("minute")) {
+      final int minute = Math.toIntExact((Long) time.get("minute"));
+      result = result.withMinute(minute);
+    }
+    return result.withZoneSameInstant(ZoneOffset.UTC);
+  }
+
+  /**
+   * Model class for the bulk update instructions which are sent by the UI.
+   */
+  public static class BulkUpdateInstructions {
+    private static final String KEY_EVENTS = "events";
+    private static final String KEY_METADATA = "metadata";
+    private static final String KEY_SCHEDULING = "scheduling";
+
+    private final List<String> eventIds;
+    private final JSONObject metadata;
+    private final JSONObject scheduling;
+
+    /**
+     * Create a new instance by parsing the given json String.
+     *
+     * @param json The json serialized version of the bulk update instructions sent by the UI.
+     *
+     * @throws IllegalArgumentException If the json string cannot be parsed.
+     */
+    @SuppressWarnings("unchecked")
+    public BulkUpdateInstructions(final String json) throws IllegalArgumentException {
+      try {
+        final JSONObject jsonObject = (JSONObject) parser.parse(json);
+        eventIds = (JSONArray) jsonObject.get(KEY_EVENTS);
+        metadata = (JSONObject) jsonObject.get(KEY_METADATA);
+        scheduling = (JSONObject) jsonObject.get(KEY_SCHEDULING);
+      } catch (ParseException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+
+    /**
+     * Get the list of IDs of events to apply the bulk update to.
+     *
+     * @return The list of IDs of the events to apply the bulk update to.
+     */
+    public List<String> getEventIds() {
+      return eventIds;
+    }
+
+    /**
+     * Get the meta data update to apply.
+     *
+     * @return The meta data update to apply.
+     */
+    public JSONObject getMetadata() {
+      return metadata;
+    }
+
+    /**
+     *  Get the scheduling information update to apply.
+     *
+     * @return The scheduling information update to apply.
+     */
+    public JSONObject getScheduling() {
+      return scheduling;
+    }
+  }
+
+}

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
@@ -140,6 +140,7 @@
       "EMAIL_SENT": "Die Nachricht wurde gesendet",
       "EMAIL_NOT_SENT": "Die Nachricht konnte nicht gesendet werden",
       "CONFLICT_DETECTED": "Planungskonflikt: Die neue Aufzeichnung überlappt zeitlich mit einer bereits bestehenden Aufzeichnung. Bitte Ort, Datum oder Zeit anpassen.",
+      "CONFLICT_BULK_DETECTED":   "Planungskonflikt: Die Änderungen führen zu Konflikten. Bitte Ort, Datum oder Zeit anpassen.",
       "CONFLICT_ALREADY_ENDED": "Planungskonflikt: Aufzeichnungen können nicht in der Vergangenheit geplant werden.",
       "CONFLICT_END_BEFORE_START": "Planungskonflikt: Der Endzeitpunkt der Aufzeichnung muss nach dem Anfangszeitpunkt liegen.",
       "INVALID_ACL_RULES": "Regeln müssen eine gültige Rolle und Lese-/Schreibrechte enthalten.",
@@ -231,6 +232,29 @@
             "CONFIGURATION": "Konfiguration",
             "WORKFLOW": "Task"
          }
+      },
+      "EDIT_EVENTS": {
+          "CAPTION": "Geplante Aufzeichnungen bearbeiten",
+          "GENERAL": {
+              "CAPTION": "Allgemein",
+              "CANNOTSTART": "Markierte Aufzeichnungen können nicht verarbeitet werden, nur geplante Aufzeichnungen werden unterstützt.",
+              "NOCHANGES": "Es wurden keine Änderungen an den Aufzeichnungen festgestellt!"
+          },
+          "METADATA": {
+              "EDIT": "Metadaten bearbeiten"
+          },
+          "SUMMARY": {
+              "CAPTION": "Zusammenfassung",
+              "SINGLE_EVENT_CAPTION": "Aufzeichnung “{{ title }}”",
+              "TYPE": "Typ",
+              "PREVIOUS": "Alter Wert",
+              "NEXT": "Neuer Wert"
+          },
+          "EDIT": {
+              "CAPTION": "Bearbeiten",
+              "METADATA": "Metadaten",
+              "SCHEDULING": "Planung"
+          }
       }
    },
    "DATES": {
@@ -447,6 +471,7 @@
             "SERIES": "Serien",
             "DATE": "Datum",
             "START": "Beginn",
+            "END": "Ende",
             "STOP": "Ende",
             "STATUS": "Status",
             "LOCATION": "Raum",
@@ -460,7 +485,8 @@
             "REVIEW_STATUS": "Prüfstatus",
             "PREVIOUS": "Zurück",
             "NOCONTENT": "Keine Daten verfügbar",
-            "PUBLISHED": "Veröffentlicht"
+            "PUBLISHED": "Veröffentlicht",
+            "WEEKDAY": "Wochentag"
          },
          "SCHEDULING_STATUS": {
             "READY_FOR_RECORDING": "Bereit für die Aufnahme",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -146,6 +146,7 @@
      "EMAIL_SENT": "The message has been sent",
      "EMAIL_NOT_SENT": "The message could not be sent",
      "CONFLICT_DETECTED":   "Scheduling conflict: this new event overlaps with an existing event. Please change the location, dates or times.",
+     "CONFLICT_BULK_DETECTED":   "Scheduling conflict: changing the events results in conflicts. Please change the location, dates or times.",
      "CONFLICT_ALREADY_ENDED":   "Scheduling error: The event has already ended.",
      "CONFLICT_END_BEFORE_START":   "Scheduling error: Schedule end has to be later than the start.",
      "INVALID_ACL_RULES":   "Rules have to contain a valid role and read or/and write right(s).",
@@ -237,6 +238,29 @@
              "EVENTS_SUMMARY": "You have selected {{numberOfEvents}} events",
              "CONFIGURATION": "Configuration",
              "WORKFLOW": "Task"
+          }
+      },
+      "EDIT_EVENTS": {
+          "CAPTION": "Edit scheduled events",
+          "GENERAL": {
+              "CAPTION": "General",
+              "CANNOTSTART": "Highlighted event(s) cannot be processed, only scheduled events are supported.",
+              "NOCHANGES": "No changes to the events detected!"
+          },
+          "METADATA": {
+              "EDIT": "Edit metadata"
+          },
+          "SUMMARY": {
+              "CAPTION": "Summary",
+              "SINGLE_EVENT_CAPTION": "Event “{{ title }}”",
+              "TYPE": "Type",
+              "PREVIOUS": "Old value",
+              "NEXT": "New value"
+          },
+          "EDIT": {
+              "CAPTION": "Edit",
+              "METADATA": "Metadata",
+              "SCHEDULING": "Scheduling"
           }
       }
    },
@@ -455,6 +479,7 @@
          "SERIES":   "Series",
          "DATE":     "Date",
          "START":    "Start",
+         "END":      "End",
          "STOP":     "Stop",
          "STATUS":   "Status",
          "LOCATION": "Location",
@@ -469,6 +494,7 @@
          "PREVIOUS": "Previous",
          "NOCONTENT": "No data available",
          "PUBLISHED": "Published",
+         "WEEKDAY": "Weekday",
          "TOOLTIP": {
            "START": "Filter for this start date",
            "SERIES": "Filter for this series",

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -194,6 +194,7 @@
         <script src="scripts/shared/resources/eventPublicationDetailsResource.js"></script>
         <script src="scripts/shared/resources/eventPublicationsResource.js"></script>
         <script src="scripts/shared/resources/eventSchedulingResource.js"></script>
+        <script src="scripts/shared/resources/eventsSchedulingResource.js"></script>
         <script src="scripts/shared/resources/eventWorkflowsResource.js"></script>
         <script src="scripts/shared/resources/eventTransactionResource.js"></script>
         <script src="scripts/shared/resources/eventErrorsResource.js"></script>
@@ -208,6 +209,7 @@
         <script src="scripts/shared/resources/eventAccessResource.js"></script>
         <script src="scripts/shared/resources/eventGeneralResource.js"></script>
         <script src="scripts/shared/resources/eventHasSnapshotsResource.js"></script>
+        <script src="scripts/shared/resources/eventBulkEditResource.js"></script>
         <script src="scripts/shared/resources/toolsResource.js"></script>
         <script src="scripts/shared/resources/commentResource.js"></script>
         <script src="scripts/shared/resources/usersResource.js"></script>
@@ -332,6 +334,7 @@
         <script src="scripts/modules/events/controllers/eventsController.js"></script>
         <script src="scripts/modules/events/controllers/eventController.js"></script>
         <script src="scripts/modules/events/controllers/editStatusController.js"></script>
+        <script src="scripts/modules/events/controllers/editEventsController.js"></script>
         <script src="scripts/modules/events/controllers/newEventController.js"></script>
         <script src="scripts/modules/events/controllers/newSeriesController.js"></script>
         <script src="scripts/modules/events/controllers/seriesController.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -1,0 +1,507 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+// Controller for the "edit scheduled events" wizard
+angular.module('adminNg.controllers')
+    .controller('EditEventsCtrl', ['$scope', 'Table', 'Notifications', 'EventBulkEditResource', 'SeriesResource', 'CaptureAgentsResource', 'EventsSchedulingResource', 'JsHelper', 'SchedulingHelperService', 'WizardHandler', 'Language', '$translate', 'decorateWithTableRowSelection',
+function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, CaptureAgentsResource, EventsSchedulingResource, JsHelper, SchedulingHelperService, WizardHandler, Language, $translate, decorateWithTableRowSelection) {
+    var me = this;
+    var SCHEDULING_CONTEXT = 'event-scheduling';
+
+    // Conflict checking should only be done and be enabled once we
+    // get to the second wizard stage.
+    // However, since we're checking conflicts "on change" for the
+    // input fields in the form, we are inadvertantly checking them
+    // once the list of capture agent arrives as well (since that
+    // apparently constitutes a "change"). This happens way earlier
+    // than the second wizard step, so we protect against early checks
+    // here.
+    $scope.conflictCheckingEnabled = false;
+    $scope.rows = Table.copySelected();
+    $scope.conflicts = [];
+    $scope.eventSummaries = [];
+    // by default, all rows are selected
+    $scope.allSelected = true;
+    $scope.test = false;
+    $scope.currentForm = 'generalForm';
+    /* Get the current client timezone */
+    var tzOffset = (new Date()).getTimezoneOffset() / -60;
+    $scope.tz = 'UTC' + (tzOffset < 0 ? '-' : '+') + tzOffset;
+
+    // Get available series
+    $scope.seriesResults = {};
+    SeriesResource.query().$promise.then(function(results) {
+        angular.forEach(results.rows, function(row) {
+            $scope.seriesResults[row.title] = row.id;
+        });
+    });
+
+    // Given a series id, get me the title (we need this for the summary prettification)
+    var seriesTitleForId = function(id) {
+        var result = null;
+        angular.forEach($scope.seriesResults, function(value, key) {
+            if (value === id) {
+                result = key;
+            }
+        });
+        return result;
+    };
+
+    // Get available capture agents
+    $scope.captureAgents = [];
+    CaptureAgentsResource.query({inputs: true}).$promise.then(function (data) {
+        $scope.captureAgents = data.rows;
+    });
+
+    // Given a capture agent id, get me the whole capture agent from the list
+    var getCaById = function(agentId) {
+        if (agentId === null) {
+            return null;
+        }
+        for (var i = 0; i < $scope.captureAgents.length; i++) {
+            if ($scope.captureAgents[i].id === agentId) {
+                return $scope.captureAgents[i];
+            }
+        }
+        return null;
+    };
+
+    // Given an event id, get me the row
+    var getRowForId = function(eventId) {
+        for (var i = 0; i < $scope.rows.length; i++) {
+            var row = $scope.rows[i];
+            if (row.id === eventId) {
+                return row;
+            }
+        }
+        return null;
+    };
+
+    // Given an event id, get me the title
+    var eventTitleForId = function(id) {
+        return getRowForId(id).title;
+    };
+
+    // Iterate over all (selected) events (via the rows) and get the
+    // specific metadata element. Returns the empty string if the
+    // value is ambiguous between the rows.
+    var getMetadataPart = function(getter) {
+        var result = null;
+        for (var i = 0; i < $scope.rows.length; i++) {
+            var row = $scope.rows[i];
+            if (!row.selected) {
+                continue;
+            }
+            var val = getter(row);
+            if (!angular.isDefined(val)) {
+                val = null;
+            }
+            if (result === null) {
+                result = val;
+            } else if (result !== val) {
+                return "";
+            }
+        }
+        if (result === null) {
+            return "";
+        } else {
+            return result;
+        }
+    };
+
+    // Return if the event with the given ID is selected
+    var isSelected = function(id) {
+        return JsHelper.arrayContains($scope.getSelectedIds(), id);
+    };
+
+    // see "getMetadataPart", but this one is for scheduling information
+    var getSchedulingPart = function(getter) {
+        var result = { ambiguous: false, value: null };
+        angular.forEach($scope.schedulingSingle, function(value) {
+            if (!isSelected(value.eventId)) {
+                return;
+            }
+            var val = getter(value);
+            if (result.ambiguous === false) {
+                if (result.value === null) {
+                    result.value = val;
+                } else if (result.value !== val) {
+                    result.ambiguous = true;
+                    result.value = null;
+                }
+            }
+        });
+        if (result.ambiguous === true) {
+            return null;
+        } else {
+            return result.value;
+        }
+    };
+
+    // Convert a Javascript, sunday-based weekday to the corresponding
+    // OC weekday object
+    var fromJsWeekday = function(d) {
+        // Javascript week days start at sunday (so 0=SU), so we have to roll over.
+        return JsHelper.getWeekDays()[(d + 6) % 7];
+    };
+
+    $scope.hours = JsHelper.initArray(24);
+    $scope.minutes = JsHelper.initArray(60);
+    $scope.weekdays = JsHelper.getWeekDays();
+
+    // Get scheduling information for the events
+    $scope.scheduling = {};
+    $scope.schedulingSingle = EventsSchedulingResource.bulkGet({
+            eventIds: JsHelper.mapFunction($scope.rows, function(v) { return v.id; }),
+            ignoreNonScheduled: true
+        });
+
+    $scope.onTemporalValueChange = function(type) {
+        SchedulingHelperService.applyTemporalValueChange($scope.scheduling, type, false);
+    };
+
+    this.clearConflicts = function () {
+        $scope.conflicts = [];
+        if (me.notificationConflict) {
+            Notifications.remove(me.notificationConflict, SCHEDULING_CONTEXT);
+            me.notificationConflict = undefined;
+        }
+    };
+
+    this.conflictsDetected = function (response) {
+        me.clearConflicts();
+        if (response.status === 409) {
+            me.notificationConflict = Notifications.add('error', 'CONFLICT_BULK_DETECTED', SCHEDULING_CONTEXT);
+            angular.forEach(response.data, function (data) {
+                angular.forEach(data.conflicts, function(conflict) {
+                    $scope.conflicts.push({
+                        eventId: eventTitleForId(data.eventId),
+                        title: conflict.title,
+                        start: Language.formatDateTime('medium', conflict.start),
+                        end: Language.formatDateTime('medium', conflict.end)
+                    });
+                });
+            });
+        }
+        $scope.checkingConflicts = false;
+    };
+
+    this.noConflictsDetected = function () {
+        me.clearConflicts();
+        $scope.checkingConflicts = false;
+    };
+
+    // What we send to the server is slightly different than what we
+    // internally use for the forms. This function returns the
+    // "cleaned up" result.
+    var postprocessScheduling = function() {
+        var scheduling = $.extend(true, {}, $scope.scheduling);
+        JsHelper.removeNulls(scheduling);
+        JsHelper.removeNulls(scheduling.start);
+        JsHelper.removeNulls(scheduling.end);
+        if ($.isEmptyObject(scheduling.start)) {
+            delete scheduling.start;
+        }
+        if ($.isEmptyObject(scheduling.end)) {
+            delete scheduling.end;
+        }
+        if (angular.isDefined(scheduling.location)) {
+            scheduling.agentId = scheduling.location.id;
+            delete scheduling.location;
+        }
+        delete scheduling.duration;
+        return scheduling;
+    };
+
+    $scope.checkConflicts = function () {
+        if ($scope.conflictCheckingEnabled === false) {
+            return;
+        }
+        return new Promise(function(resolve, reject) {
+            $scope.checkingConflicts = true;
+            var payload = {
+                events: $scope.getSelectedIds(),
+                scheduling: postprocessScheduling()
+            };
+            EventBulkEditResource.conflicts(payload, me.noConflictsDetected, me.conflictsDetected)
+                .$promise.then(function() {
+                    resolve();
+                })
+                .catch(function(err) {
+                    reject();
+                });
+        });
+    };
+
+    $scope.checkingConflicts = false;
+
+    var nextWizardStep = function() {
+        WizardHandler.wizard("editEventsWz").next();
+    };
+
+    var getterForMetadata = function(metadataId) {
+        switch (metadataId) {
+        case 'title':
+            return function(row) { return row.title; };
+        case 'isPartOf':
+            return function(row) { return row.series_id; };
+        default:
+            console.log('There is no getter for metadata item "'+metadataId+'"');
+        }
+    };
+
+    var prettifyMetadata = function(metadataId, value) {
+        if (value === null) {
+            return value;
+        } else if (metadataId === 'isPartOf') {
+            return seriesTitleForId(value);
+        } else {
+            return value;
+        }
+    };
+
+
+    // This is triggered after the user selected some events in the first wizard step
+    $scope.clearFormAndContinue = function() {
+        $scope.conflictCheckingEnabled = true;
+        $scope.metadataRows = [
+            {
+                id: "title",
+                label: "EVENTS.EVENTS.DETAILS.METADATA.TITLE",
+                readOnly: false,
+                required: true,
+                type: "text",
+                value: getMetadataPart(getterForMetadata('title'))
+            },
+            {
+                id: "isPartOf",
+                collection: $scope.seriesResults,
+                label: "EVENTS.EVENTS.DETAILS.METADATA.SERIES",
+                readOnly: false,
+                required: false,
+                translatable: false,
+                type: "text",
+                value: getMetadataPart(getterForMetadata('isPartOf'))
+            },
+        ];
+        $scope.scheduling = {
+            timezone: JsHelper.getTimeZoneName(),
+            location: getCaById(getMetadataPart(function(row) { return row.agent_id; })),
+            start: {
+                hour: getSchedulingPart(function(entry) { return entry.start.hour; }),
+                minute: getSchedulingPart(function(entry) { return entry.start.minute; })
+            },
+            end: {
+                hour: getSchedulingPart(function(entry) { return entry.end.hour; }),
+                minute: getSchedulingPart(function(entry) { return entry.end.minute; })
+            },
+            duration: {
+                hour: getSchedulingPart(function(entry) { return entry.duration.hour; }),
+                minute: getSchedulingPart(function(entry) { return entry.duration.minute; })
+            },
+            weekday: getSchedulingPart(function(entry) { return fromJsWeekday(new Date(entry.start.date).getDay()).key; })
+        };
+        nextWizardStep();
+    };
+
+    $scope.metadataRows = [];
+
+    $scope.saveField = function(arg, callback) {
+        // Nothing to do here yet, but the "save" attribute is non-optional.
+    };
+
+    $scope.valid = function () {
+        return $scope.getSelectedIds().length > 0;
+    };
+
+    $scope.nonSchedule = function(row) {
+        return row.source !== 'SCHEDULE';
+    };
+
+    $scope.nonScheduleSelected = function() {
+        return JsHelper.filter($scope.getSelected(),function (r) { return r.source !== 'SCHEDULE'; }).length > 0;
+    };
+
+    $scope.rowsValid = function() {
+        return !$scope.nonScheduleSelected() && $scope.hasAnySelected();
+    };
+
+    $scope.generateEventSummariesAndContinue = function() {
+        $scope.eventSummaries = [];
+        angular.forEach($scope.schedulingSingle, function(value) {
+            if (!isSelected(value.eventId)) {
+                return;
+            }
+
+            var changes = [];
+
+            if ($scope.scheduling.location !== null && $scope.scheduling.location.id !== null && $scope.scheduling.location.id !== value.agentId) {
+                changes.push({
+                    type: 'EVENTS.EVENTS.TABLE.LOCATION',
+                    previous: value.agentId,
+                    next: $scope.scheduling.location.id
+                });
+            }
+
+            var valueWeekDay = fromJsWeekday(new Date(value.start.date).getDay());
+            if ($scope.scheduling.weekday !== null && valueWeekDay.key !== $scope.scheduling.weekday) {
+                changes.push({
+                    type: 'EVENTS.EVENTS.TABLE.WEEKDAY',
+                    // Might be better to actually use the promise rather than using instant,
+                    // but it's difficult with the two-way binding here.
+                    previous: $translate.instant(valueWeekDay.translation),
+                    next: $translate.instant(JsHelper.weekdayTranslation($scope.scheduling.weekday))
+                });
+            }
+
+            var row = getRowForId(value.eventId);
+            angular.forEach($scope.metadataRows, function(metadata) {
+                var rowValue = getterForMetadata(metadata.id)(row);
+                if (!angular.isDefined(rowValue)) {
+                    rowValue = "";
+                }
+                // This is an very subtle hack to circumvent MH-12876,
+                // so I'll have to explain: Normally, we could just
+                // test if "metadata.value" is equal to "rowValue",
+                // and if so, there's no difference for that field.
+                // Done...
+                //
+                // ...However, there are drop-downs. "Series" is a
+                // drop-down, for example. And an event might have no
+                // series assigned to it, so the drop-down is
+                // "unselected". Now, when the form with the
+                // unselected series drop-down (i.e. its value set to
+                // the empty string) is constructed, it automatically
+                // resets its value to the first series available. And
+                // here's the hack: This first "mis-assignment"
+                // doesn't set the value to the series ID. Instead, it
+                // assigns itself a whole object, with label and
+                // id. This we can test and then assume the value is
+                // just "null". If you then change the drop-down,
+                // we'll get a string and not an object.
+                // Phew...
+                // Better leave this as a separate "if" as a reminder
+                // and for easy removal later.
+                if (typeof metadata.value === 'object') {
+                    return;
+                }
+                if (metadata.value !== "" && metadata.value !== rowValue) {
+                    var prettyRow = prettifyMetadata(metadata.id, rowValue);
+                    var prettyMeta = prettifyMetadata(metadata.id, metadata.value);
+                    changes.push({
+                        type: metadata.label,
+                        previous: prettyRow,
+                        next: prettyMeta
+                    });
+                }
+            });
+
+            var formatTimeHourMinute = function (date, hour, minute) {
+                // This somewhat deliberately ignores the time zone,
+                // since it's only for display.
+                var jsDate = new Date(
+                    parseInt(date.substring(0, 4)),
+                    parseInt(date.substring(5,7))-1,
+                    parseInt(date.substring(8,10)),
+                    hour,
+                    minute);
+                return Language.formatTime('short', jsDate.toISOString());
+            };
+
+            // Little helper function so we can treat "start" and "end" the same.
+            var formatPart = function(schedObj, valObj, translation) {
+                if (schedObj.hour !== null && schedObj.hour !== valObj.hour || schedObj.minute !== null && schedObj.minute !== valObj.minute) {
+                    var oldTime = formatTimeHourMinute(valObj.date, valObj.hour, valObj.minute);
+                    var newHour = valObj.hour;
+                    if (schedObj.hour !== null && schedObj.hour !== valObj.hour) {
+                        newHour = schedObj.hour;
+                    }
+                    var newMinute = valObj.minute;
+                    if (schedObj.minute !== null && schedObj.minute !== valObj.minute) {
+                        newMinute = schedObj.minute;
+                    }
+                    var newTime = formatTimeHourMinute(valObj.date, newHour, newMinute);
+                    changes.push({
+                        type: 'EVENTS.EVENTS.TABLE.'+translation,
+                        previous: oldTime,
+                        next: newTime
+                    });
+                }
+            };
+
+            formatPart($scope.scheduling.start, value.start, 'START');
+            formatPart($scope.scheduling.end, value.end, 'END');
+
+            if (changes.length > 0) {
+                $scope.eventSummaries.push({
+                    title: row.title,
+                    changes: changes
+                });
+            }
+        });
+        nextWizardStep();
+    };
+
+    $scope.noChanges = function() {
+        return $scope.eventSummaries.length === 0;
+    };
+
+    $scope.hasConflicts = function() {
+        return $scope.conflicts.length > 0;
+    };
+
+    var onSuccess = function () {
+        $scope.submitButton = false;
+        $scope.close();
+        Notifications.add('success', 'EVENTS_UPDATED_ALL');
+        Table.deselectAll();
+    };
+
+    var onFailure = function () {
+        $scope.submitButton = false;
+        $scope.close();
+        Notifications.add('error', 'EVENTS_NOT_UPDATED', 'global', -1);
+    };
+
+    $scope.submitButton = false;
+    $scope.submit = function () {
+        $scope.submitButton = true;
+        var payload = {
+            metadata: {
+                flavor: "dublincore/episode",
+                title: "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
+                fields: JsHelper.filter(
+                    $scope.metadataRows,
+                    function(row) {
+                        // Search for "hack" in this file for an explanation of this typeof magic.
+                        return angular.isDefined(row.value) && row.value !== null && typeof row.value !== 'object' && row.value !== '';
+                    })
+            },
+            scheduling: postprocessScheduling(),
+            events: $scope.getSelectedIds()
+        };
+        if ($scope.valid()) {
+            EventBulkEditResource.update(payload, onSuccess, onFailure);
+        }
+    };
+    decorateWithTableRowSelection($scope);
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -471,7 +471,7 @@ angular.module('adminNg.controllers')
           $scope.conflicts = [];
           if (me.notificationConflict) {
               Notifications.remove(me.notificationConflict, SCHEDULING_CONTEXT);
-              me.notifictationConflict = undefined;
+              me.notificationConflict = undefined;
           }
         }
 

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/index.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/index.html
@@ -35,6 +35,11 @@
                             {{ 'BULK_ACTIONS.SCHEDULE_TASK.CAPTION' | translate}}
                         </a>
                     </li>
+                    <li ng-if="table.resource == 'events' && $root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT') && $root.userIs('ROLE_UI_EVENTS_DETAILS_METADATA_EDIT')">
+                        <a data-open-modal="edit-events-modal">
+                            {{ 'BULK_ACTIONS.EDIT_EVENTS.CAPTION' | translate}}
+                        </a>
+                    </li>
                 </ul>
             </div>
             <div data-admin-ng-table-filter="" data-filters="filters" data-namespace="table.resource"></div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
@@ -26,10 +26,10 @@
                                         <th class="full-width" translate="EVENTS.EVENTS.TABLE.TITLE">
                                             <!-- Title -->
                                         </th>
-                                        <th class="full-width" translate="EVENTS.EVENTS.TABLE.SERIES">
+                                        <th class="nowrap" translate="EVENTS.EVENTS.TABLE.SERIES">
                                             <!-- Series -->
                                         </th>
-                                        <th class="full-width" translate="EVENTS.EVENTS.TABLE.WORKFLOW_STATE">
+                                        <th class="nowrap" translate="EVENTS.EVENTS.TABLE.STATUS">
                                             <!-- Progress -->
                                         </th>
                                     </tr>
@@ -38,8 +38,8 @@
                                     <tr ng-repeat="row in rows" ng-form="rowsForm" ng-class="{error: nonSchedule(row)}">
                                         <td><input name="selection" ng-required="!hasAnySelected()" type="checkbox" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
                                         <td>{{ row.title }}</td>
-                                        <td>{{ row.series_name}}</td>
-                                        <td>{{ row.source }}</td>
+                                        <td class="nowrap">{{ row.series_name}}</td>
+                                        <td class="nowrap">{{ row.event_status }}</td>
                                     </tr>
                                     </tbody>
                                 </table>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
@@ -1,0 +1,278 @@
+<section ng-form="editEventsForm" ng-show="open" ng-keyup="keyUp($event)" tabindex="1" class="modal wizard modal-animation ng-hide" ng-controller="EditEventsCtrl">
+    <header>
+        <a class="fa fa-times close-modal" ng-click="close()"></a>
+        <h2 translate="BULK_ACTIONS.EDIT_EVENTS.CAPTION"><!-- Template --></h2>
+    </header>
+    <wizard edit-mode="false" name="editEventsWz" on-finish="submit()" template="shared/partials/wizardNav.html">
+        <wz-step wz-title="General" canexit="editEventsForm.generalForm.$valid" wz-disabled="!editEventsForm.generalForm.$valid" ng-form="generalForm" novalidate>
+            <!-- First Step: General -->
+            <div class="modal-content active">
+                <div class="modal-body">
+                    <div class="row">
+                        <div ng-show="nonScheduleSelected()" class="alert sticky warning">
+                            <p translate="BULK_ACTIONS.EDIT_EVENTS.GENERAL.CANNOTSTART">
+                                <!-- Cannot start -->
+                            </p>
+                        </div>
+                    </div>
+                    <div class="full-col">
+                        <div class="obj tbl-list">
+                            <header translate="BULK_ACTIONS.EDIT_EVENTS.GENERAL.CAPTION" />
+                            <div class="obj-container">
+                                <table class="main-tbl">
+                                    <thead>
+                                    <tr>
+                                        <th class="small"><input type="checkbox" ng-model="allSelected" ng-change="allSelectedChanged(allSelected)" class="select-all-cbox"></th>
+                                        <th class="full-width" translate="EVENTS.EVENTS.TABLE.TITLE">
+                                            <!-- Title -->
+                                        </th>
+                                        <th class="full-width" translate="EVENTS.EVENTS.TABLE.SERIES">
+                                            <!-- Series -->
+                                        </th>
+                                        <th class="full-width" translate="EVENTS.EVENTS.TABLE.WORKFLOW_STATE">
+                                            <!-- Progress -->
+                                        </th>
+                                    </tr>
+                                    </thead>
+                                    <tbody >
+                                    <tr ng-repeat="row in rows" ng-form="rowsForm" ng-class="{error: nonSchedule(row)}">
+                                        <td><input name="selection" ng-required="!hasAnySelected()" type="checkbox" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
+                                        <td>{{ row.title }}</td>
+                                        <td>{{ row.series_name}}</td>
+                                        <td>{{ row.source }}</td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                            </div><!-- obj-container -->
+
+                        </div><!-- obj -->
+
+                    </div>
+
+                </div>
+
+            </div><!-- modal-content [general] -->
+
+            <footer>
+                <a class="submit"
+                   ng-click="clearFormAndContinue()"
+                   ng-class="{active: rowsValid(), disabled: !rowsValid()}">
+                    {{ 'WIZARD.NEXT_STEP' | translate }}
+                </a>
+            </footer>
+        </wz-step>
+
+        <!-- Second Step: The actual Editing -->
+        <wz-step wz-title="{{ 'BULK_ACTIONS.EDIT_EVENTS.EDIT.CAPTION' | translate }}" ng-form="editEventsForm" novalidate canenter="rowsValid()" canexit="editEventsForm.$valid">
+            <div class="modal-content active">
+
+                <div class="modal-body">
+                    <div class="full-col">
+                      <div data-admin-ng-notifications="" context="event-scheduling"></div>
+                      <div class="obj list-obj" ng-show="conflicts.length > 0">
+                        <table class="main-tbl scheduling-conflict">
+                          <tr ng-repeat="conflict in conflicts">
+                            <td>{{ conflict.eventId }}</td>
+                            <td>{{ conflict.title }}</td>
+                            <td>{{ conflict.start }}</td>
+                            <td>{{ conflict.end }}</td>
+                          </tr>
+                        </table>
+                      </div>
+
+                        <div class="obj tbl-details">
+                            <header translate="BULK_ACTIONS.EDIT_EVENTS.EDIT.METADATA"><!-- Edit Metadata --></header>
+                            <div class="obj-container">
+
+                              <table class="main-tbl">
+                                <tr ng-repeat="row in metadataRows">
+                                  <td>
+                                    <span translate="{{ row.label }}"></span>
+                                    <i ng-show="row.required" class="required">*</i>
+                                  </td>
+                                  <td admin-ng-editable
+                                      required-role="ROLE_UI_EVENTS_DETAILS_METADATA_EDIT"
+                                      params="row"
+                                      save="saveField">
+                                  </td>
+                                </tr>
+                              </table>
+
+                            </div><!-- obj-container -->
+
+                        </div><!--list-obj -->
+
+                        <div class="obj tbl-details">
+                            <header translate="BULK_ACTIONS.EDIT_EVENTS.EDIT.SCHEDULING"><!-- Edit scheduling --></header>
+                            <div class="obj-container">
+
+                              <table class="main-tbl">
+                                <tr>
+                                  <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.TIMEZONE' | translate }}</td>
+                                  <td>{{ tz }}</td>
+                                </tr>
+                                <tr>
+                                  <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.START_TIME' | translate }}</td>
+                                  <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                    <select chosen
+                                            ng-disabled="checkingConflicts"
+                                            data-width="'100px'"
+                                            data-disable-search-threshold="8"
+                                            ng-model="scheduling.start.hour"
+                                            ng-change="onTemporalValueChange('start'); checkConflicts();"
+                                            data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}"
+                                            ng-options="h.index as h.value for h in hours"
+                                            />
+                                    <select chosen
+                                            ng-disabled="checkingConflicts"
+                                            data-width="'100px'"
+                                            data-disable-search-threshold="8"
+                                            ng-model="scheduling.start.minute"
+                                            ng-change="onTemporalValueChange('start'); checkConflicts();"
+                                            data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
+                                            ng-options="m.index as m.value for m in minutes"
+                                            />
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.END_TIME' | translate }}</td>
+                                  <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                    <select chosen
+                                            ng-disabled="checkingConflicts"
+                                            data-width="'100px'"
+                                            data-disable-search-threshold="8"
+                                            ng-model="scheduling.end.hour"
+                                            ng-change="onTemporalValueChange('end'); checkConflicts();"
+                                            data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}"
+                                            ng-options="h.index as h.value for h in hours"
+                                            />
+                                    <select chosen
+                                            ng-disabled="checkingConflicts"
+                                            data-width="'100px'"
+                                            data-disable-search-threshold="8"
+                                            ng-model="scheduling.end.minute"
+                                            ng-change="onTemporalValueChange('end'); checkConflicts();"
+                                            data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}"
+                                            ng-options="m.index as m.value for m in minutes"
+                                            />
+                                    <span ng-bind="scheduling.end.date"
+                                          ng-show="scheduling.end.date !== scheduling.start.date"
+                                          />
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}</td>
+                                  <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                    <select chosen pre-select-from="captureAgents"
+                                            ng-disabled="checkingConflicts"
+                                            data-width="'200px'"
+                                            ng-change="roomChanged(); checkConflicts()"
+                                            data-disable-search-threshold="8"
+                                            ng-model="scheduling.location"
+                                            ng-options="value.name for (id, value) in captureAgents"
+                                            data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}"
+                                            />
+                                  </td>
+                                  <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                                    {{ source.device.name }}
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.INPUTS' | translate }}</td>
+                                  <td>
+                                    <label ng-repeat="inputMethod in source.device.inputs">
+                                      <input type="checkbox"
+                                             ng-change="checkConflicts()"
+                                             ng-model="source.device.inputMethods[inputMethod.id]"
+                                             ng-disabled="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')"> {{ inputMethod.value | translate }}
+                                      <br>
+                                    </label>
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.SCHEDULE_MULTIPLE.WEEKDAYS' | translate }}</td>
+                                  <td class="weekdays">
+                                    <label ng-repeat="weekday in weekdays">
+                                      <input type="radio"
+                                             ng-change="checkConflicts()"
+                                             ng-model="scheduling.weekday"
+                                             name="weekdays"
+                                             value="{{weekday.key}}"
+                                             ng-disabled="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')"> {{ weekday.translation | translate }}
+                                    </label>
+                                  </td>
+                                </tr>
+                              </table>
+
+                            </div>
+
+                          </div><!-- obj-container -->
+
+                        </div><!--list-obj -->
+                    </div><!-- full-col-->
+                </div><!-- modal-body -->
+            </div><!-- modal-content [task] -->
+            <footer>
+                <a class="submit"
+                   ng-click="generateEventSummariesAndContinue()"
+                   ng-class="{active: !hasConflicts(), disabled: hasConflicts() || checkingConflicts}">
+                    {{ 'WIZARD.NEXT_STEP' | translate }}
+                </a>
+                <a wz-previous translate="WIZARD.BACK" class="cancel">
+                </a>
+            </footer>
+        </wz-step>
+
+        <!-- Third step: Summary -->
+        <wz-step wz-title="{{ 'BULK_ACTIONS.EDIT_EVENTS.SUMMARY.CAPTION' | translate }}" novalidate canenter="rowsValid() && !hasConflicts()">
+            <div class="modal-content active">
+                <div class="modal-body">
+                    <div class="row">
+                        <div ng-show="noChanges()" class="alert sticky warning">
+                            <p translate="BULK_ACTIONS.EDIT_EVENTS.GENERAL.NOCHANGES">
+                                <!-- No actual changes -->
+                            </p>
+                        </div>
+                    </div>
+                    <div class="full-col">
+                        <div class="obj tbl-list" ng-repeat="event in eventSummaries">
+                            <header translate="BULK_ACTIONS.EDIT_EVENTS.SUMMARY.SINGLE_EVENT_CAPTION" translate-values='{ title: event.title}'><!-- Summary --></header>
+                            <div class="obj-container">
+                                <table class="main-tbl">
+                                    <thead>
+                                    <tr>
+                                        <th class="fit" translate="BULK_ACTIONS.EDIT_EVENTS.SUMMARY.TYPE" />
+                                        <th class="fit" translate="BULK_ACTIONS.EDIT_EVENTS.SUMMARY.PREVIOUS" />
+                                        <th class="fit" translate="BULK_ACTIONS.EDIT_EVENTS.SUMMARY.NEXT" />
+                                    </tr>
+                                    </thead>
+                                    <tbody >
+                                    <tr ng-repeat="row in event.changes">
+                                        <td>{{ row.type | translate }}</td>
+                                        <td>{{ row.previous}}</td>
+                                        <td class="highlighted-cell">{{ row.next }}</td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div><!-- obj-container -->
+                        </div>
+                    </div>
+
+                </div>
+            </div><!-- modal-content [summary] -->
+            <footer>
+                <a wz-next class="submit"
+                   ng-class="{active: editEventsForm.$valid, disabled: noChanges() || submitButton}">
+                    {{ 'WIZARD.UPDATE' | translate }}
+                </a>
+                <a wz-previous translate="WIZARD.BACK" class="cancel">
+                </a>
+            </footer>
+        </wz-step>
+
+    </wizard>
+
+
+    <div class="btm-spacer"></div>
+</section>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
@@ -30,10 +30,10 @@
                                         <th class="full-width" translate="EVENTS.EVENTS.TABLE.TITLE">
                                             <!-- Title -->
                                         </th>
-                                        <th class="full-width" translate="EVENTS.EVENTS.TABLE.SERIES">
+                                        <th class="nowrap" translate="EVENTS.EVENTS.TABLE.SERIES">
                                             <!-- Series -->
                                         </th>
-                                        <th class="full-width" translate="EVENTS.EVENTS.TABLE.WORKFLOW_STATE">
+                                        <th class="nowrap" translate="EVENTS.EVENTS.TABLE.STATUS">
                                             <!-- Progress -->
                                         </th>
                                     </tr>
@@ -42,8 +42,8 @@
                                     <tr ng-repeat="row in rows" ng-form="rowsForm" ng-class="{error: rowsForm.selection.$error.taskStartable}">
                                         <td><input name="selection" ng-required="!hasAnySelected()" type="checkbox" task-startable="{{row.source}}" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
                                         <td>{{ row.title }}</td>
-                                        <td>{{ row.series_name}}</td>
-                                        <td>{{ row.source }}</td>
+                                        <td class="nowrap">{{ row.series_name}}</td>
+                                        <td class="nowrap">{{ row.event_status }}</td>
                                     </tr>
                                     </tbody>
                                 </table>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventBulkEditResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventBulkEditResource.js
@@ -1,0 +1,44 @@
+
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.resources')
+    .factory('EventBulkEditResource', ['$resource', '$httpParamSerializerJQLike', function ($resource, $httpParamSerializerJQLike) {
+    return $resource('/admin-ng/event/bulk/:ext', {}, {
+        update: {
+            method: 'PUT',
+            params: { ext: 'update' },
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            transformRequest: function (data) {
+                return $httpParamSerializerJQLike({update: JSON.stringify(data)});
+            },
+        },
+        conflicts: {
+            method: 'POST',
+            params: { ext: 'conflicts' },
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            transformRequest: function (data) {
+                return $httpParamSerializerJQLike({update: JSON.stringify(data)});
+            },
+        }
+    });
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsSchedulingResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsSchedulingResource.js
@@ -1,0 +1,68 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.resources')
+    .factory('EventsSchedulingResource', ['$resource', 'JsHelper', '$httpParamSerializer', function ($resource, JsHelper, $httpParamSerializer) {
+    var transformRequest = function (data) {
+        return $httpParamSerializer(data);
+    };
+    var transformSingle = function (parsedData) {
+        // Better deep-copy our response, testing frameworks use immutable structures.
+        var data = jQuery.extend(true, {}, parsedData);
+
+        var startDate = new Date(parsedData.start);
+        var endDate = new Date(parsedData.end);
+        var duration = (endDate - startDate) / 1000;
+        var durationHours = (duration - (duration % 3600)) / 3600;
+        var durationMinutes = (duration % 3600) / 60;
+
+
+        data.start = JsHelper.zuluTimeToDateObject(startDate);
+        data.end = JsHelper.zuluTimeToDateObject(endDate);
+        data.duration = {
+            hour: durationHours,
+            minute: durationMinutes
+        };
+
+        return data;
+    };
+    var transformResponse = function (parsedData) {
+        var result = [];
+        angular.forEach(parsedData, function(value) {
+            result.push(transformSingle(value));
+        });
+        return result;
+    };
+
+    return $resource('/admin-ng/event/scheduling.json', {}, {
+        bulkGet: {
+            method: 'POST',
+            responseType: 'json',
+            isArray: true,
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+            },
+            transformRequest: transformRequest,
+            transformResponse: transformResponse
+        }
+    });
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/jsHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/jsHelperService.js
@@ -25,9 +25,7 @@
 angular.module('adminNg.services')
 .factory('JsHelper', [
     function () {
-        return {
-            getWeekDays: function () {
-                return [
+        var weekdaysArray = [
                     { key: 'MO', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.MO' },
                     { key: 'TU', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.TU' },
                     { key: 'WE', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.WE' },
@@ -35,7 +33,60 @@ angular.module('adminNg.services')
                     { key: 'FR', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.FR' },
                     { key: 'SA', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.SA' },
                     { key: 'SU', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.SU' }
-                ];
+        ];
+        return {
+            getWeekDays: function () {
+                return weekdaysArray;
+            },
+
+            weekdayTranslation: function(d) {
+                for (var i = 0; i < weekdaysArray.length; i++) {
+                    if (weekdaysArray[i].key === d) {
+                        return weekdaysArray[i].translation;
+                    }
+                }
+                return null;
+            },
+
+            filter: function(array, callback) {
+                var result = [];
+                angular.forEach(array, function(v) {
+                    if (callback(v)) {
+                        result.push(v);
+                    }
+                });
+                return result;
+            },
+
+            removeNulls: function(obj) {
+                var propNames = Object.getOwnPropertyNames(obj);
+                for (var i = 0; i < propNames.length; i++) {
+                    var propName = propNames[i];
+                    if (obj[propName] === null || obj[propName] === undefined) {
+                        delete obj[propName];
+                    }
+                }
+            },
+
+            arrayContains: function(array, v) {
+                for(var i = 0; i < array.length; i++) {
+                    if (array[i] === v) {
+                        return true;
+                    }
+                }
+                return false;
+            },
+
+            getTimeZoneName: function() {
+                return Intl.DateTimeFormat().resolvedOptions().timeZone;
+            },
+
+            mapFunction: function(array, callback) {
+                var result = [];
+                angular.forEach(array, function(v) {
+                    result.push(callback(v));
+                });
+                return result;
             },
 
             map: function (array, key) {

--- a/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
@@ -196,6 +196,10 @@
         }
     }
 
+    td.highlighted-cell {
+        font-weight: bold;
+    }
+
     td {
         padding: $col-padding;
         color: $medium-prim-color;

--- a/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
@@ -284,6 +284,10 @@
             }
         }
 
+        &.nowrap {
+            white-space: nowrap;
+        }
+
         // For action row that only has one button
         &.single-btn > a {
             margin-left: 10px;

--- a/modules/admin-ui/src/main/webapp/styles/views/_views-config.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/_views-config.scss
@@ -37,3 +37,4 @@
 @import "modals/new-event-series";
 @import "modals/blacklist-modal";
 @import "modals/event-series";
+@import "modals/edit-events";

--- a/modules/admin-ui/src/main/webapp/styles/views/modals/_edit-events.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/modals/_edit-events.scss
@@ -1,0 +1,16 @@
+td.weekdays {
+    // Horizontal alignment
+    input[type="radio"], label {
+        display:inline-block;
+        vertical-align: middle;
+    }
+
+    input[type="radio"] {
+        margin-right:2px !important;
+        margin-top:0px !important;
+    }
+
+    label {
+        margin-right:5px;
+    }
+}

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -63,6 +63,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.WebApplicationException;
 
@@ -271,6 +272,26 @@ public class AbstractEventEndpointTest {
             .get(rt.host("{eventId}/scheduling.json")).asString();
 
     assertThat(eventSchedulingString, SameJSONAs.sameJSONAs(result));
+  }
+
+  @Test
+  public void testGetEventSchedulingBulk() throws Exception {
+    final String eventSchedulingBulkString = IOUtils
+      .toString(getClass().getResource("/eventSchedulingBulk.json"), StandardCharsets.UTF_8);
+
+    // Event that does not exist, and we are not ignoring that fact.
+    given().formParam("eventIds", "notExists").expect().statusCode(HttpStatus.SC_NOT_FOUND).when()
+      .post(rt.host("scheduling.json"));
+
+    // Event that does not exist, and we are ignoring that.
+    given().formParam("eventIds", "notExists").formParam("ignoreNonScheduled", "true").expect().statusCode(HttpStatus.SC_OK).when()
+      .post(rt.host("scheduling.json"));
+
+    // Check if the actual result is what we expect.
+    final String result = given().formParam("eventIds", "exists").expect().statusCode(HttpStatus.SC_OK).when()
+      .post(rt.host("scheduling.json")).asString();
+
+    assertThat(eventSchedulingBulkString, SameJSONAs.sameJSONAs(result));
   }
 
   @Test

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -513,6 +513,7 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
     TechnicalMetadata technicalMetadata = new TechnicalMetadataImpl("asdasd", "demo",
             new Date(fromUTC("2017-01-27T10:00:37Z")), new Date(fromUTC("2017-01-27T10:10:37Z")), false, userIds,
             wfProperties, caProperties, Opt.<Recording> none());
+    expect(schedulerService.getTechnicalMetadata("notExists")).andThrow(new NotFoundException()).anyTimes();
     expect(schedulerService.getTechnicalMetadata(anyString())).andReturn(technicalMetadata).anyTimes();
 
     EasyMock.replay(schedulerService);

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/util/BulkUpdateUtilTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/util/BulkUpdateUtilTest.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.adminui.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.opencastproject.index.service.impl.index.event.Event;
+
+import com.google.common.io.Files;
+
+import org.easymock.EasyMock;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import uk.co.datumedge.hamcrest.json.SameJSONAs;
+
+public class BulkUpdateUtilTest {
+
+  @Test
+  public void testAddSchedulingDates() {
+    final Event event = EasyMock.mock(Event.class);
+    EasyMock.expect(event.getRecordingStartDate()).andReturn("2018-05-16T13:22:23Z").anyTimes();
+    EasyMock.expect(event.getRecordingEndDate()).andReturn("2018-05-16T17:12:13Z").anyTimes();
+    EasyMock.replay(event);
+    testAddSchedulingDates("scheduling1", event); // Change start and end time
+    testAddSchedulingDates("scheduling2", event); // Change end time to be before start time
+    testAddSchedulingDates("scheduling3", event); // Change weekday
+    testAddSchedulingDates("scheduling4", event); // Change duration
+    testAddSchedulingDates("scheduling5", event); // Change duration and end time
+  }
+
+  @Test
+  public void testToNonTechnicalMetadataJson() {
+    final JSONObject scheduling = loadJson("metadata.json");
+    final JSONObject expected = loadJson("metadata-expected.json");
+    final JSONObject actual = BulkUpdateUtil.toNonTechnicalMetadataJson(scheduling);
+    assertThat(actual.toJSONString(), SameJSONAs.sameJSONAs(expected.toJSONString()));
+  }
+
+  @Test
+  public void testMergeMetadataFields() {
+    final JSONObject metadata1 = loadJson("merge1.json");
+    final JSONObject metadata2 = loadJson("merge2.json");
+    final JSONObject expected = loadJson("metadata-expected.json");
+    final JSONObject actual = BulkUpdateUtil.mergeMetadataFields(metadata1, metadata2);
+    assertThat(actual.toJSONString(), SameJSONAs.sameJSONAs(expected.toJSONString()));
+  }
+
+  @Test
+  public void testMergeMetadataFieldsFirstNull() {
+    final JSONObject metadata1 = null;
+    final JSONObject metadata2 = loadJson("merge2.json");
+    final JSONObject expected = loadJson("merge2.json");
+    final JSONObject actual = BulkUpdateUtil.mergeMetadataFields(metadata1, metadata2);
+    assertThat(actual.toJSONString(), SameJSONAs.sameJSONAs(expected.toJSONString()));
+  }
+
+  @Test
+  public void testMergeMetadataFieldsSecondNull() {
+    final JSONObject metadata1 = loadJson("merge1.json");
+    final JSONObject metadata2 = null;
+    final JSONObject expected = loadJson("merge1.json");
+    final JSONObject actual = BulkUpdateUtil.mergeMetadataFields(metadata1, metadata2);
+    assertThat(actual.toJSONString(), SameJSONAs.sameJSONAs(expected.toJSONString()));
+  }
+
+  @Test
+  public void testBulkUpdateInstructions() {
+    final JSONObject json = loadJson("instructions.json");
+    final BulkUpdateUtil.BulkUpdateInstructions actual = new BulkUpdateUtil.BulkUpdateInstructions(json.toJSONString());
+    final List<String> expectedIds = (JSONArray) json.get("events");
+    final JSONObject expectedScheduling = (JSONObject) json.get("scheduling");
+    final JSONObject expectedMetadata = (JSONObject) json.get("metadata");
+    assertThat(actual.getMetadata().toJSONString(), SameJSONAs.sameJSONAs(expectedMetadata.toJSONString()));
+    assertThat(actual.getScheduling().toJSONString(), SameJSONAs.sameJSONAs(expectedScheduling.toJSONString()));
+    assertEquals(expectedIds, actual.getEventIds());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBulkUpdateInstructionsParseError() {
+    new BulkUpdateUtil.BulkUpdateInstructions("hello");
+  }
+
+  private void testAddSchedulingDates(final String filename, final Event event) {
+    final JSONObject scheduling = loadJson(filename + ".json");
+    final JSONObject expected = loadJson(filename + "-expected.json");
+    final JSONObject actual = BulkUpdateUtil.addSchedulingDates(event, scheduling);
+    assertThat(actual.toJSONString(), SameJSONAs.sameJSONAs(expected.toJSONString()));
+  }
+
+  private static JSONObject loadJson(String filename) {
+    final Charset utf8 = Charset.forName("utf-8");
+    final String fullName = "/bulkupdate/" +  filename;
+    try (Reader reader = Files.newReader(new File(BulkUpdateUtil.class.getResource(fullName).toURI()), utf8)) {
+      return (JSONObject) new JSONParser().parse(reader);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/event/scheduling.json
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/event/scheduling.json
@@ -1,0 +1,32 @@
+[
+  {
+    "eventId": "first",
+    "optOut": false,
+    "agentId": "agent1",
+    "agentConfiguration": {
+      "test": "true",
+      "clear": "all"
+    },
+    "presenters": [
+      "user1",
+      "user2"
+    ],
+    "start": "2017-01-27T10:00:37Z",
+    "end": "2017-01-27T10:10:37Z"
+  },
+  {
+    "eventId": "second",
+    "optOut": false,
+    "agentId": "agent1",
+    "agentConfiguration": {
+      "test": "true",
+      "clear": "all"
+    },
+    "presenters": [
+      "user1",
+      "user2"
+    ],
+    "start": "2017-01-28T10:00:37Z",
+    "end": "2017-01-28T10:10:37Z"
+  }
+]

--- a/modules/admin-ui/src/test/resources/bulkupdate/instructions.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/instructions.json
@@ -1,0 +1,24 @@
+{
+  "events": [
+    "24323ba3-7ff5-4962-85a6-313cb9d9176d",
+    "29c059d8-4e8d-48e8-98ca-453082935704",
+    "b2d2caa4-ac72-47c3-acd5-f5732a0987da"
+  ],
+  "metadata": {
+    "flavor": "dublincore/episode",
+    "title": "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
+    "fields": [
+      {
+        "id": "title",
+        "value": "Test12"
+      }
+    ]
+  },
+  "scheduling": {
+    "timezone": "CET",
+    "duration": {
+      "hour": 10
+    },
+    "agentId": "der_werner"
+  }
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/merge-expected.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/merge-expected.json
@@ -1,0 +1,18 @@
+{
+  "flavor": "dublincore/episode",
+  "title": "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
+  "fields": [
+    {
+      "id": "location",
+      "value": "der_werner"
+    },
+    {
+      "id": "startDate",
+      "value": "2018-05-16T10:13:23.000Z"
+    },
+    {
+      "id": "duration",
+      "value": "01:09:50"
+    }
+  ]
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/merge1.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/merge1.json
@@ -1,0 +1,14 @@
+{
+  "flavor": "dublincore/episode",
+  "title": "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
+  "fields": [
+    {
+      "id": "location",
+      "value": "der_werner"
+    },
+    {
+      "id": "startDate",
+      "value": "2018-05-16T10:13:23.000Z"
+    }
+  ]
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/merge2.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/merge2.json
@@ -1,0 +1,10 @@
+{
+  "flavor": "dublincore/episode",
+  "title": "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
+  "fields": [
+    {
+      "id": "duration",
+      "value": "01:09:50"
+    }
+  ]
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/metadata-expected.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/metadata-expected.json
@@ -1,0 +1,18 @@
+{
+  "flavor": "dublincore/episode",
+  "title": "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE",
+  "fields": [
+    {
+      "id": "location",
+      "value": "der_werner"
+    },
+    {
+      "id": "startDate",
+      "value": "2018-05-16T10:13:23.000Z"
+    },
+    {
+      "id": "duration",
+      "value": "01:09:50"
+    }
+  ]
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/metadata.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/metadata.json
@@ -1,0 +1,6 @@
+{
+  "timezone": "UTC",
+  "start": "2018-05-16T10:13:23Z",
+  "end": "2018-05-16T11:23:13Z",
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling1-expected.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling1-expected.json
@@ -1,0 +1,6 @@
+{
+  "timezone": "UTC",
+  "start": "2018-05-16T10:13:23Z",
+  "end": "2018-05-16T11:23:13Z",
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling1.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling1.json
@@ -1,0 +1,12 @@
+{
+  "timezone": "UTC",
+  "start": {
+    "hour": 10,
+    "minute": 13
+  },
+  "end": {
+    "hour": 11,
+    "minute": 23
+  },
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling2-expected.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling2-expected.json
@@ -1,0 +1,6 @@
+{
+  "timezone": "UTC",
+  "start": "2018-05-16T13:22:23Z",
+  "end": "2018-05-17T11:23:13Z",
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling2.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling2.json
@@ -1,0 +1,8 @@
+{
+  "timezone": "UTC",
+  "end": {
+    "hour": 11,
+    "minute": 23
+  },
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling3-expected.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling3-expected.json
@@ -1,0 +1,7 @@
+{
+  "timezone": "UTC",
+  "weekday": "MO",
+  "start": "2018-05-14T13:22:23Z",
+  "end": "2018-05-14T17:12:13Z",
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling3.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling3.json
@@ -1,0 +1,5 @@
+{
+  "timezone": "UTC",
+  "weekday": "MO",
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling4-expected.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling4-expected.json
@@ -1,0 +1,10 @@
+{
+  "timezone": "UTC",
+  "start": "2018-05-16T13:22:23Z",
+  "end": "2018-05-16T14:32:13Z",
+  "duration": {
+    "hour": 1,
+    "minute": 9
+  },
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling4.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling4.json
@@ -1,0 +1,8 @@
+{
+  "timezone": "UTC",
+  "duration": {
+    "hour": 1,
+    "minute": 9
+  },
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling5-expected.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling5-expected.json
@@ -1,0 +1,10 @@
+{
+  "timezone": "UTC",
+  "start": "2018-05-16T14:13:23Z",
+  "end": "2018-05-16T15:23:13Z",
+  "duration": {
+    "hour": 1,
+    "minute": 9
+  },
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/bulkupdate/scheduling5.json
+++ b/modules/admin-ui/src/test/resources/bulkupdate/scheduling5.json
@@ -1,0 +1,12 @@
+{
+  "timezone": "UTC",
+  "duration": {
+    "hour": 1,
+    "minute": 9
+  },
+  "end": {
+    "hour": 15,
+    "minute": 23
+  },
+  "agentId": "der_werner"
+}

--- a/modules/admin-ui/src/test/resources/eventSchedulingBulk.json
+++ b/modules/admin-ui/src/test/resources/eventSchedulingBulk.json
@@ -1,0 +1,17 @@
+[
+  {
+    "eventId": "asdasd",
+    "optOut": false,
+    "agentId": "demo",
+    "agentConfiguration": {
+      "test": "true",
+      "clear": "all"
+    },
+    "presenters": [
+      "user1",
+      "user2"
+    ],
+    "start": "2017-01-27T10:00:37Z",
+    "end": "2017-01-27T10:10:37Z"
+  }
+]

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/editEventsControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/editEventsControllerSpec.js
@@ -1,0 +1,96 @@
+describe('Edit events controller', function () {
+    var $scope, $controller, $httpBackend, TableServiceMock, FormNavigatorServiceMock, NotificationsMock, SeriesResourceMock, $timeout;
+
+    beforeEach(module('adminNg'));
+
+    // initiate mocks
+    TableServiceMock = jasmine.createSpyObj('TableService', ['fetch', 'copySelected', 'deselectAll']);
+    FormNavigatorServiceMock = jasmine.createSpyObj('FormNavigatorService', ['navigateTo']);
+    NotificationsMock = jasmine.createSpyObj('Notifications', ['add']);
+    WizardHandlerMock = jasmine.createSpyObj('WizardHandler', { wizard: { next: function() {} } });
+    TableServiceMock.copySelected.and.returnValue([
+        {id: 'first', selected: true, series_id: "4581", title: "haha", agent_id: "agent1"},
+        {id: 'second', selected: true, series_id: "4581", title: "hoho", agent_id: "agent1"}
+        ]);
+
+    beforeEach(module(function ($provide) {
+        $provide.value('FormNavigatorService', FormNavigatorServiceMock);
+        $provide.value('Notifications', NotificationsMock);
+        $provide.value('Table', TableServiceMock);
+        $provide.value('WizardHandler', WizardHandlerMock);
+    }));
+    // provide fake language service
+    beforeEach(module(function ($provide) {
+        var service = {
+            configureFromServer: function () {},
+            formatDate: function (val, date) { return date; },
+            formatTime: function (val, date) { return date; },
+            formatDateTime: function (val, format, time) { return time; },
+            getLanguageCode: function () { return 'en'; }
+        };
+        $provide.value('Language', service);
+    }));
+    beforeEach(inject(function ($rootScope, _$controller_, _$timeout_, _$httpBackend_, _JsHelper_) {
+        $controller = _$controller_;
+        $scope = $rootScope.$new();
+        $scope.close = jasmine.createSpy('close');
+        $timeout = _$timeout_;
+        JsHelper = _JsHelper_;
+        $httpBackend = _$httpBackend_;
+    }));
+
+    beforeEach(function () {
+        $controller('EditEventsCtrl', {$scope: $scope});
+        jasmine.getJSONFixtures().fixturesPath = 'base/app/GET';
+        // These are the requests that are necessary to construct the modal.
+        $httpBackend.expectGET('/admin-ng/series/series.json').respond(JSON.stringify(getJSONFixture('admin-ng/series/series.json')));
+        $httpBackend.expectGET('/admin-ng/capture-agents/agents.json?inputs=true').respond(JSON.stringify(getJSONFixture('admin-ng/capture-agents/agents.json')));
+        $httpBackend.expectPOST('/admin-ng/event/scheduling.json').respond(JSON.stringify(getJSONFixture('admin-ng/event/scheduling.json')));
+        $httpBackend.flush();
+    });
+
+    describe('basic functionality', function () {
+
+        it('instantiation', function () {
+            expect(TableServiceMock.copySelected).toHaveBeenCalled();
+        });
+
+        it('is decorated with table functionality', function () {
+            expect($scope.hasAnySelected).toBeDefined();
+        });
+
+        it('processes series information', function() {
+            expect($scope.seriesResults).not.toEqual({});
+        })
+
+        it('processes capture agent', function() {
+            expect($scope.captureAgents).not.toEqual([]);
+        })
+    });
+
+    describe('wizard edit step', function () {
+        it('is correctly instantiated', function () {
+            spyOn(JsHelper, 'getTimeZoneName').and.returnValue("UTC");
+            $scope.clearFormAndContinue();
+            expect($scope.conflictCheckingEnabled).toBe(true);
+            expect($scope.metadataRows).not.toBe([]);
+            // Title is ambiguous
+            expect($scope.metadataRows[0].value).toBe("");
+            // Series is non-ambiguous
+            expect($scope.metadataRows[1].value).toBe("4581");
+            expect($scope.scheduling).not.toBe({});
+            // Agent is non-ambiguous
+            expect($scope.scheduling.location.id).toBe("agent1");
+            // Yadda yadda, test the rest of the data. :)
+        });
+    });
+
+    describe('wizard summary step', function () {
+        it('is correctly instantiated', function () {
+            spyOn(JsHelper, 'getTimeZoneName').and.returnValue("UTC");
+            $scope.clearFormAndContinue();
+            $scope.generateEventSummariesAndContinue();
+            expect($scope.eventSummaries.length).toBe(0);
+        });
+    });
+});

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/RestUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/RestUtils.java
@@ -103,6 +103,18 @@ public final class RestUtils {
   }
 
   /**
+   * Create a NOT FOUND (404) response with the given JSON as body
+   *
+   * @param json
+   *          the JSON string to add to the response body.
+   * @return a NOT FOUND response
+   */
+  public static Response notFoundJson(JValue json) {
+    return Response.status(Status.NOT_FOUND).entity(stream(serializer.fn.toJson(json)))
+        .type(MediaType.APPLICATION_JSON_TYPE).build();
+  }
+
+  /**
    * Create a INTERNAL SERVER ERROR (500) response with the given messages and arguments
    *
    * @param msg
@@ -112,6 +124,18 @@ public final class RestUtils {
   public static Response serverError(String msg, Object... args) {
     return Response.status(Status.INTERNAL_SERVER_ERROR).entity(format(msg, args)).type(MediaType.TEXT_PLAIN_TYPE)
             .build();
+  }
+
+  /**
+   * Create an INTERNAL SERVER ERROR (500) response with the given JSON as body
+   *
+   * @param json
+   *          the JSON string to add to the response body.
+   * @return an INTERNAL SERVER ERROR response
+   */
+  public static Response serverErrorJson(JValue json) {
+    return Response.status(Status.INTERNAL_SERVER_ERROR).entity(stream(serializer.fn.toJson(json)))
+        .type(MediaType.APPLICATION_JSON_TYPE).build();
   }
 
   /**


### PR DESCRIPTION
This PR adds a new modal dialog, accessible via Actions->"Start Task" in
the events table. It only works for events that are scheduled, and
allows editing of such events using a simple wizard. It’s possible to
modify some of the metadata attributes as well as the scheduling
information.

This addresses the following requirement:

As a organisation administrator, I want to be able to edit multiple scheduled events at once

Note that the “start date” is not editable, because it’s unclear what
that would do to multiple events. Also, you can only edit the start
time and the end time, not the duration. Again, this hopefully reduces
confusion.

Here are some screenshots:

A new action "Edit Scheduled Events" has been added to the Actions dropdown on the Events page:

![screen shot 2018-05-15 at 10 13 56](https://user-images.githubusercontent.com/1590263/40044799-c9ae78d6-5828-11e8-863c-215eb6b95247.png)


The dialog can only be used to edit scheduled events. The first page of the wizard will check this and enables users to unselect archived events:

![screen shot 2018-05-15 at 09 39 44](https://user-images.githubusercontent.com/1590263/40043281-52295ba4-5824-11e8-82f0-5a597affc84d.png)

The second page of the wizard allows users to edit most of the scheduling and the most important metadata fields:

![screen shot 2018-05-15 at 09 41 09](https://user-images.githubusercontent.com/1590263/40043329-74fa1af6-5824-11e8-82b9-8d29d71e07df.png)

Finally, the first page provides an overview about what would be changed:

![screen shot 2018-05-15 at 09 41 32](https://user-images.githubusercontent.com/1590263/40043351-8699d148-5824-11e8-9ce5-88037de6c530.png)

This work was sponsored by SWITCH.