### PR TITLE
MH-12905 TEMPORARY Karaf config assembly workaround (KARAF-5693)

### DIFF
--- a/etc/config.properties
+++ b/etc/config.properties
@@ -1,0 +1,412 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+################################################################################
+############## OPENCAST PROJECT WARNING  #######################################
+################################################################################
+# This is a TEMPORARY fixed copy of a Karaf assembled config.properties
+# The file is checked into source control as temporary workaround for MH-12905 (KARAF-5693)
+#
+# https://opencast.jira.com/browse/MH-12905 "Karaf assembly omits extra system packages"
+# https://issues.apache.org/jira/browse/KARAF-5693 "Incomplete config.properties file in built assemblies"
+# https://github.com/apache/karaf/pull/511 [KARAF-5693] Run the processing synchronously after downloads #511 gnodet
+#
+# CONSIDERATIONS:
+#
+# I. IF you change from JAVA 8 to another version:
+#    REMOVE THIS FILE PRIOR TO BUILDING, verify the new file contains the expected set of libraries and check it into source control.
+#
+# II. IF you modify assemblies/pom.xml libraries in the org.apache.karaf.tooling section
+#     REMOVE THIS FILE PRIOR TO BUILDING, verify the new file contains the expected set of libraries and check it into source control.
+#
+# III. WHEN KARAF-5693 is resolved and absorbed into this Opencast version:
+#     This file will not be checked into source control. It will be dynamically created during the build.
+#
+#
+#############################################################################
+##############################################################################
+
+#
+# This file lists Karaf default settings for this particular version of Karaf.
+# For easier maintenance when upgrading Karaf and to better document which
+# default values have changed, it is recommended to place any changes to
+# these values in a custom.properties file in the same folder as this file.
+# Each value specified in custom.properties will override the default value
+# here.
+#
+
+#
+# Properties file inclusions (as a space separated list of relative paths)
+# Included files will override the values specified in this file
+# NB: ${includes} properties files are mandatory, it means that Karaf will not start
+# if the include file is not found
+#
+${includes} = jre.properties custom.properties
+
+#
+# Properties file inclusions (as a space separated list of relative paths)
+# Included files will override the values specified in this file
+# NB: ${optionals} properties files are optionals, it means that Karaf will just
+# display a warning message but the bootstrap will be performed
+#
+# ${optionals} = my.properties
+
+#
+# Framework selection properties
+#
+karaf.framework=felix
+
+#
+# Location of the OSGi frameworks
+#
+karaf.framework.equinox=mvn\:org.eclipse.tycho/org.eclipse.osgi/3.10.101.v20150820-1432
+karaf.framework.felix=mvn\:org.apache.felix/org.apache.felix.framework/5.6.4
+
+#
+# Framework config properties.
+#
+org.osgi.framework.system.packages= \ com.sun.image.codec.jpeg, \
+ org.osgi.dto;version="1.0",\
+ org.osgi.resource;version="1.0",\
+ org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",\
+ org.osgi.framework;version="1.8",\
+ org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",\
+ org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",\
+ org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",\
+ org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",\
+ org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",\
+ org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",\
+ org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",\
+ org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",\
+ org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",\
+ org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",\
+ org.osgi.framework.wiring.dto;version="1.2";uses:="org.osgi.dto,org.osgi.resource.dto",\
+ org.osgi.service.condpermadmin;version="1.1.1";uses:="org.osgi.framework,org.osgi.service.permissionadmin",\
+ org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",org.osgi.service.permissionadmin;version="1.2",\
+ org.osgi.service.resolver;version="1.0";uses:="org.osgi.resource",\
+ org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",\
+ org.osgi.service.url;version="1.0",\
+ org.osgi.util.tracker;version="1.5.1";uses:="org.osgi.framework",\
+ org.apache.karaf.version;version="4.0.10",\
+ org.apache.karaf.jaas.boot.principal;uses:=javax.security.auth;version="4.0.10",\
+ org.apache.karaf.jaas.boot;uses:="javax.security.auth,javax.security.auth.callback,javax.security.auth.login,javax.security.auth.spi,org.osgi.framework";version="4.0.10",\
+ ${jre-${java.specification.version}}
+
+#
+# Extra packages appended after standard packages
+#
+org.osgi.framework.system.packages.extra = \
+    org.apache.karaf.branding, \
+    org.apache.karaf.jaas.boot.principal, \
+    org.apache.karaf.jaas.boot, \
+    sun.misc, \
+    javax.xml.stream;uses:=\"javax.xml.namespace,javax.xml.stream.events,javax.xml.stream.util,javax.xml.transform\";version=1.2, \
+    javax.xml.stream.events;uses:=\"javax.xml.namespace,javax.xml.stream\";version=1.2, \
+    javax.xml.stream.util;uses:=\"javax.xml.namespace,javax.xml.stream,javax.xml.stream.events\";version=1.2, \
+    javax.xml;version=1.4, \
+    javax.xml.datatype;uses:=javax.xml.namespace;version=1.4, \
+    javax.xml.namespace;version=1.4, \
+    javax.xml.parsers;uses:=\"javax.xml.validation,org.w3c.dom,org.xml.sax,org.xml.sax.helpers\";version=1.4, \
+    javax.xml.transform;version=1.4, \
+    javax.xml.transform.dom;uses:=\"javax.xml.transform,org.w3c.dom\";version=1.4, \
+    javax.xml.transform.sax;uses:=\"javax.xml.transform,org.xml.sax,org.xml.sax.ext\";version=1.4, \
+    javax.xml.transform.stax;uses:=\"javax.xml.stream,javax.xml.transform\";version=1.4, \
+    javax.xml.transform.stream;uses:=javax.xml.transform;version=1.4, \
+    javax.xml.validation;uses:=\"javax.xml.transform,org.w3c.dom,org.w3c.dom.ls,org.xml.sax\";version=1.4, \
+    javax.xml.xpath;uses:=\"javax.xml.namespace,org.xml.sax\";version=1.4, \
+    org.w3c.dom;version=1.0, \
+    org.w3c.dom.bootstrap;uses:=org.w3c.dom;version=1.0, \
+    org.w3c.dom.css;uses:=\"org.w3c.dom,org.w3c.dom.stylesheets,org.w3c.dom.views\";version=1.0, \
+    org.w3c.dom.events;uses:=\"org.w3c.dom,org.w3c.dom.views\";version=1.0, \
+    org.w3c.dom.html;uses:=org.w3c.dom;version=1.0, \
+    org.w3c.dom.ls;uses:=\"org.w3c.dom,org.w3c.dom.events,org.w3c.dom.traversal\";version=1.0, \
+    org.w3c.dom.ranges;uses:=org.w3c.dom;version=1.0, \
+    org.w3c.dom.stylesheets;uses:=org.w3c.dom;version=1.0, \
+    org.w3c.dom.traversal;uses:=org.w3c.dom;version=1.0, \
+    org.w3c.dom.views;version=1.0, \
+    org.w3c.dom.xpath;uses:=org.w3c.dom;version=1.0, \
+    org.xml.sax;version=2.0.2, \
+    org.xml.sax.ext;uses:=\"org.xml.sax,org.xml.sax.helpers\";version=2.0.2, \
+    org.xml.sax.helpers;uses:=org.xml.sax;version=2.0.2, \
+    javax.xml.soap;uses:=\"javax.activation,javax.xml.namespace,javax.xml.transform,javax.xml.transform.dom,org.w3c.dom\";version=1.3, \
+    org.apache.xml.serializer;uses:=\"org.xml.sax.helpers,org.xml.sax,org.apache.xml.serializer.utils,javax.xml.transform,org.w3c.dom.ls,org.w3c.dom,org.xml.sax.ext,org.apache.xml.serializer.dom3\";version=2.7.2, \
+    org.apache.xml.serializer.utils;uses:=\"org.w3c.dom,org.xml.sax,javax.xml.transform\";version=2.7.2, \
+    org.apache.xml.serializer.dom3;uses:=\"org.apache.xml.serializer,org.w3c.dom.ls,org.apache.xml.serializer.utils,org.w3c.dom,org.xml.sax,org.xml.sax.ext,org.xml.sax.helpers\";version=2.7.2, \
+    javax.xml.bind;uses:=\"javax.xml.bind.annotation.adapters,javax.xml.bind.attachment,javax.xml.namespace,javax.xml.stream,javax.xml.transform,javax.xml.validation,org.w3c.dom,org.xml.sax\";version=2.2.1, \
+    javax.xml.bind.annotation;uses:=\"javax.xml.bind,javax.xml.parsers,javax.xml.transform,javax.xml.transform.dom,org.w3c.dom\";version=2.2.1, \
+    javax.xml.bind.annotation.adapters;version=2.2.1, \
+    javax.xml.bind.attachment;uses:=javax.activation;version=2.2.1, \
+    javax.xml.bind.helpers;uses:=\"javax.xml.bind,javax.xml.bind.annotation.adapters,javax.xml.bind.attachment,javax.xml.stream,javax.xml.transform,javax.xml.validation,org.w3c.dom,org.xml.sax\";version=2.2.1, \
+    javax.xml.bind.util;uses:=\"javax.xml.bind,javax.xml.transform.sax\";version=2.2.1, \
+    javax.activation;version=1.1, \
+    javax.annotation;version=1.2, \
+    javax.annotation.security;version=1.2, \
+    javax.annotation.sql;version=1.2, \
+    javax.xml.ws;uses:=\"javax.xml.bind,javax.xml.bind.annotation,javax.xml.namespace,javax.xml.transform,javax.xml.ws.handler,javax.xml.ws.spi,javax.xml.ws.spi.http,org.w3c.dom\";version=2.2, \
+    javax.xml.ws.handler;uses:=\"javax.xml.namespace,javax.xml.ws\";version=2.2, \
+    javax.xml.ws.handler.soap;uses:=\"javax.xml.bind,javax.xml.namespace,javax.xml.soap,javax.xml.ws.handler\";version=2.2, \
+    javax.xml.ws.http;uses:=javax.xml.ws;version=2.2, \
+    javax.xml.ws.soap;uses:=\"javax.xml.soap,javax.xml.ws,javax.xml.ws.spi\";version=2.2, \
+    javax.xml.ws.spi;uses:=\"javax.xml.bind,javax.xml.namespace,javax.xml.transform,javax.xml.ws,javax.xml.ws.handler,javax.xml.ws.wsaddressing,org.w3c.dom\";version=2.2, \
+    javax.xml.ws.spi.http;version=2.2, \
+    javax.xml.ws.wsaddressing;uses:=\"javax.xml.bind.annotation,javax.xml.namespace,javax.xml.transform,javax.xml.ws,org.w3c.dom\";version=2.2, \
+    java_cup.runtime;version=2.7.2, \
+    org.apache.xalan;version=2.7.2, \
+    org.apache.xalan.xslt;uses:=\"org.w3c.dom,org.xml.sax,org.apache.xalan,org.xml.sax.helpers,javax.xml.transform.sax,org.apache.xalan.res,org.apache.xml.utils,org.apache.xalan.transformer,javax.xml.transform.dom,javax.xml.parsers,javax.xml.transform,org.apache.xalan.trace,javax.xml.transform.stream\";version=2.7.2, \
+    org.apache.xalan.transformer;uses:=\"org.apache.xml.dtm,org.xml.sax.ext,org.apache.xml.serializer,org.apache.xalan.serialize,org.xml.sax,org.apache.xml.utils,javax.xml.transform,org.apache.xpath,org.apache.xalan.templates,org.apache.xalan.res,org.apache.xpath.axes,org.apache.xpath.objects,org.w3c.dom,org.xml.sax.helpers,javax.xml.parsers,org.w3c.dom.traversal,javax.xml.transform.sax,org.apache.xml.dtm.ref.sax2dtm,org.apache.xml.dtm.ref,javax.xml.transform.dom,javax.xml.transform.stream,org.apache.xpath.functions,org.apache.xalan.trace,org.apache.xalan.extensions\";version=2.7.2, \
+    org.apache.xalan.xsltc.trax;uses:=\"org.xml.sax.ext,org.xml.sax.helpers,org.w3c.dom,org.xml.sax,org.apache.xalan.xsltc.dom,org.apache.xml.serializer,org.apache.xalan.xsltc.runtime,javax.xml.parsers,javax.xml.transform.sax,javax.xml.transform,org.apache.xalan.xsltc.compiler.util,org.apache.xalan.xsltc.compiler,javax.xml,org.apache.xalan.xsltc,org.apache.xml.utils,javax.xml.transform.dom,org.apache.xalan.xsltc.runtime.output,org.apache.xml.dtm,javax.xml.transform.stream\";version=2.7.2, \
+    org.apache.xalan.xsltc.compiler.util;uses:=\"org.apache.bcel.generic,org.apache.xalan.xsltc.compiler,org.apache.bcel.classfile,org.apache.xml.utils\";version=2.7.2, \
+    org.apache.xalan.xsltc.cmdline.getopt;uses:=org.apache.xalan.xsltc.compiler.util;version=2.7.2, \
+    org.apache.xalan.lib;uses:=\"org.w3c.dom,org.apache.xml.dtm.ref,org.apache.xml.dtm,org.apache.xpath,org.apache.xpath.axes,org.apache.xalan.extensions,org.apache.xpath.objects,org.xml.sax,org.apache.xalan.res,org.apache.xml.utils,javax.xml.parsers,javax.xml.transform,org.apache.xalan.xslt,org.w3c.dom.traversal,org.xml.sax.helpers,org.apache.xml.serializer,javax.xml.transform.sax,org.apache.xalan.templates,org.apache.xalan.transformer,javax.xml.transform.stream\";version=2.7.2, \
+    org.apache.xalan.xsltc.runtime;uses:=\"org.apache.xml.serializer,org.w3c.dom,org.apache.xalan.xsltc.runtime.output,javax.xml.parsers,javax.xml.transform,org.apache.xml.dtm,org.apache.xalan.xsltc,org.apache.xalan.xsltc.dom,org.xml.sax,org.apache.xml.utils,javax.xml.transform.dom,org.apache.xml.dtm.ref\";version=2.7.2, \
+    org.apache.xalan.extensions;uses:=\"org.w3c.dom,org.apache.xpath,org.apache.xpath.objects,org.apache.xml.utils,javax.xml.transform,org.w3c.dom.traversal,org.apache.xpath.functions,org.apache.xalan.templates,org.apache.xalan.transformer,org.apache.xalan.res,org.apache.xml.dtm,org.apache.xml.dtm.ref,org.apache.xalan.trace,javax.xml.namespace,javax.xml.xpath,org.apache.xml.serializer,org.xml.sax,org.apache.xalan.serialize,org.apache.xpath.axes\";version=2.7.2, \
+    org.apache.xalan.processor;uses:=\"org.xml.sax.helpers,org.w3c.dom,org.apache.xalan.templates,org.xml.sax,org.apache.xml.utils,javax.xml.transform,javax.xml.transform.sax,org.apache.xalan.res,javax.xml.parsers,javax.xml.transform.dom,javax.xml.transform.stream,org.apache.xpath,org.apache.xpath.compiler,org.apache.xalan.extensions,org.apache.xalan.transformer\";version=2.7.2, \
+    org.apache.xalan.xsltc.runtime.output;uses:=\"org.xml.sax.ext,org.apache.xml.serializer,org.w3c.dom,org.xml.sax,javax.xml.parsers,org.apache.xalan.xsltc.trax\";version=2.7.2, \
+    org.apache.xalan.templates;uses:=\"org.apache.xpath,org.xml.sax,org.apache.xalan.res,org.apache.xml.utils,org.apache.xalan.processor,javax.xml.transform,org.apache.xpath.compiler,org.apache.xpath.objects,org.apache.xpath.operations,org.apache.xpath.functions,org.apache.xpath.axes,org.apache.xalan.transformer,org.apache.xalan.trace,org.apache.xml.dtm,org.apache.xml.serializer,org.apache.xalan.serialize,org.apache.xml.dtm.ref,org.w3c.dom,org.apache.xalan.extensions,org.apache.xml.utils.res,org.xml.sax.helpers,org.apache.xpath.patterns\";version=2.7.2, \
+    org.apache.xalan.xsltc.compiler;uses:=\"org.apache.bcel.generic,org.apache.xalan.xsltc.compiler.util,org.apache.xml.utils,java_cup.runtime,org.apache.xml.serializer,org.apache.xalan.xsltc.runtime,org.xml.sax,org.apache.bcel.util,org.apache.bcel.classfile,javax.xml.parsers,org.apache.xml.dtm\";version=2.7.2, \
+    org.apache.xalan.res;uses:=org.apache.xpath.res;version=2.7.2, \
+    org.apache.xalan.trace;uses:=\"org.w3c.dom,org.apache.xpath,org.apache.xpath.objects,org.apache.xalan.templates,org.apache.xalan.transformer,org.xml.sax,org.apache.xml.utils,javax.xml.transform,org.apache.xml.dtm,org.apache.xml.dtm.ref\";version=2.7.2, \
+    org.apache.xalan.client;uses:=\"javax.xml.transform.stream,org.apache.xalan.res,javax.xml.transform\";version=2.7.2, \
+    org.apache.xalan.lib.sql;uses:=\"org.apache.xalan.res,org.w3c.dom,org.xml.sax,org.apache.xml.dtm,org.xml.sax.ext,org.apache.xml.utils,org.apache.xml.dtm.ref,javax.xml.transform,javax.naming,org.apache.xpath,org.apache.xalan.extensions,org.apache.xpath.objects\";version=2.7.2, \
+    org.apache.xalan.xsltc;uses:=\"org.apache.xml.dtm,org.apache.xml.serializer,org.w3c.dom,org.apache.xalan.xsltc.runtime,org.xml.sax\";version=2.7.2, \
+    org.apache.xalan.xsltc.cmdline;uses:=\"org.apache.xalan.xsltc.cmdline.getopt,org.apache.xalan.xsltc.compiler,org.apache.xalan.xsltc.compiler.util,org.apache.xml.serializer,javax.xml.transform.sax,org.apache.xalan.xsltc.runtime.output,javax.xml.parsers,javax.xml.transform,org.apache.xml.dtm,org.apache.xalan.xsltc,org.xml.sax,org.apache.xalan.xsltc.runtime,org.apache.xalan.xsltc.dom\";version=2.7.2, \
+    org.apache.xalan.serialize;uses:=\"org.apache.xml.serializer,org.xml.sax,org.w3c.dom,org.apache.xml.dtm,org.apache.xpath.objects,org.apache.xpath,org.apache.xml.utils,org.apache.xalan.transformer,javax.xml.transform\";version=2.7.2, \
+    org.apache.xalan.xsltc.dom;uses:=\"org.apache.xml.dtm,org.apache.xalan.xsltc.runtime,org.apache.xml.dtm.ref,org.xml.sax.ext,org.apache.xml.serializer,org.w3c.dom,org.apache.xalan.xsltc,org.xml.sax,org.apache.xml.utils,javax.xml.transform,org.apache.xalan.xsltc.util,javax.xml.transform.sax,javax.xml.parsers,javax.xml.transform.stream,org.apache.xalan.xsltc.trax,org.apache.xml.dtm.ref.sax2dtm,javax.xml.transform.dom,org.apache.xml.res\";version=2.7.2, \
+    org.apache.xalan.xsltc.util;version=2.7.2, \
+    org.apache.xml.dtm.ref.dom2dtm;uses:=\"org.w3c.dom,org.xml.sax,org.apache.xml.dtm,org.xml.sax.ext,org.apache.xml.res,org.apache.xml.utils,org.apache.xml.dtm.ref,javax.xml.transform.dom,javax.xml.transform\";version=2.7.2, \
+    org.apache.xml.dtm;uses:=\"org.xml.sax.ext,org.w3c.dom,org.xml.sax,org.apache.xml.utils,javax.xml.transform,org.apache.xml.res\";version=2.7.2, \
+    org.apache.xml.dtm.ref;uses:=\"org.apache.xml.res,org.xml.sax.ext,org.xml.sax,org.apache.xml.dtm,org.w3c.dom,org.apache.xml.utils,javax.xml.transform,org.xml.sax.helpers,javax.xml.transform.sax,org.apache.xml.dtm.ref.sax2dtm,org.apache.xml.dtm.ref.dom2dtm,javax.xml.parsers,javax.xml.transform.dom,javax.xml.transform.stream,org.w3c.dom.traversal,org.apache.xpath,org.apache.xerces.parsers,org.apache.xml.serialize\";version=2.7.2, \
+    org.apache.xml.dtm.ref.sax2dtm;uses:=\"org.apache.xml.dtm,org.xml.sax.ext,org.apache.xml.res,org.xml.sax,org.apache.xml.utils,org.apache.xml.dtm.ref,javax.xml.transform,org.apache.xml.serializer\";version=2.7.2, \
+    org.apache.xml.res;version=2.7.2, \
+    org.apache.xml.serializer;uses:=\"org.xml.sax.helpers,org.xml.sax,org.apache.xml.serializer.utils,javax.xml.transform,org.w3c.dom,org.w3c.dom.ls,org.xml.sax.ext,org.apache.xml.serializer.dom3\";version=2.7.2, \
+    org.apache.xml.serializer.dom3;uses:=\"org.apache.xml.serializer,org.w3c.dom,org.w3c.dom.ls,org.xml.sax,org.apache.xml.serializer.utils,org.xml.sax.ext,org.xml.sax.helpers\";version=2.7.2, \
+    org.apache.xml.utils.res;version=2.7.2, \
+    org.apache.xml.utils;uses:=\"org.w3c.dom,org.xml.sax,javax.xml.parsers,javax.xml.transform,org.xml.sax.ext,org.apache.xml.res,org.apache.xml.dtm.ref,org.xml.sax.helpers,javax.xml.transform.sax,org.apache.xml.dtm.ref.dom2dtm\";version=2.7.2, \
+    org.apache.xpath;uses:=\"org.apache.xpath.objects,org.apache.xml.utils,org.w3c.dom,javax.xml.transform,org.w3c.dom.traversal,org.apache.xml.dtm,org.xml.sax,org.apache.xalan.res,org.apache.xpath.functions,org.apache.xpath.axes,org.xml.sax.helpers,javax.xml.transform.sax,javax.xml.transform.stream,javax.xml.parsers,org.apache.xalan.templates,org.apache.xpath.compiler,org.apache.xalan.extensions,org.apache.xml.dtm.ref,org.apache.xml.dtm.ref.sax2dtm,org.apache.xpath.operations,org.apache.xpath.patterns\";version=2.7.2, \
+    org.apache.xpath.compiler;uses:=\"org.apache.xpath.operations,org.apache.xpath,org.apache.xpath.functions,org.apache.xalan.res,org.apache.xml.utils,javax.xml.transform,org.apache.xml.dtm,org.apache.xpath.objects,org.apache.xpath.axes,org.apache.xpath.patterns,org.apache.xalan.templates,org.apache.xpath.domapi\";version=2.7.2, \
+    org.apache.xpath.res;uses:=org.apache.xml.res;version=2.7.2, \
+    org.apache.xpath.objects;uses:=\"org.apache.xml.utils,org.apache.xml.dtm,org.apache.xpath,javax.xml.transform,org.w3c.dom,org.xml.sax,org.apache.xpath.axes,org.apache.xml.dtm.ref,org.w3c.dom.traversal,org.apache.xalan.res,org.xml.sax.ext\";version=2.7.2, \
+    org.apache.xpath.patterns;uses:=\"org.apache.xml.dtm,org.apache.xpath,org.apache.xpath.objects,org.apache.xpath.axes,javax.xml.transform\";version=2.7.2, \
+    org.apache.xpath.operations;uses:=\"org.apache.xpath,org.apache.xpath.objects,javax.xml.transform,org.apache.xml.utils,org.apache.xml.dtm,org.w3c.dom,org.apache.xalan.templates,org.apache.xalan.res,org.apache.xpath.axes\";version=2.7.2, \
+    org.apache.xpath.domapi;uses:=\"org.w3c.dom,org.apache.xpath.res,org.apache.xml.utils,org.w3c.dom.xpath,org.apache.xpath,javax.xml.transform,org.apache.xpath.objects,org.w3c.dom.events,org.w3c.dom.traversal\";version=2.7.2, \
+    org.apache.xpath.functions;uses:=\"org.apache.xpath,org.apache.xpath.objects,javax.xml.transform,org.apache.xalan.res,org.apache.xml.dtm,org.apache.xpath.axes,org.apache.xpath.patterns,org.apache.xalan.templates,org.apache.xml.utils,org.apache.xalan.transformer,org.apache.xpath.res,org.apache.xpath.compiler,org.xml.sax\";version=2.7.2, \
+    org.apache.xpath.jaxp;uses:=\"org.w3c.dom,javax.xml.namespace,org.apache.xpath.objects,org.apache.xpath,org.apache.xpath.functions,org.apache.xalan.res,org.apache.xml.utils,javax.xml.transform,javax.xml.xpath,javax.xml.parsers,org.w3c.dom.traversal,org.xml.sax\";version=2.7.2, \
+    org.apache.xpath.axes;uses:=\"org.apache.xml.dtm,org.apache.xpath.compiler,javax.xml.transform,org.apache.xpath,org.apache.xalan.res,org.apache.xpath.patterns,org.apache.xml.utils,org.w3c.dom,org.w3c.dom.traversal,org.apache.xpath.objects,org.apache.xpath.operations,org.apache.xpath.functions,org.xml.sax\";version=2.7.2, \
+    org.apache.html.dom;uses:=\"org.apache.xerces.dom,org.w3c.dom,org.xml.sax\";version=2.11.0, \
+    org.apache.wml;uses:=org.w3c.dom;version=2.11.0, \
+    org.apache.wml.dom;uses:=\"org.apache.wml,org.apache.xerces.dom,org.w3c.dom\";version=2.11.0, \
+    org.apache.xerces.dom;uses:=\"org.apache.xerces.dom3.as,org.apache.xerces.impl,org.apache.xerces.impl.dv,org.apache.xerces.impl.validation,org.apache.xerces.impl.xs,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xni.parser,org.apache.xerces.xs,org.w3c.dom,org.w3c.dom.events,org.w3c.dom.ls,org.w3c.dom.ranges,org.w3c.dom.traversal\";version=2.11.0, \
+    org.apache.xerces.dom.events;uses:=\"org.w3c.dom,org.w3c.dom.events,org.w3c.dom.views\";version=2.11.0, \
+    org.apache.xerces.dom3.as;uses:=\"org.w3c.dom,org.w3c.dom.ls\";version=2.11.0, \
+    org.apache.xerces.impl;uses:=\"org.apache.xerces.impl.dtd,org.apache.xerces.impl.validation,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xni.grammars,org.apache.xerces.xni.parser,org.xml.sax\";version=2.11.0, \
+    org.apache.xerces.impl.dtd;uses:=\"org.apache.xerces.impl,org.apache.xerces.impl.dtd.models,org.apache.xerces.impl.dv,org.apache.xerces.impl.validation,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xni.grammars,org.apache.xerces.xni.parser\";version=2.11.0, \
+    org.apache.xerces.impl.dtd.models;uses:=org.apache.xerces.xni;version=2.11.0, \
+    org.apache.xerces.impl.dv;uses:=\"org.apache.xerces.impl.xs.util,org.apache.xerces.util,org.apache.xerces.xs\";version=2.11.0, \
+    org.apache.xerces.impl.dv.dtd;uses:=org.apache.xerces.impl.dv;version=2.11.0, \
+    org.apache.xerces.impl.dv.util;uses:=\"org.apache.xerces.xs,org.apache.xerces.xs.datatypes\";version=2.11.0, \
+    org.apache.xerces.impl.dv.xs;uses:=\"javax.xml.datatype,org.apache.xerces.impl.dv,org.apache.xerces.impl.xs,org.apache.xerces.impl.xs.util,org.apache.xerces.util,org.apache.xerces.xs,org.apache.xerces.xs.datatypes,org.w3c.dom\";version=2.11.0, \
+    org.apache.xerces.impl.io;uses:=org.apache.xerces.util;version=2.11.0, \
+    org.apache.xerces.impl.msg;uses:=org.apache.xerces.util;version=2.11.0, \
+    org.apache.xerces.impl.validation;uses:=\"org.apache.xerces.impl.dv,org.apache.xerces.util,org.apache.xerces.xni\";version=2.11.0, \
+    org.apache.xerces.impl.xpath;uses:=\"org.apache.xerces.util,org.apache.xerces.xni\";version=2.11.0, \
+    org.apache.xerces.impl.xpath.regex;version=2.11.0, \
+    org.apache.xerces.impl.xs;uses:=\"org.apache.xerces.dom,org.apache.xerces.impl,org.apache.xerces.impl.dv,org.apache.xerces.impl.dv.xs,org.apache.xerces.impl.validation,org.apache.xerces.impl.xs.identity,org.apache.xerces.impl.xs.models,org.apache.xerces.impl.xs.util,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xni.grammars,org.apache.xerces.xni.parser,org.apache.xerces.xs,org.apache.xerces.xs.datatypes,org.w3c.dom,org.w3c.dom.ls\";version=2.11.0, \
+    org.apache.xerces.impl.xs.identity;uses:=\"org.apache.xerces.impl.xpath,org.apache.xerces.impl.xs,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xs\";version=2.11.0, \
+    org.apache.xerces.impl.xs.models;uses:=\"org.apache.xerces.impl.dtd.models,org.apache.xerces.impl.xs,org.apache.xerces.xni,org.apache.xerces.xni.parser\";version=2.11.0, \
+    org.apache.xerces.impl.xs.opti;uses:=\"org.apache.xerces.impl,org.apache.xerces.impl.dv,org.apache.xerces.impl.validation,org.apache.xerces.parsers,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xni.grammars,org.apache.xerces.xni.parser,org.w3c.dom\";version=2.11.0, \
+    org.apache.xerces.impl.xs.traversers;uses:=\"org.apache.xerces.impl.dv,org.apache.xerces.impl.xs,org.apache.xerces.impl.xs.util,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xni.parser,org.w3c.dom\";version=2.11.0, \
+    org.apache.xerces.impl.xs.util;uses:=\"org.apache.xerces.impl.xs,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xni.parser,org.apache.xerces.xs,org.apache.xerces.xs.datatypes,org.w3c.dom.ls\";version=2.11.0, \
+    org.apache.xerces.jaxp;uses:=\"javax.xml.parsers,javax.xml.validation,org.apache.xerces.parsers,org.apache.xerces.xs,org.w3c.dom,org.xml.sax,org.xml.sax.helpers\";version=2.11.0, \
+    org.apache.xerces.jaxp.datatype;uses:=javax.xml.datatype;version=2.11.0, \
+    org.apache.xerces.jaxp.validation;uses:=\"javax.xml.transform,javax.xml.validation,org.apache.xerces.xni.grammars,org.w3c.dom.ls,org.xml.sax\";version=2.11.0, \
+    org.apache.xerces.parsers;uses:=\"org.apache.xerces.dom,org.apache.xerces.dom3.as,org.apache.xerces.impl,org.apache.xerces.impl.dtd,org.apache.xerces.impl.dv,org.apache.xerces.impl.validation,org.apache.xerces.impl.xs,org.apache.xerces.util,org.apache.xerces.xinclude,org.apache.xerces.xni,org.apache.xerces.xni.grammars,org.apache.xerces.xni.parser,org.apache.xerces.xs,org.w3c.dom,org.w3c.dom.ls,org.xml.sax,org.xml.sax.ext\";version=2.11.0, \
+    org.apache.xerces.stax;uses:=\"javax.xml.namespace,javax.xml.stream,javax.xml.stream.events\";version=2.11.0, \
+    org.apache.xerces.stax.events;uses:=\"javax.xml.namespace,javax.xml.stream,javax.xml.stream.events\";version=2.11.0, \
+    org.apache.xerces.util;uses:=\"javax.xml.namespace,javax.xml.stream,org.apache.xerces.dom,org.apache.xerces.impl,org.apache.xerces.xni,org.apache.xerces.xni.grammars,org.apache.xerces.xni.parser,org.w3c.dom,org.w3c.dom.ls,org.xml.sax,org.xml.sax.ext\";version=2.11.0, \
+    org.apache.xerces.xinclude;uses:=\"org.apache.xerces.impl,org.apache.xerces.util,org.apache.xerces.xni,org.apache.xerces.xni.parser,org.apache.xerces.xpointer\";version=2.11.0, \
+    org.apache.xerces.xni;uses:=org.apache.xerces.xni.parser;version=2.11.0, \
+    org.apache.xerces.xni.grammars;uses:=\"org.apache.xerces.xni,org.apache.xerces.xni.parser,org.apache.xerces.xs\";version=2.11.0, \
+    org.apache.xerces.xni.parser;uses:=org.apache.xerces.xni;version=2.11.0, \
+    org.apache.xerces.xpointer;uses:=\"org.apache.xerces.impl,org.apache.xerces.util,org.apache.xerces.xinclude,org.apache.xerces.xni,org.apache.xerces.xni.parser\";version=2.11.0, \
+    org.apache.xerces.xs;uses:=\"org.apache.xerces.xs.datatypes,org.w3c.dom,org.w3c.dom.ls\";version=2.11.0, \
+    org.apache.xerces.xs.datatypes;uses:=\"javax.xml.datatype,javax.xml.namespace,org.apache.xerces.xni,org.apache.xerces.xs\";version=2.11.0, \
+    org.apache.xml.serialize;uses:=\"org.apache.xerces.dom,org.apache.xerces.util,org.w3c.dom,org.w3c.dom.ls,org.xml.sax,org.xml.sax.ext\";version=2.11.0, \
+    org.apache.karaf.jaas.boot.principal;uses:=javax.security.auth;version=4.0.10, \
+    org.apache.karaf.jaas.boot;uses:=\"javax.security.auth,javax.security.auth.callback,javax.security.auth.login,javax.security.auth.spi,org.osgi.framework\";version=4.0.10
+
+org.osgi.framework.system.capabilities= \
+ ${eecap-${java.specification.version}}, \
+ osgi.service;effective:=active;objectClass=org.osgi.service.packageadmin.PackageAdmin, \
+ osgi.service;effective:=active;objectClass=org.osgi.service.resolver.Resolver, \
+ osgi.service;effective:=active;objectClass=org.osgi.service.startlevel.StartLevel, \
+ osgi.service;effective:=active;objectClass=org.osgi.service.url.URLHandlers
+
+eecap-1.8= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
+eecap-1.7= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7"
+eecap-1.6= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6"
+eecap-1.5= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5"
+eecap-1.4= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4"
+eecap-1.3= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3"
+eecap-1.2= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2"
+
+#
+# javax.transaction is needed to avoid class loader constraint violation when using javax.sql
+#
+org.osgi.framework.bootdelegation = \
+    com.sun.*, \
+    javax.transaction, \
+    javax.transaction.*, \
+    javax.xml.crypto, \
+    javax.xml.crypto.*, \
+    jdk.nashorn.*, \
+    sun.*, \
+    org.apache.karaf.jaas.boot, \
+    org.apache.karaf.jaas.boot.principal, \
+    org.apache.html.dom, \
+    org.apache.wml, \
+    org.apache.wml.dom, \
+    org.apache.xerces.dom, \
+    org.apache.xerces.dom.events, \
+    org.apache.xerces.dom3.as, \
+    org.apache.xerces.impl, \
+    org.apache.xerces.impl.dtd, \
+    org.apache.xerces.impl.dtd.models, \
+    org.apache.xerces.impl.dv, \
+    org.apache.xerces.impl.dv.dtd, \
+    org.apache.xerces.impl.dv.util, \
+    org.apache.xerces.impl.dv.xs, \
+    org.apache.xerces.impl.io, \
+    org.apache.xerces.impl.msg, \
+    org.apache.xerces.impl.validation, \
+    org.apache.xerces.impl.xpath, \
+    org.apache.xerces.impl.xpath.regex, \
+    org.apache.xerces.impl.xs, \
+    org.apache.xerces.impl.xs.identity, \
+    org.apache.xerces.impl.xs.models, \
+    org.apache.xerces.impl.xs.opti, \
+    org.apache.xerces.impl.xs.traversers, \
+    org.apache.xerces.impl.xs.util, \
+    org.apache.xerces.jaxp, \
+    org.apache.xerces.jaxp.datatype, \
+    org.apache.xerces.jaxp.validation, \
+    org.apache.xerces.parsers, \
+    org.apache.xerces.stax, \
+    org.apache.xerces.stax.events, \
+    org.apache.xerces.util, \
+    org.apache.xerces.xinclude, \
+    org.apache.xerces.xni, \
+    org.apache.xerces.xni.grammars, \
+    org.apache.xerces.xni.parser, \
+    org.apache.xerces.xpointer, \
+    org.apache.xerces.xs, \
+    org.apache.xerces.xs.datatypes, \
+    org.apache.xml.serialize
+
+# jVisualVM support
+# in order to use Karaf with jvisualvm, the org.osgi.framework.bootdelegation property has to contain the org.netbeans.lib.profiler.server package
+# and, so, it should look like:
+#
+# org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,org.netbeans.lib.profiler.server
+#
+# YourKit support
+# in order to use Karaf with YourKit, the org.osgi.framework.bootdelegation property has to contain the com.yourkit.* packages
+# and, so, it should look like:
+#
+# org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,com.yourkit.*
+#
+
+#
+# OSGi Execution Environment
+#
+org.osgi.framework.executionenvironment=J2SE-1.7,JavaSE-1.7,J2SE-1.6,JavaSE-1.6,J2SE-1.5,JavaSE-1.5,J2SE-1.4,JavaSE-1.4,J2SE-1.3,JavaSE-1.3,J2SE-1.2,,JavaSE-1.2,CDC-1.1/Foundation-1.1,CDC-1.0/Foundation-1.0,J2ME,OSGi/Minimum-1.1,OSGi/Minimum-1.0
+
+#
+# Set the parent classloader for the bundle to the classloader that loads the Framework (i.e. everything in lib/*.jar)
+#
+org.osgi.framework.bundle.parent=framework
+
+#
+# Definition of the default bundle start level
+#
+org.osgi.framework.startlevel.beginning=100
+karaf.startlevel.bundle=80
+
+#
+# The location of the Karaf shutdown port file used to stop instance
+#
+karaf.shutdown.port.file=${karaf.data}/port
+
+#
+# The location of the Karaf pid file
+#
+karaf.pid.file=${karaf.base}/karaf.pid
+
+#
+# Configuration FileMonitor properties
+#
+felix.fileinstall.enableConfigSave = false
+felix.fileinstall.dir    = ${karaf.etc}
+felix.fileinstall.filter = .*\\.cfg
+felix.fileinstall.poll   = 1000
+felix.fileinstall.noInitialDelay = true
+felix.fileinstall.log.level = 3
+felix.fileinstall.log.default = jul
+
+# Use cached urls for bundle CodeSource to avoid
+# problems with JCE cached informations, see KARAF-3974
+felix.bundlecodesource.usecachedurls = true
+
+#
+# Delay for writing the framework state to disk in equinox
+# must be  >= 1000 and <= 1800000
+#
+eclipse.stateSaveDelayInterval = 1000
+
+#
+# OBR Repository list
+# This property will be modified by the obr:addUrl and obr:removeUrl commands.
+#
+obr.repository.url =
+
+#
+# Start blueprint bundles synchronously when possible
+#
+org.apache.aries.blueprint.synchronous=true
+
+#
+# Do not weave all any classes by default
+#
+org.apache.aries.proxy.weaving.enabled=
+
+#
+# mvn url handler requires config instance configuration
+#
+org.ops4j.pax.url.mvn.requireConfigAdminConfig=true
+
+#
+# Don't delay the console startup. Set to true if you want the console to start after all other bundles
+#
+karaf.delay.console=false


### PR DESCRIPTION
As discussed in last Tues devOps meeting and proposed on list earlier, this is the workaround for missing libs in some of the assembled config.properties after a build. 
