### PR TITLE
MH-13082: Removed LTI security vulnerability again

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
@@ -108,6 +108,18 @@ public class LtiLaunchAuthenticationHandler
   }
 
   /**
+   * Constructor for a LTI authentication handler that includes a list of highly trusted keys
+   *
+   * @param userDetailsService
+   * @param highlyTrustedkeys
+   */
+  public LtiLaunchAuthenticationHandler(UserDetailsService userDetailsService, SecurityService securityService,
+          List<String> highlyTrustedkeys) {
+    this(userDetailsService, securityService, highlyTrustedkeys, "^(admin|opencast_system_account)$");
+    logger.warn("No untrusted users pattern configured - using default \"" + this.untrustedUsersPattern + "\"");
+  }
+
+  /**
    * Full constructor for a LTI authentication handler that includes a list of highly trusted keys with exceptions.
    *
    * @param userDetailsService

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
@@ -104,18 +104,7 @@ public class LtiLaunchAuthenticationHandler
    *          the user details service used to map user identifiers to more detailed information
    */
   public LtiLaunchAuthenticationHandler(UserDetailsService userDetailsService) {
-    this(userDetailsService, null, new ArrayList<String>());
-  }
-
-  /**
-   * Constructor for a LTI authentication handler that includes a list of highly trusted keys
-   *
-   * @param userDetailsService
-   * @param highlyTrustedkeys
-   */
-  public LtiLaunchAuthenticationHandler(UserDetailsService userDetailsService, SecurityService securityService,
-          List<String> highlyTrustedkeys) {
-    this(userDetailsService, securityService, highlyTrustedkeys, null);
+    this(userDetailsService, null, new ArrayList<String>(), null);
   }
 
   /**


### PR DESCRIPTION
After https://github.com/opencast/opencast/commit/ef7bc8e94936b426bec5cb52f846d81c8c903657 the 3 parameter constructor silently discarded the second and third parameter. I found this behavior confusing so I "fixed" it by reverting that constructor back to its old behavior with #378 not realizing that that brought back the security vulnerability that @mtneug originally fixed with https://github.com/opencast/opencast/commit/ef7bc8e94936b426bec5cb52f846d81c8c903657.

To resolve this problem I simply removed the 3 parameter constructor. That way if you e.g. upgrade from Opencast 4.3 and forget to add the fourth parameter in your config file the `highlyTrustedKeys` you pass to your constructor won't just be silently discarded. Instead the constructor call itself will fail which (I hope) means people will see more quickly that something stopped working and what stopped working.