### PR TITLE
MH-12970, Senseless XACML parsing

### DIFF
--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -125,15 +125,13 @@ public class XACMLAuthorizationService implements AuthorizationService {
   }
 
   /** Returns an ACL based on a given file/inputstream. */
-  public Tuple<AccessControlList, AclScope> getAclFromInputStream(final InputStream in) {
+  public AccessControlList getAclFromInputStream(final InputStream in) throws IOException {
     logger.debug("Get ACL from inputstream");
-    return withContextClassLoader(new Function0<Tuple<AccessControlList, AclScope>>() {
-      @Override
-      public Tuple<AccessControlList, AclScope> apply() {
-        Option<AccessControlList> episode = loadAclFromFile(in);
-        return tuple(episode.get(), AclScope.Episode);
-      }
-    });
+    try {
+      return XACMLUtils.parseXacml(in);
+    } catch (XACMLParsingException e) {
+      throw new IOException(e);
+    }
   }
 
   private Tuple<AccessControlList, AclScope> getDefaultAcl(final MediaPackage mp) {
@@ -398,20 +396,6 @@ public class XACMLAuthorizationService implements AuthorizationService {
       logger.debug("URI {} not found", uri);
     } catch (Exception e) {
       logger.warn("Unable to load or parse Acl", e);
-    }
-    return Option.none();
-  }
-
-
-  /** Produces an ACL derived from a given security policy file. */
-  private Option<AccessControlList> loadAclFromFile(final InputStream in) {
-    try {
-      AccessControlList acl = XACMLUtils.parseXacml(in);
-      if (acl != null) {
-        return Option.option(acl);
-      }
-    } catch (Exception e) {
-      logger.error("Failed to produce Acl when reading file:", e);
     }
     return Option.none();
   }

--- a/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
@@ -26,6 +26,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.Tuple;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
@@ -84,13 +85,13 @@ public interface AuthorizationService {
   Tuple<AccessControlList, AclScope> getActiveAcl(MediaPackage mp);
 
   /**
-   * Gets the active permissions as specified by the given XACML attachment.
+   * Gets the active permissions as specified by the given XACML.
    *
    * @param in
    *          the XACML attachment used to determine a set of permissions and explicit denials
    * @return a set of permissions and explicit denials
    */
-  Tuple<AccessControlList, AclScope> getAclFromInputStream(InputStream in);
+  AccessControlList getAclFromInputStream(InputStream in) throws IOException;
 
   /**
    * Gets the permissions by its scope associated with this media package, as specified by its XACML attachment.

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -83,6 +83,7 @@ import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -897,7 +898,7 @@ public class LiveScheduleServiceImplTest {
     }
 
     @Override
-    public Tuple<AccessControlList, AclScope> getAclFromInputStream(InputStream in) {
+    public AccessControlList getAclFromInputStream(InputStream in) throws IOException {
       // TODO Auto-generated method stub
       return null;
     }


### PR DESCRIPTION
The method `getAclFromInputStream(…)` should parse an XACML file from a
given input stream and return the ACL object. The current implementation
internally parses the input stream, catching possible exceptions and
packing the result in an `Option` only to unpack it again right
afterwards which throws an exception in case the exception had been
caught before. Then the result is packed in a `Tuple` with a statically
set `AclScope` which, of course, is immediately unpacked again with the
scope just being discarded.

Finally, the one usage of this would break if there was any problem with
the ACL instead of handling this gracefully, falling back to a strict
non-permissive access rule.

This patch replaces all this mess with a straightforward implementation
of parsing the ACL from the given XACML input stream.

*Work sponsored by SWITCH*