### PR TITLE
 MH-12958 image-convert WOH 

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/image-convert-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/image-convert-woh.md
@@ -1,0 +1,53 @@
+# Image-Convert Workflow Operation
+
+## Description
+The Image-Convert workflow operation allows source images to be converted into target images with different encoding
+settings. One example is the conversion of preview images into different formats.
+
+This operation expects an attachment as input and creates one attachment as output.
+
+
+## Parameter Table
+
+|configuration keys|example|description|default value|
+|------------------|-------|-----------|-------------|
+|source-tags*|preview+player,preview+search|A comma separated lsit of source image(s) tags.|EMPTY|
+|source-flavors*|*/image|A comma separated list of source image(s) flavors.|EMPTY|
+|tags-and-flavors|false|An boolean value wether to select elements with tags and flavors (then set this option to true) or either tags or flavors (then set this option to false).|false|
+|target-tags|+preview-converted,-preview+player|Apply these (comma separated) tags to the output attachments. If a target-tag starts with a '-', it will be removed from preexisting tags, if a target-tag starts with a '+', it will be added to preexisting tags. If there is no prefix, all preexisting tags are removed and replaced by the target-tags.|EMPTY|
+|target-flavor*|*/image+converted|Apply these flavor to the output attachments.|EMPTY|
+|encoding-profiles*|jpeg-player,jpeg-search|A comma separated list of encoding profiles to be applied to each input image.|EMPTY|
+
+\* mandatory configuration key
+
+Note: At least `source-tags` or `source-flavors` parameter must be set.
+
+## Operation Example
+
+This operation would convert all image attachments with flavor matches `*/preview` and tag `player` into two different
+formats described by the encoding profiles `preview-regular.image` and `preview-small.image`.
+The produced image attachments will have an flavor with the subtype `preview+player`.
+
+    <operation
+      id="image-convert"
+      exception-handler-workflow="error"
+      description="Resize images to fixed size">
+      <configurations>
+        <configuration key="source-tags">player</configuration>
+        <configuration key="source-flavors">*/preview</configuration>
+        <configuration key="tags-and-flavors">true</configuration>
+        <configuration key="target-tags"></configuration>
+        <configuration key="target-flavor">*/preview+player</configuration>
+        <configuration key="encoding-profiles">preview-regular.image,preview-small.image</configuration>
+      </configurations>
+    </operation>
+
+### Encoding Profile Example
+
+    # Player preview image regular size
+    profile.preview-regular.image.name = player preview image regular size
+    profile.preview-regular.image.input = image
+    profile.preview-regular.image.output = image
+    profile.preview-regular.image.suffix = -preview-regular.jpg
+    profile.preview-regular.image.mimetype = image/jpeg
+    profile.preview-regular.image.ffmpeg.command = -i #{in.video.path} -vf scale=480:-2 #{out.dir}/#{out.name}#{out.suffix}

--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -50,6 +50,7 @@ The following table contains the workflow operations that are available in an ou
 |failing             |Operations that always fails                                   |[Documentation](failing-woh.md)|
 |http-notify         |Notifies an HTTP endpoint about the process of the workflow    |[Documentation](httpnotify-woh.md)|
 |image               |Extract images from a video using FFmpeg                       |[Documentation](image-woh.md)|
+|image-convert       |Convert images using FFmpeg                                    |[Documentation](image-convert-woh.md)|
 |image-to-video      |Create a video track from a source image                       |[Documentation](imagetovideo-woh.md)|
 |import-wf-properties|Import workflow properties                                     |[Documentation](import-wf-properties-woh.md)|
 |incident            |Testing incidents on a dummy job                               |[Documentation](incident-woh.md)|

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -116,6 +116,7 @@ pages:
    - Failing: 'workflowoperationhandlers/failing-woh.md'
    - HTTP Notify: 'workflowoperationhandlers/httpnotify-woh.md'
    - Image: 'workflowoperationhandlers/image-woh.md'
+   - Image convert: 'workflowoperationhandlers/image-convert-woh.md'
    - Image to Video: 'workflowoperationhandlers/imagetovideo-woh.md'
    - Import Workflow Properties: 'workflowoperationhandlers/import-wf-properties-woh.md'
    - Incident: 'workflowoperationhandlers/incident-woh.md'

--- a/etc/encoding/opencast-images.properties
+++ b/etc/encoding/opencast-images.properties
@@ -71,7 +71,6 @@ profile.editor.thumbnail.preview.downscale.name = Downscale thumbnail preview im
 profile.editor.thumbnail.preview.downscale.input = visual
 profile.editor.thumbnail.preview.downscale.output = image
 profile.editor.thumbnail.preview.downscale.suffix = -small.jpg
