### PR TITLE
MH-12810 External API 1.1.0 - Add filters for new fields

### DIFF
--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -16,13 +16,32 @@ Query String Parameter |Type                         | Description
 
 The following filters are available:
 
-Filter Name    | Description
-:--------------|:-----------
-`contributors` | Events where the contributors match
-`location`     | Events based upon the location it is scheduled in
-`series`       | Events based upon which series they are a part of
-`subject`      | Filters events based upon which subject they are a part of
-`textFilter`   | Filters events where any part of the event's metadata fields match this value
+Filter Name       | Description
+:-----------------|:-----------
+`contributors`    | Events where the contributors match. Can occur multiple times
+`location`        | Events based upon the location it is scheduled in
+`series`          | Events based upon which series they are a part of. Use the series identifier here. If using version 1.1.0 or higher, please use `is_part_of` instead
+`subject`         | Filters events based upon which subject they are a part of
+`textFilter`      | Filters events where any part of the event's metadata fields match this value
+`identifier`      | Filters events whose identifiers match this value. Can occur multiple times (version 1.1.0 and higher)
+`title`           | Filters events whose title match this value (version 1.1.0 and higher)
+`description`     | Filters events whose description match this value (version 1.1.0 and higher)
+`series_name`     | Filters events that belong to series with the given name (version 1.1.0 or higher)
+`language`        | Filters events whose language match this value (version 1.1.0 or higher)
+`created`         | Filters events whose created match this value (version 1.1.0 or higher)
+`license`         | Filters events whose license match this value (version 1.1.0 or higher)
+`rightsholder`    | Filters events whose rights holder matches this value (version 1.1.0 or higher)
+`status`          | Filters events based on their status (version 1.1.0 or higher)
+`is_part_of`      | Events based upon which series they are a part of. Use the series identifier here (version 1.1.0 or higher)
+`source`          | Filter events whose source match this value (version 1.1.0 or higher)
+`agent_id`        | Filter events based on the capture agent id (version 1.1.0 or higher)
+`start`           | Filter events based on start date (version 1.1.0 or higer)
+`technical_start` | Filter events based on the technical start date (version 1.1.0 or higher)
+
+Note:
+The filters `start` and `technical_start` expect the following value:
+
+[`datetime`](types.md#date-and-time) + '/' + [`datetime`](types.md#date-and-time)
 
 The list can be sorted by the following criteria:
 

--- a/docs/guides/developer/docs/api/series-api.md
+++ b/docs/guides/developer/docs/api/series-api.md
@@ -19,16 +19,21 @@ The following filters are available:
 
 Filter Name    | Description
 :--------------|:-----------
-`contributors` | Series where the contributors specified in the metadata field match
-`creator`      | Series where the creator specified in the metadata field match
+`contributors` | Series where the contributors specified in the metadata field match. Can occur multiple times
+`Creator`      | Series where the creator specified in the metadata field match (please use `creator` for version 1.1.0 and higher instead)
 `creationDate` | Series that were created between two dates. The two dates are in UTC format to the second i.e. yyyy-MM-ddTHH:mm:ssZ e.g. 2014-09-27T16:25Z. They are seperated by a forward slash (url encoded or not) so an example of the full filter would be CreationDate:2015-05-08T00:00:00.000Z/2015-05-10T00:00:00.000Z
 `language`     | Series based upon the language specified
 `license`      | Series based upon the license specified
-`organizers`   | Series where the organizers specified in the metadata field match
+`organizers`   | Series where the organizers specified in the metadata field match. Can occur multiple times
 `managedAcl`   | Series who have the same managed acl name
-`subject`      | By the subject they are a part of
+`subject`      | By the subject they are a part of. Can occur multiple times
 `textFilter`   | Filters series where any part of the series' metadata fields match this value
 `title`        | By the title of the series
+`identifier`   | By the technical identifiers of the series. Can occur multiple times (version 1.1.0 and higher)
+`desription`   | By the description of the series (version 1.1.0 and higher)
+`creator`      | Series where the creator specified in the metadata field match (version 1.1.0 and higher)
+`publishers`   | Series where the publishers specified in the metadata field match. Can occur multiple times (version 1.1.0 and higher)
+`rightsholder` | By the rights holder of the series (version 1.1.0 and higher)
 
 The list can be sorted by the following criteria:
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -640,7 +640,7 @@ public class EventsEndpoint implements ManagedService {
         } else if ("subject".equals(name)) {
           query.withSubject(value);
         } else if (!requestedVersion.isSmallerThan(ApiVersion.VERSION_1_1_0)) {
-          // add filters only available with Version 1.1.0 or higher
+          // additional filters only available with Version 1.1.0 or higher
           if ("identifier".equals(name)) {
             query.withIdentifier(value);
           } else if ("title".equals(name)) {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -251,7 +251,7 @@ public class SeriesEndpoint {
           } else if ("title".equals(name)) {
             query.withTitle(value);
           } else if (!requestedVersion.isSmallerThan(ApiVersion.VERSION_1_1_0)) {
-            // add filters only available with Version 1.1.0 or higher
+            // additional filters only available with Version 1.1.0 or higher
             if ("identifier".equals(name)) {
               query.withIdentifier(value);
             } else if ("description".equals(name)) {


### PR DESCRIPTION
This PR adds more filters to GET /api/events and GET /api/series for version 1.1.0 of the External API.

The changes are backwards-compatible and therefore included in the not yet released minor version 1.1.0.

Note that I did by intention not add the filter "creator" to GET /api/events as I found that it is not working and I unfortunately don't have time to dig into that.

Since the new date range filters require the character ":" in the filter values, I've stumbled over  MH-13038 (":" not working in filter values) which I have fixed for version 1.1.0. Fixing that for older Opencast version could be done by introducing version 1.0.1 (to avoid different "versions" of version 1.0.0) but it would require some workaround for the not correctly working versioning in < 1.1.0. As I never heard of anybody running into this so far, there seems to be a chance the problem solves itself by time (as 1.1.0 is backwards compatible, people could move to 1.1.0 instead of 1.0.1). In case that changes, there is still the option to add 1.0.1.
The same problem exists with "," characters that cannot be used in values currently, but that is another issue.