### PR TITLE
MH-13015, 5.x database upgrade scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,16 +76,18 @@ jobs:
         - (cd docs/guides/user && mkdocs build)
         - (cd docs/guides && grunt)
 
-    # Test database scripts with MariaDB
+    # Test database scripts with MariaDB 10.x
     - stage: quick tests
-      env: name=mariadb
+      env: name=mariadb10
       sudo: false
       addons:
         mariadb: '10.3'
       install:
+        - echo "select version()" | mysql -u root
         - echo 'create database opencast;' | mysql -u root
       script:
         - mysql -u root opencast < docs/scripts/ddl/mysql5.sql
+        - sh docs/upgrade/.test.sh
 
     # Test database scripts with MySQL
     - stage: quick tests
@@ -94,9 +96,11 @@ jobs:
       services:
         - mysql
       install:
+        - echo "select version()" | mysql -u root
         - echo 'create database opencast;' | mysql -u root
       script:
         - mysql -u root opencast < docs/scripts/ddl/mysql5.sql
+        - ./docs/upgrade/.test.sh
 
     # Make a build excluding the assembly steps
     - stage: build

--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -22,7 +22,9 @@ As part of removing mentions of the old name Matterhorn, all database table name
 with `oc_`.  This requires an database schema update. As with all database migrations, we recommend to make a database
 backup before attempting the upgrade.
 
-You can find the database upgrade script at `docs/upgrade/4_to_5/mysql5.sql`.
+You can find the database upgrade script in `docs/upgrade/4_to_5/`. There are two scripts which are essentially doing
+the same thing with the MariaDB one running a few more checks on the database for safety which cannot be run like this
+on MySQL.  More information about the differences can be found in the readme next to the scripts.
 
 ActiveMQ Migration
 ------------------

--- a/docs/upgrade/.test.sh
+++ b/docs/upgrade/.test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -eu
+cd "$(dirname "$0")"
+
+versions="$(
+  set -eu
+  for dir in *_to_*; do
+    version=$(echo "$dir" | sed 's/[^0-9.].*$/.0/;s/\([0-9]*\.[0-9]*\)\..*$/\1/')
+    if [ "$(echo "$version >= 2.2" | bc -l)" = 1 ]; then
+      if [ -n "$version" ]; then
+        echo "$version $dir"
+      fi
+    fi
+  done | sort -h)"
+
+tmp22sql="$(mktemp)"
+curl -s -L -o "$tmp22sql" https://raw.githubusercontent.com/opencast/opencast/2.2.0/docs/scripts/ddl/mysql5.sql
+
+echo "# Creating database and applying Opencast 2.2 ddl script"
+
+echo "create database octest;" | mysql -u root
+echo "mysql -u root octest < $tmp22sql"
+mysql -u root octest < "$tmp22sql"
+rm "$tmp22sql"
+
+echo "# Running upgrade scripts"
+
+echo "$versions" | while read -r line; do
+  dir="$(echo "$line" | cut -d' ' -f2)"
+  echo "mysql -u root octest < $dir/mysql5.sql"
+  mysql -u root octest < "$dir/mysql5.sql"
+done

