### PR TITLE
MH-12929 Change paella URL to /paella/ui

### DIFF
--- a/docs/guides/admin/docs/modules/paella.player.md
+++ b/docs/guides/admin/docs/modules/paella.player.md
@@ -10,5 +10,5 @@ Select the Paella Player
 
 To activate the paella player set:
 
-    prop.player=/engage/paella/ui/watch.html
+    prop.player=/paella/ui/watch.html
 

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -273,7 +273,7 @@ prop.engageui.link_mobile_redirect.description=For more information have a look 
 # Path to the default video player used by the engage interfaces and the LTI tools. Parameters for selecting the
 # specific videos will be appended automatically.  Common values include:
 # - theodul player: /engage/theodul/ui/core.html
-# - paella  player: /engage/paella/ui/watch.html
+# - paella  player: /paella/ui/watch.html
 prop.player=/engage/theodul/ui/core.html
 
 # The default flavor of the master video (the video on the "left side" in the video display)

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -240,8 +240,8 @@
     <sec:intercept-url pattern="/info/components.json" method="GET" access="ROLE_ANONYMOUS" />
 
     <!-- Paella player -->
-    <sec:intercept-url pattern="/engage/paella/ui/auth.html" access="ROLE_USER" />
-    <sec:intercept-url pattern="/engage/paella/ui/**" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/paella/ui/auth.html" access="ROLE_USER" />
+    <sec:intercept-url pattern="/paella/ui/**" access="ROLE_ANONYMOUS" />
 
     <!-- Enable anonymous access to the engage player and the GET endpoints it requires -->
     <sec:intercept-url pattern="/engage/ui/**" access="ROLE_ANONYMOUS" />

--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -199,7 +199,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Private-Package>ui.*</Private-Package>
-            <Http-Alias>/engage/paella/ui</Http-Alias>
+            <Http-Alias>/paella/ui</Http-Alias>
             <Http-Classpath>/ui</Http-Classpath>
             <Http-Welcome>watch.html</Http-Welcome>
             <Import-Package>

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/05_initdelegate.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/05_initdelegate.js
@@ -8,7 +8,7 @@ function loadOpencastPaella(containerId) {
 			if (data.streams.length < 1) {
 				paella.messageBox.showError("Error loading video! No video traks found");
 			}
-			paella.load(containerId, {data:data, configUrl:'/engage/paella/config/config.json'});
+			paella.load(containerId, {data:data, configUrl:'/paella/config/config.json'});
 		},
 		function(){
 			var oacl = new OpencastAccessControl();

--- a/modules/engage-paella-player/src/main/resources/OSGI-INF/paella-config-file.xml
+++ b/modules/engage-paella-player/src/main/resources/OSGI-INF/paella-config-file.xml
@@ -5,7 +5,7 @@
   <property name="service.description" value="Paella config REST Endpoint" />
 
   <property name="opencast.service.type" value="org.opencastproject.engage.paella.config" />
-  <property name="opencast.service.path" value="/engage/paella/config" />
+  <property name="opencast.service.path" value="/paella/config" />
 
   <service>
     <provide interface="org.opencastproject.engage.paella.PaellaConfigRest" />


### PR DESCRIPTION
Paella player external bundle URL was in /paella/ui/watch.html.

When bundle moved inside opencast, URL was changed to /engage/paella/ui/watch.html
This is causing problems to people using paella in opencast 4.x when migrating to 5.0, because the URL change (Old mediapackages has URL /paella/ui/watch.html)

This PR change the paella URL to /paella/ui/watch.html to be compatible with OC 4.x and external paella bundle.