### PR TITLE
MH-12917, Remove debug logging

### DIFF
--- a/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/AbstractOaiPmhServerInfoRestEndpointTest.java
+++ b/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/AbstractOaiPmhServerInfoRestEndpointTest.java
@@ -37,15 +37,13 @@ public class AbstractOaiPmhServerInfoRestEndpointTest {
 
   @Test
   public void testHasRepo() throws Exception {
-    given().log().all()
-            .pathParam("repoId", "UNKNOWN")
-            .expect().log().all()
+    given().pathParam("repoId", "UNKNOWN")
+            .expect()
             .statusCode(HttpStatus.SC_OK)
             .body(equalTo("false"))
             .when().get(env.host("/hasrepo/{repoId}"));
-    given().log().all()
-            .pathParam("repoId", "default")
-            .expect().log().all()
+    given().pathParam("repoId", "default")
+            .expect()
             .statusCode(HttpStatus.SC_OK)
             .body(equalTo("true"))
             .when().get(env.host("/hasrepo/{repoId}"));
@@ -53,8 +51,7 @@ public class AbstractOaiPmhServerInfoRestEndpointTest {
 
   @Test
   public void testGetMountPoint() throws Exception {
-    given().log().all()
-            .expect().log().all()
+    given().expect()
             .body(equalTo("/oaipmh"))
             .when().get(env.host("/mountpoint"));
   }

--- a/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/OaiPmhRepositoryPersistenceTest.java
+++ b/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/OaiPmhRepositoryPersistenceTest.java
@@ -83,7 +83,6 @@ public class OaiPmhRepositoryPersistenceTest {
   /** Turn an XmlGen into a Source. */
   private static Source s(XmlGen g) {
     final Source s = new DOMSource(g.generate());
-    print(s);
     return s;
   }
 


### PR DESCRIPTION
This patch removes a bunch of debug log and print statements from the
OAI-PMH tests to ensure errors don't get lost in the output.