### PR TITLE
MH-12864 Don't attempt to parse 'undefined'

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableDirective.js
@@ -53,7 +53,7 @@ angular.module('adminNg.directives')
                            result = value;
                        }
                     });
-                    if (scope.params.type === 'ordered_text') {
+                    if ((scope.params.type === 'ordered_text') && angular.isDefined(result)) {
                         result = JSON.parse(result)['label'];
                     }
                 } else if ((scope.mode === 'multiSelect') || (scope.mode === 'multiValue')) {


### PR DESCRIPTION
Attempts to parse 'undefined' as JSON fail which causes the Admin UI to display the following (see field License):

![screen shot 2018-06-07 at 12 22 52](https://user-images.githubusercontent.com/1590263/41094296-188e8720-6a4e-11e8-8268-fd5901b8fb13.png)

To test this, create an event with a license set and open Event Details->Metadata while the event is being processed.