### PR TITLE
MH-13064, Encoding profile mimetypes are mostly ignored

### DIFF
--- a/docs/guides/admin/docs/configuration/encoding.md
+++ b/docs/guides/admin/docs/configuration/encoding.md
@@ -69,7 +69,6 @@ All profiles should have the following properties:
     .input  = [audio|visual|stream|image]
     .output = [audio|visual|stream|image]
     .suffix
-    .mimetype
     .ffmpeg.command
 
 For example:
@@ -79,7 +78,6 @@ For example:
     profile.my-av-profile.http.input          = visual
     profile.my-av-profile.http.output         = visual
     profile.my-av-profile.http.suffix         = -encoded.enc
-    profile.my-av-profile.http.mimetype       = video/x-enc
     profile.my-av-profile.http.ffmpeg.command = -i #{in.video.path} -c:v venc -c:a aenc #{out.dir}/#{out.name}#{out.suffix}
 
 The most important part of this profile is the `ffmpeg.command`. This line specifies FFmpeg command line options using

--- a/docs/guides/admin/docs/workflowoperationhandlers/demux-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/demux-woh.md
@@ -47,7 +47,6 @@ profile.demux.name = demux
 profile.demux.input = visual
 profile.demux.output = visual
 profile.demux.suffix = .mp4
-profile.demux.mimetype = video/mp4
 profile.demux.ffmpeg.command = -i #{in.video.path} -c copy \
   -map 0:a:0 -map 0:v:0 #{out.dir}/#{out.name}_presenter#{out.suffix} \
   -map 0:a:1 -map 0:v:1 #{out.dir}/#{out.name}_presentation#{out.suffix}

--- a/docs/guides/admin/docs/workflowoperationhandlers/imagetovideo-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/imagetovideo-woh.md
@@ -45,5 +45,4 @@ Tags and flavors can be used in combination. But combined they should match one 
     profile.image-movie.input = image
     profile.image-movie.output = visual
     profile.image-movie.suffix = -image-video.mp4
-    profile.image-movie.mimetype = video/mp4
     profile.image-movie.ffmpeg.command = -loop 1 -i #{in.video.path} -c:v libx264 -r 25 -t #{time} -pix_fmt yuv420p #{out.dir}/#{out.name}#{out.suffix}

--- a/docs/guides/admin/docs/workflowoperationhandlers/start-watson-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/start-watson-transcription-woh.md
@@ -55,6 +55,5 @@ profile.audio-opus.name = audio-opus
 profile.audio-opus.input = stream
 profile.audio-opus.output = audio
 profile.audio-opus.suffix = -audio.opus
