### PR TITLE
MH-12922 Job load fixes

### DIFF
--- a/docs/guides/admin/docs/configuration/load.md
+++ b/docs/guides/admin/docs/configuration/load.md
@@ -50,32 +50,10 @@ system.  If you wish to change this, set the `org.opencastproject.server.maxload
 maximum load you want this node to accept.  Keep in mind that exceeding the number of CPU cores present in the system is
 not recommended.
 
-The load values for the non-encoding jobs are set in the etc/services files.  Look for files containing the prefix
-`job.load`.  These configuration keys control the load for each job type.  For example, the
-`job.load.download.distribute` configuration key controls the load placed on the system when a download distribution job
-is running.  The current files with relevant configuration keys are:
-
-| File                                                                                     | Controls                           |
-|------------------------------------------------------------------------------------------|------------------------------------|
-| org.opencastproject.animate.impl.AnimateServiceImpl.cfg                                  | Animate service                    |
-| org.opencastproject.caption.impl.CaptionServiceImpl.cfg                                  | Caption convertion services        |
-| org.opencastproject.distribution.aws.s3.AwsS3DistributionServiceImpl.cfg                 | AWS S3 distribution service        |
-| org.opencastproject.distribution.download.DownloadDistributionServiceImpl.cfg            | Download distribution              |
-| org.opencastproject.distribution.distribution.streaming.<br/>StreamingDistributionService.cfg | Streaming distribution             |
-| org.opencastproject.distribution.streaming.wowza.<br/>WowzaAdaptiveStreamingDistributionService.cfg | Adaptive streaming distribution |
-| org.opencastproject.execute.impl.ExecuteServiceImpl.cfg                                  | Execute service                    |
-| org.opencastproject.ingest.impl.IngestServiceImpl.cfg                                    | Ingest services                    |
-| org.opencastproject.inspection.ffmpeg.MediaInspectionServiceImpl.cfg                     | Media inspection using ffmpeg      |
-| org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg              | Youtube distribution               |
-| org.opencastproject.search.impl.SearchServiceImpl.cfg                                    | Opencast engage index jobs         |
-| org.opencastproject.silencedetection.impl.SilenceDetectionServiceImpl.cfg                | Silence detection                  |
-| org.opencastproject.sox.impl.SoxServiceImpl.cfg                                          | Sox service                        |
-| org.opencastproject.textanalyzer.impl.TextAnalyzerServiceImpl.cfg                        | Text analysis, including slide OCR |
-| org.opencastproject.timelinepreviews.ffmpeg.TimelinePreviewsServiceImpl.cfg              | Timeline previews service          |
-| org.opencastproject.transcription.ibmwatson.IBMWatsonTranscriptionService.cfg            | IBM Watson start transcription job |
-| org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg                          | Video editor                       |
-| org.opencastproject.videosegmenter.ffmpeg.VideoSegmenterServiceImpl.cfg                  | Video segmentation                 |
-| org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg                              | Waveform generation for video editing |
+The load values for the non-encoding jobs are set in the configuration files in the `etc` directory.  Search the
+this directory for files that contain the string `job.load` to find the relevant configuration keys.  These
+configuration keys control the load for each job type.  For example, the `job.load.download.distribute` configuration
+key controls the load placed on the system when a download distribution job is running.
 
 Note: Ingest jobs are a special case in Opencast.  Because of their immediate nature there is no way to limit the number
 of running jobs.  However, these jobs will block other jobs from running on the ingest/admin nodes if enough ingests

--- a/docs/guides/admin/docs/configuration/load.md
+++ b/docs/guides/admin/docs/configuration/load.md
@@ -50,8 +50,8 @@ system.  If you wish to change this, set the `org.opencastproject.server.maxload
 maximum load you want this node to accept.  Keep in mind that exceeding the number of CPU cores present in the system is
 not recommended.
 
-The load values for the non-encoding jobs are set in the configuration files in the `etc` directory.  Search the
-this directory for files that contain the string `job.load` to find the relevant configuration keys.  These
+The load values for the non-encoding jobs are set in the configuration files in the `etc` directory.  Search this
+directory for files that contain the string `job.load` to find the relevant configuration keys.  These
 configuration keys control the load for each job type.  For example, the `job.load.download.distribute` configuration
 key controls the load placed on the system when a download distribution job is running.
 

--- a/docs/guides/admin/docs/configuration/load.md
+++ b/docs/guides/admin/docs/configuration/load.md
@@ -37,7 +37,7 @@ job.
 
 Note: These job loads are specific for each *node* in the cluster.  This means that for any given job, each node can
 have a different load value associated.  For instance, if worker A has no job load specified for its encoding profiles,
-and worker B has job loads specified then any encoding jobs created by A will have the default load (0.6), and jobs
+and worker B has job loads specified then any encoding jobs created by A will have the default load (0.8), and jobs
 created by B will have a different, presumably higher load.  There are edge cases where this may be useful, but in
 most cases this will only cause confusion.  It is therefore highly recommended that these settings be put into your
 configuration management system, and be applied on a cluster level to ensure consistency across all nodes.
@@ -63,7 +63,7 @@ Step 3: Setting the load values for encoding profiles
 -----------------------------------------------------
 
 Each encoding profile can have a load value associated with it.  By default, we have not set any, which means that the
-default value of 0.6 is used.  To set the load associated with a profile, you simply add a .jobload key to the profile.
+default value of 0.8 is used.  To set the load associated with a profile, you simply add a .jobload key to the profile.
 For example, the composite encoding profile is prefixed with `profile.composite.http`.  If we want to set a different
 job load than the default, we would create the `profile.composite.http.jobload` key, and set it to an appropriate job value.
 

