### PR TITLE
MH-13005 Skip waveform operation when no tracks

### DIFF
--- a/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
+++ b/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
@@ -120,7 +120,7 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
     if (sourceTracks.isEmpty()) {
       logger.info("No tracks found in mediapackage {} with specified {} = {}", mediaPackage, SOURCE_FLAVOR_PROPERTY,
               sourceFlavorProperty);
-      createResult(mediaPackage, WorkflowOperationResult.Action.SKIP);
+      return createResult(mediaPackage, WorkflowOperationResult.Action.SKIP);
     }
 
     List<Job> waveformJobs = new ArrayList<>(sourceTracks.size());


### PR DESCRIPTION
Actually return the skip result in the waveform operation handler if no tracks match the configured source flavor and tags.

_This work is sponsored by SWITCH._