### PR TITLE
MH-12996: Add header row to conflict table in “Edit scheduled”

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
@@ -244,7 +244,9 @@
           "GENERAL": {
               "CAPTION": "Allgemein",
               "CANNOTSTART": "Markierte Aufzeichnungen können nicht verarbeitet werden, nur geplante Aufzeichnungen werden unterstützt.",
-              "NOCHANGES": "Es wurden keine Änderungen an den Aufzeichnungen festgestellt!"
+              "NOCHANGES": "Es wurden keine Änderungen an den Aufzeichnungen festgestellt!",
+              "CONFLICT_FIRST_EVENT": "Geänderte Aufzeichnung",
+              "CONFLICT_SECOND_EVENT": "Aufzeichnung in Konflikt"
           },
           "METADATA": {
               "EDIT": "Metadaten bearbeiten"

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -246,7 +246,9 @@
           "GENERAL": {
               "CAPTION": "General",
               "CANNOTSTART": "Highlighted event(s) cannot be processed, only scheduled events are supported.",
-              "NOCHANGES": "No changes to the events detected!"
+              "NOCHANGES": "No changes to the events detected!",
+              "CONFLICT_FIRST_EVENT": "Changed event",
+              "CONFLICT_SECOND_EVENT": "Event in conflict"
           },
           "METADATA": {
               "EDIT": "Edit metadata"

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
@@ -72,6 +72,12 @@
                       <div data-admin-ng-notifications="" context="event-scheduling"></div>
                       <div class="obj list-obj" ng-show="conflicts.length > 0">
                         <table class="main-tbl scheduling-conflict">
+                          <tr>
+                            <th>{{ 'BULK_ACTIONS.EDIT_EVENTS.GENERAL.CONFLICT_FIRST_EVENT' | translate }}</th>
+                            <th>{{ 'BULK_ACTIONS.EDIT_EVENTS.GENERAL.CONFLICT_SECOND_EVENT' | translate }}</th>
+                            <th>{{ 'EVENTS.EVENTS.TABLE.START' | translate }}</th>
+                            <th>{{ 'EVENTS.EVENTS.TABLE.END' | translate }}</th>
+                          </tr>
                           <tr ng-repeat="conflict in conflicts">
                             <td>{{ conflict.eventId }}</td>
                             <td>{{ conflict.title }}</td>


### PR DESCRIPTION
The conflict table in the "Edit scheduled events" doesn't have a
header row indicating which column signifies what. This makes it a bit
difficult to comprehend. This commit adds one.

![screenshot](https://user-images.githubusercontent.com/178496/42510030-f4e78140-844d-11e8-8216-3bc17f3dc375.png)

This work was sponsored by SWITCH.