### PR TITLE
MH-13079, Introduce REST Interface for AssetManager Properties

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/Value.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/Value.java
@@ -69,7 +69,7 @@ public abstract class Value {
   }
 
   /** Get the wrapped value. */
-  protected abstract Object get();
+  public abstract Object get();
 
   /**
    * Get the wrapped value in a type safe way. Use this method if you are

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>opencast-message-broker-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-asset-manager-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- -->
     <dependency>
       <groupId>org.osgi</groupId>
@@ -148,6 +153,10 @@
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Asset manager properties allow for an event based key-value store under
a given namespace. This is currently used, for example, by the workflow
service which stores workflow variables passed to workflows as user
input to ensure they are available for a new workflow as well.

One problem of these properties is that they are never exposed, making
them extremely hard to access for things like a migration from
file-based workflow variable storage to asset manager based storage.

This patch aims to provide a basic API to read and write properties. It
is especially focused on workflow variables.

- *This is based on pull request #410*
- *Work sponsored by SWITCH*