### PR TITLE
Documentation: message-broker: binding localhost

### DIFF
--- a/docs/guides/admin/docs/configuration/message-broker.md
+++ b/docs/guides/admin/docs/configuration/message-broker.md
@@ -32,7 +32,7 @@ What you need to do:
 
 The first task is easy. Opencast comes with a ActiveMQ configuration file, located at
 `docs/scripts/activemq/activemq.xml` (RPM repo: `/usr/share/opencast/docs/scripts/activemq/activemq.xml`). This file
-will give you a basic configuration with all queues set-up and accepting connections from all hosts over TCP port
+will give you a basic configuration with all queues set-up and accepting connections from the local host over TCP port
 `61616`.
 
 Replacing the default ActiveMQ configuration with this file will already give you a fully functional ActiveMQ set-up for


### PR DESCRIPTION
Default is not accepting connections from all hosts; only localhost. This changed with 31e88e23982c61c859ebd33879086b3930890538