### PR TITLE
MH-12885 Capture Agent Access Management

### DIFF
--- a/docs/guides/user/docs/advanced/capture-agent-access.md
+++ b/docs/guides/user/docs/advanced/capture-agent-access.md
@@ -1,0 +1,42 @@
+# Capture Agent Access Control
+
+Opencast allows restrictions considering what a user or group of users can do with capture agents to be configured.
+
+There are three kind of access restriction levels:
+
+- Unrestriced Access: Full access to all capture agents
+- Restricted Access: No access to any capture agent
+- Selective Access: Selected access to a subset of capture agents
+
+### Unrestricted Access
+
+Users that have the global administration role (`ROLE_ADMIN`) or the organization administration role
+(value depends on configuration) always have access to all capture agents.
+
+### Restricted Access
+
+Unprivileged users by default have no permission to modify anything that is relevant to control capture agents.
+Those users cannot:
+
+- Edit scheduling information of scheduled events (Events->Event Details->Scheduling is read-only)
+- Edit workflow configuration of scheduled events (Events->Event Details->Processing is read-only)
+- Schedule new events (Events->Add Event->Source will only allow upload)
+- Delete scheduled events (Events->Actions->Delete and Events->Action->Delete)
+- Remove capture agents (Locations->Locations->Action->Remove)
+
+### Selective Access
+
+It is possible to selectively allow specific users or groups of users to access subsets of capture agents.
+
+Each capture agent has a role which is derived froms its id by removing all non-alphanumerical characters and
+prepending the prefix `ROLE_CAPTURE_AGENT_`.
+If a user with restriced access owns the roles of a set of given capture agents, the user has selective access
+to those capture agents. 
+
+**Example**
+
+- Capture agent ID: `Opencast's Capture Agent`
+- Derived role: `ROLE_CAPTURE_AGENT_OPENCASTSCAPTUREAGENT`
+
+If the user Bob with restricted access has the role `ROLE_CAPTURE_AGENT_OPENCASTSCAPTUREAGENT`, Bob is allowed
+to control the capture agent with the id `Opencast's Capture Agent`.

--- a/docs/guides/user/docs/advanced/capture-agent-access.md
+++ b/docs/guides/user/docs/advanced/capture-agent-access.md
@@ -2,9 +2,9 @@
 
 Opencast allows restrictions considering what a user or group of users can do with capture agents to be configured.
 
-There are three kind of access restriction levels:
+There are three kinds of access restriction levels:
 
-- Unrestriced Access: Full access to all capture agents
+- Unrestricted Access: Full access to all capture agents
 - Restricted Access: No access to any capture agent
 - Selective Access: Selected access to a subset of capture agents
 
@@ -28,10 +28,10 @@ Those users cannot:
 
 It is possible to selectively allow specific users or groups of users to access subsets of capture agents.
 
-Each capture agent has a role which is derived froms its id by removing all non-alphanumerical characters and
+Each capture agent has a role which is derived from its id by removing all non-alphanumerical characters and
 prepending the prefix `ROLE_CAPTURE_AGENT_`.
-If a user with restriced access owns the roles of a set of given capture agents, the user has selective access
-to those capture agents. 
+If a user with restricted access owns the roles of a set of given capture agents, the user has selective access
+to those capture agents.
 
 **Example**
 

--- a/docs/guides/user/docs/advanced/capture-agent-access.md
+++ b/docs/guides/user/docs/advanced/capture-agent-access.md
@@ -35,7 +35,7 @@ to those capture agents.
 
 **Example**
 
-- Capture agent ID: `Opencast's Capture Agent`
+- Capture agent ID: `OpencastsCaptureAgent`
 - Derived role: `ROLE_CAPTURE_AGENT_OPENCASTSCAPTUREAGENT`
 
 If the user Bob with restricted access has the role `ROLE_CAPTURE_AGENT_OPENCASTSCAPTUREAGENT`, Bob is allowed

--- a/docs/guides/user/docs/advanced/index.md
+++ b/docs/guides/user/docs/advanced/index.md
@@ -4,7 +4,7 @@ This section describes facilities supposed to be used by advanced users.
 
 ### Unprivileged Users
 
-If a user owns the global administration role (`ROLE_ADMIN`), he is a privileged users in means of having access
+Privileged users are users that own the global administration role (`ROLE_ADMIN`) which grants them access
 to all data and all functionality Opencast offers.
 
 Unprivileged users are users that don't own the global administration role. For unprivileged users, Opencast offers

--- a/docs/guides/user/docs/advanced/index.md
+++ b/docs/guides/user/docs/advanced/index.md
@@ -2,4 +2,15 @@
 
 This section describes facilities supposed to be used by advanced users.
 
-- [Role-Based Visibility](role-based-visibility.md)
+### Unprivileged Users
+
+If a user owns the global administration role (`ROLE_ADMIN`), he is a privileged users in means of having access
+to all data and all functionality Opencast offers.
+
+Unprivileged users are users that don't own the global administration role. For unprivileged users, Opencast offers
+two mechanisms to configure their privileges:
+
+- [Capture Agent Access Control](capture-agent-access.md) can be used to configure the Admin UI to provide selective
+  access to capture agents for different users or groups of users
+- [Role-Based Visibility](role-based-visibility.md) can be used to configure the Admin UI to provide selective access
+  to Opencast's functionality for different users or groups of users

--- a/docs/guides/user/mkdocs.yml
+++ b/docs/guides/user/mkdocs.yml
@@ -32,4 +32,5 @@ pages:
 - Internationalization: 'i18n.md'
 - Advanced:
   - Overview: 'advanced/index.md'
+  - Capture Agent Access Control: 'advanced/capture-agent-access.md'
   - Role-Based Visibility: 'advanced/role-based-visibility.md'

--- a/modules/admin-ui/src/main/resources/OSGI-INF/captureagents_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/captureagents_endpoint.xml
@@ -13,9 +13,16 @@
 
   <reference name="captureAgentService" interface="org.opencastproject.capture.admin.api.CaptureAgentStateService"
     cardinality="1..1" policy="static" bind="setCaptureAgentService" />
+  <reference name="captureAgentRoleProvider" interface="org.opencastproject.capture.admin.api.CaptureAgentAdminRoleProvider"
+             cardinality="1..1" policy="static" bind="setRoleProvider" />
   <reference bind="setParticipationPersistence"
     cardinality="0..1"
     interface="org.opencastproject.pm.api.persistence.ParticipationManagementDatabase"
     name="participationPersistence"
     policy="dynamic" />
