### PR TITLE
MH-12972, Drop unused getAclAttachments

### DIFF
--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -229,11 +229,6 @@ public class XACMLAuthorizationService implements AuthorizationService {
   }
 
   @Override
-  public List<Attachment> getAclAttachments(MediaPackage mp, Option<AclScope> scope) {
-    return getAttachments(mp, toFlavors(scope.get()));
-  }
-
-  @Override
   public MediaPackage removeAcl(MediaPackage mp, AclScope scope) {
     return removeFromMediaPackageAndWorkspace(mp, toFlavors(scope)).getA();
   }

--- a/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
@@ -27,7 +27,6 @@ import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.Tuple;
 
 import java.io.InputStream;
-import java.util.List;
 
 
 /**
@@ -102,17 +101,6 @@ public interface AuthorizationService {
    * @return the set of permissions and explicit denials
    */
   Option<AccessControlList> getAcl(MediaPackage mp, AclScope scope);
-
-  /**
-   * Return access control attachments of a certain scope or all.
-   *
-   * @param mp
-   *          the media package
-   * @param scope
-   *          the scope or none to get all ACL attachments
-   * @return a list of attachments that fit the given criteria
-   */
-  List<Attachment> getAclAttachments(MediaPackage mp, Option<AclScope> scope);
 
   /**
    * Attaches the provided policies to a media package as a XACML attachment, replacing any previous policy element of

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -887,11 +887,6 @@ public class LiveScheduleServiceImplTest {
     }
 
     @Override
-    public List<Attachment> getAclAttachments(MediaPackage mp, Option<AclScope> scope) {
-      return null;
-    }
-
-    @Override
     public Option<AccessControlList> getAcl(MediaPackage mp, AclScope scope) {
       return null;
     }


### PR DESCRIPTION
Opencast comes with several methods to get an ACL from a given media
package which are mostly redundant. This patch removes one which is
completely unused.

*Work sponsored by SWITCH*