### PR TITLE
MH-12889 Intuitive Merging of Video Segments

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/video/editController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/video/editController.js
@@ -57,17 +57,17 @@ angular.module('adminNg.controllers')
         };
 
         $scope.clearSelectedSegment = function () {
-            
+
             angular.forEach($scope.video.segments, function (segment) {
                 if (segment.selected) {
-                    
+
                     var index = $scope.video.segments.indexOf(segment);
 
-                    if ($scope.video.segments[index - 1]) {
-                        $scope.video.segments[index - 1].end = segment.end;
-                        $scope.video.segments.splice(index, 1);
-                    } else if ($scope.video.segments[index + 1]) {
+                    if ($scope.video.segments[index + 1]) {
                         $scope.video.segments[index + 1].start = segment.start;
+                        $scope.video.segments.splice(index, 1);
+                    } else if ($scope.video.segments[index - 1]) {
+                        $scope.video.segments[index - 1].end = segment.end;
                         $scope.video.segments.splice(index, 1);
                     }
                 }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
@@ -482,7 +482,7 @@ function (AuthService, PlayerAdapter, $document, VideoService, $timeout) {
             /**
              * Removes the given segment.
              *
-             * The previous or, failing that, the next segment will take up
+             * The next or, failing that, the previous segment will take up
              * the space of the given segment.
              *
              * @param {Event} event that triggered the merge action
@@ -500,11 +500,11 @@ function (AuthService, PlayerAdapter, $document, VideoService, $timeout) {
 
                 var index = scope.video.segments.indexOf(segment);
 
-                if (scope.video.segments[index - 1]) {
-                    scope.video.segments[index - 1].end = segment.end;
-                    scope.video.segments.splice(index, 1);
-                } else if (scope.video.segments[index + 1]) {
+                if (scope.video.segments[index + 1]) {
                     scope.video.segments[index + 1].start = segment.start;
+                    scope.video.segments.splice(index, 1);
+                } else if (scope.video.segments[index - 1]) {
+                    scope.video.segments[index - 1].end = segment.end;
                     scope.video.segments.splice(index, 1);
                 }
 

--- a/modules/admin-ui/src/test/resources/test/unit/shared/directives/timelineDirectiveSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/directives/timelineDirectiveSpec.js
@@ -166,35 +166,35 @@ describe('adminNg.directives.timelineDirective', function () {
         beforeEach(function () {
         });
 
-        describe('with a previous segment', function () {
+        describe('with a next segment', function () {
 
-            it('merges the previous with the current segment', function () {
+            it('merges the next with the current segment', function () {
                 expect($rootScope.video.segments.length).toBe(3);
-                expect($rootScope.video.segments[0].end).toEqual(17003);
+                expect($rootScope.video.segments[2].start).toEqual(28009);
 
                 element.isolateScope().
                     mergeSegment($.Event(''), $rootScope.video.segments[1]);
 
                 expect($rootScope.video.segments.length).toBe(2);
-                expect($rootScope.video.segments[0].end).toEqual(28009);
+                expect($rootScope.video.segments[1].start).toEqual(17003);
             });
         });
 
-        describe('without a previous but a next segment', function () {
+        describe('without a next but a previous segment', function () {
 
-            it('merges the next with the current segment', function () {
+            it('merges the previous with the current segment', function () {
                 expect($rootScope.video.segments.length).toBe(3);
-                expect($rootScope.video.segments[0].end).toEqual(17003);
+                expect($rootScope.video.segments[2].start).toEqual(28009);
 
                 element.isolateScope().
-                    mergeSegment($.Event(''), $rootScope.video.segments[0]);
+                    mergeSegment($.Event(''), $rootScope.video.segments[2]);
 
                 expect($rootScope.video.segments.length).toBe(2);
-                expect($rootScope.video.segments[0].end).toEqual(28009);
+                expect($rootScope.video.segments[1].start).toEqual(17003);
             });
         });
 
-        describe('without only one segment', function () {
+        describe('with only one segment', function () {
 
             beforeEach(function () {
                 $rootScope.video.segments.splice(1, 2);


### PR DESCRIPTION
This patch changes the behavior when removing segments in the video
editor. Previously, the free space resulting from removing a segment was
taken up by extending the previous segment. Now, the subsequent segment
is extended instead, which leads to a more intuitive behavior. This is
especially the case when editing a video from left to right (from start
to end), which should be the most common use case.

For the last segment, the behavior is different: it has to be merged
with the previous segment since a subsequent one doesn't exist.

This very subtle change is based on two assumptions:

- Western culture people tend to read from left to right
- The icon 'X' for segment deletion is very close to the right boundary of the segment. It seems more expected that that boundary is removed (instead the left boundary of the segment which is not close to the 'X' button)

So that means:

`|  segment 1 ---- X1 | segment 2 ---- X2 | segment 3 ----  X3|`

Pressing the 'X2' on segment 2 previously resulted in...

`|  segment 1 ------------------------X1 | segment 3 ----  X3|`

So hitting 'X2' removed the segment boundary just next to 'X1'.

This now results in ...

`|  segment 1 ---- X1 | segment 3 --------------------------  X3|`

Update: June 15th, 2018
Just tested this on our staging environment. It indeed seems more intuitive ;-)

This work is sponsored by SWITCH.