### PR TITLE
MH-13012 The iterable metadata values should not be splitted by `,`

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
 public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
@@ -159,8 +158,7 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
                 getCollection(metadataField, listProvidersService), metadataField.getCollectionID(),
                 metadataField.getOrder(), metadataField.getNamespace());
         if (StringUtils.isNotBlank(value)) {
-          List<String> valueList = Arrays.asList(StringUtils.split(value, ","));
-          iterableTextField.setValue(valueList);
+          iterableTextField.setValue(Arrays.asList(value));
         }
         addField(iterableTextField);
         break;
@@ -173,8 +171,7 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
                 getCollection(metadataField, listProvidersService), metadataField.getCollectionID(),
                 metadataField.getOrder(), metadataField.getNamespace());
         if (StringUtils.isNotBlank(value)) {
-          List<String> valueList = Arrays.asList(StringUtils.split(value, ","));
-          mixedIterableTextField.setValue(valueList);
+          mixedIterableTextField.setValue(Arrays.asList(value));
         }
         addField(mixedIterableTextField);
         break;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
@@ -102,14 +102,11 @@ public final class DublinCoreMetadataUtil {
   }
 
   /**
-   * Set the value of an iterable string, comma separated
+   * Set the value of an iterable string (each element as an separate entry)
    *
-   * @param dc
-   *          The dublin core catalog to add the iterable string value to (or remove it if empty)
-   * @param field
-   *          The {@link MetadataField} with the value to update.
-   * @param ename
-   *          The {@link EName} of the property in the {@link DublinCoreCatalog} to update.
+   * @param dc    The dublin core catalog to add the iterable string values to (or remove it if empty)
+   * @param field The {@link MetadataField} with the values to update.
+   * @param ename The {@link EName} of the property in the {@link DublinCoreCatalog} to update.
    */
   private static void setIterableString(DublinCoreCatalog dc, MetadataField<?> field, final EName ename) {
     if (field.getValue().isSome()) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.index.service.impl.index.event;
 
-import static org.opencastproject.index.service.util.ListProviderUtil.splitStringList;
 
 import org.opencastproject.index.service.impl.index.AbstractSearchIndex;
 import org.opencastproject.index.service.impl.index.series.Series;
@@ -473,8 +472,8 @@ public final class EventIndexUtils {
     updateTechnicalDate(event);
 
     // TODO: Add support for language
-    event.setContributors(splitStringList(dc.get(DublinCore.PROPERTY_CONTRIBUTOR, DublinCore.LANGUAGE_ANY)));
-    event.setPresenters(splitStringList(dc.get(DublinCore.PROPERTY_CREATOR, DublinCore.LANGUAGE_ANY)));
+    event.setContributors(dc.get(DublinCore.PROPERTY_CONTRIBUTOR, DublinCore.LANGUAGE_ANY));
+    event.setPresenters(dc.get(DublinCore.PROPERTY_CREATOR, DublinCore.LANGUAGE_ANY));
     return event;
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -130,16 +131,16 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_CREATOR.getLocalName())) {
       MetadataField<?> presenters = metadata.getOutputFields().get(DublinCore.PROPERTY_CREATOR.getLocalName());
       metadata.removeField(presenters);
-      MetadataField<String> newPresenters = MetadataUtils.copyMetadataField(presenters);
-      newPresenters.setValue(StringUtils.join(event.getPresenters(), ", "));
+      MetadataField<List<String>> newPresenters = MetadataUtils.copyMetadataField(presenters);
+      newPresenters.setValue(event.getPresenters());
       metadata.addField(newPresenters);
     }
 
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_CONTRIBUTOR.getLocalName())) {
       MetadataField<?> contributors = metadata.getOutputFields().get(DublinCore.PROPERTY_CONTRIBUTOR.getLocalName());
       metadata.removeField(contributors);
-      MetadataField<String> newContributors = MetadataUtils.copyMetadataField(contributors);
-      newContributors.setValue(StringUtils.join(event.getContributors(), ", "));
+      MetadataField<List<String>> newContributors = MetadataUtils.copyMetadataField(contributors);
+      newContributors.setValue(event.getContributors());
       metadata.addField(newContributors);
     }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.index.service.impl.index.series;
 
