### PR TITLE
MH-12992: Trigger conflict check in “Edit scheduled” on “Next”

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
@@ -242,6 +242,7 @@
       },
       "EDIT_EVENTS": {
          "CAPTION": "Geplante Aufzeichnungen bearbeiten",
+         "CONFLICT_CHECK_RUNNING": "Konfliktprüfung läuft…",
          "GENERAL": {
             "CAPTION": "Allgemein",
             "CANNOTSTART": "Hervorgehobene Aufzeichnungen können nicht verarbeitet werden, nur geplante Aufzeichnungen werden unterstützt.",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -243,6 +243,7 @@
       },
       "EDIT_EVENTS": {
           "CAPTION": "Edit scheduled events",
+          "CONFLICT_CHECK_RUNNING": "Conflict check is running…",
           "GENERAL": {
               "CAPTION": "General",
               "CANNOTSTART": "Highlighted event(s) cannot be processed, only scheduled events are supported.",

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -22,8 +22,8 @@
 
 // Controller for the "edit scheduled events" wizard
 angular.module('adminNg.controllers')
-    .controller('EditEventsCtrl', ['$scope', 'Table', 'Notifications', 'EventBulkEditResource', 'SeriesResource', 'CaptureAgentsResource', 'EventsSchedulingResource', 'JsHelper', 'SchedulingHelperService', 'WizardHandler', 'Language', '$translate', 'decorateWithTableRowSelection',
-function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, CaptureAgentsResource, EventsSchedulingResource, JsHelper, SchedulingHelperService, WizardHandler, Language, $translate, decorateWithTableRowSelection) {
+    .controller('EditEventsCtrl', ['$scope', 'Table', 'Notifications', 'EventBulkEditResource', 'SeriesResource', 'CaptureAgentsResource', 'EventsSchedulingResource', 'JsHelper', 'SchedulingHelperService', 'WizardHandler', 'Language', '$translate', 'decorateWithTableRowSelection','$timeout',
+function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, CaptureAgentsResource, EventsSchedulingResource, JsHelper, SchedulingHelperService, WizardHandler, Language, $translate, decorateWithTableRowSelection, $timeout) {
     var me = this;
     var SCHEDULING_CONTEXT = 'event-scheduling';
 
@@ -208,6 +208,7 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
     this.noConflictsDetected = function () {
         me.clearConflicts();
         $scope.checkingConflicts = false;
+        $scope.generateEventSummariesAndContinue();
     };
 
     // What we send to the server is slightly different than what we
@@ -236,20 +237,12 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
         if ($scope.conflictCheckingEnabled === false) {
             return;
         }
-        return new Promise(function(resolve, reject) {
-            $scope.checkingConflicts = true;
-            var payload = {
-                events: $scope.getSelectedIds(),
-                scheduling: postprocessScheduling()
-            };
-            EventBulkEditResource.conflicts(payload, me.noConflictsDetected, me.conflictsDetected)
-                .$promise.then(function() {
-                    resolve();
-                })
-                .catch(function(err) {
-                    reject();
-                });
-        });
+        $scope.checkingConflicts = true;
+        var payload = {
+            events: $scope.getSelectedIds(),
+            scheduling: postprocessScheduling()
+        };
+        EventBulkEditResource.conflicts(payload, me.noConflictsDetected, me.conflictsDetected);
     };
 
     $scope.checkingConflicts = false;
@@ -458,7 +451,9 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
                 });
             }
         });
-        nextWizardStep();
+        $timeout(function() {
+            nextWizardStep();
+        });
     };
 
     $scope.noChanges = function() {
@@ -480,6 +475,14 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
         $scope.submitButton = false;
         $scope.close();
         Notifications.add('error', 'EVENTS_NOT_UPDATED', 'global', -1);
+    };
+
+    $scope.nextButtonText = function() {
+        if ($scope.checkingConflicts) {
+            return 'BULK_ACTIONS.EDIT_EVENTS.CONFLICT_CHECK_RUNNING';
+        } else {
+            return 'WIZARD.NEXT_STEP';
+        }
     };
 
     $scope.submitButton = false;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