-profile.editor.thumbnail.preview.downscale.mimetype = image/jpeg
 profile.editor.thumbnail.preview.downscale.ffmpeg.command = -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=320:-1 #{out.dir}/#{out.name}#{out.suffix}
 
 # Extract thumbnail preview image for video editor
@@ -79,5 +78,4 @@ profile.editor.thumbnail.preview.name = Thumbnail preview image for video editor
 profile.editor.thumbnail.preview.input = visual
 profile.editor.thumbnail.preview.output = image
 profile.editor.thumbnail.preview.suffix = -preview.jpg
-profile.editor.thumbnail.preview.mimetype = image/jpeg
 profile.editor.thumbnail.preview.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=320:-1 #{out.dir}/#{out.name}#{out.suffix}

--- a/modules/composer-ffmpeg/pom.xml
+++ b/modules/composer-ffmpeg/pom.xml
@@ -93,6 +93,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -1240,9 +1240,13 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
               JOB_TYPE, Operation.Image.toString(), null, null, false, profile.getJobLoad());
       job.setStatus(Job.Status.RUNNING);
       job = serviceRegistry.updateJob(job);
-      Option<Attachment> result = convertImage(job, image, profileId);
+      List<Attachment> result = convertImage(job, image, profileId);
+      if (result.isEmpty()) {
+        job.setStatus(Job.Status.FAILED);
+        return null;
+      }
       job.setStatus(Job.Status.FINISHED);
-      return result.getOrElseNull();
+      return result.get(0);
     } catch (ServiceRegistryException | NotFoundException e) {
       throw new EncoderException("Unable to create a job", e);
     } finally {
@@ -1257,8 +1261,8 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    *          the associated job
    * @param sourceImage
    *          the source image
-   * @param profileId
-   *          the identifer of the encoding profiles to use
+   * @param profileIds
+   *          the identifier of the encoding profiles to use
    * @return the list of converted images as an attachment.
    * @throws EncoderException
    *           if converting the image fails

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -68,7 +68,9 @@ import org.opencastproject.smil.entity.media.param.api.SmilMediaParamGroup;
 import org.opencastproject.util.FileSupport;
 import org.opencastproject.util.JsonObj;
 import org.opencastproject.util.LoadUtil;
+import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
+import org.opencastproject.util.UnknownFileTypeException;
 import org.opencastproject.util.data.Collections;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.Tuple;
@@ -1316,6 +1318,12 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
         MediaPackageElementBuilder builder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
         Attachment convertedImage = (Attachment) builder.elementFromURI(workspaceURI, Attachment.TYPE, null);
         convertedImage.setIdentifier(idBuilder.createNew().toString());
+        try {
+          convertedImage.setMimeType(MimeTypes.fromURI(convertedImage.getURI()));
+        } catch (UnknownFileTypeException e) {
+          logger.warn("Mime type unknown for file {}. Setting none.", convertedImage.getURI(), e);
+        }
+
         convertedImages.add(convertedImage);
       }
     } catch (Throwable t) {

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -74,6 +74,8 @@ import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.Tuple;
 import org.opencastproject.workspace.api.Workspace;
 
+import com.google.gson.Gson;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -1205,21 +1207,24 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * {@inheritDoc}
    *
    * @see org.opencastproject.composer.api.ComposerService#convertImage(org.opencastproject.mediapackage.Attachment,
-   *      java.lang.String)
+   *      java.lang.String...)
    */
   @Override
