### PR TITLE
MH-12966: Fix pre-select-from for metadata fields

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/preSelectFromDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/preSelectFromDirective.js
@@ -44,7 +44,14 @@ function (_) {
                     }
 
                     if (_.size(options) === 1 && _.size(ngModel) > 0) { // supports objects and arrays
-                        ngModel[0].$setViewValue(options[_.keys(options)[0]], 'myevent');
+                        var valueToSet = options[_.keys(options)[0]];
+                        // There's an additional attribute you can set: "pre-select-from-value", which
+                        // sets the value not to the "v" in the array itself, but to "v.value". This
+                        // is currently used in the metadata fields for certain dialogs.
+                        if (!angular.isUndefined($attr.preSelectFromValue)) {
+                            valueToSet = valueToSet.value;
+                        }
+                        ngModel[0].$setViewValue(valueToSet, 'myevent');
                         unregister();
                     }
                 }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
@@ -7,6 +7,7 @@
   <div class="editable-select" ng-show="editMode">
 
     <select chosen pre-select-from="collection"
+            pre-select-from-value
             ng-model="params.value"
             name="{{ params.name }}"
             ng-change="submit()"


### PR DESCRIPTION
This adds a new attribute called `pre-select-from-value` to select inputs which use `pre-select-from`. With this enabled, the single value isn’t taken directly from the list given, but from the `.value` attribute of the selected list element.

We need this for the metadata fields, for example in the “Event Details” modal. This is currently broken, as it tries to set the value of the series to an object containing a label and a value, instead of just the value.

This work was sponsored by SWITCH.