### PR TITLE
MH-12813: Add audio and video track selection to video editor

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -77,6 +77,7 @@ The following table contains the workflow operations that are available in an ou
 |retract-youtube     |Retracts media from YouTube                                    |[Documentation](retract-youtube-woh.md)|
 |segment-video       |Extracting segments from presentation                          |[Documentation](segmentvideo-woh.md)|
 |segmentpreviews     |Extract segment images from a video using FFmpeg               |[Documentation](segmentpreviews-woh.md)|
+|select-streams       |Select streams for further processing                           |[Documentation](select-streams-woh.md)|
 |send-email          |Sends email notifications at any part of a workflow            |[Documentation](send-email-woh.md)|
 |series              |Apply series to the mediapackage                               |[Documentation](series-woh.md)|
 |silence             |Silence detection on audio of the mediapackage                 |[Documentation](silence-woh.md)|

--- a/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
@@ -1,0 +1,79 @@
+SelectStreamsWorkflowOperationHandler
+====================================
+
+
+Description
+-----------
+
+The SelectStreamsWorkflowOperationHandler can be used in case not all source streams should be processed. For example,
+given a recording with a presenter and a presentation track, the final recording to be published should only include the
+video stream of the presenter track and the audio stream of the presentation track.
+
+The workflow operation will use workflow properties set by the Opencast video editor to determine which streams should be
+selected for further processing and add them to the media package based on `target-flavor` and `target-tags`.
+
+
+Parameter Table
+---------------
+
+Configuration Key | Example   | Description
+:-----------------|:----------|:-----------
+source-flavor\*   | */source  | The flavor of the track(s) to use as a source input
+target-flavor\*   | */work    | The flavor of the target track(s)
+target-tags       | download  | The tags applied to all target tracks
+audio-muxing      | force     | Move single-audio media packages to a specific track (see below)
+force-target      | presenter     | Target track for the `force` setting for `audio-muxing`
+
+\* mandatory configuration key
+
+Audio Muxing
+-----------------
+
+The optional `audio-muxing` parameter has three possible values: `none` (same as omitting the option), `force` and
+`duplicate`.
+
+### `none` ###
+
+If `none` is specified or the option is omitted, the audio stream is taken from the specified `source-flavor` track and is
+edited according to the selections in video editor’s “Tracks” panel. The resulting tracks are stored in the
+corresponding `target-flavor` and `target-tags` are applied.
+
+Note: If your editing results in a single video and single audio (track/stream) they will be muxed together even if
+this option is set to `none`.
+
+### `force` ###
+
+The parameter value `force` only applies to media packages that have exactly one non-hidden audio stream. For media
+packages without an audio stream or with more than one audio stream, the behavior is the same as if the parameter were
+omitted. The same applies to media packages for which there is only one audio stream, and it already belongs to the
+track with flavor type given by `force-target` (or `presenter` if that parameter is omitted).
+
+If, however, there is only one non-hidden audio stream and it does *not* belong to the track given by `force-target`,
+then the WOH will “move” the audio stream to this target track. Specifically, it will mux the video stream of
+`force-target` with the audio stream it found. Then, it removes the audio stream from the original track.
+
+For example, consider a media package with two tracks, *presenter* and *presentation*. Both of these tracks have
+audio components, however the *presenter* audio stream is hidden. This WOH will mux *presentations*'s audio stream
+with *presenter*'s video, and remove the audio track from *presentation*'s video.
+
+### `duplicate` ###
+
+The parameter value `duplicate` only applies to media packages that have exactly one non-hidden audio stream and no
+hidden video streams. For these media packages, the WOH will mux the audio stream it found to all video streams in
+the media package. For media packages without an audio stream or with more than one audio stream, the behavior is
+the same as if the parameter were omitted.
+
+Operation Example
+-----------------
+
+    <operation
+      id="select-tracks"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error"
+      description="Select tracks for further processing">
+      <configurations>
+        <configuration key="source-flavor">*/source</configuration>
+        <configuration key="target-flavor">*/work</configuration>
+        <configuration key="audio-muxing">force</configuration>
+      </configurations>
+    </operation>

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -143,6 +143,7 @@ pages:
    - Retract YouTube: 'workflowoperationhandlers/retract-youtube-woh.md'
    - Segment Previews: 'workflowoperationhandlers/segmentpreviews-woh.md'
    - Segment Video: 'workflowoperationhandlers/segmentvideo-woh.md'
+   - Select Streams: 'workflowoperationhandlers/select-streams-woh.md'
    - Send Email: 'workflowoperationhandlers/send-email-woh.md'
    - Series: 'workflowoperationhandlers/series-woh.md'
    - Silence: 'workflowoperationhandlers/silence-woh.md'

--- a/etc/encoding/opencast-images.properties
+++ b/etc/encoding/opencast-images.properties
@@ -81,3 +81,11 @@ profile.editor.thumbnail.preview.output = image
 profile.editor.thumbnail.preview.suffix = -preview.jpg
 profile.editor.thumbnail.preview.mimetype = image/jpeg
 profile.editor.thumbnail.preview.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=320:-1 #{out.dir}/#{out.name}#{out.suffix}
+
+# Extract video preview image for video editor
+profile.editor.tracks.preview.name = Video preview image for video editor
+profile.editor.tracks.preview.input = visual
+profile.editor.tracks.preview.output = image
+profile.editor.tracks.preview.suffix = -preview.jpg
+profile.editor.tracks.preview.mimetype = image/jpeg
+profile.editor.tracks.preview.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=320:-1 #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/opencast-movies.properties
+++ b/etc/encoding/opencast-movies.properties
@@ -48,7 +48,7 @@ profile.mux-av.work.name = mux audio and video
 profile.mux-av.work.input = stream
 profile.mux-av.work.output = visual
 profile.mux-av.work.suffix = -work.#{in.video.suffix}
-profile.mux-av.work.ffmpeg.command = -i #{in.video.path} -i #{in.audio.path} -shortest -c copy #{out.dir}/#{out.name}#{out.suffix}
+profile.mux-av.work.ffmpeg.command = -i #{in.video.path} -i #{in.audio.path} -shortest -c copy -map 0:v:0 -map 1:a:0 #{out.dir}/#{out.name}#{out.suffix}
 
 # Trim a stream
 #   This command will trim and input stream. Trimming will be fast, as no

--- a/etc/org.opencastproject.adminui.cfg
+++ b/etc/org.opencastproject.adminui.cfg
@@ -157,3 +157,23 @@
 #
 # Default: presentation/source
 #sourcetrack.right.flavor=presentation/source
+
+# Flavor subtype that identifies audio preview elements, for use in the
+# "Tracks" panel of the video editor.
+#
+# The default workflows will produce and publish audio preview artifacts
+# like 'presenter/audio+preview', therefore 'audio+preview' is the
+# recommended default value.
+#
+# Default: audio+preview
+#preview.audio.subtype=audio+preview
+
+# Flavor subtype that identifies video preview elements, for use in the
+# "Tracks" panel of the video editor.
+#
+# The default workflows will produce and publish video preview artifacts
+# like 'presenter/video+preview', therefore 'video+preview' is the
+# recommended default value.
+#
+# Default: video+preview
+#preview.video.subtype=video+preview

--- a/etc/workflows/partial-preview.xml
+++ b/etc/workflows/partial-preview.xml
@@ -78,6 +78,39 @@
       </configurations>
     </operation>
 
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Track previews                                                    -->
+    <!--                                                                   -->
+    <!-- Create track previews for video editor stream selection feature   -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <operation
+      id="image"
+      description="Create video preview images for presenter and presentation"
+      exception-handler-workflow="partial-error">
+      <configurations>
+        <configuration key="source-flavor">*/work</configuration>
+        <configuration key="target-flavor">*/video+preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="encoding-profile">editor.tracks.preview</configuration>
+        <configuration key="time">50%</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Once WOH waveform supports setting the image size of the waveform image,
+         those preview images should be way smaller than the preview image used for the timeline
+         as those previews cannot be zoomed -->
+    <operation
+      id="waveform"
+      fail-on-error="false"
+      description="Generating waveform">
+      <configurations>
+        <configuration key="source-flavor">*/work</configuration>
+        <configuration key="target-flavor">*/audio+preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+      </configurations>
+    </operation>
+
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- Extract the thumbnail preview image for the video editor          -->
     <!-- Depending on the processing settings of the event, this might be  -->