-  public Job convertImage(Attachment image, String profileId) throws EncoderException, MediaPackageException {
+  public Job convertImage(Attachment image, String... profileIds) throws EncoderException, MediaPackageException {
     if (image == null)
       throw new IllegalArgumentException("Source image cannot be null");
 
-    String[] parameters = new String[2];
-    parameters[0] = profileId;
-    parameters[1] = MediaPackageElementParser.getAsXml(image);
+    if (profileIds == null)
+      throw new IllegalArgumentException("At least one encoding profile must be set");
 
+    Gson gson = new Gson();
+    List<String> params = Arrays.asList(gson.toJson(profileIds), MediaPackageElementParser.getAsXml(image));
+    float jobLoad = Arrays.stream(profileIds)
+            .map(p -> profileScanner.getProfile(p).getJobLoad())
+            .max(Float::compare)
+            .orElse(0.f);
     try {
-      final EncodingProfile profile = profileScanner.getProfile(profileId);
-      return serviceRegistry.createJob(JOB_TYPE, Operation.ImageConversion.toString(), Arrays.asList(parameters),
-              profile.getJobLoad());
+      return serviceRegistry.createJob(JOB_TYPE, Operation.ImageConversion.toString(), params, jobLoad);
     } catch (ServiceRegistryException e) {
       throw new EncoderException("Unable to create a job", e);
     }
@@ -1253,61 +1258,77 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @param sourceImage
    *          the source image
    * @param profileId
-   *          the identifer of the encoding profile to use
-   * @return the image as an attachment or none if the operation does not return an image. This may happen for example
-   *         when doing two pass encodings where the first pass only creates metadata for the second one
+   *          the identifer of the encoding profiles to use
+   * @return the list of converted images as an attachment.
    * @throws EncoderException
    *           if converting the image fails
    */
-  private Option<Attachment> convertImage(Job job, Attachment sourceImage, String profileId) throws EncoderException,
+  private List<Attachment> convertImage(Job job, Attachment sourceImage, String... profileIds) throws EncoderException,
           MediaPackageException {
-    logger.info("Converting {}", sourceImage);
-
-    // Get the encoding profile
-    final EncodingProfile profile = getProfile(job, profileId);
-
-    // Create the encoding engine
+    List<Attachment> convertedImages = new ArrayList<>();
     final EncoderEngine encoderEngine = getEncoderEngine();
-
-    // Finally get the file that needs to be encoded
-    File imageFile;
     try {
-      imageFile = workspace.get(sourceImage.getURI());
-    } catch (NotFoundException e) {
-      incident().recordFailure(job, WORKSPACE_GET_NOT_FOUND, e,
-              getWorkspaceMediapackageParams("source image", sourceImage), NO_DETAILS);
-      throw new EncoderException("Requested video track " + sourceImage + " was not found", e);
-    } catch (IOException e) {
-      incident().recordFailure(job, WORKSPACE_GET_IO_EXCEPTION, e,
-              getWorkspaceMediapackageParams("source image", sourceImage), NO_DETAILS);
-      throw new EncoderException("Error accessing video track " + sourceImage, e);
-    }
+      for (String profileId : profileIds) {
+        logger.info("Converting {} using encoding profile {}", sourceImage, profileId);
 
-    // Do the work
-    File output;
-    try {
-      output = encoderEngine.encode(imageFile, profile, null);
-    } catch (EncoderException e) {
-      Map<String, String> params = new HashMap<>();
-      params.put("image", sourceImage.getURI().toString());
-      params.put("profile", profile.getIdentifier());
-      incident().recordFailure(job, CONVERT_IMAGE_FAILED, e, params, detailsFor(e, encoderEngine));
-      throw e;
+        // Get the encoding profile
+        final EncodingProfile profile = getProfile(job, profileId);
+
+        // Finally get the file that needs to be encoded
+        File imageFile;
+        try {
+          imageFile = workspace.get(sourceImage.getURI());
+        } catch (NotFoundException e) {
+          incident().recordFailure(job, WORKSPACE_GET_NOT_FOUND, e,
+                  getWorkspaceMediapackageParams("source image", sourceImage), NO_DETAILS);
+          throw new EncoderException("Requested video track " + sourceImage + " was not found", e);
+        } catch (IOException e) {
+          incident().recordFailure(job, WORKSPACE_GET_IO_EXCEPTION, e,
+                  getWorkspaceMediapackageParams("source image", sourceImage), NO_DETAILS);
+          throw new EncoderException("Error accessing video track " + sourceImage, e);
+        }
+
+        // Do the work
+        File output;
+        try {
+          output = encoderEngine.encode(imageFile, profile, null);
+        } catch (EncoderException e) {
+          Map<String, String> params = new HashMap<>();
+          params.put("image", sourceImage.getURI().toString());
+          params.put("profile", profile.getIdentifier());
+          incident().recordFailure(job, CONVERT_IMAGE_FAILED, e, params, detailsFor(e, encoderEngine));
+          throw e;
+        }
+
+        // encoding did not return a file
+        if (!output.exists() || output.length() == 0)
+          throw new EncoderException(format(
+              "Image conversion job %d doesn't created an output file for the source image %s with encoding profile %s",
+              job.getId(), sourceImage.getURI().toString(), profileId));
+
+        // Put the file in the workspace
+        URI workspaceURI = putToCollection(job, output, "converted image file");
+
+        MediaPackageElementBuilder builder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
+        Attachment convertedImage = (Attachment) builder.elementFromURI(workspaceURI, Attachment.TYPE, null);
+        convertedImage.setIdentifier(idBuilder.createNew().toString());
+        convertedImages.add(convertedImage);
+      }
+    } catch (Throwable t) {
+      for (Attachment convertedImage : convertedImages) {
+        try {
+          workspace.delete(convertedImage.getURI());
+        } catch (NotFoundException ex) {
+          // do nothing here
+        } catch (IOException ex) {
+          logger.warn("Unable to delete converted image {} from workspace", convertedImage.getURI(), ex);
+        }
+      }
+      throw t;
     } finally {
       activeEncoder.remove(encoderEngine);
     }
-
-    // encoding did not return a file
-    if (!output.exists() || output.length() == 0)
-      return none();
-
-    // Put the file in the workspace
-    URI workspaceURI = putToCollection(job, output, "converted image file");
-
-    MediaPackageElementBuilder builder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
-    Attachment attachment = (Attachment) builder.elementFromURI(workspaceURI, Attachment.TYPE, null);
-
-    return some(attachment);
+    return convertedImages;
   }
 
   /**
@@ -1352,9 +1373,11 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
           serialized = MediaPackageElementParser.getArrayAsXml(resultingElements);
           break;
         case ImageConversion:
+          Gson gson = new Gson();
+          String[] encodingProfilesArr = gson.fromJson(arguments.get(0), String[].class);
           Attachment sourceImage = (Attachment) MediaPackageElementParser.getFromXml(arguments.get(1));
-          serialized = convertImage(job, sourceImage, encodingProfile).map(
-                  MediaPackageElementParser.getAsXml()).getOrElse("");
+          List<Attachment> convertedImages = convertImage(job, sourceImage, encodingProfilesArr);
+          serialized = MediaPackageElementParser.getArrayAsXml(convertedImages);
           break;
         case Mux:
           firstTrack = (Track) MediaPackageElementParser.getFromXml(arguments.get(1));

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -668,7 +668,7 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
   @Produces(MediaType.TEXT_XML)
   @RestQuery(name = "convertimage", description = "Starts an image conversion process, based on the specified encoding profile ID and the source image", restParameters = {
           @RestParameter(description = "The original image", isRequired = true, name = "sourceImage", type = Type.TEXT, defaultValue = "${this.imageAttachmentDefault}"),
-          @RestParameter(description = "The encoding profile to use", isRequired = true, name = "profileId", type = Type.STRING, defaultValue = "image-conversion.http") }, reponses = {
+          @RestParameter(description = "A comma separated list of encoding profiles to use", isRequired = true, name = "profileId", type = Type.STRING, defaultValue = "image-conversion.http") }, reponses = {
           @RestResponse(description = "Results in an xml document containing the image attachment", responseCode = HttpServletResponse.SC_OK),
           @RestResponse(description = "If required parameters aren't set or if sourceImage isn't from the type Attachment", responseCode = HttpServletResponse.SC_BAD_REQUEST) }, returnDescription = "")
   public Response convertImage(@FormParam("sourceImage") String sourceImageXml, @FormParam("profileId") String profileId)
@@ -684,7 +684,7 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
 
     try {
       // Asynchronously convert the specified image
-      Job job = composerService.convertImage((Attachment) sourceImage, profileId);
+      Job job = composerService.convertImage((Attachment) sourceImage, StringUtils.split(profileId, ','));
       return Response.ok().entity(new JaxbJob(job)).build();
     } catch (EncoderException e) {
       logger.warn("Unable to convert image: " + e.getMessage());

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/ComposerService.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/ComposerService.java
@@ -232,19 +232,19 @@ public interface ComposerService {
           MediaPackageException;
 
   /**
-   * Converts the given image to a different image format using the specified image profile.
+   * Converts the given image to a different image format using the specified image profiles.
    *
    * @param image
    *          the image
-   * @param profileId
-   *          the profile to use for conversion
+   * @param profileIds
+   *          the profiles to use for conversion
    * @return the job for the image conversion
    * @throws EncoderException
    *           if image conversion fails
    * @throws MediaPackageException
    *           if the mediapackage is invalid
    */
-  Job convertImage(Attachment image, String profileId) throws EncoderException, MediaPackageException;
+  Job convertImage(Attachment image, String... profileIds) throws EncoderException, MediaPackageException;
 
 
   /**

--- a/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
+++ b/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
@@ -335,15 +335,15 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
    * {@inheritDoc}
    *
    * @see org.opencastproject.composer.api.ComposerService#convertImage(org.opencastproject.mediapackage.Attachment,
-   *      java.lang.String)
+   *      java.lang.String...)
    */
   @Override
-  public Job convertImage(Attachment image, String profileId) throws EncoderException, MediaPackageException {
+  public Job convertImage(Attachment image, String... profileIds) throws EncoderException, MediaPackageException {
     HttpPost post = new HttpPost("/convertimage");
     try {
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("sourceImage", MediaPackageElementParser.getAsXml(image)));
-      params.add(new BasicNameValuePair("profileId", profileId));
+      params.add(new BasicNameValuePair("profileId", StringUtils.join(profileIds, ',')));
       post.setEntity(new UrlEncodedFormEntity(params));
     } catch (Exception e) {
       throw new EncoderException(e);

--- a/modules/composer-workflowoperation/pom.xml
+++ b/modules/composer-workflowoperation/pom.xml
@@ -123,6 +123,7 @@
               OSGI-INF/operations/concat.xml,
               OSGI-INF/operations/demux.xml,
               OSGI-INF/operations/encode.xml,
+              OSGI-INF/operations/image-convert.xml,
               OSGI-INF/operations/image-to-video.xml,
               OSGI-INF/operations/image.xml,
               OSGI-INF/operations/multiencode.xml,

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandler.java
@@ -1,0 +1,248 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.composer;
+
+import org.opencastproject.composer.api.ComposerService;
+import org.opencastproject.composer.api.EncodingProfile;
+import org.opencastproject.job.api.Job;
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.Attachment;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageElementParser;
+import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.selector.AttachmentSelector;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.util.PathSupport;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+public class ImageConvertWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(ImageConvertWorkflowOperationHandler.class);
+
+  /** The composer service */
+  private ComposerService composerService = null;
+
+  /** The workspace */
+  private Workspace workspace = null;
+
+  /**
+   * Callback for the OSGi declarative services configuration.
+   *
+   * @param composerService
+   *          the composer service
+   */
+  protected void setComposerService(ComposerService composerService) {
+    this.composerService = composerService;
+  }
+
+  /**
+   * Callback for declarative services configuration that will introduce us to the local workspace service.
+   *
+   * @param workspace
+   *          an instance of the workspace
+   */
+  public void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
+  }
+
+  @Override
+  public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context) throws WorkflowOperationException {
+    WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
+    String sourceFlavorOption = StringUtils.trimToNull(operation.getConfiguration("source-flavor"));
+    String sourceFlavorsOption = StringUtils.trimToNull(operation.getConfiguration("source-flavors"));
+    String sourceTagsOption = StringUtils.trimToNull(operation.getConfiguration("source-tags"));
+    String targetFlavorOption = StringUtils.trimToNull(operation.getConfiguration("target-flavor"));
+    if (targetFlavorOption == null)
+      targetFlavorOption = StringUtils.trimToNull(operation.getConfiguration("target-flavors"));
+    String targetTagsOption = StringUtils.trimToNull(operation.getConfiguration("target-tags"));
+    String encodingProfileOption = StringUtils.trimToNull(operation.getConfiguration("encoding-profile"));
+    if (encodingProfileOption == null)
+      encodingProfileOption = StringUtils.trimToNull(operation.getConfiguration("encoding-profiles"));
+    String tagsAndFlavorsOption = StringUtils.trimToNull(operation.getConfiguration("tags-and-flavors"));
+    boolean tagsAndFlavors = BooleanUtils.toBoolean(tagsAndFlavorsOption);
+
+
+    MediaPackage mediaPackage = workflowInstance.getMediaPackage();
+
+    // Make sure either one of tags or flavors are provided
+    if (StringUtils.isBlank(sourceFlavorOption) && StringUtils.isBlank(sourceFlavorsOption)
+            && StringUtils.isBlank(sourceTagsOption)) {
+      logger.info("No source tags or flavors have been specified, not matching anything");
+      return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE);
+    }
+
+    // Target flavor
+    MediaPackageElementFlavor targetFlavor = null;
+    if (StringUtils.isNotBlank(targetFlavorOption)) {
+      try {
+        targetFlavor = MediaPackageElementFlavor.parseFlavor(targetFlavorOption);
+      } catch (IllegalArgumentException e) {
+        throw new WorkflowOperationException("Target flavor '" + targetFlavorOption + "' is malformed");
+      }
+    }
+
+    List<String> profiles = new ArrayList<>();
+    for (String encodingProfileId : asList(encodingProfileOption)) {
+      EncodingProfile profile = composerService.getProfile(encodingProfileId);
+      if (profile == null)
+        throw new WorkflowOperationException("Encoding profile '" + encodingProfileId + "' was not found");
+      // just test if the profile exists, we only need the profile id for further work
+      profiles.add(encodingProfileId);
+    }
+
+    // Make sure there is at least one profile
+    if (profiles.isEmpty())
+      throw new WorkflowOperationException("No encoding profile was specified");
+
+    AttachmentSelector attachmentSelector = new AttachmentSelector();
+    for (String sourceFlavor : asList(sourceFlavorsOption)) {
+      attachmentSelector.addFlavor(sourceFlavor);
+    }
+    for (String sourceFlavor : asList(sourceFlavorOption)) {
+      attachmentSelector.addFlavor(sourceFlavor);
+    }
+    for (String sourceTag : asList(sourceTagsOption)) {
+      attachmentSelector.addTag(sourceTag);
+    }
+
+    // Look for elements matching the tag
+    Collection<Attachment> sourceElements = attachmentSelector.select(mediaPackage, tagsAndFlavors);
+
+    Map<Job, Attachment> jobs = new Hashtable<>();
+    try {
+      for (Attachment sourceElement : sourceElements) {
+        Job job = composerService.convertImage(sourceElement, profiles.toArray(new String[profiles.size()]));
+        jobs.put(job, sourceElement);
+      }
+      if (!waitForStatus(jobs.keySet().toArray(new Job[jobs.size()])).isSuccess()) {
+        throw new WorkflowOperationException("At least one image conversation job does not succeeded.");
+      }
+      for (Map.Entry<Job, Attachment> jobEntry : jobs.entrySet()) {
+        Job job = jobEntry.getKey();
+        Attachment sourceElement = jobEntry.getValue();
+        List<Attachment> targetElements =
+                (List<Attachment>) MediaPackageElementParser.getArrayFromXml(job.getPayload());
+        for (Attachment targetElement : targetElements) {
+          String targetFileName = PathSupport.toSafeName(FilenameUtils.getName(targetElement.getURI().getPath()));
+          URI newTargetElementUri = workspace.moveTo(targetElement.getURI(), mediaPackage.getIdentifier().compact(),
+                  targetElement.getIdentifier(), targetFileName);
+          targetElement.setURI(newTargetElementUri);
+          targetElement.setChecksum(null);
+
+          // set flavor on target element
+          if (targetFlavor != null) {
+            targetElement.setFlavor(targetFlavor);
+            if (StringUtils.equalsAny("*", targetFlavor.getType())) {
+              targetElement.setFlavor(MediaPackageElementFlavor.flavor(
+                      sourceElement.getFlavor().getType(), targetElement.getFlavor().getSubtype()));
+            }
+            if (StringUtils.equalsAny("*", targetFlavor.getSubtype())) {
+              targetElement.setFlavor(MediaPackageElementFlavor.flavor(
+                      targetElement.getFlavor().getType(), sourceElement.getFlavor().getSubtype()));
+            }
+          }
+          // set tags on target element
+          List<String> fixedTags = new ArrayList<>();
+          List<String> additionalTags = new ArrayList<>();
+          List<String> removingTags = new ArrayList<>();
+          for (String targetTag : asList(targetTagsOption)) {
+            if (!StringUtils.startsWithAny(targetTag, "+", "-")) {
+              if (additionalTags.size() > 0 || removingTags.size() > 0) {
+                logger.warn("You may not mix fixed tags and tag changes. "
+                        + "Please review target-tags option on image-convert operation of your workflow definition. "
+                        + "The tag {} is not prefixed with '+' or '-'.", targetTag);
+              }
+              fixedTags.add(targetTag);
+            } else if (StringUtils.startsWith(targetTag, "+")) {
+              additionalTags.add(StringUtils.substring(targetTag, 1));
+            } else if (StringUtils.startsWith(targetTag, "-")) {
+              removingTags.add(StringUtils.substring(targetTag, 1));
+            }
+          }
+          targetElement.clearTags();
+          if (fixedTags.isEmpty() && (!additionalTags.isEmpty() || !removingTags.isEmpty())) {
+            for (String tag : sourceElement.getTags()) {
+              targetElement.addTag(tag);
+            }
+          }
+          for (String targetTag : fixedTags) {
+            targetElement.addTag(targetTag);
+          }
+          for (String additionalTag : additionalTags) {
+            targetElement.addTag(additionalTag);
+          }
+          for (String removingTag : removingTags) {
+            targetElement.removeTag(removingTag);
+          }
+          mediaPackage.addDerived(targetElement, sourceElement);
+        }
+      }
+      return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE);
+    } catch (WorkflowOperationException ex) {
+      throw ex;
+    } catch (Throwable t) {
+      throw new WorkflowOperationException("Convert image operation failed", t);
+    } finally {
+      cleanupWorkspace(jobs.keySet());
+    }
+  }
+
+  private void cleanupWorkspace(Collection<Job> jobs) {
+    for (Job job : jobs) {
+      try {
+        List<Attachment> targetElements =
+                (List<Attachment>) MediaPackageElementParser.getArrayFromXml(job.getPayload());
+        for (Attachment targetElement : targetElements) {
+          try {
+            workspace.delete(targetElement.getURI());
+          } catch (NotFoundException ex) {
+            logger.trace("The image file {} not found", targetElement, ex);
+          } catch (IOException ex) {
+            logger.warn("Unable to delete image file {} from workspace", targetElement, ex);
+          }
+        }
+      } catch (MediaPackageException ex) {
+        logger.debug("Unable to parse job payload from job {}", job.getId(), ex);
+      }
+    }
+  }
+}