--- a/docs/guides/admin/docs/configuration/load.md
+++ b/docs/guides/admin/docs/configuration/load.md
@@ -37,10 +37,10 @@ job.
 
 Note: These job loads are specific for each *node* in the cluster.  This means that for any given job, each node can
 have a different load value associated.  For instance, if worker A has no job load specified for its encoding profiles,
-and worker B has job loads specified then any encoding jobs dispatched to A will have a load of 1.0, and jobs dispatched
-to B will have a different, presumably higher load.  There are edge cases where this may be useful, but is most cases
-this will only cause confusion.  It is therefore highly recommended that these settings be put into your configuration
-management system, and be applied on a cluster level to ensure consistency across all nodes.
+and worker B has job loads specified then any encoding jobs created by A will have the default load (0.6), and jobs
+created by B will have a different, presumably higher load.  There are edge cases where this may be useful, but in
+most cases this will only cause confusion.  It is therefore highly recommended that these settings be put into your
+configuration management system, and be applied on a cluster level to ensure consistency across all nodes.
 
 Step 2: Setting the load values for system jobs
 -----------------------------------------------
@@ -57,21 +57,25 @@ is running.  The current files with relevant configuration keys are:
 
 | File                                                                                     | Controls                           |
 |------------------------------------------------------------------------------------------|------------------------------------|
+| org.opencastproject.animate.impl.AnimateServiceImpl.cfg                                  | Animate service                    |
 | org.opencastproject.caption.impl.CaptionServiceImpl.cfg                                  | Caption convertion services        |
-| org.opencastproject.composer.impl.ComposerServiceImpl.cfg                                | Caption embedding services         |
-| org.opencastproject.distribution.distribution.streaming.StreamingDistributionService.cfg | Streaming distribution             |
+| org.opencastproject.distribution.aws.s3.AwsS3DistributionServiceImpl.cfg                 | AWS S3 distribution service        |
 | org.opencastproject.distribution.download.DownloadDistributionServiceImpl.cfg            | Download distribution              |
+| org.opencastproject.distribution.distribution.streaming.<br/>StreamingDistributionService.cfg | Streaming distribution             |
+| org.opencastproject.distribution.streaming.wowza.<br/>WowzaAdaptiveStreamingDistributionService.cfg | Adaptive streaming distribution |
 | org.opencastproject.execute.impl.ExecuteServiceImpl.cfg                                  | Execute service                    |
 | org.opencastproject.ingest.impl.IngestServiceImpl.cfg                                    | Ingest services                    |
 | org.opencastproject.inspection.ffmpeg.MediaInspectionServiceImpl.cfg                     | Media inspection using ffmpeg      |
-| org.opencastproject.inspection.impl.MediaInspectionServiceImpl.cfg                       | Media inspection using mediainfo   |
-| org.opencastproject.publication.youtube.YouTubePublicationServiceImpl.cfg                | Youtube distribution               |
 | org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg              | Youtube distribution               |
 | org.opencastproject.search.impl.SearchServiceImpl.cfg                                    | Opencast engage index jobs         |
 | org.opencastproject.silencedetection.impl.SilenceDetectionServiceImpl.cfg                | Silence detection                  |
+| org.opencastproject.sox.impl.SoxServiceImpl.cfg                                          | Sox service                        |
 | org.opencastproject.textanalyzer.impl.TextAnalyzerServiceImpl.cfg                        | Text analysis, including slide OCR |
+| org.opencastproject.timelinepreviews.ffmpeg.TimelinePreviewsServiceImpl.cfg              | Timeline previews service          |
+| org.opencastproject.transcription.ibmwatson.IBMWatsonTranscriptionService.cfg            | IBM Watson start transcription job |
 | org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg                          | Video editor                       |
 | org.opencastproject.videosegmenter.ffmpeg.VideoSegmenterServiceImpl.cfg                  | Video segmentation                 |
+| org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg                              | Waveform generation for video editing |
 
 Note: Ingest jobs are a special case in Opencast.  Because of their immediate nature there is no way to limit the number
 of running jobs.  However, these jobs will block other jobs from running on the ingest/admin nodes if enough ingests
@@ -81,9 +85,9 @@ Step 3: Setting the load values for encoding profiles
 -----------------------------------------------------
 
 Each encoding profile can have a load value associated with it.  By default, we have not set any, which means that the
-default value of 1.0 is used.  To set the load associated with a profile, you simply add a .jobload key to the profile.
+default value of 0.6 is used.  To set the load associated with a profile, you simply add a .jobload key to the profile.
 For example, the composite encoding profile is prefixed with `profile.composite.http`.  If we want to set a different
-job load than 1.0, we would create the `profile.composite.http.jobload` key, and set it to an appropriate job value.
+job load than the default, we would create the `profile.composite.http.jobload` key, and set it to an appropriate job value.
 
 Step 4: Restart Opencast
 --------------------------

--- a/etc/org.opencastproject.animate.impl.AnimateServiceImpl.cfg
+++ b/etc/org.opencastproject.animate.impl.AnimateServiceImpl.cfg
@@ -3,5 +3,5 @@
 #synfig.path=synfig
 
 # Job load for an animation job
-# Default: 0.1
-#job.load.animate=0.1
+# Default: 0.8
+#job.load.animate=0.8

