### PR TITLE
MH-12906 Composoer should ignore system specific output pathes like /dev/null

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -371,9 +371,15 @@ public class EncoderEngine implements AutoCloseable {
       logger.debug(message);
       Matcher matcher = outputPattern.matcher(message);
       if (matcher.find()) {
-        File outputFile = new File(matcher.group(1));
-        logger.info("Identified output file {}", outputFile);
-        output.add(outputFile);
+        String outputPath = StringUtils.trimToNull(matcher.group(1));
+        if (outputPath != null && !StringUtils.equalsIgnoreCase("null", outputPath)
+                && !StringUtils.equals("NUL", outputPath)
+                && !StringUtils.equals("/dev/null", outputPath)
+                && !StringUtils.startsWith("pipe:", outputPath)) {
+          File outputFile = new File(outputPath);
+          logger.info("Identified output file {}", outputFile);
+          output.add(outputFile);
+        }
       }
 
     // Some to debug

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -371,9 +371,8 @@ public class EncoderEngine implements AutoCloseable {
       logger.debug(message);
       Matcher matcher = outputPattern.matcher(message);
       if (matcher.find()) {
-        String outputPath = StringUtils.trimToNull(matcher.group(1));
-        if (outputPath != null && !StringUtils.equalsIgnoreCase("null", outputPath)
-                && !StringUtils.equals("NUL", outputPath)
+        String outputPath = matcher.group(1);
+        if (!StringUtils.equals("NUL", outputPath)
                 && !StringUtils.equals("/dev/null", outputPath)
                 && !StringUtils.startsWith("pipe:", outputPath)) {
           File outputFile = new File(outputPath);


### PR DESCRIPTION
With ffmpeg you can define an output format 'null' (e.g. `ffmpeg -i file.mp4 … -f null -`). This will not create any media files. Composer should handle this case properly.