### PR TITLE
MH-12910: Put temporary grunt files into the target folder

### DIFF
--- a/modules/matterhorn-admin-ui-ng/.gitignore
+++ b/modules/matterhorn-admin-ui-ng/.gitignore
@@ -1,6 +1,5 @@
 /node_modules
 /dist
-/.tmp
 /.sass-cache
 www
 .jshintrc
@@ -8,7 +7,6 @@ deploy.sh
 proxy.sh
 *.swo
 bin
-coverage
 src/test/resources/*.jar
 src/test/resources/chromedriver
 .agignore

--- a/modules/matterhorn-admin-ui-ng/Gruntfile.js
+++ b/modules/matterhorn-admin-ui-ng/Gruntfile.js
@@ -23,7 +23,8 @@ module.exports = function (grunt) {
   // Configurable paths for the application
   var appConfig = {
     app: require('./bower.json').appPath,
-    dist: 'target/grunt/webapp'
+    dist: 'target/grunt/webapp',
+    staging: 'target/grunt/.tmp'
   };
 
   // Define the configuration for all the tasks
@@ -64,7 +65,7 @@ module.exports = function (grunt) {
         },
         files: [
           '<%= yeoman.app %>/{,*/}*.html',
-          '.tmp/styles/{,*/}*.css',
+          '<%= yeoman.staging %>/styles/{,*/}*.css',
           '<%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
         ]
       }
@@ -170,13 +171,13 @@ module.exports = function (grunt) {
         files: [{
           dot: true,
           src: [
-            '.tmp',
+            '<%= yeoman.staging %>',
             '<%= yeoman.dist %>/{,*/}*',
             '!<%= yeoman.dist %>/.git{,*/}*'
           ]
         }]
       },
-      server: '.tmp'
+      server: '<%= yeoman.staging %>'
     },
 
     // Add vendor prefixed styles
@@ -192,17 +193,17 @@ module.exports = function (grunt) {
         },
         files: [{
           expand: true,
-          cwd: '.tmp/styles/',
+          cwd: '<%= yeoman.staging %>/styles/',
           src: '{,*/}*.css',
-          dest: '.tmp/styles/'
+          dest: '<%= yeoman.staging %>/styles/'
         }]
       },
       dist: {
         files: [{
           expand: true,
-          cwd: '.tmp/styles/',
+          cwd: '<%= yeoman.staging %>/styles/',
           src: '{,*/}*.css',
-          dest: '.tmp/styles/'
+          dest: '<%= yeoman.staging %>/styles/'
         }]
       }
     },
