### PR TITLE
MH-13091, Concat operation problem with FFMPEG 4.x 

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -1537,7 +1537,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
       if (hasAudio) {
         for (int i = 0; i < files.size(); i++) {
           if (!tracks.get(i).hasAudio())
-            sb.append("aevalsrc=0::d=1[silent").append(i + 1).append("];");
+            sb.append("aevalsrc=0:d=1[silent").append(i + 1).append("];");
         }
       }
     }


### PR DESCRIPTION
A deprecated syntax for ffmpeg call, that with the latest ffmpeg version is no longer accepted.