--- a/etc/workflows/partial-work.xml
+++ b/etc/workflows/partial-work.xml
@@ -18,33 +18,14 @@
     <!-- making sure that the audio track is part of each video track.     -->
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
-    <!-- Prepare presenter track -->
-
     <operation
-      id="prepare-av"
+      id="select-tracks"
       exception-handler-workflow="partial-error"
       description="Preparing presenter (camera) audio and video work versions">
       <configurations>
-        <configuration key="source-flavor">presenter/source</configuration>
-        <configuration key="target-flavor">presenter/work</configuration>
+        <configuration key="source-flavor">*/source</configuration>
+        <configuration key="target-flavor">*/work</configuration>
         <configuration key="target-tags">-archive</configuration>
-        <configuration key="rewrite">false</configuration>
-        <configuration key="audio-muxing-source-flavors">*/?,*/*</configuration>
-      </configurations>
-    </operation>
-
-    <!-- Prepare presentation track -->
-
-    <operation
-      id="prepare-av"
-      exception-handler-workflow="partial-error"
-      description="Preparing presentation (screen) audio and video work version">
-      <configurations>
-        <configuration key="source-flavor">presentation/source</configuration>
-        <configuration key="target-flavor">presentation/work</configuration>
-        <configuration key="target-tags">-archive</configuration>
-        <configuration key="rewrite">false</configuration>
-        <configuration key="audio-muxing-source-flavors">*/?,*/*</configuration>
       </configurations>
     </operation>
 

--- a/etc/workflows/publish-after-cutting.xml
+++ b/etc/workflows/publish-after-cutting.xml
@@ -21,6 +21,7 @@
         <configuration key="publishToApi">true</configuration>
         <configuration key="publishToYouTube">false</configuration>
         <configuration key="thumbnailType">0</configuration>
+        <configuration key="thumbnailPosition">1</configuration>
       </configurations>
     </operation>
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -125,6 +125,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Dictionary;
@@ -182,6 +183,9 @@ public class ToolsEndpoint implements ManagedService {
 
   /** The Json key for the default thumbnail position. */
   private static final String DEFAULT_THUMBNAIL_POSITION_KEY = "defaultThumbnailPosition";
+
+  /** The Json key for the source_tracks array. */
+  private static final String SOURCE_TRACKS_KEY = "source_tracks";
 
   /** Tag that marks workflow for being used from the editor tool */
   private static final String EDITOR_WORKFLOW_TAG = "editor";
@@ -434,29 +438,65 @@ public class ToolsEndpoint implements ManagedService {
       throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
     }
 
-    final MediaPackageElementFlavor sourceTracksFlavor = new MediaPackageElementFlavor("*",
-      adminUIConfiguration.getThumbnailSourceFlavorSubtype());
+    final Map<String, String> latestWfProperties = WorkflowPropertiesUtil
+      .getLatestWorkflowProperties(assetManager, mediaPackageId);
+    // The properties have the format "hide_flavor_audio" or "hide_flavor_video", where flavor is preconfigured.
+    // We filter all the properties that have this format, and then those which have values "true".
+    final Collection<Tuple<String, String>> hiddens = latestWfProperties.entrySet()
+      .stream()
+      .map(p -> Tuple.tuple(p.getKey().split("_"), p.getValue()))
+      .filter(p -> p.getA().length == 3)
+      .filter(p -> p.getA()[0].equals("hide"))
+      .filter(p -> p.getB().equals("true"))
+      .map(p -> Tuple.tuple(p.getA()[1], p.getA()[2]))
+      .collect(Collectors.toSet());
 
-    final List<JValue> sourceTracks = Arrays.stream(mp.getTracks(sourceTracksFlavor))
-          .map(MediaPackageElement::getFlavor)
-          .map(e -> {
-            String side;
-            if (e.equals(this.adminUIConfiguration.getSourceTrackLeftFlavor())) {
-              side = "left";
-            } else if (e.equals(this.adminUIConfiguration.getSourceTrackRightFlavor())) {
-              side = "right";
-            } else {
-              side = "unknown";
-            }
-            return obj(f("flavor", obj(f("type" ,e.getType()), f("subtype", e.getSubtype()))), f("side", side));
-          })
-          .collect(Collectors.toList());
+    final Collection<MediaPackageElementFlavor> acceptedFlavors = Arrays
+      .asList(this.adminUIConfiguration.getSourceTrackLeftFlavor(),
+        this.adminUIConfiguration.getSourceTrackRightFlavor());
+
+    // We already know the internal publication exists, so just "get" it here.
+    final Publication internalPub = getInternalPublication(mp).get();
+
+    final List<JValue> sourceTracks = Arrays.stream(mp.getElements())
+      .filter(e -> e.getElementType().equals(Type.Track))
+      .map(e -> (Track)e)
+      .filter(e -> acceptedFlavors.contains(e.getFlavor()))
+      .map(e -> {
+        String side = null;
+        if (e.getFlavor().equals(this.adminUIConfiguration.getSourceTrackLeftFlavor())) {
+          side = "left";
+        } else if (e.getFlavor().equals(this.adminUIConfiguration.getSourceTrackRightFlavor())) {
+          side = "right";
+        }
+        final boolean audioHidden = hiddens.contains(Tuple.tuple(e.getFlavor().getType(), "audio"));
+        final String audioPreview = Arrays.stream(internalPub.getAttachments())
+          .filter(a -> a.getFlavor().getType().equals(e.getFlavor().getType()))
+          .filter(a -> a.getFlavor().getSubtype().equals(this.adminUIConfiguration.getPreviewAudioSubtype()))
+          .map(MediaPackageElement::getURI).map(URI::toString)
+          .findAny()
+          .orElse(null);
+        final SourceTrackSubInfo audio = new SourceTrackSubInfo(e.hasAudio(), audioPreview,
+          audioHidden);
+        final boolean videoHidden = hiddens.contains(Tuple.tuple(e.getFlavor().getType(), "video"));
+        final String videoPreview = Arrays.stream(internalPub.getAttachments())
+          .filter(a -> a.getFlavor().getType().equals(e.getFlavor().getType()))
+          .filter(a -> a.getFlavor().getSubtype().equals(this.adminUIConfiguration.getPreviewVideoSubtype()))
+          .map(MediaPackageElement::getURI).map(URI::toString)
+          .findAny()
+          .orElse(null);
+        final SourceTrackSubInfo video = new SourceTrackSubInfo(e.hasVideo(), videoPreview,
+          videoHidden);
+        return new SourceTrackInfo(e.getFlavor().getType(), e.getFlavor().getSubtype(), audio, video, side);
+      })
+      .map(SourceTrackInfo::toJson)
+      .collect(Collectors.toList());
 
     return RestUtils.okJson(obj(f("title", v(mp.getTitle(), Jsons.BLANK)),
             f("date", v(event.getRecordingStartDate(), Jsons.BLANK)),
             f("series", obj(f("id", v(event.getSeriesId(), Jsons.BLANK)), f("title", v(event.getSeriesName(), Jsons.BLANK)))),
             f("presenters", arr($(event.getPresenters()).map(Functions.stringToJValue))),
-            f("source_tracks", arr(sourceTracks)),
+            f(SOURCE_TRACKS_KEY, arr(sourceTracks)),
             f("previews", arr(jPreviews)), f(TRACKS_KEY, arr(jTracks)),
             f("thumbnail", obj(thumbnailFields)),
             f("duration", v(mp.getDuration())), f(SEGMENTS_KEY, arr(jSegments)), f("workflows", arr(jWorkflows))));
@@ -586,6 +626,20 @@ public class ToolsEndpoint implements ManagedService {
         logger.warn("Unable to create a SMIL cutting catalog ({}): {}", details, getStackTrace(e));
         return R.badRequest("Unable to create SMIL cutting catalog");
       }
