### PR TITLE
MH-12899, Fix streaming distribution job load defaults

### DIFF
--- a/etc/org.opencastproject.distribution.streaming.StreamingDistributionServiceImpl.cfg
+++ b/etc/org.opencastproject.distribution.streaming.StreamingDistributionServiceImpl.cfg
@@ -1,11 +1,10 @@
-#The load on the system introduced by creating a distribute job
-#Each job involves copying the output file to the final output directory which can be expensive depending on file size
-#Since this will fairly quickly add up, these should be relatively expensive, but not cripplingly so
+# The load on the system introduced by creating a distribute job Each job involves copying the output file to the final
+# output directory. If possible, hard-linking is used for this which makes the job less expensive. If hard-linking if
+# not possible, you might want to increase this value.
+# Default: 0.2
+#job.load.streaming.distribute=0.2
 
-job.load.streaming.distribute = 1.0
-
-#The load on the system introduced by creating a retract job
-#Each job involves deleting the output file from the final output directory
-#This is a quick and inexpensive operation, so we can run a lot of these in parallel
-
-job.load.streaming.retract = 0.1
+# The load on the system introduced by creating a retract job. Each job involves deleting the output file from the
+# final output directory. This is a quick and inexpensive operation, so we can run a lot of these in parallel.
+# Default: 0.1
+#job.load.streaming.retract=0.1

--- a/etc/org.opencastproject.distribution.streaming.wowza.WowzaAdaptiveStreamingDistributionService.cfg
+++ b/etc/org.opencastproject.distribution.streaming.wowza.WowzaAdaptiveStreamingDistributionService.cfg
@@ -1,21 +1,21 @@
 # Configures the formats that are distributed to the Wowza streaming service.
 # Possible options are: rtmp, hls, hds, smooth, dash
-# Defaults are: hls, hds, smooth, dash
-# org.opencastproject.streaming.formats=hls, hds, smooth, dash
+# Default: hls, hds, smooth, dash
+#org.opencastproject.streaming.formats=hls, hds, smooth, dash
 
 # Configure the order in which the different video qualities will be written in the
 # SMIL files. The sorting criteria is the video bitrate.
-# Possible values are "ascending" or "descending". Default is "ascending"
-#org.opencastproject.adaptive-streaming.smil.order = ascending
+# Possible values are "ascending" or "descending".
+# Default: ascending
+#org.opencastproject.adaptive-streaming.smil.order=ascending
 
-#The load on the system introduced by creating a distribute job
-#Each job involves copying the output file to the final output directory which can be expensive depending on file size
-#Since this will fairly quickly add up, these should be relatively expensive, but not cripplingly so
+# The load on the system introduced by creating a distribute job Each job involves copying the output file to the final
+# output directory. If possible, hard-linking is used for this which makes the job less expensive. If hard-linking if
+# not possible, you might want to increase this value.
+# Default: 0.2
+#job.load.streaming.distribute=0.2
 
-job.load.streaming.distribute = 1.0
-
-#The load on the system introduced by creating a retract job
-#Each job involves deleting the output file from the final output directory
-#This is a quick and inexpensive operation, so we can run a lot of these in parallel
-
-job.load.streaming.retract = 0.1
+# The load on the system introduced by creating a retract job. Each job involves deleting the output file from the
+# final output directory. This is a quick and inexpensive operation, so we can run a lot of these in parallel.
+# Default: 0.1
+#job.load.streaming.retract=0.1

--- a/modules/distribution-service-streaming/src/main/java/org/opencastproject/distribution/streaming/StreamingDistributionServiceImpl.java
+++ b/modules/distribution-service-streaming/src/main/java/org/opencastproject/distribution/streaming/StreamingDistributionServiceImpl.java
@@ -97,10 +97,10 @@ public class StreamingDistributionServiceImpl extends AbstractDistributionServic
   }
 
   /** The load on the system introduced by creating a distribute job */
-  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.1f;
+  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.2f;
 
   /** The load on the system introduced by creating a retract job */
-  public static final float DEFAULT_RETRACT_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_RETRACT_JOB_LOAD = 0.1f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_DISTRIBUTE_JOB_LOAD} */
   public static final String DISTRIBUTE_JOB_LOAD_KEY = "job.load.streaming.distribute";


### PR DESCRIPTION
This patch fixes the default values for the streaming distribution job
loads. It increases the default value for distribution jobs since they
can be slightly more expensive due to file transfers though it does not
go so far as to raise it all the way up to one like the configuration
file did.

The retract job load is lowered to 0.1 since it is a very simple job
after all and a system should be able to handle multiple retract jobs in
parallel.

These changes are equivalent to the changes made in pull request #244 .