### PR TITLE
MH-13014 Don't show stale search results

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsResource.js
@@ -39,7 +39,7 @@ angular.module('adminNg.resources')
 
     // We are live and are getting the real thing.
     return $resource('/admin-ng/event/:id', { id: '@id' }, {
-        query: {method: 'GET', params: { id: 'events.json' }, isArray: false, transformResponse: function (data) {
+        query: {method: 'GET', params: { id: 'events.json' }, isArray: false, cancellable: true, transformResponse: function (data) {
             return ResourceHelper.parseResponse(data, function (r) {
                 var row = {};
                 row.id = r.id;
@@ -68,7 +68,7 @@ angular.module('adminNg.resources')
                 if (typeof(r.publications) != 'undefined' && r.publications != null) {
                 	var now = new Date();
                 	for (var i = 0; i < row.publications.length; i++)
-                		if (row.publications[i].id == "engage-live" && 
+                		if (row.publications[i].id == "engage-live" &&
                 				(now < new Date(r.start_date) || now > new Date(r.end_date)))
                 			row.publications[i].enabled = false;
                 		else row.publications[i].enabled = true;


### PR DESCRIPTION
Don't show stale search results in the table of the Admin UI for a moment after the new results have already been shown. Instead cancel old requests so only current results are received and displayed.

_This work is sponsored by SWITCH._