### PR TITLE
MH-13055: Stop making events with no ACL public on ingest

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -58,10 +58,8 @@ import org.opencastproject.scheduler.api.SchedulerException;
 import org.opencastproject.scheduler.api.SchedulerService;
 import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
-import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.OrganizationDirectoryService;
-import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.UnauthorizedException;
@@ -1134,9 +1132,6 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       // Merge scheduled mediapackage with ingested
       mp = mergeScheduledMediaPackage(mp);
 
-      // Set public ACL if empty
-      setPublicAclIfEmpty(mp);
-
       ingestStatistics.successful();
       if (workflowDef != null) {
         logger.info("Starting new workflow with ingested mediapackage '{}' using the specified template '{}'",
@@ -1273,16 +1268,6 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       return mp;
     } finally {
       properties.remove(LEGACY_MEDIAPACKAGE_ID_KEY);
-    }
-  }
-
-  private void setPublicAclIfEmpty(MediaPackage mp) {
-    AccessControlList activeAcl = authorizationService.getActiveAcl(mp).getA();
-    if (activeAcl.getEntries().size() == 0) {
-      String anonymousRole = securityService.getOrganization().getAnonymousRole();
-      activeAcl = new AccessControlList(
-              new AccessControlEntry(anonymousRole, Permissions.Action.READ.toString(), true));
-      authorizationService.setAcl(mp, AclScope.Series, activeAcl);
     }
   }
 


### PR DESCRIPTION
See also the [JIRA issue](https://opencast.jira.com/browse/MH-13055).

This PR stops giving events a default, "everybody can read" ACL when it is ingested without one. This happens for example when you use the [ingest scripts](https://github.com/opencast/helper-scripts/tree/master/ingest), which I used to test this, but as evidenced by [this length thread](https://groups.google.com/a/opencast.org/forum/#!topic/anwender/qj94Xqr2Luw) on the German users list it also happens in real life. :wink: It does not happen when going through the admin UI.

#150 (merged in `develop`) introduced the `GLOBAL_CAPTURE_AGENT_ROLE` that was also part of this default ACL. I don't know whether it is actually necessary; tests with the different ingest scripts worked but I do not have multi tenant system here, so maybe it breaks there? (This is just a hunch based on the title of that PR.) Maybe the (co-)authors of that PR can say something about that? @lkiesow, @smarquard, @pmiddend

If it is still needed we might want to incorporate it into the fallback (basically empty) ACL that other parts of the system return when no ACL is found. Either way, putting together a custom ACL in this part of the code, when we already have fallbacks in place elsewhere, is wrong IMO.