### PR TITLE
MH-13022: Fix LTI highly trusted keys being discarded

### DIFF
--- a/modules/matterhorn-kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
+++ b/modules/matterhorn-kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
@@ -115,7 +115,7 @@ public class LtiLaunchAuthenticationHandler
    */
   public LtiLaunchAuthenticationHandler(UserDetailsService userDetailsService, SecurityService securityService,
           List<String> highlyTrustedkeys) {
-    this(userDetailsService, null, new ArrayList<String>(), null);
+    this(userDetailsService, securityService, highlyTrustedkeys, null);
   }
 
   /**


### PR DESCRIPTION
This ports #378 back to 3.x (please merge forward to 4.x and 5.x).