### PR TITLE
MH-12016: Scrolling role fetch

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
@@ -24,8 +24,8 @@ angular.module('adminNg.controllers')
 .controller('UserCtrl', ['$scope', 'Table', 'UserRolesResource', 'UserResource', 'UsersResource', 'JsHelper', 'Notifications', 'Modal', 'AuthService', 'underscore',
     function ($scope, Table, UserRolesResource, UserResource, UsersResource, JsHelper, Notifications, Modal, AuthService, _) {
         $scope.manageable = true;
-        var roleSlice = 100;
-        var roleOffset = roleSlice; //Note that the initial offset is the same size as the initial slice so that the *next* slice starts at the right place
+        $scope.roleSlice = 100;
+        $scope.roleOffset = $scope.roleSlice; //Note that the initial offset is the same size as the initial slice so that the *next* slice starts at the right place
         var loading = false;
         var showExternalRoles = false; // Should the External Roles tab be visible
 
@@ -40,7 +40,7 @@ angular.module('adminNg.controllers')
         });
 
         $scope.role = {
-            available: UserRolesResource.query({limit: $scope.roleSlice, offset: 0, filter: 'role_target:USER'}), // Load all the internal roles
+            available: UserRolesResource.query({limit: $scope.roleSlice, offset: 0, filter: 'role_target:USER'}), // Load the first rolesSlice internal roles
             external: [],
             selected:  [],
             derived: [],
@@ -57,8 +57,8 @@ angular.module('adminNg.controllers')
 
             loading = true;
             UserRolesResource.query({limit: $scope.roleSlice, offset: $scope.roleOffset, filter: 'role_target:USER'}).$promise.then(function (data) {
-                angular.extend($scope.role.available, data);
-                roleOffset = roleOffset + roleSlice;
+                $scope.role.available = $scope.role.available.concat(data);
+                $scope.roleOffset = $scope.roleOffset + $scope.roleSlice;
             }, this).finally(function () {
                 loading = false;
             });

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
@@ -40,7 +40,7 @@ angular.module('adminNg.controllers')
         });
 
         $scope.role = {
-            available: UserRolesResource.query({limit: 0, offset: 0, filter: 'role_target:USER'}), // Load all the internal roles
+            available: UserRolesResource.query({limit: $scope.roleSlice, offset: 0, filter: 'role_target:USER'}), // Load all the internal roles
             external: [],
             selected:  [],
             derived: [],

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/loadingScrollerDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/loadingScrollerDirective.js
@@ -38,7 +38,7 @@ angular.module('adminNg.directives')
 
             element.bind('scroll', function () {
                 if (raw.scrollTop + raw.offsetHeight > raw.scrollHeight) {
-                    scope.$apply(attrs.adminNgLoadingScroller);
+                    scope.$apply(attrs.loadingScroller);
                 }
             });
         }

--- a/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/userControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/userControllerSpec.js
@@ -31,7 +31,7 @@ describe('User controller', function () {
         $httpBackend.whenGET('/roles/roles.json').respond(JSON.stringify(getJSONFixture('roles/roles.json')));
         $httpBackend.whenGET('/admin-ng/users/matterhorn_system_account.json')
             .respond(JSON.stringify(getJSONFixture('admin-ng/users/matterhorn_system_account.json')));
-        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:USER&limit=0&offset=0').respond('{}');
+        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:USER&limit=100&offset=0').respond('{}');
         $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
         $controller('UserCtrl', {$scope: $scope});
         $httpBackend.flush();


### PR DESCRIPTION
Previously the list of the roles in the user creation/modification modal would load additional roles when scrolled to  the bottom.  This behaviour is currently broken, and this patch resolves the issue.

To test, modify modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js, set the limit to 20 in the UserRolesResource.query, and then rebuild (or better, use the proxy).  Scrolling to the bottom should pull up the *rest* of the roles from the system.