### PR TITLE
[MH-12930] Fill creator metadata field with actual user when new event

### DIFF
--- a/etc/index/adminui/event-mapping.json
+++ b/etc/index/adminui/event-mapping.json
@@ -51,6 +51,8 @@
 
             "creator": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
+            "publisher": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
+
             "license": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
             "rights": { "type" : "string", "index" : "not_analyzed", "store" : "no" },

--- a/etc/index/externalapi/event-mapping.json
+++ b/etc/index/externalapi/event-mapping.json
@@ -51,6 +51,8 @@
 
             "creator": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
+            "publisher": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
+
             "license": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
             "rights": { "type" : "string", "index" : "not_analyzed", "store" : "no" },

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -31,7 +31,7 @@ property.uid.label=EVENTS.EVENTS.DETAILS.METADATA.ID
 property.uid.type=text
 property.uid.readOnly=true
 property.uid.required=false
-property.uid.order=16
+property.uid.order=17
 
 # Presenters
 property.presenters.inputID=creator
@@ -144,3 +144,11 @@ property.license.readOnly=false
 property.license.required=false
 property.license.listprovider=LICENSES
 property.license.order=5
+
+# Created By
+property.createdBy.inputID=publisher
+property.createdBy.label=EVENTS.EVENTS.DETAILS.METADATA.CREATED_BY
+property.createdBy.type=text
+property.createdBy.readOnly=true
+property.createdBy.required=false
+property.createdBy.order=16

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -105,6 +105,7 @@ import org.opencastproject.mediapackage.track.VideoStreamImpl;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.EventCatalogUIAdapter;
 import org.opencastproject.metadata.dublincore.MetadataCollection;
+import org.opencastproject.metadata.dublincore.MetadataField;
 import org.opencastproject.rest.BulkOperationResult;
 import org.opencastproject.rest.RestConstants;
 import org.opencastproject.scheduler.api.Recording;
@@ -1938,6 +1939,10 @@ public abstract class AbstractEventEndpoint {
         collection.removeField(collection.getOutputFields().get("startTime"));
       if (collection.getOutputFields().containsKey("location"))
         collection.removeField(collection.getOutputFields().get("location"));
+      if (collection.getOutputFields().containsKey(DublinCore.PROPERTY_PUBLISHER.getLocalName())) {
+        MetadataField<String> publisher = (MetadataField<String>) collection.getOutputFields().get(DublinCore.PROPERTY_PUBLISHER.getLocalName());
+        publisher.setValue(getSecurityService().getUser().getName());
+      }
       metadataList.add(getIndexService().getCommonEventCatalogUIAdapter(), collection);
     }
     return okJson(metadataList.toJSON());
