### PR TITLE
[MH-12930] Fill creator metadata field with actual user when new event

### DIFF
--- a/etc/index/adminui/event-mapping.json
+++ b/etc/index/adminui/event-mapping.json
@@ -51,6 +51,8 @@
 
             "creator": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
+            "publisher": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
+
             "license": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
             "rights": { "type" : "string", "index" : "not_analyzed", "store" : "no" },

--- a/etc/index/externalapi/event-mapping.json
+++ b/etc/index/externalapi/event-mapping.json
@@ -51,6 +51,8 @@
 
             "creator": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
+            "publisher": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
+
             "license": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
             "rights": { "type" : "string", "index" : "not_analyzed", "store" : "no" },

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -31,7 +31,7 @@ property.uid.label=EVENTS.EVENTS.DETAILS.METADATA.ID
 property.uid.type=text
 property.uid.readOnly=true
 property.uid.required=false
-property.uid.order=16
+property.uid.order=17
 
 # Presenters
 property.presenters.inputID=creator
@@ -144,3 +144,22 @@ property.license.readOnly=false
 property.license.required=false
 property.license.listprovider=LICENSES
 property.license.order=5
+
+# Publisher
+# By default, the publisher is the logged in user in the creation event
+# and it is read only.
+# You can set up a list provider, changing the properties:
+#   property.publisher.readOnly=false
+#   property.publisher.listprovider=YOUR_LIST_PROVIDER
+# If you want to use the events publishers as list provider, you must
+# set up the provider in this way:
+#   property.publisher.listprovider=EVENTS.PUBLISHER
+# If you use a list provider, the property will have the users of the list plus
+# the logged in user in the event creation wizard and the users of the list
+# in the edit properties.
+property.publisher.inputID=publisher
+property.publisher.label=EVENTS.EVENTS.DETAILS.METADATA.PUBLISHER
+property.publisher.type=text
+property.publisher.readOnly=true
+property.publisher.required=true
+property.publisher.order=16

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/index/AdminUISearchIndex.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/index/AdminUISearchIndex.java
@@ -154,4 +154,14 @@ public class AdminUISearchIndex extends AbstractSearchIndex implements EventInde
     return getTermsForField(ThemeIndexSchema.NAME, Option.some(new String[] { Theme.DOCUMENT_TYPE }));
   }
 
+  /**
+   * Returns all the known events' publishers
+   *
+   * @return a list of events' publishers
+   */
+  @Override
+  public List<String> getEventPublishers() {
+    return getTermsForField(EventIndexSchema.PUBLISHER, Option.some(new String[] { Event.DOCUMENT_TYPE }));
+  }
+
 }

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -833,6 +833,7 @@
            "SOURCE":         "Source",
            "CREATED":        "Created",
            "CREATED_BY":     "Created by",
+           "PUBLISHER":      "Publisher",
            "LICENSE":        "License",
            "CONTRIBUTORS":   "Contributor(s)",
            "RIGHTS":         "Rights",