@@ -217,7 +218,7 @@ module.exports = function (grunt) {
         devDependencies: true,
         src: '<%= karma.unit.configFile %>',
         ignorePath:  /\.\.\//,
-        fileTypes:{
+        fileTypes: {
           js: {
             block: /(([\s\t]*)\/{2}\s*?bower:\s*?(\S*))(\n|\r|.)*?(\/{2}\s*endbower)/gi,
               detect: {
@@ -247,7 +248,7 @@ module.exports = function (grunt) {
                 expand: true,
                 cwd: '<%= yeoman.app %>/styles',
                 src: ['*.scss'],
-                dest: '.tmp/styles',
+                dest: '<%= yeoman.staging %>/styles',
                 ext: '.css'
             }]
         },
@@ -256,7 +257,7 @@ module.exports = function (grunt) {
                 expand: true,
                 cwd: '<%= yeoman.app %>/styles',
                 src: ['*.scss'],
-                dest: '.tmp/styles',
+                dest: '<%= yeoman.staging %>/styles',
                 ext: '.css'
             }]
         }
@@ -280,6 +281,7 @@ module.exports = function (grunt) {
     useminPrepare: {
       html: ['<%= yeoman.app %>/index.html', '<%= yeoman.app %>/index.html'],
       options: {
+        staging: '<%= yeoman.staging %>',
         dest: '<%= yeoman.dist %>',
         flow: {
           html: {
@@ -333,9 +335,9 @@ module.exports = function (grunt) {
       dist: {
         files: [{
           expand: true,
-          cwd: '.tmp/concat/scripts',
+          cwd: '<%= yeoman.staging %>/concat/scripts',
           src: '*.js',
-          dest: '.tmp/concat/scripts'
+          dest: '<%= yeoman.staging %>/concat/scripts'
         }]
       }
     },
@@ -357,7 +359,7 @@ module.exports = function (grunt) {
           ]
         }, {
           expand: true,
-          cwd: '.tmp/images',
+          cwd: '<%= yeoman.staging %>/images',
           dest: '<%= yeoman.dist %>/images',
           src: ['generated/*']
         }, {
@@ -384,7 +386,7 @@ module.exports = function (grunt) {
       styles: {
         expand: true,
         cwd: '<%= yeoman.app %>/styles',
-        dest: '.tmp/styles/',
+        dest: '<%= yeoman.staging %>/styles/',
         src: '{,*/}*.css'
       }
     },

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/index.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/index.html
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="../../bower_components/angular-hotkeys/build/hotkeys.css" />
         <!-- endbower -->
         <!-- endbuild -->
-        <!-- build:css(.tmp) styles/main.css -->
+        <!-- build:css(target/grunt/.tmp) styles/main.css -->
         <link rel="stylesheet" href="styles/main.css">
         <!-- endbuild -->
         <link type="text/css" href="lib/datepicker/themes/smoothness/jquery-ui-1.10.3.min.css" rel="stylesheet">
@@ -102,7 +102,7 @@
         </footer>
 
 
-        <!-- build:js({.tmp,src/main}) scripts/bower.js -->
+        <!-- build:js(src/main) scripts/bower.js -->
         <!-- bower:js -->
         <script src="../../bower_components/angular/angular.js"></script>
         <script src="../../bower_components/angular-md5/angular-md5.js"></script>
@@ -116,7 +116,7 @@
         <!-- endbower -->
         <!-- endbuild -->
 
-        <!-- build:js({.tmp,src/main/webapp}) scripts/vendor.js -->
+        <!-- build:js(src/main/webapp) scripts/vendor.js -->
         <script src="scripts/lib/angular-file-upload/angular-file-upload-shim.js"></script>
         <script src="scripts/lib/angular/angular-local-storage.js"></script>
         <script src="scripts/lib/angular-file-upload/angular-file-upload.js"></script>
@@ -126,7 +126,7 @@
         <script src="scripts/lib/javascript-md5/js/md5.min.js"></script>
         <!-- endbuild -->
 
-        <!-- build:js({.tmp,src/main/webapp}) scripts/scripts.js -->
+        <!-- build:js(src/main/webapp) scripts/scripts.js -->
         <script src="scripts/app.js"></script>
         <script src="scripts/shared/services/services.js"></script>
         <script src="scripts/shared/services/resourceHelperService.js"></script>

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/login.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/login.html
@@ -65,7 +65,7 @@
             </div>
         </section>
 
-        <!-- build:js({.tmp,src/main}) scripts/bower.js -->
+        <!-- build:js(src/main) scripts/bower.js -->
         <!-- bower:js -->
         <script src="../../bower_components/angular/angular.js"></script>
         <script src="../../bower_components/angular-md5/angular-md5.js"></script>
@@ -79,12 +79,12 @@
         <!-- endbower -->
         <!-- endbuild -->
 
-        <!-- build:js({.tmp,src/main/webapp}) scripts/vendor.js -->
+        <!-- build:js(src/main/webapp) scripts/vendor.js -->
         <script src="scripts/lib/chosen.js"></script>
         <script src="scripts/lib/javascript-md5/js/md5.min.js"></script>
         <!-- endbuild -->
 
-        <!-- build:js({.tmp,src/main/webapp}) scripts/scripts.js -->
+        <!-- build:js(src/main/webapp) scripts/scripts.js -->
         <script src="scripts/app.js"></script>
         <script src="scripts/shared/controllers/controllers.js"></script>
         <script src="scripts/shared/controllers/navigationController.js"></script>

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/karma.conf.js
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/karma.conf.js
@@ -87,7 +87,7 @@ module.exports = function (config) {
 
         coverageReporter: {
             type : 'html',
-            dir : '../../../coverage/'
+            dir : '../../../target/coverage/'
         },
 
         ngHtml2JsPreprocessor: {


### PR DESCRIPTION
This moves some temporary files grunt, or more specifically the usemin plugin, creates during the admin UI build into the `target` folder, which is ignored in `.gitignore`.

This way, `git` should no longer show untracked files after switching between branches with different module naming schemes (`matterhorn-*` vs. no prefix), at least as soon as #216 is merged and propagated through all the releases. :wink: 

Note that previously, `.tmp` and `coverage` were ignored in a directory local `.gitignore`. This is not sufficient, because that `.gitignore` vanishes, too, in a branch switch as described above. The alternative solution would be to ignore them in the (or a more) global `.gitignore`, but I preferred to collect all (or most, I guess; I didn't check thoroughly. Let's say "more" :wink:) of grunts artifacts in one location.