### PR TITLE
MH-12900, Fix search service job loads

### DIFF
--- a/etc/org.opencastproject.search.impl.SearchServiceImpl.cfg
+++ b/etc/org.opencastproject.search.impl.SearchServiceImpl.cfg
@@ -1,11 +1,9 @@
-#The load introduced on the system by creating an add job
-#Each job involves adding a mediapackage (XML) to the Solr index and database
-#This is relatively inexpensive, so many can be run at once
+# The load introduced on the system by creating an add job. Each job involves adding a mediapackage (XML) to the Solr
+# index and database. This is relatively inexpensive, so many can be run at once.
+# Default: 0.1
+#job.load.add=0.1
 
-job.load.add = 0.1
-
-#The load introduced on the system by creating a delete job
-#Each job involves removing a mediapackage (XML) from the Solr index and database
-#This is relatively inexpensive, so many can be run at once
-
-job.load.delete = 0.1
+# The load introduced on the system by creating a delete job. Each job involves removing a mediapackage (XML) from the
+# Solr index and database. This is relatively inexpensive, so many can be run at once.
+# Default: 0.1
+#job.load.delete=0.1

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
@@ -102,10 +102,10 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
   public static final String JOB_TYPE = "org.opencastproject.search";
 
   /** The load introduced on the system by creating an add job */
-  public static final float DEFAULT_ADD_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_ADD_JOB_LOAD = 0.1f;
 
   /** The load introduced on the system by creating a delete job */
-  public static final float DEFAULT_DELETE_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_DELETE_JOB_LOAD = 0.1f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_ADD_JOB_LOAD} */
   public static final String ADD_JOB_LOAD_KEY = "job.load.add";


### PR DESCRIPTION
This patch fixes the search service job load defaults setting them to
the values previously defined in the configuration file.