### PR TITLE
MH-12963 Localize dates/times in add-event summary

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/localizeDateFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/localizeDateFilter.js
@@ -33,10 +33,6 @@ angular.module('adminNg.filters')
             case 'dateTime':
                 return Language.formatDateTime(format, input);
             case 'time':
-                if (!angular.isDate(Date.parse(input))) {
-                    return input;
-                }
-
                 return Language.formatTime(format, input);
             default:
                 return input;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -683,20 +683,20 @@
                         <!-- Start date schedule -->
                         <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.date">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_DATE"><!-- Start Date --></td>
-                            <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.date }}</td>
+                            <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.date | localizeDate:'date' }}</td>
                         </tr>
 
                         <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.hour !== undefined">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_TIME"><!-- Start Time --></td>
-                            <td>{{ wizard.getStateControllerByName('source').getFormattedStartTime() }}</td>
+                            <td>{{ wizard.getStateControllerByName('source').getFormattedStartTime() | localizeDate:'time' }}</td>
                         </tr>
                         <tr ng-if="(wizard.step.ud.type === 'SCHEDULE_MULTIPLE') && wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].end.date">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_DATE"><!-- End Date --></td>
-                            <td>{{ wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.end.date }}</td>
+                            <td>{{ wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.end.date | localizeDate:'date' }}</td>
                         </tr>
                         <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].end.hour !== undefined">
                           <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_TIME"><!-- End Time --></td>
-                          <td>{{ wizard.getStateControllerByName('source').getFormattedEndTime() }}</td>
+                          <td>{{ wizard.getStateControllerByName('source').getFormattedEndTime() | localizeDate:'time' }}</td>
                         </tr>
                         <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].repetitionOption">
                             <td translate="EVENTS.EVENTS.NEW.SOURCE.SCHEDULE_MULTIPLE.REPEAT_ON"><!-- Repeat On --></td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
@@ -39,8 +39,6 @@ angular.module('adminNg.resources')
 
             transformRequest: function (data) {
 
-                console.log(JSON.stringify(data));
-
                 if (angular.isUndefined(data)) {
                     return data = [];
                 }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -412,7 +412,7 @@ angular.module('adminNg.services')
                 var hour = self.ud[getType()].start.hour;
                 var minute = self.ud[getType()].start.minute;
                 if (angular.isDefined(hour) && angular.isDefined(minute)) {
-                    time = JsHelper.humanizeTime(hour, minute);
+                    time = moment().hour(hour).minute(minute).toISOString();
                 }
             }
 
@@ -426,7 +426,7 @@ angular.module('adminNg.services')
                 var hour = self.ud[getType()].end.hour;
                 var minute = self.ud[getType()].end.minute;
                 if (angular.isDefined(hour) && angular.isDefined(minute)) {
-                    time = JsHelper.humanizeTime(hour, minute);
+                    time = moment().hour(hour).minute(minute).toISOString();
                 }
             }
 
@@ -434,14 +434,17 @@ angular.module('adminNg.services')
         };
 
         this.getFormattedDuration = function () {
+
             var time;
 
             if (!self.isUpload()) {
-                var hour = self.ud[getType()].duration.hour;
-                var minute = self.ud[getType()].duration.minute;
-                if (angular.isDefined(hour) && angular.isDefined(minute)) {
-                    time = JsHelper.secondsToTime(((hour * 60) + minute) * 60);
-                }
+                var hours = self.ud[getType()].duration.hour;
+                var minutes = self.ud[getType()].duration.minute;
+
+                if (hours < 10)   { hours = '0' + hours; }
+                if (minutes < 10) { minutes = '0' + minutes; }
+
+                return hours + ':' + minutes;
             }
 
             return time;


### PR DESCRIPTION
Localize the start and end dates and times in the summary of the
add-event dialog when creating a scheduled event. Also don't show the
seconds for the duration since they can't be set, so are always 0.