--- a/etc/org.opencastproject.animate.impl.AnimateServiceImpl.cfg
+++ b/etc/org.opencastproject.animate.impl.AnimateServiceImpl.cfg
@@ -3,5 +3,5 @@
 #synfig.path=synfig
 
 # Job load for an animation job
-# Default: 1.0
-#job.load.animate=1.0
+# Default: 0.1
+#job.load.animate=0.1

--- a/etc/org.opencastproject.caption.impl.CaptionServiceImpl.cfg
+++ b/etc/org.opencastproject.caption.impl.CaptionServiceImpl.cfg
@@ -1,4 +1,4 @@
 #The load induced on the system by running a captioning job
 #These jobs are inexpensive, so many can run at once
-
-job.load.caption = 0.1
+# Default: 0.1
+#job.load.caption = 0.1

--- a/etc/org.opencastproject.distribution.aws.s3.AwsS3DistributionServiceImpl.cfg
+++ b/etc/org.opencastproject.distribution.aws.s3.AwsS3DistributionServiceImpl.cfg
@@ -25,8 +25,8 @@ org.opencastproject.distribution.aws.s3.distribution.enable=false
 #org.opencastproject.distribution.aws.s3.secret.key=
 
 # Job loads
-# Default distribute job load: 0.2
-#job.load.aws.s3.distribute=0.2
+# Default distribute job load: 0.1
+#job.load.aws.s3.distribute=0.1
 
 # Default retract job load: 0.1
 #job.load.aws.s3.retract=0.1

--- a/etc/org.opencastproject.distribution.download.DownloadDistributionServiceImpl.cfg
+++ b/etc/org.opencastproject.distribution.download.DownloadDistributionServiceImpl.cfg
@@ -1,8 +1,8 @@
 # The load on the system introduced by creating a distribute job Each job involves copying the output file to the final
 # output directory. If possible, hard-linking is used for this which makes the job less expensive. If hard-linking if
 # not possible, you might want to increase this value.
-# Default: 0.2
-#job.load.download.distribute=0.2
+# Default: 0.1
+#job.load.download.distribute=0.1
 
 # The load on the system introduced by creating a retract job. Each job involves deleting the output file from the
 # final output directory. This is a quick and inexpensive operation, so we can run a lot of these in parallel.

--- a/etc/org.opencastproject.distribution.streaming.StreamingDistributionServiceImpl.cfg
+++ b/etc/org.opencastproject.distribution.streaming.StreamingDistributionServiceImpl.cfg
@@ -1,8 +1,8 @@
 # The load on the system introduced by creating a distribute job Each job involves copying the output file to the final
 # output directory. If possible, hard-linking is used for this which makes the job less expensive. If hard-linking if
 # not possible, you might want to increase this value.
-# Default: 0.2
-#job.load.streaming.distribute=0.2
+# Default: 0.1
+#job.load.streaming.distribute=0.1
 
 # The load on the system introduced by creating a retract job. Each job involves deleting the output file from the
 # final output directory. This is a quick and inexpensive operation, so we can run a lot of these in parallel.

--- a/etc/org.opencastproject.distribution.streaming.wowza.WowzaAdaptiveStreamingDistributionService.cfg
+++ b/etc/org.opencastproject.distribution.streaming.wowza.WowzaAdaptiveStreamingDistributionService.cfg
@@ -12,8 +12,8 @@
 # The load on the system introduced by creating a distribute job Each job involves copying the output file to the final
 # output directory. If possible, hard-linking is used for this which makes the job less expensive. If hard-linking if
 # not possible, you might want to increase this value.
-# Default: 0.2
-#job.load.streaming.distribute=0.2
+# Default: 0.1
+#job.load.streaming.distribute=0.1
 
 # The load on the system introduced by creating a retract job. Each job involves deleting the output file from the
 # final output directory. This is a quick and inexpensive operation, so we can run a lot of these in parallel.

--- a/etc/org.opencastproject.execute.impl.ExecuteServiceImpl.cfg
+++ b/etc/org.opencastproject.execute.impl.ExecuteServiceImpl.cfg
@@ -1,5 +1,7 @@
 # Load factor
-job.load.execute = 1.0
+# Default: 0.1
+# Note that the load on the system will depend on which command is executed...
+#job.load.execute = 0.1
 
 # The list of commands, separated by spaces, which may be run by the Execute Service.
 # A value of * means any command is allowed.

--- a/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
+++ b/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
@@ -13,11 +13,11 @@ org.opencastproject.series.overwrite=true
 #The approximate load placed on the system by ingesting a file
 #Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node
 #These jobs involve heavy I/O, so we want them to be expensive, but not cripplingly so
-
-job.load.ingest.file = 1.0
+# Default: 0.2
+#job.load.ingest.file=0.2
 
 #The approximate load placed on the system by ingesting a zip file
 #Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node
 #These jobs involve heavy I/O, so we want them to be expensive
-
-job.load.ingest.zip = 1.0
+# Default: 0.2
+# job.load.ingest.zip=0.2

--- a/etc/org.opencastproject.inspection.ffmpeg.MediaInspectionServiceImpl.cfg
+++ b/etc/org.opencastproject.inspection.ffmpeg.MediaInspectionServiceImpl.cfg
@@ -1,11 +1,12 @@
 #The load introduced on the system by creating an inspect job
 #Each job involves reading the metadata from a file, and calculates the checksum if it is not present
 #Since this will fairly quickly add up, these should be relatively expensive, but not cripplingly so
