### PR TITLE
MH-12974, Access denial to event for unprivileged user

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -106,7 +106,6 @@ import org.opencastproject.scheduler.api.TechnicalMetadataImpl;
 import org.opencastproject.scheduler.api.Util;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlUtil;
-import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.Organization;
@@ -610,7 +609,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
       // Load dublincore and acl for update
       Opt<DublinCoreCatalog> dublinCore = DublinCoreUtil.loadEpisodeDublinCore(workspace, mediaPackage);
-      Option<AccessControlList> acl = authorizationService.getAcl(mediaPackage, AclScope.Episode);
+      AccessControlList acl = authorizationService.getActiveAcl(mediaPackage).getA();
 
       // Get updated agent properties
       Map<String, String> finalCaProperties = getFinalAgentProperties(caMetadata, wfProperties, captureAgentId,
@@ -619,14 +618,14 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       // Persist asset
       String checksum = calculateChecksum(workspace, getEventCatalogUIAdapterFlavors(), startDateTime, endDateTime,
                                           captureAgentId, userIds, mediaPackage, dublinCore, wfProperties, finalCaProperties, optOut,
-                                          acl.toOpt().getOr(new AccessControlList()));
+                                          acl);
       persistEvent(mediaPackageId, modificationOrigin, checksum, Opt.some(startDateTime), Opt.some(endDateTime),
               Opt.some(captureAgentId), Opt.some(userIds), Opt.some(mediaPackage), Opt.some(wfProperties),
               Opt.some(finalCaProperties), Opt.some(optOut), schedulingSource, trxId);
 
       if (trxId.isNone()) {
         // Send updates
-        sendUpdateAddEvent(mediaPackageId, acl.toOpt(), dublinCore, Opt.some(startDateTime),
+        sendUpdateAddEvent(mediaPackageId, some(acl), dublinCore, Opt.some(startDateTime),
                 Opt.some(endDateTime), Opt.some(userIds), Opt.some(captureAgentId), Opt.some(finalCaProperties),
                 Opt.some(optOut));
 
@@ -763,7 +762,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         Date endDateTime = cal.getTime();
         // Load dublincore and acl for update
         Opt<DublinCoreCatalog> dublinCore = DublinCoreUtil.loadEpisodeDublinCore(workspace, mediaPackage);
-        Option<AccessControlList> acl = authorizationService.getAcl(mediaPackage, AclScope.Episode);
+        AccessControlList acl = authorizationService.getActiveAcl(mediaPackage).getA();
 
         // Get updated agent properties
         Map<String, String> finalCaProperties = getFinalAgentProperties(caMetadata, wfProperties, captureAgentId,
@@ -771,13 +770,13 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
         // Persist asset
         String checksum = calculateChecksum(workspace, getEventCatalogUIAdapterFlavors(), startDateTime, endDateTime,
-                captureAgentId, userIds, mediaPackage, dublinCore, wfProperties, finalCaProperties, optOut, acl.toOpt().getOr(new AccessControlList()));
+                captureAgentId, userIds, mediaPackage, dublinCore, wfProperties, finalCaProperties, optOut, acl);
         persistEvent(mediaPackageId, modificationOrigin, checksum, Opt.some(startDateTime), Opt.some(endDateTime), Opt.some(captureAgentId), Opt.some(userIds), Opt.some(mediaPackage), Opt.some(wfProperties),
                 Opt.some(finalCaProperties), Opt.some(optOut), schedulingSource, trxId);
 
         if (trxId.isNone()) {
           // Send updates
-          sendUpdateAddEvent(mediaPackageId, acl.toOpt(), dublinCore, Opt.some(startDateTime), Opt.some(endDateTime),
+          sendUpdateAddEvent(mediaPackageId, some(acl), dublinCore, Opt.some(startDateTime), Opt.some(endDateTime),
                   Opt.some(userIds), Opt.some(captureAgentId), Opt.some(finalCaProperties), Opt.some(optOut));
 
           // Update last modified
@@ -934,11 +933,9 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         }
 
         // Check for ACL change and send update
-        Option<AccessControlList> aclNew = authorizationService.getAcl(mpToUpdate, AclScope.Episode);
-        if (aclNew.isSome()) {
-          if (aclOld.isNone() || !AccessControlUtil.equals(aclNew.get(), aclOld.get())) {
-            acl = aclNew.toOpt();
-          }
+        AccessControlList aclNew = authorizationService.getActiveAcl(mpToUpdate).getA();
+        if (aclOld.isNone() || !AccessControlUtil.equals(aclNew, aclOld.get())) {
+          acl = some(aclNew);
         }
 
         // Check for dublin core change and send update
@@ -960,7 +957,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
               endDateTime.getOr(end), captureAgentId.getOr(agentId), userIds.getOr(presenters),
               mediaPackage.getOr(record.getSnapshot().get().getMediaPackage()),
               some(dublinCore.getOr(dublinCoreOpt.get())), wfProperties.getOr(wfProps),
-              finalCaProperties.getOr(caProperties), optOut.getOr(oldOptOut), acl.getOr(aclOld.getOr(new AccessControlList())));
+              finalCaProperties.getOr(caProperties), optOut.getOr(oldOptOut), acl.getOr(new AccessControlList()));
 
       if (trxId.isNone()) {
         String oldChecksum = record.getProperties().apply(Properties.getString(CHECKSUM));

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -295,8 +295,9 @@ public class SchedulerServiceImplTest {
     acl = new AccessControlList(new AccessControlEntry("ROLE_ADMIN", "write", true),
             new AccessControlEntry("ROLE_ADMIN", "read", true), new AccessControlEntry("ROLE_USER", "read", true));
     EasyMock.expect(
-            authorizationService.getAcl(EasyMock.anyObject(MediaPackage.class), EasyMock.anyObject(AclScope.class)))
-            .andReturn(Option.some(acl)).anyTimes();
+            authorizationService.getActiveAcl(EasyMock.anyObject(MediaPackage.class)))
+            .andReturn(tuple(acl, AclScope.Episode)).anyTimes();
+
 
     orgDirectoryService = EasyMock.createNiceMock(OrganizationDirectoryService.class);
     EasyMock.expect(orgDirectoryService.getOrganizations())


### PR DESCRIPTION
Due to the incorrect usage of ``getAcl()``, unprivileged users may not
have access to events despite the ACL explicitly allowing them access.
Instead, `getActiveAcl()` should be used to evaluate the correct access
permissions for a given event.

Note that there are further, less critical issues with `getAcl()` as
mentioned on list [1] which will be dealt with separately with a patch
against `r/6.x`.

[1] https://groups.google.com/a/opencast.org/forum/#!topic/dev/CqGR1K3LNXE

*Work sponsored by SWITCH*