--- a/modules/composer-workflowoperation/src/main/resources/OSGI-INF/operations/image-convert.xml
+++ b/modules/composer-workflowoperation/src/main/resources/OSGI-INF/operations/image-convert.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+ name="org.opencastproject.workflow.handler.composer.ImageConvertWorkflowOperationHandler" immediate="true">
+  <implementation class="org.opencastproject.workflow.handler.composer.ImageConvertWorkflowOperationHandler" />
+  <property name="service.description" value="Image Convert Workflow Operation Handler" />
+  <property name="workflow.operation" value="image-convert" />
+  <service>
+    <provide interface="org.opencastproject.workflow.api.WorkflowOperationHandler" />
+  </service>
+  <reference cardinality="1..1" interface="org.opencastproject.composer.api.ComposerService"
+    name="ComposerService" policy="static" bind="setComposerService"/>
+  <reference cardinality="1..1" interface="org.opencastproject.workspace.api.Workspace" name="Workspace"
+    policy="static" bind="setWorkspace" />
+  <reference name="ServiceRegistry" cardinality="1..1" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
+    policy="static" bind="setServiceRegistry" />
+</scr:component>

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandlerTest.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.composer;
+
+import org.opencastproject.composer.api.ComposerService;
+import org.opencastproject.composer.api.EncoderException;
+import org.opencastproject.composer.api.EncodingProfile;
+import org.opencastproject.job.api.Job;
+import org.opencastproject.mediapackage.Attachment;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilder;
+import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.serviceregistry.api.ServiceRegistryException;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.IOUtils;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ImageConvertWorkflowOperationHandlerTest {
+
+  private MediaPackage mp = null;
+
+  @Before
+  public void setUp() throws URISyntaxException, MalformedURLException, IOException, MediaPackageException {
+    MediaPackageBuilder builder = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder();
+    mp = builder.loadFromXml(getClass().getResource("/image_convert_mediapackage.xml").toURI().toURL().openStream());
+  }
+
+  @Test
+  public void testImageConvert() throws WorkflowOperationException, NotFoundException, IOException, URISyntaxException,
+          EncoderException, MediaPackageException, ServiceRegistryException {
+    // create workflow operation configuration
+    Map<String, String> config = new HashMap<>();
+    config.put("source-flavor", "image/intro");
+    config.put("target-flavor", "image/converted");
+    config.put("target-tags", "convert");
+    config.put("encoding-profile", "image.convert");
+    // mock workspace
+    Workspace workspace = EasyMock.createNiceMock(Workspace.class);
+    URI targetElementUri = new URI("/converted.jpg");
+    EasyMock.expect(workspace.moveTo(EasyMock.anyObject(URI.class), EasyMock.anyString(), EasyMock.anyString(),
+            EasyMock.anyString())).andReturn(targetElementUri).anyTimes();
+    // mock job to be created
+    Job job = EasyMock.createNiceMock(Job.class);
+    String jobPayloadAttachment = IOUtils.resourceToString("/image_convert_attachment.xml", Charset.forName("UTF-8"));
+    EasyMock.expect(job.getPayload()).andReturn(jobPayloadAttachment).anyTimes();
+    EasyMock.expect(job.getStatus()).andReturn(Job.Status.FINISHED);
+    // mock service registry
+    ServiceRegistry serviceRegistry = EasyMock.createNiceMock(ServiceRegistry.class);
+    EasyMock.expect(serviceRegistry.getJob(EasyMock.anyLong())).andReturn(job);
+    // mock composer service
+    ComposerService composerService = EasyMock.createNiceMock(ComposerService.class);
+    Capture<Attachment> sourceImageAttachmentCapture = EasyMock.newCapture();
+    Capture<String[]> encodingProfilesCapture = EasyMock.newCapture();
+    EasyMock.expect(composerService.convertImage(EasyMock.capture(sourceImageAttachmentCapture),
+            EasyMock.capture(encodingProfilesCapture))).andReturn(job);
+    EncodingProfile encodingProfile = EasyMock.createNiceMock(EncodingProfile.class);
+    EasyMock.expect(composerService.getProfile("image.convert")).andReturn(encodingProfile);
+
+    EasyMock.replay(workspace, composerService, job, encodingProfile, serviceRegistry);
+
+    WorkflowInstance workflowInstance = mockWorkflowInstance(config);
+    // initialize WOH
+    ImageConvertWorkflowOperationHandler imageConvertWOH = new ImageConvertWorkflowOperationHandler();
+    imageConvertWOH.setServiceRegistry(serviceRegistry);
+    imageConvertWOH.setWorkspace(workspace);
+    imageConvertWOH.setComposerService(composerService);
+    // run test
+    WorkflowOperationResult result = imageConvertWOH.start(workflowInstance, null);
+    // check result
+    MediaPackage resultMP = result.getMediaPackage();
+    Attachment[] resultElements = resultMP.getAttachments(MediaPackageElementFlavor.parseFlavor("image/converted"));
+    Assert.assertNotNull(resultElements);
+    Assert.assertEquals(1, resultElements.length);
+    Attachment convertedImageAttachment = resultElements[0];
+    Assert.assertTrue(convertedImageAttachment.containsTag("convert"));
+
+    // check captures
+    Assert.assertTrue(sourceImageAttachmentCapture.hasCaptured());
+    Assert.assertEquals("image/intro", sourceImageAttachmentCapture.getValue().getFlavor().toString());
+
+    Assert.assertTrue(encodingProfilesCapture.hasCaptured());
+    Assert.assertEquals("image.convert", encodingProfilesCapture.getValue());
+  }
+
+  private WorkflowInstance mockWorkflowInstance(Map<String, String> configurations) {
+    WorkflowOperationInstance operation = EasyMock.createNiceMock(WorkflowOperationInstance.class);
+    EasyMock.expect(operation.getConfiguration(EasyMock.anyString())).andAnswer(() -> {
+      String key = (String) EasyMock.getCurrentArguments()[0];
+      return configurations.get(key);
+    }).anyTimes();
+
+    WorkflowInstance workflowInstance = EasyMock.createNiceMock(WorkflowInstance.class);
+    EasyMock.expect(workflowInstance.getMediaPackage()).andReturn(mp).anyTimes();
+    EasyMock.expect(workflowInstance.getCurrentOperation()).andReturn(operation).anyTimes();
+    EasyMock.replay(operation, workflowInstance);
+    return workflowInstance;
+  }
+}