-
-job.load.inspect = 1.0
+# Default: 0.2
+#job.load.inspect=0.2
 
 #The load introduced on the system by creating an enrich job
 #Each job involves reading the metadata from a file, and calculates the checksum if it is not present
 #Since this will fairly quickly add up, these should be relatively expensive, but not cripplingly so
+# Default: 0.2
+#job.load.enrich=0.2
 
-job.load.enrich = 1.0

--- a/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
+++ b/etc/org.opencastproject.publication.youtube.YouTubeV3PublicationServiceImpl.cfg
@@ -22,8 +22,8 @@ org.opencastproject.publication.youtube.dataStore=${org.opencastproject.storage.
 # The load on the system introduced by creating a publish job. Each job involves copying the output file to Youtube
 # which can be expensive depending on file size. Since this will fairly quickly add up, these should be relatively
 # expensive, while not crippling the system.
-# Default: 0.4
-#job.load.youtube.publish=0.4
+# Default: 0.1
+#job.load.youtube.publish=0.1
 
 # The load on the system introduced by creating a retract job. Each job involves instructing Youtube to delete the
 # media. This is a quick and inexpensive operation, so we can run a lot of these in parallel.

--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -20,3 +20,7 @@ jobstats.collect=false
 # Note that this setting does have a large impact on the performance of service statistics generation.
 # Default: 14
 #org.opencastproject.statistics.services.max_job_age = 14
+
+# The max load on this server.
+# Default: number of cores
+#org.opencastproject.server.maxload=

--- a/etc/org.opencastproject.silencedetection.impl.SilenceDetectionServiceImpl.cfg
+++ b/etc/org.opencastproject.silencedetection.impl.SilenceDetectionServiceImpl.cfg
@@ -16,5 +16,5 @@ voice.min.length = 60000
 # The approximate load placed on the node while running silence detection
 #Each job uses ffmpeg to examine the audio track for silence
 #These are somewhat expensive operations, so their load should be medium
-
-job.load.videoeditor.silencedetection = 2
+# Default: 0.2
+#job.load.videoeditor.silencedetection=0.2

--- a/etc/org.opencastproject.sox.impl.SoxServiceImpl.cfg
+++ b/etc/org.opencastproject.sox.impl.SoxServiceImpl.cfg
@@ -1,9 +1,11 @@
 # The load introduced on the system by creating an analyze job
 # This job involves a sox processes to analyze the audio stream
 # Since this will fairly quickly add up, these should be relatively expensive, but not cripplingly so
-job.load.analyze = 1.0
+# Default: 0.2
+#job.load.analyze=0.2
 
 # The load introduced on the system by creating a normalize job
 # This job involves a sox processes to normalize the audio stream
 # This is a long, expensive operations and it's load should be high
-job.load.normalize = 2.0
+# Default: 0.2
+#job.load.normalize=0.2

--- a/etc/org.opencastproject.textanalyzer.impl.TextAnalyzerServiceImpl.cfg
+++ b/etc/org.opencastproject.textanalyzer.impl.TextAnalyzerServiceImpl.cfg
@@ -1,5 +1,5 @@
 #The approximate load placed on the system by creating a text analysis job
 #Each job converts the image for OCR if necessary, then extracts the text from the image
 #Since this will fairly quickly add up, these should be relatively expensive, but not cripplingly so
-
-job.load.analysis = 1.0
+# Default: 0.2
+#job.load.analysis=0.2

--- a/etc/org.opencastproject.timelinepreviews.ffmpeg.TimelinePreviewsServiceImpl.cfg
+++ b/etc/org.opencastproject.timelinepreviews.ffmpeg.TimelinePreviewsServiceImpl.cfg
@@ -18,5 +18,5 @@
 #mimetype = "image/png"
 
 # An estimate of how much load the timeline previews image generation puts on the node
-
-job.load.timelinepreviews = 1.0
+# Default: 0.1
+#job.load.timelinepreviews=0.1

--- a/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
+++ b/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
@@ -26,5 +26,5 @@ ffmpeg.scalefilter = w=trunc(in_w/2)*2:h=trunc(in_h/2)*2
 #The estimated load placed on the system by one videoeditor job
 #Each job involves encoding potentially multiple videos in parallel
 #These are long, expensive operations and their load should be high
-# Default: 0.6
-#job.load.videoeditor=0.6
+# Default: 0.8
+#job.load.videoeditor=0.8

--- a/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
+++ b/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
@@ -26,5 +26,5 @@ ffmpeg.scalefilter = w=trunc(in_w/2)*2:h=trunc(in_h/2)*2
 #The estimated load placed on the system by one videoeditor job
 #Each job involves encoding potentially multiple videos in parallel
 #These are long, expensive operations and their load should be high
-
-job.load.videoeditor = 4.0
+# Default: 0.6
+#job.load.videoeditor=0.6

--- a/etc/org.opencastproject.videosegmenter.ffmpeg.VideoSegmenterServiceImpl.cfg
+++ b/etc/org.opencastproject.videosegmenter.ffmpeg.VideoSegmenterServiceImpl.cfg
@@ -45,5 +45,5 @@
 
 # An estimate of how much load the video segmenter puts on the node. This job involves a number of sequential FFmpeg
 # processes with no video or audio encoding involved to detect segments in the video.
-# Default: 0.6
-#job.load.videosegmenter=0.6
+# Default: 0.3
+#job.load.videosegmenter=0.3

--- a/etc/org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg
+++ b/etc/org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg
@@ -1,5 +1,6 @@
 # The job load
-job.load.waveform = 0.5
+# Default: 0.1
+#job.load.waveform=0.1
 
 # Waveform output image minimum width in pixels.
 # default: 5000

--- a/modules/animate-impl/src/main/java/org/opencastproject/animate/impl/AnimateServiceImpl.java
+++ b/modules/animate-impl/src/main/java/org/opencastproject/animate/impl/AnimateServiceImpl.java
@@ -79,7 +79,7 @@ public class AnimateServiceImpl extends AbstractJobProducer implements AnimateSe
   private static final String JOB_LOAD_CONFIG = "job.load.animate";
 
   /** The load introduced on the system by creating an inspect job */
-  private static final float JOB_LOAD_DEFAULT = 0.1f;
+  private static final float JOB_LOAD_DEFAULT = 0.8f;
 
   /** The load introduced on the system by creating an inspect job */
   private float jobLoad = JOB_LOAD_DEFAULT;

--- a/modules/animate-impl/src/main/java/org/opencastproject/animate/impl/AnimateServiceImpl.java
+++ b/modules/animate-impl/src/main/java/org/opencastproject/animate/impl/AnimateServiceImpl.java
@@ -79,7 +79,7 @@ public class AnimateServiceImpl extends AbstractJobProducer implements AnimateSe
   private static final String JOB_LOAD_CONFIG = "job.load.animate";
 
   /** The load introduced on the system by creating an inspect job */
-  private static final float JOB_LOAD_DEFAULT = 1.0f;
+  private static final float JOB_LOAD_DEFAULT = 0.1f;
 
   /** The load introduced on the system by creating an inspect job */
   private float jobLoad = JOB_LOAD_DEFAULT;

--- a/modules/common/src/main/java/org/opencastproject/job/api/AbstractJobProducer.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/AbstractJobProducer.java
@@ -173,22 +173,32 @@ public abstract class AbstractJobProducer implements JobProducer {
     // Note: We are not adding the job load in the next line because it is already accounted for in the load values we
     // get back from the service registry.
     float currentLoad = getServiceRegistry().getOwnLoad();
+    logger.debug("{} Current load on this host: {}, job's load: {}, job's status: {}, max load: {}", new Object[] {
+            Thread.currentThread().getId(), currentLoad, job.getJobLoad(), job.getStatus().name(),
+            maxload.getLoadFactor() });
+    // Add the current job load to compare below
+    currentLoad += job.getJobLoad();
 
     /* Note that this first clause looks at the *job's*, the other two look at the *node's* load
      * We're assuming that if this case is true, then we're also the most powerful node in the system for this service,
      * per the current job dispatching code in ServiceRegistryJpaImpl */
     if (job.getJobLoad() > maxload.getLoadFactor() && acceptJobLoadsExeedingMaxLoad) {
-      logger.warn("Accepting job {} of type {} with load {} even though load of {} is above this node's limit of {}.",
-              new Object[] { job.getId(), job.getJobType(), df.format(job.getJobLoad()), df.format(currentLoad), df.format(maxload.getLoadFactor()) });
+      logger.warn(
+              "{} Accepting job {} of type {} with load {} even though load of {} is above this node's limit of {}.",
+              new Object[] { Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
+                      df.format(currentLoad), df.format(maxload.getLoadFactor()) });
       logger.warn("This is a configuration issue that you should resolve in a production system!");
       return true;
     } else if (currentLoad > maxload.getLoadFactor()) {
-      logger.debug("Declining job {} of type {} with load {} because load of {} would exceed this node's limit of {}.",
-              new Object[] { job.getId(), job.getJobType(), df.format(job.getJobLoad()), df.format(currentLoad), df.format(maxload.getLoadFactor()) });
+      logger.debug(
+              "{} Declining job {} of type {} with load {} because load of {} would exceed this node's limit of {}.",
+              new Object[] { Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
+                      df.format(currentLoad), df.format(maxload.getLoadFactor()) });
       return false;
     } else  {
-      logger.debug("Accepting job {} of type {} with load {} because load of {} is within this node's limit of {}.",
-            new Object[] { job.getId(), job.getJobType(), df.format(job.getJobLoad()), df.format(currentLoad), df.format(maxload.getLoadFactor()) });
+      logger.debug("{} Accepting job {} of type {} with load {} because load of {} is within this node's limit of {}.",
+              new Object[] { Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
+                      df.format(currentLoad), df.format(maxload.getLoadFactor()) });
       return true;
     }
   }

--- a/modules/common/src/main/java/org/opencastproject/job/api/AbstractJobProducer.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/AbstractJobProducer.java
@@ -173,9 +173,9 @@ public abstract class AbstractJobProducer implements JobProducer {
     // Note: We are not adding the job load in the next line because it is already accounted for in the load values we
     // get back from the service registry.
     float currentLoad = getServiceRegistry().getOwnLoad();
-    logger.debug("{} Current load on this host: {}, job's load: {}, job's status: {}, max load: {}", new Object[] {
+    logger.debug("{} Current load on this host: {}, job's load: {}, job's status: {}, max load: {}",
             Thread.currentThread().getId(), currentLoad, job.getJobLoad(), job.getStatus().name(),
-            maxload.getLoadFactor() });
+            maxload.getLoadFactor());
     // Add the current job load to compare below
     currentLoad += job.getJobLoad();
 
@@ -185,20 +185,20 @@ public abstract class AbstractJobProducer implements JobProducer {
     if (job.getJobLoad() > maxload.getLoadFactor() && acceptJobLoadsExeedingMaxLoad) {
       logger.warn(
               "{} Accepting job {} of type {} with load {} even though load of {} is above this node's limit of {}.",
-              new Object[] { Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
-                      df.format(currentLoad), df.format(maxload.getLoadFactor()) });
+              Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
+              df.format(currentLoad), df.format(maxload.getLoadFactor()));
       logger.warn("This is a configuration issue that you should resolve in a production system!");
       return true;
     } else if (currentLoad > maxload.getLoadFactor()) {
       logger.debug(
               "{} Declining job {} of type {} with load {} because load of {} would exceed this node's limit of {}.",
-              new Object[] { Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
-                      df.format(currentLoad), df.format(maxload.getLoadFactor()) });
+              Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
+              df.format(currentLoad), df.format(maxload.getLoadFactor()));
       return false;
     } else  {
       logger.debug("{} Accepting job {} of type {} with load {} because load of {} is within this node's limit of {}.",
-              new Object[] { Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
-                      df.format(currentLoad), df.format(maxload.getLoadFactor()) });
+              Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
+              df.format(currentLoad), df.format(maxload.getLoadFactor()));
       return true;
     }
   }

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
@@ -89,7 +89,7 @@ public class EncodingProfileImpl implements EncodingProfile {
   protected HashMap<String,String> suffixes = new HashMap<String, String>();
 
   @XmlElement(name = "jobLoad")
-  protected Float jobLoad = 0.6f;
+  protected Float jobLoad = 0.8f;
 
   /**
    * Private, since the profile should be created using the static factory method.

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
@@ -89,7 +89,7 @@ public class EncodingProfileImpl implements EncodingProfile {
   protected HashMap<String,String> suffixes = new HashMap<String, String>();
 
   @XmlElement(name = "jobLoad")
-  protected Float jobLoad = 1.0f;
+  protected Float jobLoad = 0.6f;
 
   /**
    * Private, since the profile should be created using the static factory method.

--- a/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaAdaptiveStreamingDistributionService.java
+++ b/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaAdaptiveStreamingDistributionService.java
@@ -178,7 +178,7 @@ public class WowzaAdaptiveStreamingDistributionService extends AbstractDistribut
   };
 
   /** The load on the system introduced by creating a distribute job */
-  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.1f;
 
   /** The load on the system introduced by creating a retract job */
   public static final float DEFAULT_RETRACT_JOB_LOAD = 0.1f;

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -110,7 +110,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
   public static final String OPENCAST_DOWNLOAD_URL = "org.opencastproject.download.url";
 
   /** The load on the system introduced by creating a distribute job */
-  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.2f;
+  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.1f;
 
   /** The load on the system introduced by creating a retract job */
   public static final float DEFAULT_RETRACT_JOB_LOAD = 0.1f;

--- a/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
+++ b/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
@@ -100,7 +100,7 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
   private static final long TIMEOUT = 60000L;
 
   /** The load on the system introduced by creating a distribute job */
-  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.2f;
+  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.1f;
 
   /** The load on the system introduced by creating a retract job */
   public static final float DEFAULT_RETRACT_JOB_LOAD = 0.1f;

--- a/modules/distribution-service-streaming/src/main/java/org/opencastproject/distribution/streaming/StreamingDistributionServiceImpl.java
+++ b/modules/distribution-service-streaming/src/main/java/org/opencastproject/distribution/streaming/StreamingDistributionServiceImpl.java
@@ -97,7 +97,7 @@ public class StreamingDistributionServiceImpl extends AbstractDistributionServic
   }
 
   /** The load on the system introduced by creating a distribute job */