+
+      final Map<String, String> workflowProperties = java.util.stream.Stream
+        .of(this.adminUIConfiguration.getSourceTrackLeftFlavor(), this.adminUIConfiguration.getSourceTrackRightFlavor())
+        .flatMap(flavor -> {
+          final java.util.stream.Stream.Builder<Tuple<String, String>> r = java.util.stream.Stream.builder();
+          final Optional<SourceTrackInfo> track = editingInfo.sourceTracks.stream().filter(s -> s.getFlavor().equals(flavor)).findAny();
+          final boolean audioHidden = track.map(e -> e.audio.hidden).orElse(false);
+          r.accept(Tuple.tuple("hide_" + flavor.getType() + "_audio", Boolean.toString(audioHidden)));
+          final boolean videoHidden = track.map(e -> e.video.hidden).orElse(false);
+          r.accept(Tuple.tuple("hide_" + flavor.getType() + "_video", Boolean.toString(videoHidden)));
+          return r.build();
+        }).collect(Collectors.toMap(Tuple::getA, Tuple::getB));
+
+      WorkflowPropertiesUtil.storeProperties(assetManager, mediaPackage, workflowProperties);
 
       try {
         addSmilToArchive(mediaPackage, smil);
@@ -993,6 +1047,68 @@ public class ToolsEndpoint implements ManagedService {
     }
   }
 
