### PR TITLE
NOJIRA-live-schedule-fix-issue-in-documatation

### DIFF
--- a/docs/guides/admin/docs/modules/liveschedule.md
+++ b/docs/guides/admin/docs/modules/liveschedule.md
@@ -109,8 +109,8 @@ If:
 * live.targetFlavors=presenter/delivery
 * capture agent name: ca01
 
-Then, the capture agent should stream to ('/' is replaced by '_'):
-rtmp://STREAMING_SERVER_HOST:PORT/STREAMING_APPLICATION/ca01-presenter_delivery.stream
+Then, the capture agent should stream to ('/' is replaced by '-'):
+rtmp://STREAMING_SERVER_HOST:PORT/STREAMING_APPLICATION/ca01-presenter-delivery.stream
 
 Note: Please refer to your streaming server or CDN documentation for the correct syntax of the streaming url. The
 _live.streamingUrl_ may be very different from the url the capture agent streams to. For instance, with Akamai, the url


### PR DESCRIPTION
The documentation for configuring a live schedule contains a wrong pattern for naming the live stream.
The slash for the flavor (i.e. presenter/delivery) is substituted in the module by  '-' not '_' .