### PR TITLE
MH-12965 Add more logging data to metadata parse WARN

### DIFF
--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
@@ -1000,7 +1000,7 @@ public class MetadataField<A> {
         if (jsonValue == null)
           return "";
         if (!(jsonValue instanceof String)) {
-          logger.warn("Value cannot be parsed as String.");
+          logger.warn("Value cannot be parsed as String. Expecting type 'String', but received type '{}'.", jsonValue.getClass().getName());
           return null;
         }
         return (String) jsonValue;


### PR DESCRIPTION
Related to Opencast user thread " 5.x: opening the event details will create a new asset version in the archive"

This log line is too sparse:
2018-06-20 22:21:23,453 | WARN  | (MetadataField$16:1003) - Value cannot be parsed as String.