### PR TITLE
MH-12933, Link documentation from Systemd unit

### DIFF
--- a/docs/scripts/service/opencast.service
+++ b/docs/scripts/service/opencast.service
@@ -3,6 +3,7 @@ Description=Opencast
 After=local-fs.target
 After=network.target
 After=remote-fs.target
+Documentation=https://docs.opencast.org
 
 [Service]
 ExecStart=/opt/opencast/bin/start-opencast server


### PR DESCRIPTION
This adds a missing documentation entry to the Systemd unit file
template shipped with Opencast.