### PR TITLE
MH-13032, Asset Upload fix for missing reset()

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/services/wizards/new-event/uploadAssetNewEvent.js
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/services/wizards/new-event/uploadAssetNewEvent.js
@@ -1,3 +1,25 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
 // Asset Upload service for New Events (MH-12085)
 // This is used in the new events states wizard directive
 
@@ -39,13 +61,17 @@ function (ResourcesListResource, UploadAssetOptions, JsHelper, Notifications, $i
   var NewEventUploadAsset = function () {
 
     var self = this;
-    self.requiredMetadata = {};
-    self.ud = {};
-    self.ud.assets = {};
-    self.ud.defaults = {};
-    self.ud.namemap = {};
-    self.ud.assetlistforsummary = [];
-    self.ud.hasNonTrackOptions = false;
+
+    this.reset = function () {
+      self.requiredMetadata = {};
+      self.ud = {};
+      self.ud.assets = {};
+      self.ud.defaults = {};
+      self.ud.namemap = {};
+      self.ud.assetlistforsummary = [];
+      self.ud.hasNonTrackOptions = false;
+    };
+    self.reset();
 
     // This is used as the callback from the uploadAssetDirective
     self.onAssetUpdate = function() {


### PR DESCRIPTION
Fix for sticky asset upload, MH-13032. Prevents a new event from getting assets assigned to the previous new event.

This fix also applies to r/5.x and develop branch.