### PR TITLE
MH-12699: Remove opencast-paella binding dependency on Admin server 

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/01_prerequisites.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/01_prerequisites.js
@@ -79,20 +79,30 @@ class Opencast {
     return this.getEpisode()
     .then(function(episode) {
       return new Promise((resolve, reject)=>{
-        var serie = episode.mediapackage.series;
-        if (serie != undefined) {
-          base.ajax.get({url:'/series/'+serie+'.json'},
-            function(data,contentType,code) {
-              self._series = data;
-              resolve(self._series);
-            },
-            function(data, contentType, code) {
-              reject();
-            }
-          );
-        }
-        else {
-          reject();
+        if (self._series) {
+	  resolve(self.series);
+	}
+	else {
+          var serie = episode.mediapackage.series;
+          if (serie != undefined) {
+            base.ajax.get({url:'/search/series.json', params:{'id': serie}},
+              function(data, contentType, code) {
+                if (data['search-results'].result) {
+                  self._series = data['search-results'].result;
+                  resolve(self._series);
+                }
+                else {
+                  reject();
+                }
+              },
+              function(data, contentType, code) {
+                reject();
+              }
+            );
+          }
+          else {
+            reject();
+          }
         }
       });
     });

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/01_prerequisites.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/01_prerequisites.js
@@ -80,9 +80,9 @@ class Opencast {
     .then(function(episode) {
       return new Promise((resolve, reject)=>{
         if (self._series) {
-	  resolve(self.series);
-	}
-	else {
+	        resolve(self.series);
+	      }
+	      else {
           var serie = episode.mediapackage.series;
           if (serie != undefined) {
             base.ajax.get({url:'/search/series.json', params:{'id': serie}},

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/01_prerequisites.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/01_prerequisites.js
@@ -80,9 +80,9 @@ class Opencast {
     .then(function(episode) {
       return new Promise((resolve, reject)=>{
         if (self._series) {
-	        resolve(self.series);
-	      }
-	      else {
+          resolve(self.series);
+        }
+        else {
           var serie = episode.mediapackage.series;
           if (serie != undefined) {
             base.ajax.get({url:'/search/series.json', params:{'id': serie}},


### PR DESCRIPTION
JIRA ticket: https://opencast.jira.com/browse/MH-12699

The Paella Player's opencast-paella binding uses the Opencast Series service's REST endpoint to get series metadata. The default configuration is for series-remote to be on the Engage server which calls the series-impl on admin to retrieve series information. This makes an unwanted dependency between Paella player and the Opencast admin node.

The admin node dependency, and issues introduced by it, can be avoided by using the search/series endpoint on the Search servie's REST endpoint to retrieve series information. The Search service is native to the Opencast engage server, and it is already used by Paella's opencast-paella binding to get the mediapackage. So, it does not introduce additional unwanted service dependencies.