### PR TITLE
MH-12913, Fix Admin Interface Deprecation Warnings

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -375,7 +375,7 @@ public class ToolsEndpoint implements ManagedService {
           @Context HttpServletRequest request) throws IndexServiceException, NotFoundException {
     String details;
     try (InputStream is = request.getInputStream()) {
-      details = IOUtils.toString(is);
+      details = IOUtils.toString(is, request.getCharacterEncoding());
     } catch (IOException e) {
       logger.error("Error reading request body: {}", getStackTrace(e));
       return R.serverError();

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AclEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AclEndpointTest.java
@@ -74,7 +74,7 @@ public class AclEndpointTest {
     InputStreamReader reader = new InputStreamReader(stream);
     JSONObject expected = (JSONObject) new JSONParser().parse(reader);
 
-    JSONObject actual = (JSONObject) parser.parse(given().log().all().expect().statusCode(HttpStatus.SC_OK)
+    JSONObject actual = (JSONObject) parser.parse(given().expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(2)).body("offset", equalTo(0))
             .body("limit", equalTo(100)).body("results", hasSize(2)).when().get(rt.host("/acls.json")).asString());
 
@@ -86,21 +86,21 @@ public class AclEndpointTest {
     int limit = 100;
     int offset = 1;
 
-    given().log().all().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+    given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(2)).body("offset", equalTo(offset))
             .body("limit", equalTo(limit)).body("results", hasSize(1)).when().get(rt.host("/acls.json"));
 
     offset = 0;
     limit = 1;
 
-    given().log().all().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+    given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(2)).body("offset", equalTo(offset))
             .body("limit", equalTo(limit)).body("results", hasSize(1)).when().get(rt.host("/acls.json"));
 
     offset = 2;
     limit = 0;
 
-    given().log().all().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+    given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(2)).body("offset", equalTo(offset))
             .body("limit", equalTo(100)).body("results", hasSize(0)).when().get(rt.host("/acls.json"));
   }

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpointTest.java
@@ -119,9 +119,10 @@ public class CaptureAgentsEndpointTest {
 
   @Test
   public void testGetAllCaptureAgents() throws Exception {
-    String expectedWithInputs = IOUtils.toString(CaptureAgentsEndpointTest.class.getResource("/capture_agents.json"));
+    String expectedWithInputs = IOUtils.toString(CaptureAgentsEndpointTest.class.getResource("/capture_agents.json"),
+      "utf-8");
     String expectedWithoutInputs = IOUtils.toString(CaptureAgentsEndpointTest.class
-            .getResource("/capture_agents_noinputs.json"));
+            .getResource("/capture_agents_noinputs.json"), "utf-8");
 
     String result = given().queryParam("inputs", true).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(4)).body("offset", equalTo(0))
@@ -144,7 +145,7 @@ public class CaptureAgentsEndpointTest {
 
     given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(total)).body("offset", equalTo(offset))
-            .body("limit", equalTo(limit)).body("results", hasSize(limit > 0 ? limit : total - offset)).when()
+            .body("limit", equalTo(limit)).body("results", hasSize(total - offset)).when()
             .get(rt.host("/agents.json"));
 
     offset = 0;
@@ -152,7 +153,7 @@ public class CaptureAgentsEndpointTest {
 
     given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(total)).body("offset", equalTo(offset))
-            .body("limit", equalTo(limit)).body("results", hasSize(limit > 0 ? limit : total - offset)).when()
+            .body("limit", equalTo(limit)).body("results", hasSize(limit)).when()
             .get(rt.host("/agents.json"));
 
     offset = 2;
@@ -160,7 +161,7 @@ public class CaptureAgentsEndpointTest {
 
     given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(total)).body("offset", equalTo(offset))
