### PR TITLE
MH-13034: Add lis_person_sourcedid back as LTI source field for the username

### DIFF
--- a/modules/matterhorn-kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
+++ b/modules/matterhorn-kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
@@ -173,12 +173,16 @@ public class LtiLaunchAuthenticationHandler
     if (highlyTrustedKeys.contains(oaAuthKey)) {
       logger.debug("{} is a trusted key", oaAuthKey);
 
-      // If supplied we use the human readable name
+      // If supplied we use the human readable name coming from:
+      //   1. ext_user_username    (optional Moodle-only field)
+      //   2. lis_person_sourcedid (optional standard field)
       String ltiUsername = request.getParameter("ext_user_username");
-      // This is an optional field it could be null
       if (StringUtils.isBlank(ltiUsername)) {
-        // if no eid is set we use the supplied ID
-        ltiUsername = userIdFromConsumer;
+        ltiUsername = request.getParameter("lis_person_sourcedid");
+        if (StringUtils.isBlank(ltiUsername)) {
+          // If no eid is set we use the supplied ID
+          ltiUsername = userIdFromConsumer;
+        }
       }
 
       // Check if the provided username should be trusted


### PR DESCRIPTION
MH-12840 (ef7bc8e94936b426bec5cb52f846d81c8c903657) change the use of the LTI field `lis_person_sourcedid` to `ext_user_username` which is Moodle specific. This adds `lis_person_sourcedid` back in case `ext_user_username` does not exist.