### PR TITLE
MH-12948, Directly read XACML files

### DIFF
--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -37,6 +37,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementBuilderFactory;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
@@ -53,19 +54,9 @@ import org.opencastproject.util.data.Option.Match;
 import org.opencastproject.util.data.Tuple;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
-import org.jboss.security.xacml.core.JBossPDP;
-import org.jboss.security.xacml.core.model.context.AttributeType;
-import org.jboss.security.xacml.core.model.context.RequestType;
-import org.jboss.security.xacml.core.model.context.SubjectType;
-import org.jboss.security.xacml.factories.RequestAttributeFactory;
-import org.jboss.security.xacml.factories.RequestResponseContextFactory;
-import org.jboss.security.xacml.interfaces.PolicyDecisionPoint;
-import org.jboss.security.xacml.interfaces.RequestContext;
-import org.jboss.security.xacml.interfaces.XACMLConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +64,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -428,88 +418,36 @@ public class XACMLAuthorizationService implements AuthorizationService {
 
   @Override
   public boolean hasPermission(final MediaPackage mp, final String action) {
-    return withContextClassLoader(new Function0<Boolean>() {
-      @Override
-      public Boolean apply() {
-        return getXacmlAttachment(mp).map(new Function<Attachment, Boolean>() {
-          @Override
-          public Boolean apply(Attachment attachment) {
-            final File xacmlPolicyFile = fromWorkspace(attachment.getURI());
-            if (xacmlPolicyFile == null) {
-              logger.warn("Unable to read XACML file from {}! Prevent access permissions.", attachment);
-              return false;
-            }
-
-            final RequestContext requestCtx = RequestResponseContextFactory.createRequestCtx();
-            final User user = securityService.getUser();
-
-            // Create a subject type
-            SubjectType subject = new SubjectType();
-            subject.getAttribute().add(
-                    RequestAttributeFactory.createStringAttributeType(XACMLUtils.SUBJECT_IDENTIFIER, XACMLUtils.ISSUER,
-                            user.getUsername()));
-            for (Role role : user.getRoles()) {
-              AttributeType attSubjectID = RequestAttributeFactory.createStringAttributeType(
-                      XACMLUtils.SUBJECT_ROLE_IDENTIFIER, XACMLUtils.ISSUER, role.getName());
-              subject.getAttribute().add(attSubjectID);
-            }
-
-            // Create a resource type
-            URI uri = null;
-            try {
-              uri = new URI(mp.getIdentifier().toString());
-            } catch (URISyntaxException e) {
-              logger.warn("Unable to represent mediapackage identifier '{}' as a URI", mp.getIdentifier().toString());
-            }
-            org.jboss.security.xacml.core.model.context.ResourceType resourceType = new org.jboss.security.xacml.core.model.context.ResourceType();
-            resourceType.getAttribute().add(
-                    RequestAttributeFactory.createAnyURIAttributeType(XACMLUtils.RESOURCE_IDENTIFIER,
-                            XACMLUtils.ISSUER, uri));
-
-            // Create an action type
-            org.jboss.security.xacml.core.model.context.ActionType actionType = new org.jboss.security.xacml.core.model.context.ActionType();
-            actionType.getAttribute().add(
-                    RequestAttributeFactory.createStringAttributeType(XACMLUtils.ACTION_IDENTIFIER, XACMLUtils.ISSUER,
-                            action));
-
-            // Create a Request Type
-            RequestType requestType = new RequestType();
-            requestType.getSubject().add(subject);
-            requestType.getResource().add(resourceType);
-            requestType.setAction(actionType);
-            try {
-              requestCtx.setRequest(requestType);
-            } catch (IOException e) {
-              logger.warn("Unable to set the xacml request type", e);
-              return false;
-            }
-
-            PolicyDecisionPoint pdp = getPolicyDecisionPoint(xacmlPolicyFile);
-            FileUtils.deleteQuietly(xacmlPolicyFile);
-
-            return pdp.evaluate(requestCtx).getDecision() == XACMLConstants.DECISION_PERMIT;
-          }
-        }).getOrElse(false);
-      }
-    });
-  }
-
-  private PolicyDecisionPoint getPolicyDecisionPoint(File xacmlFile) {
-    // Build a JBoss PDP configuration. This is a custom jboss format, so we're just hacking it together here
-    StringBuilder sb = new StringBuilder();
-    sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
-    sb.append("<ns:jbosspdp xmlns:ns=\"urn:jboss:xacml:2.0\">");
-    sb.append("<ns:Policies><ns:Policy><ns:Location>");
-    sb.append(xacmlFile.toURI().toString());
-    sb.append("</ns:Location></ns:Policy></ns:Policies><ns:Locators>");
-    sb.append("<ns:Locator Name=\"org.jboss.security.xacml.locators.JBossPolicyLocator\">");
-    sb.append("</ns:Locator></ns:Locators></ns:jbosspdp>");
-    try (InputStream is = IOUtils.toInputStream(sb.toString(), "UTF-8")) {
-      return new JBossPDP(is);
-    } catch (IOException e) {
-      // Only happens if 'UTF-8' is an invalid encoding, which it isn't
-      throw new IllegalStateException("Unable to transform a string into a stream");
+    Option<Attachment> xacml = getXacmlAttachment(mp);
+    if (xacml.isNone()) {
+      return false;
     }
+    Attachment attachment = xacml.get();
+    AccessControlList acl;
+    try {
+      acl = XACMLUtils.parseXacml(workspace.read(attachment.getURI()));
+    } catch (XACMLParsingException | NotFoundException | IOException e) {
+      return false;
+    }
+    boolean allowed = false;
+    final User user = securityService.getUser();
+    for (AccessControlEntry entry: acl.getEntries()) {
+      // ignore entries for other actions
+      if (!entry.getAction().equals(action)) {
+        continue;
+      }
+      for (Role role : user.getRoles()) {
+        if (entry.getRole().equals(role.getName())) {
+          // immediately abort on matching deny rules
+          // (never allow if a deny rule matches, even if another allow rule matches)
+          if (!entry.isAllow()) {
+            return false;
+          }
+          allowed = true;
+        }
+      }
+    }
+    return allowed;
   }
 
   /**


### PR DESCRIPTION
The XACML authorization service passed configuration files to a JBoss
library to determine if a specific action is allowed for a user given an
XACML file. The configuration itself contained file locations specifying
where the library could load the XACML file. This caused Opencast to
repeatedly load the XACML attachments into the workspace, cleaning them
up again afterwards.

This patch now allows Opencast to directly read those files from the
working file repository by using Opencast's internal parser for rules
and actions instead.

*Work sponsored by SWITCH*