+  <reference name="SecurityService"
+    interface="org.opencastproject.security.api.SecurityService"
+    cardinality="1..1"
+    policy="static"
+    bind="setSecurityService" />
 </scr:component>

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -121,6 +121,7 @@
      "SERIES_NOT_UPDATED_ALL":  "None of the series could be saved",
      "EVENTS_DELETED":      "The event has been deleted",
      "EVENTS_NOT_DELETED":  "The event(s) could not be deleted",
+     "EVENTS_NOT_DELETED_NOT_AUTHORIZED":  "The event could not be deleted, because you don't have the permission to do so.",
      "SERIES_DELETED": "The series has been deleted",
      "SERIES_NOT_DELETED": "The series could not be deleted",
      "USER_BLACKLIST_CREATED": "The blacklist has been created",
@@ -131,6 +132,7 @@
      "USER_BLACKLIST_NOT_DELETED":  "The blacklist could not be deleted",
      "LOCATION_DELETED": "The location has been deleted",
      "LOCATION_NOT_DELETED": "The location could not be deleted",
+     "LOCATION_NOT_DELETED_NOT_AUTHORIZED": "The location could not be deleted, because you don't have the permission to do so.",
      "LOCATION_BLACKLIST_CREATED": "The blacklist has been created",
      "LOCATION_BLACKLIST_NOT_CREATED":  "The blacklist could not be created",
      "LOCATION_BLACKLIST_SAVED": "The blacklist has been saved",
@@ -211,6 +213,7 @@
                 "EVENTS_RETRACTED": "Events to be Retracted",
                 "RETRACT_WORKFLOW": "Workflow to Retract Events"
             },
+            "UNAUTHORIZED": "You are not authorized to delete the highlighted events. Please unselect them to continue.",
             "UNPUBLISHED": {
                 "NONE": "None of the selected events can be deleted without leaving orphan files."
             },
@@ -248,7 +251,8 @@
               "CANNOTSTART": "Highlighted event(s) cannot be processed, only scheduled events are supported.",
               "NOCHANGES": "No changes to the events detected!",
               "CONFLICT_FIRST_EVENT": "Changed event",
-              "CONFLICT_SECOND_EVENT": "Event in conflict"
+              "CONFLICT_SECOND_EVENT": "Event in conflict",
+              "CANNOTEDITSCHEDULE": "For the highlighted events, you don't have the permission to edit scheduling information. You can continue, but you won't be able to edit scheduling information of any events at all."
           },
           "METADATA": {
               "EDIT": "Edit metadata"

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -349,6 +349,7 @@
         <script src="scripts/modules/events/subresources/controllers/video/editController.js"></script>
         <script src="scripts/modules/events/validators/taskStartableValidator.js"></script>
         <script src="scripts/modules/events/validators/notEmptySelectionValidator.js"></script>
+        <script src="scripts/modules/events/validators/schedulingAuthorizedValidator.js"></script>
         <script src="scripts/modules/recordings/controllers/recordingController.js"></script>
         <script src="scripts/modules/recordings/controllers/recordingsController.js"></script>
         <script src="scripts/modules/recordings/controllers/locationblacklistsController.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -503,5 +503,27 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
             EventBulkEditResource.update(payload, onSuccess, onFailure);
         }
     };
