### PR TITLE
MH-12946 Fix summary of add-event-dialog

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -255,7 +255,7 @@
                             <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION' | translate }} <i class="required">*</i></td>
                             <td>
                             <select chosen
-                                data-width="'200px'"
+                                data-width="'203px'"
                                 tabindex="11"
                                 ng-disabled="wizard.step.checkingConflicts"
                                 ng-change="wizard.step.roomChanged(); wizard.step.checkConflicts()"
@@ -410,7 +410,7 @@
                             <td>
                             <select chosen
                                 ng-disabled="wizard.step.checkingConflicts"
-                                data-width="'100%'"
+                                data-width="'203px'"
                                 tabindex="19"
                                 ng-change="wizard.step.roomChanged(); wizard.step.checkConflicts()"
                                 data-disable-search-threshold="8"
@@ -425,11 +425,9 @@
                         <tr>
                             <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.INPUTS' | translate }} <i class="required">*</i></td>
                             <td>
-                                <label ng-repeat-start="inputMethod in wizard.step.ud.SCHEDULE_MULTIPLE.device.inputs">
+                                <label ng-repeat="inputMethod in wizard.step.ud.SCHEDULE_MULTIPLE.device.inputs">
                                     <input type="checkbox" ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.device.inputMethods[inputMethod.id]" tabindex="20">{{ inputMethod.id | translate }}</input>
-                                     <br>
                                 </label>
-                                <br ng-repeat-end>
                             </td>
                         </tr>
                     </table>
@@ -675,37 +673,50 @@
                     </table>
                   <!-- scheduled items -->
                     <table class="main-tbl">
+
+                        <!-- Start date upload -->
+                        <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].metadata.start">
+                          <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_DATE"><!-- Start Date --></td>
+                          <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].metadata.start.value | localizeDate:'dateTime' }}</td>
+                        </tr>
+
+                        <!-- Start date schedule -->
                         <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.date">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_DATE"><!-- Start Date --></td>
                             <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.date }}</td>
                         </tr>
+
                         <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.hour !== undefined">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_TIME"><!-- Start Time --></td>
-                            <td>{{ wizard.getStateControllerByName('source').getFormatedStartTime() }}</td>
+                            <td>{{ wizard.getStateControllerByName('source').getFormattedStartTime() }}</td>
                         </tr>
-                        <tr ng-if="wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.end">
+                        <tr ng-if="(wizard.step.ud.type === 'SCHEDULE_MULTIPLE') && wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].end.date">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_DATE"><!-- End Date --></td>
-                            <td>{{ wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.end }}</td>
+                            <td>{{ wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.end.date }}</td>
                         </tr>
-                        <tr ng-if="wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.repetitionOption">
+                        <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].end.hour !== undefined">
+                          <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_TIME"><!-- End Time --></td>
+                          <td>{{ wizard.getStateControllerByName('source').getFormattedEndTime() }}</td>
+                        </tr>
+                        <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].repetitionOption">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.SCHEDULE_MULTIPLE.REPEAT_ON"><!-- Repeat On --></td>
                             <td>{{ wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.repetitionOption }}</td>
                         </tr>
-                        <tr ng-if="!isEmpty(wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.weekdays)">
+                        <tr ng-if="!isEmpty(wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].weekdays)">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.SCHEDULE_MULTIPLE.WEEKDAYS"><!-- Weekdays --></td>
                             <td>{{ wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.presentableWeekdays }}</td>
                         </tr>
                         <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].duration.hour !== undefined">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.DURATION"><!-- Duration --></td>
-                            <td>{{ wizard.getStateControllerByName('source').getFormatedDuration() }}</td>
+                            <td>{{ wizard.getStateControllerByName('source').getFormattedDuration() }}</td>
                         </tr>
                         <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].device.name">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION"><!-- Location --></td>
                             <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].device.name }}</td>
                         </tr>
-                        <tr ng-repeat="(key, value) in wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].SCHEDULE_SINGLE.device.inputs">
-                            <td>Input {{ key}}</td>
-                            <td>{{ value.value }}</td>
+                        <tr ng-repeat="(key, value) in wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].device.inputMethods">
+                            <td>{{ key }}</td>
+                            <td>{{ value }}</td>
                         </tr>
                     </table>
                 </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -405,7 +405,7 @@ angular.module('adminNg.services')
             });
         };
 
-        this.getFormatedStartTime = function () {
+        this.getFormattedStartTime = function () {
             var time;
 
             if (!self.isUpload()) {
@@ -419,7 +419,21 @@ angular.module('adminNg.services')
             return time;
         };
 
-        this.getFormatedDuration = function () {
+        this.getFormattedEndTime = function () {
+            var time;
+
+            if (!self.isUpload()) {
+                var hour = self.ud[getType()].end.hour;
+                var minute = self.ud[getType()].end.minute;
+                if (angular.isDefined(hour) && angular.isDefined(minute)) {
+                    time = JsHelper.humanizeTime(hour, minute);
+                }
+            }
+
+            return time;
+        };
+
+        this.getFormattedDuration = function () {
             var time;
 
             if (!self.isUpload()) {


### PR DESCRIPTION
Fix the summary of the add-event-dialog. In detail:
* show input settings for chosen capture agent in summary
* show start date for 'upload'
* don't show weekdays for 'upload' and 'schedule single'
* don't show end date for 'schedule single' and 'upload'
* fix presentation of end date
* make width of capture agent dropdown for scheduled events in 'source' tab consistent
* improve presentation of input settings for chosen ca in 'source' tab
* show end time for scheduled events
* fix typos in method names

Screenshots of source and summary tab each for 'upload', 'schedule single' and 'schedule multiple':
![source_schedule_multiple](https://user-images.githubusercontent.com/11960278/41232435-a24e4dac-6d86-11e8-84a2-88c3ea213363.png)
![source_schedule_single](https://user-images.githubusercontent.com/11960278/41232437-a26667c0-6d86-11e8-8827-70e01789ac5c.png)
![summary_schedule_multiple](https://user-images.githubusercontent.com/11960278/41232438-a27d89a0-6d86-11e8-9821-b0b2f5e5d1b6.png)
![summary_schedule_single](https://user-images.githubusercontent.com/11960278/41232439-a2941eb8-6d86-11e8-8ced-f9704a19b8a1.png)
![summary_upload](https://user-images.githubusercontent.com/11960278/41232440-a2acd89a-6d86-11e8-826a-30c2ef42ad13.png)

_This work is sponsored by SWITCH._