-  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.2f;
+  public static final float DEFAULT_DISTRIBUTE_JOB_LOAD = 0.1f;
 
   /** The load on the system introduced by creating a retract job */
   public static final float DEFAULT_RETRACT_JOB_LOAD = 0.1f;

--- a/modules/execute-impl/src/main/java/org/opencastproject/execute/impl/ExecuteServiceImpl.java
+++ b/modules/execute-impl/src/main/java/org/opencastproject/execute/impl/ExecuteServiceImpl.java
@@ -110,7 +110,7 @@ public class ExecuteServiceImpl extends AbstractJobProducer implements ExecuteSe
   private Dictionary properties = null;
 
   /** The approximate load placed on the system by running an execute operation */
-  public static final float DEFAULT_EXECUTE_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_EXECUTE_JOB_LOAD = 0.1f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_EXECUTE_JOB_LOAD} */
   public static final String EXECUTE_JOB_LOAD_KEY = "job.load.execute";

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -184,10 +184,10 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
   public static final String INGEST_CATALOG_FROM_URI = "uri-catalog";
 
   /** The approximate load placed on the system by ingesting a file */
-  public static final float DEFAULT_INGEST_FILE_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_INGEST_FILE_JOB_LOAD = 0.2f;
 
   /** The approximate load placed on the system by ingesting a zip file */
