### PR TITLE
MH-12988-delete-scheduled-live Fix for scheduled live event not deleted

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
@@ -33,7 +33,9 @@ angular.module('adminNg.controllers')
             publicationCount++;
         });
 
-        if (publicationCount > 0) {
+        if (publicationCount == 1 && currentEvent.publications[0].id == "engage-live") {
+        	return false;
+        } else if (publicationCount > 0) {
             return true;
         } else {
             return false;

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/bulkDeleteController.js
@@ -33,13 +33,7 @@ angular.module('adminNg.controllers')
             publicationCount++;
         });
 
-        if (publicationCount == 1 && currentEvent.publications[0].id == "engage-live") {
-        	return false;
-        } else if (publicationCount > 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return publicationCount > 0 && currentEvent.publications[0].id != "engage-live";
     },
     tableByPublicationStatus = function(isPublished) {
         var result = {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -134,7 +134,7 @@ angular.module('adminNg.controllers')
                 });
                 row.checkedDelete = function() {
                   EventHasSnapshotsResource.get({id: row.id},function(o) {
-                    if ((angular.isUndefined(row.publications) || row.publications.length <= 0 || !o.hasSnapshots) && !row.has_preview )
+                    if ((angular.isUndefined(row.publications) || row.publications.length <= 0 || (row.publications.length == 1 && row.publications[0].id == "engage-live") || !o.hasSnapshots) && !row.has_preview )
                           // Works, opens simple modal
                           ConfirmationModal.show('confirm-modal',Table.delete,row);
                       else

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/bulkDeleteControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/bulkDeleteControllerSpec.js
@@ -4,9 +4,9 @@ describe('Bulk Delete controller', function () {
 
     // Both published and unpublished selected, workflow selected, is valid
     sampleRows = function () {
-       return [ { id: 1, selected: true, 'publications': { 'Engage': 'http://engage.localdomain' } },
+       return [ { id: 1, selected: true, 'publications': [{ 'id': 'engage-player', 'url': 'http://engage.localdomain' }] },
             { id: 2, selected: true },
-            { id: 3, selected: false, 'publications': { 'Engage': 'http://engage.localdomain' } },
+            { id: 3, selected: false, 'publications': [{ 'id': 'engage-player', 'url': 'http://engage.localdomain' }] },
             { id: 4, selected: false }];
     };
 

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/SchedulerUpdateHandler.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/SchedulerUpdateHandler.java
@@ -79,8 +79,9 @@ public class SchedulerUpdateHandler extends UpdateHandler {
           break;
         case Delete:
         case DeleteRecordingStatus:
-          if (isLive(mpId))
-            liveScheduleService.deleteLiveEvent(mpId);
+          // We can't check workflow config here to determine if the event is live because the
+          // event has already been deleted. The live scheduler service will do that.
+          liveScheduleService.deleteLiveEvent(mpId);
           break;
         case UpdateAgentId:
         case UpdateStart:


### PR DESCRIPTION
Problem: the Live Scheduler service listens to messages from services (Scheduler, Asset Manager), including delete messages, to update/retract the live media package from the search index, but the admin UI blocks the deletion if the event has a publication channel.

This was fixed by changing the admin UI to allow the scheduled event be deleted if it has only a live publication channel.

To test:
* Configure the live scheduler service
* Register a capture agent 
* Schedule a capture in the future
* Before the capture starts, delete the event
* The event should be deleted without having to run a workflow to retract it before
* The live event should be retracted from the search index (use rest endpoint to verify)

