### PR TITLE
MH-12902, closing videoeditor should continue in events list

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
@@ -22,8 +22,8 @@
 
 // Controller for all event screens.
 angular.module('adminNg.controllers')
-.controller('ToolsCtrl', ['$scope', '$route', '$location', '$window', 'ToolsResource', 'Notifications', 'EventHelperService',
-    function ($scope, $route, $location, $window, ToolsResource, Notifications, EventHelperService) {
+.controller('ToolsCtrl', ['$scope', '$route', '$location', 'Storage', '$window', 'ToolsResource', 'Notifications', 'EventHelperService',
+    function ($scope, $route, $location, Storage, $window, ToolsResource, Notifications, EventHelperService) {
 
         $scope.navigateTo = function (path) {
             $location.path(path).replace();
@@ -91,6 +91,11 @@ angular.module('adminNg.controllers')
                 $scope.submitButton = false;
                 Notifications.add('error', 'VIDEO_CUT_NOT_SAVED', 'video-tools');
             });
+        };
+
+        $scope.leave = function () {
+            Storage.put('pagination', $scope.resource, 'resume', true);
+            $location.url('/events/' + $scope.resource);
         };
     }
 ]);

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
@@ -243,7 +243,7 @@
                           <!-- Save and Continue -->
                         </a>
 
-                        <a class="return-button" ng-click="navigateTo('/events/events')" translate>VIDEO_TOOL.BUTTONS.CLOSE</a>
+                        <a class="return-button" ng-click="leave()" translate>VIDEO_TOOL.BUTTONS.CLOSE</a>
                     </div>
                 </div>
             </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
@@ -142,7 +142,11 @@ angular.module('adminNg.services')
             var p = me.pagination, oldPageSize = p.limit;
 
             p.limit = pageSize;
-            p.offset = 0;
+            if (!p.resume) {
+                p.offset = 0;
+            }
+            p.resume = false;
+            Storage.put('pagination', me.resource, 'resume', p.resume);
 
             me.updatePagination();
 
@@ -190,6 +194,10 @@ angular.module('adminNg.services')
 
                 if (angular.isDefined(pagination.offset)) {
                     me.pagination.offset = pagination.offset;
+                }
+
+                if (angular.isDefined(pagination.resume)) {
+                    me.pagination.resume = pagination.resume;
                 }
             }
 


### PR DESCRIPTION
This patch adds a resume feature to admin ui events module

Before this patch every way you could leave the video editor and go to the events list got you back to the beginngn of the list. With this patch the close button brings to the page of the events list where you left off from.

This work was sponsored by SWITCH