### PR TITLE
MH-12982, 3.0 database upgrade error

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -29,7 +29,8 @@ Opencast 3.0 includes the following database changes:
 It should be needless to say that this migration should not take a lot of time and should be safe. Nevertheless, as with
 all database migrations, we recommend to make a database backup before attempting the upgrade.
 
-You can find the database upgrade script at `…/docs/upgrade/2.3_to_3.0/`.
+You can find the database upgrade script [in the Opencast repository
+](https://github.com/opencast/opencast/tree/r/3.x/docs/upgrade/2.3_to_3.0).
 
 Recreate Admin UI Search Index
 ------------------------------

--- a/docs/upgrade/2.3_to_3.0/mysql5.sql
+++ b/docs/upgrade/2.3_to_3.0/mysql5.sql
@@ -24,7 +24,7 @@ FOR EACH ROW SET NEW.modification_date = NOW();
 CREATE TRIGGER mh_update_oaipmh_date BEFORE UPDATE ON `mh_oaipmh`
 FOR EACH ROW SET NEW.modification_date = NOW();
 
-CREATE TABLE mh_oaipmh_harvesting (
+CREATE TABLE IF NOT EXISTS mh_oaipmh_harvesting (
   url VARCHAR(255) NOT NULL,
   last_harvested datetime,
   PRIMARY KEY (url)


### PR DESCRIPTION
The database upgrade script from 2.3 to 3 tries to create a database
table called `mh_oaipmh_harvesting` which already exists in previous
versions. Hence, the upgrade will fail if users do not simply ignore the
error.