### PR TITLE
MH-12690: Add i18n support for capture agent statuses

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpoint.java
@@ -35,6 +35,7 @@ import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
 import org.opencastproject.adminui.util.TextFilter;
 import org.opencastproject.capture.CaptureParameters;
 import org.opencastproject.capture.admin.api.Agent;
+import org.opencastproject.capture.admin.api.AgentState;
 import org.opencastproject.capture.admin.api.CaptureAgentAdminRoleProvider;
 import org.opencastproject.capture.admin.api.CaptureAgentStateService;
 import org.opencastproject.index.service.resources.list.query.AgentsListQuery;
@@ -273,7 +274,7 @@ public class CaptureAgentsEndpoint {
    */
   private JValue generateJsonAgent(Agent agent, boolean withInputs, boolean details) {
     List<Field> fields = new ArrayList<>();
-    fields.add(f("Status", v(agent.getState(), Jsons.BLANK)));
+    fields.add(f("Status", v(AgentState.TRANSLATION_PREFIX + agent.getState().toUpperCase(), Jsons.BLANK)));
     fields.add(f("Name", v(agent.getName())));
     fields.add(f("Update", v(toUTC(agent.getLastHeardFrom()), Jsons.BLANK)));
     fields.add(f("URL", v(agent.getUrl(), Jsons.BLANK)));

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
@@ -2015,5 +2015,16 @@
             "PLAY_ENDING_OF_CURRENT_SEGMENT": "Segmentende"
          }
       }
-   }
+   },
+  "AGENTS": {
+    "STATUS": {
+      "CAPTURING": "Aufzeichnend",
+      "ERROR": "Fehlerhaft",
+      "IDLE": "Untätig",
+      "OFFLINE": "Offline",
+      "SHUTTING_DOWN": "Herunterfahrend",
+      "UNKNOWN": "Unbekannt",
+      "UPLOADING": "Hochladend"
+    }
+  }
 }

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2031,5 +2031,16 @@
                "PLAY_ENDING_OF_CURRENT_SEGMENT": "End of segment"
            }
        }
