### PR TITLE
MH-12896, Clarify default player configuration

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -270,13 +270,11 @@ prop.engageui.link_mobile_redirect.description=For more information have a look 
 # - zoom: user changes the zoom of the video
 # prop.player.matomo.track_events=play, pause, seek, ended, playbackrate, volume, quality, fullscreen, focus, layout_reset, zoom
 
-# Choose the default video player
-# comment in the following line for the old flash player
-# prop.player=/engage/ui/player.html
-# comment in the following line for the html5 player
+# Path to the default video player used by the engage interfaces and the LTI tools. Parameters for selecting the
+# specific videos will be appended automatically.  Common values include:
+# - theodul player: /engage/theodul/ui/core.html
+# - paella  player: /engage/paella/ui/watch.html
 prop.player=/engage/theodul/ui/core.html
-# comment in the following line for the paella  player
-# prop.player=/engage/paella/ui/watch.html
 
 # The default flavor of the master video (the video on the "left side" in the video display)
 prop.player.mastervideotype=presenter/delivery


### PR DESCRIPTION
This patch removes the references to the no more existent Flash player
and adds a bit more structure and explanations to the default player
configuration.