### PR TITLE
MH-12941, Gracefully handle empty flavors

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -1335,18 +1335,19 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       mergeMediaPackageMetadata(mp, scheduledMp);
       return mp;
     } catch (NotFoundException e) {
-      logger.debug("No scheduler mediapackage found with id {}, skip merging", mp.getIdentifier().compact());
+      logger.debug("No scheduler mediapackage found with id {}, skip merging", mp.getIdentifier());
       return mp;
     } catch (Exception e) {
-      logger.error("Unable to get event mediapackage from scheduler event {}", mp.getIdentifier().compact(), e);
-      throw new IngestException(e);
+      throw new IngestException(String.format("Unable to get event media package from scheduler event %s",
+              mp.getIdentifier()), e);
     }
   }
 
   private void mergeMediaPackageElements(MediaPackage mp, MediaPackage scheduledMp) {
     for (MediaPackageElement element : scheduledMp.getElements()) {
       // Asset manager media package may have a publication element (for live) if retract live has not run yet
-      if (!MediaPackageElement.Type.Publication.equals(element.getElementType())
+      if (element.getFlavor() != null
+              && !MediaPackageElement.Type.Publication.equals(element.getElementType())
               && mp.getElementsByFlavor(element.getFlavor()).length > 0) {
         logger.info("Ignore scheduled element '{}', there is already an ingested element with flavor '{}'", element,
                 element.getFlavor());


### PR DESCRIPTION
While a media package element's flavor *should* always be set in the
scheduler, when it is not, the ingest for that event will fail. If the
capture agent which did record that event dutifully tries to upload the
event again later, this might force the ingest service repeatedly into
an error state.

This patch fixes the issue by not trying to merge elements with unset
flavors which makes sense in any case since the merge is based on
flavors and you cannot merge an element based on something which does
not exist.

*Work sponsored by SWITCH*