-            .body("limit", equalTo(limit)).body("results", hasSize(limit > 0 ? limit : total - offset)).when()
+            .body("limit", equalTo(limit)).body("results", hasSize(limit)).when()
             .get(rt.host("/agents.json"));
   }
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/JobEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/JobEndpointTest.java
@@ -68,143 +68,144 @@ public class JobEndpointTest {
 
   @Test
   public void testJobsRequest() throws Exception {
-    String eventString = IOUtils.toString(getClass().getResource("/jobs.json"));
+    String eventString = IOUtils.toString(getClass().getResource("/jobs.json"), "utf-8");
 
     String actual = given().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON).when()
             .get(rt.host("/jobs.json")).asString();
 
-    eventString = IOUtils.toString(getClass().getResource("/jobsLimitOffset.json"));
+    assertThat(eventString, SameJSONAs.sameJSONAs(actual));
 
-    actual = given().queryParam("offset", 1).queryParam("limit", 1).expect().log().all().statusCode(HttpStatus.SC_OK)
+    eventString = IOUtils.toString(getClass().getResource("/jobsLimitOffset.json"), "utf-8");
+
+    actual = given().queryParam("offset", 1).queryParam("limit", 1).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).when().get(rt.host("/jobs.json")).asString();
-    logger.info(actual);
 
     assertThat(eventString, SameJSONAs.sameJSONAs(actual));
   }
 
   @Test
   public void testSortCreator() {
-    given().param("sort", "creator:ASC").log().all().expect()
+    given().param("sort", "creator:ASC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].creator", equalTo("testuser1"))
-            .content("results[1].creator", equalTo("testuser1"))
-            .content("results[2].creator", equalTo("testuser2"))
-            .content("results[3].creator", equalTo("testuser3"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].creator", equalTo("testuser1"))
+            .body("results[1].creator", equalTo("testuser1"))
+            .body("results[2].creator", equalTo("testuser2"))
+            .body("results[3].creator", equalTo("testuser3"))
             .when().get(rt.host("/jobs.json"));
 
-    given().param("sort", "creator:DESC").log().all().expect()
+    given().param("sort", "creator:DESC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].creator", equalTo("testuser3"))
-            .content("results[1].creator", equalTo("testuser2"))
-            .content("results[2].creator", equalTo("testuser1"))
-            .content("results[3].creator", equalTo("testuser1"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].creator", equalTo("testuser3"))
+            .body("results[1].creator", equalTo("testuser2"))
+            .body("results[2].creator", equalTo("testuser1"))
+            .body("results[3].creator", equalTo("testuser1"))
             .when().get(rt.host("/jobs.json"));
   }
 
   @Test
   public void testSortOperation() {
-    given().param("sort", "operation:ASC").log().all().expect()
+    given().param("sort", "operation:ASC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].operation", equalTo("Encode"))
-            .content("results[1].operation", equalTo("Inspect"))
-            .content("results[2].operation", equalTo("RESUME"))
-            .content("results[3].operation", equalTo("test"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].operation", equalTo("Encode"))
+            .body("results[1].operation", equalTo("Inspect"))
+            .body("results[2].operation", equalTo("RESUME"))
+            .body("results[3].operation", equalTo("test"))
             .when().get(rt.host("/jobs.json"));
 
-    given().param("sort", "operation:DESC").log().all().expect()
+    given().param("sort", "operation:DESC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].operation", equalTo("test"))
-            .content("results[1].operation", equalTo("RESUME"))
-            .content("results[2].operation", equalTo("Inspect"))
-            .content("results[3].operation", equalTo("Encode"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].operation", equalTo("test"))
+            .body("results[1].operation", equalTo("RESUME"))
+            .body("results[2].operation", equalTo("Inspect"))
+            .body("results[3].operation", equalTo("Encode"))
             .when().get(rt.host("/jobs.json"));
   }
 
   @Test
   public void testSortProcessingHost() {
-    given().param("sort", "processingHost:ASC").log().all().expect()
+    given().param("sort", "processingHost:ASC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].processingHost", equalTo("host1"))
-            .content("results[1].processingHost", equalTo("host1"))
-            .content("results[2].processingHost", equalTo("host2"))
-            .content("results[3].processingHost", equalTo("host3"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].processingHost", equalTo("host1"))
+            .body("results[1].processingHost", equalTo("host1"))
+            .body("results[2].processingHost", equalTo("host2"))
+            .body("results[3].processingHost", equalTo("host3"))
             .when().get(rt.host("/jobs.json"));
 
-    given().param("sort", "processingHost:DESC").log().all().expect()
+    given().param("sort", "processingHost:DESC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].processingHost", equalTo("host3"))
-            .content("results[1].processingHost", equalTo("host2"))
-            .content("results[2].processingHost", equalTo("host1"))
-            .content("results[3].processingHost", equalTo("host1"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].processingHost", equalTo("host3"))
+            .body("results[1].processingHost", equalTo("host2"))
+            .body("results[2].processingHost", equalTo("host1"))
+            .body("results[3].processingHost", equalTo("host1"))
             .when().get(rt.host("/jobs.json"));
   }
 
   @Test
   public void testSortStarted() {
-    given().param("sort", "started:ASC").log().all().expect()
+    given().param("sort", "started:ASC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].started", equalTo("2014-06-05T09:05:00Z"))
-            .content("results[1].started", equalTo("2014-06-05T09:10:00Z"))
-            .content("results[2].started", equalTo("2014-06-05T09:11:11Z"))
-            .content("results[3].started", equalTo("2014-06-05T09:16:00Z"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].started", equalTo("2014-06-05T09:05:00Z"))
+            .body("results[1].started", equalTo("2014-06-05T09:10:00Z"))
+            .body("results[2].started", equalTo("2014-06-05T09:11:11Z"))
+            .body("results[3].started", equalTo("2014-06-05T09:16:00Z"))
             .when().get(rt.host("/jobs.json"));
 
-    given().param("sort", "started:DESC").log().all().expect()
+    given().param("sort", "started:DESC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].started", equalTo("2014-06-05T09:16:00Z"))
-            .content("results[1].started", equalTo("2014-06-05T09:11:11Z"))
-            .content("results[2].started", equalTo("2014-06-05T09:10:00Z"))
-            .content("results[3].started", equalTo("2014-06-05T09:05:00Z"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].started", equalTo("2014-06-05T09:16:00Z"))
+            .body("results[1].started", equalTo("2014-06-05T09:11:11Z"))
+            .body("results[2].started", equalTo("2014-06-05T09:10:00Z"))
+            .body("results[3].started", equalTo("2014-06-05T09:05:00Z"))
             .when().get(rt.host("/jobs.json"));
   }
 
   @Test
   public void testSortSubmitted() {
-    given().param("sort", "submitted:ASC").log().all().expect()
+    given().param("sort", "submitted:ASC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].submitted", equalTo("2014-06-05T09:05:00Z"))
-            .content("results[1].submitted", equalTo("2014-06-05T09:10:00Z"))
-            .content("results[2].submitted", equalTo("2014-06-05T09:11:11Z"))
-            .content("results[3].submitted", equalTo("2014-06-05T09:16:00Z"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].submitted", equalTo("2014-06-05T09:05:00Z"))
+            .body("results[1].submitted", equalTo("2014-06-05T09:10:00Z"))
+            .body("results[2].submitted", equalTo("2014-06-05T09:11:11Z"))
+            .body("results[3].submitted", equalTo("2014-06-05T09:16:00Z"))
             .when().get(rt.host("/jobs.json"));
 
-    given().param("sort", "started:DESC").log().all().expect()
+    given().param("sort", "started:DESC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].submitted", equalTo("2014-06-05T09:16:00Z"))
-            .content("results[1].submitted", equalTo("2014-06-05T09:11:11Z"))
-            .content("results[2].submitted", equalTo("2014-06-05T09:10:00Z"))
-            .content("results[3].submitted", equalTo("2014-06-05T09:05:00Z"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].submitted", equalTo("2014-06-05T09:16:00Z"))
+            .body("results[1].submitted", equalTo("2014-06-05T09:11:11Z"))
+            .body("results[2].submitted", equalTo("2014-06-05T09:10:00Z"))
+            .body("results[3].submitted", equalTo("2014-06-05T09:05:00Z"))
             .when().get(rt.host("/jobs.json"));
   }
 
   @Test
   public void testSortType() {
-    given().param("sort", "type:ASC").log().all().expect()
+    given().param("sort", "type:ASC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].type", equalTo("org.opencastproject.composer"))
-            .content("results[1].type", equalTo("org.opencastproject.composer"))
-            .content("results[2].type", equalTo("org.opencastproject.inspection"))
-            .content("results[3].type", equalTo("org.opencastproject.workflow"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].type", equalTo("org.opencastproject.composer"))
+            .body("results[1].type", equalTo("org.opencastproject.composer"))
+            .body("results[2].type", equalTo("org.opencastproject.inspection"))
+            .body("results[3].type", equalTo("org.opencastproject.workflow"))
             .when().get(rt.host("/jobs.json"));
 
-    given().param("sort", "type:DESC").log().all().expect()
+    given().param("sort", "type:DESC").expect()
             .statusCode(org.apache.commons.httpclient.HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].type", equalTo("org.opencastproject.workflow"))
-            .content("results[1].type", equalTo("org.opencastproject.inspection"))
-            .content("results[2].type", equalTo("org.opencastproject.composer"))
-            .content("results[3].type", equalTo("org.opencastproject.composer"))
+            .body("count", equalTo(4)).body("total", equalTo(4))
+            .body("results[0].type", equalTo("org.opencastproject.workflow"))
+            .body("results[1].type", equalTo("org.opencastproject.inspection"))
+            .body("results[2].type", equalTo("org.opencastproject.composer"))
+            .body("results[3].type", equalTo("org.opencastproject.composer"))
             .when().get(rt.host("/jobs.json"));
   }
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ListProvidersEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ListProvidersEndpointTest.java
@@ -50,19 +50,19 @@ public class ListProvidersEndpointTest {
 
   @Test
   public void testGetGeneric() throws ParseException {
-    JSONObject all = (JSONObject) parser.parse(given().log().all()
+    JSONObject all = (JSONObject) parser.parse(given()
             .pathParam("id", TestListProvidersEndpoint.PROVIDER_NAME).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("2", containsString(TestListProvidersEndpoint.PROVIDER_VALUES[2]))
             .body("", hasValue("z")).when().get(rt.host("/{id}.json")).asString());
 
     assertEquals(TestListProvidersEndpoint.PROVIDER_VALUES.length, all.entrySet().size());
 
-    given().log().all().pathParam("id", "missingprovider").expect().statusCode(HttpStatus.SC_NOT_FOUND).when()
+    given().pathParam("id", "missingprovider").expect().statusCode(HttpStatus.SC_NOT_FOUND).when()
             .get(rt.host("/{id}.json"));
 
     int limit = 2;
     int offset = 2;
-    JSONObject limited = (JSONObject) parser.parse(given().log().all()
+    JSONObject limited = (JSONObject) parser.parse(given()
             .pathParam("id", TestListProvidersEndpoint.PROVIDER_NAME).queryParam("limit", limit)
             .queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK).when().get(rt.host("/{id}.json"))
             .asString());
@@ -79,7 +79,7 @@ public class ListProvidersEndpointTest {
 
   @Test
   public void testGetWithFilters() throws ParseException {
-    Response response = given().log().all().pathParam("id", "SERVERS").param("filter", "name=non existing name")
+    Response response = given().pathParam("id", "SERVERS").param("filter", "name=non existing name")
       .when().get(rt.host("/{id}.json"))
       .then().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
       .extract().response();

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServerEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServerEndpointTest.java
@@ -54,7 +54,7 @@ public class ServerEndpointTest {
     InputStream stream = ServerEndpointTest.class.getResourceAsStream("/servers.json");
     InputStreamReader reader = new InputStreamReader(stream);
     JSONObject expected = (JSONObject) new JSONParser().parse(reader);
-    JSONObject actual = (JSONObject) parser.parse(given().log().all().expect().statusCode(HttpStatus.SC_OK)
+    JSONObject actual = (JSONObject) parser.parse(given().expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).when().get(rt.host("/servers.json")).asString());
 
     ServiceEndpointTestsUtil.testJSONObjectEquality(expected, actual);
@@ -65,162 +65,162 @@ public class ServerEndpointTest {
     int total = 4;
     int limit = 3;
     int offset = 2;
-    given().param("limit", limit).param("offset", offset).log().all().expect().statusCode(HttpStatus.SC_OK)
-            .contentType(ContentType.JSON).content("limit", equalTo(limit)).content("offset", equalTo(offset))
-            .content("count", equalTo(total - offset)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
+    given().param("limit", limit).param("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON).body("limit", equalTo(limit)).content("offset", equalTo(offset))
+            .body("count", equalTo(total - offset)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
 
     limit = 10;
     offset = 2;
-    given().param("limit", limit).param("offset", offset).log().all().expect().statusCode(HttpStatus.SC_OK)
-            .contentType(ContentType.JSON).content("limit", equalTo(limit)).content("offset", equalTo(offset))
-            .content("count", equalTo(total - offset)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
+    given().param("limit", limit).param("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON).body("limit", equalTo(limit)).content("offset", equalTo(offset))
+            .body("count", equalTo(total - offset)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
 
     offset = 4;
-    given().param("limit", limit).param("offset", offset).log().all().expect().statusCode(HttpStatus.SC_OK)
-            .contentType(ContentType.JSON).content("limit", equalTo(limit)).content("offset", equalTo(offset))
-            .content("count", equalTo(total - offset)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
+    given().param("limit", limit).param("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON).body("limit", equalTo(limit)).content("offset", equalTo(offset))
+            .body("count", equalTo(total - offset)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
 
     limit = 0;
     offset = 0;
-    given().param("limit", limit).param("offset", offset).log().all().expect().statusCode(HttpStatus.SC_OK)
-            .contentType(ContentType.JSON).content("limit", equalTo(limit)).content("offset", equalTo(offset))
-            .content("count", equalTo(total - offset)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
+    given().param("limit", limit).param("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON).body("limit", equalTo(limit)).content("offset", equalTo(offset))
+            .body("count", equalTo(total - offset)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
 
     limit = 4;
     offset = -1; // negatiive offset not allowed and will be changed to 0
-    given().param("limit", limit).param("offset", offset).log().all().expect().statusCode(HttpStatus.SC_OK)
-            .contentType(ContentType.JSON).content("limit", equalTo(limit)).content("offset", equalTo(offset))
-            .content("count", equalTo(4)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
+    given().param("limit", limit).param("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON).body("limit", equalTo(limit)).content("offset", equalTo(offset))
+            .body("count", equalTo(4)).content("total", equalTo(total)).when().get(rt.host("/servers.json"));
 
   }
 
   @Test
   public void testHostNameFilter() {
-    given().param("filter", "hostname:host1").log().all().expect()
+    given().param("filter", "hostname:host1").expect()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("total", equalTo(1))
-            .content("count", equalTo(1))
-            .content("results[0].hostname", equalTo("host1"))
+            .body("total", equalTo(1))
+            .body("count", equalTo(1))
+            .body("results[0].hostname", equalTo("host1"))
             .when().get(rt.host("/servers.json"));
 
-    given().param("filter", "hostname:non-existing").log().all().expect()
+    given().param("filter", "hostname:non-existing").expect()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("total", equalTo(0))
-            .content("count", equalTo(0))
+            .body("total", equalTo(0))
+            .body("count", equalTo(0))
             .when().get(rt.host("/servers.json"));
   }
 
   @Test
   public void testStatusFilter() {
-    given().param("filter", "status:online").log().all().expect()
+    given().param("filter", "status:online").expect()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("total", equalTo(3))
-            .content("count", equalTo(3))
-            .content("results[0].online", equalTo(true))
-            .content("results[1].online", equalTo(true))
-            .content("results[2].online", equalTo(true))
+            .body("total", equalTo(3))
+            .body("count", equalTo(3))
+            .body("results[0].online", equalTo(true))
+            .body("results[1].online", equalTo(true))
+            .body("results[2].online", equalTo(true))
             .when().get(rt.host("/servers.json"));
 
-    given().param("filter", "status:offline").log().all().expect()
+    given().param("filter", "status:offline").expect()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("total", equalTo(1))
-            .content("count", equalTo(1))
-            .content("results[0].online", equalTo(false))
+            .body("total", equalTo(1))
+            .body("count", equalTo(1))
+            .body("results[0].online", equalTo(false))
             .when().get(rt.host("/servers.json"));
 
-    given().param("filter", "status:maintenance").log().all().expect()
+    given().param("filter", "status:maintenance").expect()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("total", equalTo(2))
-            .content("count", equalTo(2))
-            .content("results[0].maintenance", equalTo(true))
-            .content("results[1].maintenance", equalTo(true))
+            .body("total", equalTo(2))
+            .body("count", equalTo(2))
+            .body("results[0].maintenance", equalTo(true))
+            .body("results[1].maintenance", equalTo(true))
             .when().get(rt.host("/servers.json"));
   }
 
   @Test
   public void testFreeTextFilter() {
-    given().param("filter", "textFilter:host1").log().all().expect()
+    given().param("filter", "textFilter:host1").expect()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("total", equalTo(1))
-            .content("count", equalTo(1))
-            .content("results[0].hostname", equalTo("host1"))
+            .body("total", equalTo(1))
+            .body("count", equalTo(1))
+            .body("results[0].hostname", equalTo("host1"))
             .when().get(rt.host("/servers.json"));
 
-    given().param("filter", "textFilter:ost").param("sort", "hostname:ASC").log().all().expect()
+    given().param("filter", "textFilter:ost").param("sort", "hostname:ASC").expect()
             .statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("total", equalTo(4))
-            .content("count", equalTo(4))
-            .content("results[0].hostname", equalTo("host1"))
-            .content("results[1].hostname", equalTo("host2"))
-            .content("results[2].hostname", equalTo("host3"))
-            .content("results[3].hostname", equalTo("host4"))
+            .body("total", equalTo(4))
+            .body("count", equalTo(4))
+            .body("results[0].hostname", equalTo("host1"))
+            .body("results[1].hostname", equalTo("host2"))
+            .body("results[2].hostname", equalTo("host3"))
+            .body("results[3].hostname", equalTo("host4"))
             .when().get(rt.host("/servers.json"));
   }
 
   @Test
   public void testSortCores() throws ParseException {
-    given().param("sort", "CORES:ASC").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host3"))
-            .content("results[1].hostname", equalTo("host2")).when().get(rt.host("/servers.json"));
+    given().param("sort", "CORES:ASC").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host3"))
+            .body("results[1].hostname", equalTo("host2")).when().get(rt.host("/servers.json"));
 
-    given().param("sort", "CORES:DESC").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host1"))
-            .content("results[1].hostname", equalTo("host4")).when().get(rt.host("/servers.json"));
+    given().param("sort", "CORES:DESC").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host1"))
+            .body("results[1].hostname", equalTo("host4")).when().get(rt.host("/servers.json"));
   }
 
   @Test
   public void testSortHostName() throws ParseException {
-    given().param("sort", "HOSTNAME:ASC").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host1"))
-            .content("results[1].hostname", equalTo("host2")).when().get(rt.host("/servers.json"));
+    given().param("sort", "HOSTNAME:ASC").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host1"))
+            .body("results[1].hostname", equalTo("host2")).when().get(rt.host("/servers.json"));
 
-    given().param("sort", "HOSTNAME:DESC").log().all().expect().statusCode(HttpStatus.SC_OK)
-            .contentType(ContentType.JSON).content("count", equalTo(4)).content("total", equalTo(4))
-            .content("results[0].hostname", equalTo("host4")).content("results[1].hostname", equalTo("host3")).when()
+    given().param("sort", "HOSTNAME:DESC").expect().statusCode(HttpStatus.SC_OK)
+            .contentType(ContentType.JSON).body("count", equalTo(4)).content("total", equalTo(4))
+            .body("results[0].hostname", equalTo("host4")).content("results[1].hostname", equalTo("host3")).when()
             .get(rt.host("/servers.json"));
   }
 
   @Test
   public void testSortMeanRunTime() {
-    given().param("sort", "meanRunTime:ASC").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host3"))
-            .content("results[1].hostname", equalTo("host1")).content("results[2].hostname", equalTo("host2"))
+    given().param("sort", "meanRunTime:ASC").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host3"))
+            .body("results[1].hostname", equalTo("host1")).content("results[2].hostname", equalTo("host2"))
             .when().get(rt.host("/servers.json"));
 
-    given().param("sort", "meanRunTime:DESC").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host4"))
-            .content("results[1].hostname", equalTo("host2")).content("results[2].hostname", equalTo("host1"))
+    given().param("sort", "meanRunTime:DESC").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host4"))
+            .body("results[1].hostname", equalTo("host2")).content("results[2].hostname", equalTo("host1"))
             .when().get(rt.host("/servers.json"));
   }
 
   @Test
   public void testSortMeanQueueTime() {
-    given().param("sort", "meanQueueTime:asc").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host2"))
-            .content("results[1].hostname", equalTo("host1")).content("results[2].hostname", equalTo("host3"))
+    given().param("sort", "meanQueueTime:asc").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host2"))
+            .body("results[1].hostname", equalTo("host1")).content("results[2].hostname", equalTo("host3"))
             .when().get(rt.host("/servers.json"));
 
-    given().param("sort", "meanQueueTime:desc").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host4"))
-            .content("results[1].hostname", equalTo("host3")).content("results[2].hostname", equalTo("host1"))
+    given().param("sort", "meanQueueTime:desc").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host4"))
+            .body("results[1].hostname", equalTo("host3")).content("results[2].hostname", equalTo("host1"))
             .when().get(rt.host("/servers.json"));
   }
 
   @Test
   public void testSortStatus() throws ParseException {
-    given().param("sort", "ONLINE:ASC").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host3"))
+    given().param("sort", "ONLINE:ASC").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host3"))
             .when().get(rt.host("/servers.json"));
 
-    given().param("sort", "ONLINE:DESC").log().all().expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
-            .content("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host1"))
+    given().param("sort", "ONLINE:DESC").expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON)
+            .body("count", equalTo(4)).content("total", equalTo(4)).content("results[0].hostname", equalTo("host1"))
             .when().get(rt.host("/servers.json"));
   }
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServicesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServicesEndpointTest.java
@@ -77,7 +77,7 @@ public class ServicesEndpointTest {
     InputStream stream = ServicesEndpointTest.class.getResourceAsStream(TEST_DATA_JSON);
     InputStreamReader reader = new InputStreamReader(stream);
     JSONObject expected = (JSONObject) new JSONParser().parse(reader);
-    JSONObject actual = (JSONObject) parser.parse(given().log().all().expect().statusCode(HttpStatus.SC_OK)
+    JSONObject actual = (JSONObject) parser.parse(given().expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).when().get(rt.host(TEST_DATA_JSON)).asString());
 
     ServiceEndpointTestsUtil.testJSONObjectEquality(expected, actual);
@@ -85,327 +85,327 @@ public class ServicesEndpointTest {
 
   @Test
   public void testLimitAndOffset() {
-    given().param("limit", 10).param("offset", 2).log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("limit", 10).param("offset", 2).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("limit", equalTo(10))
-            .content("count", equalTo(4))
-            .content("total", equalTo(6))
-            .content("results[0].name", equalTo("service3"))
-            .content("results[3].name", equalTo("service6"))
+            .body("limit", equalTo(10))
+            .body("count", equalTo(4))
+            .body("total", equalTo(6))
+            .body("results[0].name", equalTo("service3"))
+            .body("results[3].name", equalTo("service6"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("limit", 2).param("offset", 3).log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("limit", 2).param("offset", 3).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("limit", equalTo(2))
-            .content("count", equalTo(2))
-            .content("total", equalTo(6))
-            .content("results[0].name", equalTo("service4"))
-            .content("results[1].name", equalTo("service5"))
+            .body("limit", equalTo(2))
+            .body("count", equalTo(2))
+            .body("total", equalTo(6))
+            .body("results[0].name", equalTo("service4"))
+            .body("results[1].name", equalTo("service5"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("limit", 0).param("offset", 10).log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("limit", 0).param("offset", 10).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("limit", equalTo(0))
-            .content("count", equalTo(0))
-            .content("total", equalTo(6))
+            .body("limit", equalTo(0))
+            .body("count", equalTo(0))
+            .body("total", equalTo(6))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testNameFilter() {
-    given().param("filter", "name:service2").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "name:service2").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(1))
-            .content("total", equalTo(1))
-            .content("results[0].name", equalTo("service2"))
+            .body("count", equalTo(1))
+            .body("total", equalTo(1))
+            .body("results[0].name", equalTo("service2"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("filter", "name:service").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "name:service").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(0))
-            .content("total", equalTo(0))
+            .body("count", equalTo(0))
+            .body("total", equalTo(0))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("filter", " name:service2 ").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", " name:service2 ").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(1))
-            .content("total", equalTo(1))
-            .content("results[0].name", equalTo("service2"))
+            .body("count", equalTo(1))
+            .body("total", equalTo(1))
+            .body("results[0].name", equalTo("service2"))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testHostnameFilter() {
-    given().param("filter", "hostname:host1").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "hostname:host1").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(2))
-            .content("total", equalTo(2))
-            .content("results[0].hostname", equalTo("host1"))
-            .content("results[1].hostname", equalTo("host1"))
+            .body("count", equalTo(2))
+            .body("total", equalTo(2))
+            .body("results[0].hostname", equalTo("host1"))
+            .body("results[1].hostname", equalTo("host1"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("filter", "hostname:host").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "hostname:host").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(0))
-            .content("total", equalTo(0))
+            .body("count", equalTo(0))
+            .body("total", equalTo(0))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("filter", " hostname:host1 ").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", " hostname:host1 ").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(2))
-            .content("total", equalTo(2))
-            .content("results[0].hostname", equalTo("host1"))
-            .content("results[1].hostname", equalTo("host1"))
+            .body("count", equalTo(2))
+            .body("total", equalTo(2))
+            .body("results[0].hostname", equalTo("host1"))
+            .body("results[1].hostname", equalTo("host1"))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testActionsFilter() {
-    given().param("filter", "actions:true").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "actions:true").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(2))
-            .content("total", equalTo(2))
-            .content("results[0].hostname", equalTo("host1"))
-            .content("results[0].name", equalTo("service2"))
-            .content("results[1].hostname", equalTo("host3"))
-            .content("results[1].name", equalTo("service4"))
+            .body("count", equalTo(2))
+            .body("total", equalTo(2))
+            .body("results[0].hostname", equalTo("host1"))
+            .body("results[0].name", equalTo("service2"))
+            .body("results[1].hostname", equalTo("host3"))
+            .body("results[1].name", equalTo("service4"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("filter", "actions:false").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "actions:false").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(4))
-            .content("total", equalTo(4))
-            .content("results[0].hostname", equalTo("host1"))
-            .content("results[0].name", equalTo("service1"))
-            .content("results[1].hostname", equalTo("host2"))
-            .content("results[1].name", equalTo("service3"))
-            .content("results[2].hostname", equalTo("host2"))
-            .content("results[2].name", equalTo("service5"))
-            .content("results[3].hostname", equalTo("host4"))
-            .content("results[3].name", equalTo("service6"))
+            .body("count", equalTo(4))
+            .body("total", equalTo(4))
+            .body("results[0].hostname", equalTo("host1"))
+            .body("results[0].name", equalTo("service1"))
+            .body("results[1].hostname", equalTo("host2"))
+            .body("results[1].name", equalTo("service3"))
+            .body("results[2].hostname", equalTo("host2"))
+            .body("results[2].name", equalTo("service5"))
+            .body("results[3].hostname", equalTo("host4"))
+            .body("results[3].name", equalTo("service6"))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testFreeTextFilter() {
-    given().param("filter", "textFilter:host1").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "textFilter:host1").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(2))
-            .content("total", equalTo(2))
-            .content("results[0].hostname", equalTo("host1"))
-            .content("results[1].hostname", equalTo("host1"))
+            .body("count", equalTo(2))
+            .body("total", equalTo(2))
+            .body("results[0].hostname", equalTo("host1"))
+            .body("results[1].hostname", equalTo("host1"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("filter", "textFilter:service4").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "textFilter:service4").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(1))
-            .content("total", equalTo(1))
-            .content("results[0].name", equalTo("service4"))
+            .body("count", equalTo(1))
+            .body("total", equalTo(1))
+            .body("results[0].name", equalTo("service4"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("filter", "textFilter:2").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("filter", "textFilter:2").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(3))
-            .content("total", equalTo(3))
-            .content("results[0].name", equalTo("service2"))
-            .content("results[1].hostname", equalTo("host2"))
-            .content("results[2].hostname", equalTo("host2"))
+            .body("count", equalTo(3))
+            .body("total", equalTo(3))
+            .body("results[0].name", equalTo("service2"))
+            .body("results[1].hostname", equalTo("host2"))
+            .body("results[2].hostname", equalTo("host2"))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testHostSort() {
-    given().param("sort", "hostname:asc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "hostname:asc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[0].hostname", equalTo("host1"))
-            .content("results[1].hostname", equalTo("host1"))
-            .content("results[2].hostname", equalTo("host2"))
-            .content("results[3].hostname", equalTo("host2"))
-            .content("results[4].hostname", equalTo("host3"))
-            .content("results[5].hostname", equalTo("host4"))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[0].hostname", equalTo("host1"))
+            .body("results[1].hostname", equalTo("host1"))
+            .body("results[2].hostname", equalTo("host2"))
+            .body("results[3].hostname", equalTo("host2"))
+            .body("results[4].hostname", equalTo("host3"))
+            .body("results[5].hostname", equalTo("host4"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("sort", "hostname:desc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "hostname:desc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[5].hostname", equalTo("host1"))
-            .content("results[4].hostname", equalTo("host1"))
-            .content("results[3].hostname", equalTo("host2"))
-            .content("results[2].hostname", equalTo("host2"))
-            .content("results[1].hostname", equalTo("host3"))
-            .content("results[0].hostname", equalTo("host4"))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[5].hostname", equalTo("host1"))
+            .body("results[4].hostname", equalTo("host1"))
+            .body("results[3].hostname", equalTo("host2"))
+            .body("results[2].hostname", equalTo("host2"))
+            .body("results[1].hostname", equalTo("host3"))
+            .body("results[0].hostname", equalTo("host4"))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testNameSort() {
-    given().param("sort", "name:asc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "name:asc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[0].name", equalTo("service1"))
-            .content("results[1].name", equalTo("service2"))
-            .content("results[2].name", equalTo("service3"))
-            .content("results[3].name", equalTo("service4"))
-            .content("results[4].name", equalTo("service5"))
-            .content("results[5].name", equalTo("service6"))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[0].name", equalTo("service1"))
+            .body("results[1].name", equalTo("service2"))
+            .body("results[2].name", equalTo("service3"))
+            .body("results[3].name", equalTo("service4"))
+            .body("results[4].name", equalTo("service5"))
+            .body("results[5].name", equalTo("service6"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("sort", "name:desc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "name:desc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[5].name", equalTo("service1"))
-            .content("results[4].name", equalTo("service2"))
-            .content("results[3].name", equalTo("service3"))
-            .content("results[2].name", equalTo("service4"))
-            .content("results[1].name", equalTo("service5"))
-            .content("results[0].name", equalTo("service6"))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[5].name", equalTo("service1"))
+            .body("results[4].name", equalTo("service2"))
+            .body("results[3].name", equalTo("service3"))
+            .body("results[2].name", equalTo("service4"))
+            .body("results[1].name", equalTo("service5"))
+            .body("results[0].name", equalTo("service6"))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testRunningJobsSort() {
-    given().param("sort", "running:asc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "running:asc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[3].running", equalTo(0))
-            .content("results[4].running", equalTo(1))
-            .content("results[5].running", equalTo(2))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[3].running", equalTo(0))
+            .body("results[4].running", equalTo(1))
+            .body("results[5].running", equalTo(2))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("sort", "running:desc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "running:desc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[0].running", equalTo(2))
-            .content("results[1].running", equalTo(1))
-            .content("results[2].running", equalTo(0))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[0].running", equalTo(2))
+            .body("results[1].running", equalTo(1))
+            .body("results[2].running", equalTo(0))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testQueuedJobsSort() {
-    given().param("sort", "queued:asc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "queued:asc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[1].queued", equalTo(0))
-            .content("results[2].queued", equalTo(1))
-            .content("results[3].queued", equalTo(1))
-            .content("results[4].queued", equalTo(3))
-            .content("results[5].queued", equalTo(5))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[1].queued", equalTo(0))
+            .body("results[2].queued", equalTo(1))
+            .body("results[3].queued", equalTo(1))
+            .body("results[4].queued", equalTo(3))
+            .body("results[5].queued", equalTo(5))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("sort", "queued:desc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "queued:desc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[4].queued", equalTo(0))
-            .content("results[3].queued", equalTo(1))
-            .content("results[2].queued", equalTo(1))
-            .content("results[1].queued", equalTo(3))
-            .content("results[0].queued", equalTo(5))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[4].queued", equalTo(0))
+            .body("results[3].queued", equalTo(1))
+            .body("results[2].queued", equalTo(1))
+            .body("results[1].queued", equalTo(3))
+            .body("results[0].queued", equalTo(5))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testCompletedJobsSort() {
-    given().param("sort", "completed:asc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "completed:asc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[2].completed", equalTo(0))
-            .content("results[3].completed", equalTo(5))
-            .content("results[4].completed", equalTo(10))
-            .content("results[5].completed", equalTo(20))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[2].completed", equalTo(0))
+            .body("results[3].completed", equalTo(5))
+            .body("results[4].completed", equalTo(10))
+            .body("results[5].completed", equalTo(20))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("sort", "completed:desc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "completed:desc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[3].completed", equalTo(0))
-            .content("results[2].completed", equalTo(5))
-            .content("results[1].completed", equalTo(10))
-            .content("results[0].completed", equalTo(20))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[3].completed", equalTo(0))
+            .body("results[2].completed", equalTo(5))
+            .body("results[1].completed", equalTo(10))
+            .body("results[0].completed", equalTo(20))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testMeanRunTimeSort() {
-    given().param("sort", "meanRunTime:asc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "meanRunTime:asc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[2].meanRunTime", equalTo(0))
-            .content("results[3].meanRunTime", equalTo(10))
-            .content("results[4].meanRunTime", equalTo(30))
-            .content("results[5].meanRunTime", equalTo(123))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[2].meanRunTime", equalTo(0))
+            .body("results[3].meanRunTime", equalTo(10))
+            .body("results[4].meanRunTime", equalTo(30))
+            .body("results[5].meanRunTime", equalTo(123))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("sort", "meanRunTime:desc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "meanRunTime:desc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[3].meanRunTime", equalTo(0))
-            .content("results[2].meanRunTime", equalTo(10))
-            .content("results[1].meanRunTime", equalTo(30))
-            .content("results[0].meanRunTime", equalTo(123))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[3].meanRunTime", equalTo(0))
+            .body("results[2].meanRunTime", equalTo(10))
+            .body("results[1].meanRunTime", equalTo(30))
+            .body("results[0].meanRunTime", equalTo(123))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testMeanQueuedTimeSort() {
-    given().param("sort", "meanQueueTime:asc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "meanQueueTime:asc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[0].meanQueueTime", equalTo(0))
-            .content("results[1].meanQueueTime", equalTo(0))
-            .content("results[2].meanQueueTime", equalTo(10))
-            .content("results[3].meanQueueTime", equalTo(30))
-            .content("results[4].meanQueueTime", equalTo(60))
-            .content("results[5].meanQueueTime", equalTo(456))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[0].meanQueueTime", equalTo(0))
+            .body("results[1].meanQueueTime", equalTo(0))
+            .body("results[2].meanQueueTime", equalTo(10))
+            .body("results[3].meanQueueTime", equalTo(30))
+            .body("results[4].meanQueueTime", equalTo(60))
+            .body("results[5].meanQueueTime", equalTo(456))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("sort", "meanQueueTime:desc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "meanQueueTime:desc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[5].meanQueueTime", equalTo(0))
-            .content("results[4].meanQueueTime", equalTo(0))
-            .content("results[3].meanQueueTime", equalTo(10))
-            .content("results[2].meanQueueTime", equalTo(30))
-            .content("results[1].meanQueueTime", equalTo(60))
-            .content("results[0].meanQueueTime", equalTo(456))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[5].meanQueueTime", equalTo(0))
+            .body("results[4].meanQueueTime", equalTo(0))
+            .body("results[3].meanQueueTime", equalTo(10))
+            .body("results[2].meanQueueTime", equalTo(30))
+            .body("results[1].meanQueueTime", equalTo(60))
+            .body("results[0].meanQueueTime", equalTo(456))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 
   @Test
   public void testStatusSort() {
-    given().param("sort", "status:asc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "status:asc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[0].status", equalTo("NORMAL"))
-            .content("results[1].status", equalTo("NORMAL"))
-            .content("results[4].status", equalTo("WARNING"))
-            .content("results[5].status", equalTo("ERROR"))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[0].status", equalTo("NORMAL"))
+            .body("results[1].status", equalTo("NORMAL"))
+            .body("results[4].status", equalTo("WARNING"))
+            .body("results[5].status", equalTo("ERROR"))
             .when().get(rt.host(TEST_DATA_JSON));
 
-    given().param("sort", "status:desc").log().all().expect().statusCode(HttpStatus.SC_OK)
+    given().param("sort", "status:desc").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON)
-            .content("count", equalTo(6))
-            .content("total", equalTo(6))
-            .content("results[5].status", equalTo("NORMAL"))
-            .content("results[4].status", equalTo("NORMAL"))
-            .content("results[1].status", equalTo("WARNING"))
-            .content("results[0].status", equalTo("ERROR"))
+            .body("count", equalTo(6))
+            .body("total", equalTo(6))
+            .body("results[5].status", equalTo("NORMAL"))
+            .body("results[4].status", equalTo("NORMAL"))
+            .body("results[1].status", equalTo("WARNING"))
+            .body("results[0].status", equalTo("ERROR"))
             .when().get(rt.host(TEST_DATA_JSON));
   }
 }

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestThemesEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestThemesEndpoint.java
@@ -33,7 +33,6 @@ import org.opencastproject.matterhorn.search.impl.SearchResultImpl;
 import org.opencastproject.message.broker.api.MessageSender;
 import org.opencastproject.messages.MailServiceException;
 import org.opencastproject.security.api.DefaultOrganization;
-import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
@@ -49,7 +48,6 @@ import org.opencastproject.util.data.Option;
 
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.Ignore;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
@@ -87,8 +85,7 @@ public class TestThemesEndpoint extends ThemesEndpoint {
   }
 
   private void setupServices() throws Exception {
-    user = new JaxbUser("test", null, "Test User", "test@test.com", "test", new DefaultOrganization(),
-            new HashSet<JaxbRole>());
+    user = new JaxbUser("test", null, "Test User", "test@test.com", "test", new DefaultOrganization(), new HashSet<>());
 
     UserDirectoryService userDirectoryService = EasyMock.createNiceMock(UserDirectoryService.class);
     EasyMock.expect(userDirectoryService.loadUser((String) EasyMock.anyObject())).andReturn(user).anyTimes();
@@ -110,24 +107,12 @@ public class TestThemesEndpoint extends ThemesEndpoint {
 
     // Create AdminUI Search Index
     AdminUISearchIndex adminUISearchIndex = EasyMock.createMock(AdminUISearchIndex.class);
-    final Capture<ThemeSearchQuery> themeQueryCapture = new Capture<ThemeSearchQuery>();
+    final Capture<ThemeSearchQuery> themeQueryCapture = EasyMock.newCapture();
     EasyMock.expect(adminUISearchIndex.getByQuery(EasyMock.capture(themeQueryCapture)))
-            .andAnswer(new IAnswer<SearchResult<org.opencastproject.index.service.impl.index.theme.Theme>>() {
-
-              @Override
-              public SearchResult<org.opencastproject.index.service.impl.index.theme.Theme> answer() throws Throwable {
-                return createThemeCaptureResult(themeQueryCapture);
-              }
-            });
-    final Capture<SeriesSearchQuery> seriesQueryCapture = new Capture<SeriesSearchQuery>();
+            .andAnswer(() -> createThemeCaptureResult(themeQueryCapture));
+    final Capture<SeriesSearchQuery> seriesQueryCapture = EasyMock.newCapture();
     EasyMock.expect(adminUISearchIndex.getByQuery(EasyMock.capture(seriesQueryCapture)))
-            .andAnswer(new IAnswer<SearchResult<Series>>() {
-
-              @Override
-              public SearchResult<Series> answer() throws Throwable {
-                return createSeriesCaptureResult(seriesQueryCapture);
-              }
-            });
+            .andAnswer(() -> createSeriesCaptureResult(seriesQueryCapture));
     EasyMock.replay(adminUISearchIndex);
 
     themesServiceDatabaseImpl = new ThemesServiceDatabaseImpl();
@@ -151,7 +136,7 @@ public class TestThemesEndpoint extends ThemesEndpoint {
 
     ComponentContext componentContext = EasyMock.createNiceMock(ComponentContext.class);
     EasyMock.expect(componentContext.getBundleContext()).andReturn(bundleContext).anyTimes();
-    EasyMock.expect(componentContext.getProperties()).andReturn(new Hashtable<String, Object>()).anyTimes();
+    EasyMock.expect(componentContext.getProperties()).andReturn(new Hashtable<>()).anyTimes();
     EasyMock.replay(componentContext);
 
     StaticFileRestService staticFileRestService = new StaticFileRestService();

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestUserSettingsEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestUserSettingsEndpoint.java
@@ -28,7 +28,6 @@ import org.opencastproject.adminui.usersettings.persistence.UserSettingsServiceE
 
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.Ignore;
 
 import javax.ws.rs.Path;
@@ -65,15 +64,10 @@ public class TestUserSettingsEndpoint extends UserSettingsEndpoint {
     UserSettings userSettings = createUserSettings(start, finish, limit, offset, total);
     userSettingsService = EasyMock.createNiceMock(UserSettingsService.class);
     EasyMock.expect(userSettingsService.findUserSettings(limit, 0)).andReturn(userSettings);
-    final Capture<String> inputKey = new Capture<String>();
-    final Capture<String> inputValue = new Capture<String>();
+    final Capture<String> inputKey = EasyMock.newCapture();
+    final Capture<String> inputValue = EasyMock.newCapture();
     EasyMock.expect(userSettingsService.addUserSetting(EasyMock.capture(inputKey), EasyMock.capture(inputValue)))
-            .andAnswer(new IAnswer<UserSetting>() {
-              public UserSetting answer() {
-                UserSetting userSetting = new UserSetting(19, inputKey.getValue(), inputValue.getValue());
-                return userSetting;
-              }
-            });
+            .andAnswer(() -> new UserSetting(19, inputKey.getValue(), inputValue.getValue()));
     userSettingsService.deleteUserSetting(18L);
     EasyMock.expectLastCall();
     EasyMock.expect(userSettingsService.updateUserSetting(18, EXAMPLE_KEY, EXAMPLE_VALUE)).andReturn(

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersEndpointTest.java
@@ -58,7 +58,7 @@ public class UsersEndpointTest {
     InputStreamReader reader = new InputStreamReader(stream);
     JSONObject expected = (JSONObject) new JSONParser().parse(reader);
 
-    JSONObject actual = (JSONObject) parser.parse(given().log().all().expect().statusCode(HttpStatus.SC_OK)
+    JSONObject actual = (JSONObject) parser.parse(given().expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(4)).body("offset", equalTo(0))
             .body("limit", equalTo(100)).body("results", hasSize(4)).when().get(rt.host("/users.json")).asString());
 
@@ -71,30 +71,30 @@ public class UsersEndpointTest {
     int offset = 2;
     int total = 4;
 
-    given().log().all().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+    given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(total)).body("offset", equalTo(offset))
             .body("limit", equalTo(limit)).body("results", hasSize(2)).when().get(rt.host("/users.json"));
 
     offset = 0;
     limit = 2;
 
-    given().log().all().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+    given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(total)).body("offset", equalTo(offset))
-            .body("limit", equalTo(limit)).body("results", hasSize(limit > 0 ? limit : total - offset)).when()
+            .body("limit", equalTo(limit)).body("results", hasSize(limit)).when()
             .get(rt.host("/users.json"));
 
     offset = 2;
     limit = 2;
 
-    given().log().all().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
+    given().queryParam("limit", limit).queryParam("offset", offset).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(total)).body("offset", equalTo(offset))
-            .body("limit", equalTo(limit)).body("results", hasSize(limit > 0 ? limit : total - offset)).when()
+            .body("limit", equalTo(limit)).body("results", hasSize(limit)).when()
             .get(rt.host("/users.json"));
   }
 
   @Test
   public void testSorting() throws Exception {
-    JSONObject actual = (JSONObject) parser.parse(given().log().all().queryParam("sort", "name:ASC").expect()
+    JSONObject actual = (JSONObject) parser.parse(given().queryParam("sort", "name:ASC").expect()
             .statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON).body("total", equalTo(4))
             .body("offset", equalTo(0)).body("limit", equalTo(100)).body("results", hasSize(4)).when()
             .get(rt.host("/users.json")).asString());

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersSettingsEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersSettingsEndpointTest.java
@@ -47,7 +47,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Set;
 
 import io.restassured.http.ContentType;
@@ -66,16 +65,14 @@ public class UsersSettingsEndpointTest {
     JSONObject exObject;
     JSONObject acObject;
     int actualId;
-    for (int i = 0; i < actualArray.size(); i++) {
-      acObject = (JSONObject) actualArray.get(i);
+    for (Object anActualArray : actualArray) {
+      acObject = (JSONObject) anActualArray;
       actualId = Integer.parseInt(acObject.get("id").toString()) - 1;
       exObject = (JSONObject) expectedArray.get(actualId);
-      Set<String> exEntrySet = exObject.keySet();
+      Set exEntrySet = exObject.keySet();
       Assert.assertEquals(exEntrySet.size(), acObject.size());
-      Iterator<String> exIter = exEntrySet.iterator();
 
-      while (exIter.hasNext()) {
-        String item = exIter.next();
+      for (Object item : exEntrySet) {
         Object exValue = exObject.get(item);
         Object acValue = acObject.get(item);
         Assert.assertEquals(exValue, acValue);
@@ -89,7 +86,7 @@ public class UsersSettingsEndpointTest {
     InputStream stream = UsersSettingsEndpointTest.class.getResourceAsStream("/usersettings.json");
     InputStreamReader reader = new InputStreamReader(stream);
     JSONObject expected = (JSONObject) new JSONParser().parse(reader);
-    JSONObject actual = (JSONObject) parser.parse(given().log().all().expect().statusCode(HttpStatus.SC_OK)
+    JSONObject actual = (JSONObject) parser.parse(given().expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(10)).body("offset", equalTo(0))
             .body("limit", equalTo(100)).body("results", hasSize(10)).when().get(rt.host("/settings.json")).asString());
 
@@ -104,7 +101,7 @@ public class UsersSettingsEndpointTest {
     InputStreamReader reader = new InputStreamReader(stream);
     JSONObject expected = (JSONObject) new JSONParser().parse(reader);
 
-    JSONObject actual = (JSONObject) parser.parse(given().log().all().expect().statusCode(HttpStatus.SC_OK)
+    JSONObject actual = (JSONObject) parser.parse(given().expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body("total", equalTo(10)).body("offset", equalTo(0))
             .body("limit", equalTo(100)).body("results", hasSize(10)).when()
             .get(rt.host("/settings.json?limit=100&offset=0")).asString());
@@ -116,7 +113,7 @@ public class UsersSettingsEndpointTest {
   @Ignore
   @Test
   public void testGetSignatureExpectsOK() throws ParseException, IOException {
-    JSONObject actual = (JSONObject) parser.parse(given().log().all().expect().statusCode(HttpStatus.SC_OK)
+    JSONObject actual = (JSONObject) parser.parse(given().expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).when().get(rt.host("/signature")).asString());
     logger.info(actual.toJSONString());
   }
@@ -147,7 +144,7 @@ public class UsersSettingsEndpointTest {
 
     JSONObject actual = (JSONObject) parser.parse(given().formParam(nameKey, nameValue)
             .formParam(fromNameKey, fromNameValue).formParam(fromAddressKey, fromAddressValue)
-            .formParam(textKey, textValue).log().all().expect().statusCode(HttpStatus.SC_OK)
+            .formParam(textKey, textValue).expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).body(nameKey, equalTo(nameValue)).body("creator", equalTo(creator))
             .body("signature", equalTo(textValue)).when().post(rt.host("/signature")).asString());
     logger.info(actual.toJSONString());
@@ -158,7 +155,7 @@ public class UsersSettingsEndpointTest {
     String key = "example_key";
     String value = "example_value";
 
-    JSONObject actual = (JSONObject) parser.parse(given().formParam("key", key).formParam("value", value).log().all()
+    JSONObject actual = (JSONObject) parser.parse(given().formParam("key", key).formParam("value", value)
             .expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON).body("key", equalTo(key))
             .body("value", equalTo(value)).when().post(rt.host("setting")).asString());
     logger.info(actual.toJSONString());
@@ -167,12 +164,12 @@ public class UsersSettingsEndpointTest {
   @Ignore
   @Test
   public void testDeleteSignatureExpectsOK() throws ParseException, IOException {
-    given().log().all().expect().statusCode(HttpStatus.SC_OK).when().delete(rt.host("/signature/19"));
+    given().expect().statusCode(HttpStatus.SC_OK).when().delete(rt.host("/signature/19"));
   }
 
   @Test
   public void testDeleteUserSettingExpectsOK() throws ParseException, IOException {
-    given().log().all().expect().statusCode(HttpStatus.SC_OK).when().delete(rt.host("/setting/18"));
+    given().expect().statusCode(HttpStatus.SC_OK).when().delete(rt.host("/setting/18"));
   }
 
   // FIXME
@@ -204,7 +201,7 @@ public class UsersSettingsEndpointTest {
     String key = TestUserSettingsEndpoint.EXAMPLE_KEY;
     String value = TestUserSettingsEndpoint.EXAMPLE_VALUE;
 
-    given().pathParam("settingId", Long.toString(18)).formParam("key", key).formParam("value", value).log().all()
+    given().pathParam("settingId", Long.toString(18)).formParam("key", key).formParam("value", value)
             .expect().statusCode(HttpStatus.SC_OK).contentType(ContentType.JSON).body("key", equalTo(key))
             .body("value", equalTo(value)).when().put(rt.host("/setting/{settingId}")).asString();
   }

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/usersettings/UserSettingsServiceTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/usersettings/UserSettingsServiceTest.java
@@ -194,7 +194,7 @@ public class UserSettingsServiceTest {
   public void addUserSettingInputNormalValuesExpectsSavedSetting() throws UserSettingsServiceException {
     String key = "newKey";
     String value = "newValue";
-    Capture<UserSettingDto> userSettingDto = new Capture<UserSettingDto>();
+    Capture<UserSettingDto> userSettingDto = EasyMock.newCapture();
     EntityTransaction tx = EasyMock.createNiceMock(EntityTransaction.class);
     EasyMock.replay(tx);
 

--- a/modules/admin-ui/src/test/resources/jobs.json
+++ b/modules/admin-ui/src/test/resources/jobs.json
@@ -1,48 +1,48 @@
 {
-    "count": 4,
-    "limit": 0,
-    "offset": 0,
-    "results": [
-        {
-            "creator": "testuser1",
-            "id": 1,
-            "operation": "test",
-            "processingHost": "host1",
-            "started": "2014-06-05T09:10:00Z",
-            "status": "RUNNING",
-            "submitted": "2014-06-05T09:10:00Z",
-            "type": "org.opencastproject.composer"
-        },
-        {
-            "creator": "testuser2",
-            "id": 3,
-            "operation": "RESUME",
-            "processingHost": "host3",
-            "started": "2014-06-05T09:11:11Z",
-            "status": "RUNNING",
-            "submitted": "2014-06-05T09:11:11Z",
-            "type": "org.opencastproject.workflow"
-        },
-        {
-            "creator": "testuser1",
-            "id": 4,
-            "operation": "Inspect",
-            "processingHost": "host2",
-            "started": "2014-06-05T09:16:00Z",
-            "status": "RUNNING",
-            "submitted": "2014-06-05T09:16:00Z",
-            "type": "org.opencastproject.inspection"
-        },
-        {
-            "creator": "testuser3",
-            "id": 5,
-            "operation": "Encode",
-            "processingHost": "host1",
-            "started": "2014-06-05T09:05:00Z",
-            "status": "RUNNING",
-            "submitted": "2014-06-05T09:05:00Z",
-            "type": "org.opencastproject.composer"
-        }
-    ],
-    "total": 5
+  "total": 4,
+  "offset": 0,
+  "count": 4,
+  "limit": 0,
+  "results": [
+    {
+      "creator": "testuser3",
+      "submitted": "2014-06-05T09:05:00Z",
+      "processingHost": "host1",
+      "started": "2014-06-05T09:05:00Z",
+      "id": 5,
+      "type": "org.opencastproject.composer",
+      "operation": "Encode",
+      "status": "RUNNING"
+    },
+    {
+      "creator": "testuser1",
+      "submitted": "2014-06-05T09:10:00Z",
+      "processingHost": "host1",
+      "started": "2014-06-05T09:10:00Z",
+      "id": 1,
+      "type": "org.opencastproject.composer",
+      "operation": "test",
+      "status": "RUNNING"
+    },
+    {
+      "creator": "testuser2",
+      "submitted": "2014-06-05T09:11:11Z",
+      "processingHost": "host3",
+      "started": "2014-06-05T09:11:11Z",
+      "id": 3,
+      "type": "org.opencastproject.workflow",
+      "operation": "RESUME",
+      "status": "RUNNING"
+    },
+    {
+      "creator": "testuser1",
+      "submitted": "2014-06-05T09:16:00Z",
+      "processingHost": "host2",
+      "started": "2014-06-05T09:16:00Z",
+      "id": 4,
+      "type": "org.opencastproject.inspection",
+      "operation": "Inspect",
+      "status": "RUNNING"
+    }
+  ]
 }


### PR DESCRIPTION
This patch fixes a bunch of deprecation warnings in the tests of the
admin interface REST endpoints. Most commonly, the problems were:

- Usage of restassured's `content()` istead of the new `body()`
- Usage of old EasyMock `new Capture()`
- Omitting encodings

Note that this removes the unnecessary restassured `.log().all()` to
make the logs a bit more readable.