### PR TITLE
MH-12981 fix for local admin-ui develop finding main.css

### DIFF
--- a/modules/admin-ui/lib/staticMiddleware.js
+++ b/modules/admin-ui/lib/staticMiddleware.js
@@ -4,7 +4,7 @@ var serveStatic = require('serve-static');
 module.exports = function (grunt, appPath) {
     return function (connect) {
             var middlewares = [
-              serveStatic('.tmp'),
+              serveStatic('target/grunt/.tmp'),
               connect().use(
                 '/admin-ng',
                 serveStatic('./src/test/resources/app/GET/admin-ng')


### PR DESCRIPTION
@JulianKniephoff  This pull updates the tmp ath in an additional static file to support "grunt serve". related ticket MH-12910 See steps to duplicate issue in MH-12981  (cross verified by @lkiesow and @gregorydlogan ).

I tested that the main.css is found in local testing and also when deployed from admin-ui jar.


