### PR TITLE
MH-13003: Implement detection of already recorded (as opposed to yet to be recorded, scheduled) events by the index service

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
@@ -36,7 +36,6 @@ import org.codehaus.jettison.mapped.Configuration;
 import org.codehaus.jettison.mapped.MappedNamespaceConvention;
 import org.codehaus.jettison.mapped.MappedXMLStreamReader;
 import org.codehaus.jettison.mapped.MappedXMLStreamWriter;
-import org.joda.time.DateTime;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -44,7 +43,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1174,13 +1172,22 @@ public class Event implements IndexObject {
     eventStatus = "EVENTS.EVENTS.STATUS.PROCESSED";
   }
 
+  /**
+   * Check whether or not the start time of the recording of this event has passed, yet.
+   *
+   * This method treats non-scheduled (i.e.) uploaded events as always having
+   * a recording start time in the pase, because for the video to be able
+   * to be uploaded, it obviously must have been recorded, already.
+   *
+   * @return <code>true</code> if the start ime of the recording of this event
+   *         is in the past, and <code>false</code> otherwise
+   */
   public boolean hasRecordingStarted() {
-    if (getSchedulingStatus() == null)
-      return true;
-
-    Date startDate = new DateTime(getTechnicalStartTime()).toDate();
-    Date now = new DateTime().toDate();
-    return startDate.before(now);
+    return
+            // handle uploaded events
+            getSchedulingStatus() == null
+            // handle scheduled events
+            || getRecordingStatus() != null;
   }
 
   /**

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/event/EventTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/event/EventTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
 
 import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.index.service.impl.index.event.Event.SchedulingStatus;
+import org.opencastproject.scheduler.api.RecordingState;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.util.DateTimeSupport;
 
@@ -208,10 +209,12 @@ public class EventTest {
 
     event.setSchedulingStatus(SchedulingStatus.READY_FOR_RECORDING.toString());
     event.setTechnicalStartTime(DateTimeSupport.toUTC(now.getTime() - (3 * 60 * 1000)));
+    event.setRecordingStatus(RecordingState.CAPTURING);
     assertTrue(event.hasRecordingStarted());
 
     event.setSchedulingStatus(SchedulingStatus.OPTED_OUT.toString());
     event.setTechnicalStartTime(DateTimeSupport.toUTC(now.getTime() + (3 * 60 * 1000)));
+    event.setRecordingStatus(null);
     assertFalse(event.hasRecordingStarted());
   }
 


### PR DESCRIPTION
This is my second attempt to fix [MH-13003](https://opencast.jira.com/browse/MH-13003). For a detailed description of the problem please refer to my first pull request: #349. I hope this does not brake any other use cases, but if it does not, then this was simpler than I thought. :smile: