### PR TITLE
MH-13075: make ACL entries unique prior to running ACL comparisons

### DIFF
--- a/modules/matterhorn-common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/matterhorn-common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -52,7 +52,7 @@ public final class EqualsUtil {
     return bothNotNull(a, b) && a.getClass().equals(b.getClass());
   }
 
-  /** Compare the elements of two lists for equality treating the lists as sets. */
+  /** Compare the (distinct) elements of two lists for equality treating the lists as sets. */
   public static boolean eqListUnsorted(List<?> as, List<?> bs) {
     if (as == null || bs == null) {
       return eqObj(as, bs);

--- a/modules/matterhorn-common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/matterhorn-common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -25,6 +25,7 @@ package org.opencastproject.util;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /** Utility function helping to implement equality. */
 public final class EqualsUtil {
@@ -53,7 +54,12 @@ public final class EqualsUtil {
 
   /** Compare the elements of two lists for equality treating the lists as sets. */
   public static boolean eqListUnsorted(List<?> as, List<?> bs) {
-    if (as != null && bs != null && as.size() == bs.size()) {
+    if (as != null && bs != null) {
+      as = as.stream().distinct().collect(Collectors.toList());
+
+      if (as.size() != bs.size()) {
+        return false;
+      }
       for (Object a : as) {
         if (!bs.contains(a))
           return false;

--- a/modules/matterhorn-common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/matterhorn-common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -52,7 +52,16 @@ public final class EqualsUtil {
     return bothNotNull(a, b) && a.getClass().equals(b.getClass());
   }
 
-  /** Compare the (distinct) elements of two lists for equality treating the lists as sets. */
+  /**
+   * Compare the (distinct) elements of two lists for equality treating the lists as sets.
+   * <p>
+   * Sets by definition do not allow multiplicity of elements; a set is a (possibly empty) collection of distinct elements.
+   * As Lists may contain non-unique entries, this method removes duplicates before continuing with the comparison check.
+   *
+   * Examples of
+   * 1. equality: {1, 2} = {2, 1} = {1, 1, 2} = {1, 2, 2, 1, 2}, null = null
+   * 2. unequal: {1, 2, 2} != {1, 2, 3}, null != {}
+   */
   public static boolean eqListUnsorted(List<?> as, List<?> bs) {
     if (as == null || bs == null) {
       return eqObj(as, bs);
@@ -65,8 +74,9 @@ public final class EqualsUtil {
       return false;
     }
     for (Object a : as) {
-      if (!bs.contains(a))
+      if (!bs.contains(a)) {
         return false;
+      }
     }
 
     return true;

--- a/modules/matterhorn-common/src/main/java/org/opencastproject/util/EqualsUtil.java
+++ b/modules/matterhorn-common/src/main/java/org/opencastproject/util/EqualsUtil.java
@@ -54,20 +54,22 @@ public final class EqualsUtil {
 
   /** Compare the elements of two lists for equality treating the lists as sets. */
   public static boolean eqListUnsorted(List<?> as, List<?> bs) {
-    if (as != null && bs != null) {
-      as = as.stream().distinct().collect(Collectors.toList());
-
-      if (as.size() != bs.size()) {
-        return false;
-      }
-      for (Object a : as) {
-        if (!bs.contains(a))
-          return false;
-      }
-      return true;
-    } else {
+    if (as == null || bs == null) {
       return eqObj(as, bs);
     }
+
+    as = as.stream().distinct().collect(Collectors.toList());
+    bs = bs.stream().distinct().collect(Collectors.toList());
+
+    if (as.size() != bs.size()) {
+      return false;
+    }
+    for (Object a : as) {
+      if (!bs.contains(a))
+        return false;
+    }
+
+    return true;
   }
 
   /**

--- a/modules/matterhorn-common/src/test/java/org/opencastproject/util/EqualUtilTest.java
+++ b/modules/matterhorn-common/src/test/java/org/opencastproject/util/EqualUtilTest.java
@@ -22,9 +22,11 @@
 
 package org.opencastproject.util;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.opencastproject.util.EqualsUtil.eqListUnsorted;
 import static org.opencastproject.util.EqualsUtil.eqMap;
 import static org.opencastproject.util.EqualsUtil.hash;
 import static org.opencastproject.util.data.Arrays.array;
@@ -32,6 +34,8 @@ import static org.opencastproject.util.data.Collections.map;
 import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.junit.Test;
+
+import java.util.List;
 
 public class EqualUtilTest {
   @Test
@@ -50,5 +54,30 @@ public class EqualUtilTest {
     assertFalse(eqMap(map(tuple(4, array(1, 2, 4))), map(tuple(4, array(1, 2, 4)))));
     assertFalse(eqMap(map(tuple(1, new Object())), map(tuple(1, new Object()))));
     assertFalse(eqMap(map(tuple("a", "b"), tuple("x", "y")), map(tuple("a", "b"), tuple("x", "z"))));
+  }
+
+  @Test
+  public void testEqualListUnsorted() {
+    // A List is equal to itself
+    List<String> as = asList("a", "b");
+    List<String> bs = asList("a", "b");
+    assertTrue(eqListUnsorted(as, bs));
+    // Permutations of unsorted Lists are equal
+    List<String> permutedA = asList("a", "b");
+    List<String> permutedB = asList("b", "a");
+    assertTrue(eqListUnsorted(permutedA, permutedB));
+
+    List<String> emptyA = asList();
+    List<String> emptyB = asList();
+    assertTrue(eqListUnsorted(emptyA, emptyB));
+
+    List<String> nullA = null;
+    List<String> nullB = null;
+    assertTrue(eqListUnsorted(nullA, nullB));
+    assertFalse(eqListUnsorted(nullA, emptyA));
+    // Unsorted Lists are equal if their distinct entries correspond
+    List<String> distinct = asList("a", "b");
+    List<String> multiples = asList("a", "b", "a", "b", "a");
+    assertTrue(eqListUnsorted(distinct, multiples));
   }
 }

--- a/modules/matterhorn-series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
+++ b/modules/matterhorn-series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
@@ -387,6 +387,33 @@ public class SeriesServiceImplTest {
   }
 
   @Test
+  public void testACLEquality6() {
+    AccessControlList a = new AccessControlList(
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), false),
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), false),
+            new AccessControlEntry("b", Permissions.Action.READ.toString(), true));
+    AccessControlList b = new AccessControlList(
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), false),
+            new AccessControlEntry("b", Permissions.Action.READ.toString(), true));
+    assertTrue(AccessControlUtil.equals(a, b));
+  }
+
+  @Test
+  public void testACLEquality7() {
+    // It is possible to apply this contradictory ACL to a series or event in OC,
+    // where "a" is allowed AND disallowed from writing to the resource.
+    // See MH-13089
+    AccessControlList a = new AccessControlList(
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), false),
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), true),
+            new AccessControlEntry("b", Permissions.Action.READ.toString(), true));
+    AccessControlList b = new AccessControlList(
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), false),
+            new AccessControlEntry("b", Permissions.Action.READ.toString(), true));
+    assertFalse(AccessControlUtil.equals(a, b));
+  }
+
+  @Test
   public void testSeriesElements() throws Exception {
     seriesService.updateSeries(testCatalog);
     final String seriesId = testCatalog.getFirst(DublinCoreCatalog.PROPERTY_IDENTIFIER);

--- a/modules/matterhorn-series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
+++ b/modules/matterhorn-series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
@@ -376,6 +376,17 @@ public class SeriesServiceImplTest {
   }
 
   @Test
+  public void testACLEquality5() {
+    AccessControlList a = new AccessControlList(
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), false),
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), false));
+    AccessControlList b = new AccessControlList(
+            new AccessControlEntry("a", Permissions.Action.WRITE.toString(), false),
+            new AccessControlEntry("b", Permissions.Action.READ.toString(), false));
+    assertFalse(AccessControlUtil.equals(a, b));
+  }
+
+  @Test
   public void testSeriesElements() throws Exception {
     seriesService.updateSeries(testCatalog);
     final String seriesId = testCatalog.getFirst(DublinCoreCatalog.PROPERTY_IDENTIFIER);


### PR DESCRIPTION
The ACL comparator method assumes that the entries of the ACLs to check are unique. However, it is possible to construct an ACL where entries are duplicated.

This patch alters one of the ACLs to have distinct entries prior to running the comparison check. The included unit test is an example of a false positive match.