### PR TITLE
MH-12803 Fix for mp 'start' when event is created (affects live scheduler service)

### DIFF
--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -517,6 +517,8 @@ public class IndexServiceImplTest {
     EasyMock.expect(mediapackage.getSeries()).andReturn(null).anyTimes();
     mediapackage.setSeries(EasyMock.anyString());
     EasyMock.expectLastCall();
+    mediapackage.setDate(EasyMock.anyObject(Date.class));
+    EasyMock.expectLastCall();
     EasyMock.replay(mediapackage);
 
     IngestService ingestService = setupIngestService(mediapackage, Capture.<InputStream> newInstance());
@@ -656,6 +658,8 @@ public class IndexServiceImplTest {
     EasyMock.expectLastCall().anyTimes();
     mediapackage.setSeries(EasyMock.anyString());
     mediapackage.setSeriesTitle(EasyMock.anyString());
+    EasyMock.expectLastCall();
+    mediapackage.setDate(EasyMock.anyObject(Date.class));
     EasyMock.expectLastCall();
     EasyMock.replay(mediapackage);
 

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -454,11 +454,12 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       }
 
       // Capture agent did not pass any CA_PROPERTY_RESOLUTION_URL_PREFIX property when registering
-      // so use the service configuration, including stream overrides (temporary)
-      if (liveStreamingUrl == null)
-        throw new LiveScheduleException(
-                "Cannot build live tracks because '" + LIVE_STREAMING_URL + "' configuration was not set.");
+      // so use the service configuration
       if (mp.getTracks().length == 0) {
+        if (liveStreamingUrl == null)
+          throw new LiveScheduleException(
+                  "Cannot build live tracks because '" + LIVE_STREAMING_URL + "' configuration was not set.");
+
         for (MediaPackageElementFlavor flavor : liveFlavors) {
           for (int i = 0; i < streamResolution.length; i++) {
             String uri = replaceVariables(mpId, caName, UrlSupport.concat(liveStreamingUrl.toString(), streamName),


### PR DESCRIPTION
Problem:
The media package was created with 'start' set to date/time the event was created.
According to MH-12250, media package 'created' and 'start' should match and come from the temporal dc property.
The 'createEvent' method was checking for a PROPERTY_TEMPORAL in the metadata, but the 'temporal' at that point was stored with output id 'startDate' and had no value so it was never found.
After the capture agent ingested, 'start' was correctly set to the same value as temporal so everything else worked fine.
Solution:
The change was to get the 'temporal' from the 'source' metadata if it (as 'startDate') doesn't come in the 'event' metadata and set the 'created' and 'start' to the same value, complying to MH-12250.
