### PR TITLE
MH-12950 Fix for workflow with no acl in solr index

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/WorkflowMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/WorkflowMessageReceiverImpl.java
@@ -93,10 +93,7 @@ public class WorkflowMessageReceiverImpl extends BaseMessageReceiverImpl<Workflo
           event.setWorkflowState(wf.getState());
           WorkflowInstance.WorkflowState state = wf.getState();
 
-          if (!(WorkflowInstance.WorkflowState.SUCCEEDED.equals(state)
-                  || WorkflowInstance.WorkflowState.FAILED.equals(state)
-                  || WorkflowInstance.WorkflowState.STOPPED.equals(state))) {
-
+          if (!state.isTerminated()) {
             Tuple<AccessControlList, AclScope> activeAcl = authorizationService.getActiveAcl(mp);
             List<ManagedAcl> acls = aclServiceFactory.serviceFor(getSecurityService().getOrganization()).getAcls();
             Option<ManagedAcl> managedAcl = AccessInformationUtil.matchAcls(acls, activeAcl.getA());
@@ -111,7 +108,8 @@ public class WorkflowMessageReceiverImpl extends BaseMessageReceiverImpl<Workflo
               if (loadedDC.isSome())
                 updateEvent(event, loadedDC.get());
             } catch (Throwable t) {
-              logger.warn("Unable to load dublincore catalog for the workflow {}", wf.getId(), t);
+              logger.warn(String.format("Unable to load dublincore catalog for the workflow %d, mp %s", wf.getId(),
+                      mp.getIdentifier().compact()), t);
             }
 
           }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/WorkflowMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/WorkflowMessageReceiverImpl.java
