### PR TITLE
MH-12091, Revert implementation of capture agent users

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -68,13 +68,6 @@ admin_role=ROLE_ADMIN
 #
 anonymous_role=ROLE_ANONYMOUS
 
-# The username and password for capture agents.
-#prop.org.opencastproject.security.capture_agent.user=opencast_ca
-#prop.org.opencastproject.security.capture_agent.pass=CHANGE_ME
-
-# Optional extra roles for the capture agent user. These roles may be used to manage which series are visible to the capture agent.
-#prop.org.opencastproject.security.capture_agent.roles=ROLE_ONE, ROLE_TWO, ROLE_THREE
-
 
 # The base URL of the file server. When using a shared filesystem between servers, set all servers to use the same URL.
 # Only then will hard linking between the working file repository and the workspace be enabled to prevent downloads.

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -255,7 +255,7 @@
     <sec:intercept-url pattern="/export/**" method="GET" access="ROLE_ANONYMOUS" />
 
     <!-- Enable anonymous access to the annotation and the series endpoints -->
-    <sec:intercept-url pattern="/series/**" method="GET" access="ROLE_ANONYMOUS, ROLE_CAPTURE_AGENT" />
+    <sec:intercept-url pattern="/series/**" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/annotation/**" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/annotation/**" method="PUT" access="ROLE_ANONYMOUS" />
 
@@ -270,16 +270,10 @@
     <sec:intercept-url pattern="/feeds/**" method="GET" access="ROLE_ANONYMOUS" />
 
     <!-- Secure the system management URLs for admins only -->
-    <sec:intercept-url pattern="/services/available.*" method="GET" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
-    <sec:intercept-url pattern="/services/**" access="ROLE_ADMIN"/>
+    <sec:intercept-url pattern="/services/*" access="ROLE_ADMIN" />
     <sec:intercept-url pattern="/signing/**" access="ROLE_ADMIN" />
     <sec:intercept-url pattern="/system/**" access="ROLE_ADMIN" />
     <sec:intercept-url pattern="/config/**" access="ROLE_ADMIN" />
-
-    <!-- Enable capture agent updates and ingest -->
-    <sec:intercept-url pattern="/capture-admin/**" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
-    <sec:intercept-url pattern="/recordings/**" method="GET" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
-    <sec:intercept-url pattern="/ingest/**" access="ROLE_ADMIN, ROLE_CAPTURE_AGENT" />
 
     <!-- Secure the user management URLs for admins only -->
     <sec:intercept-url pattern="/users/**" access="ROLE_ADMIN" />

--- a/modules/common/src/main/java/org/opencastproject/security/api/SecurityConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/SecurityConstants.java
@@ -47,9 +47,6 @@ public interface SecurityConstants {
   /** Name of the Opencast admin role */
   String GLOBAL_ADMIN_ROLE = "ROLE_ADMIN";
 
-  /** Name of the Opencast capture agent role */
-  String GLOBAL_CAPTURE_AGENT_ROLE = "ROLE_CAPTURE_AGENT";
-
   /** Name of the Opencast global sudo role */
   String GLOBAL_SUDO_ROLE = "ROLE_SUDO";
 
