### PR TITLE
MH-12987 Prohibit changing a scheduled event to be in the past

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -152,6 +152,7 @@
      "CONFLICT_BULK_DETECTED":   "Scheduling conflict: changing the events results in conflicts. Please change the location, dates or times.",
      "CONFLICT_ALREADY_ENDED":   "Scheduling error: The event has already ended.",
      "CONFLICT_END_BEFORE_START":   "Scheduling error: Schedule end has to be later than the start.",
+     "CONFLICT_IN_THE_PAST": "The schedule could not be updated: You cannot schedule an event to be in the past.",
      "INVALID_ACL_RULES":   "Rules have to contain a valid role and read or/and write right(s).",
      "MISSING_ACL_RULES":   "At least one role with Read and Write permissions is required!",
      "SAVED_ACL_RULES":   "The access rules have been saved.",

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/schedulingHelperService.js
@@ -69,6 +69,30 @@ angular.module('adminNg.services')
             var role = "ROLE_CAPTURE_AGENT_" + agentId.replace(/[^a-zA-Z0-9_]/g, "").toUpperCase();
             return AuthService.userIsAuthorizedAs(role);
         };
+
+        this.alreadyEnded = function(start, duration) {
+            if (angular.isDefined(start) && angular.isDefined(start.hour)
+                && angular.isDefined(start.minute) && angular.isDefined(start.date)
+                && angular.isDefined(duration) && angular.isDefined(duration.hour)
+                && angular.isDefined(duration.minute)) {
+                var startDate = this.parseDate(start.date, start.hour, start.minute);
+                var endDate = new Date(startDate.getTime());
+                endDate.setHours(endDate.getHours() + duration.hour, endDate.getMinutes() + duration.minute, 0, 0);
+                var nowDate = new Date();
+                return endDate < nowDate;
+            }
+            return false;
+        };
+
+        this.endBeforeStart = function(start, end) {
+           if (angular.isDefined(start) && angular.isDefined(start.date) && angular.isDefined(end)
+               && angular.isDefined(end.date)) {
+               var startDate = new Date(start.date);
+               var endDate = new Date(end.date);
+               return endDate < startDate;
+            }
+            return false;
+        };
     };
     return new SchedulingHelperService();
 }]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -327,11 +327,6 @@ angular.module('adminNg.services')
             }
         };
 
-        this.getStartDate = function() {
-            var start = self.ud[getType()].start;
-            return SchedulingHelperService.parseDate(start.date, start.hour, start.minute);
-        };
-
         this.checkValidity = function () {
             var data = self.ud[getType()];
 
@@ -339,34 +334,20 @@ angular.module('adminNg.services')
                 Notifications.remove(self.alreadyEndedNotification, NOTIFICATION_CONTEXT);
             }
             // check if start is in the past and has already ended
-            if (angular.isDefined(data.start) && angular.isDefined(data.start.hour)
-                && angular.isDefined(data.start.minute) && angular.isDefined(data.start.date)
-                && angular.isDefined(data.duration) && angular.isDefined(data.duration.hour)
-                && angular.isDefined(data.duration.minute)) {
-                var startDate = self.getStartDate();
-                var endDate = new Date(startDate.getTime());
-                endDate.setHours(endDate.getHours() + data.duration.hour, endDate.getMinutes() + data.duration.minute, 0, 0);
-                var nowDate = new Date();
-                if (endDate < nowDate) {
-                    self.alreadyEndedNotification = Notifications.add('error', 'CONFLICT_ALREADY_ENDED',
-                        NOTIFICATION_CONTEXT, -1);
-                    self.hasConflicts = true;
-                }
+            if (SchedulingHelperService.alreadyEnded(data.start, data.duration)) {
+                self.alreadyEndedNotification = Notifications.add('error', 'CONFLICT_ALREADY_ENDED',
+                    NOTIFICATION_CONTEXT, -1);
+                self.hasConflicts = true;
             }
 
             if (self.endBeforeStartNotification) {
                 Notifications.remove(self.endBeforeStartNotification, NOTIFICATION_CONTEXT);
             }
             // check if end date is before start date
-            if (angular.isDefined(data.start) && angular.isDefined(data.start.date)
-                && angular.isDefined(data.end.date)) {
-                var startDate = new Date(data.start.date);
-                var endDate = new Date(data.end.date);
-                if (endDate < startDate) {
-                    self.endBeforeStartNotification = Notifications.add('error', 'CONFLICT_END_BEFORE_START',
-                        NOTIFICATION_CONTEXT, -1);
-                    self.hasConflicts = true;
-                }
+            if (SchedulingHelperService.endBeforeStart(data.start, data.end)) {
+                self.endBeforeStartNotification = Notifications.add('error', 'CONFLICT_END_BEFORE_START',
+                    NOTIFICATION_CONTEXT, -1);
+                self.hasConflicts = true;
             }
         };
 


### PR DESCRIPTION
While it is not possible to create a scheduled event which ends in the
past, changing an existing one to end in the past is still possible
using Event Details -> Scheduling.

Fixed by adding an error message and not saving the data.

Please note: The problem also exists for Actions -> Edit scheduled events. Also, the backend should check accordingly and refuse to save scheduling information when the event ends in the past. We did not fix this, yet, since we didn't want to put too much effort into this right now.

This work is sponsored by SWITCH.