### PR TITLE
MH-12928, Mitigation for KARAF-5526

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -131,6 +131,8 @@
                   <replaceregexp file="target/assembly/bin/karaf" match="-Dcom.sun.management.jmxremote" replace="" byline="true"/>
                   <!-- Correct the start script name -->
                   <replaceregexp file="target/assembly/bin/karaf" match="^KARAF_SCRIPT=.*$" replace="KARAF_SCRIPT='start-opencast'" byline="true"/>
+                  <!-- Mitigation for https://issues.apache.org/jira/browse/KARAF-5526 -->
+                  <replaceregexp file="target/assembly/bin/karaf" match=" init$" replace=" [[ &quot;$TERM&quot; == *-256color ]] &amp;&amp; export TERM=xterm-color&#x0A;    init" byline="true"/>
                   <!-- Make sure bundle cache gets cleared by default -->
                   <replaceregexp file="target/assembly/etc/system.properties" match="^karaf.clean.cache .*=.*$" replace="karaf.clean.cache = true" byline="true"/>
                   <!-- Additional config lines to system.properties -->


### PR DESCRIPTION
This patch introduces a mitigation for KARAF-5526 which causes the
interactive Karaf shell to fail for some terminals. This patch can be
removed once we update Karaf again but it seems like Karaf 4.0.11 will
not be released and updating to a new major version is no bugfix.

Note that for a major Karaf update, we likely need to update our
assembly step anyway since they made somemodifications to their scripts
and assembly plugin meaning this is unlikely to stay in our code
forever.

[KARAF-5526] https://issues.apache.org/jira/browse/KARAF-5526