-   }
+   },
+  "AGENTS": {
+    "STATUS": {
+      "CAPTURING": "Capturing",
+      "ERROR": "Error",
+      "IDLE": "Idle",
+      "OFFLINE": "Offline",
+      "SHUTTING_DOWN": "Shutting down",
+      "UNKNOWN": "Unknown",
+      "UPLOADING": "Uploading"
+    }
+  }
 }

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/controllers/recordingsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/controllers/recordingsController.js
@@ -30,7 +30,8 @@ angular.module('adminNg.controllers')
             columns: [{
                 name:  'status',
                 template: 'modules/recordings/partials/recordingStatusCell.html',
-                label: 'RECORDINGS.RECORDINGS.TABLE.STATUS'
+                label: 'RECORDINGS.RECORDINGS.TABLE.STATUS',
+                translate: true
             }, {
                 template: 'modules/recordings/partials/recordingsNameCell.html',
                 name:  'name',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingStatusCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingStatusCell.html
@@ -1,1 +1,1 @@
-<span data-status="{{row.status}}">{{ row.status }}</span>
+<span data-status="{{row.status}}">{{ row.status | translate }}</span>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/recording-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/recording-details.html
@@ -42,7 +42,7 @@
                 </tr>
                 <tr>
                   <td translate="RECORDINGS.RECORDINGS.DETAILS.GENERAL.STATUS"><!-- Status --></td>
-                  <td>{{ agent.status }}</td>
+                  <td>{{ agent.status | translate }}</td>
                 </tr>
                 <tr>
                   <td translate="RECORDINGS.RECORDINGS.DETAILS.GENERAL.UPDATE"><!-- Last Heard From --></td>

--- a/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
@@ -327,23 +327,23 @@
             vertical-align: top;
         }
 
-        span[data-status=offline]:before {
+        span[data-status="AGENTS.STATUS.OFFLINE"]:before {
             background: black;
         }
 
-        span[data-status=idle]:before {
+        span[data-status="AGENTS.STATUS.IDLE"]:before {
             background: $green;
         }
 
-        span[data-status="shutting_down"]:before,span[data-status=unknown]:before {
+        span[data-status="AGENTS.STATUS.SHUTTING_DOWN"]:before,span[data-status="AGENTS.STATUS.UNKNOWN"]:before {
             background: $yellow;
         }
 
-        span[data-status="capturing"]:before,span[data-status="uploading"]:before {
+        span[data-status="AGENTS.STATUS.CAPTURING"]:before,span[data-status="AGENTS.STATUS.UPLOADING"]:before {
             background: $l-blue;
         }
 
-        span[data-status="error"]:before {
+        span[data-status="AGENTS.STATUS.ERROR"]:before {
             background: $red;
         }
 

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/capture-agents/agent1
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/capture-agents/agent1
@@ -1,5 +1,5 @@
 {
-  "Status": "idle",
+  "Status": "AGENTS.STATUS.IDLE",
   "capabilities": [
     {
       "value": "defaults",

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/capture-agents/agent2
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/capture-agents/agent2
@@ -1,5 +1,5 @@
 {
-  "Status": "error",
+  "Status": "AGENTS.STATUS.ERROR",
   "capabilities": [],
   "configuration": [],
   "inputs": [],

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/capture-agents/agent3
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/capture-agents/agent3
@@ -1,5 +1,5 @@
 {
-  "Status": "uploading",
+  "Status": "AGENTS.STATUS.UPLOADING",
   "capabilities": [
     {
       "value": "defaults",

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/capture-agents/agents.json
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/capture-agents/agents.json
@@ -5,7 +5,7 @@
   "results": [
     {
       "Name": "agent1",
-      "Status": "idle",
+      "Status": "AGENTS.STATUS.IDLE",
       "Update": "2014-05-26T15:37:02Z",
       "blacklist": {
         "start": "2014-08-10T22:00:00Z",
@@ -25,7 +25,7 @@
     },
     {
       "Name": "agent2",
-      "Status": "error",
+      "Status": "AGENTS.STATUS.ERROR",
       "Update": "2016-03-11T15:15:38Z",
       "blacklist": {
         "start": "2014-08-10T22:00:00Z",
@@ -36,7 +36,7 @@
     },
     {
       "Name": "agent3",
-      "Status": "uploading",
+      "Status": "AGENTS.STATUS.UPLOADING",
       "Update": "2014-05-26T15:37:02Z",
       "blacklist": {
         "start": "2014-08-10T22:00:00Z",

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/recordings/filters.json
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/recordings/filters.json
@@ -2,19 +2,22 @@
   "Status":{
     "translatable":true,
     "options":{
-      "offline":"offline",
-      "shutting_down":"shutting_down",
-      "idle":"idle",
-      "capturing":"capturing",
-      "uploading":"uploading",
-      "error":"error",
-      "unknown":"unknown"
+      "offline":"AGENTS.STATUS.OFFLINE",
+      "shutting_down":"AGENTS.STATUS.SHUTTING_DOWN",
+      "idle":"AGENTS.STATUS.IDLE",
+      "capturing":"AGENTS.STATUS.CAPTURING",
+      "uploading":"AGENTS.STATUS.UPLOADING",
+      "error":"AGENTS.STATUS.ERROR",
+      "unknown":"AGENTS.STATUS.UNKNOWN"
     },
     "label":"FILTERS.AGENTS.STATUS.LABEL",
     "type":"select"
   },
   "Name":{
     "translatable":false,
+    "options":{
+      "F300.1":"F300.1"
+    },
     "label":"FILTERS.AGENTS.NAME.LABEL",
     "type":"select"
   }

--- a/modules/admin-ui/src/test/resources/app/GET/capture-agents/agents.json
+++ b/modules/admin-ui/src/test/resources/app/GET/capture-agents/agents.json
@@ -5,25 +5,25 @@
     "results": [
         {
             "Name": "agent4",
-            "Status": "ok",
+            "Status": "AGENTS.STATUS.OK",
             "Update": "2014-05-26T15:37:02Z",
             "blacklist": ""
         },
         {
             "Name": "agent3",
-            "Status": "ok",
+            "Status": "AGENTS.STATUS.OK",
             "Update": "2014-05-26T15:37:02Z",
             "blacklist": ""
         },
         {
             "Name": "agent2",
-            "Status": "ok",
+            "Status": "AGENTS.STATUS.OK",
             "Update": "2014-05-26T15:37:02Z",
             "blacklist": ""
         },
         {
             "Name": "agent1",
-            "Status": "ok",
+            "Status": "AGENTS.STATUS.OK",
             "Update": "2014-05-26T15:37:02Z",
             "blacklist": {
                 "end": "2025-12-24T12:12:12Z",

--- a/modules/admin-ui/src/test/resources/capture_agents.json
+++ b/modules/admin-ui/src/test/resources/capture_agents.json
@@ -5,7 +5,7 @@
    "limit":0,
    "results":[
       {
-         "Status":"ok",
+         "Status":"AGENTS.STATUS.OK",
          "inputs":[
             {
                "id":"microphone",
@@ -18,7 +18,7 @@
          "Name":"agent4"
       },
       {
-         "Status":"ok",
+         "Status":"AGENTS.STATUS.OK",
          "inputs":[
             {
                "id":"microphone",
@@ -31,7 +31,7 @@
          "Name":"agent3"
       },
       {
-         "Status":"ok",
+         "Status":"AGENTS.STATUS.OK",
          "inputs":[
             {
                "id":"microphone",
@@ -44,7 +44,7 @@
          "Name":"agent2"
       },
       {
-         "Status":"ok",
+         "Status":"AGENTS.STATUS.OK",
          "inputs":[
             {
                "id":"microphone",

--- a/modules/admin-ui/src/test/resources/capture_agents_noinputs.json
+++ b/modules/admin-ui/src/test/resources/capture_agents_noinputs.json
@@ -5,28 +5,28 @@
    "limit":0,
    "results":[
       {
-         "Status":"ok",
+         "Status":"AGENTS.STATUS.OK",
          "blacklist":"",
          "Update":"2016-06-09T06:00:00Z",
          "roomId":-1,
          "Name":"agent4"
       },
       {
-         "Status":"ok",
+         "Status":"AGENTS.STATUS.OK",
          "blacklist":"",
          "Update":"2016-06-09T18:00:00Z",
          "roomId":-1,
          "Name":"agent3"
       },
       {
-         "Status":"ok",
+         "Status":"AGENTS.STATUS.OK",
          "blacklist":"",
          "Update":"2016-05-26T07:07:07Z",
          "roomId":-1,
          "Name":"agent2"
       },
       {
-         "Status":"ok",
+         "Status":"AGENTS.STATUS.OK",
          "blacklist":{
             "start":"2025-12-12T12:12:12Z",
             "end":"2025-12-24T12:12:12Z"

--- a/modules/admin-ui/src/test/resources/test/unit/shared/resources/captureAgentsResourceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/resources/captureAgentsResourceSpec.js
@@ -38,7 +38,7 @@ describe('Recordings API Resource', function () {
             $httpBackend.flush();
             expect(data.rows.length).toBe(3);
             expect(data.rows[0].id).toBe(data.rows[0].name);
-            expect(data.rows[0].status).toBe('idle');
+            expect(data.rows[0].status).toBe('AGENTS.STATUS.IDLE');
             expect(data.rows[0].name).toBe('agent1');
             expect(data.rows[0].updated).toBe('2014-05-26T15:37:02Z');
         });

--- a/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/AgentState.java
+++ b/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/AgentState.java
@@ -54,4 +54,6 @@ public interface AgentState {
   /** The collection of all known states. TODO: Remove this when the states are replaced with enums */
   List<String> KNOWN_STATES = Arrays.asList(IDLE, SHUTTING_DOWN, CAPTURING, UPLOADING, ERROR, UNKNOWN, OFFLINE);
 
+  String TRANSLATION_PREFIX = "AGENTS.STATUS.";
+
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AgentsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AgentsListProvider.java
@@ -67,7 +67,7 @@ public class AgentsListProvider implements ResourceListProvider {
 
     if (STATUS.equals(listName)) {
       for (String state : AgentState.KNOWN_STATES) {
-        result.put(state, state);
+        result.put(state, STATUS + "." + state.toUpperCase());
       }
     } else {
       Map<String, Agent> knownAgents = agentsService.getKnownAgents();

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AgentsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AgentsListProvider.java
@@ -67,7 +67,7 @@ public class AgentsListProvider implements ResourceListProvider {
 
     if (STATUS.equals(listName)) {
       for (String state : AgentState.KNOWN_STATES) {
-        result.put(state, STATUS + "." + state.toUpperCase());
+        result.put(state, AgentState.TRANSLATION_PREFIX + state.toUpperCase());
       }
     } else {
       Map<String, Agent> knownAgents = agentsService.getKnownAgents();


### PR DESCRIPTION
This will ensure that capture agent statuses are translated in every place they appear (in the main table, in the filter list and in the details modal). For the purpose of showcasing, throw-away German translations are supplied. Additionally, the mockup data has been adapted to reflect said changes.

Regarding the translation prefix constant: I was not sure if a convention existed for such cases (where a constant is used in multiple locations), so I figured I place the prefix in the AgentState interface.