@@ -2164,6 +2169,8 @@ public abstract class AbstractEventEndpoint {
         query.withOptedOut(Boolean.parseBoolean(filters.get(name)));
       if (EventListQuery.FILTER_REVIEW_STATUS_NAME.equals(name))
         query.withReviewStatus(filters.get(name));
+      if (EventListQuery.FILTER_PUBLISHER_NAME.equals(name))
+        query.withPublisher(filters.get(name));
       if (EventListQuery.FILTER_COMMENTS_NAME.equals(name)) {
         switch (Comments.valueOf(filters.get(name))) {
           case NONE:

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/index/AdminUISearchIndex.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/index/AdminUISearchIndex.java
@@ -154,4 +154,14 @@ public class AdminUISearchIndex extends AbstractSearchIndex implements EventInde
     return getTermsForField(ThemeIndexSchema.NAME, Option.some(new String[] { Theme.DOCUMENT_TYPE }));
   }
 
+  /**
+   * Returns all the known events' publishers
+   *
+   * @return a list of events' publishers
+   */
+  @Override
+  public List<String> getEventPublishers() {
+    return getTermsForField(EventIndexSchema.PUBLISHER, Option.some(new String[] { Event.DOCUMENT_TYPE }));
+  }
+
 }

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1730,6 +1730,9 @@
        "CREATOR": {
          "LABEL": "Creator"
        },
+       "CREATED_BY": {
+         "LABEL": "Created by"
+       },
        "HOSTNAME": {
          "LABEL": "Host name"
        },

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/EventIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/EventIndex.java
@@ -67,4 +67,11 @@ public interface EventIndex {
    */
   List<String> getThemeNames();
 
+  /**
+   * Returns all the known events publishers' usernames
+   *
+   * @return a list of events publishers' usernames
+   */
+  List<String> getEventPublishers();
+
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
@@ -69,7 +69,7 @@ import javax.xml.transform.stream.StreamSource;
  */
 @XmlType(name = "event", namespace = IndexObject.INDEX_XML_NAMESPACE, propOrder = { "identifier", "organization",
         "title", "description", "subject", "location", "presenters", "contributors", "seriesId", "seriesName",
-        "language", "source", "created", "creator", "license", "rights", "accessPolicy", "managedAcl", "workflowState",
+        "language", "source", "created", "creator", "publisher", "license", "rights", "accessPolicy", "managedAcl", "workflowState",
         "workflowId", "workflowDefinitionId", "recordingStartTime", "recordingEndTime", "duration", "trackMimetypes",
         "trackStreamResolutions", "trackFlavors", "metadataFlavors", "metadataMimetypes", "attachmentFlavors",
         "reviewStatus", "reviewDate", "optedOut", "blacklisted", "hasComments", "hasOpenComments", "hasPreview", "needsCutting",
@@ -172,6 +172,10 @@ public class Event implements IndexObject {
   /** The creator of the event */
   @XmlElement(name = "creator")
   private String creator = null;
+
+  /** The publisher of the event */
+  @XmlElement(name = "publisher")
+  private String publisher = null;
 
   /** The license of the event */
   @XmlElement(name = "license")
@@ -550,6 +554,25 @@ public class Event implements IndexObject {
    */
   public String getCreator() {
     return creator;
+  }
+
+  /**
+   * Sets the publisher
+   *
+   * @param publisher
+   *          the publisher
+   */
+  public void setPublisher(String publisher) {
+    this.publisher = publisher;
+  }
+
+  /**
+   * Returns the publisher
+   *
+   * @return the publisher
+   */
+  public String getPublisher() {
+    return publisher;
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexSchema.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexSchema.java
@@ -129,6 +129,9 @@ public interface EventIndexSchema extends IndexSchema {
   /** The creator */
   String CREATOR = "creator";
 
+  /** The publisher */
+  String PUBLISHER = "publisher";
+
   /** The license */
   String LICENSE = "license";
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -131,6 +131,8 @@ public final class EventIndexUtils {
       metadata.addField(EventIndexSchema.CREATED, event.getCreated(), true);
     if (StringUtils.isNotBlank(event.getCreator()))
       metadata.addField(EventIndexSchema.CREATOR, event.getCreator(), true);
+    if (StringUtils.isNotBlank(event.getPublisher()))
+      metadata.addField(EventIndexSchema.PUBLISHER, event.getPublisher(), true);
     if (StringUtils.isNotBlank(event.getLicense()))
       metadata.addField(EventIndexSchema.LICENSE, event.getLicense(), true);
     if (StringUtils.isNotBlank(event.getRights()))
@@ -447,6 +449,7 @@ public final class EventIndexUtils {
     event.setSeriesId(dc.getFirst(DublinCore.PROPERTY_IS_PART_OF));
     event.setLicense(dc.getFirst(DublinCore.PROPERTY_LICENSE));
     event.setRights(dc.getFirst(DublinCore.PROPERTY_RIGHTS_HOLDER));
+    event.setPublisher(dc.getFirst(DublinCore.PROPERTY_PUBLISHER));
     Date created;
     String encodedDate = dc.getFirst(DublinCore.PROPERTY_CREATED);
     if (StringUtils.isBlank(encodedDate)) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventQueryBuilder.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventQueryBuilder.java
@@ -142,6 +142,11 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
       and(EventIndexSchema.CREATOR, query.getCreator(), true);
     }
 
+    // Publisher
+    if (query.getPublisher() != null) {
+      and(EventIndexSchema.PUBLISHER, query.getPublisher(), true);
+    }
+
     // License
     if (query.getLicense() != null) {
       and(EventIndexSchema.LICENSE, query.getLicense(), true);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventSearchQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventSearchQuery.java
@@ -59,6 +59,7 @@ public class EventSearchQuery extends AbstractSearchQuery {
   private Date technicalStartFrom = null;
   private Date technicalStartTo = null;
   private String creator = null;
+  private String publisher = null;
   private String license = null;
   private String rights = null;
   private final List<String> trackMimetypes = new ArrayList<String>();
@@ -533,6 +534,28 @@ public class EventSearchQuery extends AbstractSearchQuery {
    */
   public String getCreator() {
     return creator;
+  }
+
+  /**
+   * Selects recordings with the given publisher.
+   *
+   * @param publisher
+   *          the publisher
+   * @return the enhanced search query
+   */
+  public EventSearchQuery withPublisher(String publisher) {
+    clearExpectations();
+    this.publisher = publisher;
+    return this;
+  }
+
+  /**
+   * Returns the publisher of the recording.
+   *
+   * @return the publisher
+   */
+  public String getPublisher() {
+    return publisher;
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
@@ -201,6 +201,14 @@ public final class EventUtils {
       metadata.addField(newUID);
     }
 
+    if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_PUBLISHER.getLocalName())) {
+      MetadataField<?> publisher = metadata.getOutputFields().get(DublinCore.PROPERTY_PUBLISHER.getLocalName());
+      metadata.removeField(publisher);
+      MetadataField<String> newPublisher = MetadataUtils.copyMetadataField(publisher);
+      newPublisher.setValue(event.getPublisher());
+      metadata.addField(newPublisher);
+    }
+
     return metadata;
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
@@ -129,6 +129,8 @@ public class ContributorsListProvider implements ResourceListProvider {
             Option.some(new String[] { Event.DOCUMENT_TYPE }))));
     contributorsList.addAll(splitStringList(searchIndex.getTermsForField(EventIndexSchema.PRESENTER,
             Option.some(new String[] { Event.DOCUMENT_TYPE }))));
+    contributorsList.addAll(splitStringList(searchIndex.getTermsForField(EventIndexSchema.PUBLISHER,
+            Option.some(new String[] { Event.DOCUMENT_TYPE }))));
     contributorsList.addAll(splitStringList(searchIndex.getTermsForField(SeriesIndexSchema.CONTRIBUTORS,
             Option.some(new String[] { Series.DOCUMENT_TYPE }))));
     contributorsList.addAll(splitStringList(searchIndex.getTermsForField(SeriesIndexSchema.ORGANIZERS,

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
@@ -50,13 +50,14 @@ public class EventsListProvider implements ResourceListProvider {
   public static final String STATUS = PROVIDER_PREFIX + ".STATUS";
   public static final String REVIEW_STATUS = PROVIDER_PREFIX + ".REVIEW_STATUS";
   public static final String COMMENTS = PROVIDER_PREFIX + ".COMMENTS";
+  public static final String PUBLISHER = PROVIDER_PREFIX + ".PUBLISHER";
 
   public enum Comments {
     NONE, OPEN, RESOLVED;
   }
 
   private static final String[] NAMES = { PROVIDER_PREFIX, CONTRIBUTORS, PRESENTERS_BIBLIOGRAPHIC, PRESENTERS_TECHNICAL,
-          SUBJECT, LOCATION, PROGRESS, STATUS, REVIEW_STATUS, COMMENTS };
+          SUBJECT, LOCATION, PROGRESS, STATUS, REVIEW_STATUS, COMMENTS, PUBLISHER };
 
   private static final Logger logger = LoggerFactory.getLogger(EventsListProvider.class);
 
@@ -118,6 +119,9 @@ public class EventsListProvider implements ResourceListProvider {
     } else if (COMMENTS.equals(listName)) {
       for (Comments comments : Comments.values())
         list.put(comments.toString(), comments.toString());
+    } else if (PUBLISHER.equals(listName)) {
+      for (String publisher : index.getEventPublishers())
+        list.put(publisher, publisher);
     }
 
     return list;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
@@ -88,6 +88,9 @@ public class EventListQuery extends ResourceListQueryImpl {
   public static final String FILTER_REVIEW_STATUS_NAME = "reviewStatus";
   private static final String FILTER_REVIEW_STATUS_LABEL = "FILTERS.EVENTS.REVIEW_STATUS.LABEL";
 
+  public static final String FILTER_PUBLISHER_NAME = "publisher";
+  private static final String FILTER_PUBLISHER_LABEL = "FILTERS.EVENTS.CREATED_BY.LABEL";
+
   public static final String FILTER_TEXT_NAME = "textFilter";
 
   public EventListQuery() {
@@ -101,6 +104,7 @@ public class EventListQuery extends ResourceListQueryImpl {
     this.availableFilters.add(createStartDateFilter(Option.<Tuple<Date, Date>> none()));
     this.availableFilters.add(createStatusFilter(Option.<String> none()));
     this.availableFilters.add(createCommentsFilter(Option.<String> none()));
+    this.availableFilters.add(createPublisherFilter(Option.<String> none()));
 //    this.availableFilters.add(createOptedoutFilter(Option.<Boolean> none()));
 //    this.availableFilters.add(createReviewStatusFilter(Option.<String> none()));
   }
@@ -334,6 +338,25 @@ public class EventListQuery extends ResourceListQueryImpl {
   }
 
   /**
+   * Add a {@link ResourceListFilter} filter to the query with the given publishers
+   *
+   * @param publishers
+   *          the publishers to filter for
+   */
+  public void withPublishers(String publishers) {
+    this.addFilter(createPublisherFilter(Option.option(publishers)));
+  }
+
+  /**
+   * Returns an {@link Option} containing the publisher used to filter if set
+   *
+   * @return an {@link Option} containing the publisher or none.
+   */
+  public Option<String> getPublisher() {
+    return this.getFilterValue(FILTER_PUBLISHER_NAME);
+  }
+
+  /**
    * Create a new {@link ResourceListFilter} based on the Series id
    *
    * @param seriesId
@@ -451,6 +474,18 @@ public class EventListQuery extends ResourceListQueryImpl {
   public static ResourceListFilter<String> createCommentsFilter(Option<String> comments) {
     return FiltersUtils.generateFilter(comments, FILTER_COMMENTS_NAME, FILTER_COMMENTS_LABEL, SourceType.SELECT,
             Option.some(EventsListProvider.COMMENTS));
+  }
+
+  /**
+   * Create a new {@link ResourceListFilter} based on publishers
+   *
+   * @param publishers
+   *          the publishers to filter on wrapped in an {@link Option} or {@link Option#none()}
+   * @return a new {@link ResourceListFilter} for progress based query
+   */
+  public static ResourceListFilter<String> createPublisherFilter(Option<String> publisher) {
+    return FiltersUtils.generateFilter(publisher, FILTER_PUBLISHER_NAME, FILTER_PUBLISHER_LABEL, SourceType.SELECT,
+            Option.some(EventsListProvider.PUBLISHER));
   }
 
   /**


### PR DESCRIPTION
Creates a new field for events. This field contains the user who created the event, that is, the user who was logged in.

- The field is in the configuration and is persistent.
- The field used for this purpose is the dublincore _publisher_ field.