+
+    $scope.hasAgentAccess = function (agent, index, array) {
+        return SchedulingHelperService.hasAgentAccess(agent.id);
+    };
+
+    $scope.noAgentAccess = function (row) {
+        return !$scope.nonSchedule(row) && !SchedulingHelperService.hasAgentAccess(row.agent_id);
+    };
+
+    $scope.hasAllAgentsAccess = function () {
+        for (var i = 0; i < $scope.rows.length; i++) {
+            var row = $scope.rows[i];
+            if (!row.selected || $scope.nonSchedule(row)) {
+                continue;
+            }
+            if (!SchedulingHelperService.hasAgentAccess(row.agent_id)) {
+                return false;
+            }
+        }
+        return true;
+    };
+
     decorateWithTableRowSelection($scope);
 }]);

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -342,7 +342,7 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
     };
 
     $scope.rowsValid = function() {
-        return !$scope.nonScheduleSelected() && $scope.hasAnySelected();
+        return !$scope.nonScheduleSelected() && $scope.hasAnySelected() && $scope.hasAllAgentsAccess();
     };
 
     $scope.generateEventSummariesAndContinue = function() {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editStatusController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editStatusController.js
@@ -52,10 +52,11 @@ angular.module('adminNg.controllers')
                 var nbErrors = data.error ? data.error.length : 0,
                     nbOK = data.ok ? data.ok.length : 0,
                     nbNotFound = data.notFound ? data.notFound.length : 0,
+                    nbUnauthorized = data.unauthorized ? data.unauthorized.length : 0,
                     nbBadRequest = data.badRequest ? data.badRequest.length : 0;
                 Table.deselectAll();
                 Modal.$scope.close();
-                if (nbErrors === 0 && nbBadRequest === 0 && nbNotFound === 0) {
+                if (nbErrors === 0 && nbBadRequest === 0 && nbNotFound === 0 && nbUnauthorized === 0) {
                     Notifications.add('success', sourceNotification + '_UPDATED_ALL');
                 } else {
                     if (nbOK > 0) {
@@ -74,7 +75,11 @@ angular.module('adminNg.controllers')
 
                     if (data.badRequest) {
                         errors = errors.concat(data.badRequest);
-                    }                    
+                    }
+
+                    if (data.unauthorized) {
+                        errors = errors.concat(data.unauthorized);
+                    }
 
                     if (data.forbidden) {
                         errors = errors.concat(data.forbidden);

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -541,7 +541,16 @@ angular.module('adminNg.controllers')
         $scope.onTemporalValueChange = function(type) {
             SchedulingHelperService.applyTemporalValueChange($scope.source, type, true);
             $scope.saveScheduling();
-        }
+        };
+
+
+        $scope.hasCurrentAgentAccess = function() {
+            return SchedulingHelperService.hasAgentAccess($scope.source.agentId);
+        };
+
+        $scope.currentAgentOrAccess = function(agent, index, array) {
+            return agent.id === $scope.source.agentId || SchedulingHelperService.hasAgentAccess(agent.id);
+        };
 
         /**
          * End Scheduling related resources

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -154,8 +154,12 @@ angular.module('adminNg.controllers')
             EventsResource.delete({id: row.id}, function () {
                 Table.fetch();
                 Notifications.add('success', 'EVENTS_DELETED');
-            }, function () {
-                Notifications.add('error', 'EVENTS_NOT_DELETED');
+            }, function (error) {
+                if (error.status === 401) {
+                  Notifications.add('error', 'EVENTS_NOT_DELETED_NOT_AUTHORIZED');
+                } else {
+                  Notifications.add('error', 'EVENTS_NOT_DELETED');
+                }
             });
         };
 

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/newEventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/newEventController.js
@@ -65,6 +65,9 @@ angular.module('adminNg.controllers')
               args.current.stateController.loadCaptureAgents();
               args.current.stateController.setDefaultsIfNeeded();
             }
+            if (!args.current.stateController.hasAgents()) {
+              args.current.stateController.ud.type = "UPLOAD";
+            }
         }
     });
 

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
@@ -6,6 +6,7 @@
 </a>
 
 <!-- Remove button for published events. -->
+<!-- TODO: Falls event status SCHEDULED Berechtigungen prüfen. Ggf Button deaktivieren bzw nicht anzeigen. -->
 <a class="remove"
   ng-click="row.checkedDelete()"
   title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.DELETE' | translate }}"

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
@@ -6,7 +6,6 @@
 </a>
 
 <!-- Remove button for published events. -->
-<!-- TODO: Falls event status SCHEDULED Berechtigungen prüfen. Ggf Button deaktivieren bzw nicht anzeigen. -->
 <a class="remove"
   ng-click="row.checkedDelete()"
   title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.DELETE' | translate }}"

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/validators/schedulingAuthorizedValidator.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/validators/schedulingAuthorizedValidator.js
@@ -1,0 +1,54 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name adminNg.modules.events.validators.schedulingAuthorized
+ * @description
+ * Checks if the current user is authorized to change scheduling of current event.
+ *
+ */
+angular.module('adminNg.directives')
+.directive('schedulingAuthorized', ['Notifications', 'SchedulingHelperService', function (Notifications, SchedulingHelperService) {
+    var link = function (scope, elm, attrs, ctrl) {
+        scope, elm, attrs, ctrl, Notifications;
+        ctrl.$validators.schedulingAuthorized = function (modelValue, viewValue) {
+            if (viewValue) {
+                if (angular.isDefined(attrs.schedulingAuthorized)) {
+                    var event = JSON.parse(attrs.schedulingAuthorized);
+                    return event.source !== "SCHEDULE" || SchedulingHelperService.hasAgentAccess(event.agent_id);
+                }
+                else {
+                    return false;
+                }
+            }
+            else {
+                return true;
+            }
+        };
+    };
+
+    return {
+        require: 'ngModel',
+        link: link
+    };
+}]);

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/controllers/recordingsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/controllers/recordingsController.js
@@ -62,8 +62,12 @@ angular.module('adminNg.controllers')
                 Table.fetch();
                 Modal.$scope.close();
                 Notifications.add('success', 'LOCATION_DELETED');
-            }, function () {
-                Notifications.add('error', 'LOCATION_NOT_DELETED');
+            }, function (error) {
+                if (error.status === 401) {
+                    Notifications.add('error', 'LOCATION_NOT_DELETED_NOT_AUTHORIZED');
+                } else {
+                    Notifications.add('error', 'LOCATION_NOT_DELETED');
+                }
             });
         };
     }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-events-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-events-modal.html
@@ -1,4 +1,4 @@
-<section class="modal wizard active modal-open" id="delete-events-status-modal" style="display: block;" ng-controller="BulkDeleteCtrl">
+<section class="modal wizard active modal-open" ng-form="bulkDeleteForm" id="delete-events-status-modal" style="display: block;" ng-controller="BulkDeleteCtrl">
     <header>
         <a ng-click="close()" class="fa fa-times close-modal"></a>
         <h2 translate="BULK_ACTIONS.DELETE.EVENTS.CAPTION"><!-- Delete Events --></h2>
@@ -27,6 +27,12 @@
                             <!-- By pressing delete you understand that these files are unrecoverable. -->
                         </p>
                     </div>
+                    <div ng-show="bulkDeleteForm.deleteForm.$error.schedulingAuthorized" class="alert sticky warning">
+                        <p translate="BULK_ACTIONS.DELETE.EVENTS.UNAUTHORIZED">
+                            <!-- Unauthorized -->
+                        </p>
+                    </div>
+
 
                     <div class="full-col" ng-if="events.unpublished.has">
                         <div class="obj">
@@ -42,8 +48,8 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr ng-repeat="row in unpublished.rows">
-                                        <td><input type="checkbox" ng-model="row.selected" ng-change="unpublished.rowSelectionChanged($index)" class="child-cbox"/></td>
+                                    <tr ng-repeat="row in unpublished.rows" ng-form="rowsForm" ng-class="{error: rowsForm.selection.$error.schedulingAuthorized}">
+                                        <td><input name="selection" type="checkbox" ng-model="row.selected" scheduling-authorized="{{row}}" ng-change="unpublished.rowSelectionChanged($index)" class="child-cbox"/></td>
                                         <td>{{ row.title }}</td>
                                         <td>{{ row.presenters }}</td>
                                     </tr>
@@ -67,7 +73,7 @@
     <footer ng-if="currentForm === 'deleteForm'">
         <a ng-click="navigateTo('retractForm', currentForm, [])"
             data-modal-tab="next" class="submit"
-            ng-class="{active: deleteForm.$valid, disabled: deleteForm.$invalid}">
+            ng-class="{active: bulkDeleteForm.deleteForm.$valid, disabled: bulkDeleteForm.deleteForm.$invalid}">
             {{ 'WIZARD.NEXT_STEP' | translate }}
         </a>
         <a ng-click="navigateTo('deleteForm', currentForm, [])"
@@ -204,7 +210,7 @@
     <footer ng-if="currentForm === 'summaryForm'">
         <a ng-click="submit()"
             data-modal-tab="next" class="submit"