@@ -1862,6 +1863,9 @@
        },
        "CREATOR": {
          "LABEL": "Creator"
+       },
+       "PUBLISHER": {
+         "LABEL": "Publisher"
        },
        "HOSTNAME": {
          "LABEL": "Host name"

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/EventIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/EventIndex.java
@@ -67,4 +67,11 @@ public interface EventIndex {
    */
   List<String> getThemeNames();
 
+  /**
+   * Returns all the known events publishers' usernames
+   *
+   * @return a list of events publishers' usernames
+   */
+  List<String> getEventPublishers();
+
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
@@ -67,7 +67,7 @@ import javax.xml.transform.stream.StreamSource;
  */
 @XmlType(name = "event", namespace = IndexObject.INDEX_XML_NAMESPACE, propOrder = { "identifier", "organization",
         "title", "description", "subject", "location", "presenters", "contributors", "seriesId", "seriesName",
-        "language", "source", "created", "creator", "license", "rights", "accessPolicy", "managedAcl", "workflowState",
+        "language", "source", "created", "creator", "publisher", "license", "rights", "accessPolicy", "managedAcl", "workflowState",
         "workflowId", "workflowDefinitionId", "recordingStartTime", "recordingEndTime", "duration", "trackMimetypes",
         "trackStreamResolutions", "trackFlavors", "metadataFlavors", "metadataMimetypes", "attachmentFlavors",
         "reviewStatus", "reviewDate", "optedOut", "blacklisted", "hasComments", "hasOpenComments", "hasPreview", "needsCutting",
@@ -170,6 +170,10 @@ public class Event implements IndexObject {
   /** The creator of the event */
   @XmlElement(name = "creator")
   private String creator = null;
+
+  /** The publisher of the event */
+  @XmlElement(name = "publisher")
+  private String publisher = null;
 
   /** The license of the event */
   @XmlElement(name = "license")
@@ -548,6 +552,25 @@ public class Event implements IndexObject {
    */
   public String getCreator() {
     return creator;
+  }
+
+  /**
+   * Sets the publisher
+   *
+   * @param publisher
+   *          the publisher
+   */
+  public void setPublisher(String publisher) {
+    this.publisher = publisher;
+  }
+
+  /**
+   * Returns the publisher
+   *
+   * @return the publisher
+   */
+  public String getPublisher() {
+    return publisher;
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexSchema.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexSchema.java
@@ -129,6 +129,9 @@ public interface EventIndexSchema extends IndexSchema {
   /** The creator */
   String CREATOR = "creator";
 
+  /** The publisher */
+  String PUBLISHER = "publisher";
+
   /** The license */
   String LICENSE = "license";
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -130,6 +130,8 @@ public final class EventIndexUtils {
       metadata.addField(EventIndexSchema.CREATED, event.getCreated(), true);
     if (StringUtils.isNotBlank(event.getCreator()))
       metadata.addField(EventIndexSchema.CREATOR, event.getCreator(), true);
+    if (StringUtils.isNotBlank(event.getPublisher()))
+      metadata.addField(EventIndexSchema.PUBLISHER, event.getPublisher(), true);
     if (StringUtils.isNotBlank(event.getLicense()))
       metadata.addField(EventIndexSchema.LICENSE, event.getLicense(), true);
     if (StringUtils.isNotBlank(event.getRights()))
@@ -446,6 +448,7 @@ public final class EventIndexUtils {
     event.setSeriesId(dc.getFirst(DublinCore.PROPERTY_IS_PART_OF));
     event.setLicense(dc.getFirst(DublinCore.PROPERTY_LICENSE));
     event.setRights(dc.getFirst(DublinCore.PROPERTY_RIGHTS_HOLDER));
+    event.setPublisher(dc.getFirst(DublinCore.PROPERTY_PUBLISHER));
     Date created;
     String encodedDate = dc.getFirst(DublinCore.PROPERTY_CREATED);
     if (StringUtils.isBlank(encodedDate)) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventQueryBuilder.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventQueryBuilder.java
@@ -142,6 +142,11 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
       and(EventIndexSchema.CREATOR, query.getCreator(), true);
     }
 
+    // Publisher
+    if (query.getPublisher() != null) {
+      and(EventIndexSchema.PUBLISHER, query.getPublisher(), true);
+    }
+
     // License
     if (query.getLicense() != null) {
       and(EventIndexSchema.LICENSE, query.getLicense(), true);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventSearchQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventSearchQuery.java
@@ -59,6 +59,7 @@ public class EventSearchQuery extends AbstractSearchQuery {
   private Date technicalStartFrom = null;
   private Date technicalStartTo = null;
   private String creator = null;
+  private String publisher = null;
   private String license = null;
   private String rights = null;
   private final List<String> trackMimetypes = new ArrayList<String>();
@@ -533,6 +534,28 @@ public class EventSearchQuery extends AbstractSearchQuery {
    */
   public String getCreator() {
     return creator;
+  }
+
+  /**
+   * Selects recordings with the given publisher.
+   *
+   * @param publisher
+   *          the publisher
+   * @return the enhanced search query
+   */
+  public EventSearchQuery withPublisher(String publisher) {
+    clearExpectations();
+    this.publisher = publisher;
+    return this;
+  }
+
+  /**
+   * Returns the publisher of the recording.
+   *
+   * @return the publisher
+   */
+  public String getPublisher() {
+    return publisher;
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
@@ -202,6 +202,14 @@ public final class EventUtils {
       metadata.addField(newUID);
     }
 
+    if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_PUBLISHER.getLocalName())) {
+      MetadataField<?> publisher = metadata.getOutputFields().get(DublinCore.PROPERTY_PUBLISHER.getLocalName());
+      metadata.removeField(publisher);
+      MetadataField<String> newPublisher = MetadataUtils.copyMetadataField(publisher);
+      newPublisher.setValue(event.getPublisher());
+      metadata.addField(newPublisher);
+    }
+
     return metadata;
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
@@ -128,6 +128,8 @@ public class ContributorsListProvider implements ResourceListProvider {
             Option.some(new String[] { Event.DOCUMENT_TYPE })));
     contributorsList.addAll(searchIndex.getTermsForField(EventIndexSchema.PRESENTER,
             Option.some(new String[] { Event.DOCUMENT_TYPE })));
+    contributorsList.addAll(searchIndex.getTermsForField(EventIndexSchema.PUBLISHER,
+            Option.some(new String[] { Event.DOCUMENT_TYPE })));
     contributorsList.addAll(searchIndex.getTermsForField(SeriesIndexSchema.CONTRIBUTORS,
             Option.some(new String[] { Series.DOCUMENT_TYPE })));
     contributorsList.addAll(searchIndex.getTermsForField(SeriesIndexSchema.ORGANIZERS,

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
@@ -50,13 +50,14 @@ public class EventsListProvider implements ResourceListProvider {
   public static final String STATUS = PROVIDER_PREFIX + ".STATUS";
   public static final String REVIEW_STATUS = PROVIDER_PREFIX + ".REVIEW_STATUS";
   public static final String COMMENTS = PROVIDER_PREFIX + ".COMMENTS";
+  public static final String PUBLISHER = PROVIDER_PREFIX + ".PUBLISHER";
 
   public enum Comments {
     NONE, OPEN, RESOLVED;
   }
 
   private static final String[] NAMES = { PROVIDER_PREFIX, CONTRIBUTORS, PRESENTERS_BIBLIOGRAPHIC, PRESENTERS_TECHNICAL,
-          SUBJECT, LOCATION, PROGRESS, STATUS, REVIEW_STATUS, COMMENTS };
+          SUBJECT, LOCATION, PROGRESS, STATUS, REVIEW_STATUS, COMMENTS, PUBLISHER };
 
   private static final Logger logger = LoggerFactory.getLogger(EventsListProvider.class);
 
@@ -118,6 +119,9 @@ public class EventsListProvider implements ResourceListProvider {
     } else if (COMMENTS.equals(listName)) {
       for (Comments comments : Comments.values())
         list.put(comments.toString(), "FILTERS.EVENTS.COMMENTS." + comments.toString());
+    } else if (PUBLISHER.equals(listName)) {
+      for (String publisher : index.getEventPublishers())
+        list.put(publisher, publisher);
     }
 
     return list;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
@@ -88,6 +88,9 @@ public class EventListQuery extends ResourceListQueryImpl {
   public static final String FILTER_REVIEW_STATUS_NAME = "reviewStatus";
   private static final String FILTER_REVIEW_STATUS_LABEL = "FILTERS.EVENTS.REVIEW_STATUS.LABEL";
 
+  public static final String FILTER_PUBLISHER_NAME = "publisher";
+  private static final String FILTER_PUBLISHER_LABEL = "FILTERS.EVENTS.PUBLISHER.LABEL";
+
   public static final String FILTER_TEXT_NAME = "textFilter";
 
   public EventListQuery() {
@@ -101,6 +104,7 @@ public class EventListQuery extends ResourceListQueryImpl {
     this.availableFilters.add(createStartDateFilter(Option.<Tuple<Date, Date>> none()));
     this.availableFilters.add(createStatusFilter(Option.<String> none()));
     this.availableFilters.add(createCommentsFilter(Option.<String> none()));
+    this.availableFilters.add(createPublisherFilter(Option.<String> none()));
 //    this.availableFilters.add(createOptedoutFilter(Option.<Boolean> none()));
 //    this.availableFilters.add(createReviewStatusFilter(Option.<String> none()));
   }
@@ -334,6 +338,25 @@ public class EventListQuery extends ResourceListQueryImpl {
   }
 
   /**
+   * Add a {@link ResourceListFilter} filter to the query with the given publishers
+   *
+   * @param publishers
+   *          the publishers to filter for
+   */
+  public void withPublishers(String publishers) {
+    this.addFilter(createPublisherFilter(Option.option(publishers)));
+  }
+
+  /**
+   * Returns an {@link Option} containing the publisher used to filter if set
+   *
+   * @return an {@link Option} containing the publisher or none.
+   */
+  public Option<String> getPublisher() {
+    return this.getFilterValue(FILTER_PUBLISHER_NAME);
+  }
+
+  /**
    * Create a new {@link ResourceListFilter} based on the Series id
    *
    * @param seriesId
@@ -451,6 +474,18 @@ public class EventListQuery extends ResourceListQueryImpl {
   public static ResourceListFilter<String> createCommentsFilter(Option<String> comments) {
     return FiltersUtils.generateFilter(comments, FILTER_COMMENTS_NAME, FILTER_COMMENTS_LABEL, SourceType.SELECT,
             Option.some(EventsListProvider.COMMENTS));
+  }
+
+  /**
+   * Create a new {@link ResourceListFilter} based on publishers
+   *
+   * @param publisher
+   *          the publisher to filter on wrapped in an {@link Option} or {@link Option#none()}
+   * @return a new {@link ResourceListFilter} for progress based query
+   */
+  public static ResourceListFilter<String> createPublisherFilter(Option<String> publisher) {
+    return FiltersUtils.generateFilter(publisher, FILTER_PUBLISHER_NAME, FILTER_PUBLISHER_LABEL, SourceType.SELECT,
+            Option.some(EventsListProvider.PUBLISHER));
   }
 
   /**


### PR DESCRIPTION
When I create a new event, I would like to save the user, who has created it.
- This user must be the one, who is logged in, in the new event wizard.
- And the user who has created the event in the details window.
- The publisher dublincore metadata is used.
- The field is persistent.