@@ -108,8 +108,8 @@ public class WorkflowMessageReceiverImpl extends BaseMessageReceiverImpl<Workflo
               if (loadedDC.isSome())
                 updateEvent(event, loadedDC.get());
             } catch (Throwable t) {
-              logger.warn(String.format("Unable to load dublincore catalog for the workflow %d, mp %s", wf.getId(),
-                      mp.getIdentifier().compact()), t);
+              logger.warn("Unable to load dublincore catalog for the workflow {}, mp {}", wf.getId(),
+                      mp.getIdentifier().compact(), t);
             }
 
           }

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -36,7 +36,18 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 @XmlJavaTypeAdapter(WorkflowInstanceImpl.Adapter.class)
 public interface WorkflowInstance extends Configurable {
   enum WorkflowState {
-    INSTANTIATED, RUNNING, STOPPED, PAUSED, SUCCEEDED, FAILED, FAILING
+    INSTANTIATED, RUNNING, STOPPED, PAUSED, SUCCEEDED, FAILED, FAILING;
+
+    public boolean isTerminated() {
+      switch (this) {
+        case STOPPED:
+        case SUCCEEDED:
+        case FAILED:
+          return true;
+        default:
+          return false;
+      }
+    }
   }
 
   /**

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -56,6 +56,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-asset-manager-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.entwinemedia.common</groupId>
       <artifactId>functional</artifactId>
     </dependency>

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
@@ -25,6 +25,9 @@ import static org.apache.solr.client.solrj.util.ClientUtils.escapeQueryChars;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.data.Option.option;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.AResult;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.security.api.AccessControlEntry;
@@ -43,7 +46,6 @@ import org.opencastproject.solr.SolrServerFactory;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.SolrUtils;
 import org.opencastproject.workflow.api.WorkflowDatabaseException;
-import org.opencastproject.workflow.api.WorkflowException;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowOperationInstance;
@@ -191,6 +193,9 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
 
   /** The security service */
   private SecurityService securityService = null;
+
+  /** The asset manager */
+  private AssetManager assetManager = null;
 
   /** Whether to index workflows synchronously as they are stored */
   protected boolean synchronousIndexing = true;
@@ -491,19 +496,27 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
     doc.addField(WORKFLOW_CREATOR_KEY, workflowCreator.getUsername());
     doc.addField(ORG_KEY, instance.getOrganization().getId());
 
-    WorkflowInstance.WorkflowState state = instance.getState();
-    if (!(WorkflowInstance.WorkflowState.SUCCEEDED.equals(state)
-            || WorkflowInstance.WorkflowState.FAILED.equals(state)
-            || WorkflowInstance.WorkflowState.STOPPED.equals(state))) {
+    // Media package used to get the active acl
+    MediaPackage aclMp = mp;
 
-      AccessControlList acl;
-      try {
-        acl = authorizationService.getActiveAcl(mp).getA();
-      } catch (Error e) {
-        logger.error("No security xacml found on media package {}", mp);
-        throw new WorkflowException(e);
+    // If workflow has ended, get the latest acl from the asset manager because there may be no security
+    // attachments in the workspace anymore
+    WorkflowInstance.WorkflowState state = instance.getState();
+    if (state.isTerminated()) {
+      AQueryBuilder query = assetManager.createQuery();
+      AResult result = query.select(query.snapshot())
+              .where(query.mediaPackageId(mp.getIdentifier().compact()).and(query.version().isLatest())).run();
+      if (result.getSize() > 0 && result.getRecords().head().isSome()) {
+        aclMp = result.getRecords().head().get().getSnapshot().get().getMediaPackage();
       }
+    }
+
+    try {
+      AccessControlList acl = authorizationService.getActiveAcl(aclMp).getA();
       addAuthorization(doc, acl);
+    } catch (Error e) {
+      logger.warn("Could not find active acl for media package {}", mp, e);
+      // Solr document will not have acl info
     }
 
     return doc;
@@ -1113,6 +1126,16 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
    */
   protected void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
+  }
+
+  /**
+   * Callback for setting the asset manager.
+   *
+   * @param assetManager
+   *          the asset manager
+   */
+  protected void setAssetManager(AssetManager assetManager) {
+    this.assetManager = assetManager;
   }
 
 }

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
@@ -501,12 +501,11 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
 
     // If workflow has ended, get the latest acl from the asset manager because there may be no security
     // attachments in the workspace anymore
-    WorkflowInstance.WorkflowState state = instance.getState();
-    if (state.isTerminated()) {
+    if (instance.getState().isTerminated()) {
       AQueryBuilder query = assetManager.createQuery();
       AResult result = query.select(query.snapshot())
               .where(query.mediaPackageId(mp.getIdentifier().compact()).and(query.version().isLatest())).run();
-      if (result.getSize() > 0 && result.getRecords().head().isSome()) {
+      if (result.getRecords().head().isSome()) {
         aclMp = result.getRecords().head().get().getSnapshot().get().getMediaPackage();
       }
     }
@@ -514,7 +513,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
     try {
       AccessControlList acl = authorizationService.getActiveAcl(aclMp).getA();
       addAuthorization(doc, acl);
-    } catch (Error e) {
+    } catch (Exception e) {
       logger.warn("Could not find active acl for media package {}", mp, e);
       // Solr document will not have acl info
     }

--- a/modules/workflow-service-impl/src/main/resources/OSGI-INF/workflow-service-index.xml
+++ b/modules/workflow-service-impl/src/main/resources/OSGI-INF/workflow-service-index.xml
@@ -15,4 +15,6 @@
     cardinality="1..1" policy="static" bind="setSecurityService" />
   <reference name="orgDirectory" interface="org.opencastproject.security.api.OrganizationDirectoryService"
     cardinality="1..1" policy="static" bind="setOrgDirectory" />
+  <reference name="assetManager" interface="org.opencastproject.assetmanager.api.AssetManager"
+    cardinality="1..1" policy="static" bind="setAssetManager" />
 </scr:component>

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
@@ -195,7 +195,6 @@ public class CountWorkflowsTest {
     Predicate p = EasyMock.createNiceMock(Predicate.class);
     EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
     AResult r = EasyMock.createNiceMock(AResult.class);
-    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
     EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
     Target t = EasyMock.createNiceMock(Target.class);
     ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
@@ -24,6 +24,16 @@ package org.opencastproject.workflow.impl;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Snapshot;
+import org.opencastproject.assetmanager.api.Version;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.DefaultMediaPackageSerializerImpl;
 import org.opencastproject.mediapackage.MediaPackage;
@@ -54,6 +64,9 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workflow.api.WorkflowParser;
 import org.opencastproject.workflow.api.WorkflowStateListener;
 import org.opencastproject.workflow.impl.WorkflowServiceImpl.HandlerRegistration;
+
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -169,12 +182,42 @@ public class CountWorkflowsTest {
     serviceRegistry = new ServiceRegistryInMemoryImpl(service, securityService, userDirectoryService,
             organizationDirectoryService, EasyMock.createNiceMock(IncidentService.class));
 
+    AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
+    Version version = EasyMock.createNiceMock(Version.class);
+    Snapshot snapshot = EasyMock.createNiceMock(Snapshot.class);
+    // Just needs to return a mp, not checking which one
+    EasyMock.expect(snapshot.getMediaPackage()).andReturn(mp).anyTimes();
+    EasyMock.expect(snapshot.getOrganizationId()).andReturn(organization.getId()).anyTimes();
+    EasyMock.expect(snapshot.getVersion()).andReturn(version).anyTimes();
+    ARecord aRec = EasyMock.createNiceMock(ARecord.class);
+    EasyMock.expect(aRec.getSnapshot()).andReturn(Opt.some(snapshot)).anyTimes();
+    Stream<ARecord> recStream = Stream.mk(aRec);
+    Predicate p = EasyMock.createNiceMock(Predicate.class);
+    EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
+    AResult r = EasyMock.createNiceMock(AResult.class);
+    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
+    EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+    Target t = EasyMock.createNiceMock(Target.class);
+    ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+    EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+    EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+    AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+    EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+    EasyMock.expect(query.mediaPackageId(EasyMock.anyObject(String.class))).andReturn(p).anyTimes();
+    EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+    VersionField v = EasyMock.createNiceMock(VersionField.class);
+    EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+    EasyMock.expect(query.version()).andReturn(v).anyTimes();
+    EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+    EasyMock.replay(assetManager, version, snapshot, aRec, p, r, t, selectQuery, query, v);
+
     dao = new WorkflowServiceSolrIndex();
     dao.setServiceRegistry(serviceRegistry);
     dao.solrRoot = sRoot + File.separator + "solr";
     dao.setAuthorizationService(authzService);
     dao.setSecurityService(securityService);
     dao.setOrgDirectory(organizationDirectoryService);
+    dao.setAssetManager(assetManager);
     dao.activate("System Admin");
     service.setDao(dao);
     service.setMessageSender(messageSender);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
@@ -23,6 +23,16 @@ package org.opencastproject.workflow.impl;
 
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Snapshot;
+import org.opencastproject.assetmanager.api.Version;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.DefaultMediaPackageSerializerImpl;
 import org.opencastproject.mediapackage.MediaPackage;
@@ -51,6 +61,9 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workflow.api.WorkflowParser;
 import org.opencastproject.workflow.api.WorkflowStateListener;
 import org.opencastproject.workflow.impl.WorkflowServiceImpl.HandlerRegistration;
+
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -169,12 +182,42 @@ public class HoldStateTest {
     ServiceRegistryInMemoryImpl serviceRegistry = new ServiceRegistryInMemoryImpl(service, securityService,
             userDirectoryService, organizationDirectoryService, EasyMock.createNiceMock(IncidentService.class));
 
+    AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
+    Version version = EasyMock.createNiceMock(Version.class);
+    Snapshot snapshot = EasyMock.createNiceMock(Snapshot.class);
+    // Just needs to return a mp, not checking which one
+    EasyMock.expect(snapshot.getMediaPackage()).andReturn(mp).anyTimes();
+    EasyMock.expect(snapshot.getOrganizationId()).andReturn(organization.getId()).anyTimes();
+    EasyMock.expect(snapshot.getVersion()).andReturn(version).anyTimes();
+    ARecord aRec = EasyMock.createNiceMock(ARecord.class);
+    EasyMock.expect(aRec.getSnapshot()).andReturn(Opt.some(snapshot)).anyTimes();
+    Stream<ARecord> recStream = Stream.mk(aRec);
+    Predicate p = EasyMock.createNiceMock(Predicate.class);
+    EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
+    AResult r = EasyMock.createNiceMock(AResult.class);
+    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
+    EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+    Target t = EasyMock.createNiceMock(Target.class);
+    ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+    EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+    EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+    AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+    EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+    EasyMock.expect(query.mediaPackageId(EasyMock.anyObject(String.class))).andReturn(p).anyTimes();
+    EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+    VersionField v = EasyMock.createNiceMock(VersionField.class);
+    EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+    EasyMock.expect(query.version()).andReturn(v).anyTimes();
+    EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+    EasyMock.replay(assetManager, version, snapshot, aRec, p, r, t, selectQuery, query, v);
+
     dao = new WorkflowServiceSolrIndex();
     dao.solrRoot = sRoot + File.separator + "solr";
     dao.setServiceRegistry(serviceRegistry);
     dao.setAuthorizationService(authzService);
     dao.setSecurityService(securityService);
     dao.setOrgDirectory(organizationDirectoryService);
+    dao.setAssetManager(assetManager);
     dao.activate("System Admin");
     service.setDao(dao);
     service.setMessageSender(messageSender);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
@@ -195,7 +195,6 @@ public class HoldStateTest {
     Predicate p = EasyMock.createNiceMock(Predicate.class);
     EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
     AResult r = EasyMock.createNiceMock(AResult.class);
-    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
     EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
     Target t = EasyMock.createNiceMock(Target.class);
     ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
@@ -23,6 +23,16 @@ package org.opencastproject.workflow.impl;
 
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Snapshot;
+import org.opencastproject.assetmanager.api.Version;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.mediapackage.DefaultMediaPackageSerializerImpl;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilder;
@@ -47,6 +57,9 @@ import org.opencastproject.workflow.api.WorkflowParser;
 import org.opencastproject.workflow.api.WorkflowStateListener;
 import org.opencastproject.workflow.impl.WorkflowServiceImpl.HandlerRegistration;
 import org.opencastproject.workspace.api.Workspace;
+
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -162,12 +175,43 @@ public class PauseFinalOperationTest {
     workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.getCollectionContents((String) EasyMock.anyObject())).andReturn(new URI[0]);
     EasyMock.replay(workspace);
+
+    AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
+    Version version = EasyMock.createNiceMock(Version.class);
+    Snapshot snapshot = EasyMock.createNiceMock(Snapshot.class);
+    // Just needs to return a mp, not checking which one
+    EasyMock.expect(snapshot.getMediaPackage()).andReturn(mp).anyTimes();
+    EasyMock.expect(snapshot.getOrganizationId()).andReturn(securityService.getOrganization().getId()).anyTimes();
+    EasyMock.expect(snapshot.getVersion()).andReturn(version).anyTimes();
+    ARecord aRec = EasyMock.createNiceMock(ARecord.class);
+    EasyMock.expect(aRec.getSnapshot()).andReturn(Opt.some(snapshot)).anyTimes();
+    Stream<ARecord> recStream = Stream.mk(aRec);
+    Predicate p = EasyMock.createNiceMock(Predicate.class);
+    EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
+    AResult r = EasyMock.createNiceMock(AResult.class);
+    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
+    EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+    Target t = EasyMock.createNiceMock(Target.class);
+    ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+    EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+    EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+    AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+    EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+    EasyMock.expect(query.mediaPackageId(EasyMock.anyObject(String.class))).andReturn(p).anyTimes();
+    EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+    VersionField v = EasyMock.createNiceMock(VersionField.class);
+    EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+    EasyMock.expect(query.version()).andReturn(v).anyTimes();
+    EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+    EasyMock.replay(assetManager, version, snapshot, aRec, p, r, t, selectQuery, query, v);
+
     dao = new WorkflowServiceSolrIndex();
     dao.setServiceRegistry(serviceRegistry);
     dao.setAuthorizationService(authzService);
     dao.solrRoot = sRoot + File.separator + "solr";
     dao.setSecurityService(securityService);
     dao.setOrgDirectory(organizationDirectoryService);
+    dao.setAssetManager(assetManager);
     dao.activate("System Admin");
     service.setDao(dao);
     service.setMessageSender(messageSender);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
@@ -189,7 +189,6 @@ public class PauseFinalOperationTest {
     Predicate p = EasyMock.createNiceMock(Predicate.class);
     EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
     AResult r = EasyMock.createNiceMock(AResult.class);
-    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
     EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
     Target t = EasyMock.createNiceMock(Target.class);
     ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
@@ -25,6 +25,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Snapshot;
+import org.opencastproject.assetmanager.api.Version;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.DefaultMediaPackageSerializerImpl;
 import org.opencastproject.mediapackage.MediaPackage;
@@ -55,6 +65,9 @@ import org.opencastproject.workflow.api.WorkflowParser;
 import org.opencastproject.workflow.api.WorkflowStateListener;
 import org.opencastproject.workflow.impl.WorkflowServiceImpl.HandlerRegistration;
 import org.opencastproject.workspace.api.Workspace;
+
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -169,11 +182,40 @@ public class WorkflowOperationSkippingTest {
     EasyMock.replay(authzService);
     service.setAuthorizationService(authzService);
 
+    AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
+    Version version = EasyMock.createNiceMock(Version.class);
+    Snapshot snapshot = EasyMock.createNiceMock(Snapshot.class);
+    // Just needs to return a mp, not checking which one
+    EasyMock.expect(snapshot.getMediaPackage()).andReturn(mediapackage1).anyTimes();
+    EasyMock.expect(snapshot.getOrganizationId()).andReturn(securityService.getOrganization().getId()).anyTimes();
+    EasyMock.expect(snapshot.getVersion()).andReturn(version).anyTimes();
+    ARecord aRec = EasyMock.createNiceMock(ARecord.class);
+    EasyMock.expect(aRec.getSnapshot()).andReturn(Opt.some(snapshot)).anyTimes();
+    Stream<ARecord> recStream = Stream.mk(aRec);
+    Predicate p = EasyMock.createNiceMock(Predicate.class);
+    EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
+    AResult r = EasyMock.createNiceMock(AResult.class);
+    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
+    EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+    Target t = EasyMock.createNiceMock(Target.class);
+    ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+    EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+    EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+    AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+    EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+    EasyMock.expect(query.mediaPackageId(EasyMock.anyObject(String.class))).andReturn(p).anyTimes();
+    EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+    VersionField v = EasyMock.createNiceMock(VersionField.class);
+    EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+    EasyMock.expect(query.version()).andReturn(v).anyTimes();
+    EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+    EasyMock.replay(assetManager, version, snapshot, aRec, p, r, t, selectQuery, query, v);
+
     dao.setServiceRegistry(serviceRegistry);
     dao.setSecurityService(securityService);
     dao.setAuthorizationService(authzService);
     dao.setOrgDirectory(organizationDirectoryService);
-
+    dao.setAssetManager(assetManager);
     dao.activate("System Admin");
     service.setDao(dao);
     service.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
@@ -195,7 +195,6 @@ public class WorkflowOperationSkippingTest {
     Predicate p = EasyMock.createNiceMock(Predicate.class);
     EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
     AResult r = EasyMock.createNiceMock(AResult.class);
-    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
     EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
     Target t = EasyMock.createNiceMock(Target.class);
     ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -28,6 +28,16 @@ import static org.junit.Assert.assertEquals;
 import static org.opencastproject.workflow.api.WorkflowOperationResult.Action.CONTINUE;
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Snapshot;
+import org.opencastproject.assetmanager.api.Version;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.job.api.JobImpl;
@@ -78,6 +88,9 @@ import org.opencastproject.workflow.handler.workflow.ErrorResolutionWorkflowOper
 import org.opencastproject.workflow.impl.WorkflowServiceImpl.HandlerRegistration;
 import org.opencastproject.workspace.api.Workspace;
 
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.easymock.EasyMock;
@@ -121,6 +134,7 @@ public class WorkflowServiceImplTest {
   private Workspace workspace = null;
   private ServiceRegistryInMemoryImpl serviceRegistry = null;
   private SecurityService securityService = null;
+  private DefaultOrganization organization = null;
 
   private File sRoot = null;
 
@@ -168,7 +182,7 @@ public class WorkflowServiceImplTest {
     service.addWorkflowDefinitionScanner(scanner);
 
     // security service
-    DefaultOrganization organization = new DefaultOrganization();
+    organization = new DefaultOrganization();
     securityService = createNiceMock(SecurityService.class);
     expect(securityService.getUser()).andReturn(SecurityServiceStub.DEFAULT_ORG_ADMIN).anyTimes();
     expect(securityService.getOrganization()).andReturn(organization).anyTimes();
@@ -267,6 +281,36 @@ public class WorkflowServiceImplTest {
     } catch (Exception e) {
       Assert.fail(e.getMessage());
     }
+
+    AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
+    Version version = EasyMock.createNiceMock(Version.class);
+    Snapshot snapshot = EasyMock.createNiceMock(Snapshot.class);
+    // Just needs to return a mp, not checking which one
+    EasyMock.expect(snapshot.getMediaPackage()).andReturn(mediapackage1).anyTimes();
+    EasyMock.expect(snapshot.getOrganizationId()).andReturn(organization.getId()).anyTimes();
+    EasyMock.expect(snapshot.getVersion()).andReturn(version).anyTimes();
+    ARecord aRec = EasyMock.createNiceMock(ARecord.class);
+    EasyMock.expect(aRec.getSnapshot()).andReturn(Opt.some(snapshot)).anyTimes();
+    Stream<ARecord> recStream = Stream.mk(aRec);
+    Predicate p = EasyMock.createNiceMock(Predicate.class);
+    EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
+    AResult r = EasyMock.createNiceMock(AResult.class);
+    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
+    EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+    Target t = EasyMock.createNiceMock(Target.class);
+    ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+    EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+    EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+    AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+    EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+    EasyMock.expect(query.mediaPackageId(EasyMock.anyObject(String.class))).andReturn(p).anyTimes();
+    EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+    VersionField v = EasyMock.createNiceMock(VersionField.class);
+    EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+    EasyMock.expect(query.version()).andReturn(v).anyTimes();
+    EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+    EasyMock.replay(assetManager, version, snapshot, aRec, p, r, t, selectQuery, query, v);
+    dao.setAssetManager(assetManager);
   }
 
   @After

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -295,7 +295,6 @@ public class WorkflowServiceImplTest {
     Predicate p = EasyMock.createNiceMock(Predicate.class);
     EasyMock.expect(p.and(p)).andReturn(p).anyTimes();
     AResult r = EasyMock.createNiceMock(AResult.class);
-    EasyMock.expect(r.getSize()).andReturn(1L).anyTimes();
     EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
     Target t = EasyMock.createNiceMock(Target.class);
     ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);


### PR DESCRIPTION
This is not ideal, but the best solution we could come up with at this point. When a workflow finishes, the acl is gotten from asset manager because security attachments may have already been deleted from the workspace/wfr.