### PR TITLE
MH-12949 Fix spacing between action items

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
@@ -24,7 +24,7 @@
   data-resource-id="{{ row.id }}"
   data-tab="comments"
   title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS' | translate }}"
-  class="fa fa-comment-o">
+  class="comments">
 </a>
 
 <a ng-if="row.has_comments && row.has_open_comments"
@@ -32,7 +32,7 @@
   data-resource-id="{{ row.id }}"
   data-tab="comments"
   title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.COMMENTS' | translate }}"
-  class="fa fa-comment">
+  class="comments-open">
 </a>
 
 <a ng-if="row.workflow_state == 'PAUSED'"

--- a/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
@@ -216,13 +216,11 @@
 
             &.remove {
                 @include build-icon(auto, auto, remove-icon, 17px, 17px);
-                //@include fa-icon($fa-var-play-circle-o, before, block, 0, 0, inherit, 22px, normal, inherit);
             }
 
             &.play {
                 color: $color-silver;
                 @include build-icon(auto, auto, play-icon, 17px, 17px);
-                //@include fa-icon($fa-var-play-circle-o, before, block, 0, 0, inherit, 22px, normal, inherit);
 
                 &.on {
                    color: $primary-color-green;
@@ -249,11 +247,21 @@
                 margin-right: 15px;
             }
 
+            &.comments {
+                @include fa-icon($fa-var-comment-o, before, block, -3px 0 0 0, 0, inherit, 20px, normal,
+                                 inherit);
+            }
+
+            &.comments-open {
+                @include fa-icon($fa-var-comment, before, block, -3px 0 0 0, 0, inherit, 20px, normal, inherit);
+            }
+
             &.cut {
-                @include fa-icon($fa-var-scissors, before, inline-block, 0, 0, inherit, 18px, normal, inherit);
-                
+                @include fa-icon($fa-var-scissors, before, inline-block, 2px 0 0 0, 0, inherit, 18px, normal, inherit);
+
                 .badge {
                   position: relative;
+                  margin-right: -9px;
                   left: -8px;
                   bottom: 8px;
                   width: 6px;


### PR DESCRIPTION
Fix the wrong spacing between the video editor and the comments symbol introduced by PR #219 , arrange all icons so that they are horizontally aligned and the space between them is approximately of the same size.

![action_items](https://user-images.githubusercontent.com/11960278/41291733-cc2163ce-6e50-11e8-9c9f-6721d63c4a20.png)
(It isn't perfect, but it's better in my opinion...)

_This work is sponsored by SWITCH._