-  public static final float DEFAULT_INGEST_ZIP_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_INGEST_ZIP_JOB_LOAD = 0.2f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_INGEST_FILE_JOB_LOAD} */
   public static final String FILE_JOB_LOAD_KEY = "job.load.ingest.file";

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImpl.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImpl.java
@@ -54,10 +54,10 @@ import java.util.Map;
 public class MediaInspectionServiceImpl extends AbstractJobProducer implements MediaInspectionService, ManagedService {
 
   /** The load introduced on the system by creating an inspect job */
-  public static final float DEFAULT_INSPECT_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_INSPECT_JOB_LOAD = 0.2f;
 
   /** The load introduced on the system by creating an enrich job */
-  public static final float DEFAULT_ENRICH_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_ENRICH_JOB_LOAD = 0.2f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_INSPECT_JOB_LOAD} */
   public static final String INSPECT_JOB_LOAD_KEY = "job.load.inspect";

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -71,7 +71,7 @@ import java.util.UUID;
 public class YouTubeV3PublicationServiceImpl extends AbstractJobProducer implements YouTubePublicationService, ManagedService {
 
   /** The load on the system introduced by creating a publish job */
-  public static final float DEFAULT_YOUTUBE_PUBLISH_JOB_LOAD = 0.4f;
+  public static final float DEFAULT_YOUTUBE_PUBLISH_JOB_LOAD = 0.1f;
 
   /** The load on the system introduced by creating a retract job */
   public static final float DEFAULT_YOUTUBE_RETRACT_JOB_LOAD = 0.1f;

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -214,6 +214,9 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** Default delay between checking if hosts are still alive in seconds * */
   static final long DEFAULT_HEART_BEAT = 60;
 
+  /** Default job load when not passed by service creating the job * */
+  static final float DEFAULT_JOB_LOAD = 0.1f;
+
   /** This host's base URL */
   protected String hostName;
 
@@ -394,7 +397,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    */
   @Override
   public Job createJob(String type, String operation) throws ServiceRegistryException {
-    return createJob(this.hostName, type, operation, null, null, true, getCurrentJob(), 1.0f);
+    return createJob(this.hostName, type, operation, null, null, true, getCurrentJob(), DEFAULT_JOB_LOAD);
   }
 
   /**
@@ -415,7 +418,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    */
   @Override
   public Job createJob(String type, String operation, List<String> arguments) throws ServiceRegistryException {
-    return createJob(this.hostName, type, operation, arguments, null, true, getCurrentJob(), 1.0f);
+    return createJob(this.hostName, type, operation, arguments, null, true, getCurrentJob(), DEFAULT_JOB_LOAD);
   }
 
   /**
@@ -439,7 +442,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   @Override
   public Job createJob(String type, String operation, List<String> arguments, String payload)
           throws ServiceRegistryException {
-    return createJob(this.hostName, type, operation, arguments, payload, true, getCurrentJob(), 1.0f);
+    return createJob(this.hostName, type, operation, arguments, payload, true, getCurrentJob(), DEFAULT_JOB_LOAD);
   }
 
   /**
@@ -463,7 +466,8 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   @Override
   public Job createJob(String type, String operation, List<String> arguments, String payload, boolean dispatchable)
           throws ServiceRegistryException {
-    return createJob(this.hostName, type, operation, arguments, payload, dispatchable, getCurrentJob(), 1.0f);
+    return createJob(this.hostName, type, operation, arguments, payload, dispatchable, getCurrentJob(),
+            DEFAULT_JOB_LOAD);
   }
 
   /**
@@ -486,7 +490,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   @Override
   public Job createJob(String type, String operation, List<String> arguments, String payload, boolean dispatchable,
           Job parentJob) throws ServiceRegistryException {
-    return createJob(this.hostName, type, operation, arguments, payload, dispatchable, parentJob, 1.0f);
+    return createJob(this.hostName, type, operation, arguments, payload, dispatchable, parentJob, DEFAULT_JOB_LOAD);
   }
 
   /**
@@ -506,7 +510,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    */
   public Job createJob(String host, String serviceType, String operation, List<String> arguments, String payload,
           boolean dispatchable, Job parentJob) throws ServiceRegistryException {
-    return createJob(host, serviceType, operation, arguments, payload, dispatchable, parentJob, 1.0f);
+    return createJob(host, serviceType, operation, arguments, payload, dispatchable, parentJob, DEFAULT_JOB_LOAD);
   }
 
   /**

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
@@ -160,7 +160,7 @@ public class ServiceRegistrationTest {
 
     // Create a job and mark it as running.
     Job job = serviceRegistry.createJob(regType1Localhost.getHost(), regType1Localhost.getServiceType(), OPERATION_NAME_1, null,
-            null, false, null);
+            null, false, null, 1.0f);
     job.setStatus(Job.Status.RUNNING);
     job = serviceRegistry.updateJob(job);
 

--- a/modules/silencedetection-impl/src/main/java/org/opencastproject/silencedetection/impl/SilenceDetectionServiceImpl.java
+++ b/modules/silencedetection-impl/src/main/java/org/opencastproject/silencedetection/impl/SilenceDetectionServiceImpl.java
@@ -69,7 +69,7 @@ public class SilenceDetectionServiceImpl extends AbstractJobProducer implements 
 
   public static final String JOB_LOAD_KEY = "job.load.videoeditor.silencedetection";
 
-  private static final float DEFAULT_JOB_LOAD = 2.0f;
+  private static final float DEFAULT_JOB_LOAD = 0.2f;
 
   private float jobload = DEFAULT_JOB_LOAD;
 

--- a/modules/sox-impl/src/main/java/org/opencastproject/sox/impl/SoxServiceImpl.java
+++ b/modules/sox-impl/src/main/java/org/opencastproject/sox/impl/SoxServiceImpl.java
@@ -80,7 +80,7 @@ public class SoxServiceImpl extends AbstractJobProducer implements SoxService, M
   public static final String CONFIG_SOX_PATH = "org.opencastproject.sox.path";
 
   /** The load introduced on the system by creating a analyze job */
-  public static final float DEFAULT_ANALYZE_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_ANALYZE_JOB_LOAD = 0.2f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_ANALYZE_JOB_LOAD} */
   public static final String ANALYZE_JOB_LOAD_KEY = "job.load.analyze";
