### PR TITLE
MH-12942 Paella player config REST endpoint should be accessible by anonymous user

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -242,6 +242,7 @@
     <!-- Paella player -->
     <sec:intercept-url pattern="/paella/ui/auth.html" access="ROLE_USER" />
     <sec:intercept-url pattern="/paella/ui/**" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/paella/config/**" access="ROLE_ANONYMOUS" />
 
     <!-- Enable anonymous access to the engage player and the GET endpoints it requires -->
     <sec:intercept-url pattern="/engage/ui/**" access="ROLE_ANONYMOUS" />


### PR DESCRIPTION
The paella player itself and the underlying configuration should be public accessible. Otherwise you will get an error on loading the player page. As the configuration does not include any passwords or secret data, it should be ok.