### PR TITLE
MH-12975, Inconsistent access control handling

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
@@ -23,7 +23,6 @@ package org.opencastproject.security.api;
 
 import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.Tuple;
 
 import java.io.IOException;
@@ -56,30 +55,23 @@ public interface AuthorizationService {
   boolean hasPermission(MediaPackage mp, String action);
 
   /**
-   * Gets the active permissions associated with this media package, as specified by its XACML attachment. The following
-   * rules are used to determine the access control in descending order:
+   * Gets the active access control list associated with the given media package, as specified by its XACML
+   * attachments. XACML attachments are evaluated in the following order:
+   *
    * <ol>
-   * <li>If exactly zero {@link org.opencastproject.mediapackage.MediaPackageElements#XACML_POLICY_EPISODE} and
-   * {@link org.opencastproject.mediapackage.MediaPackageElements#XACML_POLICY_SERIES} attachments are present, the
-   * returned ACL will be empty.</li>
-   * <li>If exactly one {@link org.opencastproject.mediapackage.MediaPackageElements#XACML_POLICY_EPISODE} is attached
-   * to the media package, this is the source of authority</li>
-   * <li>If exactly one {@link org.opencastproject.mediapackage.MediaPackageElements#XACML_POLICY_SERIES} is attached to
-   * the media package, this is the source of authority</li>
-   * <li>If more than one XACML attachments are present, and one of them has no reference (
-   * {@link org.opencastproject.mediapackage.MediaPackageElement#getReference()} returns null), that attachment is
-   * presumed to be the source of authority. Episode XACMLs are considered before series XACMLs.</li>
-   * <li>If more than one XACML attachments are present, and more than one of them has no reference (
-   * {@link org.opencastproject.mediapackage.MediaPackageElement#getReference()} returns null), the returned ACL will be
-   * empty. Episode XACMLs are considered before series XACMLs.</li>
-   * <li>If more than one XACML attachments are present, and all of them have references (
-   * {@link org.opencastproject.mediapackage.MediaPackageElement#getReference()} returns a non-null reference), the
-   * returned ACL will be empty. Episode XACMLs are considered before series XACMLs.</li>
+   *   <li>Use episode XACML attachment if present</li>
+   *   <li>Use series XACML attachment if present</li>
+   *   <li>Use non-specific XACML attachment if present. Note that the usage of this is deprecated!</li>
+   *   <li>Use the global default ACL</li>
    * </ol>
+   *
+   * Note that this is identical to calling {@link #getAcl(MediaPackage, AclScope)} with scope set to
+   * {@link AclScope#Series}.
    *
    * @param mp
    *          the media package
-   * @return the set of permissions and explicit denials
+   * @return the active access control list as well as the scope identifying the source of the access rules (episode,
+   *          series, …).
    */
   Tuple<AccessControlList, AclScope> getActiveAcl(MediaPackage mp);
 
@@ -93,15 +85,25 @@ public interface AuthorizationService {
   AccessControlList getAclFromInputStream(InputStream in) throws IOException;
 
   /**
-   * Gets the permissions by its scope associated with this media package, as specified by its XACML attachment.
+   * Gets the access control list for a given scope associated with the given media package, as specified by its XACML
+   * attachments. XACML attachments are evaluated in the following order:
+   *
+   * <ol>
+   *   <li>Use episode XACML attachment if present. This applies only if scope is set to {@link AclScope#Episode}</li>
+   *   <li>Use series XACML attachment if present. This applies only if scope is set to {@link AclScope#Episode} or
+   *      {@link AclScope#Series}</li>
+   *   <li>Use non-specific XACML attachment if present. Note that the usage of this is deprecated!</li>
+   *   <li>Use the global default ACL</li>
+   * </ol>
    *
    * @param mp
    *          the media package
    * @param scope
    *          the acl scope
-   * @return the set of permissions and explicit denials
+   * @return the access control list as well as the scope identifying the source of the access rules (episode,
+   *          series, …) for the given media package and scope.
    */
-  Option<AccessControlList> getAcl(MediaPackage mp, AclScope scope);
+  Tuple<AccessControlList, AclScope> getAcl(MediaPackage mp, AclScope scope);
 
   /**
    * Attaches the provided policies to a media package as a XACML attachment, replacing any previous policy element of

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -68,7 +68,6 @@ import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.DateTimeSupport;
 import org.opencastproject.util.MimeType;
 import org.opencastproject.util.MimeTypes;
-import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.Tuple;
 import org.opencastproject.workspace.api.Workspace;
 
@@ -888,7 +887,7 @@ public class LiveScheduleServiceImplTest {
     }
 
     @Override
-    public Option<AccessControlList> getAcl(MediaPackage mp, AclScope scope) {
+    public Tuple<AccessControlList, AclScope> getAcl(MediaPackage mp, AclScope scope) {
       return null;
     }
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -106,7 +106,6 @@ import org.opencastproject.scheduler.api.TechnicalMetadataImpl;
 import org.opencastproject.scheduler.api.Util;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlUtil;
-import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.Organization;
@@ -610,7 +609,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
       // Load dublincore and acl for update
       Opt<DublinCoreCatalog> dublinCore = DublinCoreUtil.loadEpisodeDublinCore(workspace, mediaPackage);
-      Option<AccessControlList> acl = authorizationService.getAcl(mediaPackage, AclScope.Episode);
+      AccessControlList acl = authorizationService.getActiveAcl(mediaPackage).getA();
 
       // Get updated agent properties
       Map<String, String> finalCaProperties = getFinalAgentProperties(caMetadata, wfProperties, captureAgentId,
@@ -619,14 +618,14 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       // Persist asset
       String checksum = calculateChecksum(workspace, getEventCatalogUIAdapterFlavors(), startDateTime, endDateTime,
                                           captureAgentId, userIds, mediaPackage, dublinCore, wfProperties, finalCaProperties, optOut,
-                                          acl.toOpt().getOr(new AccessControlList()));
+                                          acl);
       persistEvent(mediaPackageId, modificationOrigin, checksum, Opt.some(startDateTime), Opt.some(endDateTime),
               Opt.some(captureAgentId), Opt.some(userIds), Opt.some(mediaPackage), Opt.some(wfProperties),
               Opt.some(finalCaProperties), Opt.some(optOut), schedulingSource, trxId);
 
       if (trxId.isNone()) {
         // Send updates
-        sendUpdateAddEvent(mediaPackageId, acl.toOpt(), dublinCore, Opt.some(startDateTime),
+        sendUpdateAddEvent(mediaPackageId, some(acl), dublinCore, Opt.some(startDateTime),
                 Opt.some(endDateTime), Opt.some(userIds), Opt.some(captureAgentId), Opt.some(finalCaProperties),
                 Opt.some(optOut));
 
@@ -763,7 +762,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         Date endDateTime = cal.getTime();
         // Load dublincore and acl for update
         Opt<DublinCoreCatalog> dublinCore = DublinCoreUtil.loadEpisodeDublinCore(workspace, mediaPackage);
-        Option<AccessControlList> acl = authorizationService.getAcl(mediaPackage, AclScope.Episode);
+        AccessControlList acl = authorizationService.getActiveAcl(mediaPackage).getA();
 
         // Get updated agent properties
         Map<String, String> finalCaProperties = getFinalAgentProperties(caMetadata, wfProperties, captureAgentId,
@@ -771,13 +770,13 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
         // Persist asset
         String checksum = calculateChecksum(workspace, getEventCatalogUIAdapterFlavors(), startDateTime, endDateTime,
-                captureAgentId, userIds, mediaPackage, dublinCore, wfProperties, finalCaProperties, optOut, acl.toOpt().getOr(new AccessControlList()));
+                captureAgentId, userIds, mediaPackage, dublinCore, wfProperties, finalCaProperties, optOut, acl);
         persistEvent(mediaPackageId, modificationOrigin, checksum, Opt.some(startDateTime), Opt.some(endDateTime), Opt.some(captureAgentId), Opt.some(userIds), Opt.some(mediaPackage), Opt.some(wfProperties),
                 Opt.some(finalCaProperties), Opt.some(optOut), schedulingSource, trxId);
 
         if (trxId.isNone()) {
           // Send updates
-          sendUpdateAddEvent(mediaPackageId, acl.toOpt(), dublinCore, Opt.some(startDateTime), Opt.some(endDateTime),
+          sendUpdateAddEvent(mediaPackageId, some(acl), dublinCore, Opt.some(startDateTime), Opt.some(endDateTime),
                   Opt.some(userIds), Opt.some(captureAgentId), Opt.some(finalCaProperties), Opt.some(optOut));
 
           // Update last modified
@@ -934,11 +933,9 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         }
 
         // Check for ACL change and send update
-        Option<AccessControlList> aclNew = authorizationService.getAcl(mpToUpdate, AclScope.Episode);
-        if (aclNew.isSome()) {
-          if (aclOld.isNone() || !AccessControlUtil.equals(aclNew.get(), aclOld.get())) {
-            acl = aclNew.toOpt();
-          }
+        AccessControlList aclNew = authorizationService.getActiveAcl(mpToUpdate).getA();
+        if (aclOld.isNone() || !AccessControlUtil.equals(aclNew, aclOld.get())) {
+          acl = some(aclNew);
         }
 
         // Check for dublin core change and send update
@@ -960,7 +957,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
               endDateTime.getOr(end), captureAgentId.getOr(agentId), userIds.getOr(presenters),
               mediaPackage.getOr(record.getSnapshot().get().getMediaPackage()),
               some(dublinCore.getOr(dublinCoreOpt.get())), wfProperties.getOr(wfProps),
-              finalCaProperties.getOr(caProperties), optOut.getOr(oldOptOut), acl.getOr(aclOld.getOr(new AccessControlList())));
+              finalCaProperties.getOr(caProperties), optOut.getOr(oldOptOut), acl.getOr(new AccessControlList()));
 
       if (trxId.isNone()) {
         String oldChecksum = record.getProperties().apply(Properties.getString(CHECKSUM));

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -295,8 +295,9 @@ public class SchedulerServiceImplTest {
     acl = new AccessControlList(new AccessControlEntry("ROLE_ADMIN", "write", true),
             new AccessControlEntry("ROLE_ADMIN", "read", true), new AccessControlEntry("ROLE_USER", "read", true));
     EasyMock.expect(
-            authorizationService.getAcl(EasyMock.anyObject(MediaPackage.class), EasyMock.anyObject(AclScope.class)))
-            .andReturn(Option.some(acl)).anyTimes();
+            authorizationService.getActiveAcl(EasyMock.anyObject(MediaPackage.class)))
+            .andReturn(tuple(acl, AclScope.Episode)).anyTimes();
+
 
     orgDirectoryService = EasyMock.createNiceMock(OrganizationDirectoryService.class);
     EasyMock.expect(orgDirectoryService.getOrganizations())

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -71,7 +71,7 @@ import org.opencastproject.serviceregistry.api.UndispatchableJobException;
 import org.opencastproject.util.Log;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Effect0;
-import org.opencastproject.util.data.Option;
+import org.opencastproject.util.data.Tuple;
 import org.opencastproject.util.jmx.JmxUtil;
 import org.opencastproject.workflow.api.ResumableWorkflowOperationHandler;
 import org.opencastproject.workflow.api.RetryStrategy;
@@ -1324,8 +1324,9 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           // mediapackage
 
           AccessControlList acl = seriesService.getSeriesAccessControl(seriesId);
-          Option<AccessControlList> activeSeriesAcl = authorizationService.getAcl(updatedMediaPackage, AclScope.Series);
-          if (activeSeriesAcl.isNone() || !AccessControlUtil.equals(activeSeriesAcl.get(), acl))
+          Tuple<AccessControlList, AclScope> activeSeriesAcl = authorizationService.getAcl(updatedMediaPackage,
+                  AclScope.Series);
+          if (!AclScope.Series.equals(activeSeriesAcl.getB()) || !AccessControlUtil.equals(activeSeriesAcl.getA(), acl))
             authorizationService.setAcl(updatedMediaPackage, AclScope.Series, acl);
         }
       } catch (SeriesException e) {


### PR DESCRIPTION
Opencast's authorization service has two different methods of evaluating
XACML (access control) attachments with should work similarly but do
work differently resulting in an unwanted denial of access in some cases.

In the end, both paths should work the same way and could even share most
of the code making the whole process less confusing and easier to
understand.

*This contains and extends pull request #318 and addresses [this post on list](https://groups.google.com/a/opencast.org/forum/#!topic/dev/CqGR1K3LNXE)*

*Work sponsored by SWITCH*
