### PR TITLE
MH-13029 Don't show old notifications

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
@@ -25,6 +25,8 @@ angular.module('adminNg.controllers')
 .controller('ToolsCtrl', ['$scope', '$route', '$location', 'Storage', '$window', 'ToolsResource', 'Notifications', 'EventHelperService',
     function ($scope, $route, $location, Storage, $window, ToolsResource, Notifications, EventHelperService) {
 
+        var LOCAL_CONTEXT = 'video-tools';
+
         $scope.navigateTo = function (path) {
             $location.path(path).replace();
         };
@@ -89,7 +91,7 @@ angular.module('adminNg.controllers')
                 $scope.unsavedChanges = false;
             }, function () {
                 $scope.submitButton = false;
-                Notifications.add('error', 'VIDEO_CUT_NOT_SAVED', 'video-tools');
+                Notifications.add('error', 'VIDEO_CUT_NOT_SAVED', LOCAL_CONTEXT);
             });
         };
 
@@ -97,5 +99,9 @@ angular.module('adminNg.controllers')
             Storage.put('pagination', $scope.resource, 'resume', true);
             $location.url('/events/' + $scope.resource);
         };
+
+        $scope.$on('$destroy', function () {
+            Notifications.removeAll(LOCAL_CONTEXT);
+         });
     }
 ]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/notificationsService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/notificationsService.js
@@ -92,6 +92,18 @@ angular.module('adminNg.services')
             }
         };
 
+        scope.removeAll = function(context) {
+
+            if (!context) {
+                context = 'global';
+            }
+
+            delete keyList[context]
+            delete notifications[context]
+
+            scope.$emit('deleted', context);
+        }
+
         scope.addWithParams = function (type, key, messageParams, context, duration) {
             scope.add(type, key, context, duration, messageParams);
         };


### PR DESCRIPTION
Remove notifications belonging to the local context when the videoeditor is closed so they are not shown when another event is opened in the videoeditor later.

_This work was sponsored by SWITCH._