### PR TITLE
MH-13001 Fixed live scheduler service pom 

### DIFF
--- a/modules/live-schedule-impl/pom.xml
+++ b/modules/live-schedule-impl/pom.xml
@@ -114,6 +114,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Service-Component>
+              OSGI-INF/asset-manager-update-handler.xml,
               OSGI-INF/live-schedule-message-receiver.xml,
               OSGI-INF/live-schedule-service.xml,
               OSGI-INF/scheduler-update-handler.xml

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -302,7 +302,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     // If the snapshot version is in our local cache, it means that this snapshot was created by us so
     // nothing to do. Note that this is just to save time; if the entry has already been deleted, the mp
     // will be compared below.
-    if (snapshot.getVersion().equals(snapshotVersionCache.getIfPresent(previousMp.getIdentifier()))) {
+    if (snapshot.getVersion().equals(snapshotVersionCache.getIfPresent(previousMp.getIdentifier().toString()))) {
       logger.debug("Snapshot version {} was created by us so this change is ignored.", snapshot.getVersion());
       return false;
     }


### PR DESCRIPTION
Live scheduler service wasn't getting asset manager notifications so, if a capture was in progress and metadata was changed via admin UI (e.g. title), the metadata would not get updated in the live media package in the search index.

(This was in the original dce branch and has been tested, but somehow it got lost when I created the original pull request).
