### PR TITLE
MH-12991: Display long weekdays in “Edit scheduled” summary

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
@@ -460,6 +460,15 @@
                "FR": "Fr",
                "SA": "Sa",
                "SU": "So"
+            },
+            "WEEKDAYSLONG": {
+               "MO": "Montag",
+               "TU": "Dienstag",
+               "WE": "Mittwoch",
+               "TH": "Donnerstag",
+               "FR": "Freitag",
+               "SA": "Samstag",
+               "SU": "Sonntag"
             }
          },
          "NAVIGATION": {

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -465,6 +465,15 @@
            "FR": "Fr",
            "SA": "Sa",
            "SU": "Su"
+         },
+         "WEEKDAYSLONG": {
+           "MO": "Monday",
+           "TU": "Tuesday",
+           "WE": "Wednesday",
+           "TH": "Thursday",
+           "FR": "Friday",
+           "SA": "Saturday",
+           "SU": "Sunday"
          }
        },
        "NAVIGATION": {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -368,8 +368,8 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
                     type: 'EVENTS.EVENTS.TABLE.WEEKDAY',
                     // Might be better to actually use the promise rather than using instant,
                     // but it's difficult with the two-way binding here.
-                    previous: $translate.instant(valueWeekDay.translation),
-                    next: $translate.instant(JsHelper.weekdayTranslation($scope.scheduling.weekday))
+                    previous: $translate.instant(valueWeekDay.translationLong),
+                    next: $translate.instant(JsHelper.weekdayTranslation($scope.scheduling.weekday, true))
                 });
             }
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/jsHelperService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/jsHelperService.js
@@ -26,23 +26,55 @@ angular.module('adminNg.services')
 .factory('JsHelper', [
     function () {
         var weekdaysArray = [
-                    { key: 'MO', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.MO' },
-                    { key: 'TU', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.TU' },
-                    { key: 'WE', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.WE' },
-                    { key: 'TH', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.TH' },
-                    { key: 'FR', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.FR' },
-                    { key: 'SA', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.SA' },
-                    { key: 'SU', translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.SU' }
+            {
+                key: 'MO',
+                translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.MO',
+                translationLong: 'EVENTS.EVENTS.NEW.WEEKDAYSLONG.MO',
+            },
+            {
+                key: 'TU',
+                translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.TU',
+                translationLong: 'EVENTS.EVENTS.NEW.WEEKDAYSLONG.TU',
+            },
+            {
+                key: 'WE',
+                translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.WE',
+                translationLong: 'EVENTS.EVENTS.NEW.WEEKDAYSLONG.WE',
+            },
+            {
+                key: 'TH',
+                translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.TH',
+                translationLong: 'EVENTS.EVENTS.NEW.WEEKDAYSLONG.TH',
+            },
+            {
+                key: 'FR',
+                translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.FR',
+                translationLong: 'EVENTS.EVENTS.NEW.WEEKDAYSLONG.FR',
+            },
+            {
+                key: 'SA',
+                translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.SA',
+                translationLong: 'EVENTS.EVENTS.NEW.WEEKDAYSLONG.SA',
+            },
+            {
+                key: 'SU',
+                translation: 'EVENTS.EVENTS.NEW.WEEKDAYS.SU',
+                translationLong: 'EVENTS.EVENTS.NEW.WEEKDAYSLONG.SU',
+            }
         ];
         return {
             getWeekDays: function () {
                 return weekdaysArray;
             },
 
-            weekdayTranslation: function(d) {
+            weekdayTranslation: function(d, longTranslation) {
                 for (var i = 0; i < weekdaysArray.length; i++) {
                     if (weekdaysArray[i].key === d) {
-                        return weekdaysArray[i].translation;
+                        if (longTranslation === true) {
+                            return weekdaysArray[i].translationLong;
+                        } else {
+                            return weekdaysArray[i].translation;
+                        }
                     }
                 }
                 return null;


### PR DESCRIPTION
There's enough space available to show the weekdays (if they've
changed) in full in the last tab of the "Edit Scheduled Events" modal.

This work was sponsored by SWITCH.