### PR TITLE
MH-13006 Waveform operation cleanup creates problem with asynchronous NFS

### DIFF
--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/UnitTestWorkspace.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/UnitTestWorkspace.java
@@ -191,6 +191,11 @@ public class UnitTestWorkspace implements Workspace {
   }
 
   @Override
+  public void cleanup(Id mediaPackageId, boolean filesOnly) throws IOException {
+    // Nothing to do
+  }
+
+  @Override
   public String rootDirectory() {
     return null;
   }

--- a/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
+++ b/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
@@ -88,70 +88,64 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
    */
   @Override
   public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context) throws WorkflowOperationException {
+
     MediaPackage mediaPackage = workflowInstance.getMediaPackage();
     logger.info("Start waveform workflow operation for mediapackage {}", mediaPackage);
 
-    String sourceFlavorProperty = StringUtils.trimToNull(
-            workflowInstance.getCurrentOperation().getConfiguration(SOURCE_FLAVOR_PROPERTY));
-    String sourceTagsProperty = StringUtils.trimToNull(
-            workflowInstance.getCurrentOperation().getConfiguration(SOURCE_TAGS_PROPERTY));
-    if (StringUtils.isEmpty(sourceFlavorProperty) && StringUtils.isEmpty(sourceTagsProperty)) {
-      throw new WorkflowOperationException(String.format("Required property %s or %s not set",
-              SOURCE_FLAVOR_PROPERTY, SOURCE_TAGS_PROPERTY));
-    }
-
-    String targetFlavorProperty = StringUtils.trimToNull(
-            workflowInstance.getCurrentOperation().getConfiguration(TARGET_FLAVOR_PROPERTY));
-    if (targetFlavorProperty == null) {
-      throw new WorkflowOperationException(String.format("Required property %s not set", TARGET_FLAVOR_PROPERTY));
-    }
-
-    String targetTagsProperty = StringUtils.trimToNull(
-            workflowInstance.getCurrentOperation().getConfiguration(TARGET_TAGS_PROPERTY));
-
-    TrackSelector trackSelector = new TrackSelector();
-    for (String flavor : asList(sourceFlavorProperty)) {
-      trackSelector.addFlavor(flavor);
-    }
-    for (String tag : asList(sourceTagsProperty)) {
-      trackSelector.addTag(tag);
-    }
-    Collection<Track> sourceTracks = trackSelector.select(mediaPackage, false);
-    if (sourceTracks.isEmpty()) {
-      logger.info("No tracks found in mediapackage {} with specified {} = {}", mediaPackage, SOURCE_FLAVOR_PROPERTY,
-              sourceFlavorProperty);
-      return createResult(mediaPackage, WorkflowOperationResult.Action.SKIP);
-    }
-
-    List<Job> waveformJobs = new ArrayList<>(sourceTracks.size());
-    for (Track sourceTrack : sourceTracks) {
-      // Skip over track with no audio stream
-      if (!sourceTrack.hasAudio()) {
-        logger.info("Skipping waveform extraction of track {} since it has no audio", sourceTrack.getIdentifier());
-        continue;
-      }
-      try {
-        // generate waveform
-        logger.info("Creating waveform extraction job for track '{}' in mediapackage '{}'",
-                sourceTrack.getIdentifier(), mediaPackage);
-
-        Job waveformJob = waveformService.createWaveformImage(sourceTrack);
-        waveformJobs.add(waveformJob);
-      } catch (MediaPackageException | WaveformServiceException e) {
-        logger.error("Creating waveform extraction job for track '{}' in media package '{}' failed",
-                sourceTrack.getIdentifier(), mediaPackage, e);
-      }
-    }
-
-    logger.debug("Waiting for waveform jobs for media package {}", mediaPackage);
-    if (!waitForStatus(waveformJobs.toArray(new Job[waveformJobs.size()])).isSuccess()) {
-      cleanupWorkspace(waveformJobs);
-      throw new WorkflowOperationException(
-              String.format("Waveform extraction jobs for media package '%s' have not completed successfully",
-                      mediaPackage.getIdentifier()));
-    }
-
     try {
+
+      String sourceFlavorProperty = StringUtils.trimToNull(workflowInstance.getCurrentOperation().getConfiguration(SOURCE_FLAVOR_PROPERTY));
+      String sourceTagsProperty = StringUtils.trimToNull(workflowInstance.getCurrentOperation().getConfiguration(SOURCE_TAGS_PROPERTY));
+      if (StringUtils.isEmpty(sourceFlavorProperty) && StringUtils.isEmpty(sourceTagsProperty)) {
+        throw new WorkflowOperationException(
+                String.format("Required property %s or %s not set", SOURCE_FLAVOR_PROPERTY, SOURCE_TAGS_PROPERTY));
+      }
+
+      String targetFlavorProperty = StringUtils.trimToNull(workflowInstance.getCurrentOperation().getConfiguration(TARGET_FLAVOR_PROPERTY));
+      if (targetFlavorProperty == null) {
+        throw new WorkflowOperationException(String.format("Required property %s not set", TARGET_FLAVOR_PROPERTY));
+      }
+
+      String targetTagsProperty = StringUtils.trimToNull(workflowInstance.getCurrentOperation().getConfiguration(TARGET_TAGS_PROPERTY));
+
+      TrackSelector trackSelector = new TrackSelector();
+      for (String flavor : asList(sourceFlavorProperty)) {
+        trackSelector.addFlavor(flavor);
+      }
+      for (String tag : asList(sourceTagsProperty)) {
+        trackSelector.addTag(tag);
+      }
+      Collection<Track> sourceTracks = trackSelector.select(mediaPackage, false);
+      if (sourceTracks.isEmpty()) {
+        logger.info("No tracks found in mediapackage {} with specified {} = {}", mediaPackage, SOURCE_FLAVOR_PROPERTY,
+                sourceFlavorProperty);
+        return createResult(mediaPackage, WorkflowOperationResult.Action.SKIP);
+      }
+
+      List<Job> waveformJobs = new ArrayList<>(sourceTracks.size());
+      for (Track sourceTrack : sourceTracks) {
+        // Skip over track with no audio stream
+        if (!sourceTrack.hasAudio()) {
+          logger.info("Skipping waveform extraction of track {} since it has no audio", sourceTrack.getIdentifier());
+          continue;
+        }
+        try {
+          // generate waveform
+          logger.info("Creating waveform extraction job for track '{}' in mediapackage '{}'", sourceTrack.getIdentifier(), mediaPackage);
+
+          Job waveformJob = waveformService.createWaveformImage(sourceTrack);
+          waveformJobs.add(waveformJob);
+        } catch (MediaPackageException | WaveformServiceException e) {
+          logger.error("Creating waveform extraction job for track '{}' in media package '{}' failed", sourceTrack.getIdentifier(), mediaPackage, e);
+        }
+      }
+
+      logger.debug("Waiting for waveform jobs for media package {}", mediaPackage);
+      if (!waitForStatus(waveformJobs.toArray(new Job[waveformJobs.size()])).isSuccess()) {
+        throw new WorkflowOperationException(String.format("Waveform extraction jobs for media package '%s' have not completed successfully",
+                mediaPackage.getIdentifier()));
+      }
+
       // copy waveform attachments into workspace and add them to the media package
       for (Job job : waveformJobs) {
         String jobPayload = job.getPayload();
@@ -161,8 +155,8 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
         MediaPackageElement waveformMpe = null;
         try {
           waveformMpe = MediaPackageElementParser.getFromXml(jobPayload);
-          URI newURI = workspace.moveTo(waveformMpe.getURI(), mediaPackage.getIdentifier().toString(),
-                                        waveformMpe.getIdentifier(), "waveform.png");
+          URI newURI = workspace.moveTo(waveformMpe.getURI(), mediaPackage.getIdentifier().toString(), waveformMpe.getIdentifier(),
+                  "waveform.png");
           waveformMpe.setURI(newURI);
         } catch (MediaPackageException ex) {
           // unexpected job payload
@@ -170,8 +164,7 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
         } catch (NotFoundException ex) {
           throw new WorkflowOperationException("Waveform image file '" + waveformMpe.getURI() + "' not found", ex);
         } catch (IOException ex) {
-          throw new WorkflowOperationException("Can't get workflow image file '" + waveformMpe.getURI()
-                  + "' from workspace");
+          throw new WorkflowOperationException("Can't get workflow image file '" + waveformMpe.getURI() + "' from workspace");
         }
 
         // set the waveform attachment flavor and add it to the media package
@@ -188,44 +181,17 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
         }
         mediaPackage.add(waveformMpe);
       }
+
+      logger.info("Waveform workflow operation for mediapackage {} completed", mediaPackage);
+      return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE);
+
     } finally {
-      cleanupWorkspace(waveformJobs);
-    }
-
-    try {
-      workspace.cleanup(mediaPackage.getIdentifier());
-    } catch (IOException e) {
-      throw new WorkflowOperationException(e);
-    }
-
-    logger.info("Waveform workflow operation for mediapackage {} completed", mediaPackage);
-    return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE);
-  }
-
-  /**
-   * Remove all files created by the given jobs
-   * @param jobs
-   *          Jobs to clean up for
-   */
-  private void cleanupWorkspace(List<Job> jobs) {
-    for (Job job : jobs) {
-        String jobPayload = job.getPayload();
-        if (StringUtils.isNotEmpty(jobPayload)) {
-          try {
-            MediaPackageElement waveformMpe = MediaPackageElementParser.getFromXml(jobPayload);
-            URI waveformUri = waveformMpe.getURI();
-            workspace.delete(waveformUri);
-          } catch (MediaPackageException ex) {
-            // unexpected job payload
-            logger.error("Can't parse waveform attachment from job {}", job.getId());
-          } catch (NotFoundException ex) {
-            // this is ok, because we want delete the file
-          } catch (IOException ex) {
-            logger.warn("Deleting waveform image file from workspace failed: {}", ex.getMessage());
-            // this is ok, because workspace cleaner will remove old files if they exist
-          }
-        }
+      try {
+        workspace.cleanup(mediaPackage.getIdentifier(), true);
+      } catch (IOException e) {
+        throw new WorkflowOperationException(e);
       }
+    }
   }
 
   public void setWaveformService(WaveformService waveformService) {

--- a/modules/workspace-api/src/main/java/org/opencastproject/workspace/api/Workspace.java
+++ b/modules/workspace-api/src/main/java/org/opencastproject/workspace/api/Workspace.java
@@ -297,6 +297,16 @@ public interface Workspace extends StorageUsage {
   void cleanup(Id mediaPackageId) throws IOException;
 
   /**
+   * Clean up elements of one media package from the local workspace, not touching the working file repository.
+   *
+   * @param mediaPackageId
+   *          Id specifying the media package to remove files for.
+   * @param filesOnly
+   *          Boolean specifying whether only files or also directories (including the root directory) are deleted.
+   */
+  void cleanup(Id mediaPackageId, boolean filesOnly) throws IOException;
+
+  /**
    * Returns the workspace's root directory
    *
    * @return Path to the workspace root directory

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -930,9 +930,21 @@ public final class WorkspaceImpl implements Workspace {
 
   @Override
   public void cleanup(Id mediaPackageId) throws IOException {
-    final File f = workspaceFile(WorkingFileRepository.MEDIAPACKAGE_PATH_PREFIX, mediaPackageId.toString());
-    logger.debug("Clean workspace media package directory {}", f);
-    FileUtils.deleteDirectory(f);
+    cleanup(mediaPackageId, false);
+  }
+
+  @Override
+  public void cleanup(Id mediaPackageId, boolean filesOnly) throws IOException {
+    final File mediaPackageDir = workspaceFile(WorkingFileRepository.MEDIAPACKAGE_PATH_PREFIX, mediaPackageId.toString());
+
+    if (filesOnly) {
+      logger.debug("Clean workspace media package directory {} (files only)", mediaPackageDir);
+      FileSupport.delete(mediaPackageDir, FileSupport.DELETE_FILES);
+    }
+    else {
+      logger.debug("Clean workspace media package directory {}", mediaPackageDir);
+      FileUtils.deleteDirectory(mediaPackageDir);
+    }
   }
 
   @Override


### PR DESCRIPTION
Currently the WaveformOperationHandler deletes the whole folder for the mediapackage from the workspace after the operation is done. This can create problems when using an asynchronous NFS: Sometimes the deleted folder is still visible for the  worker node (after deleting it from the admin node) at the beginning of the next operation (an image operation in this case), but when FFMPEG tries to open the output file it fails because the directory that's supposed to contain it no longer exists.

The (sort of hacky and not really satisfactory, but working) solution is to make the WaveformOperationHandler clean up only the files from the workspace but leave the folder structure, thus avoiding this problem. The rest of it should be cleaned up at the end of the workflow...

_This work is sponsored by SWITCH._