--- a/docs/upgrade/4_to_5/mariadb10.sql
+++ b/docs/upgrade/4_to_5/mariadb10.sql
@@ -3,7 +3,7 @@ UPDATE SEQUENCE SET SEQ_NAME = REPLACE(SEQ_NAME, 'seq_mh_assets_snapshot', 'seq_
 
 RENAME TABLE mh_bundleinfo TO oc_bundleinfo;
 ALTER TABLE oc_bundleinfo ADD CONSTRAINT UNQ_oc_bundleinfo UNIQUE (host, bundle_name, bundle_version);
-ALTER TABLE oc_bundleinfo DROP INDEX UNQ_mh_bundleinfo;
+ALTER TABLE oc_bundleinfo DROP INDEX IF EXISTS UNQ_mh_bundleinfo;
 
 RENAME TABLE mh_organization TO oc_organization;
 
@@ -12,44 +12,44 @@ ALTER TABLE oc_organization_node ADD CONSTRAINT FK_oc_organization_node_organiza
 ALTER TABLE oc_organization_node DROP FOREIGN KEY FK_mh_organization_node_organization;
 
 CREATE INDEX IX_oc_organization_node_pk ON oc_organization_node (organization);
-DROP INDEX IX_mh_organization_node_pk ON oc_organization_node;
+DROP INDEX IF EXISTS IX_mh_organization_node_pk ON oc_organization_node;
 CREATE INDEX IX_oc_organization_node_name ON oc_organization_node (name);
-DROP INDEX IX_mh_organization_node_name ON oc_organization_node;
+DROP INDEX IF EXISTS IX_mh_organization_node_name ON oc_organization_node;
 CREATE INDEX IX_oc_organization_node_port ON oc_organization_node (port);
-DROP INDEX IX_mh_organization_node_port ON oc_organization_node;
+DROP INDEX IF EXISTS IX_mh_organization_node_port ON oc_organization_node;
 
 RENAME TABLE mh_organization_property TO oc_organization_property;
 ALTER TABLE oc_organization_property ADD CONSTRAINT FK_oc_organization_property_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_organization_property DROP FOREIGN KEY FK_mh_organization_property_organization;
 
 CREATE INDEX IX_oc_organization_property_pk ON oc_organization_property (organization);
-DROP INDEX IX_mh_organization_property_pk ON oc_organization_property;
+DROP INDEX IF EXISTS IX_mh_organization_property_pk ON oc_organization_property;
 
 RENAME TABLE mh_annotation TO oc_annotation;
 
 CREATE INDEX IX_oc_annotation_created ON oc_annotation (created);
-DROP INDEX IX_mh_annotation_created ON oc_annotation;
+DROP INDEX IF EXISTS IX_mh_annotation_created ON oc_annotation;
 CREATE INDEX IX_oc_annotation_inpoint ON oc_annotation (inpoint);
-DROP INDEX IX_mh_annotation_inpoint ON oc_annotation;
+DROP INDEX IF EXISTS IX_mh_annotation_inpoint ON oc_annotation;
 CREATE INDEX IX_oc_annotation_outpoint ON oc_annotation (outpoint);
-DROP INDEX IX_mh_annotation_outpoint ON oc_annotation;
+DROP INDEX IF EXISTS IX_mh_annotation_outpoint ON oc_annotation;
 CREATE INDEX IX_oc_annotation_mediapackage ON oc_annotation (mediapackage);
-DROP INDEX IX_mh_annotation_mediapackage ON oc_annotation;
+DROP INDEX IF EXISTS IX_mh_annotation_mediapackage ON oc_annotation;
 CREATE INDEX IX_oc_annotation_private ON oc_annotation (private);
-DROP INDEX IX_mh_annotation_private ON oc_annotation;
+DROP INDEX IF EXISTS IX_mh_annotation_private ON oc_annotation;
 CREATE INDEX IX_oc_annotation_user ON oc_annotation (user_id);
-DROP INDEX IX_mh_annotation_user ON oc_annotation;
+DROP INDEX IF EXISTS IX_mh_annotation_user ON oc_annotation;
 CREATE INDEX IX_oc_annotation_session ON oc_annotation (session);
-DROP INDEX IX_mh_annotation_session ON oc_annotation;
+DROP INDEX IF EXISTS IX_mh_annotation_session ON oc_annotation;
 CREATE INDEX IX_oc_annotation_type ON oc_annotation (type);
-DROP INDEX IX_mh_annotation_type ON oc_annotation;
+DROP INDEX IF EXISTS IX_mh_annotation_type ON oc_annotation;
 
 RENAME TABLE mh_capture_agent_role TO oc_capture_agent_role;
 ALTER TABLE oc_capture_agent_role ADD CONSTRAINT FK_oc_capture_agent_role_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_capture_agent_role DROP FOREIGN KEY FK_mh_capture_agent_role_organization;
 
 CREATE INDEX IX_oc_capture_agent_role_pk ON oc_capture_agent_role (id, organization);
-DROP INDEX IX_mh_capture_agent_role_pk ON oc_capture_agent_role;
+DROP INDEX IF EXISTS IX_mh_capture_agent_role_pk ON oc_capture_agent_role;
 
 RENAME TABLE mh_capture_agent_state TO oc_capture_agent_state;
 ALTER TABLE oc_capture_agent_state ADD CONSTRAINT FK_oc_capture_agent_state_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
@@ -57,27 +57,27 @@ ALTER TABLE oc_capture_agent_state DROP FOREIGN KEY FK_mh_capture_agent_state_or
 
 RENAME TABLE mh_host_registration TO oc_host_registration;
 ALTER TABLE oc_host_registration ADD CONSTRAINT UNQ_oc_host_registration UNIQUE (host);
-ALTER TABLE oc_host_registration DROP INDEX UNQ_mh_host_registration;
+ALTER TABLE oc_host_registration DROP INDEX IF EXISTS UNQ_mh_host_registration;
 
 CREATE INDEX IX_oc_host_registration_online ON oc_host_registration (online);
-DROP INDEX IX_mh_host_registration_online ON oc_host_registration;
+DROP INDEX IF EXISTS IX_mh_host_registration_online ON oc_host_registration;
 CREATE INDEX IX_oc_host_registration_active ON oc_host_registration (active);
-DROP INDEX IX_mh_host_registration_active ON oc_host_registration;
+DROP INDEX IF EXISTS IX_mh_host_registration_active ON oc_host_registration;
 
 RENAME TABLE mh_service_registration TO oc_service_registration;
 ALTER TABLE oc_service_registration ADD CONSTRAINT UNQ_oc_service_registration UNIQUE (host_registration, service_type);
-ALTER TABLE oc_service_registration DROP INDEX UNQ_mh_service_registration;
+ALTER TABLE oc_service_registration DROP INDEX IF EXISTS UNQ_mh_service_registration;
 ALTER TABLE oc_service_registration ADD CONSTRAINT FK_oc_service_registration_host_registration FOREIGN KEY (host_registration) REFERENCES oc_host_registration (id) ON DELETE CASCADE;
 ALTER TABLE oc_service_registration DROP FOREIGN KEY FK_mh_service_registration_host_registration;
 
 CREATE INDEX IX_oc_service_registration_service_type ON oc_service_registration (service_type);
-DROP INDEX IX_mh_service_registration_service_type ON oc_service_registration;
+DROP INDEX IF EXISTS IX_mh_service_registration_service_type ON oc_service_registration;
 CREATE INDEX IX_oc_service_registration_service_state ON oc_service_registration (service_state);
-DROP INDEX IX_mh_service_registration_service_state ON oc_service_registration;
+DROP INDEX IF EXISTS IX_mh_service_registration_service_state ON oc_service_registration;
 CREATE INDEX IX_oc_service_registration_active ON oc_service_registration (active);
-DROP INDEX IX_mh_service_registration_active ON oc_service_registration;
+DROP INDEX IF EXISTS IX_mh_service_registration_active ON oc_service_registration;
 CREATE INDEX IX_oc_service_registration_host_registration ON oc_service_registration (host_registration);
-DROP INDEX IX_mh_service_registration_host_registration ON oc_service_registration;
+DROP INDEX IF EXISTS IX_mh_service_registration_host_registration ON oc_service_registration;
 
 RENAME TABLE mh_job TO oc_job;
 ALTER TABLE oc_job ADD CONSTRAINT FK_oc_job_creator_service FOREIGN KEY (creator_service) REFERENCES oc_service_registration (id) ON DELETE CASCADE;
@@ -92,32 +92,32 @@ ALTER TABLE oc_job ADD CONSTRAINT FK_oc_job_organization FOREIGN KEY (organizati
 ALTER TABLE oc_job DROP FOREIGN KEY FK_mh_job_organization;
 
 CREATE INDEX IX_oc_job_parent ON oc_job (parent);
-DROP INDEX IX_mh_job_parent ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_parent ON oc_job;
 CREATE INDEX IX_oc_job_root ON oc_job (root);
-DROP INDEX IX_mh_job_root ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_root ON oc_job;
 CREATE INDEX IX_oc_job_creator_service ON oc_job (creator_service);
-DROP INDEX IX_mh_job_creator_service ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_creator_service ON oc_job;
 CREATE INDEX IX_oc_job_processor_service ON oc_job (processor_service);
-DROP INDEX IX_mh_job_processor_service ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_processor_service ON oc_job;
 CREATE INDEX IX_oc_job_status ON oc_job (status);
-DROP INDEX IX_mh_job_status ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_status ON oc_job;
 CREATE INDEX IX_oc_job_date_created ON oc_job (date_created);
-DROP INDEX IX_mh_job_date_created ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_date_created ON oc_job;
 CREATE INDEX IX_oc_job_date_completed ON oc_job (date_completed);
-DROP INDEX IX_mh_job_date_completed ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_date_completed ON oc_job;
 CREATE INDEX IX_oc_job_dispatchable ON oc_job (dispatchable);
-DROP INDEX IX_mh_job_dispatchable ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_dispatchable ON oc_job;
 CREATE INDEX IX_oc_job_operation ON oc_job (operation);
-DROP INDEX IX_mh_job_operation ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_operation ON oc_job;
 CREATE INDEX IX_oc_job_statistics ON oc_job (processor_service, status, queue_time, run_time);
-DROP INDEX IX_mh_job_statistics ON oc_job;
+DROP INDEX IF EXISTS IX_mh_job_statistics ON oc_job;
 
 RENAME TABLE mh_job_argument TO oc_job_argument;
 ALTER TABLE oc_job_argument ADD CONSTRAINT FK_oc_job_argument_id FOREIGN KEY (id) REFERENCES oc_job (id) ON DELETE CASCADE;
 ALTER TABLE oc_job_argument DROP FOREIGN KEY FK_mh_job_argument_id;
 
 CREATE INDEX IX_oc_job_argument_id ON oc_job_argument (id);
-DROP INDEX IX_mh_job_argument_id ON oc_job_argument;
+DROP INDEX IF EXISTS IX_mh_job_argument_id ON oc_job_argument;
 
 RENAME TABLE mh_blocking_job TO oc_blocking_job;
 /* Note the constraint name is changing subtly here FK_blocking_job_id to FK*_oc*_blocking_job_id */
@@ -126,12 +126,12 @@ ALTER TABLE oc_blocking_job DROP FOREIGN KEY FK_blocking_job_id;
 
 RENAME TABLE mh_job_context TO oc_job_context;
 ALTER TABLE oc_job_context ADD CONSTRAINT UNQ_oc_job_context UNIQUE (id, name);
-ALTER TABLE oc_job_context DROP INDEX UNQ_mh_job_context;
+ALTER TABLE oc_job_context DROP INDEX IF EXISTS UNQ_mh_job_context;
 ALTER TABLE oc_job_context ADD CONSTRAINT FK_oc_job_context_id FOREIGN KEY (id) REFERENCES oc_job (id) ON DELETE CASCADE;
 ALTER TABLE oc_job_context DROP FOREIGN KEY FK_mh_job_context_id;
 
 CREATE INDEX IX_oc_job_context_id ON oc_job_context (id);
-DROP INDEX IX_mh_job_context_id ON oc_job_context;
+DROP INDEX IF EXISTS IX_mh_job_context_id ON oc_job_context;
 
 RENAME TABLE mh_job_mh_service_registration TO oc_job_oc_service_registration;
 ALTER TABLE oc_job_oc_service_registration ADD CONSTRAINT FK_oc_job_oc_service_registration_Job_id FOREIGN KEY (Job_id) REFERENCES oc_job (id) ON DELETE CASCADE;
@@ -140,23 +140,23 @@ ALTER TABLE oc_job_oc_service_registration ADD CONSTRAINT FK_oc_job_oc_service_r
 ALTER TABLE oc_job_oc_service_registration DROP FOREIGN KEY FK_mh_job_mh_service_registration_servicesRegistration_id;
 
 CREATE INDEX IX_oc_job_oc_service_registration_servicesRegistration_id ON oc_job_oc_service_registration (servicesRegistration_id);
-DROP INDEX IX_mh_job_mh_service_registration_servicesRegistration_id ON oc_job_oc_service_registration;
+DROP INDEX IF EXISTS IX_mh_job_mh_service_registration_servicesRegistration_id ON oc_job_oc_service_registration;
 
 RENAME TABLE mh_incident TO oc_incident;
 ALTER TABLE oc_incident ADD CONSTRAINT FK_oc_incident_jobid FOREIGN KEY (jobid) REFERENCES oc_job (id) ON DELETE CASCADE;
 ALTER TABLE oc_incident DROP FOREIGN KEY FK_mh_incident_jobid;
 
 CREATE INDEX IX_oc_incident_jobid ON oc_incident (jobid);
-DROP INDEX IX_mh_incident_jobid ON oc_incident;
+DROP INDEX IF EXISTS IX_mh_incident_jobid ON oc_incident;
 CREATE INDEX IX_oc_incident_severity ON oc_incident (severity);
-DROP INDEX IX_mh_incident_severity ON oc_incident;
+DROP INDEX IF EXISTS IX_mh_incident_severity ON oc_incident;
 
 RENAME TABLE mh_incident_text TO oc_incident_text;
 
 RENAME TABLE mh_scheduled_last_modified TO oc_scheduled_last_modified;
 
 CREATE INDEX IX_oc_scheduled_last_modified_last_modified ON oc_scheduled_last_modified (last_modified);
-DROP INDEX IX_mh_scheduled_last_modified_last_modified ON oc_scheduled_last_modified;
+DROP INDEX IF EXISTS IX_mh_scheduled_last_modified_last_modified ON oc_scheduled_last_modified;
 
 RENAME TABLE mh_scheduled_extended_event TO oc_scheduled_extended_event;
 ALTER TABLE oc_scheduled_extended_event ADD CONSTRAINT FK_oc_scheduled_extended_event_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
@@ -164,19 +164,19 @@ ALTER TABLE oc_scheduled_extended_event DROP FOREIGN KEY FK_mh_scheduled_extende
 
 RENAME TABLE mh_scheduled_transaction TO oc_scheduled_transaction;
 ALTER TABLE oc_scheduled_transaction ADD CONSTRAINT UNQ_oc_scheduled_transaction UNIQUE (id, organization, source);
-ALTER TABLE oc_scheduled_transaction DROP INDEX UNQ_mh_scheduled_transaction;
+ALTER TABLE oc_scheduled_transaction DROP INDEX IF EXISTS UNQ_mh_scheduled_transaction;
 ALTER TABLE oc_scheduled_transaction ADD CONSTRAINT FK_oc_scheduled_transaction_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_scheduled_transaction DROP FOREIGN KEY FK_mh_scheduled_transaction_organization;
 
 CREATE INDEX IX_oc_scheduled_transaction_source ON oc_scheduled_transaction (source);
-DROP INDEX IX_mh_scheduled_transaction_source ON oc_scheduled_transaction;
+DROP INDEX IF EXISTS IX_mh_scheduled_transaction_source ON oc_scheduled_transaction;
 
 RENAME TABLE mh_search TO oc_search;
 ALTER TABLE oc_search ADD CONSTRAINT FK_oc_search_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_search DROP FOREIGN KEY FK_mh_search_organization;
 
 CREATE INDEX IX_oc_search_organization ON oc_search (organization);
-DROP INDEX IX_mh_search_organization ON oc_search;
+DROP INDEX IF EXISTS IX_mh_search_organization ON oc_search;
 
 RENAME TABLE mh_series TO oc_series;
 ALTER TABLE oc_series ADD CONSTRAINT FK_oc_series_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
@@ -184,10 +184,10 @@ ALTER TABLE oc_series DROP FOREIGN KEY FK_mh_series_organization;
 
 RENAME TABLE mh_oaipmh TO oc_oaipmh;
 ALTER TABLE oc_oaipmh ADD CONSTRAINT UNQ_oc_oaipmh UNIQUE (modification_date);
-ALTER TABLE oc_oaipmh DROP INDEX UNQ_mh_oaipmh;
+ALTER TABLE oc_oaipmh DROP INDEX IF EXISTS UNQ_mh_oaipmh;
 
 CREATE INDEX IX_oc_oaipmh_modification_date ON oc_oaipmh (modification_date);
-DROP INDEX IX_mh_oaipmh_modification_date ON oc_oaipmh;
+DROP INDEX IF EXISTS IX_mh_oaipmh_modification_date ON oc_oaipmh;
 
 DROP TRIGGER mh_init_oaipmh_date;
 CREATE TRIGGER oc_init_oaipmh_date BEFORE INSERT ON `oc_oaipmh`
@@ -207,88 +207,88 @@ ALTER TABLE oc_oaipmh_elements DROP FOREIGN KEY FK_mh_oaipmh_elements;
 RENAME TABLE mh_user_session TO oc_user_session;
 
 CREATE INDEX IX_oc_user_session_user_id ON oc_user_session (user_id);
-DROP INDEX IX_mh_user_session_user_id ON oc_user_session;
+DROP INDEX IF EXISTS IX_mh_user_session_user_id ON oc_user_session;
 
 RENAME TABLE mh_user_action TO oc_user_action;
 ALTER TABLE oc_user_action ADD CONSTRAINT FK_oc_user_action_session_id FOREIGN KEY (session_id) REFERENCES oc_user_session (session_id) ON DELETE CASCADE;
 ALTER TABLE oc_user_action DROP FOREIGN KEY FK_mh_user_action_session_id;
 
 CREATE INDEX IX_oc_user_action_created ON oc_user_action (created);
-DROP INDEX IX_mh_user_action_created ON oc_user_action;
+DROP INDEX IF EXISTS IX_mh_user_action_created ON oc_user_action;
 CREATE INDEX IX_oc_user_action_inpoint ON oc_user_action (inpoint);
-DROP INDEX IX_mh_user_action_inpoint ON oc_user_action;
+DROP INDEX IF EXISTS IX_mh_user_action_inpoint ON oc_user_action;
 CREATE INDEX IX_oc_user_action_outpoint ON oc_user_action (outpoint);
-DROP INDEX IX_mh_user_action_outpoint ON oc_user_action;
+DROP INDEX IF EXISTS IX_mh_user_action_outpoint ON oc_user_action;
 CREATE INDEX IX_oc_user_action_mediapackage_id ON oc_user_action (mediapackage);
-DROP INDEX IX_mh_user_action_mediapackage_id ON oc_user_action;
+DROP INDEX IF EXISTS IX_mh_user_action_mediapackage_id ON oc_user_action;
 CREATE INDEX IX_oc_user_action_type ON oc_user_action (type);
-DROP INDEX IX_mh_user_action_type ON oc_user_action;
+DROP INDEX IF EXISTS IX_mh_user_action_type ON oc_user_action;
 
 RENAME TABLE mh_oaipmh_harvesting TO oc_oaipmh_harvesting;
 
 RENAME TABLE mh_assets_snapshot TO oc_assets_snapshot;
 ALTER TABLE oc_assets_snapshot ADD CONSTRAINT UNQ_oc_assets_snapshot  UNIQUE (mediapackage_id, version);
-ALTER TABLE oc_assets_snapshot DROP INDEX UNQ_mh_assets_snapshot;
+ALTER TABLE oc_assets_snapshot DROP INDEX IF EXISTS UNQ_mh_assets_snapshot;
 ALTER TABLE oc_assets_snapshot ADD CONSTRAINT FK_oc_assets_snapshot_organization FOREIGN KEY (organization_id) REFERENCES oc_organization (id);
 ALTER TABLE oc_assets_snapshot DROP FOREIGN KEY FK_mh_assets_snapshot_organization;
 CREATE INDEX IX_oc_assets_snapshot_archival_date ON oc_assets_snapshot (archival_date);
-DROP INDEX IX_mh_assets_snapshot_archival_date ON oc_assets_snapshot;
+DROP INDEX IF EXISTS IX_mh_assets_snapshot_archival_date ON oc_assets_snapshot;
 CREATE INDEX IX_oc_assets_snapshot_mediapackage_id ON oc_assets_snapshot (mediapackage_id);
-DROP INDEX IX_mh_assets_snapshot_mediapackage_id ON oc_assets_snapshot;
+DROP INDEX IF EXISTS IX_mh_assets_snapshot_mediapackage_id ON oc_assets_snapshot;
 CREATE INDEX IX_oc_assets_snapshot_organization_id ON oc_assets_snapshot (organization_id);
-DROP INDEX IX_mh_assets_snapshot_organization_id ON oc_assets_snapshot;
+DROP INDEX IF EXISTS IX_mh_assets_snapshot_organization_id ON oc_assets_snapshot;
 CREATE INDEX IX_oc_assets_snapshot_owner ON oc_assets_snapshot (owner);
-DROP INDEX IX_mh_assets_snapshot_owner ON oc_assets_snapshot;
+DROP INDEX IF EXISTS IX_mh_assets_snapshot_owner ON oc_assets_snapshot;
 
 RENAME TABLE mh_assets_asset TO oc_assets_asset;
 CREATE INDEX IX_oc_assets_asset_checksum ON oc_assets_asset (checksum);
-DROP INDEX IX_mh_assets_asset_checksum ON oc_assets_asset;
+DROP INDEX IF EXISTS IX_mh_assets_asset_checksum ON oc_assets_asset;
 CREATE INDEX IX_oc_assets_asset_mediapackage_element_id ON oc_assets_asset (mediapackage_element_id);
-DROP INDEX IX_mh_assets_asset_mediapackage_element_id ON oc_assets_asset;
+DROP INDEX IF EXISTS IX_mh_assets_asset_mediapackage_element_id ON oc_assets_asset;
 
 RENAME TABLE mh_assets_properties TO oc_assets_properties;
 CREATE INDEX IX_oc_assets_properties_val_date ON oc_assets_properties (val_date);
-DROP INDEX IX_mh_assets_properties_val_date on oc_assets_properties;
+DROP INDEX IF EXISTS IX_mh_assets_properties_val_date on oc_assets_properties;
 CREATE INDEX IX_oc_assets_properties_val_long ON oc_assets_properties  (val_long);
-DROP INDEX IX_mh_assets_properties_val_long on oc_assets_properties;
+DROP INDEX IF EXISTS IX_mh_assets_properties_val_long on oc_assets_properties;
 CREATE INDEX IX_oc_assets_properties_val_string ON oc_assets_properties  (val_string);
-DROP INDEX IX_mh_assets_properties_val_string on oc_assets_properties;
+DROP INDEX IF EXISTS IX_mh_assets_properties_val_string on oc_assets_properties;
 CREATE INDEX IX_oc_assets_properties_val_bool ON oc_assets_properties  (val_bool);
-DROP INDEX IX_mh_assets_properties_val_bool on oc_assets_properties;
+DROP INDEX IF EXISTS IX_mh_assets_properties_val_bool on oc_assets_properties;
 CREATE INDEX IX_oc_assets_properties_mediapackage_id ON oc_assets_properties  (mediapackage_id);
-DROP INDEX IX_mh_assets_properties_mediapackage_id on oc_assets_properties;
+DROP INDEX IF EXISTS IX_mh_assets_properties_mediapackage_id on oc_assets_properties;
 CREATE INDEX IX_oc_assets_properties_namespace ON oc_assets_properties  (namespace);
-DROP INDEX IX_mh_assets_properties_namespace on oc_assets_properties;
+DROP INDEX IF EXISTS IX_mh_assets_properties_namespace on oc_assets_properties;
 CREATE INDEX IX_oc_assets_properties_property_name ON oc_assets_properties  (property_name);
-DROP INDEX IX_mh_assets_properties_property_name on oc_assets_properties;
+DROP INDEX IF EXISTS IX_mh_assets_properties_property_name on oc_assets_properties;
 
 RENAME TABLE mh_assets_version_claim TO oc_assets_version_claim;
 
 RENAME TABLE mh_acl_managed_acl TO oc_acl_managed_acl;
 ALTER TABLE oc_acl_managed_acl ADD CONSTRAINT UNQ_oc_acl_managed_acl UNIQUE (name, organization_id);
-ALTER TABLE oc_acl_managed_acl DROP INDEX UNQ_mh_acl_managed_acl;
+ALTER TABLE oc_acl_managed_acl DROP INDEX IF EXISTS UNQ_mh_acl_managed_acl;
 
 RENAME TABLE mh_acl_episode_transition TO oc_acl_episode_transition;
 ALTER TABLE oc_acl_episode_transition ADD CONSTRAINT UNQ_oc_acl_episode_transition UNIQUE (episode_id, organization_id, application_date);
-ALTER TABLE oc_acl_episode_transition DROP INDEX UNQ_mh_acl_episode_transition;
+ALTER TABLE oc_acl_episode_transition DROP INDEX IF EXISTS UNQ_mh_acl_episode_transition;
 ALTER TABLE oc_acl_episode_transition ADD CONSTRAINT FK_oc_acl_episode_transition_managed_acl_fk FOREIGN KEY (managed_acl_fk) REFERENCES oc_acl_managed_acl (pk);
 ALTER TABLE oc_acl_episode_transition DROP FOREIGN KEY FK_mh_acl_episode_transition_managed_acl_fk;
 
 RENAME TABLE mh_acl_series_transition TO oc_acl_series_transition;
 ALTER TABLE oc_acl_series_transition ADD CONSTRAINT UNQ_oc_acl_series_transition UNIQUE (series_id, organization_id, application_date);
-ALTER TABLE oc_acl_series_transition DROP INDEX  UNQ_mh_acl_series_transition;
+ALTER TABLE oc_acl_series_transition DROP INDEX IF EXISTS  UNQ_mh_acl_series_transition;
 ALTER TABLE oc_acl_series_transition ADD CONSTRAINT FK_oc_acl_series_transition_managed_acl_fk FOREIGN KEY (managed_acl_fk) REFERENCES oc_acl_managed_acl (pk);
 ALTER TABLE oc_acl_series_transition DROP FOREIGN KEY FK_mh_acl_series_transition_managed_acl_fk;
 
 RENAME TABLE mh_role TO oc_role;
 ALTER TABLE oc_role ADD CONSTRAINT UNQ_oc_role UNIQUE (name, organization);
-ALTER TABLE oc_role DROP INDEX UNQ_mh_role;
+ALTER TABLE oc_role DROP INDEX IF EXISTS UNQ_mh_role;
 ALTER TABLE oc_role ADD CONSTRAINT FK_oc_role_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_role DROP FOREIGN KEY FK_mh_role_organization;
 
 RENAME TABLE mh_group TO oc_group;
 ALTER TABLE oc_group ADD CONSTRAINT UNQ_oc_group UNIQUE (group_id, organization);
-ALTER TABLE oc_group DROP INDEX UNQ_mh_group;
+ALTER TABLE oc_group DROP INDEX IF EXISTS UNQ_mh_group;
 ALTER TABLE oc_group ADD CONSTRAINT FK_oc_group_organization FOREIGN KEY (organization) REFERENCES oc_organization (id);
 ALTER TABLE oc_group DROP FOREIGN KEY FK_mh_group_organization;
 
@@ -296,7 +296,7 @@ RENAME TABLE mh_group_member TO oc_group_member;
 
 RENAME TABLE mh_group_role TO oc_group_role;
 ALTER TABLE oc_group_role ADD CONSTRAINT UNQ_oc_group_role UNIQUE (group_id, role_id);
-ALTER TABLE oc_group_role DROP INDEX UNQ_mh_group_role;
+ALTER TABLE oc_group_role DROP INDEX IF EXISTS UNQ_mh_group_role;
 ALTER TABLE oc_group_role ADD CONSTRAINT FK_oc_group_role_group_id FOREIGN KEY (group_id) REFERENCES oc_group (id);
 ALTER TABLE oc_group_role DROP FOREIGN KEY FK_mh_group_role_group_id;
 ALTER TABLE oc_group_role ADD CONSTRAINT FK_oc_group_role_role_id FOREIGN KEY (role_id) REFERENCES oc_role (id);
@@ -304,16 +304,16 @@ ALTER TABLE oc_group_role DROP FOREIGN KEY FK_mh_group_role_role_id;
 
 RENAME TABLE mh_user TO oc_user;
 ALTER TABLE oc_user ADD CONSTRAINT UNQ_oc_user UNIQUE (username, organization);
-ALTER TABLE oc_user DROP INDEX UNQ_mh_user;
+ALTER TABLE oc_user DROP INDEX IF EXISTS UNQ_mh_user;
 ALTER TABLE oc_user ADD CONSTRAINT FK_oc_user_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_user DROP FOREIGN KEY FK_mh_user_organization;
 
 CREATE INDEX IX_oc_role_pk ON oc_role (name, organization);
-DROP INDEX IX_mh_role_pk ON oc_role;
+DROP INDEX IF EXISTS IX_mh_role_pk ON oc_role;
 
 RENAME TABLE mh_user_role TO oc_user_role;
 ALTER TABLE oc_user_role ADD CONSTRAINT UNQ_oc_user_role UNIQUE (user_id, role_id);
-ALTER TABLE oc_user_role DROP INDEX UNQ_mh_user_role;
+ALTER TABLE oc_user_role DROP INDEX IF EXISTS UNQ_mh_user_role;
 ALTER TABLE oc_user_role ADD CONSTRAINT FK_oc_user_role_role_id FOREIGN KEY (role_id) REFERENCES oc_role (id);
 ALTER TABLE oc_user_role DROP FOREIGN KEY FK_mh_user_role_role_id;
 ALTER TABLE oc_user_role ADD CONSTRAINT FK_oc_user_role_user_id FOREIGN KEY (user_id) REFERENCES oc_user (id);
@@ -321,12 +321,12 @@ ALTER TABLE oc_user_role DROP FOREIGN KEY FK_mh_user_role_user_id;
 
 RENAME TABLE mh_user_ref TO oc_user_ref;
 ALTER TABLE oc_user_ref ADD CONSTRAINT UNQ_oc_user_ref UNIQUE (username, organization);
-ALTER TABLE oc_user_ref DROP INDEX UNQ_mh_user_ref;
+ALTER TABLE oc_user_ref DROP INDEX IF EXISTS UNQ_mh_user_ref;
 ALTER TABLE oc_user_ref ADD CONSTRAINT FK_oc_user_ref_organization FOREIGN KEY (organization) REFERENCES oc_organization (id);
 ALTER TABLE oc_user_ref DROP FOREIGN KEY FK_mh_user_ref_organization;
 
 RENAME TABLE mh_user_ref_role TO oc_user_ref_role;
-DROP INDEX UNQ_mh_user_ref_role ON oc_user_ref_role;
+DROP INDEX IF EXISTS UNQ_mh_user_ref_role ON oc_user_ref_role;
 ALTER TABLE oc_user_ref_role ADD CONSTRAINT FK_oc_user_ref_role_role_id FOREIGN KEY (role_id) REFERENCES oc_role (id);
 ALTER TABLE oc_user_ref_role DROP FOREIGN KEY FK_mh_user_ref_role_role_id;
 ALTER TABLE oc_user_ref_role ADD CONSTRAINT FK_oc_user_ref_role_user_id FOREIGN KEY (user_id) REFERENCES oc_user_ref (id);
@@ -334,41 +334,41 @@ ALTER TABLE oc_user_ref_role DROP FOREIGN KEY FK_mh_user_ref_role_user_id;
 
 RENAME TABLE mh_user_settings TO oc_user_settings;
 ALTER TABLE oc_user_settings ADD CONSTRAINT UNQ_oc_user_settings UNIQUE (username, organization);
-ALTER TABLE oc_user_settings DROP INDEX UNQ_mh_user_settings;
+ALTER TABLE oc_user_settings DROP INDEX IF EXISTS UNQ_mh_user_settings;
 
 CREATE INDEX IX_oc_user_setting_organization ON oc_user_settings (organization);
-DROP INDEX IX_mh_user_setting_organization ON oc_user_settings;
+DROP INDEX IF EXISTS IX_mh_user_setting_organization ON oc_user_settings;
 
 RENAME TABLE mh_email_configuration TO oc_email_configuration;
 ALTER TABLE oc_email_configuration ADD CONSTRAINT UNQ_oc_email_configuration UNIQUE (organization);
-ALTER TABLE oc_email_configuration DROP INDEX UNQ_mh_email_configuration;
+ALTER TABLE oc_email_configuration DROP INDEX IF EXISTS UNQ_mh_email_configuration;
 ALTER TABLE oc_email_configuration ADD CONSTRAINT FK_oc_email_configuration_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_email_configuration DROP FOREIGN KEY FK_mh_email_configuration_organization;
 
 CREATE INDEX IX_oc_email_configuration_organization ON oc_email_configuration (organization);
-DROP INDEX IX_mh_email_configuration_organization ON oc_email_configuration;
+DROP INDEX IF EXISTS IX_mh_email_configuration_organization ON oc_email_configuration;
 
 RENAME TABLE mh_message_signature TO oc_message_signature;
 ALTER TABLE oc_message_signature ADD CONSTRAINT UNQ_oc_message_signature UNIQUE (organization, name);
-ALTER TABLE oc_message_signature DROP INDEX UNQ_mh_message_signature;
+ALTER TABLE oc_message_signature DROP INDEX IF EXISTS UNQ_mh_message_signature;
 ALTER TABLE oc_message_signature ADD CONSTRAINT FK_oc_message_signature_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_message_signature DROP FOREIGN KEY FK_mh_message_signature_organization;
 
 CREATE INDEX IX_oc_message_signature_organization ON oc_message_signature (organization);
-DROP INDEX IX_mh_message_signature_organization ON oc_message_signature;
+DROP INDEX IF EXISTS IX_mh_message_signature_organization ON oc_message_signature;
 CREATE INDEX IX_oc_message_signature_name ON oc_message_signature (name);
-DROP INDEX IX_mh_message_signature_name ON oc_message_signature;
+DROP INDEX IF EXISTS IX_mh_message_signature_name ON oc_message_signature;
 
 RENAME TABLE mh_message_template TO oc_message_template;
 ALTER TABLE oc_message_template ADD CONSTRAINT UNQ_oc_message_template UNIQUE (organization, name);
-ALTER TABLE oc_message_template DROP INDEX UNQ_mh_message_template;
+ALTER TABLE oc_message_template DROP INDEX IF EXISTS UNQ_mh_message_template;
 ALTER TABLE oc_message_template ADD CONSTRAINT FK_oc_message_template_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;
 ALTER TABLE oc_message_template DROP FOREIGN KEY FK_mh_message_template_organization;
 
 CREATE INDEX IX_oc_message_template_organization ON oc_message_template (organization);
-DROP INDEX IX_mh_message_template_organization ON oc_message_template;
+DROP INDEX IF EXISTS IX_mh_message_template_organization ON oc_message_template;
 CREATE INDEX IX_oc_message_template_name ON oc_message_template (name);
-DROP INDEX IX_mh_message_template_name ON oc_message_template;
+DROP INDEX IF EXISTS IX_mh_message_template_name ON oc_message_template;
 
 RENAME TABLE mh_event_comment TO oc_event_comment;
 
@@ -383,7 +383,7 @@ ALTER TABLE oc_series_property ADD CONSTRAINT FK_oc_series_property_organization
 ALTER TABLE oc_series_property DROP FOREIGN KEY FK_mh_series_property_organization_series;
 
 CREATE INDEX IX_oc_series_property_pk ON oc_series_property (series);
-DROP INDEX IX_mh_series_property_pk ON oc_series_property;
+DROP INDEX IF EXISTS IX_mh_series_property_pk ON oc_series_property;
 
 RENAME TABLE mh_themes TO oc_themes;
 ALTER TABLE oc_themes ADD CONSTRAINT FK_oc_themes_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE;

--- a/docs/upgrade/4_to_5/mysql5.sql
+++ b/docs/upgrade/4_to_5/mysql5.sql
@@ -337,7 +337,6 @@ ALTER TABLE oc_user_settings ADD CONSTRAINT UNQ_oc_user_settings UNIQUE (usernam
 ALTER TABLE oc_user_settings DROP INDEX UNQ_mh_user_settings;
 
 CREATE INDEX IX_oc_user_setting_organization ON oc_user_settings (organization);
-DROP INDEX IX_mh_user_setting_organization ON oc_user_settings;
 
 RENAME TABLE mh_email_configuration TO oc_email_configuration;
 ALTER TABLE oc_email_configuration ADD CONSTRAINT UNQ_oc_email_configuration UNIQUE (organization);

--- a/docs/upgrade/4_to_5/readme.md
+++ b/docs/upgrade/4_to_5/readme.md
@@ -1,0 +1,8 @@
+SQL Upgrade Scripts for migration from Opencast 4.x to Opencast 5.x
+===================================================================
+
+Both `mysql5.sql` and `mariadb10.sql` essentially do the same thing and you should be able to use the first on MariaDB
+as well. The difference is that the latter contains a set of additional checks, trying to deal with possible database
+inconsistencies during the update. For that, `DROP INDEX IF EXISTS` statements are used which are not supported by
+MySQL. Hence, if you are using MySQL, use the `mariadb10.sql` script and watch out for errors yourself when running the
+script.


### PR DESCRIPTION
This patch adds additional uphrade scripts which only use statements
supported by MySQL and older MariaDB versions. The previous script still
exists but has been moved to a separate `mariadb.sql` file.
    
Documentation about these two scripts and the difference between them
has also been added so users can choose what their need during an
upgrade.

This pull request also adds additional Travis CI tests to ensure a proper upgrade
path from Opencast 2.2 onwards.