-import static org.opencastproject.index.service.util.ListProviderUtil.splitStringList;
-
 import org.opencastproject.index.service.impl.index.AbstractSearchIndex;
 import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.index.service.impl.index.event.EventSearchQuery;
@@ -231,9 +229,9 @@ public final class SeriesIndexUtils {
     if (createdDateStr != null) {
       series.setCreatedDateTime(EncodingSchemeUtils.decodeDate(createdDateStr));
     }
-    series.setPublishers(splitStringList(dc.get(DublinCore.PROPERTY_PUBLISHER, DublinCore.LANGUAGE_ANY)));
-    series.setContributors(splitStringList(dc.get(DublinCore.PROPERTY_CONTRIBUTOR, DublinCore.LANGUAGE_ANY)));
-    series.setOrganizers(splitStringList(dc.get(DublinCoreCatalog.PROPERTY_CREATOR, DublinCore.LANGUAGE_ANY)));
+    series.setPublishers(dc.get(DublinCore.PROPERTY_PUBLISHER, DublinCore.LANGUAGE_ANY));
+    series.setContributors(dc.get(DublinCore.PROPERTY_CONTRIBUTOR, DublinCore.LANGUAGE_ANY));
+    series.setOrganizers(dc.get(DublinCoreCatalog.PROPERTY_CREATOR, DublinCore.LANGUAGE_ANY));
     return series;
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.index.service.resources.list.provider;
 
-import static org.opencastproject.index.service.util.ListProviderUtil.splitStringList;
 
 import org.opencastproject.index.service.impl.index.AbstractSearchIndex;
 import org.opencastproject.index.service.impl.index.event.Event;
@@ -125,16 +124,16 @@ public class ContributorsListProvider implements ResourceListProvider {
         contributorsList.add(u.getName());
     }
 
-    contributorsList.addAll(splitStringList(searchIndex.getTermsForField(EventIndexSchema.CONTRIBUTOR,
-            Option.some(new String[] { Event.DOCUMENT_TYPE }))));
-    contributorsList.addAll(splitStringList(searchIndex.getTermsForField(EventIndexSchema.PRESENTER,
-            Option.some(new String[] { Event.DOCUMENT_TYPE }))));
-    contributorsList.addAll(splitStringList(searchIndex.getTermsForField(SeriesIndexSchema.CONTRIBUTORS,
-            Option.some(new String[] { Series.DOCUMENT_TYPE }))));
-    contributorsList.addAll(splitStringList(searchIndex.getTermsForField(SeriesIndexSchema.ORGANIZERS,
-            Option.some(new String[] { Series.DOCUMENT_TYPE }))));
-    contributorsList.addAll(splitStringList(searchIndex.getTermsForField(SeriesIndexSchema.PUBLISHERS,
-            Option.some(new String[] { Series.DOCUMENT_TYPE }))));
+    contributorsList.addAll(searchIndex.getTermsForField(EventIndexSchema.CONTRIBUTOR,
+            Option.some(new String[] { Event.DOCUMENT_TYPE })));
+    contributorsList.addAll(searchIndex.getTermsForField(EventIndexSchema.PRESENTER,
+            Option.some(new String[] { Event.DOCUMENT_TYPE })));
+    contributorsList.addAll(searchIndex.getTermsForField(SeriesIndexSchema.CONTRIBUTORS,
+            Option.some(new String[] { Series.DOCUMENT_TYPE })));
+    contributorsList.addAll(searchIndex.getTermsForField(SeriesIndexSchema.ORGANIZERS,
+            Option.some(new String[] { Series.DOCUMENT_TYPE })));
+    contributorsList.addAll(searchIndex.getTermsForField(SeriesIndexSchema.PUBLISHERS,
+            Option.some(new String[] { Series.DOCUMENT_TYPE })));
 
     // TODO: TThis is not a good idea.
     // TODO: The search index can handle limit and offset.
@@ -186,16 +185,16 @@ public class ContributorsListProvider implements ResourceListProvider {
       }
     }
 