@@ -89,7 +89,7 @@ public class SoxServiceImpl extends AbstractJobProducer implements SoxService, M
   private float analyzeJobLoad = DEFAULT_ANALYZE_JOB_LOAD;
 
   /** The load introduced on the system by creating a normalize job */
-  public static final float DEFAULT_NORMALIZE_JOB_LOAD = 2.0f;
+  public static final float DEFAULT_NORMALIZE_JOB_LOAD = 0.2f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_NORMALIZE_JOB_LOAD} */
   public static final String NORMALIZE_JOB_LOAD_KEY = "job.load.normalize";

--- a/modules/textanalyzer-impl/src/main/java/org/opencastproject/textanalyzer/impl/TextAnalyzerServiceImpl.java
+++ b/modules/textanalyzer-impl/src/main/java/org/opencastproject/textanalyzer/impl/TextAnalyzerServiceImpl.java
@@ -88,7 +88,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
   public static final String COLLECTION_ID = "ocrtext";
 
   /** The approximate load placed on the system by creating a text analysis job */
-  public static final float DEFAULT_ANALYSIS_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_ANALYSIS_JOB_LOAD = 0.2f;
 
   /** The key to look for in the service configuration file to override the {@link DEFAULT_ANALYSIS_JOB_LOAD} */
   public static final String ANALYSIS_JOB_LOAD_KEY = "job.load.analysis";