--- a/modules/composer-workflowoperation/src/test/resources/image_convert_attachment.xml
+++ b/modules/composer-workflowoperation/src/test/resources/image_convert_attachment.xml
@@ -1,0 +1,5 @@
+<attachment id="attachment-2" ref="track:intro-image" type="image/converted" xmlns="http://mediapackage.opencastproject.org">
+  <mimetype>image/jpeg</mimetype>
+  <url>converted.jpg</url>
+  <size>0</size>
+</attachment>

--- a/modules/composer-workflowoperation/src/test/resources/image_convert_mediapackage.xml
+++ b/modules/composer-workflowoperation/src/test/resources/image_convert_mediapackage.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:mediapackage start="2010-05-19T09:27:46"
+	id="d51f9d4e-b5e7-41e0-8640-0d1f43b2fed0" duration="65649"
+	xmlns:ns2="http://mediapackage.opencastproject.org">
+	<ns2:title>Image convert operation handler test</ns2:title>
+	<ns2:metadata>
+		<ns2:catalog type="dublincore/episode" id="9a9eb5dd-e0e1-4321-b46b-66a1feb5bac7">
+			<ns2:mimetype>text/xml</ns2:mimetype>
+			<ns2:tags />
+			<ns2:url>fooDC.xml</ns2:url>
+		</ns2:catalog>
+	</ns2:metadata>
+	<ns2:attachments>
+		<ns2:attachment type="image/intro" id="intro-image">
+			<ns2:mimetype>image/png</ns2:mimetype>
+			<ns2:tags>intro</ns2:tags>
+			<ns2:url>image.png</ns2:url>
+		</ns2:attachment>
+	</ns2:attachments>
+</ns2:mediapackage>


### PR DESCRIPTION
With the image-convert WOH you will be able to run encoding operations on media package attachments. The best usage example is the image conversation or modification.

Sponsored by SWITCH.