### PR TITLE
MH-13003, Stop changing technical start date after event started

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -479,17 +479,10 @@ public final class EventIndexUtils {
   }
 
   public static Event updateTechnicalDate(Event event) {
-    if (event.hasRecordingStarted()) {
-      // Override technical dates from recording if already started
+    if (StringUtils.isBlank(event.getTechnicalStartTime()))
       event.setTechnicalStartTime(event.getRecordingStartDate());
+    if (StringUtils.isBlank(event.getTechnicalEndTime()))
       event.setTechnicalEndTime(event.getRecordingEndDate());
-    } else {
-      // If this is an upload where the start time is not set, set the start time to same as dublin core
-      if (StringUtils.isBlank(event.getTechnicalStartTime()))
-        event.setTechnicalStartTime(event.getRecordingStartDate());
-      if (StringUtils.isBlank(event.getTechnicalEndTime()))
-        event.setTechnicalEndTime(event.getRecordingEndDate());
-    }
     return event;
   }
 


### PR DESCRIPTION
This should fix the problem described in [MH-13003](https://opencast.jira.com/browse/MH-13003), however, I have to say that I am not that sure about the changes. I don't know whether the lines I removed weren't there for a reason; comment above them subtly suggests to me that they were. But I wouldn't know why you would want to override the technical start date with the bibliographical one when the event has started (or is finished) recording.

# The problem

What follows is a lengthy description of my findings regarding MH-13003, so that other people can reproduce the error and track it through the code.

The first part of the problem is that the `IndexServiceImpl#updateEventMetadata` method which the `/event/:id/metadata` endpoint delegates more or less immediately to treats the event differently based on what it calls the "event source", which---for all of our intents and purposes---just means whether the events technical start date lies in the past. (Workflows also play into this, but let's ignore this here; for details: I'm referring to the `switch`-statement in the aforementioned method and the `getEventSource` method in the same class.)

If it does, the event is handled by the "`ARCHIVE`" branch and a snapshot is taken via the asset manager, and everything is find from our point of view. If the technical start date does **not** lie in the past, though, the event is treated as "`SCHEDULED`" and handed to the scheduler service.
The scheduler service in turn calls `SchedulerServiceImpl#verifyActive`, which throws the exception we see in the log when the current time is after the end date of the event.

Now you might ask: *"How can that be? The index service things the event starts in the future, gives it to the scheduler and that complains that the event is in the past?!"* Well, behold the power of caches/indexes/other redundant storage systems! :smile:

The crux is that the scheduler asks the asset manager for the start date, which still has the original scheduled date (or the one that you set manually in the Scheduling tab after the fact, as described in MH-13003). The index service on the other hand has this information stored itself, too, and of course uses **that**. This is a problem once these two pieces of information get out of sync.

One place where that might happen is the one I changed. `EventIndexUtils#updateTechnicalDate` is called from `updateEvent` in the same class as a response to both, the asset manager and scheduler service messages generated by `IndexServiceImpl#updateEventMetadata`, and what it does is override the technical start date in the admin UI index with the bibliographical one **if** the former has already passed as reported, again, by the index service itself.

So step 2 in the description of MH-13003 generates a `takeSnapshot` message, in which the technical start date of the event **in the index service** is set to the future, which makes further metadata updates as in step 3 be handled by the scheduler, which still thinks that the event is in the past and thus refuses to update the metadata, which makes sense in my opinion. (Well, you might of course want to change meta data of a passed event, but keep in mind that the treatment of the event in question as an event that is scheduled as opposed to archived is already a faulty consequence of the above behavior. At least I think it is. :wink:)