### PR TITLE
MH-13067, Configuration panel does not work for default workflow

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
@@ -34,8 +34,7 @@ angular.module('adminNg.services')
             isWorkflowSet = function () {
                 return angular.isDefined(me.ud.workflow) && angular.isDefined(me.ud.workflow.id);
             },
-            idConfigElement = '#new-event-workflow-configuration',
-            workflowConfigEl = angular.element(idConfigElement);
+            idConfigElement = '#new-event-workflow-configuration';
 
         this.isProcessingState = true;
         this.ud = {};
@@ -87,7 +86,6 @@ angular.module('adminNg.services')
         // Listener for the workflow selection
         this.changeWorkflow = function () {
             me.changingWorkflow = true;
-            workflowConfigEl = angular.element(idConfigElement);
             if (angular.isDefined(me.ud.workflow)) {
                 updateConfigurationPanel(me.ud.workflow.configuration_panel);
             } else {
@@ -99,7 +97,10 @@ angular.module('adminNg.services')
 
         // Get the workflow configuration
         this.getWorkflowConfig = function () {
-            var workflowConfig = {}, element, isRendered = workflowConfigEl.find('.configField').length > 0;
+            var workflowConfig = {},
+                element,
+                workflowConfigEl = angular.element(idConfigElement),
+                isRendered = workflowConfigEl.find('.configField').length > 0;
 
             if (!isRendered) {
                 element = angular.element(me.ud.workflow.configuration_panel).find('.configField');


### PR DESCRIPTION
If a default workflow is configured in `custopm.properties` and hence
automatically selected in the “New Event” wizard, all user input from
the configuration panel is discarded and the default settings are used
instead.

This can be easily tested by configuring the default workflow:

    org.opencastproject.workflow.default.definition=schedule-and-upload

…and selecting the first two options in the configuration panel of the
“New Event” wizard. The summary will already show these values to be set
to false (despite of them being selected earlier).

This patch ensures the configuration panel is looked up when updating
the configuration to ensure the used configuration is always up-to-date.