-            ng-class="{active: summaryForm.$valid, inactive: summaryForm.$invalid, disabled: submitButton}">
+            ng-class="{active: bulkDeleteForm.summaryForm.$valid, inactive: bulkDeleteForm.summaryForm.$invalid, disabled: submitButton}">
             {{ 'WIZARD.RETRACT' | translate }}
         </a>
         <a ng-click="navigateTo('retractForm', currentForm, [])"

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
@@ -114,7 +114,7 @@
 
                         </div><!--list-obj -->
 
-                        <div class="obj tbl-details" ng-if="hasAllAgentsAccess() && $root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
+                        <div class="obj tbl-details" ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                             <header translate="BULK_ACTIONS.EDIT_EVENTS.EDIT.SCHEDULING"><!-- Edit scheduling --></header>
                             <div class="obj-container">
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
@@ -14,6 +14,11 @@
                                 <!-- Cannot start -->
                             </p>
                         </div>
+                        <div ng-show="!hasAllAgentsAccess()" class="alert sticky info">
+                          <p translate="BULK_ACTIONS.EDIT_EVENTS.GENERAL.CANNOTEDITSCHEDULE">
+                            <!-- Cannot update scheduling -->
+                          </p>
+                        </div>
                     </div>
                     <div class="full-col">
                         <div class="obj tbl-list">
@@ -35,7 +40,7 @@
                                     </tr>
                                     </thead>
                                     <tbody >
-                                    <tr ng-repeat="row in rows" ng-form="rowsForm" ng-class="{error: nonSchedule(row)}">
+                                    <tr ng-repeat="row in rows" ng-form="rowsForm" ng-class="{error: nonSchedule(row), info: noAgentAccess(row)}">
                                         <td><input name="selection" ng-required="!hasAnySelected()" type="checkbox" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
                                         <td>{{ row.title }}</td>
                                         <td class="nowrap">{{ row.series_name}}</td>
@@ -109,7 +114,7 @@
 
                         </div><!--list-obj -->
 
-                        <div class="obj tbl-details">
+                        <div class="obj tbl-details" ng-if="hasAllAgentsAccess() && $root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                             <header translate="BULK_ACTIONS.EDIT_EVENTS.EDIT.SCHEDULING"><!-- Edit scheduling --></header>
                             <div class="obj-container">
 
@@ -176,7 +181,7 @@
                                             ng-change="roomChanged(); checkConflicts()"
                                             data-disable-search-threshold="8"
                                             ng-model="scheduling.location"
-                                            ng-options="value.name for (id, value) in captureAgents"
+                                            ng-options="value.name for (id, value) in captureAgents | filter:hasAgentAccess"
                                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
                                             />
                                   </td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -240,7 +240,7 @@
                                 <td>
                                     <input datepicker
                                         type="text"
-                                        ng-disabled="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')"
+                                        ng-disabled="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT') || !hasCurrentAgentAccess()"
                                         placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.START_DATE' | translate }}"
                                         ng-model="source.start.date"
                                         ng-change="onTemporalValueChange('start')" />
@@ -250,7 +250,7 @@
                                 <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.START_TIME' | translate }}</td>
                                 <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     <select chosen
-                                        ng-disabled="checkingConflicts"
+                                        ng-disabled="checkingConflicts  || !hasCurrentAgentAccess()"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.start.hour" ng-change="onTemporalValueChange('start')"
@@ -258,7 +258,7 @@
                                         ng-options="h.index as h.value for h in hours"
                                     />
                                     <select chosen
-                                        ng-disabled="checkingConflicts"
+                                        ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.start.minute" ng-change="onTemporalValueChange('start')"
@@ -274,7 +274,7 @@
                                 <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.DURATION' | translate }}</td>
                                 <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     <select chosen
-                                        ng-disabled="checkingConflicts"
+                                        ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.duration.hour" ng-change="onTemporalValueChange('duration')"
@@ -283,7 +283,7 @@
                                     />
 
                                     <select chosen
-                                        ng-disabled="checkingConflicts"
+                                        ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.duration.minute" ng-change="onTemporalValueChange('duration')"
@@ -299,7 +299,7 @@
                                 <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.DATE_TIME.END_TIME' | translate }}</td>
                                 <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                     <select chosen
-                                        ng-disabled="checkingConflicts"
+                                        ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.end.hour" ng-change="onTemporalValueChange('end')"
@@ -307,7 +307,7 @@
                                         ng-options="h.index as h.value for h in hours"
                                     />
                                     <select chosen
-                                        ng-disabled="checkingConflicts"
+                                        ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                                         data-width="'100px'"
                                         data-disable-search-threshold="8"
                                         ng-model="source.end.minute" ng-change="onTemporalValueChange('end')"
@@ -329,12 +329,12 @@
                                 <td>{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}</td>
                                 <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                                 <select chosen pre-select-from="captureAgents"
-                                    ng-disabled="checkingConflicts"
+                                    ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                                     data-width="'200px'"
                                     ng-change="roomChanged(); saveScheduling()"
                                     data-disable-search-threshold="8"
                                     ng-model="source.device"
-                                    ng-options="value.name for (id, value) in captureAgents"
+                                    ng-options="value.name for (id, value) in captureAgents | filter:currentAgentOrAccess"
                                     data-placeholder="{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}"
                                 />
                                 </td>
@@ -349,7 +349,7 @@
                                         <input type="checkbox"
                                             ng-change="saveScheduling()"
                                             ng-model="source.device.inputMethods[inputMethod.id]"
-                                            ng-disabled="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')"> {{ inputMethod.value | translate }}
+                                            ng-disabled="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT') || !hasCurrentAgentAccess()"> {{ inputMethod.value | translate }}
                                         <br>
                                     </label>
                                 </td>
@@ -480,7 +480,7 @@
                                                             ng-change="changeWorkflow(false)"
                                                             data-disable-search-threshold="8"
                                                             data-search_contains="true"
-                                                            ng-disabled="!$root.userIs('ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT')"
+                                                            ng-disabled="!$root.userIs('ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT') || !hasCurrentAgentAccess()"
                                                             ng-options="w.id as w.title for w in workflowDefinitions | orderBy: 'displayOrder':true"
                                                             data-placeholder="{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW' | translate }}"
                                                             no-results-text="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY' | translate }}'"
@@ -510,7 +510,7 @@
                                                     <div class="obj-container padded">
                                                         <div id="event-workflow-configuration"
                                                              class="checkbox-container"
