### PR TITLE
MH-12910: Fix location of CSS files in proxy middleware

### DIFF
--- a/modules/matterhorn-admin-ui-ng/lib/proxyMiddleware.js
+++ b/modules/matterhorn-admin-ui-ng/lib/proxyMiddleware.js
@@ -25,7 +25,7 @@ module.exports = function (grunt, appPath) {
       ),
       connect().use(
         '/styles',
-        serveStatic('./.tmp/styles')
+        serveStatic('./target/grunt/.tmp/styles')
       ),
       connect().use(
         '/modules',


### PR DESCRIPTION
This should fix the issues raised in #254.

@staubesv unfortunately this has to go through the whole process from 3.x to develop again, since it is broken everywhere now. In general I would even agree with you that changes like this should just go in `develop` but in this special case the whole point of the original patch was to have it in all (active) branches. Again, sorry for the inconvenience; you should just be able to grab the patch and run with it, as long as this PR has not made it all the way to `develop`.