### PR TITLE
NOJIRA: Skip install of Crowdin if it is already installed

### DIFF
--- a/.upload-crowdin.sh
+++ b/.upload-crowdin.sh
@@ -13,7 +13,9 @@ if ! echo "${TRAVIS_BRANCH}" | grep -Eq '^(r/[0-9]+\.x|develop)$'; then
 fi
 # Crowdin branches do not use the `r/` prefix
 CROWDIN_BRANCH="${TRAVIS_BRANCH//r\//}"
-wget --quiet https://artifacts.crowdin.com/repo/deb/crowdin.deb
-sudo dpkg -i crowdin.deb
+command -v crowdin >/dev/null 2>&1 || {
+  wget --quiet https://artifacts.crowdin.com/repo/deb/crowdin.deb
+  sudo dpkg -i crowdin.deb
+}
 echo "api_key: ${CROWDIN_API_KEY}" > ~/.crowdin.yaml
 crowdin --config .crowdin.yaml upload sources -b "${CROWDIN_BRANCH}"


### PR DESCRIPTION
This patch checks to see if crowdin is installed prior to installing it.  This preserves existing behaviour for Travis, while also using the pre-installed crowdin binary built into the Buildbot docker images.  This also means that the docker worker process doesn't need to have sudo, which is handy.