### PR TITLE
MH-12953, stop loading editor.json twice

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
@@ -13,7 +13,7 @@
 <section class="main-content">
     <nav id="roll-up-menu"></nav>
 
-    <div class="main-view" ng-controller="ToolsCtrl">
+    <div class="main-view">
       <div ng-controller="VideoEditCtrl">
         <div class="video-header">
             <div class="main-video-details">


### PR DESCRIPTION
The tools.html is specifying the ng-controller even though this is already configured by the routeProvider in app.js. This lead to there being two ToolsCtrls