### PR TITLE
MH-13024 Video editor does not display information when being opened while an event is being processed

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -284,8 +284,6 @@ public class ToolsEndpoint implements ManagedService {
                   @RestResponse(description = "Media package not found", responseCode = SC_NOT_FOUND) })
   public Response getVideoEditor(@PathParam("mediapackageid") final String mediaPackageId)
           throws IndexServiceException, NotFoundException {
-    if (!isEditorAvailable(mediaPackageId))
-      return R.notFound();
 
     // Select tracks
     final Event event = getEvent(mediaPackageId).get();


### PR DESCRIPTION
See https://opencast.jira.com/browse/MH-13024

Before:

![without_patch](https://user-images.githubusercontent.com/1590263/43832714-9c66bee2-9b08-11e8-92e9-ed9d5d1715e2.png)

After:

![with_patch](https://user-images.githubusercontent.com/1590263/43832711-9a4ce8ac-9b08-11e8-828b-8aca6acc14f7.png)
