### PR TITLE
MH-13090: Added support for blacklisting languages from the admin UI

### DIFF
--- a/docs/guides/admin/docs/configuration/ui.md
+++ b/docs/guides/admin/docs/configuration/ui.md
@@ -70,3 +70,10 @@ currently not possible.
 
 Be advised that a too big amount of filters can lead to filters disappearing from view depending on the width of the
 user's screen.
+
+
+Available Language Configuration
+--------------------------------
+
+The admin UI is translated into a number of languages by default.  If you wish to restrict the languages available to
+your users, add the relevant locale code to `etc/org.opencastproject.adminui.endpoint.LanguageServiceEndpoint.cfg`.

--- a/etc/org.opencastproject.adminui.endpoint.LanguageServiceEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.LanguageServiceEndpoint.cfg
@@ -1,0 +1,3 @@
+# Optional param to exclude languages from the admin-UI
+# Add languages to exclude using xx_XX notation, comma separated values
+org.opencastproject.adminui.languages.exclude=

--- a/etc/org.opencastproject.adminui.endpoint.LanguageServiceEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.LanguageServiceEndpoint.cfg
@@ -1,3 +1,4 @@
 # Optional param to exclude languages from the admin-UI
 # Add languages to exclude using xx_XX notation, comma separated values
-org.opencastproject.adminui.languages.exclude=
+# Default: <empty>
+#org.opencastproject.adminui.languages.exclude=

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/LanguageServiceEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/LanguageServiceEndpoint.java
@@ -79,13 +79,14 @@ public class LanguageServiceEndpoint implements ManagedService {
   /** OSGi callback if properties file is present */
   @Override
   public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+    excludedLocales = new HashSet<>();
     if (properties == null) {
       logger.info("No configuration available, using defaults");
       return;
     }
 
     String excludes = StringUtils.trimToEmpty((String) properties.get(EXCLUDE_CONFIG_KEY));
-    excludedLocales = new HashSet<>(Arrays.asList(excludes.split(",")));
+    excludedLocales.addAll(Arrays.asList(StringUtils.split(excludes, ", ")));
   }
 
   @GET

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/LanguageServiceEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/LanguageServiceEndpoint.java
@@ -24,17 +24,24 @@ package org.opencastproject.adminui.endpoint;
 import org.opencastproject.adminui.api.LanguageService;
 import org.opencastproject.adminui.util.Language;
 import org.opencastproject.adminui.util.LocaleFormattingStringProvider;
+import org.opencastproject.util.ConfigurationException;
 import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
@@ -52,7 +59,7 @@ import javax.ws.rs.core.MediaType;
               + "<em>This service is for exclusive use by the module admin-ui. Its API might change "
               + "anytime without prior notice. Any dependencies other than the admin UI will be strictly ignored. "
               + "DO NOT use this for integration of third-party applications.<em>"})
-public class LanguageServiceEndpoint {
+public class LanguageServiceEndpoint implements ManagedService {
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(LanguageServiceEndpoint.class);
@@ -63,6 +70,22 @@ public class LanguageServiceEndpoint {
   /** OSGi callback to bind a {@link LanguageService} instance. */
   void setLanguageService(LanguageService languageSrv) {
     this.languageSrv = languageSrv;
+  }
+
+  private static Set<String> excludedLocales;
+
+  public static final String EXCLUDE_CONFIG_KEY = "org.opencastproject.adminui.languages.exclude";
+
+  /** OSGi callback if properties file is present */
+  @Override
+  public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+    if (properties == null) {
+      logger.info("No configuration available, using defaults");
+      return;
+    }
+
+    String excludes = StringUtils.trimToEmpty((String) properties.get(EXCLUDE_CONFIG_KEY));
+    excludedLocales = new HashSet<>(Arrays.asList(excludes.split(",")));
   }
 
   @GET
@@ -80,7 +103,11 @@ public class LanguageServiceEndpoint {
     JSONObject json = new JSONObject();
     JSONArray availableLanguages = new JSONArray();
     for (Language serverLang : serversAvailableLanguages) {
-      availableLanguages.add(languageToJson(serverLang));
+      if (!excludedLocales.contains(serverLang.getCode())) {
+        availableLanguages.add(languageToJson(serverLang));
+      } else {
+        logger.debug("Filtering out " + serverLang.getCode() + " because it is excluded");
+      }
     }
     json.put("availableLanguages", availableLanguages);
 

--- a/modules/admin-ui/src/main/resources/OSGI-INF/languages_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/languages_endpoint.xml
@@ -6,6 +6,7 @@
 
   <service>
     <provide interface="org.opencastproject.adminui.endpoint.LanguageServiceEndpoint"/>
+    <provide interface="org.osgi.service.cm.ManagedService"/>
   </service>
 
   <property name="service.description" value="Translation File information, utilities about languages"/>


### PR DESCRIPTION
Usecase is that the Taiwanese flag is banned within mainland China, per the discussion on the mailing list.

* Blacklisting a user's current language causes them to use their fallback.
* Blacklisting *all* languages locks the user into either English, or whatever their default would be.
    * This causes a very minor UI bug in that the list is present, but blank, however I feel like this is highly unlikely to happen in a production system, and does not actually cause any issues anyway.