@@ -58,8 +55,5 @@ public interface SecurityConstants {
 
   /** The roles associated with the Opencast system account */
   String[] GLOBAL_SYSTEM_ROLES = new String[] { GLOBAL_ADMIN_ROLE, GLOBAL_SUDO_ROLE };
-
-  /** The roles associated with the Opencast capture agent account */
-  String[] GLOBAL_CAPTURE_AGENT_ROLES = new String[] { GLOBAL_CAPTURE_AGENT_ROLE };
 
 }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -64,20 +63,14 @@ public class InMemoryUserAndRoleProvider implements UserProvider, RoleProvider {
 
   public static final String PROVIDER_NAME = "system";
 
-  /** The digest users */
+  /** The digest user */
   public static final String DIGEST_USER_NAME = "System User";
-  public static final String CAPTURE_AGENT_USER_NAME = "Capture Agent";
 
-  /** Configuration key for the digest users */
+  /** Configuration key for the digest user */
   public static final String DIGEST_USER_KEY = "org.opencastproject.security.digest.user";
-  public static final String CAPTURE_AGENT_USER_KEY = "org.opencastproject.security.capture_agent.user";
 
   /** Configuration key for the digest password */
   public static final String DIGEST_PASSWORD_KEY = "org.opencastproject.security.digest.pass";
-  public static final String CAPTURE_AGENT_PASSWORD_KEY = "org.opencastproject.security.capture_agent.pass";
-
-  /** Configuration key for optional additional roles for the capture agent user */
-  public static final String CAPTURE_AGENT_EXTRA_ROLES_KEY = "org.opencastproject.security.capture_agent.roles";
 
   /** The list of in-memory users */
   private final List<User> inMemoryUsers = new ArrayList<User>();
@@ -121,49 +114,18 @@ public class InMemoryUserAndRoleProvider implements UserProvider, RoleProvider {
     for (Organization organization : orgDirectoryService.getOrganizations()) {
       JaxbOrganization jaxbOrganization = JaxbOrganization.fromOrganization(organization);
 
-      // Create the digest auth users with clear text passwords
-
-      // Role set for the system user
+      // Create the digest auth user with a clear text password
       Set<JaxbRole> roleList = new HashSet<JaxbRole>();
       for (String roleName : SecurityConstants.GLOBAL_SYSTEM_ROLES) {
         roleList.add(new JaxbRole(roleName, jaxbOrganization));
       }
 
-      // Create the system user
+      // Create the digest user
       if (digestUsername != null && digestUserPass != null) {
-        logger.info("Creating the system digest user '{}'", digestUsername);
+        logger.info("Creating the system digest user");
         User digestUser = new JaxbUser(digestUsername, digestUserPass, DIGEST_USER_NAME, null, getName(), true,
                 jaxbOrganization, roleList);
         inMemoryUsers.add(digestUser);
-      }
-
-      String caUsername = organization.getProperties().get(CAPTURE_AGENT_USER_KEY);
-      String caUserPass = organization.getProperties().get(CAPTURE_AGENT_PASSWORD_KEY);
-      if (caUsername != null && caUserPass != null) {
-        // Role set for the capture agent user
-        Set<JaxbRole> caRoleList = new HashSet<>();
-        for (String roleName : SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLES) {
-          caRoleList.add(new JaxbRole(roleName, jaxbOrganization));
-        }
-
-        // Add the organization anonymous role to the capture agent user
-        caRoleList.add(new JaxbRole(organization.getAnonymousRole(), jaxbOrganization));
-
-        String caExtraRoles = organization.getProperties().get(CAPTURE_AGENT_EXTRA_ROLES_KEY);
-        // Add any extra custom roles to the CA user
-        if (caExtraRoles != null) {
-          List<String> items = Arrays.asList(caExtraRoles.split("\\s*,\\s*"));
-          for (String item : items) {
-            logger.debug("Adding custom role '{}' to capture agent user {}", item, caUsername);
-            caRoleList.add(new JaxbRole(item, jaxbOrganization));
-          }
-        }
-
-        // Create the capture agent user
-        logger.info("Creating the capture agent digest user '{}'", caUsername);
-        User caUser = new JaxbUser(caUsername, caUserPass, CAPTURE_AGENT_USER_NAME, null, getName(), true,
-                jaxbOrganization, caRoleList);
-        inMemoryUsers.add(caUser);
       }
     }
   }


### PR DESCRIPTION
…both for security reasons (see security list) and for technical reasons (see [MH-13065](https://opencast.jira.com/browse/MH-13065)). Since it is both unreliable and dangerous at the moment, we can better revert this and add it properly once it is fixed.