### PR TITLE
MH-12986 Admin UI deployed debugging: include source in SourceMap files

### DIFF
--- a/modules/admin-ui/Gruntfile.js
+++ b/modules/admin-ui/Gruntfile.js
@@ -390,7 +390,9 @@ module.exports = function (grunt) {
 
     uglify: {
       options: {
-        sourceMap: true,
+        sourceMap: {
+          includeSources: true
+        },
         sourceMapIn: function (file) {
           return file + '.map';
         }


### PR DESCRIPTION
See details in https://opencast.jira.com/browse/MH-12986

Accesss to source maps in the deployed admin-ui webapp is important to debug the deployed system. Local developer debugging is not affected (i.e. grunt serve).

This change makes the sourcemap map files bigger because they include the source, but source map files are only retrieved when in browser debugger/developer mode, not for the normal UI client.