-profile.audio-opus.mimetype = audio/ogg
 profile.audio-opus.ffmpeg.command = -i /#{in.video.path} -c:a libvorbis -ac 1 -ar 16k -b:a 64k #{out.dir}/#{out.name}#{out.suffix}
 ```

--- a/etc/encoding/adaptive-streaming-movies.properties
+++ b/etc/encoding/adaptive-streaming-movies.properties
@@ -26,7 +26,6 @@ profile.adaptive-2160p.http.name = encoding highest quality with 2160p for adapt
 profile.adaptive-2160p.http.input = visual
 profile.adaptive-2160p.http.output = visual
 profile.adaptive-2160p.http.suffix = -preview.mp4
-profile.adaptive-2160p.http.mimetype = video/mp4
 profile.adaptive-2160p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 10000k -bufsize 10000k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
@@ -38,7 +37,6 @@ profile.adaptive-1080p.http.name = encoding high quality with 1080p for adaptive
 profile.adaptive-1080p.http.input = visual
 profile.adaptive-1080p.http.output = visual
 profile.adaptive-1080p.http.suffix = -preview.mp4
-profile.adaptive-1080p.http.mimetype = video/mp4
 profile.adaptive-1080p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 4000k -bufsize 8000k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
@@ -50,7 +48,6 @@ profile.adaptive-720p.http.name = encoding with 720p for adaptive streaming
 profile.adaptive-720p.http.input = visual
 profile.adaptive-720p.http.output = visual
 profile.adaptive-720p.http.suffix = -preview.mp4
-profile.adaptive-720p.http.mimetype = video/mp4
 profile.adaptive-720p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 1200k -bufsize 2400k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
@@ -62,7 +59,6 @@ profile.adaptive-480p.http.name = encoding with 480p for adaptive streaming
 profile.adaptive-480p.http.input = visual
 profile.adaptive-480p.http.output = visual
 profile.adaptive-480p.http.suffix = -preview.mp4
-profile.adaptive-480p.http.mimetype = video/mp4
 profile.adaptive-480p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 800k -bufsize 800k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
@@ -74,7 +70,6 @@ profile.adaptive-360p.http.name = encoding low quality with 360p for adaptive st
 profile.adaptive-360p.http.input = visual
 profile.adaptive-360p.http.output = visual
 profile.adaptive-360p.http.suffix = -preview.mp4
-profile.adaptive-360p.http.mimetype = video/mp4
 profile.adaptive-360p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 30 -maxrate 600k -bufsize 600k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
@@ -88,7 +83,6 @@ profile.adaptive-parallel.http.output = visual
 profile.adaptive-parallel.http.suffix.1080p-quality = -1080p.mp4
 profile.adaptive-parallel.http.suffix.720p-quality = -720p.mp4
 profile.adaptive-parallel.http.suffix.480p-quality = -480p.mp4
-profile.adaptive-parallel.http.mimetype = video/mp4
 profile.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 4000k -bufsize 8000k -profile:v high -level 4.0 -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart -vf scale='-2:min(ih\\,1080)',fps=fps=25 \

--- a/etc/encoding/engage-images.properties
+++ b/etc/encoding/engage-images.properties
@@ -33,7 +33,6 @@ profile.player-preview.http.name = cover image for engage
 profile.player-preview.http.input = visual
 profile.player-preview.http.output = image
 profile.player-preview.http.suffix = -player.jpg
-profile.player-preview.http.mimetype = image/jpeg
 profile.player-preview.http.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=-1:480 #{out.dir}/#{out.name}#{out.suffix}
 
 # Slide preview images as shown in the player
@@ -41,7 +40,6 @@ profile.player-slides.http.name = slide preview image for engage
 profile.player-slides.http.input = visual
 profile.player-slides.http.output = image
 profile.player-slides.http.suffix = .#{time}.jpg
-profile.player-slides.http.mimetype = image/jpeg
 profile.player-slides.http.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=160:-1 #{out.dir}/#{out.name}#{out.suffix}
 
 # Cover image for search results
@@ -49,5 +47,4 @@ profile.search-cover.http.name = cover image for engage
 profile.search-cover.http.input = visual
 profile.search-cover.http.output = image
 profile.search-cover.http.suffix = -search.jpg
-profile.search-cover.http.mimetype = image/jpeg
 profile.search-cover.http.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=160:-1 #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/engage-movies.properties
+++ b/etc/encoding/engage-movies.properties
@@ -26,49 +26,42 @@ profile.mp4-preview.http.name = preview video
 profile.mp4-preview.http.input = visual
 profile.mp4-preview.http.output = visual
 profile.mp4-preview.http.suffix = -preview.mp4
-profile.mp4-preview.http.mimetype = video/mp4
 profile.mp4-preview.http.ffmpeg.command = -i #{in.video.path} -c:v libx264 -filter:v yadif,scale=-2:360 -preset veryfast -crf 23 -profile:v baseline -pix_fmt yuv420p -tune film  -movflags faststart -c:a aac -strict -2 -ar 22050 -ab 64k #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-preview.dual.http.name = preview video (picture-by-picture)
 profile.mp4-preview.dual.http.input = visual
 profile.mp4-preview.dual.http.output = visual
 profile.mp4-preview.dual.http.suffix = -preview-composite.mp4
-profile.mp4-preview.dual.http.mimetype = video/mp4
 profile.mp4-preview.dual.http.ffmpeg.command = -i #{in.video.path} #{compositeCommand} -c:v libx264 -preset veryfast -crf 23 -profile:v baseline -pix_fmt yuv420p -tune film -movflags faststart -c:a aac -strict -2 -ar 22050 -ab 64k #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-low.http.name = low quality video
 profile.mp4-low.http.input = visual
 profile.mp4-low.http.output = visual
 profile.mp4-low.http.suffix = -low.mp4
-profile.mp4-low.http.mimetype = video/mp4
 profile.mp4-low.http.ffmpeg.command = -i #{in.video.path} -c:v libx264 -filter:v yadif,scale=-2:288 -preset slower -crf 28 -r 25 -profile:v baseline -tune film -pix_fmt yuv420p -movflags faststart -c:a aac -strict -2 -ar 22050 -ab 64k #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-medium.http.name = Medium Quality Video
 profile.mp4-medium.http.input = visual
 profile.mp4-medium.http.output = visual
 profile.mp4-medium.http.suffix = -medium.mp4
-profile.mp4-medium.http.mimetype = video/mp4
 profile.mp4-medium.http.ffmpeg.command = -i #{in.video.path} -c:v libx264 -filter:v yadif,scale=-2:360 -preset slower -crf 25 -r 25 -profile:v baseline -pix_fmt yuv420p -tune film  -movflags faststart -c:a aac -strict -2 -ar 44100 -ab 96k #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-vga-medium.http.name = Medium Quality VGA video
 profile.mp4-vga-medium.http.input = visual
 profile.mp4-vga-medium.http.output = visual
 profile.mp4-vga-medium.http.suffix = -vga-high.mp4
-profile.mp4-vga-medium.http.mimetype = video/mp4
 profile.mp4-vga-medium.http.ffmpeg.command = -i #{in.video.path} -c:v libx264 -vf scale=800:-2 -preset slow -crf 34 -r 25 -profile:v high -level 4.0  -pix_fmt yuv420p -tune animation -movflags faststart -c:a aac -strict -2 -ar 22050 -ab 64k #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-hd.http.name = HD-Video
 profile.mp4-hd.http.input = visual
 profile.mp4-hd.http.output = visual
 profile.mp4-hd.http.suffix = -hd.mp4
-profile.mp4-hd.http.mimetype = video/mp4
 profile.mp4-hd.http.ffmpeg.command = -i #{in.video.path} -c:v libx264 -filter:v yadif,scale=-2:720 -preset medium -crf 23 -r 25 -profile:v high -level 4.0  -pix_fmt yuv420p -tune film  -movflags faststart -c:a aac -strict -2 -ar 44100 -ab 128k #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-vga-hd.http.name = HD-VGA-Video
 profile.mp4-vga-hd.http.input = visual
 profile.mp4-vga-hd.http.output = visual
 profile.mp4-vga-hd.http.suffix = -vga-hd.mp4
-profile.mp4-vga-hd.http.mimetype = video/mp4
 profile.mp4-vga-hd.http.ffmpeg.command = -i #{in.video.path} -c:v libx264 -preset slower -crf 30 -r 25 -profile:v high -level 4.0  -pix_fmt yuv420p -tune animation -movflags faststart -c:a aac -strict -2 -ar 44100 -ab 96k #{out.dir}/#{out.name}#{out.suffix}
 
 
@@ -77,7 +70,6 @@ profile.mp3.http.name = mp3
 profile.mp3.http.input = audio
 profile.mp3.http.output = audio
 profile.mp3.http.suffix = -audio.mp3
-profile.mp3.http.mimetype = audio/mpeg
 profile.mp3.http.ffmpeg.command = -i #{in.video.path} -ar 44100 -ab 128k -vn -f mp3 #{out.dir}/#{out.name}#{out.suffix}
 
 
@@ -86,5 +78,4 @@ profile.audio.wav.name = audio waveform
 profile.audio.wav.input = stream
 profile.audio.wav.output = audio
 profile.audio.wav.suffix = -waveform-audio.wav
-profile.audio.wav.mimetype = audio/wav
 profile.audio.wav.ffmpeg.command = -i /#{in.video.path} -c:a pcm_s16le -ac 1 -filter:a aresample=8000 #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/fast-movies.properties
+++ b/etc/encoding/fast-movies.properties
@@ -27,6 +27,5 @@ profile.fast.http.name = fast processed mp4
 profile.fast.http.input = visual
 profile.fast.http.output = visual
 profile.fast.http.suffix = .mp4
-profile.fast.http.mimetype = video/mp4
 profile.fast.http.ffmpeg.command = -i #{in.video.path} -c:a aac -c:v libx264 -preset veryfast -g 30 -pix_fmt yuv420p \
                                    #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/feed-images.properties
+++ b/etc/encoding/feed-images.properties
@@ -32,5 +32,4 @@ profile.feed-cover.http.name = cover image for feeds
 profile.feed-cover.http.input = visual
 profile.feed-cover.http.output = image
 profile.feed-cover.http.suffix = -feed.jpg
-profile.feed-cover.http.mimetype = image/jpeg
 profile.feed-cover.http.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=-1:54 #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/opencast-images.properties
+++ b/etc/encoding/opencast-images.properties
@@ -33,7 +33,6 @@ profile.text-analysis.http.name = still image for text extraction
 profile.text-analysis.http.input = visual
 profile.text-analysis.http.output = image
 profile.text-analysis.http.suffix = .#{time}.png
-profile.text-analysis.http.mimetype = image/png
 profile.text-analysis.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
   -filter:v boxblur=1:1,curves=all=0.4/0#{space}0.6/1 \
   -frames:v 1 -pix_fmt:v gray -r 1 #{out.dir}/#{out.name}#{out.suffix}
@@ -44,7 +43,6 @@ profile.image-conversion.http.name = still image for text extraction
 profile.image-conversion.http.input = visual
 profile.image-conversion.http.output = image
 profile.image-conversion.http.suffix = .tif
-profile.image-conversion.http.mimetype = image/tiff
 profile.image-conversion.http.ffmpeg.command = -f image2 -i #{in.video.path} #{out.dir}/#{out.name}#{out.suffix}
 
 # Image to video
@@ -52,7 +50,6 @@ profile.image-movie.work.name = image to video
 profile.image-movie.work.input = image
 profile.image-movie.work.output = visual
 profile.image-movie.work.suffix = -image-video.mp4
-profile.image-movie.work.mimetype = video/mp4
 profile.image-movie.work.ffmpeg.command = -loop 1 -i #{in.video.path} -c:v libx264 -r 30 -t #{time} -pix_fmt yuv420p #{out.dir}/#{out.name}#{out.suffix}
 
 # Extract image for partial import operation
@@ -60,7 +57,6 @@ profile.import.preview.name = Extract an image
 profile.import.preview.input = visual
 profile.import.preview.output = image
 profile.import.preview.suffix = -image.jpg
-profile.import.preview.mimetype = image/jpeg
 profile.import.preview.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
 
 # Extract image by video frame number for partial import operation
@@ -68,5 +64,4 @@ profile.import.image-frame.name = Extract image by video frame number
 profile.import.image-frame.input = visual
 profile.import.image-frame.output = image
 profile.import.image-frame.suffix = -image.jpg
-profile.import.image-frame.mimetype = image/jpeg
 profile.import.image-frame.ffmpeg.command = -i #{in.video.path} -filter:v select=eq(n\\,#{frame}) -r 1 -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/opencast-movies.properties
+++ b/etc/encoding/opencast-movies.properties
@@ -102,7 +102,6 @@ profile.composite.http.name = composite
 profile.composite.http.input = visual
 profile.composite.http.output = visual
 profile.composite.http.suffix = -compound.mkv
-profile.composite.http.mimetype = video/x-matroska
 profile.composite.http.ffmpeg.command = -i #{in.video.path} #{compositeCommand} -c:a flac -c:v libx264 -crf 10 -preset fast #{out.dir}/#{out.name}#{out.suffix}
 
 # Concat
@@ -115,7 +114,6 @@ profile.concat.work.name = concat
 profile.concat.work.input = visual
 profile.concat.work.output = visual
 profile.concat.work.suffix = -concatenated.mkv
-profile.concat.work.mimetype = video/x-matroska
 profile.concat.work.ffmpeg.command = #{concatCommand} -c:a flac -c:v libx264 -crf 10 -preset fast #{out.dir}/#{out.name}#{out.suffix}
 
 # Concat - lossless concat
@@ -127,7 +125,6 @@ profile.concat-samecodec.work.name = concat-samecodec
 profile.concat-samecodec.work.input = visual
 profile.concat-samecodec.work.output = visual
 profile.concat-samecodec.work.suffix = -concatenated.#{in.video.suffix}
-profile.concat-samecodec.work.mimetype = video/mp4
 profile.concat-samecodec.work.ffmpeg.command = #{concatCommand} -c copy #{out.dir}/#{out.name}#{out.suffix}
 
 # Generate silent audio tracks for filling gaps for partial import operation
@@ -135,5 +132,4 @@ profile.import.silent.name = Generate silent audio tracks for filling gaps
 profile.import.silent.input = nothing
 profile.import.silent.output = audio
 profile.import.silent.suffix = -silent-audio.mp4
-profile.import.silent.mimetype = audio/mp4
 profile.import.silent.ffmpeg.command = -strict -2 -filter_complex aevalsrc=0::d=#{time} -c:a aac -b:a 8k #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/watson-audio.properties
+++ b/etc/encoding/watson-audio.properties
@@ -2,5 +2,4 @@ profile.audio-opus.name = audio-opus
 profile.audio-opus.input = stream
 profile.audio-opus.output = audio
 profile.audio-opus.suffix = -audio.opus
-profile.audio-opus.mimetype = audio/ogg
 profile.audio-opus.ffmpeg.command = -i /#{in.video.path} -c:a libvorbis -ac 1 -ar 16k -b:a 64k #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/webm.properties
+++ b/etc/encoding/webm.properties
@@ -2,7 +2,6 @@
 profile.webm.vp8.input = stream
 profile.webm.vp8.output = audiovisual
 profile.webm.vp8.suffix = .webm
-profile.webm.vp8.mimetype = video/webm
 profile.webm.vp8.ffmpeg.command = -i #{in.video.path} \
   -filter:v yadif,scale=-1:360 -threads 6 \
   -c:v libvpx -crf 10 -b:v 800k -speed 2 \
@@ -13,7 +12,6 @@ profile.webm.vp9.name = webm video encoding
 profile.webm.vp9.input = stream
 profile.webm.vp9.output = audiovisual
 profile.webm.vp9.suffix = .webm
-profile.webm.vp9.mimetype = video/webm
 profile.webm.vp9.ffmpeg.command = -i #{in.video.path} \
   -filter:v yadif,scale=-1:360 -threads 6 \
   -c:v libvpx-vp9 -frame-parallel 1 -speed 2 -crf 23 -b:v 0 \

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -68,7 +68,6 @@ import org.opencastproject.smil.entity.media.param.api.SmilMediaParamGroup;
 import org.opencastproject.util.FileSupport;
 import org.opencastproject.util.JsonObj;
 import org.opencastproject.util.LoadUtil;
-import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Collections;
 import org.opencastproject.util.data.Option;
@@ -393,9 +392,6 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     // Have the encoded track inspected and return the result
     Track inspectedTrack = inspect(job, workspaceURI);
     inspectedTrack.setIdentifier(targetTrackId);
-
-    if (profile.getMimeType() != null)
-      inspectedTrack.setMimeType(MimeTypes.parseMimeType(profile.getMimeType()));
 
     return some(inspectedTrack);
   }
@@ -748,9 +744,6 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
       Track inspectedTrack = inspect(job, workspaceURI);
       inspectedTrack.setIdentifier(targetTrackId);
 
-      if (profile.getMimeType() != null)
-        inspectedTrack.setMimeType(MimeTypes.parseMimeType(profile.getMimeType()));
-
       return some(inspectedTrack);
     } catch (Exception e) {
       if (upperLaidOutElement.isSome()) {
@@ -905,9 +898,6 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     Track inspectedTrack = inspect(job, workspaceURI);
     inspectedTrack.setIdentifier(targetTrackId);
 
-    if (profile.getMimeType() != null)
-      inspectedTrack.setMimeType(MimeTypes.parseMimeType(profile.getMimeType()));
-
     return some(inspectedTrack);
   }
 
@@ -983,9 +973,6 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     // Have the compound track inspected and return the result
     Track inspectedTrack = inspect(job, workspaceURI);
     inspectedTrack.setIdentifier(targetTrackId);
-
-    if (profile.getMimeType() != null)
-      inspectedTrack.setMimeType(MimeTypes.parseMimeType(profile.getMimeType()));
 
     return some(inspectedTrack);
   }

--- a/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/EncodingProfileTest.java
+++ b/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/EncodingProfileTest.java
@@ -174,15 +174,6 @@ public class EncodingProfileTest {
   }
 
   /**
-   * Test method for {@link org.opencastproject.composer.api.EncodingProfileImpl#getMimeType()}.
-   */
-  @Test
-  public void testGetMimeType() {
-    EncodingProfile profile = profiles.get(h264ProfileId);
-    assertEquals("visual/x-m4v", profile.getMimeType());
-  }
-
-  /**
    * Test method for {@link org.opencastproject.composer.api.EncodingProfileImpl#getExtension(java.lang.String)}.
    */
   @Test

--- a/modules/composer-ffmpeg/src/test/resources/encodingprofiles.properties
+++ b/modules/composer-ffmpeg/src/test/resources/encodingprofiles.properties
@@ -14,7 +14,6 @@
 # profile.<format>.suffix:
 #     Extension that will be appended to the download.
 #
-# profile.<format>.mimetype:
 #     Mime type used to provide proper content types.
 #
 # profile.<format>.input:
@@ -31,7 +30,6 @@ profile.h264-low.http.name = h.264 download low quality
 profile.h264-low.http.input = visual
 profile.h264-low.http.output = visual
 profile.h264-low.http.suffix = -dl.m4v
-profile.h264-low.http.mimetype = visual/x-m4v
 profile.h264-low.http.ffmpeg.command = -i #{in.video.path} -strict -2 -acodec copy -vcodec libx264 -b:a 48k -movflags faststart -vf scale=iw*.5:-1 #{out.dir}/#{out.name}#{out.suffix}
 
 # Distribution format definition for 4 by 3 h264 presenter/presentation downloads medium
@@ -40,7 +38,6 @@ profile.h264-medium.http.name = h.264 download medium quality
 profile.h264-medium.http.input = visual
 profile.h264-medium.http.output = visual
 profile.h264-medium.http.suffix = -dm.m4v
-profile.h264-medium.http.mimetype = visual/x-m4v
 profile.h264-medium.http.ffmpeg.command = -i #{in.video.path} -strict -2 -c:a copy -c:v libx264 -ab 96k -filter:v scale=in_h*4/3:in_h,setdar=4/3 #{out.dir}/#{out.name}#{out.suffix}
 
 # Distribution format definition for 4 by 3 h264 presenter/presentation downloads medium
@@ -49,14 +46,12 @@ profile.h264-large.http.name = h.264 download medium quality
 profile.h264-large.http.input = visual
 profile.h264-large.http.output = visual
 profile.h264-large.http.suffix = -out.#{in.video.suffix}
-profile.h264-large.http.mimetype = visual/mp4
 profile.h264-large.http.ffmpeg.command = -i #{in.video.path} -strict -2 -filter:a volume=1.5 -codec:v libx264 -b:a 96k #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp3audio.http.name = mp3 audio download
 profile.mp3audio.http.input = audio
 profile.mp3audio.http.output = audio
 profile.mp3audio.http.suffix = .mp3
-profile.mp3audio.http.mimetype = audio/mp3
 profile.mp3audio.http.ffmpeg.command = -i #{in.audio.path} -f mp3 -c:a libmp3lame -b:a 96k #{out.dir}/#{out.name}#{out.suffix}
 
 # Distribution format definition for 4 by 3 h264 presenter/presentation streaming medium
@@ -65,14 +60,12 @@ profile.h264.rtsp.name = h.264 streaming medium quality
 profile.h264.rtsp.input = visual
 profile.h264.rtsp.output = visual
 profile.h264.rtsp.suffix = -sm.mp4
-profile.h264.rtsp.mimetype = visual/mp4v-es
 
 # Distribution format definition for 4 by 3 flash presenter/presentation streaming medium
 profile.flash.rtmp.name = flash streaming medium quality
 profile.flash.rtmp.input = visual
 profile.flash.rtmp.output = visual
 profile.flash.rtmp.suffix = -sm.flv
-profile.flash.rtmp.mimetype = visual/x-flv
 profile.flash.rtmp.ffmpeg.command = -i #{in.video.path} -r 15 -c:v flv -q:v 5 -filter:v yadif,scale=-1:360 -c:a libmp3lame -b:a 96k -ar 44100 #{out.dir}/#{out.name}#{out.suffix}
 
 
@@ -89,7 +82,6 @@ profile.cover-ui.http.name = cover image
 profile.cover-ui.http.input = visual
 profile.cover-ui.http.output = cover
 profile.cover-ui.http.suffix = -ui-cover.jpg
-profile.cover-ui.http.mimetype = image/jpeg
 profile.cover-ui.http.ffmpeg.command = -i #{in.path} -y -r 1 -t 1 -f image2 -s 160x120 #{out.dir}/#{in.name}#{out.suffix}
 
 # Cover image feeds
@@ -97,7 +89,6 @@ profile.cover-feed.http.name = cover image for feeds
 profile.cover-feed.http.input = visual
 profile.cover-feed.http.output = cover
 profile.cover-feed.http.suffix = -feed-cover.jpg
-profile.cover-feed.http.mimetype = image/jpeg
 profile.cover-feed.http.ffmpeg.command = -i #{in.path} -y -r 1 -t 1 -f image2 -s 72x54 #{out.dir}/#{in.name}#{out.suffix}
 
 # Slide images ui
@@ -105,7 +96,6 @@ profile.jpeg-slides.http.name = slides
 profile.jpeg-slides.http.input = visual
 profile.jpeg-slides.http.output = image
 profile.jpeg-slides.http.suffix = -player.jpg
-profile.jpeg-slides.http.mimetype = image/jpeg
 profile.jpeg-slides.http.ffmpeg.command = -i #{in.path} -y -r 1 -f image2 -s 500x376 #{out.dir}/#{in.name}#{out.suffix}
 #profile.jpeg-slides.http.ffmpeg.command = -y -i #{in.video.path} -ss #{time} -r 1 -vframes 1 -s 640x480 -f image2 #{out.dir}/#{out.name}#{out.suffix}
 
@@ -114,7 +104,6 @@ profile.image-conversion.http.name = still image for text extraction
 profile.image-conversion.http.input = visual
 profile.image-conversion.http.output = image
 profile.image-conversion.http.suffix = .tif
-profile.image-conversion.http.mimetype = image/tiff
 profile.image-conversion.http.ffmpeg.command = -y -f image2 -i #{in.video.path} -f image2 #{out.dir}/#{out.name}#{out.suffix}
 
 # Trim a stream
@@ -134,7 +123,6 @@ profile.tracks-lfr.http.name = mpeg4/avi 160x120 5fps low framerate
 profile.tracks-lfr.http.input = visual
 profile.tracks-lfr.http.output = visual
 profile.tracks-lfr.http.suffix = .avi
-profile.tracks-lfr.http.mimetype = visual/avi
 profile.tracks-lfr.http.ffmpeg.command = -i #{in.path} -y -r 5 -s 160x120 #{out.dir}/#{in.name}#{out.suffix}
 
 # Slide previews
@@ -142,7 +130,6 @@ profile.tracks-slides.http.name = slide previews
 profile.tracks-slides.http.input = visual
 profile.tracks-slides.http.output = image
 profile.tracks-slides.http.suffix = -%06d.jpg
-profile.tracks-slides.http.mimetype = image/jpeg
 profile.tracks-slides.http.ffmpeg.command = -i #{in.path} -y -r 1 -f image2 -s 500x376 #{out.dir}/#{in.name}#{out.suffix}
 
 # Preview image for the player, shown before the movie is started
@@ -150,7 +137,6 @@ profile.player-preview.http.name = cover image for engage
 profile.player-preview.http.input = visual
 profile.player-preview.http.output = image
 profile.player-preview.http.suffix = -player.jpg
-profile.player-preview.http.mimetype = image/jpeg
 profile.player-preview.http.ffmpeg.command = -y -i #{in.video.path} -ss #{time} -r 1 -vframes 1 -s 640x480 -f image2 #{out.dir}/#{out.name}#{out.suffix}
 
 # Re-encode audiovisual stream
@@ -174,7 +160,6 @@ profile.concat.work.name = concat
 profile.concat.work.input = visual
 profile.concat.work.output = visual
 profile.concat.work.suffix = -concatenated.mp4
-profile.concat.work.mimetype = video/mp4
 profile.concat.work.ffmpeg.command = #{concatCommand} -acodec libmp3lame -b:a 128k -vcodec mpeg4 -b:v 1200k -flags +aic+mv4 #{out.dir}/#{out.name}#{out.suffix}
 
 # Image to video
@@ -182,7 +167,6 @@ profile.image-movie.work.name = image to video
 profile.image-movie.work.input = image
 profile.image-movie.work.output = visual
 profile.image-movie.work.suffix = -image-video.mp4
-profile.image-movie.work.mimetype = video/mp4
 profile.image-movie.work.ffmpeg.command = -loop 1 -i #{in.video.path} -c:v libx264 -r 25 -t #{time} -pix_fmt yuv420p #{out.dir}/#{out.name}#{out.suffix}
 
 # Composite
@@ -190,7 +174,6 @@ profile.composite.work.name = composite
 profile.composite.work.input = visual
 profile.composite.work.output = visual
 profile.composite.work.suffix = -compound.mp4
-profile.composite.work.mimetype = video/mp4
 profile.composite.work.ffmpeg.command = -i #{in.video.path} #{compositeCommand} -acodec libmp3lame -b:a 128k -vcodec mpeg4 -b:v 1200k -flags +aic+mv4 #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mux-av.work.name = mux audio and video
@@ -205,5 +188,4 @@ profile.demux.work.name = demux into 2 av files
 profile.demux.work.input = visual
 profile.demux.work.output = visual
 profile.demux.work.suffix = -out.mp4
-profile.demux.work.mimetype = video/mp4
 profile.demux.work.ffmpeg.command = -i #{in.video.path} -strict -2 -acodec copy -vcodec libx264 -b:a 96k -map 0:0 -map 0:1 #{out.dir}/#{out.name}1#{out.suffix} -strict -2 -map 0:2 -map 0:3 #{out.dir}/#{out.name}2#{out.suffix}

--- a/modules/composer-ffmpeg/src/test/resources/encodingtestprofiles.properties
+++ b/modules/composer-ffmpeg/src/test/resources/encodingtestprofiles.properties
@@ -14,9 +14,6 @@
 # profile.<format>.suffix:
 #     Extension that will be appended to the download.
 #
-# profile.<format>.mimetype:
-#     Mime type used to provide proper content types.
-#
 # profile.<format>.input:
 #     Track categories for which this format is applicable.
 #     Known categories are:
@@ -31,7 +28,6 @@ profile.h264-low.http.name = h.264 download low quality
 profile.h264-low.http.input = visual
 profile.h264-low.http.output = visual
 profile.h264-low.http.suffix = -dl.m4v
-profile.h264-low.http.mimetype = visual/x-m4v
 
 # Distribution format definition for 4 by 3 h264 presenter/presentation downloads medium
 #profile.h264-medium.http.name = H.264 MPEG-4 Download Medium Quality (*.m4v)
@@ -39,7 +35,6 @@ profile.h264-medium.http.name = h.264 download medium quality
 profile.h264-medium.http.input = visual
 profile.h264-medium.http.output = visual
 profile.h264-medium.http.suffix = -dm.m4v
-profile.h264-medium.http.mimetype = visual/x-m4v
 
 # Re-mux audiovisual stream
 #   file and muxes them into the same kind of container they were in before. A
@@ -55,14 +50,12 @@ profile.flash.rtmp.name = flash streaming medium quality
 profile.flash.rtmp.input = visual
 profile.flash.rtmp.output = visual
 profile.flash.rtmp.suffix = -sm.flv
-profile.flash.rtmp.mimetype = visual/x-flv
 
 # Still image conversion for text analysis (ocr)
 profile.image-conversion.http.name = still image for text extraction
 profile.image-conversion.http.input = visual
 profile.image-conversion.http.output = image
 profile.image-conversion.http.suffix = .tif
-profile.image-conversion.http.mimetype = image/tiff
 profile.image-conversion.http.ffmpeg.command = -y -f image2 -i #{in.video.path} -f image2 #{out.dir}/#{out.name}#{out.suffix}
 
 ####
@@ -78,7 +71,6 @@ profile.cover-ui.http.name = cover image
 profile.cover-ui.http.input = visual
 profile.cover-ui.http.output = cover
 profile.cover-ui.http.suffix = -ui-cover.jpg
-profile.cover-ui.http.mimetype = image/jpeg
 profile.cover-ui.http.ffmpeg.command = -i #{in.path} -y -r 1 -t 1 -f image2 -s 160x120 #{out.dir}/#{in.name}#{out.suffix}
 
 # Cover image feeds
@@ -86,7 +78,6 @@ profile.cover-feed.http.name = cover image for feeds
 profile.cover-feed.http.input = visual
 profile.cover-feed.http.output = cover
 profile.cover-feed.http.suffix = -feed-cover.jpg
-profile.cover-feed.http.mimetype = image/jpeg
 profile.cover-feed.http.ffmpeg.command = -i #{in.path} -y -r 1 -t 1 -f image2 -s 72x54 #{out.dir}/#{in.name}#{out.suffix}
 
 # Slide images ui
@@ -94,7 +85,6 @@ profile.jpeg-slides.http.name = slides
 profile.jpeg-slides.http.input = visual
 profile.jpeg-slides.http.output = image
 profile.jpeg-slides.http.suffix = -%06d.jpg
-profile.jpeg-slides.http.mimetype = image/jpeg
 profile.jpeg-slides.http.ffmpeg.command = -i #{in.path} -y -r 1 -f image2 -s 500x376 #{out.dir}/#{in.name}#{out.suffix}
 
 ####
@@ -107,7 +97,6 @@ profile.tracks-lfr.http.name = mpeg4/avi 160x120 5fps low framerate
 profile.tracks-lfr.http.input = visual
 profile.tracks-lfr.http.output = visual
 profile.tracks-lfr.http.suffix = .avi
-profile.tracks-lfr.http.mimetype = visual/avi
 profile.tracks-lfr.http.ffmpeg.command = -i #{in.path} -y -r 5 -s 160x120 #{out.dir}/#{in.name}#{out.suffix}
 
 # Slide previews
@@ -115,7 +104,6 @@ profile.tracks-slides.http.name = slide previews
 profile.tracks-slides.http.input = visual
 profile.tracks-slides.http.output = image
 profile.tracks-slides.http.suffix = -%06d.jpg
-profile.tracks-slides.http.mimetype = image/jpeg
 profile.tracks-slides.http.ffmpeg.command = -i #{in.path} -y -r 1 -f image2 -s 500x376 #{out.dir}/#{in.name}#{out.suffix}
 
 # Re-encode audiovisual stream

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfile.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfile.java
@@ -120,13 +120,6 @@ public interface EncodingProfile {
   List<String> getTags();
 
   /**
-   * Returns the media type's mime type.
-   *
-   * @return the mime type
-   */
-  String getMimeType();
-
-  /**
    * Returns the media format that can be used with this encoding profile.
    *
    * @return the applicable input format

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
@@ -72,10 +72,6 @@ public class EncodingProfileImpl implements EncodingProfile {
   protected String suffix = null;
   */
 
-  /** Mime type */
-  @XmlElement(name = "mimetype")
-  protected String mimeType = null;
-
   /** The track type that this profile may be applied to */
   @XmlElement(name = "inputmediatype")
   protected MediaType applicableType = null;
@@ -212,26 +208,6 @@ public class EncodingProfileImpl implements EncodingProfile {
    */
   public void setSuffix(String tag ,String suffix) {
     this.suffixes.put(tag, suffix);
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.composer.api.EncodingProfile#getMimeType()
-   */
-  @Override
-  public String getMimeType() {
-    return mimeType;
-  }
-
-  /**
-   * Sets the Mimetype.
-   *
-   * @param mimeType
-   *          the Mimetype
-   */
-  public void setMimeType(String mimeType) {
-    this.mimeType = mimeType;
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -55,6 +55,7 @@ import org.opencastproject.mediapackage.selector.TrackSelector;
 import org.opencastproject.util.JobUtil;
 import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.PathSupport;
+import org.opencastproject.util.UnknownFileTypeException;
 import org.opencastproject.util.data.Collections;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -248,8 +249,10 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
         logger.debug("Resulting image has flavor '{}'", image.getFlavor());
       }
       // Set the mime type
-      for (final String mimeType : Opt.nul(extraction.profile.getMimeType())) {
-        image.setMimeType(MimeTypes.parseMimeType(mimeType));
+      try {
+        image.setMimeType(MimeTypes.fromURI(image.getURI()));
+      } catch (UnknownFileTypeException e) {
+        logger.warn("Mime type unknown for file {}. Setting none.", image.getURI(), e);
       }
       // Add tags
       for (final String tag : cfg.targetImageTags) {

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
@@ -46,6 +46,7 @@ import org.opencastproject.metadata.mpeg7.Video;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
+import org.opencastproject.util.UnknownFileTypeException;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -311,8 +312,11 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
             }
 
             // Set the mimetype
-            if (profile.getMimeType() != null)
-              composedImage.setMimeType(MimeTypes.parseMimeType(profile.getMimeType()));
+            try {
+              composedImage.setMimeType(MimeTypes.fromURI(composedImage.getURI()));
+            } catch (UnknownFileTypeException e) {
+              logger.warn("Mime type unknown for file {}. Setting none.", composedImage.getURI(), e);
+            }
 
             // Add tags
             for (String tag : asList(targetImageTags)) {

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ComposeWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ComposeWorkflowOperationHandlerTest.java
@@ -31,7 +31,6 @@ import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
-import org.opencastproject.util.MimeTypes;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -120,7 +119,6 @@ public class ComposeWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.AudioVisual);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     profileList = new EncodingProfile[] { profile };
     EasyMock.replay(profile);
 
@@ -157,7 +155,6 @@ public class ComposeWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.Stream);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     profileList = new EncodingProfile[] { profile };
     EasyMock.replay(profile);
 

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandlerTest.java
@@ -37,7 +37,6 @@ import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
-import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
@@ -290,7 +289,6 @@ public class CompositeWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.AudioVisual);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     EasyMock.replay(profile);
 
     // set up mock composer service

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandlerTest.java
@@ -37,7 +37,6 @@ import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.TrackSupport;
 import org.opencastproject.mediapackage.VideoStream;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
-import org.opencastproject.util.MimeTypes;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -444,7 +443,6 @@ public class ConcatWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.AudioVisual);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     EasyMock.replay(profile);
 
     // set up mock composer service

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/DemuxWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/DemuxWorkflowOperationHandlerTest.java
@@ -31,7 +31,6 @@ import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
-import org.opencastproject.util.MimeTypes;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -124,7 +123,6 @@ public class DemuxWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.AudioVisual);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     profileList = new EncodingProfile[] { profile };
     EasyMock.replay(profile);
 
@@ -166,7 +164,6 @@ public class DemuxWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.Stream);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     profileList = new EncodingProfile[] { profile };
     EasyMock.replay(profile);
 

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandlerTest.java
@@ -34,7 +34,6 @@ import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
-import org.opencastproject.util.MimeTypes;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -165,7 +164,6 @@ public class ImageToVideoWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Image);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.AudioVisual);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     EasyMock.replay(profile);
 
     // set up mock composer service

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandlerTest.java
@@ -31,7 +31,6 @@ import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
-import org.opencastproject.util.MimeTypes;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -143,19 +142,16 @@ public class MultiEncodeWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andStubReturn(PROFILE1_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andStubReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andStubReturn(MediaType.AudioVisual);
-    EasyMock.expect(profile.getMimeType()).andStubReturn(MimeTypes.MPEG4.toString());
     EasyMock.expect(profile.getSuffix()).andStubReturn(SUFFIX1);
     profile2 = EasyMock.createNiceMock(EncodingProfile.class);
     EasyMock.expect(profile2.getIdentifier()).andStubReturn(PROFILE2_ID);
     EasyMock.expect(profile2.getApplicableMediaType()).andStubReturn(MediaType.Stream);
     EasyMock.expect(profile2.getOutputType()).andStubReturn(MediaType.Visual);
-    EasyMock.expect(profile2.getMimeType()).andStubReturn(MimeTypes.MPEG4.toString());
     EasyMock.expect(profile2.getSuffix()).andStubReturn(SUFFIX2);
     profile3 = EasyMock.createNiceMock(EncodingProfile.class);
     EasyMock.expect(profile3.getIdentifier()).andStubReturn(PROFILE3_ID);
     EasyMock.expect(profile3.getApplicableMediaType()).andStubReturn(MediaType.Stream);
     EasyMock.expect(profile3.getOutputType()).andStubReturn(MediaType.Visual);
-    EasyMock.expect(profile3.getMimeType()).andStubReturn(MimeTypes.MPEG4.toString());
     EasyMock.expect(profile3.getSuffix()).andStubReturn(SUFFIX3);
     profileList = new EncodingProfile[] { profile, profile2, profile3 };
     EasyMock.replay(profile, profile2, profile3);
@@ -435,7 +431,6 @@ public class MultiEncodeWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE1_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.Stream);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     profileList = new EncodingProfile[] { profile };
     EasyMock.replay(profile);
 

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandlerTest.java
@@ -44,7 +44,6 @@ import org.opencastproject.smil.entity.media.element.api.SmilMediaElement;
 import org.opencastproject.smil.entity.media.param.api.SmilMediaParam;
 import org.opencastproject.smil.entity.media.param.api.SmilMediaParamGroup;
 import org.opencastproject.util.FileSupport;
-import org.opencastproject.util.MimeTypes;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -238,21 +237,18 @@ public class ProcessSmilWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID).anyTimes();
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream).anyTimes();
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.AudioVisual).anyTimes();
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).anyTimes();
     EasyMock.expect(profile.getSuffix()).andReturn("-v.flv").anyTimes();
 
     profile2 = EasyMock.createNiceMock(EncodingProfile.class); // Video Only
     EasyMock.expect(profile2.getIdentifier()).andReturn(PROFILE_ID2).anyTimes();
     EasyMock.expect(profile2.getApplicableMediaType()).andReturn(MediaType.Visual).anyTimes();
     EasyMock.expect(profile2.getOutputType()).andReturn(MediaType.Visual).anyTimes();
-    EasyMock.expect(profile2.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).anyTimes();
     EasyMock.expect(profile2.getSuffix()).andReturn("-v.mp4").anyTimes();
 
     profile3 = EasyMock.createNiceMock(EncodingProfile.class); // different suffix
     EasyMock.expect(profile3.getIdentifier()).andReturn(PROFILE_ID3).anyTimes();
     EasyMock.expect(profile3.getApplicableMediaType()).andReturn(MediaType.Audio).anyTimes();
     EasyMock.expect(profile3.getOutputType()).andReturn(MediaType.Audio).anyTimes();
-    EasyMock.expect(profile3.getMimeType()).andReturn(MimeTypes.AAC.toString()).anyTimes();
     EasyMock.expect(profile3.getSuffix()).andReturn("-a.mp4").anyTimes();
     profileList = new EncodingProfile[] { profile, profile2, profile3 };
     EasyMock.replay(profile, profile2, profile3);
@@ -569,7 +565,6 @@ public class ProcessSmilWorkflowOperationHandlerTest {
     EasyMock.expect(profile.getIdentifier()).andReturn(PROFILE_ID);
     EasyMock.expect(profile.getApplicableMediaType()).andReturn(MediaType.Stream);
     EasyMock.expect(profile.getOutputType()).andReturn(MediaType.Stream);
-    EasyMock.expect(profile.getMimeType()).andReturn(MimeTypes.MPEG4.toString()).times(2);
     profileList = new EncodingProfile[] { profile };
     EasyMock.replay(profile);
 


### PR DESCRIPTION
Encoding profiles let you define mime types for the output of an
operation (e.g. video conversion) but these are mostly ignored by the
composer since an inspection is run on the output which will also set
the files mime type.

That behavior makes the mime type specifications in encoding profiles
not only a configuration overhead but also introduces unexpected
behavior since sometimes it is been used and sometimes it is not.

In fact, the only place a mime type needs to be specified is when
Opencast generates images since inspection is implemented to be run on
tracks instead of attachments. But for that, Opencast's MimeTypes class
has another way of automatically determining the mime type.

This patch completely removes mime type specifications from encoding
profiles. Note though, that specifying one will not cause an error since
encoding profiles support extensions. But it will have no effect.