### PR TITLE
MH-13018 re-add recordings json to 5x (includes MH-12828 re-add conflicts.json)

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
@@ -1084,65 +1084,34 @@ public class SchedulerRestService {
   }
 
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("conflicts.json")
-  @RestQuery(name = "conflictingrecordingsasjson", description = "Searches for conflicting recordings based on parameters", returnDescription = "Returns NO CONTENT if no recordings are in conflict within specified period or list of conflicting recordings in JSON", restParameters = {
-          @RestParameter(name = "agent", description = "Device identifier for which conflicts will be searched", isRequired = true, type = Type.STRING),
-          @RestParameter(name = "start", description = "Start time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),
-          @RestParameter(name = "end", description = "End time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),
-          @RestParameter(name = "rrule", description = "Rule for recurrent conflicting, specified as: \"FREQ=WEEKLY;BYDAY=day(s);BYHOUR=hour;BYMINUTE=minute\". FREQ is required. BYDAY may include one or more (separated by commas) of the following: SU,MO,TU,WE,TH,FR,SA.", isRequired = false, type = Type.STRING),
-          @RestParameter(name = "duration", description = "If recurrence rule is specified duration of each conflicting period, in milliseconds", isRequired = false, type = Type.INTEGER),
-          @RestParameter(name = "timezone", description = "The timezone of the capture device", isRequired = false, type = Type.STRING) }, reponses = {
-                  @RestResponse(responseCode = HttpServletResponse.SC_NO_CONTENT, description = "No conflicting events found"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_OK, description = "Found conflicting events, returned in body of response"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_BAD_REQUEST, description = "Missing or invalid parameters"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_UNAUTHORIZED, description = "Not authorized to make this request"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, description = "A detailed stack track of the internal issue.")})
-  public Response getConflictingEventsJson(@QueryParam("agent") String device, @QueryParam("rrule") String rrule,
+  @Produces({ MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON })
+  @Path("conflicts.{type:xml|json}")
+  @RestQuery(name = "conflictingrecordings", description = "Searches for conflicting recordings based on parameters and returns result as XML or JSON", returnDescription = "Returns NO CONTENT if no recordings are in conflict within specified period or list of conflicting recordings in XML or JSON",
+       pathParameters = {
+           @RestParameter(name = "type", isRequired = true, description = "The media type of the response [xml|json]", defaultValue = "xml", type = Type.STRING), },
+       restParameters = {
+           @RestParameter(name = "agent", description = "Device identifier for which conflicts will be searched", isRequired = true, type = Type.STRING),
+           @RestParameter(name = "start", description = "Start time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),
+           @RestParameter(name = "end", description = "End time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),
+           @RestParameter(name = "rrule", description = "Rule for recurrent conflicting, specified as: \"FREQ=WEEKLY;BYDAY=day(s);BYHOUR=hour;BYMINUTE=minute\". FREQ is required. BYDAY may include one or more (separated by commas) of the following: SU,MO,TU,WE,TH,FR,SA.", isRequired = false, type = Type.STRING),
+           @RestParameter(name = "duration", description = "If recurrence rule is specified duration of each conflicting period, in milliseconds", isRequired = false, type = Type.INTEGER),
+           @RestParameter(name = "timezone", description = "The timezone of the capture device", isRequired = false, type = Type.STRING) }, reponses = {
+           @RestResponse(responseCode = HttpServletResponse.SC_NO_CONTENT, description = "No conflicting events found"),
+           @RestResponse(responseCode = HttpServletResponse.SC_OK, description = "Found conflicting events, returned in body of response"),
+           @RestResponse(responseCode = HttpServletResponse.SC_BAD_REQUEST, description = "Missing or invalid parameters"),
+           @RestResponse(responseCode = HttpServletResponse.SC_UNAUTHORIZED, description = "Not authorized to make this request"),
+           @RestResponse(responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, description = "A detailed stack track of the internal issue.")})
+  public Response getConflicts(@PathParam("type") final String type, @QueryParam("agent") String device, @QueryParam("rrule") String rrule,
           @QueryParam("start") Long startDate, @QueryParam("end") Long endDate, @QueryParam("duration") Long duration,
           @QueryParam("timezone") String timezone) throws UnauthorizedException {
     try {
       List<MediaPackage> events = getConflictingEvents(device, rrule, startDate, endDate, duration, timezone);
       if (!events.isEmpty()) {
-        String eventsJsonString = getEventListAsJsonString(events);
-        return Response.ok(eventsJsonString).build();
-      } else {
-        return Response.noContent().build();
-      }
-    } catch (IllegalArgumentException e) {
-      return Response.status(Status.BAD_REQUEST).build();
-    } catch (UnauthorizedException e) {
-      throw e;
-    } catch (Exception e) {
-      logger.error("Unable to find conflicting events for {}, {}, {}, {}, {}: {}",
-              device, rrule, startDate, endDate, duration, getStackTrace(e));
-      throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  @GET
-  @Produces(MediaType.TEXT_XML)
-  @Path("conflicts.xml")
-  @RestQuery(name = "conflictingrecordingsasxml", description = "Searches for conflicting recordings based on parameters", returnDescription = "Returns NO CONTENT if no recordings are in conflict within specified period or list of conflicting recordings in XML", restParameters = {
-          @RestParameter(name = "agent", description = "Device identifier for which conflicts will be searched", isRequired = true, type = Type.STRING),
-          @RestParameter(name = "start", description = "Start time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),
-          @RestParameter(name = "end", description = "End time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),
-          @RestParameter(name = "rrule", description = "Rule for recurrent conflicting, specified as: \"FREQ=WEEKLY;BYDAY=day(s);BYHOUR=hour;BYMINUTE=minute\". FREQ is required. BYDAY may include one or more (separated by commas) of the following: SU,MO,TU,WE,TH,FR,SA.", isRequired = false, type = Type.STRING),
-          @RestParameter(name = "duration", description = "If recurrence rule is specified duration of each conflicting period, in milliseconds", isRequired = false, type = Type.INTEGER),
-          @RestParameter(name = "timezone", description = "The timezone of the capture device", isRequired = false, type = Type.STRING) }, reponses = {
-                  @RestResponse(responseCode = HttpServletResponse.SC_NO_CONTENT, description = "No conflicting events found"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_OK, description = "Found conflicting events, returned in body of response"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_BAD_REQUEST, description = "Missing or invalid parameters"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_UNAUTHORIZED, description = "Not authorized to make this request"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, description = "A detailed stack track of the internal issue.")})
-
-  public Response getConflictingEventsXml(@QueryParam("agent") String device, @QueryParam("rrule") String rrule,
-          @QueryParam("start") Long startDate, @QueryParam("end") Long endDate, @QueryParam("duration") Long duration,
-          @QueryParam("timezone") String timezone) throws UnauthorizedException {
-    try {
-      List<MediaPackage> events = getConflictingEvents(device, rrule, startDate, endDate, duration, timezone);
-      if (!events.isEmpty()) {
-        return Response.ok(MediaPackageParser.getArrayAsXml(events)).build();
+        if ("json".equalsIgnoreCase(type)) {
+          return Response.ok(getEventListAsJsonString(events)).build();
+        } else {
+          return Response.ok(MediaPackageParser.getArrayAsXml(events)).build();
+        }
       } else {
         return Response.noContent().build();
       }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
@@ -100,6 +100,9 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1071,6 +1074,42 @@ public class SchedulerRestService {
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("conflicts.json")
+  @RestQuery(name = "conflictingrecordingsasjson", description = "Searches for conflicting recordings based on parameters", returnDescription = "Returns NO CONTENT if no recordings are in conflict within specified period or list of conflicting recordings in JSON", restParameters = {
+          @RestParameter(name = "agent", description = "Device identifier for which conflicts will be searched", isRequired = true, type = Type.STRING),
+          @RestParameter(name = "start", description = "Start time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),
+          @RestParameter(name = "end", description = "End time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),
+          @RestParameter(name = "rrule", description = "Rule for recurrent conflicting, specified as: \"FREQ=WEEKLY;BYDAY=day(s);BYHOUR=hour;BYMINUTE=minute\". FREQ is required. BYDAY may include one or more (separated by commas) of the following: SU,MO,TU,WE,TH,FR,SA.", isRequired = false, type = Type.STRING),
+          @RestParameter(name = "duration", description = "If recurrence rule is specified duration of each conflicting period, in milliseconds", isRequired = false, type = Type.INTEGER),
+          @RestParameter(name = "timezone", description = "The timezone of the capture device", isRequired = false, type = Type.STRING) }, reponses = {
+                  @RestResponse(responseCode = HttpServletResponse.SC_NO_CONTENT, description = "No conflicting events found"),
+                  @RestResponse(responseCode = HttpServletResponse.SC_OK, description = "Found conflicting events, returned in body of response"),
+                  @RestResponse(responseCode = HttpServletResponse.SC_BAD_REQUEST, description = "Missing or invalid parameters"),
+                  @RestResponse(responseCode = HttpServletResponse.SC_UNAUTHORIZED, description = "Not authorized to make this request"),
+                  @RestResponse(responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, description = "A detailed stack track of the internal issue.")})
+  public Response getConflictingEventsJson(@QueryParam("agent") String device, @QueryParam("rrule") String rrule,
+          @QueryParam("start") Long startDate, @QueryParam("end") Long endDate, @QueryParam("duration") Long duration,
+          @QueryParam("timezone") String timezone) throws UnauthorizedException {
+    try {
+      List<MediaPackage> events = getConflictingEvents(device, rrule, startDate, endDate, duration, timezone);
+      if (!events.isEmpty()) {
+        String eventsJsonString = getEventListAsJsonString(events);
+        return Response.ok(eventsJsonString).build();
+      } else {
+        return Response.noContent().build();
+      }
+    } catch (IllegalArgumentException e) {
+      return Response.status(Status.BAD_REQUEST).build();
+    } catch (UnauthorizedException e) {
+      throw e;
+    } catch (Exception e) {
+      logger.error("Unable to find conflicting events for {}, {}, {}, {}, {}: {}",
+              device, rrule, startDate, endDate, duration, getStackTrace(e));
+      throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
 
   @GET
   @Produces(MediaType.TEXT_XML)
@@ -1084,57 +1123,27 @@ public class SchedulerRestService {
           @RestParameter(name = "timezone", description = "The timezone of the capture device", isRequired = false, type = Type.STRING) }, reponses = {
                   @RestResponse(responseCode = HttpServletResponse.SC_NO_CONTENT, description = "No conflicting events found"),
                   @RestResponse(responseCode = HttpServletResponse.SC_OK, description = "Found conflicting events, returned in body of response"),
-                  @RestResponse(responseCode = HttpServletResponse.SC_BAD_REQUEST, description = "Missing or invalid parameters") })
+                  @RestResponse(responseCode = HttpServletResponse.SC_BAD_REQUEST, description = "Missing or invalid parameters"),
+                  @RestResponse(responseCode = HttpServletResponse.SC_UNAUTHORIZED, description = "Not authorized to make this request"),
+                  @RestResponse(responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR, description = "A detailed stack track of the internal issue.")})
+
   public Response getConflictingEventsXml(@QueryParam("agent") String device, @QueryParam("rrule") String rrule,
           @QueryParam("start") Long startDate, @QueryParam("end") Long endDate, @QueryParam("duration") Long duration,
           @QueryParam("timezone") String timezone) throws UnauthorizedException {
-    if (StringUtils.isBlank(device) || startDate == null || endDate == null) {
-      logger.info("Either agent, start date or end date were not specified");
-      return Response.status(Status.BAD_REQUEST).build();
-    }
-
-    RRule rule = null;
-    if (StringUtils.isNotBlank(rrule)) {
-      if (duration == null || StringUtils.isBlank(timezone)) {
-        logger.info("Either duration or timezone were not specified");
-        return Response.status(Status.BAD_REQUEST).build();
-      }
-
-      try {
-        rule = new RRule(rrule);
-        rule.validate();
-      } catch (Exception e) {
-        logger.info("Unable to parse rrule {}: {}", rrule, getMessage(e));
-        return Response.status(Status.BAD_REQUEST).build();
-      }
-
-      if (!Arrays.asList(TimeZone.getAvailableIDs()).contains(timezone)) {
-        logger.info("Unable to parse timezone: {}", timezone);
-        return Response.status(Status.BAD_REQUEST).build();
-      }
-    }
-
-    Date start = new DateTime(startDate).toDateTime(DateTimeZone.UTC).toDate();
-
-    Date end = new DateTime(endDate).toDateTime(DateTimeZone.UTC).toDate();
-
     try {
-      List<MediaPackage> events;
-      if (StringUtils.isNotBlank(rrule)) {
-        events = service.findConflictingEvents(device, rule, start, end, duration, TimeZone.getTimeZone(timezone));
-      } else {
-        events = service.findConflictingEvents(device, start, end);
-      }
+      List<MediaPackage> events = getConflictingEvents(device, rrule, startDate, endDate, duration, timezone);
       if (!events.isEmpty()) {
         return Response.ok(MediaPackageParser.getArrayAsXml(events)).build();
       } else {
         return Response.noContent().build();
       }
+    } catch (IllegalArgumentException e) {
+      return Response.status(Status.BAD_REQUEST).build();
     } catch (UnauthorizedException e) {
       throw e;
     } catch (Exception e) {
       logger.error("Unable to find conflicting events for {}, {}, {}, {}, {}: {}",
-              device, rrule, start, end, duration, getStackTrace(e));
+              device, rrule, startDate, endDate, duration, getStackTrace(e));
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
@@ -1743,6 +1752,50 @@ public class SchedulerRestService {
     }
   }
 
+  private List<MediaPackage> getConflictingEvents(String device, String rrule,
+          Long startDate, Long endDate, Long duration, String timezone)
+                  throws IllegalArgumentException, UnauthorizedException, SchedulerException {
+
+    List<MediaPackage> events = null;
+
+    if (StringUtils.isBlank(device) || startDate == null || endDate == null) {
+      logger.info("Either agent, start date or end date were not specified");
+      throw new IllegalArgumentException();
+    }
+
+    RRule rule = null;
+    if (StringUtils.isNotBlank(rrule)) {
+      if (duration == null || StringUtils.isBlank(timezone)) {
+        logger.info("Either duration or timezone were not specified");
+        throw new IllegalArgumentException();
+      }
+
+      try {
+        rule = new RRule(rrule);
+        rule.validate();
+      } catch (Exception e) {
+        logger.info("Unable to parse rrule {}: {}", rrule, getMessage(e));
+        throw new IllegalArgumentException();
+      }
+
+      if (!Arrays.asList(TimeZone.getAvailableIDs()).contains(timezone)) {
+        logger.info("Unable to parse timezone: {}", timezone);
+        throw new IllegalArgumentException();
+      }
+    }
+
+    Date start = new DateTime(startDate).toDateTime(DateTimeZone.UTC).toDate();
+
+    Date end = new DateTime(endDate).toDateTime(DateTimeZone.UTC).toDate();
+
+    if (StringUtils.isNotBlank(rrule)) {
+      events = service.findConflictingEvents(device, rule, start, end, duration, TimeZone.getTimeZone(timezone));
+    } else {
+      events = service.findConflictingEvents(device, start, end);
+    }
+    return events;
+  }
+
   private MediaPackage addCatalog(Workspace workspace, InputStream in, String fileName,
           MediaPackageElementFlavor flavor, MediaPackage mediaPackage) throws IOException {
     Catalog[] catalogs = mediaPackage.getCatalogs(flavor);
@@ -1793,4 +1846,32 @@ public class SchedulerRestService {
     caProperties.load(new StringReader(serializedProperties));
     return caProperties;
   }
+
+  /**
+   * Serializes mediapackage schedule metadata into JSON array string.
+   *
+   * @return serialized array as json array string
+   * @throws SchedulerException
+   *           if parsing list into JSON format fails
+   */
+  public String getEventListAsJsonString(List<MediaPackage> mpList) throws SchedulerException {
+    JSONParser parser = new JSONParser();
+    JSONObject jsonObj = new JSONObject();
+    JSONArray jsonArray = new JSONArray();
+    for (MediaPackage mp: mpList) {
+      JSONObject mpJson;
+      try {
+        mpJson = (JSONObject) parser.parse(MediaPackageParser.getAsJSON(mp));
+        mpJson = (JSONObject) mpJson.get("mediapackage");
+        jsonArray.add(mpJson);
+      } catch (org.json.simple.parser.ParseException e) {
+        logger.warn("Unexpected JSON parse exception for getAsJSON on mp {}", mp.getIdentifier().compact(), e);
+        throw new SchedulerException(e);
+      }
+    }
+    jsonObj.put("totalCount", String.valueOf(mpList.size()));
+    jsonObj.put("events", jsonArray);
+    return jsonObj.toJSONString();
+  }
 }
+

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
@@ -1041,7 +1041,7 @@ public class SchedulerRestService {
   @Path("recordings.{type:xml|json}")
   @RestQuery(name = "recordingsaslist", description = "Searches recordings and returns result as XML or JSON", returnDescription = "XML or JSON formated results",
        pathParameters = {
-          @RestParameter(name = "type", isRequired = true, description = "The media type of the response [xml|json]", defaultValue = "xml", type = Type.STRING), },
+          @RestParameter(name = "type", isRequired = true, description = "The media type of the response [xml|json]", type = Type.STRING) },
        restParameters = {
           @RestParameter(name = "agent", description = "Search by device", isRequired = false, type = Type.STRING),
           @RestParameter(name = "startsfrom", description = "Search by when does event start", isRequired = false, type = Type.INTEGER),
@@ -1088,7 +1088,7 @@ public class SchedulerRestService {
   @Path("conflicts.{type:xml|json}")
   @RestQuery(name = "conflictingrecordings", description = "Searches for conflicting recordings based on parameters and returns result as XML or JSON", returnDescription = "Returns NO CONTENT if no recordings are in conflict within specified period or list of conflicting recordings in XML or JSON",
        pathParameters = {
-           @RestParameter(name = "type", isRequired = true, description = "The media type of the response [xml|json]", defaultValue = "xml", type = Type.STRING), },
+           @RestParameter(name = "type", isRequired = true, description = "The media type of the response [xml|json]", type = Type.STRING) },
        restParameters = {
            @RestParameter(name = "agent", description = "Device identifier for which conflicts will be searched", isRequired = true, type = Type.STRING),
            @RestParameter(name = "start", description = "Start time of conflicting period, in milliseconds", isRequired = true, type = Type.INTEGER),

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -2298,6 +2298,16 @@ public class SchedulerServiceImplTest {
     assertEquals(orgList.size(), dublincoreCatalogs.size());
   }
 
+  public void testGetJsonMpSchedulerRestEndpoint() throws MediaPackageException, SchedulerException {
+    SchedulerRestService restService = new SchedulerRestService();
+    List<MediaPackage> mpList = new ArrayList();
+    mpList.add(generateEvent(Opt.some("mp1")));
+    mpList.add(generateEvent(Opt.some("mp2")));
+    String jsonStr = restService.getEventListAsJsonString(mpList);
+    Assert.assertTrue(jsonStr.contains("mp1"));
+    Assert.assertTrue(jsonStr.contains("mp2"));
+  }
+
   private String addDublinCore(Opt<String> id, MediaPackage mediaPackage, final DublinCoreCatalog initalEvent)
           throws URISyntaxException, IOException {
     String catalogId = UUID.randomUUID().toString();


### PR DESCRIPTION
This pull for MH-13018 to readd recordings.json, also includes as a prerequisite the MH-12828 pulll that was merged to OC develop branch in https://github.com/opencast/opencast/pull/233/files. Both fixes use the getEventListAsJsonString() helper that is reused by both conflicts.json and recordings.json. Adding both here should make it easier to merge back this fix to develop branch.

The conflicts code is not altered in this pull, but it is moved into a helper method to avoid duplication.

Example result of /recordings/recordings.json?...
{
  "totalCount": "0",
  "events": []
}

or 

{ "totalCount": "2",
  "events": [
    {
      "seriestitle": "Test Spring 2018 (29996)",
      "metadata": {"catalog": [... ]},
      "attachments": {"attachment": [...]},
      "series": 20180229996,
      "start": "2018-07-30T18:00:00Z",
      "id": "877067ba-857d-4527-980b-88f576764f5b",
      "media": "",
      "title": "Karen test schdule Jul 30 -2",
      "type": "L02",
      "publications": ""
    },
    {
      "seriestitle": "Computer Science 101 (29990) Spring 2018",
      "metadata": {"catalog": [...]},
      "attachments": {"attachment": [...]},
      "series": 20180229990,
      "creators": {"creator": "kdolan"},
      "start": "2018-08-05T18:00:00Z",
      "id": "e5d89b64-73ff-4287-98ad-a5040f5228a6",
      "media": "",
      "title": "Karen test schdule Jul 30 -1",
      "type": "L01",
      "publications": {"publication": {...}}
    }
  ]
}