### PR TITLE
MH-12985 Fix incorrect warnings in event modals

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -338,7 +338,7 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
     };
 
     $scope.nonScheduleSelected = function() {
-        return JsHelper.filter($scope.getSelected(),function (r) { return r.event_status_raw !== 'EVENTS.EVENTS.STATUS.SCHEDULED'; }).length > 0;
+        return JsHelper.filter($scope.getSelected(), $scope.nonSchedule).length > 0;
     };
 
     $scope.rowsValid = function() {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -334,11 +334,11 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
     };
 
     $scope.nonSchedule = function(row) {
-        return row.source !== 'SCHEDULE';
+        return row.event_status_raw !== 'EVENTS.EVENTS.STATUS.SCHEDULED';
     };
 
     $scope.nonScheduleSelected = function() {
-        return JsHelper.filter($scope.getSelected(),function (r) { return r.source !== 'SCHEDULE'; }).length > 0;
+        return JsHelper.filter($scope.getSelected(),function (r) { return r.event_status_raw !== 'EVENTS.EVENTS.STATUS.SCHEDULED'; }).length > 0;
     };
 
     $scope.rowsValid = function() {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/validators/taskStartableValidator.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/validators/taskStartableValidator.js
@@ -34,7 +34,9 @@ angular.module('adminNg.directives')
         ctrl.$validators.taskStartable = function (modelValue, viewValue) {
             if (viewValue) {
                 if (angular.isDefined(attrs.taskStartable) &&
-                    attrs.taskStartable.toUpperCase().indexOf('ARCHIVE') === 0) {
+                    (attrs.taskStartable.toUpperCase().indexOf('PROCESSED') > -1
+                    || attrs.taskStartable.toUpperCase().indexOf('PROCESSING_FAILURE') > -1
+                    || attrs.taskStartable.toUpperCase().indexOf('PROCESSING_CANCELED') > -1)) {
                     return true;
                 }
                 else {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
@@ -40,7 +40,7 @@
                                     </thead>
                                     <tbody >
                                     <tr ng-repeat="row in rows" ng-form="rowsForm" ng-class="{error: rowsForm.selection.$error.taskStartable}">
-                                        <td><input name="selection" ng-required="!hasAnySelected()" type="checkbox" task-startable="{{row.source}}" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
+                                        <td><input name="selection" ng-required="!hasAnySelected()" type="checkbox" task-startable="{{row.event_status_raw}}" ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></td>
                                         <td>{{ row.title }}</td>
                                         <td class="nowrap">{{ row.series_name}}</td>
                                         <td class="nowrap">{{ row.event_status }}</td>

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/validators/taskStartableValidatorSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/validators/taskStartableValidatorSpec.js
@@ -18,14 +18,14 @@ describe('adminNg.modules.events.validators.taskStartableValidator', function ()
 
     beforeEach(function () {
         $rootScope.row = {
-            source: 'ARCHIVE',
+            event_status_raw: 'PROCESSED',
             selected: true
         };
-        element = '<form name="testform"><input name="selection" type="checkbox" task-startable="{{row.source}}" ' +
+        element = '<form name="testform"><input name="selection" type="checkbox" task-startable="{{row.event_status_raw}}" ' +
             'ng-model="row.selected" ng-change="rowSelectionChanged($index)" class="child-cbox"></form>';
     });
 
-    describe('source === ARCHIVE', function () {
+    describe('event_status_raw === PROCESSED', function () {
         beforeEach(function () {
             $compile(element)($rootScope);
             $rootScope.$digest();
@@ -35,15 +35,47 @@ describe('adminNg.modules.events.validators.taskStartableValidator', function ()
             expect($rootScope.row.selected).toBeTruthy();
         });
 
-        it('is valid if it is selected and source equals ARCHIVE', function () {
+        it('is valid if it is selected and event_status_raw equals PROCESSED', function () {
             expect($rootScope.testform.$valid).toBeTruthy();
         });
-
     });
 
-    describe('source === PROCESSING', function () {
-        it('is invalid if source does not equal ARCHIVE', function () {
-            $rootScope.row.source = 'PROCESSING';
+    describe('event_status_raw === PROCESSING_CANCELED', function () {
+        beforeEach(function () {
+            $rootScope.row.event_status_raw = 'PROCESSING_CANCELED';
+            $compile(element)($rootScope);
+            $rootScope.$digest();
+        });
+
+        it('instantiates', function () {
+            expect($rootScope.row.selected).toBeTruthy();
+        });
+
+        it('is valid if it is selected and event_status_raw equals PROCESSING_CANCELED', function () {
+            expect($rootScope.testform.$valid).toBeTruthy();
+        });
+    });
+
+    describe('event_status_raw === PROCESSING_FAILURE', function () {
+        beforeEach(function () {
+            $rootScope.row.event_status_raw = 'PROCESSING_FAILURE';
+            $compile(element)($rootScope);
+            $rootScope.$digest();
+        });
+
+        it('instantiates', function () {
+            expect($rootScope.row.selected).toBeTruthy();
+        });
+
+        it('is valid if it is selected and event_status_raw equals PROCESSING_FAILURE', function () {
+            expect($rootScope.testform.$valid).toBeTruthy();
+        });
+    });
+
+
+    describe('event_status_raw === RECORDING_FAILURE', function () {
+        it('is invalid if source does not equal PROCESSED, nor PROCESSING_CANCELED, nor PROCESSING_FAILURE', function () {
+            $rootScope.row.event_status_raw = 'RECORDING_FAILURE';
             $compile(element)($rootScope);
             $rootScope.$digest();
             expect($rootScope.testform.$valid).toBeFalsy();


### PR DESCRIPTION
Using Actions->Start Task and Actions->Edit scheduled events you get a
table displaying, among other information, the event status. Under
certain circumstances, the user should be kept from continuing within
the wizard. 

However, to check if the user can proceed, the event source
is used in contrary to the event_status being displayed in the table.
This leads to weird situations where the user doesn't understand why he
can't continue. Fixed by checking for event_status instead of source
when generating the messages.

This work is sponsored by SWITCH.