-                                                             ng-disabled="!$root.userIs('ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT')"
+                                                             ng-disabled="!$root.userIs('ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT') || !hasCurrentAgentAccess()"
                                                              ng-bind-html="workflowConfiguration"
                                                              class="obj-container">
                                                         </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -62,7 +62,7 @@
                     <td>{{ conflict.end }}</td>
                 </tr>
             </table>
-            <div class="obj list-obj">
+            <div class="obj list-obj" ng-if="(wizard.step.captureAgents | filter:wizard.step.hasAgentAccess).length > 0">
                 <header class="no-expand" translate="EVENTS.EVENTS.NEW.SOURCE.SELECT_SOURCE">
                     <!-- Select Source -->
                 </header>
@@ -81,10 +81,8 @@
                             <label>
                                 <input ng-model="wizard.step.ud.type" type="radio" name="source-toggle"
                                        class="source-toggle" value="SCHEDULE_SINGLE" data-upload-type="SCHEDULE_SINGLE"
-                                       ng-change="wizard.step.changeType()" ng-disabled="wizard.step.captureAgents.length === 0">
-                                <span translate="EVENTS.EVENTS.NEW.SOURCE.SCHEDULE_SINGLE.CAPTION"
-                                      ng-class="wizard.step.captureAgents.length === 0 ? 'ui-state-disabled' : ''"
-                                      ng-attr-title="{{ (wizard.step.captureAgents.length === 0 ? 'EVENTS.EVENTS.NEW.SOURCE.NO_SOURCE_AVAILABLE' : '') | translate }}">
+                                       ng-change="wizard.step.changeType()">
+                                <span translate="EVENTS.EVENTS.NEW.SOURCE.SCHEDULE_SINGLE.CAPTION">
                                     <!-- Schedule Single Event -->
                                 </span>
                             </label>
@@ -93,10 +91,8 @@
                             <label>
                                 <input ng-model="wizard.step.ud.type" type="radio" name="source-toggle"
                                        class="source-toggle" value="SCHEDULE_MULTIPLE" data-upload-type="SCHEDULE_MULTIPLE"
-                                       ng-change="wizard.step.changeType()" ng-disabled="wizard.step.captureAgents.length === 0">
-                                <span translate="EVENTS.EVENTS.NEW.SOURCE.SCHEDULE_MULTIPLE.CAPTION"
-                                      ng-class="wizard.step.captureAgents.length === 0 ? 'ui-state-disabled' : ''"
-                                      ng-attr-title="{{ (wizard.step.captureAgents.length === 0 ? 'EVENTS.EVENTS.NEW.SOURCE.NO_SOURCE_AVAILABLE' : '') | translate }}">
+                                       ng-change="wizard.step.changeType()">
+                                <span translate="EVENTS.EVENTS.NEW.SOURCE.SCHEDULE_MULTIPLE.CAPTION">
                                     <!-- Schedule Multiple Events -->
                                 </span>
                             </label>
@@ -261,7 +257,7 @@
                                 ng-change="wizard.step.roomChanged(); wizard.step.checkConflicts()"
                                 data-disable-search-threshold="8"
                                 ng-model="wizard.step.ud.SCHEDULE_SINGLE.device"
-                                ng-options="value.name for (id, value) in wizard.step.captureAgents"
+                                ng-options="value.name for (id, value) in wizard.step.captureAgents | filter:wizard.step.hasAgentAccess"
                                 placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
                             >
                                 <option value=""></option>
@@ -415,7 +411,7 @@
                                 ng-change="wizard.step.roomChanged(); wizard.step.checkConflicts()"
                                 data-disable-search-threshold="8"
                                 ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.device"
-                                ng-options="value.name for (id, value) in wizard.step.captureAgents"
+                                ng-options="value.name for (id, value) in wizard.step.captureAgents | filter:wizard.step.hasAgentAccess"
                                 placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
                             >
                                 <option value=""></option>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/authService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/authService.js
@@ -25,6 +25,7 @@ angular.module('adminNg.services')
     var AuthService = function () {
         var me = this,
             isAdmin = false,
+            isOrgAdmin = false,
             isUserLoaded = false,
             callbacks = [],
             identity,
@@ -47,6 +48,7 @@ angular.module('adminNg.services')
                 var globalAdminRole = "ROLE_ADMIN";
                 me.user = user;
                 isAdmin = angular.isDefined(globalAdminRole) && user.roles.indexOf(globalAdminRole) > -1;
+                isOrgAdmin = angular.isDefined(user.org.adminRole) && user.roles.indexOf(user.org.adminRole) > -1;
                 if (angular.isDefined(user.userRole)) {
                     userRole = user.userRole;
                 }
@@ -63,6 +65,10 @@ angular.module('adminNg.services')
 
         this.getUserRole = function () {
             return userRole;
+        };
+
+        this.isOrganizationAdmin = function () {
+            return isOrgAdmin;
         };
 
         this.userIsAuthorizedAs = function (role, success, error) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
@@ -66,7 +66,7 @@ angular.module('adminNg.services')
 
         this.hasAgentAccess = function(agentId) {
             if (AuthService.isOrganizationAdmin()) return true;
-            var role = "ROLE_CAPTURE_AGENT_" + agentId.replace("[^a-zA-Z0-9_]", "").toUpperCase();
+            var role = "ROLE_CAPTURE_AGENT_" + agentId.replace(/[^a-zA-Z0-9_]/g, "").toUpperCase();
             return AuthService.userIsAuthorizedAs(role);
         };
     };

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
@@ -21,7 +21,7 @@
 'use strict';
 
 angular.module('adminNg.services')
