### PR TITLE
MH-12956, Incorrect permission check when requesting indexed workflows

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1473,7 +1473,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    */
   @Override
   public WorkflowSet getWorkflowInstances(WorkflowQuery query) throws WorkflowDatabaseException {
-    return index.getWorkflowInstances(query, Permissions.Action.WRITE.toString(), true);
+    return index.getWorkflowInstances(query, Permissions.Action.READ.toString(), true);
   }
 
   /**

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceIndex.java
@@ -74,8 +74,10 @@ public interface WorkflowServiceIndex {
    *
    * @param query
    *          the query to use in the search for workflow instances
-   * @param action TODO
-   * @param applyPermissions TODO
+   * @param action
+   *          ACL action (e.g. read or write) to check for
+   * @param applyPermissions
+   *          whether to apply the permissions to the query. Set to false for administrative queries.
    *
    * @return the set of matching workflow instances
    * @throws WorkflowDatabaseException

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
@@ -840,6 +840,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
    * @param query
    *          the workflow query
    * @param action
+   *          ACL action (e.g. read or write) to check for
    * @param applyPermissions
    *          whether to apply the permissions to the query. Set to false for administrative queries.
    * @return the solr query string


### PR DESCRIPTION
Opencast checks if users have write permissions on the workflow index
when users try to read data from there. It should obviously check for
read permissions.

Note that the security implications on this should be limited since in
practice users with write access should always have read access as well
and users with write access could control the contents of the index.