### PR TITLE
MH-12938, Fix NullPointerException if no flavor is set

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -2270,7 +2270,7 @@ public abstract class AbstractEventEndpoint {
   private List<Field> getEventMediaPackageElementFields(MediaPackageElement element) {
     List<Field> fields = new ArrayList<>();
     fields.add(f("id", v(element.getIdentifier(), BLANK)));
-    fields.add(f("type", v(element.getFlavor().toString(), BLANK)));
+    fields.add(f("type", v(element.getFlavor(), BLANK)));
     fields.add(f("mimetype", v(element.getMimeType(), BLANK)));
     List<JValue> tags = Stream.$(element.getTags()).map(toStringJValue).toList();
     fields.add(f("tags", arr(tags)));


### PR DESCRIPTION
If the flavor of a track was not set, the admin ui facade caused a null
pointer exception while generating the JSON for the frontend.

*Work sponsored by SWITCH*