### PR TITLE
MH-12998: Clear conflicts when closing “Edit Scheduled Events” modal

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/editEventsController.js
@@ -22,8 +22,8 @@
 
 // Controller for the "edit scheduled events" wizard
 angular.module('adminNg.controllers')
-    .controller('EditEventsCtrl', ['$scope', 'Table', 'Notifications', 'EventBulkEditResource', 'SeriesResource', 'CaptureAgentsResource', 'EventsSchedulingResource', 'JsHelper', 'SchedulingHelperService', 'WizardHandler', 'Language', '$translate', 'decorateWithTableRowSelection','$timeout',
-function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, CaptureAgentsResource, EventsSchedulingResource, JsHelper, SchedulingHelperService, WizardHandler, Language, $translate, decorateWithTableRowSelection, $timeout) {
+    .controller('EditEventsCtrl', ['$scope', 'Table', 'Notifications', 'EventBulkEditResource', 'SeriesResource', 'CaptureAgentsResource', 'EventsSchedulingResource', 'JsHelper', 'SchedulingHelperService', 'WizardHandler', 'Language', '$translate', 'decorateWithTableRowSelection','$timeout', 'Modal',
+function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, CaptureAgentsResource, EventsSchedulingResource, JsHelper, SchedulingHelperService, WizardHandler, Language, $translate, decorateWithTableRowSelection, $timeout, Modal) {
     var me = this;
     var SCHEDULING_CONTEXT = 'event-scheduling';
 
@@ -54,6 +54,21 @@ function ($scope, Table, Notifications, EventBulkEditResource, SeriesResource, C
             $scope.seriesResults[row.title] = row.id;
         });
     });
+
+    $scope.keyUp = function (event) {
+        switch (event.keyCode) {
+        case 27:
+            $scope.close();
+            break;
+        }
+    };
+
+    $scope.close = function() {
+        if (me.notificationConflict) {
+            Notifications.remove(me.notificationConflict, SCHEDULING_CONTEXT);
+        }
+        Modal.$scope.close();
+    };
 
     // Given a series id, get me the title (we need this for the summary prettification)
     var seriesTitleForId = function(id) {


### PR DESCRIPTION
When you have conflicts displayed in the “Edit scheduled events”
modal, then close the modal an reopen it again (possibly with
different events and without changing anything), the previous error
message resides.

This commit clears existing conflicts before the modal is closed.

This work was sponsored by SWITCH.