--- a/modules/timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/ffmpeg/TimelinePreviewsServiceImpl.java
+++ b/modules/timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/ffmpeg/TimelinePreviewsServiceImpl.java
@@ -116,7 +116,7 @@ TimelinePreviewsService, ManagedService {
 
 
   /** The default job load of a timeline previews job */
-  public static final float DEFAULT_TIMELINEPREVIEWS_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_TIMELINEPREVIEWS_JOB_LOAD = 0.1f;
 
   /** The key to look for in the service configuration file to override the DEFAULT_TIMELINEPREVIEWS_JOB_LOAD */
   public static final String TIMELINEPREVIEWS_JOB_LOAD_KEY = "job.load.timelinepreviews";

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -84,7 +84,7 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
 
   public static final String JOB_LOAD_KEY = "job.load.videoeditor";
 
-  private static final float DEFAULT_JOB_LOAD = 0.6f;
+  private static final float DEFAULT_JOB_LOAD = 0.8f;
 
   private float jobload = DEFAULT_JOB_LOAD;
 

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -84,7 +84,7 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
 
   public static final String JOB_LOAD_KEY = "job.load.videoeditor";
 
-  private static final float DEFAULT_JOB_LOAD = 2.0f;
+  private static final float DEFAULT_JOB_LOAD = 0.6f;
 
   private float jobload = DEFAULT_JOB_LOAD;
 

--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
@@ -148,7 +148,7 @@ VideoSegmenterService, ManagedService {
   public static final boolean DEFAULT_DURATION_DEPENDENT = false;
 
   /** The load introduced on the system by a segmentation job */
-  public static final float DEFAULT_SEGMENTER_JOB_LOAD = 0.6f;
+  public static final float DEFAULT_SEGMENTER_JOB_LOAD = 0.3f;
 
   /** The key to look for in the service configuration file to override the DEFAULT_CAPTION_JOB_LOAD */
   public static final String SEGMENTER_JOB_LOAD_KEY = "job.load.videosegmenter";

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -81,7 +81,7 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
   public static final String WAVEFORM_JOB_LOAD_CONFIG_KEY = "job.load.waveform";
 
   /** The default job load of a waveform job */
-  public static final float DEFAULT_WAVEFORM_JOB_LOAD = 1.0f;
+  public static final float DEFAULT_WAVEFORM_JOB_LOAD = 0.1f;
 
   /** The key to look for in the service configuration file to override the DEFAULT_FFMPEG_BINARY */
   public static final String FFMPEG_BINARY_CONFIG_KEY = "org.opencastproject.composer.ffmpeg.path";


### PR DESCRIPTION
Fixes:
* Fix comparison by host name, which was causing the current host load to be always 0. 
* Make sure jobs are not removed/counted twice from local load cache by first checking their presence in it. 
* Queued jobs are not considered when calculating the current load on node. The previous version would count them sometimes (when job children e.g. inspect), sometimes not (when parent job e.g. compose, etc).
* Removed job from cache when deleted or not found in db. Unexpected problems could cause the job to stay in the local cache and be counted in the current load forever.

Additional Notes:
- isReadyToAccept() should be "synchronized" across all services i.e. the decision that the job can be accepted by a node and putting it into the node's load cache should be atomic.
Since the dispatcher only runs on admin and is sequential, isReadyToAccept() will not be called simultaneously by two separate threads so this is currently fine.
This will change if we distribute the dispatcher code or if it's configured to run on > 1 node.

- When a parent jobs goes from WAITING->RUNNING after its children are finished, it doesn't go through the isReadyToAccept() logic and is put back directly into the node's load cache so, at a point in time, the node load may be > max load.
I considered this OK because normally the parent job is just finishing up after all its children are done.

- For testing, I suggest turning the DEBUG logging on to see what's happening. Please keep in mind that the node load, being a float number, will not show as exact as you expect :)
