### PR TITLE
release doc: unsorted list needs asterisk instead of dash

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -4,16 +4,16 @@ Opencast 6: Release Notes
 New Features and Improvements
 -----------------------------
 
-- …
+* …
 
 
 Configuration changes
 ---------------------
 
-- The tracking options defaults have changed to be more aware of the European Union's General Data Protection
+* The tracking options defaults have changed to be more aware of the European Union's General Data Protection
   Regulation. Note that you can [still use the old settings if you want to](configuration/user-statistics.and.privacy.md).
 
-- The role ROLE_UI_EVENTS_DETAILS_GENERAL_VIEW for viewing the publications (previously general) tab in the event
+* The role ROLE_UI_EVENTS_DETAILS_GENERAL_VIEW for viewing the publications (previously general) tab in the event
   details modal has been renamed to ROLE_UI_EVENTS_DETAILS_PUBLICATIONS_VIEW for consistency.
 
 
@@ -31,5 +31,5 @@ Release Schedule
 Release Managers
 ----------------
 
-- Matthias Neugebauer (University of Münster)
-- Lars Kiesow (ELAN e.V.)
+* Matthias Neugebauer (University of Münster)
+* Lars Kiesow (ELAN e.V.)


### PR DESCRIPTION
older release docs used asterisk in release docs. the 6.0 one uses dashes