+  static final class SourceTrackSubInfo {
+    private final boolean present;
+    private final String previewImage;
+    private final boolean hidden;
+
+    SourceTrackSubInfo(final boolean present, final String previewImage, final boolean hidden) {
+      this.present = present;
+      this.previewImage = previewImage;
+      this.hidden = hidden;
+    }
+
+    public static SourceTrackSubInfo parse(final JSONObject object) {
+      Boolean hidden = (Boolean) object.get("hidden");
+      if (hidden == null) {
+        hidden = Boolean.FALSE;
+      }
+      return new SourceTrackSubInfo((Boolean)object.get("present"), (String)object.get("preview_image"), hidden);
+    }
+
+    public JObject toJson() {
+      if (present) {
+        return obj(f("present", true), f("preview_image", previewImage == null ? Jsons.NULL : v(previewImage)),
+          f("hidden", hidden));
+      }
+      return obj(f("present", false));
+    }
+  }
+
+  static final class SourceTrackInfo {
+    private final String flavorType;
+    private final String flavorSubtype;
+    private final SourceTrackSubInfo audio;
+    private final SourceTrackSubInfo video;
+    private final String side;
+
+    MediaPackageElementFlavor getFlavor() {
+      return new MediaPackageElementFlavor(flavorType, flavorSubtype);
+    }
+
+    SourceTrackInfo(final String flavorType, final String flavorSubtype, final SourceTrackSubInfo audio,
+      final SourceTrackSubInfo video, final String side) {
+      this.flavorType = flavorType;
+      this.flavorSubtype = flavorSubtype;
+      this.audio = audio;
+      this.video = video;
+      this.side = side;
+    }
+
+    public static SourceTrackInfo parse(final JSONObject object) {
+      final JSONObject flavor = (JSONObject) object.get("flavor");
+      return new SourceTrackInfo((String) flavor.get("type"), (String) flavor.get("subtype"),
+        SourceTrackSubInfo.parse((JSONObject) object.get("audio")),
+        SourceTrackSubInfo.parse((JSONObject) object.get("video")),
+        (String) object.get("side"));
+    }
+
+    public JObject toJson() {
+      final JObject flavor = obj(f("type", flavorType), f("subtype", flavorSubtype));
+      return obj(f("flavor", flavor), f("audio", audio.toJson()), f("video", video.toJson()), f("side", side));
+    }
+  }
+
   /** Provides access to the parsed editing information */
   static final class EditingInfo {
 
@@ -1000,11 +1116,13 @@ public class ToolsEndpoint implements ManagedService {
     private final List<String> tracks;
     private final Optional<String> workflow;
     private final OptionalDouble defaultThumbnailPosition;
+    private final List<SourceTrackInfo> sourceTracks;
 
-    private EditingInfo(List<Tuple<Long, Long>> segments, List<String> tracks, Optional<String> workflow,
-        OptionalDouble defaultThumbnailPosition) {
+    private EditingInfo(List<Tuple<Long, Long>> segments, List<String> tracks, List<SourceTrackInfo> sourceTracks,
+      Optional<String> workflow, OptionalDouble defaultThumbnailPosition) {
       this.segments = segments;
       this.tracks = tracks;
+      this.sourceTracks = sourceTracks;
       this.workflow = workflow;
       this.defaultThumbnailPosition = defaultThumbnailPosition;
     }
@@ -1021,6 +1139,7 @@ public class ToolsEndpoint implements ManagedService {
       JSONObject concatObject = requireNonNull((JSONObject) obj.get(CONCAT_KEY));
       JSONArray jsonSegments = requireNonNull((JSONArray) concatObject.get(SEGMENTS_KEY));
       JSONArray jsonTracks = requireNonNull((JSONArray) concatObject.get(TRACKS_KEY));
+      JSONArray jsonSourceTracks = requireNonNull((JSONArray) concatObject.get(SOURCE_TRACKS_KEY));
 
       List<Tuple<Long, Long>> segments = new ArrayList<>();
       for (Object segment : jsonSegments) {
@@ -1043,9 +1162,15 @@ public class ToolsEndpoint implements ManagedService {
         defaultThumbnailPosition = OptionalDouble.of(Double.parseDouble(defaultThumbnailPositionObj.toString()));
       }
 
+      List<SourceTrackInfo> sourceTracks = new ArrayList<>();
+      for (Object sourceTrack : jsonSourceTracks) {
+        sourceTracks.add((SourceTrackInfo.parse((JSONObject) sourceTrack)));
+      }
+
       return new EditingInfo(
         segments,
         tracks,
+        sourceTracks,
         Optional.ofNullable((String) obj.get("workflow")),
         defaultThumbnailPosition);
     }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
@@ -57,6 +57,8 @@ public class AdminUIConfiguration implements ManagedService {
   public static final String OPT_OAIPMH_CHANNEL = "oaipmh.channel";
   public static final String OPT_SOURCE_TRACK_LEFT_FLAVOR = "sourcetrack.left.flavor";
   public static final String OPT_SOURCE_TRACK_RIGHT_FLAVOR = "sourcetrack.right.flavor";
+  public static final String OPT_PREVIEW_AUDIO_SUBTYPE = "preview.audio.subtype";
+  public static final String OPT_PREVIEW_VIDEO_SUBTYPE = "preview.video.subtype";
 
   private static final String DEFAULT_PREVIEW_SUBTYPE = "preview";
   private static final String DEFAULT_WAVEFORM_SUBTYPE = "waveform";
@@ -74,6 +76,8 @@ public class AdminUIConfiguration implements ManagedService {
   private static final String DEFAULT_THUMBNAIL_DEFAULT_TRACK_SECONDARY = "presentation";
   private static final Boolean DEFAULT_THUMBNAIL_AUTO_DISTRIBUTION = false;
   private static final String DEFAULT_OAIPMH_CHANNEL = "default";
+  private static final String DEFAULT_PREVIEW_VIDEO_SUBTYPE = "video+preview";
+  private static final String DEFAULT_PREVIEW_AUDIO_SUBTYPE = "audio+preview";
   private static final String DEFAULT_SOURCE_TRACK_LEFT_FLAVOR = "presenter/source";
   private static final String DEFAULT_SOURCE_TRACK_RIGHT_FLAVOR = "presentation/source";
 
@@ -93,6 +97,8 @@ public class AdminUIConfiguration implements ManagedService {
   private String thumbnailDefaultTrackSecondary = DEFAULT_THUMBNAIL_DEFAULT_TRACK_SECONDARY;
   private boolean thumbnailAutoDistribution = DEFAULT_THUMBNAIL_AUTO_DISTRIBUTION;
   private String oaipmhChannel = DEFAULT_OAIPMH_CHANNEL;
+  private String previewVideoSubtype = DEFAULT_PREVIEW_VIDEO_SUBTYPE;
+  private String previewAudioSubtype = DEFAULT_PREVIEW_AUDIO_SUBTYPE;
   private MediaPackageElementFlavor sourceTrackLeftFlavor = MediaPackageElementFlavor.parseFlavor(
     DEFAULT_SOURCE_TRACK_LEFT_FLAVOR);
   private MediaPackageElementFlavor sourceTrackRightFlavor = MediaPackageElementFlavor.parseFlavor(
@@ -160,6 +166,14 @@ public class AdminUIConfiguration implements ManagedService {
 
   public String getOaipmhChannel() {
     return oaipmhChannel;
+  }
+
+  public String getPreviewVideoSubtype() {
+    return previewVideoSubtype;
+  }
+
+  public String getPreviewAudioSubtype() {
+    return previewAudioSubtype;
   }
 
   public MediaPackageElementFlavor getSourceTrackLeftFlavor() {
@@ -255,6 +269,16 @@ public class AdminUIConfiguration implements ManagedService {
     oaipmhChannel = StringUtils.defaultString(
       (String) properties.get(OPT_OAIPMH_CHANNEL), DEFAULT_OAIPMH_CHANNEL);
     logger.debug("OAI-PMH channel set to '{}", oaipmhChannel);
+
+    // Preview Video subtype
+    previewVideoSubtype = StringUtils.defaultString((String) properties.get(OPT_PREVIEW_VIDEO_SUBTYPE),
+      DEFAULT_PREVIEW_VIDEO_SUBTYPE);
+    logger.debug("Preview video subtype set to '{}'", previewVideoSubtype);
+
+    // Preview Audio subtype
+    previewAudioSubtype = StringUtils.defaultString((String) properties.get(OPT_PREVIEW_AUDIO_SUBTYPE),
+      DEFAULT_PREVIEW_AUDIO_SUBTYPE);
+    logger.debug("Preview audio subtype set to '{}'", previewAudioSubtype);
 
     // Source track left flavor
     sourceTrackLeftFlavor = MediaPackageElementFlavor.parseFlavor(StringUtils.defaultString(

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -191,6 +191,8 @@
      "VIDEO_CUT_SAVED": "The editing information has been saved",
      "VIDEO_CUT_PROCESSING": "The video is being processed…",
      "THUMBNAIL_CHANGE_FAILED": "Failed to change thumbnail.",
+     "VIDEO_SOURCE_TRACKS_INVALID": "You have selected no video tracks to process",
+     "VIDEO_TOO_MANY_AUDIOS": "You cannot have more than one audio stream on a single video stream",
      "SERVER_UNRESPONSIVE": "Oops! The server seems to be unresponsive. Please try again later.",
      "SERVICE_UNAVAILABLE": "Oops! The server seems to be unresponsive. Please try again later.",
      "ACTIVE_TRANSACTION": "This event can not be edited while there is an active workflow or transaction."
@@ -1730,7 +1732,8 @@
        "METADATA":    "Metadata",
        "THUMBNAIL":   "Thumbnail",
        "COMMENTS":    "Comments",
-       "SEGMENTS":    "Segments"
+       "SEGMENTS":    "Segments",
+       "TRACKS":      "Tracks"
      },
      "ACTIONS": {
        "SPLIT": "Split",
@@ -1783,6 +1786,36 @@
          "DEFAULT": "You are currently using the default thumbnail.",
          "SNAPSHOT": "The current thumbnail has been extracted from the video.",
          "UPLOAD": "You are currently using an uploaded thumbnail."
+       }
+     },
+     "TRACKS": {
+       "DESCRIPTION": "You can unselect tracks to exclude them from further processing. Please note that you need to (re-)publish the event to actually apply the changes.",
+       "NOTIFICATION": {
+         "NO_VIDEO_TRACK_SELECTED": "You must enable at least one video track",
+         "NO_AUDIO_TRACK_SELECTED": "You must enable at least one audio track"
+       },
+       "TRACK": {
+         "HEADER": "Track"
+       },
+       "VIDEO": {
+         "HEADER": "Video track",
+         "NOT_AVAILABLE": "No video tracks available",
+         "NO_PREVIEW_AVAILABLE": "No preview image found",
+         "NO_TRACK_SELECTED": "No video track selected",
+         "TOOLTIPS": {
+           "HIDE": "This video track is currently enabled. Click to disable",
+           "UNHIDE": "This video track is currently disabled. Click to enable."
+         }
+       },
+       "AUDIO": {
+         "HEADER": "Audio track",
+         "NOT_AVAILABLE": "No audio tracks available",
+         "NO_PREVIEW_AVAILABLE": "No preview image found",
+         "NO_TRACK_SELECTED": "No audio track selected",
+         "TOOLTIPS": {
+           "HIDE": "This audio track is currently enabled. Click to disable",
+           "UNHIDE": "This audio track is currently disabled. Click to enable"
+         }
        }
      },
      "PLAYER":{

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
@@ -74,6 +74,8 @@
                             ng-click="openArea('metadata')" translate>VIDEO_TOOL.AREAS.METADATA</a>
                         <a ng-class="{active: area === 'thumbnail'}" ng-if="tab === 'editor'"
                             ng-click="openArea('thumbnail')" translate>VIDEO_TOOL.AREAS.THUMBNAIL</a>
+                        <a ng-class="{active: area === 'tracks'}" ng-if="tab === 'editor'"
+                            ng-click="openArea('tracks')" translate>VIDEO_TOOL.AREAS.TRACKS</a>
                         <a ng-class="{active: area === 'comments'}"
                             ng-click="openArea('comments')" translate>VIDEO_TOOL.AREAS.COMMENTS</a>
                     </nav>
@@ -307,6 +309,92 @@
                   </div>
                 </div>
 
+                <div ng-if="area === 'tracks'" class="editor-tracks">
+                  <div class="area-body">
+                    <div data-admin-ng-notification="" data-type="error"
+                         show="!anyTrackSelected('video')" message="VIDEO_TOOL.TRACKS.NOTIFICATION.NO_VIDEO_TRACK_SELECTED">
+                    </div>
+                    <div data-admin-ng-notification="" data-type="error"
+                         show="!anyTrackSelected('audio')" message="VIDEO_TOOL.TRACKS.NOTIFICATION.NO_AUDIO_TRACK_SELECTED">
+                    </div>
+                    <div data-admin-ng-notification="" data-type="error"
+                         show="tooManyAudios() && anyTrackSelected('video')" message="NOTIFICATIONS.VIDEO_TOO_MANY_AUDIOS">
+                    </div>
+                    <div class="full-col">
+                      <div class="obj tbl-details">
+                          <div class="obj-container">
+                          <table class="main-tbl">
+                            <tr>
+                              <th translate="VIDEO_TOOL.TRACKS.TRACK.HEADER">
+                                <!-- Track -->
+                              </th>
+                              <th translate="VIDEO_TOOL.TRACKS.VIDEO.HEADER">
+                                <!-- Video -->
+                              </th>
+                              <th translate="VIDEO_TOOL.TRACKS.AUDIO.HEADER">
+                                <!-- Audio -->
+                              </th>
+                            </tr>
+                            <tr ng-repeat="row in video.source_tracks">
+                              <td>
+                                <span class="track-name">{{ trackIndexToName($index) }}</span>
+                              </td>
+                              <td>
+                                <div ng-if="video.source_tracks[$index].video.present"
+                                  class="video-canvas"
+                                  style="background-image: url({{video.source_tracks[$index].video.preview_image}})"
+                                  ng-click="trackClicked($index, 'video')"
+                                  title="{{ video.source_tracks[$index].video.hidden ? 'VIDEO_TOOL.TRACKS.VIDEO.TOOLTIPS.UNHIDE' : 'VIDEO_TOOL.TRACKS.VIDEO.TOOLTIPS.HIDE' | translate }}">
+                                  <div class="{{video.source_tracks[$index].video.hidden ? 'track-hidden' : 'track'}}" >
+                                    <span class="video-line-height"
+                                          ng-if="!trackHasPreview($index, 'video')"
+                                          translate="VIDEO_TOOL.TRACKS.VIDEO.NO_PREVIEW_AVAILABLE">
+                                      <!-- No preview available -->
+                                    </span>
+                                    <span class="video-track-hidden-icon"
+                                          ng-if="video.source_tracks[$index].video.hidden">
+                                    </span>
+                                  </div>
+                                </div>
+
+                                <span ng-if="!video.source_tracks[$index].video.present"
+                                      class="video-line-height"
+                                      translate="VIDEO_TOOL.TRACKS.VIDEO.NOT_AVAILABLE">
+                                  <!-- Stream has no video -->
+                                </span>
+                              </td>
+                              <td>
+                                <div ng-if="video.source_tracks[$index].audio.present"
+                                  class="audio-canvas"
+                                  style="background-image: url({{video.source_tracks[$index].audio.preview_image}})"
+                                  ng-click="trackClicked($index, 'audio')"
+                                  title="{{ video.source_tracks[$index].audio.hidden ? 'VIDEO_TOOL.TRACKS.AUDIO.TOOLTIPS.UNHIDE' : 'VIDEO_TOOL.TRACKS.AUDIO.TOOLTIPS.HIDE' | translate }}">
+
+                                  <div class="{{video.source_tracks[$index].audio.hidden ? 'track-hidden' : 'track'}}">
+                                    <span class="audio-line-height"
+                                          ng-if="!trackHasPreview($index, 'audio')"
+                                          translate="VIDEO_TOOL.TRACKS.AUDIO.NO_PREVIEW_AVAILABLE">
+                                      <!-- No preview available -->
+                                    </span>
+                                    <span class="audio-track-hidden-icon"
+                                          ng-if="video.source_tracks[$index].audio.hidden">
+                                    </span>
+                                  </div>
+                                </div>
+                                <span ng-if="!video.source_tracks[$index].audio.present"
+                                      class="audio-line-height"
+                                      translate="VIDEO_TOOL.TRACKS.AUDIO.NOT_AVAILABLE">
+                                  <!-- Stream has no audio -->
+                                </span>
+                              </td>
+                            </tr>
+                          </table>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
             </div>
 
             <div data-admin-ng-notifications="" type="warning" show="activeTransaction" context="video-editor-event-access"></div>
@@ -324,7 +412,7 @@
                             ng-options="workflow.id as workflow.name for workflow in video.workflows | orderBy: 'displayOrder':true" />
 
                         <a ng-click="submit()"
-                           ng-class="{disabled: activeTransaction}"
+                           ng-class="{disabled: activeTransaction || sanityCheckFlags()}"
                            class="save-and-close-button"
                            translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
                           <!-- Save and Continue -->

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/toolsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/toolsResource.js
@@ -110,17 +110,22 @@ angular.module('adminNg.resources')
                     return data;
                 }
 
-                var response = {}, segments = [];
+                var response = {}, segments = [], source_tracks = [];
                 angular.forEach(data.segments, function (segment) {
                     delete segment.$$hashKey;
                     if (!segment.deleted) {
                         this.push(segment);
                     }
                 }, segments);
+                angular.forEach(data.source_tracks, function (source_track) {
+                    delete source_track.$$hashKey;
+                    this.push(source_track);
+                }, source_tracks);
 
                 response.concat = {
-                    segments: segments,
-                    tracks:   JsHelper.map(data.tracks, 'id')
+                    segments:      segments,
+                    tracks:        JsHelper.map(data.tracks, 'id'),
+                    source_tracks: source_tracks
                 };
 
                 if (data.workflow) {

--- a/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
@@ -817,3 +817,72 @@ $segment-deleted-selected: saturate(darken($segment-deleted, 25%), 5%);
     display: none;
   }
 }
+
+.editor-tracks {
+
+  .audio-canvas, .video-canvas {
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-origin: border-box;
+    text-align: center;
+    border: $thin-border-stroke $main-border-color;
+
+    cursor: pointer;
+
+  }
+
+  .audio-canvas {
+    background-color: rgba(28, 131, 236, 0.5);
+    border: 1px solid #1169c5;
+    width: 690px;
+    height: 60px;
+  }
+
+  .video-canvas {
+    position: relative;
+    width: 160px;
+    height: 90px;
+  }
+
+  .track-name {
+    text-transform: capitalize;
+  }
+
+  .track, .track-hidden {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .track-hidden {
+    background-color: rgba( $red, .4 );
+  }
+
+  .audio-track-hidden-icon, .video-track-hidden-icon {
+    position: absolute;
+    height: 100%;
+    text-align: center ;
+  }
+
+  .video-track-hidden-icon {
+    line-height: 120px;
+    @include fa-icon($fa-var-eye-slash, before, inline-block, 0 0 0 0, 0, lighten($black, 90%), 60px);
+  }
+
+  .audio-track-hidden-icon {
+    line-height: 80px;
+    @include fa-icon($fa-var-microphone-slash, before, inline-block, 0 0 0 0, 0, lighten($black, 90%), 60px);
+  }
+
+  .track-hidden:hover {
+    background-color: rgba( $red, .6 );
+  }
+
+  .track:hover {
+    background-color: rgba( $black, .2 );
+  }
+}

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/tools/c3a4f68d-14d4-47e2-8981-8eb2fb300d3a/editor.json
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/tools/c3a4f68d-14d4-47e2-8981-8eb2fb300d3a/editor.json
@@ -47,5 +47,21 @@
   }, {
     "start": 28009,
     "end": 52125
+  }],
+  "source_tracks":[{
+    "flavor":{
+      "subtype":"source",
+      "type":"presenter"
+    },
+    "audio":{
+      "preview_image":null,
+      "hidden":false,
+      "present":true
+    },
+    "video":{
+      "preview_image":null,
+      "hidden":false,
+      "present":true
+    }
   }]
 }

--- a/modules/admin-ui/src/test/resources/tools/POST-editor.json
+++ b/modules/admin-ui/src/test/resources/tools/POST-editor.json
@@ -18,6 +18,22 @@
         "end":20132
       }
     ],
+    "source_tracks":[{
+      "flavor":{
+        "subtype":"source",
+        "type":"presenter"
+      },
+      "audio":{
+        "preview_image":null,
+        "hidden":false,
+        "present":true
+      },
+      "video":{
+        "preview_image":null,
+        "hidden":false,
+        "present":true
+      }
+    }],
     "tracks":["6ec443e7-b097-4470-a618-5e0d848f5252"]
   },
   "workflow": "cut-workflow"

--- a/modules/composer-workflowoperation/pom.xml
+++ b/modules/composer-workflowoperation/pom.xml
@@ -129,7 +129,8 @@
               OSGI-INF/operations/partial-import.xml,
               OSGI-INF/operations/prepare-av.xml,
               OSGI-INF/operations/process-smil.xml,
-              OSGI-INF/operations/segmentpreviews.xml
+              OSGI-INF/operations/segmentpreviews.xml,
+              OSGI-INF/operations/select-tracks.xml
             </Service-Component>
           </instructions>
         </configuration>

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -592,7 +592,7 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
     if (r.isDefined() && r.getRest().isEmpty()) {
       return r.getResult();
     } else {
-      throw new WorkflowOperationException(format("Cannot parse time string %s. Rest is %s", time, r.getRest()));
+      throw new WorkflowOperationException(format("Cannot parse time string %s.", time));
     }
   }
 

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -1,0 +1,529 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.composer;
+
+import org.opencastproject.composer.api.ComposerService;
+import org.opencastproject.composer.api.EncoderException;
+import org.opencastproject.composer.api.EncodingProfile;
+import org.opencastproject.job.api.Job;
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageElementParser;
+import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.Track;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationTagUtil;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+  private static final Logger logger = LoggerFactory.getLogger(SelectStreamsWorkflowOperationHandler.class);
+
+  /** Name of the 'encode to video only work copy' encoding profile */
+  private static final String PREPARE_VIDEO_ONLY_PROFILE = "video-only.work";
+
+  /** Name of the muxing encoding profile */
+  private static final String MUX_AV_PROFILE = "mux-av.work";
+
+  /** The composer service */
+  private ComposerService composerService = null;
+
+  /** The local workspace */
+  private Workspace workspace = null;
+
+  /** The configuration options for this handler */
+  private static final SortedMap<String, String> CONFIG_OPTIONS;
+
+  private enum AudioMuxing {
+    NONE, FORCE, DUPLICATE;
+
+    @Override
+    public String toString() {
+      return super.toString().toLowerCase();
+    }
+
+    static AudioMuxing fromConfigurationString(final String s) {
+      return AudioMuxing.valueOf(s.toUpperCase());
+    }
+  }
+
+  private static final String CONFIG_AUDIO_MUXING = "audio-muxing";
+
+  private static final String CONFIG_FORCE_TARGET = "force-target";
+
+  private static final String FORCE_TARGET_DEFAULT = "presenter";
+
+  static {
+    CONFIG_OPTIONS = new TreeMap<>();
+    CONFIG_OPTIONS.put("source-flavor", "The \"flavor\" of the track to use as a video source input");
+    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the encoded file");
+    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the encoded file");
+    CONFIG_OPTIONS.put(CONFIG_FORCE_TARGET,
+            String.format("Target flavor type for the \"%s\" option \"%s\" (default %s)", CONFIG_AUDIO_MUXING,
+                    AudioMuxing.FORCE, FORCE_TARGET_DEFAULT));
+    CONFIG_OPTIONS.put(CONFIG_AUDIO_MUXING,
+            String.format("Either \"%s\", \"%s\" or \"%s\" to specially mux audio streams", AudioMuxing.NONE,
+                    AudioMuxing.DUPLICATE, AudioMuxing.FORCE));
+  }
+
+  @Override
+  public SortedMap<String, String> getConfigurationOptions() {
+    return CONFIG_OPTIONS;
+  }
+
+  /**
+   * Callback for the OSGi declarative services configuration.
+   *
+   * @param composerService
+   *          the local composer service
+   */
+  protected void setComposerService(final ComposerService composerService) {
+    this.composerService = composerService;
+  }
+
+  /**
+   * Callback for declarative services configuration that will introduce us to the local workspace service.
+   * Implementation assumes that the reference is configured as being static.
+   *
+   * @param workspace
+   *          an instance of the workspace
+   */
+  public void setWorkspace(final Workspace workspace) {
+    this.workspace = workspace;
+  }
+
+  private EncodingProfile getProfile(final String identifier) throws WorkflowOperationException {
+    final EncodingProfile profile = this.composerService.getProfile(identifier);
+    if (profile == null) {
+      throw new WorkflowOperationException(String.format("couldn't find encoding profile \"%s\"", identifier));
+    }
+    return profile;
+  }
+
+  private static Optional<String> getConfiguration(final WorkflowInstance instance, final String key) {
+    return Optional.ofNullable(instance.getCurrentOperation().getConfiguration(key)).map(StringUtils::trimToNull);
+  }
+
+  private enum SubTrack {
+    AUDIO, VIDEO
+  }
+
+  /**
+   * During our operations, we accumulate new tracks and wait times, for which we have this nice helper class
+   */
+  private static final class MuxResult {
+    private long queueTime;
+    private final Collection<Track> tracks;
+
+    private MuxResult(final long queueTime, final Collection<Track> tracks) {
+      this.queueTime = queueTime;
+      this.tracks = tracks;
+    }
+
+    static MuxResult empty() {
+      return new MuxResult(0L, new ArrayList<>(0));
+    }
+
+    void forEachTrack(final Consumer<Track> trackConsumer) {
+      tracks.forEach(trackConsumer);
+    }
+
+    public void add(final TrackJobResult jobResult) {
+      this.queueTime += jobResult.waitTime;
+      this.tracks.add(jobResult.track);
+    }
+
+    public void add(final MuxResult muxResult) {
+      this.queueTime += muxResult.queueTime;
+      this.tracks.addAll(muxResult.tracks);
+    }
+  }
+
+  private static final class AugmentedTrack {
+    private final Track track;
+    private final boolean hideAudio;
+    private final boolean hideVideo;
+
+    private AugmentedTrack(final Track track, final boolean hideAudio, final boolean hideVideo) {
+      this.track = track;
+      this.hideAudio = hideAudio;
+      this.hideVideo = hideVideo;
+    }
+
+    boolean has(final SubTrack t) {
+      if (t == SubTrack.AUDIO) {
+        return hasAudio();
+      } else {
+        return hasVideo();
+      }
+    }
+
+    boolean hide(final SubTrack t) {
+      if (t == SubTrack.AUDIO) {
+        return hideAudio;
+      } else {
+        return hideVideo;
+      }
+    }
+
+    boolean hasAudio() {
+      return track.hasAudio();
+    }
+
+    boolean hasVideo() {
+      return track.hasVideo();
+    }
+
+    String getFlavorType() {
+      return track.getFlavor().getType();
+    }
+  }
+
+  @Override
+  public WorkflowOperationResult start(final WorkflowInstance workflowInstance, final JobContext context)
+          throws WorkflowOperationException {
+    try {
+      return doStart(workflowInstance);
+    } catch (final EncoderException | MediaPackageException | IOException | NotFoundException e) {
+      throw new WorkflowOperationException(e);
+    }
+  }
+
+  private WorkflowOperationResult doStart(final WorkflowInstance workflowInstance)
+          throws WorkflowOperationException, EncoderException, MediaPackageException, NotFoundException, IOException {
+    final MediaPackage mediaPackage = workflowInstance.getMediaPackage();
+
+    final MediaPackageElementFlavor sourceFlavor = getConfiguration(workflowInstance, "source-flavor")
+            .map(MediaPackageElementFlavor::parseFlavor)
+            .orElseThrow(() -> new IllegalStateException("Source flavor must be specified"));
+
+    final MediaPackageElementFlavor targetTrackFlavor = MediaPackageElementFlavor.parseFlavor(StringUtils.trimToNull(
+            getConfiguration(workflowInstance, "target-flavor")
+                    .orElseThrow(() -> new IllegalStateException("Target flavor not specified"))));
+
+    final Track[] tracks = mediaPackage.getTracks(sourceFlavor);
+
+    if (tracks.length == 0) {
+      logger.info("No audio/video tracks with flavor '{}' found to prepare", sourceFlavor);
+      return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE);
+    }
+
+    final List<AugmentedTrack> augmentedTracks = createAugmentedTracks(tracks, workflowInstance);
+
+    final MuxResult result = MuxResult.empty();
+    // This function is formulated in a way so that it's hopefully compatible with an event with an arbitrary number of
+    // tracks. However, many of the requirements were written with one or two tracks in mind. For example, below, we
+    // test if "all tracks are non-hidden" or "exactly one track is non-hidden". This works for arbitrary tracks, of
+    // course, but with more than two, we might want something better. Hopefully, this will be easy to improve later
+    // on.
+
+    // First case: We have only tracks with non-hidden video streams. So we keep them all and possibly cut away audio.
+    if (allNonHidden(augmentedTracks, SubTrack.VIDEO)) {
+      final AudioMuxing audioMuxing = getConfiguration(workflowInstance, CONFIG_AUDIO_MUXING)
+              .map(AudioMuxing::fromConfigurationString).orElse(AudioMuxing.NONE);
+      // For both special options, we need to find out if we have exactly one audio track present
+      final Optional<AugmentedTrack> singleAudioTrackOpt = findSingleAudioTrack(augmentedTracks);
+      final boolean multipleVideo = augmentedTracks.size() > 1;
+      if (multipleVideo && audioMuxing == AudioMuxing.DUPLICATE && singleAudioTrackOpt.isPresent()) {
+        // Special option: If we have multiple video tracks, but only one audio track: copy this audio track to
+        // all video tracks.
+        final AugmentedTrack singleAudioTrack = singleAudioTrackOpt.get();
+        for (final AugmentedTrack t : augmentedTracks) {
+          if (t.track != singleAudioTrack.track) {
+            final TrackJobResult jobResult = mux(t.track, singleAudioTrack.track, mediaPackage);
+            result.add(jobResult);
+          } else {
+            result.add(copyTrack(t.track));
+          }
+        }
+      } else if (multipleVideo && audioMuxing == AudioMuxing.FORCE && singleAudioTrackOpt.isPresent()) {
+        // Special option: if the only audio track we have selected is not in the video track of "force-target", we
+        // copy it there (and remove the original audio track).
+        final AugmentedTrack singleAudioTrack = singleAudioTrackOpt.get();
+        final String forceTargetOpt = getConfiguration(workflowInstance, CONFIG_FORCE_TARGET)
+                .orElse(FORCE_TARGET_DEFAULT);
+
+        final Optional<AugmentedTrack> forceTargetTrackOpt = findTrackByFlavorType(augmentedTracks, forceTargetOpt);
+
+        if (!forceTargetTrackOpt.isPresent()) {
+          throw new IllegalStateException(
+                  String.format("\"%s\" set to \"%s\", but target flavor \"%s\" not found!",
+                          CONFIG_AUDIO_MUXING,
+                          AudioMuxing.FORCE, forceTargetOpt));
+        }
+
+        final AugmentedTrack forceTargetTrack = forceTargetTrackOpt.get();
+
+        if (singleAudioTrack.track != forceTargetTrack.track) {
+          // Copy it over...
+          final TrackJobResult muxResult = mux(forceTargetTrack.track, singleAudioTrack.track, mediaPackage);
+          result.add(muxResult);
+
+          // ...and remove the original
+          final TrackJobResult hideAudioResult = hideAudio(singleAudioTrack.track, mediaPackage);
+          result.add(hideAudioResult);
+        } else {
+          result.add(copyTrack(singleAudioTrack.track));
+        }
+
+        // Just copy the rest of the tracks to ensure they got the correct output flavor
+        for (final AugmentedTrack augmentedTrack : augmentedTracks) {
+          if (augmentedTrack.track != singleAudioTrack.track && augmentedTrack.track != forceTargetTrack.track) {
+            result.add(copyTrack(augmentedTrack.track));
+          }
+        }
+      } else {
+        // No special options selected, or conditions for special options don't match.
+        final MuxResult muxResult = muxMultipleVideoTracks(mediaPackage, augmentedTracks);
+        result.add(muxResult);
+      }
+    } else {
+      // Second case: we have exactly one video track that is not hidden (hopefully, because for all other cases there
+      // were no requirements given).
+      final MuxResult muxResult = muxSingleVideoTrack(mediaPackage, augmentedTracks);
+      result.add(muxResult);
+    }
+
+    // Update Flavor and add to media package
+    result.forEachTrack(t -> {
+      t.setFlavor(new MediaPackageElementFlavor(t.getFlavor().getType(), targetTrackFlavor.getSubtype()));
+      mediaPackage.add(t);
+    });
+
+    // Update Tags here
+    getConfiguration(workflowInstance, "target-tags").ifPresent(tags -> {
+      final WorkflowOperationTagUtil.TagDiff tagDiff = WorkflowOperationTagUtil.createTagDiff(tags);
+      result.forEachTrack(t -> WorkflowOperationTagUtil.applyTagDiff(tagDiff, t));
+    });
+
+    return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE, result.queueTime);
+  }
+
+  private Optional<AugmentedTrack> findTrackByFlavorType(final Collection<AugmentedTrack> augmentedTracks,
+          final String flavorType) {
+    return augmentedTracks.stream().filter(augmentedTrack -> augmentedTrack.getFlavorType().equals(flavorType))
+            .findAny();
+  }
+
+  private MuxResult muxSingleVideoTrack(final MediaPackage mediaPackage, final Collection<AugmentedTrack> augmentedTracks)
+          throws MediaPackageException, EncoderException, WorkflowOperationException, NotFoundException, IOException {
+    long queueTime = 0L;
+
+    final Collection<Track> resultingTracks = new ArrayList<>(0);
+
+    // Otherwise, we have just one video track that's not hidden (because hopefully, the UI prevented all other
+    // cases). We keep that, and mux in the audio from the other track.
+    final AugmentedTrack nonHiddenVideo = findNonHidden(augmentedTracks, SubTrack.VIDEO)
+            .orElseThrow(() -> new IllegalStateException("couldn't find a stream with non-hidden video"));
+    // Implicit here is the assumption that there's just _one_ other audio stream. It's written so that
+    // we can loosen this assumption later on.
+    final Optional<AugmentedTrack> nonHiddenAudio = findNonHidden(augmentedTracks, SubTrack.AUDIO);
+
+    // If there's just one non-hidden video stream, and that one has hidden audio, we have to cut that away, too.
+    if (nonHiddenVideo.hasAudio() && nonHiddenVideo.hideAudio && (!nonHiddenAudio.isPresent()
+            || nonHiddenAudio.get() == nonHiddenVideo)) {
+      final TrackJobResult jobResult = hideAudio(nonHiddenVideo.track, mediaPackage);
+      resultingTracks.add(jobResult.track);
+      queueTime += jobResult.waitTime;
+    } else if (!nonHiddenAudio.isPresent() || nonHiddenAudio.get() == nonHiddenVideo) {
+      // It could be the case that the non-hidden video stream is also the non-hidden audio stream. In that
+      // case, we don't have to mux. But have to clone it.
+      final Track clonedTrack = (Track) nonHiddenVideo.track.clone();
+      clonedTrack.setIdentifier(null);
+      resultingTracks.add(clonedTrack);
+    } else {
+      // Otherwise, we mux!
+      final TrackJobResult jobResult = mux(nonHiddenVideo.track, nonHiddenAudio.get().track, mediaPackage);
+      resultingTracks.add(jobResult.track);
+      queueTime += jobResult.waitTime;
+    }
+    return new MuxResult(queueTime, resultingTracks);
+  }
+
+  private MuxResult muxMultipleVideoTracks(final MediaPackage mediaPackage, final Iterable<AugmentedTrack> augmentedTracks)
+          throws MediaPackageException, EncoderException, WorkflowOperationException, NotFoundException, IOException {
+    long queueTime = 0L;
+    final List<Track> resultingTracks = new ArrayList<>(0);
+    for (final AugmentedTrack t : augmentedTracks) {
+      if (t.hasAudio() && t.hideAudio) {
+        // The flavor gets "nulled" in the process. Reverse that so we can treat all tracks equally.
+        final MediaPackageElementFlavor previousFlavor = t.track.getFlavor();
+        final TrackJobResult trackJobResult = hideAudio(t.track, mediaPackage);
+        trackJobResult.track.setFlavor(previousFlavor);
+        resultingTracks.add(trackJobResult.track);
+        queueTime += trackJobResult.waitTime;
+      } else {
+        // Even if we don't modify the track, we clone and re-add it to the MP (since it will be a new track with a
+        // different flavor)
+        final Track clonedTrack = (Track) t.track.clone();
+        clonedTrack.setIdentifier(null);
+        resultingTracks.add(clonedTrack);
+      }
+    }
+    return new MuxResult(queueTime, resultingTracks);
+  }
+
+  /**
+   * Returns the single track that has audio, or an empty {@code Optional} if either more than one audio track exists, or none exists.
+   * @param augmentedTracks List of tracks
+   * @return See above.
+   */
+  private Optional<AugmentedTrack> findSingleAudioTrack(final Iterable<AugmentedTrack> augmentedTracks) {
+    AugmentedTrack result = null;
+    for (final AugmentedTrack augmentedTrack : augmentedTracks) {
+      if (augmentedTrack.hasAudio() && !augmentedTrack.hideAudio) {
+        // Already got an audio track? Aw, then there's more than one! :(
+        if (result != null) {
+          return Optional.empty();
+        }
+        result = augmentedTrack;
+      }
+    }
+    return Optional.ofNullable(result);
+  }
+
+  private TrackJobResult mux(final Track videoTrack, final Track audioTrack, final MediaPackage mediaPackage)
+          throws MediaPackageException, EncoderException, WorkflowOperationException, NotFoundException, IOException {
+    // Find the encoding profile
+    final EncodingProfile profile = getProfile(MUX_AV_PROFILE);
+
+    final Job job = composerService.mux(videoTrack, audioTrack, profile.getIdentifier());
+    if (!waitForStatus(job).isSuccess()) {
+      throw new WorkflowOperationException(
+              String.format("Muxing video track %s and audio track %s failed", videoTrack, audioTrack));
+    }
+    final MediaPackageElementFlavor previousFlavor = videoTrack.getFlavor();
+    final TrackJobResult trackJobResult = processJob(videoTrack, mediaPackage, job);
+    trackJobResult.track.setFlavor(previousFlavor);
+    return trackJobResult;
+  }
+
+  private static final class TrackJobResult {
+    private final Track track;
+    private final long waitTime;
+
+    private TrackJobResult(final Track track, final long waitTime) {
+      this.track = track;
+      this.waitTime = waitTime;
+    }
+  }
+
+  private TrackJobResult hideAudio(final Track track, final MediaPackage mediaPackage)
+          throws MediaPackageException, EncoderException, WorkflowOperationException, NotFoundException, IOException {
+    // Find the encoding profile
+    final EncodingProfile profile = getProfile(PREPARE_VIDEO_ONLY_PROFILE);
+    logger.info("Encoding video only track {} to work version", track);
+    final Job job = composerService.encode(track, profile.getIdentifier());
+    if (!waitForStatus(job).isSuccess()) {
+      throw new WorkflowOperationException(String.format("Rewriting container for video track %s failed", track));
+    }
+    final MediaPackageElementFlavor previousFlavor = track.getFlavor();
+    final TrackJobResult trackJobResult = processJob(track, mediaPackage, job);
+    trackJobResult.track.setFlavor(previousFlavor);
+    return trackJobResult;
+  }
+
+  private TrackJobResult processJob(final Track track, final MediaPackage mediaPackage, final Job job)
+          throws MediaPackageException, NotFoundException, IOException {
+    final Track composedTrack = (Track) MediaPackageElementParser.getFromXml(job.getPayload());
+    final String fileName = getFileNameFromElements(track, composedTrack);
+
+    // Note that the composed track must have an ID before being moved to the mediapackage in the working file
+    // repository. This ID is generated when the track is added to the mediapackage. So the track must be added
+    // to the mediapackage before attempting to move the file.
+    composedTrack.setURI(workspace
+            .moveTo(composedTrack.getURI(), mediaPackage.getIdentifier().toString(), composedTrack.getIdentifier(),
+                    fileName));
+    return new TrackJobResult(composedTrack, job.getQueueTime());
+  }
+
+  private Optional<AugmentedTrack> findNonHidden(final Collection<AugmentedTrack> augmentedTracks, final SubTrack st) {
+    return augmentedTracks.stream().filter(t -> t.has(st) && !t.hide(st)).findAny();
+  }
+
+  private boolean allNonHidden(final Collection<AugmentedTrack> augmentedTracks,
+          @SuppressWarnings("SameParameterValue") final SubTrack st) {
+    return augmentedTracks.stream().noneMatch(t -> !t.has(st) || t.hide(st));
+  }
+
+  private static String constructHideProperty(final String s, final SubTrack st) {
+    return "hide_" + s + "_" + st.toString().toLowerCase();
+  }
+
+  private boolean trackHidden(final WorkflowInstance instance, final String subtype, final SubTrack st) {
+    final String hideProperty = instance.getConfiguration(constructHideProperty(subtype, st));
+    return Boolean.parseBoolean(hideProperty);
+  }
+
+  private List<AugmentedTrack> createAugmentedTracks(final Track[] tracks, final WorkflowInstance instance) {
+    return Arrays.stream(tracks).map(t -> {
+      final boolean hideAudio = trackHidden(instance, t.getFlavor().getType(), SubTrack.AUDIO);
+      final boolean hideVideo = trackHidden(instance, t.getFlavor().getType(), SubTrack.VIDEO);
+      return new AugmentedTrack(t, hideAudio, hideVideo);
+    }).collect(Collectors.toList());
+  }
+
+  private TrackJobResult copyTrack(final Track track) throws WorkflowOperationException {
+    final Track copiedTrack = (Track) track.clone();
+    copiedTrack.setIdentifier(UUID.randomUUID().toString());
+    try {
+      // Generate a new filename
+      String targetFilename = copiedTrack.getIdentifier();
+      final String extension = FilenameUtils.getExtension(track.getURI().getPath());
+      if (!extension.isEmpty()) {
+        targetFilename += "." + extension;
+      }
+
+      // Copy the files on dis and put them into the working file repository
+      logger.debug("Start copying element {}.", track.getURI());
+      final URI newUri = workspace.put(track.getMediaPackage().getIdentifier().toString(), copiedTrack.getIdentifier(),
+              targetFilename, workspace.read(track.getURI()));
+      copiedTrack.setURI(newUri);
+    } catch (IOException | NotFoundException e) {
+      throw new WorkflowOperationException(String.format("Error while copying track %s", track.getIdentifier()), e);
+    }
+
+    return new TrackJobResult(copiedTrack, 0);
+  }
+}

--- a/modules/composer-workflowoperation/src/main/resources/OSGI-INF/operations/select-tracks.xml
+++ b/modules/composer-workflowoperation/src/main/resources/OSGI-INF/operations/select-tracks.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+ name="org.opencastproject.workflow.handler.composer.SelectStreamsWorkflowOperationHandler" immediate="true">
+  <implementation class="org.opencastproject.workflow.handler.composer.SelectStreamsWorkflowOperationHandler" />
+  <property name="service.description" value="Hide/unhide specific tracks in a media package" />
+  <property name="workflow.operation" value="select-tracks" />
+  <service>
+    <provide interface="org.opencastproject.workflow.api.WorkflowOperationHandler" />
+  </service>
+  <reference cardinality="1..1" interface="org.opencastproject.composer.api.ComposerService"
+    name="ComposerService" policy="static" bind="setComposerService"/>
+  <reference cardinality="1..1" interface="org.opencastproject.workspace.api.Workspace" name="Workspace"
+    policy="static" bind="setWorkspace" />
+  <reference name="ServiceRegistry" cardinality="1..1" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
+    policy="static" bind="setServiceRegistry" />
+</scr:component>

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationTagUtil.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationTagUtil.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.api;
+
+import org.opencastproject.mediapackage.Track;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class WorkflowOperationTagUtil {
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory.getLogger(WorkflowOperationTagUtil.class);
+
+  public static class TagDiff {
+    private final List<String> removeTags;
+    private final List<String> addTags;
+    private final List<String> overrideTags;
+
+    TagDiff(final List<String> removeTags, final List<String> addTags, final List<String> overrideTags) {
+      this.removeTags = removeTags;
+      this.addTags = addTags;
+      this.overrideTags = overrideTags;
+    }
+  }
+
+  private WorkflowOperationTagUtil() {
+
+  }
+
+  private static final String PLUS = "+";
+  private static final String MINUS = "-";
+
+  public static TagDiff createTagDiff(final String tagList) {
+    final String[] targetTags = StringUtils.split(tagList, ",");
+
+    final List<String> removeTags = new ArrayList<>();
+    final List<String> addTags = new ArrayList<>();
+    final List<String> overrideTags = new ArrayList<>();
+
+    for (final String tag : targetTags) {
+      if (tag.startsWith(MINUS)) {
+        removeTags.add(tag);
+      } else if (tag.startsWith(PLUS)) {
+        addTags.add(tag);
+      } else {
+        overrideTags.add(tag);
+      }
+    }
+
+    return new TagDiff(removeTags, addTags, overrideTags);
+  }
+
+  public static void applyTagDiff(final TagDiff td, final Track t) {
+    // Add the target tags
+    if (!td.overrideTags.isEmpty()) {
+      t.clearTags();
+      for (final String tag : td.overrideTags) {
+        logger.trace("Tagging composed track with '{}'", tag);
+        t.addTag(tag);
+      }
+    } else {
+      for (final String tag : td.removeTags) {
+        logger.trace("Remove tagging '{}' from composed track", tag);
+        t.removeTag(tag.substring(MINUS.length()));
+      }
+      for (final String tag : td.addTags) {
+        logger.trace("Add tagging '{}' to composed track", tag);
+        t.addTag(tag.substring(PLUS.length()));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new tab “Tracks” to the video editor that allows the user to select which audio and video tracks will be published. In this new tab, the user simply clicks on the video track (represented by a
thumbnail) or the audio track (represented by its waveform) to hide it. Sanity checks are included, so its not possible to hide _every_ video and audio track there is, for example.

![40481539-0407fbda-5f52-11e8-872c-704e588a36d0](https://user-images.githubusercontent.com/178496/40575526-d22debb0-60e6-11e8-8371-128df23366b2.png)

The information about which tracks are hidden is stored in asset manager properties, which are then injected into the running workflow(s). Thus, this PR depends on [193](#193) (and is rebased on it).

This _theoretically_ works for an arbitrary number of tracks in the media package, but it currently is constrained to one and two tracks (the most common use case). The allowed flavors flavors are configurable.

To make this possible, a specialized workflow operation handler `SelectTracksWorkflowOperationHandler` had to be written, which is capable of removing audio tracks from multiple input tracks, as well as muxing a video track and an audio track from two different input
tracks (so it’s very similar to the `PrepareAV` WOH).

This work was sponsored by SWITCH.