-    addIndexNamesToMap(labels, contributorsList, splitStringList(searchIndex
-            .getTermsForField(EventIndexSchema.PRESENTER, Option.some(new String[] { Event.DOCUMENT_TYPE }))));
-    addIndexNamesToMap(labels, contributorsList, splitStringList(searchIndex
-            .getTermsForField(EventIndexSchema.CONTRIBUTOR, Option.some(new String[] { Event.DOCUMENT_TYPE }))));
-    addIndexNamesToMap(labels, contributorsList, splitStringList(searchIndex
-            .getTermsForField(SeriesIndexSchema.CONTRIBUTORS, Option.some(new String[] { Event.DOCUMENT_TYPE }))));
-    addIndexNamesToMap(labels, contributorsList, splitStringList(searchIndex
-            .getTermsForField(SeriesIndexSchema.ORGANIZERS, Option.some(new String[] { Event.DOCUMENT_TYPE }))));
-    addIndexNamesToMap(labels, contributorsList, splitStringList(searchIndex
-            .getTermsForField(SeriesIndexSchema.PUBLISHERS, Option.some(new String[] { Event.DOCUMENT_TYPE }))));
+    addIndexNamesToMap(labels, contributorsList, searchIndex
+            .getTermsForField(EventIndexSchema.PRESENTER, Option.some(new String[] { Event.DOCUMENT_TYPE })));
+    addIndexNamesToMap(labels, contributorsList, searchIndex
+            .getTermsForField(EventIndexSchema.CONTRIBUTOR, Option.some(new String[] { Event.DOCUMENT_TYPE })));
+    addIndexNamesToMap(labels, contributorsList, searchIndex
+            .getTermsForField(SeriesIndexSchema.CONTRIBUTORS, Option.some(new String[] { Event.DOCUMENT_TYPE })));
+    addIndexNamesToMap(labels, contributorsList, searchIndex
+            .getTermsForField(SeriesIndexSchema.ORGANIZERS, Option.some(new String[] { Event.DOCUMENT_TYPE })));
+    addIndexNamesToMap(labels, contributorsList, searchIndex
+            .getTermsForField(SeriesIndexSchema.PUBLISHERS, Option.some(new String[] { Event.DOCUMENT_TYPE })));
 
     Collections.sort(contributorsList, new Comparator<Contributor>() {
       @Override

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/ListProviderUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/ListProviderUtil.java
@@ -24,11 +24,8 @@ package org.opencastproject.index.service.util;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.util.SmartIterator;
 
-import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONAware;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -118,22 +115,6 @@ public final class ListProviderUtil {
     int offset = query.getOffset().getOrElse(0);
     SmartIterator<JSONAware> si = new SmartIterator<JSONAware>(limit, offset);
     return si.applyLimitAndOffset(unfilteredList);
-  }
-
-  /**
-   * Go through the given list of string and split the element with comma
-   * 
-   * @param inputList
-   *          the list with the element to split
-   * @return the list with the split strings
-   */
-  public static List<String> splitStringList(List<String> inputList) {
-    List<String> outputList = new ArrayList<>();
-    for (String item : inputList) {
-      if (StringUtils.isNotBlank(item))
-        outputList.addAll(Arrays.asList(item.split(",")));
-    }
-    return outputList;
   }
 
   /**


### PR DESCRIPTION
The backend stores the iterable metadata field values as expected (one dublincore entry per value). But on loading the values from dublincore catalog, the values are splitted by `,`. 