### PR TITLE
MH-13040, Make options fit “Actions” drop-down

### DIFF
--- a/modules/admin-ui/src/main/webapp/styles/components/_dropdowns.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_dropdowns.scss
@@ -21,7 +21,7 @@
 
 
 .drop-down-container {
-    width: 140px;
+    width: 160px;
     height: 40px;
     line-height: 40px;
     display: inline-block;


### PR DESCRIPTION
This patch adjusts the width of the “Actions” menu to ensure the new
option to bulk edit scheduled events fits properly. This is obviously
not guaranteed for arbitrary translation which may still have a line
break but at least for the default language.

![screenshot from 2018-08-18 01-18-37](https://user-images.githubusercontent.com/1008395/44292651-2da67080-a286-11e8-8cb7-690e00551d6b.png)
