### PR TITLE
MH-13068 workflow delete instance stability improvement

### DIFF
--- a/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1030,17 +1030,22 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
   private void removeTempFiles(WorkflowInstance workflowInstance) throws WorkflowDatabaseException,
           UnauthorizedException, NotFoundException {
-    logger.info("Removing temporary files for workflow %s", workflowInstance);
+    logger.info("Removing temporary files for workflow {}", workflowInstance);
+    if (null == workflowInstance.getMediaPackage()) {
+      logger.warn("Workflow instance {} does not have an media package set", workflowInstance.getId());
+      return;
+    }
     for (MediaPackageElement elem : workflowInstance.getMediaPackage().getElements()) {
       if (null == elem.getURI()) {
-        // should never pass here but just in case
+        logger.warn("Mediapackage element {} from the media package {} does not have an URI set",
+                elem.getIdentifier(), workflowInstance.getMediaPackage().getIdentifier().compact());
         continue;
       }
       try {
-        logger.debug("Removing temporary file %s for workflow %s", elem.getURI(), workflowInstance);
+        logger.debug("Removing temporary file {} for workflow {}", elem.getURI(), workflowInstance);
         workspace.delete(elem.getURI());
       } catch (IOException e) {
-        logger.warn("Unable to delete mediapackage element ", e);
+        logger.warn("Unable to delete mediapackage element", e);
       } catch (NotFoundException e) {
         // File was probably already deleted before...
       }

--- a/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/matterhorn-workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1032,6 +1032,10 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           UnauthorizedException, NotFoundException {
     logger.info("Removing temporary files for workflow %s", workflowInstance);
     for (MediaPackageElement elem : workflowInstance.getMediaPackage().getElements()) {
+      if (null == elem.getURI()) {
+        // should never pass here but just in case
+        continue;
+      }
       try {
         logger.debug("Removing temporary file %s for workflow %s", elem.getURI(), workflowInstance);
         workspace.delete(elem.getURI());


### PR DESCRIPTION
If you try to delete an workflow instance where the media package contains elements without an URI, it will end up with a `NullPointerException`. This small patch fix this issue.