### PR TITLE
MH-12907, Fix segmentation default job load

### DIFF
--- a/etc/org.opencastproject.videosegmenter.ffmpeg.VideoSegmenterServiceImpl.cfg
+++ b/etc/org.opencastproject.videosegmenter.ffmpeg.VideoSegmenterServiceImpl.cfg
@@ -43,8 +43,7 @@
 
 #durationDependent = false
 
-# An estimate of how much load the video segmenter puts on the node
-# This job involves a number of ffmpeg processes to detect segments in the video
-# This is both a CPU and I/O intensive job, so its load should reflect that
-
-job.load.videosegmenter = 2.0
+# An estimate of how much load the video segmenter puts on the node. This job involves a number of sequential FFmpeg
+# processes with no video or audio encoding involved to detect segments in the video.
+# Default: 0.6
+#job.load.videosegmenter=0.6

--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
@@ -148,8 +148,8 @@ VideoSegmenterService, ManagedService {
   /** Default value for the option whether segments numbers depend on track duration */
   public static final boolean DEFAULT_DURATION_DEPENDENT = false;
 
-  /** The load introduced on the system by creating a caption job */
-  public static final float DEFAULT_SEGMENTER_JOB_LOAD = 1.0f;
+  /** The load introduced on the system by a segmentation job */
+  public static final float DEFAULT_SEGMENTER_JOB_LOAD = 0.6f;
 
   /** The key to look for in the service configuration file to override the DEFAULT_CAPTION_JOB_LOAD */
   public static final String SEGMENTER_JOB_LOAD_KEY = "job.load.videosegmenter";


### PR DESCRIPTION
This patch fixes the default job load of the video segmentation where
the actual default, the configuration and the documentation where not
matching.

Note that this patch also slightly lowers the job load since the
operation is single-threaded, non-parallel and involves neither video
nor audio encoding.