### PR TITLE
MH-12901, Fix YouTube publication job loads

### DIFF
--- a/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
+++ b/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
@@ -19,14 +19,13 @@ org.opencastproject.publication.youtube.credentialDatastore=store
 org.opencastproject.publication.youtube.clientSecretsV3=${karaf.etc}/youtube-v3/client-secrets-youtube-v3.json
 org.opencastproject.publication.youtube.dataStore=${org.opencastproject.storage.dir}/youtube-v3/data-store
 
-#The load on the system introduced by creating a publish job
-#Each job involves copying the output file to Youtube which can be expensive depending on file size
-#Since this will fairly quickly add up, these should be relatively expensive, but not cripplingly so
+# The load on the system introduced by creating a publish job. Each job involves copying the output file to Youtube
+# which can be expensive depending on file size. Since this will fairly quickly add up, these should be relatively
+# expensive, while not crippling the system.
+# Default: 0.4
+#job.load.youtube.publish=0.4
 
-job.load.youtube.publish = 1.0
-
-#The load on the system introduced by creating a retract job
-#Each job involves instructing Youtube to delete the media
-#This is a quick and inexpensive operation, so we can run a lot of these in parallel
-
-job.load.youtube.retract = 0.1
+# The load on the system introduced by creating a retract job. Each job involves instructing Youtube to delete the
+# media. This is a quick and inexpensive operation, so we can run a lot of these in parallel.
+# Default: 0.1
+#job.load.youtube.retract=0.1

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -71,10 +71,10 @@ import java.util.UUID;
 public class YouTubeV3PublicationServiceImpl extends AbstractJobProducer implements YouTubePublicationService, ManagedService {
 
   /** The load on the system introduced by creating a publish job */
-  public static final float DEFAULT_YOUTUBE_PUBLISH_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_YOUTUBE_PUBLISH_JOB_LOAD = 0.4f;
 
   /** The load on the system introduced by creating a retract job */
-  public static final float DEFAULT_YOUTUBE_RETRACT_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_YOUTUBE_RETRACT_JOB_LOAD = 0.1f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_YOUTUBE_PUBLISH_JOB_LOAD} */
   public static final String YOUTUBE_PUBLISH_LOAD_KEY = "job.load.youtube.publish";


### PR DESCRIPTION
This patch adjusts the YouTube publication job load defaults. Retracting
should be very inexpensive as already defined in the configuration.
Publishing should be more expensive but still less expensive than tasks
like encoding.