### PR TITLE
MH-12979, Automatically test ddl scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,8 @@ jobs:
     # - Ensure no tabs are used
     # - Ensure there are no trailing spaces
     # - Run markdownlint
-    - stage: test documentation
+    - stage: quick tests
+      env: name=documentation
       sudo: false
       language: python
       python: "3.6"
@@ -74,6 +75,28 @@ jobs:
         - (cd docs/guides/developer && mkdocs build)
         - (cd docs/guides/user && mkdocs build)
         - (cd docs/guides && grunt)
+
+    # Test database scripts with MariaDB
+    - stage: quick tests
+      env: name=mariadb
+      sudo: false
+      addons:
+        mariadb: '10.3'
+      install:
+        - echo 'create database opencast;' | mysql -u root
+      script:
+        - mysql -u root opencast < docs/scripts/ddl/mysql5.sql
+
+    # Test database scripts with MySQL
+    - stage: quick tests
+      env: name=mysql
+      sudo: false
+      services:
+        - mysql
+      install:
+        - echo 'create database opencast;' | mysql -u root
+      script:
+        - mysql -u root opencast < docs/scripts/ddl/mysql5.sql
 
     # Make a build excluding the assembly steps
     - stage: build


### PR DESCRIPTION
Make Travis CI automatically test the DDL scripts to ensure they work
with both MariaDB and MySQL and continue to do so.

Note that for now, this does not test the upgrade scripts.