-.factory('SchedulingHelperService', [function () {
+.factory('SchedulingHelperService', ['AuthService', function (AuthService) {
     var SchedulingHelperService = function () {
 
         var me = this;
@@ -62,6 +62,12 @@ angular.module('adminNg.services')
             if (single) {
                 temporalValues.end.date = me.getUpdatedEndDateSingle(temporalValues.start, temporalValues.end);
             }
+        };
+
+        this.hasAgentAccess = function(agentId) {
+            if (AuthService.isOrganizationAdmin()) return true;
+            var role = "ROLE_CAPTURE_AGENT_" + agentId.replace("[^a-zA-Z0-9_]", "").toUpperCase();
+            return AuthService.userIsAuthorizedAs(role);
         };
     };
     return new SchedulingHelperService();

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -482,7 +482,7 @@ angular.module('adminNg.services')
         };
 
         this.setDefaultsIfNeeded = function() {
-                if (self.defaultsSet) {
+                if (self.defaultsSet || !self.hasAgents()) {
                   return;
                 }
 
@@ -550,6 +550,19 @@ angular.module('adminNg.services')
             SchedulingHelperService.applyTemporalValueChange(self.ud[getType()], type, self.isScheduleSingle() );
             self.checkConflicts();
         }
+
+        this.hasAgentAccess = function(agent, index, array) {
+            return SchedulingHelperService.hasAgentAccess(agent.id);
+        };
+
+        this.hasAgents = function() {
+            return angular.isDefined(self.captureAgents)
+                && self.captureAgents.filter(
+                       function(agent) {
+                           return self.hasAgentAccess(agent, undefined, undefined)
+                       }).length > 0;
+        };
+
     };
     return new Source();
 }]);

--- a/modules/admin-ui/src/main/webapp/styles/main.scss
+++ b/modules/admin-ui/src/main/webapp/styles/main.scss
@@ -545,6 +545,10 @@ tr.error {
   background: $state-warning-bg !important;
 }
 
+tr.info {
+  background: $state-info-bg !important;
+}
+
 /*
 * ----------------------------------------------------------------
 * THE FOLLOWING SECTION NEEDS TO BE DELEGATED TO THE DESIGNERS!!!

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/editEventsControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/editEventsControllerSpec.js
@@ -46,6 +46,7 @@ describe('Edit events controller', function () {
         $httpBackend.expectGET('/admin-ng/series/series.json').respond(JSON.stringify(getJSONFixture('admin-ng/series/series.json')));
         $httpBackend.expectGET('/admin-ng/capture-agents/agents.json?inputs=true').respond(JSON.stringify(getJSONFixture('admin-ng/capture-agents/agents.json')));
         $httpBackend.expectPOST('/admin-ng/event/scheduling.json').respond(JSON.stringify(getJSONFixture('admin-ng/event/scheduling.json')));
+        $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
         $httpBackend.flush();
     });
 

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/eventControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/eventControllerSpec.js
@@ -56,6 +56,7 @@ describe('Event controller', function () {
         $httpBackend.whenGET('/admin-ng/capture-agents/agents.json').respond(JSON.stringify({"results":[],"total":0}));
         $httpBackend.whenGET('/admin-ng/capture-agents/agents.json?inputs=true')
             .respond(JSON.stringify({"results":[],"total":0}));
+        $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
 
         $controller('EventCtrl', {$scope: $scope});
     });

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/schedulingHelperServiceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/schedulingHelperServiceSpec.js
@@ -1,7 +1,9 @@
 describe('SchedulingHelperService', function () {
     var $httpBackend, SchedulingHelperService;
 
+    beforeEach(module('ngResource'));
     beforeEach(module('adminNg.services'));
+    beforeEach(module('adminNg.resources'));
 
     beforeEach(inject(function (_SchedulingHelperService_) {
         SchedulingHelperService = _SchedulingHelperService_;

--- a/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/CaptureAgentAdminRoleProvider.java
+++ b/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/CaptureAgentAdminRoleProvider.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.capture.admin.api;
+
+public interface CaptureAgentAdminRoleProvider {
+  void removeRole(String agentName);
+}

--- a/modules/capture-admin-service-impl/pom.xml
+++ b/modules/capture-admin-service-impl/pom.xml
@@ -31,6 +31,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-userdirectory</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -151,7 +156,8 @@
             <Export-Package> org.opencastproject.capture.admin.*;version=${project.version} </Export-Package>
             <Service-Component>
               OSGI-INF/capture-admin-service.xml,
-              OSGI-INF/capture-admin-service-rest.xml
+              OSGI-INF/capture-admin-service-rest.xml,
+              OSGI-INF/capture-agent-admin-role-provider.xml
             </Service-Component>
             <Meta-Persistence>
               META-INF/persistence.xml

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
@@ -30,6 +30,7 @@ import static org.opencastproject.capture.admin.api.AgentState.KNOWN_STATES;
 
 import org.opencastproject.capture.admin.api.Agent;
 import org.opencastproject.capture.admin.api.AgentStateUpdate;
+import org.opencastproject.capture.admin.api.CaptureAgentAdminRoleProvider;
 import org.opencastproject.capture.admin.api.CaptureAgentStateService;
 import org.opencastproject.capture.admin.impl.RecordingStateUpdate;
 import org.opencastproject.scheduler.api.Recording;
@@ -93,6 +94,7 @@ public class CaptureAgentStateRestService {
 
   private static final Logger logger = LoggerFactory.getLogger(CaptureAgentStateRestService.class);
   private CaptureAgentStateService service;
+  private CaptureAgentAdminRoleProvider roleProvider;
   private SchedulerService schedulerService;
 
   /**
@@ -114,6 +116,10 @@ public class CaptureAgentStateRestService {
 
   public void setSchedulerService(SchedulerService schedulerService) {
     this.schedulerService = schedulerService;
+  }
+
+  public void setRoleProvider(CaptureAgentAdminRoleProvider roleProvider) {
+    this.roleProvider = roleProvider;
   }
 
   public CaptureAgentStateRestService() {
@@ -213,6 +219,9 @@ public class CaptureAgentStateRestService {
       return Response.serverError().status(Response.Status.SERVICE_UNAVAILABLE).build();
 
     service.removeAgent(agentName);
+
+    // Remove the corresponding capture agent roles
+    this.roleProvider.removeRole(agentName);
 
     logger.debug("The agent {} was successfully removed", agentName);
     return Response.ok(agentName + " removed").build();

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.capture.admin.impl;
+
+import org.opencastproject.capture.admin.api.CaptureAgentAdminRoleProvider;
+import org.opencastproject.capture.admin.api.CaptureAgentStateService;
+import org.opencastproject.security.api.JaxbOrganization;
+import org.opencastproject.security.api.JaxbRole;
+import org.opencastproject.security.api.Role;
+import org.opencastproject.security.api.RoleProvider;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.security.api.UserProvider;
+import org.opencastproject.security.impl.jpa.JpaOrganization;
+import org.opencastproject.security.impl.jpa.JpaRole;
+import org.opencastproject.security.impl.jpa.JpaUser;
+import org.opencastproject.security.util.SecurityUtil;
+import org.opencastproject.userdirectory.JpaUserAndRoleProvider;
+import org.opencastproject.util.NotFoundException;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * The capture agent admin role provider provides a role for each registered capture agent
+ */
+public class CaptureAgentAdminRoleProviderImpl implements RoleProvider, CaptureAgentAdminRoleProvider {
+
+  private SecurityService securityService;
+
+  private JpaUserAndRoleProvider userAndRoleProvider;
+
+  /**
+   * @param service
+   *          the securityService to set
+   */
+  public void setSecurityService(final SecurityService service) {
+    this.securityService = service;
+  }
+
+
+  private CaptureAgentStateService captureAgentService;
+
+  public void setCaptureAgentStateService(final CaptureAgentStateService service) {
+    this.captureAgentService = service;
+  }
+
+  public void setUserAndRoleProvider(final JpaUserAndRoleProvider userAndRoleProvider) {
+    this.userAndRoleProvider = userAndRoleProvider;
+  }
+
+  private Role generateCaRole(final String name) {
+    final String roleName = SecurityUtil.getCaptureAgentRole(name);
+    final JaxbOrganization organization = JaxbOrganization.fromOrganization(securityService.getOrganization());
+    final String description = "Role for capture agent \"" + name + "\"";
+    final Role.Type system = Role.Type.INTERNAL;
+    return new JaxbRole(roleName, organization, description, system);
+  }
+
+  /**
+   * @see RoleProvider#getRoles()
+   */
+  @Override
+  public Iterator<Role> getRoles() {
+    return getRolesStream().iterator();
+  }
+
+  private Stream<Role> getRolesStream() {
+    return this.captureAgentService.getKnownAgents()
+            .keySet()
+            .stream()
+            .map(this::generateCaRole);
+  }
+
+  /**
+   * @see RoleProvider#getRolesForUser(String)
+   */
+  @Override
+  public List<Role> getRolesForUser(final String userName) {
+    return Collections.emptyList();
+  }
+
+  /**
+   * @see RoleProvider#getOrganization()
+   */
+  @Override
+  public String getOrganization() {
+    return UserProvider.ALL_ORGANIZATIONS;
+  }
+
+  /**
+   * @see RoleProvider#findRoles(String,Role.Target, int, int)
+   */
+  @Override
+  public Iterator<Role> findRoles(final String query, final Role.Target target, final int offset, final int limit) {
+    if (query == null) {
+      throw new IllegalArgumentException("Query must be set");
+    }
+
+    Stream<Role> skip = getRolesStream()
+            .filter(e -> like(e.getName(), query) || like(e.getDescription(), query))
+            .skip(offset);
+    if (limit != 0) {
+      skip = skip.limit(limit);
+    }
+    return skip
+            .iterator();
+  }
+
+  // This is taken liberally from ConfigurableLoginHandler. This really needs to go into a separate interface.
+  private static boolean like(final String string, final String query) {
+    final String regex = query.replace("_", ".").replace("%", ".*?");
+    final Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    return p.matcher(string).matches();
+  }
+
+  @Override
+  public void removeRole(final String agentName) {
+    this.userAndRoleProvider.getUsers().forEachRemaining(user -> {
+      final Set<JpaRole> newRoles = user.getRoles().stream()
+              .filter(role -> !role.getName().equals(SecurityUtil.getCaptureAgentRole(agentName)))
+              .map(role -> (JpaRole)role)
+              .collect(Collectors.toSet());
+      try {
+        this.userAndRoleProvider.updateUser(new JpaUser(user.getUsername(), user.getPassword(),
+            (JpaOrganization) user.getOrganization(), user.getName(), user.getEmail(), user.getProvider(),
+            user.isManageable(), newRoles));
+      } catch (final NotFoundException | UnauthorizedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+}

--- a/modules/capture-admin-service-impl/src/main/resources/OSGI-INF/capture-admin-service-rest.xml
+++ b/modules/capture-admin-service-impl/src/main/resources/OSGI-INF/capture-admin-service-rest.xml
@@ -13,4 +13,6 @@
     cardinality="0..1" policy="dynamic" bind="setService" unbind="unsetService" />
   <reference name="scheduler-service" interface="org.opencastproject.scheduler.api.SchedulerService"
     cardinality="1..1" policy="static" bind="setSchedulerService" />
+  <reference name="role-provider" interface="org.opencastproject.capture.admin.api.CaptureAgentAdminRoleProvider"
+             cardinality="1..1" policy="static" bind="setRoleProvider" />
 </scr:component>

--- a/modules/capture-admin-service-impl/src/main/resources/OSGI-INF/capture-agent-admin-role-provider.xml
+++ b/modules/capture-admin-service-impl/src/main/resources/OSGI-INF/capture-agent-admin-role-provider.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+  name="org.opencastproject.capture.admin.CaptureAgentAdminRoleProviderImpl" immediate="true">
+  <implementation class="org.opencastproject.capture.admin.impl.CaptureAgentAdminRoleProviderImpl" />
+  <property name="service.description" value="Manages Roles for each capture agent" />
+  <service>
+    <provide interface="org.opencastproject.security.api.RoleProvider" />
+    <provide interface="org.opencastproject.capture.admin.api.CaptureAgentAdminRoleProvider" />
+  </service>
+  <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
+    cardinality="1..1" policy="static" bind="setSecurityService" />
+  <reference name="JpaUserAndRoleProvider"
+             interface="org.opencastproject.userdirectory.JpaUserAndRoleProvider"
+             cardinality="1..1" policy="static" bind="setUserAndRoleProvider" />
+  <reference name="CaptureAgentStateService"
+             interface="org.opencastproject.capture.admin.api.CaptureAgentStateService"
+             cardinality="1..1"
+             policy="static"
+             bind="setCaptureAgentStateService" />
+</scr:component>

--- a/modules/common/src/main/java/org/opencastproject/rest/BulkOperationResult.java
+++ b/modules/common/src/main/java/org/opencastproject/rest/BulkOperationResult.java
@@ -37,11 +37,13 @@ import java.io.StringWriter;
 public class BulkOperationResult {
   public static final String OK_KEY = "ok";
   public static final String BAD_REQUEST_KEY = "badRequest";
+  public static final String UNAUTHORIZED_KEY = "unauthorized";
   public static final String NOT_FOUND_KEY = "notFound";
   public static final String ERROR_KEY = "error";
 
   private JSONArray ok = new JSONArray();
   private JSONArray badRequest = new JSONArray();
+  private JSONArray unauthorized = new JSONArray();
   private JSONArray notFound = new JSONArray();
   private JSONArray serverError = new JSONArray();
 
@@ -73,6 +75,10 @@ public class BulkOperationResult {
     addBadRequest(Long.toString(id));
   }
 
+  public void addUnauthorized(String id) {
+    unauthorized.add(id);
+  }
+
   public void addNotFound(Long id) {
     addNotFound(Long.toString(id));
   }
@@ -89,6 +95,10 @@ public class BulkOperationResult {
     return badRequest;
   }
 
+  public JSONArray getUnauthorized() {
+    return unauthorized;
+  }
+
   public JSONArray getNotFound() {
     return notFound;
   }
@@ -103,6 +113,7 @@ public class BulkOperationResult {
     bulkOperationResult.put(OK_KEY, ok);
     bulkOperationResult.put(BAD_REQUEST_KEY, badRequest);
     bulkOperationResult.put(NOT_FOUND_KEY, notFound);
+    bulkOperationResult.put(UNAUTHORIZED_KEY, unauthorized);
     bulkOperationResult.put(ERROR_KEY, serverError);
     return bulkOperationResult.toJSONString();
   }
@@ -115,6 +126,7 @@ public class BulkOperationResult {
     this.ok = (JSONArray) result.get(OK_KEY);
     this.badRequest = (JSONArray) result.get(BAD_REQUEST_KEY);
     this.notFound = (JSONArray) result.get(NOT_FOUND_KEY);
+    this.unauthorized = (JSONArray) result.get(UNAUTHORIZED_KEY);
     this.serverError = (JSONArray) result.get(ERROR_KEY);
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
@@ -138,13 +138,15 @@ public interface IndexService {
    *
    * @param request
    *          The request containing the data to create the event.
+   * @param checkAgentAccess
+   *          In case of scheduling, whether to check if the current user has access to the desired agent.
    * @return The event's id (or a comma seperated list of event ids if it was a group of events)
    * @throws IndexServiceException
    *           Thrown if there was an internal server error while creating the event.
    * @throws IllegalArgumentException
    *           Thrown if the provided request was inappropriate.
    */
-  String createEvent(HttpServletRequest request) throws IndexServiceException, IllegalArgumentException;
+  String createEvent(HttpServletRequest request, boolean checkAgentAccess) throws IndexServiceException, IllegalArgumentException;
 
   /**
    * Creates a new event based on a json string and a media package.

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
@@ -138,15 +138,13 @@ public interface IndexService {
    *
    * @param request
    *          The request containing the data to create the event.
-   * @param checkAgentAccess
-   *          In case of scheduling, whether to check if the current user has access to the desired agent.
    * @return The event's id (or a comma seperated list of event ids if it was a group of events)
    * @throws IndexServiceException
    *           Thrown if there was an internal server error while creating the event.
    * @throws IllegalArgumentException
    *           Thrown if the provided request was inappropriate.
    */
-  String createEvent(HttpServletRequest request, boolean checkAgentAccess) throws IndexServiceException, IllegalArgumentException;
+  String createEvent(HttpServletRequest request) throws IndexServiceException, IllegalArgumentException;
 
   /**
    * Creates a new event based on a json string and a media package.

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -462,7 +462,7 @@ public class IndexServiceImpl implements IndexService {
   }
 
   @Override
-  public String createEvent(HttpServletRequest request, boolean checkAgentAccess) throws IndexServiceException {
+  public String createEvent(HttpServletRequest request) throws IndexServiceException {
     JSONObject metadataJson = null;
     MediaPackage mp = null;
     // regex for form field name matching an attachment or a catalog
@@ -484,7 +484,7 @@ public class IndexServiceImpl implements IndexService {
               try {
                 metadataJson = (JSONObject) new JSONParser().parse(metadata);
                 // in case of scheduling: Check if user has access to the CA
-                if (checkAgentAccess && metadataJson.containsKey("source")) {
+                if (metadataJson.containsKey("source")) {
                   final JSONObject sourceJson = (JSONObject) metadataJson.get("source");
                   if (sourceJson.containsKey("metadata")) {
                     final JSONObject sourceMetadataJson = (JSONObject) sourceJson.get("metadata");


### PR DESCRIPTION
This patch adds the possibility to configure which user (groups) have
access to which capture agents. Whenever a new capture agent is
registered, a new role is generated which a user needs to have when
changing scheduling information affecting the capture agent.

This includes:

- Editing schedule information of scheduled events
- Changing the workflow settings of scheduled events
- Scheduling new events
- Deleting scheduled events
- Deleting capture agents

The administrator as well as the organization administrator always has
access to all capture agents. For other users, access can be configured
by adding/removing the generated roles using the admin UI.

Here some user stories describing the reasoning behind this feature:

- As person responsible for scheduling, I do not want other users to mess up with capture agents I'm responsible for
- As a user, I want to be able to manage my recordings, including cutting of the video
- As a user, I want to see upcoming recordings ("scheduled events"), so that I know what will be recorded for me in case other persons are responsible for the actual recording
- As a institution, I might have several independent groups of people that are responsible for different sets of capture agents

Visually, this PR does not change much, but here are some impressions:

There are know three possibilities considering adding scheduled events:

1. The logged in user is system administrator (ROLE_ADMIN), tenant administrator (<Tenant Admin Role>) or has permissions to access all capture agents: Opencast will behave exactly the same as those roles have access to all capture agents

2. The logged in user is neither system administrator nor tenant administrator. He has only access rights to a subset of capture agents: The Add Event wizard looks still the same but the user can only select capture agents he has permissions to access

3. The logged in user has access to no capture agents at all: In that case, the Add Event Wizard has been adopted as this is the most common kind of users in Opencast setups that work with unprivileged users:

![screen shot 2018-06-11 at 12 23 39](https://user-images.githubusercontent.com/1590263/41226825-f3738a9e-6d72-11e8-99e5-1457abb365ab.png)

Users with no access to capture agents can see scheduled events based on the access policy, but they are not allowed to edit technical scheduling information:

![screen shot 2018-06-11 at 12 23 57](https://user-images.githubusercontent.com/1590263/41226987-904ce8e2-6d73-11e8-914c-2310ff3c015e.png)


This work is sponsored by SWITCH.