### PR TITLE
MH-12966 Do not pre-select-from option in metadata property sheets

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
@@ -6,7 +6,7 @@
 
   <div class="editable-select" ng-show="editMode">
 
-    <select chosen pre-select-from="collection"
+    <select chosen
             ng-model="params.value"
             name="{{ params.name }}"
             ng-change="submit()"


### PR DESCRIPTION
Open the Event Details modal causes the creation of a new snapshop under specific circumstances: In case that exactly one option is available, the pre-select-from directive will automatically select this option (to avoid the user to have to select the only available option manually).
In the case of the metadata property sheets, this behaviour seems neither correct nor appropriate: It is incorrect as for non-mandatory fields, there actually are two options: No option and the single available option. Inappropriate because most metadata fields can be configured and you would not configure a select for a single value, would you? I