### PR TITLE
MH-12888, Missing FFmpeg on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
      tesseract-ocr-deu
      unzip
   - mkdir -p ~/.m2 ~/bin
-  - wget -q https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
+  - wget -q https://pkg.opencast.org/bin/ffmpeg-release-64bit-static.tar.xz
   - tar xf ffmpeg-release-64bit-static.tar.xz
   - mv ffmpeg-*/ff* ~/bin/
   - >


### PR DESCRIPTION
This patch replaces the FFmpeg download source to one controlled by
Opencast.