### PR TITLE
MH-13017, JS syntax error in publish workflow

### DIFF
--- a/etc/workflows/publish.xml
+++ b/etc/workflows/publish.xml
@@ -73,9 +73,9 @@
 
       <!-- Show or hide the hold and publication configuration panel -->
       <script type="text/javascript">
-        <!-- Remove the line below if you wish to publish to AWS S3 -->
+        // Remove the line below if you wish to publish to AWS S3
         $('#publishToAws').prop('disabled', true);
-        <!-- Remove the line above if you wish to publish to AWS S3 -->
+        // Remove the line above if you wish to publish to AWS S3
 
         awsWasDisabled = $('#publishToAws').prop('disabled');
         awsWasChecked = $('#publishToAws').prop('checked');


### PR DESCRIPTION
JavaScript and XML got mixed up in the publish workflow causing a syntax
error and a partly non-functioning configuration panel.