### PR TITLE
MH-12926, Prevent cluttering of logs by invalid access

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
@@ -117,7 +117,7 @@ public class OrganizationFilter implements Filter {
 
       // If an organization was found, move on. Otherwise return a 404
       if (org == null) {
-        logger.warn("No organization is mapped to handle {}", url);
+        logger.debug("No organization is mapped to handle {}", url);
         httpResponse.sendError(HttpServletResponse.SC_NOT_FOUND, "No organization is mapped to handle " + url);
         return;
       }


### PR DESCRIPTION
Every invalid access through domains not specifically mapped to an
organization will be logged in Opencast which makes it easy for an
external attacker to generate a huge amount of log files.

In production systems, we have seen that this caused issues with people
probing for default path's like /phpmyadmin, …

Since the warning is actually not indicating any issue with
Opencast–these requests should not be served–this patch downgrades the
log message to debug.

*Work sponsored by SWITCH*