### PR TITLE
MH-12994: Make “Title” in “Edit scheduled” non-mandatory

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -288,7 +288,7 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
                 id: "title",
                 label: "EVENTS.EVENTS.DETAILS.METADATA.TITLE",
                 readOnly: false,
-                required: true,
+                required: false,
                 type: "text",
                 value: getMetadataPart(getterForMetadata('title'))
             },


### PR DESCRIPTION
Speaks for itself I think. The respective events' title will be used if this field is empty.

This work was sponsored by SWITCH.