@@ -126,7 +126,7 @@
                                             data-width="'100px'"
                                             data-disable-search-threshold="8"
                                             ng-model="scheduling.start.hour"
-                                            ng-change="onTemporalValueChange('start'); checkConflicts();"
+                                            ng-change="onTemporalValueChange('start');"
                                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}'"
                                             ng-options="h.index as h.value for h in hours"
                                             />
@@ -135,7 +135,7 @@
                                             data-width="'100px'"
                                             data-disable-search-threshold="8"
                                             ng-model="scheduling.start.minute"
-                                            ng-change="onTemporalValueChange('start'); checkConflicts();"
+                                            ng-change="onTemporalValueChange('start');"
                                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}'"
                                             ng-options="m.index as m.value for m in minutes"
                                             />
@@ -149,7 +149,7 @@
                                             data-width="'100px'"
                                             data-disable-search-threshold="8"
                                             ng-model="scheduling.end.hour"
-                                            ng-change="onTemporalValueChange('end'); checkConflicts();"
+                                            ng-change="onTemporalValueChange('end');"
                                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}'"
                                             ng-options="h.index as h.value for h in hours"
                                             />
@@ -158,7 +158,7 @@
                                             data-width="'100px'"
                                             data-disable-search-threshold="8"
                                             ng-model="scheduling.end.minute"
-                                            ng-change="onTemporalValueChange('end'); checkConflicts();"
+                                            ng-change="onTemporalValueChange('end');"
                                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}'"
                                             ng-options="m.index as m.value for m in minutes"
                                             />
@@ -173,7 +173,7 @@
                                     <select chosen pre-select-from="captureAgents"
                                             ng-disabled="checkingConflicts"
                                             data-width="'200px'"
-                                            ng-change="roomChanged(); checkConflicts()"
+                                            ng-change="roomChanged();"
                                             data-disable-search-threshold="8"
                                             ng-model="scheduling.location"
                                             ng-options="value.name for (id, value) in captureAgents"
@@ -189,7 +189,6 @@
                                   <td>
                                     <label ng-repeat="inputMethod in source.device.inputs">
                                       <input type="checkbox"
-                                             ng-change="checkConflicts()"
                                              ng-model="source.device.inputMethods[inputMethod.id]"
                                              ng-disabled="checkingConflicts || !$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')"> {{ inputMethod.value | translate }}
                                       <br>
@@ -201,7 +200,6 @@
                                   <td class="weekdays">
                                     <label ng-repeat="weekday in weekdays">
                                       <input type="radio"
-                                             ng-change="checkConflicts()"
                                              ng-model="scheduling.weekday"
                                              name="weekdays"
                                              value="{{weekday.key}}"
@@ -220,10 +218,11 @@
                 </div><!-- modal-body -->
             </div><!-- modal-content [task] -->
             <footer>
-                <a class="submit"
-                   ng-click="generateEventSummariesAndContinue()"
-                   ng-class="{active: !hasConflicts(), disabled: hasConflicts() || checkingConflicts}">
-                    {{ 'WIZARD.NEXT_STEP' | translate }}
+                <a
+                  class="submit"
+                  ng-click="checkConflicts()"
+                  ng-class="{active: !checkingConflicts, disabled: checkingConflicts}">
+                    {{ nextButtonText() | translate }}
                 </a>
                 <a wz-previous translate="WIZARD.BACK" class="cancel">
                 </a>


### PR DESCRIPTION
Conflict checking can be fairly slow on large systems with lots of
scheduled events. Currently, when you select a few of those events and
open the "Edit scheduled events" tab, changing a single item, such as
the start time, will already trigger a conflict check. If this takes
very long then, it's bad for usability.

This commit changes the behavior, so conflict checking is done when
you press the “Next” button in the wizard.

This work was sponsored by SWITCH.