### PR TITLE
MH-13094, Use global NPM repository

### DIFF
--- a/modules/admin-ui/package-lock.json
+++ b/modules/admin-ui/package-lock.json
@@ -5,41 +5,41 @@
   "dependencies": {
     "JSV": {
       "version": "4.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/JSV/-/JSV-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
       "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
       "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
       "version": "1.3.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "2.1.20",
         "negotiator": "0.6.1"
       }
     },
     "acorn": {
       "version": "2.6.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/acorn/-/acorn-2.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz",
       "integrity": "sha1-6x9FtKQ/ox0DcBpexG87Umc+kO4=",
       "dev": true
     },
     "after": {
       "version": "0.8.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/after/-/after-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
     "ajv": {
       "version": "5.5.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ajv/-/ajv-5.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
@@ -49,31 +49,9 @@
         "json-schema-traverse": "0.3.1"
       }
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
     "alter": {
       "version": "0.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/alter/-/alter-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
       "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
       "dev": true,
       "requires": {
@@ -82,23 +60,23 @@
     },
     "amdefine": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/amdefine/-/amdefine-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "1.9.3"
       }
     },
     "anymatch": {
@@ -113,13 +91,13 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/aproba/-/aproba-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
@@ -129,11 +107,19 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        }
       }
     },
     "arr-diff": {
@@ -144,7 +130,7 @@
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
@@ -156,25 +142,25 @@
     },
     "array-each": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/array-each/-/array-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-slice": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/array-slice/-/array-slice-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -183,7 +169,7 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
@@ -195,25 +181,28 @@
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
@@ -225,31 +214,31 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
     "async-each": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/async-each/-/async-each-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
     "async-foreach": {
       "version": "0.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/async-foreach/-/async-foreach-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
     },
     "async-limiter": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/async-limiter/-/async-limiter-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
@@ -260,69 +249,56 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/autoprefixer/-/autoprefixer-9.1.3.tgz",
-      "integrity": "sha512-No9xrkPCGIHc9I52e+u1MuvkwfTOIXQt3tu+jGSONAJf4awvQmqOTWmk7JhA9Q3BTvBYIRdpS9PLFtrmpZcImg==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.5.tgz",
+      "integrity": "sha512-kk4Zb6RUc58ld7gdosERHMF3DzIYJc2fp5sX46qEsGXQQy5bXsu8qyLjoxuY1NuQ/cJuCYnx99BfjwnRggrYIw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.1.0",
-        "caniuse-lite": "1.0.30000883",
+        "browserslist": "4.1.1",
+        "caniuse-lite": "1.0.30000885",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "7.0.2",
         "postcss-value-parser": "3.3.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.2",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/postcss/-/postcss-7.0.2.tgz",
-          "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.4.0"
-          }
-        }
       }
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.8.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/aws4/-/aws4-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
     },
     "babylon": {
       "version": "6.18.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/babylon/-/babylon-6.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "backo2": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/backo2/-/backo2-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -383,35 +359,43 @@
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
     "base64id": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/base64id/-/base64id-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
     },
     "basic-auth": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/basic-auth/-/basic-auth-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
       "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        }
       }
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/batch/-/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -420,13 +404,13 @@
     },
     "beeper": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/beeper/-/beeper-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
     "better-assert": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/better-assert/-/better-assert-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "dev": true,
       "requires": {
@@ -435,19 +419,54 @@
     },
     "binary-extensions": {
       "version": "1.11.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
+    "bl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "blob": {
       "version": "0.0.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/blob/-/blob-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
@@ -455,9 +474,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg==",
       "dev": true
     },
     "body": {
@@ -519,9 +538,18 @@
         }
       }
     },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
     "bower-config": {
       "version": "1.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/bower-config/-/bower-config-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
       "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "dev": true,
       "requires": {
@@ -534,7 +562,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
@@ -572,13 +600,13 @@
       }
     },
     "browserslist": {
-      "version": "4.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/browserslist/-/browserslist-4.1.0.tgz",
-      "integrity": "sha512-kQBKB8hnq1SRfSpwHDpM1JNHAyk9fydW8hIDvndR2ijTFKIlBPEvkJkCt8JznOugdm12/YCaRgyq/sqDGz9PwA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
+      "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000883",
-        "electron-to-chromium": "1.3.62",
+        "caniuse-lite": "1.0.30000885",
+        "electron-to-chromium": "1.3.66",
         "node-releases": "1.0.0-alpha.11"
       }
     },
@@ -612,7 +640,7 @@
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
@@ -641,13 +669,13 @@
     },
     "callsite": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/callsite/-/callsite-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -657,13 +685,13 @@
     },
     "camelcase": {
       "version": "2.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/camelcase/-/camelcase-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
       "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -672,37 +700,26 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000883",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/caniuse-lite/-/caniuse-lite-1.0.30000883.tgz",
-      "integrity": "sha512-ovvb0uya4cKJct8Rj9Olstz0LaWmyJhCp3NawRG5fVigka8pEhIIwipF7zyYd2Q58UZb5YfIt52pVF444uj2kQ==",
+      "version": "1.0.30000885",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
+      "integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
-    },
     "chalk": {
       "version": "2.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "supports-color": "5.5.0"
       }
     },
     "chokidar": {
@@ -728,7 +745,7 @@
       "dependencies": {
         "is-glob": {
           "version": "4.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-glob/-/is-glob-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
           "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
@@ -748,32 +765,6 @@
         "kew": "0.7.0",
         "mkdirp": "0.5.1",
         "request": "2.88.0"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
-          }
-        },
-        "extract-zip": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-          "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-          "dev": true,
-          "requires": {
-            "concat-stream": "1.6.2",
-            "debug": "2.6.9",
-            "mkdirp": "0.5.1",
-            "yauzl": "2.4.1"
-          }
-        }
       }
     },
     "circular-json": {
@@ -807,7 +798,7 @@
     },
     "clean-css": {
       "version": "4.1.11",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/clean-css/-/clean-css-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
       "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
       "dev": true,
       "requires": {
@@ -816,7 +807,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -824,17 +815,17 @@
     },
     "cli": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cli/-/cli-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
       "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.2"
+        "glob": "7.1.3"
       }
     },
     "cli-table": {
       "version": "0.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cli-table/-/cli-table-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "dev": true,
       "requires": {
@@ -843,7 +834,7 @@
       "dependencies": {
         "colors": {
           "version": "1.0.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/colors/-/colors-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
           "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
           "dev": true
         }
@@ -851,7 +842,7 @@
     },
     "cliui": {
       "version": "3.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cliui/-/cliui-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
@@ -862,19 +853,19 @@
     },
     "co": {
       "version": "4.6.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "coffeescript": {
       "version": "1.10.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/coffeescript/-/coffeescript-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
       "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
       "dev": true
     },
@@ -889,9 +880,9 @@
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -899,28 +890,28 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "colors": {
       "version": "1.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/colors/-/colors-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
     "combine-lists": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/combine-lists/-/combine-lists-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "combined-stream": {
       "version": "1.0.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/combined-stream/-/combined-stream-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
@@ -928,14 +919,14 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
       "dev": true
     },
     "comment-parser": {
       "version": "0.3.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/comment-parser/-/comment-parser-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.3.2.tgz",
       "integrity": "sha1-PAPwd2uGo239mgosl8YwfzMggv4=",
       "dev": true,
       "requires": {
@@ -944,34 +935,35 @@
     },
     "component-bind": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/component-bind/-/component-bind-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/component-emitter/-/component-emitter-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
       "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/component-inherit/-/component-inherit-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "1.1.1",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
@@ -979,7 +971,7 @@
     },
     "connect": {
       "version": "3.6.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/connect/-/connect-3.6.6.tgz",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
       "dev": true,
       "requires": {
@@ -991,13 +983,13 @@
     },
     "connect-livereload": {
       "version": "0.5.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/connect-livereload/-/connect-livereload-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.4.tgz",
       "integrity": "sha1-gBV9E3HJ83zBQDmrGJWXDRGdw7w=",
       "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/console-browserify/-/console-browserify-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
@@ -1006,13 +998,13 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
@@ -1023,14 +1015,17 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "cookie": {
       "version": "0.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cookie/-/cookie-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
@@ -1041,42 +1036,39 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cross-spawn": {
       "version": "3.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cross-spawn/-/cross-spawn-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
         "lru-cache": "4.1.3",
-        "which": "1.2.14"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        }
+        "which": "1.3.1"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
       }
     },
     "cst": {
       "version": "0.4.10",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cst/-/cst-0.4.10.tgz",
+      "resolved": "https://registry.npmjs.org/cst/-/cst-0.4.10.tgz",
       "integrity": "sha512-U5ETe1IOjq2h56ZcBE3oe9rT7XryCH6IKgPMv0L7sSk6w29yR3p5egCK0T3BDNHHV95OoUBgXsqiVG+3a900Ag==",
       "dev": true,
       "requires": {
@@ -1087,13 +1079,13 @@
     },
     "ctype": {
       "version": "0.5.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ctype/-/ctype-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
       "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -1102,19 +1094,19 @@
     },
     "custom-event": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/custom-event/-/custom-event-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
       "dev": true
     },
     "cycle": {
       "version": "1.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cycle/-/cycle-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
       "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -1123,19 +1115,19 @@
     },
     "date-format": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/date-format/-/date-format-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
       "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
       "dev": true
     },
     "date-now": {
       "version": "0.1.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/date-now/-/date-now-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "date-time": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/date-time/-/date-time-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz",
       "integrity": "sha1-GIdtC9pMGf5w3Tv0sDTygbEqQLY=",
       "dev": true,
       "requires": {
@@ -1144,7 +1136,7 @@
     },
     "dateformat": {
       "version": "1.0.12",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/dateformat/-/dateformat-1.0.12.tgz",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
       "dev": true,
       "requires": {
@@ -1154,7 +1146,7 @@
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
@@ -1163,7 +1155,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -1175,13 +1167,13 @@
     },
     "deep-equal": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/deep-equal/-/deep-equal-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -1228,7 +1220,7 @@
     },
     "del": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/del/-/del-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
@@ -1242,49 +1234,49 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "di": {
       "version": "0.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/di/-/di-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
       "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
       "dev": true
     },
     "diff": {
       "version": "3.5.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/diff/-/diff-3.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dom-serialize": {
       "version": "2.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
@@ -1296,7 +1288,7 @@
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
@@ -1306,13 +1298,13 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         },
         "entities": {
           "version": "1.1.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/entities/-/entities-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
           "dev": true
         }
@@ -1320,13 +1312,13 @@
     },
     "domelementtype": {
       "version": "1.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
     "domhandler": {
       "version": "2.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/domhandler/-/domhandler-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
@@ -1335,7 +1327,7 @@
     },
     "domutils": {
       "version": "1.5.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
@@ -1345,14 +1337,14 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
     "duplexify": {
-      "version": "3.5.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/duplexify/-/duplexify-3.5.4.tgz",
-      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "requires": {
         "end-of-stream": "1.4.1",
@@ -1363,41 +1355,42 @@
     },
     "each-async": {
       "version": "0.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/each-async/-/each-async-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz",
       "integrity": "sha1-tDYCWwjaL4ZggCVRnjCWdj3t/KM=",
       "dev": true
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.62",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
-      "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
+      "version": "1.3.66",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.66.tgz",
+      "integrity": "sha512-EXfLtc9JxX2AZxISZ10o6hXEXTtnLtj7il5eye5YMgmDf4HbBbg+QDXpUEspsFrUcUugJZd5QJ4iIkRrmQQqIg==",
       "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
@@ -1406,7 +1399,7 @@
     },
     "engine.io": {
       "version": "3.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/engine.io/-/engine.io-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "dev": true,
       "requires": {
@@ -1420,7 +1413,7 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -1431,7 +1424,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -1450,7 +1443,7 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -1461,7 +1454,7 @@
     },
     "engine.io-parser": {
       "version": "2.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "dev": true,
       "requires": {
@@ -1474,13 +1467,13 @@
     },
     "ent": {
       "version": "2.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ent/-/ent-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "dev": true
     },
     "entities": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/entities/-/entities-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
       "dev": true
     },
@@ -1495,77 +1488,108 @@
       }
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
       "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
     "esprima": {
       "version": "2.7.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/esprima/-/esprima-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
     "eventemitter3": {
       "version": "3.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
       "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
       "dev": true
     },
     "exit": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/exit/-/exit-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "expand-braces": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/expand-braces/-/expand-braces-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
       "requires": {
@@ -1576,7 +1600,7 @@
       "dependencies": {
         "array-slice": {
           "version": "0.2.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/array-slice/-/array-slice-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
           "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
           "dev": true
         },
@@ -1588,7 +1612,7 @@
         },
         "braces": {
           "version": "0.1.5",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/braces/-/braces-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
           "dev": true,
           "requires": {
@@ -1658,7 +1682,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
@@ -1667,7 +1691,7 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
@@ -1758,61 +1782,50 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
+        "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
       }
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
     "eyes": {
       "version": "0.1.8",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/eyes/-/eyes-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "faye-websocket": {
       "version": "0.10.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/faye-websocket/-/faye-websocket-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
@@ -1821,7 +1834,7 @@
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
@@ -1830,7 +1843,7 @@
     },
     "figures": {
       "version": "1.7.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/figures/-/figures-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
@@ -1840,7 +1853,7 @@
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
       "dev": true
     },
@@ -1869,7 +1882,7 @@
     },
     "finalhandler": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/finalhandler/-/finalhandler-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "dev": true,
       "requires": {
@@ -1884,7 +1897,7 @@
     },
     "find-up": {
       "version": "1.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/find-up/-/find-up-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
@@ -1894,7 +1907,7 @@
     },
     "findup-sync": {
       "version": "0.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/findup-sync/-/findup-sync-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
       "dev": true,
       "requires": {
@@ -1903,7 +1916,7 @@
       "dependencies": {
         "glob": {
           "version": "5.0.15",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
@@ -1918,7 +1931,7 @@
     },
     "fined": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fined/-/fined-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
       "requires": {
@@ -1931,14 +1944,14 @@
     },
     "flagged-respawn": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
       "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
-      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
+      "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
       "dev": true,
       "requires": {
         "debug": "3.1.0"
@@ -1946,7 +1959,7 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -1957,13 +1970,13 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/for-own/-/for-own-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
@@ -1972,19 +1985,19 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/form-data/-/form-data-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "2.1.20"
       }
     },
     "fragment-cache": {
@@ -1998,13 +2011,13 @@
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -2013,7 +2026,7 @@
     },
     "fs-extra": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fs-extra/-/fs-extra-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
       "requires": {
@@ -2024,13 +2037,13 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
       "version": "1.2.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fsevents/-/fsevents-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
@@ -2559,7 +2572,7 @@
     },
     "fstream": {
       "version": "1.0.11",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/fstream/-/fstream-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
@@ -2571,7 +2584,7 @@
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
@@ -2586,23 +2599,26 @@
       }
     },
     "gaze": {
-      "version": "1.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/gaze/-/gaze-1.1.2.tgz",
-      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "1.2.1"
       }
     },
     "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
@@ -2611,13 +2627,13 @@
     },
     "get-caller-file": {
       "version": "1.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
@@ -2629,13 +2645,13 @@
     },
     "getobject": {
       "version": "0.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/getobject/-/getobject-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -2643,9 +2659,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -2668,7 +2684,7 @@
     },
     "global-modules": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/global-modules/-/global-modules-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "dev": true,
       "requires": {
@@ -2679,7 +2695,7 @@
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
@@ -2687,17 +2703,17 @@
         "homedir-polyfill": "1.0.1",
         "ini": "1.3.5",
         "is-windows": "1.0.2",
-        "which": "1.2.14"
+        "which": "1.3.1"
       }
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/globby/-/globby-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
         "array-union": "1.0.2",
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
@@ -2705,32 +2721,32 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
     },
     "globule": {
-      "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/globule/-/globule-1.2.0.tgz",
-      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.5",
+        "glob": "7.1.3",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4"
       }
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
@@ -2747,7 +2763,7 @@
         "findup-sync": "0.3.0",
         "glob": "7.0.6",
         "grunt-cli": "1.2.0",
-        "grunt-known-options": "1.1.0",
+        "grunt-known-options": "1.1.1",
         "grunt-legacy-log": "2.0.0",
         "grunt-legacy-util": "1.1.1",
         "iconv-lite": "0.4.24",
@@ -2761,7 +2777,7 @@
       "dependencies": {
         "glob": {
           "version": "7.0.6",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/glob/-/glob-7.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
@@ -2775,12 +2791,12 @@
         },
         "grunt-cli": {
           "version": "1.2.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-cli/-/grunt-cli-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
           "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
           "dev": true,
           "requires": {
             "findup-sync": "0.3.0",
-            "grunt-known-options": "1.1.0",
+            "grunt-known-options": "1.1.1",
             "nopt": "3.0.6",
             "resolve": "1.1.7"
           }
@@ -2789,11 +2805,11 @@
     },
     "grunt-cli": {
       "version": "1.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-cli/-/grunt-cli-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.3.1.tgz",
       "integrity": "sha512-UwBRu/QpAjDc53DRLEkyilFdL0zenpxu+fddTIlsF/KJqdNcHaQmvyu1W3cDesZ9rqqZdKK5A8+QDIyLUEWoZQ==",
       "dev": true,
       "requires": {
-        "grunt-known-options": "1.1.0",
+        "grunt-known-options": "1.1.1",
         "interpret": "1.1.0",
         "liftoff": "2.5.0",
         "nopt": "4.0.1",
@@ -2802,7 +2818,7 @@
       "dependencies": {
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/nopt/-/nopt-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "requires": {
@@ -2814,7 +2830,7 @@
     },
     "grunt-concurrent": {
       "version": "2.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-concurrent/-/grunt-concurrent-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-2.3.1.tgz",
       "integrity": "sha1-Hj2zjM71o9oRleYdYx/n4yE0TSM=",
       "dev": true,
       "requires": {
@@ -2826,7 +2842,7 @@
     },
     "grunt-contrib-clean": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
       "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
       "dev": true,
       "requires": {
@@ -2836,7 +2852,7 @@
     },
     "grunt-contrib-concat": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
       "integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
       "dev": true,
       "requires": {
@@ -2846,13 +2862,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2865,13 +2881,13 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -2879,7 +2895,7 @@
     },
     "grunt-contrib-connect": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-contrib-connect/-/grunt-contrib-connect-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/grunt-contrib-connect/-/grunt-contrib-connect-1.0.2.tgz",
       "integrity": "sha1-XPkzuRpnOGBEJzwLJERgPNmIebo=",
       "dev": true,
       "requires": {
@@ -2887,7 +2903,7 @@
         "connect": "3.6.6",
         "connect-livereload": "0.5.4",
         "http2": "3.3.7",
-        "morgan": "1.9.0",
+        "morgan": "1.9.1",
         "opn": "4.0.2",
         "portscanner": "1.2.0",
         "serve-index": "1.9.1",
@@ -2896,7 +2912,7 @@
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
       "dev": true,
       "requires": {
@@ -2906,13 +2922,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2925,7 +2941,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -2933,7 +2949,7 @@
     },
     "grunt-contrib-cssmin": {
       "version": "2.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-contrib-cssmin/-/grunt-contrib-cssmin-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-2.2.1.tgz",
       "integrity": "sha512-IXNomhQ5ekVZbDbj/ik5YccoD9khU6LT2fDXqO1+/Txjq8cp0tQKjVS8i8EAbHOrSDkL7/UD6A7b+xj98gqh9w==",
       "dev": true,
       "requires": {
@@ -2944,13 +2960,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2963,7 +2979,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -2971,24 +2987,24 @@
     },
     "grunt-contrib-htmlmin": {
       "version": "2.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-contrib-htmlmin/-/grunt-contrib-htmlmin-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-htmlmin/-/grunt-contrib-htmlmin-2.4.0.tgz",
       "integrity": "sha1-afSYGRmeKsiRUrv4r6XtMhykj5k=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "html-minifier": "3.5.15",
+        "html-minifier": "3.5.20",
         "pretty-bytes": "4.0.2"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3001,13 +3017,13 @@
         },
         "pretty-bytes": {
           "version": "4.0.2",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
           "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -3015,24 +3031,24 @@
     },
     "grunt-contrib-jshint": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
       "integrity": "sha1-Np2QmyWTxA6L55lAshNAhQx5Oaw=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "hooker": "0.2.3",
-        "jshint": "2.9.5"
+        "jshint": "2.9.6"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3045,7 +3061,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -3065,13 +3081,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3082,27 +3098,11 @@
             "supports-color": "2.0.0"
           }
         },
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true
-        },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
-        },
-        "uglify-js": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-          "dev": true,
-          "requires": {
-            "commander": "2.17.1",
-            "source-map": "0.6.1"
-          }
         }
       }
     },
@@ -3113,7 +3113,7 @@
       "dev": true,
       "requires": {
         "async": "2.6.1",
-        "gaze": "1.1.2",
+        "gaze": "1.1.3",
         "lodash": "4.17.10",
         "tiny-lr": "1.1.1"
       },
@@ -3126,24 +3126,18 @@
           "requires": {
             "lodash": "4.17.10"
           }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
         }
       }
     },
     "grunt-endline": {
       "version": "0.7.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-endline/-/grunt-endline-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-endline/-/grunt-endline-0.7.0.tgz",
       "integrity": "sha512-NP2ABzCRBpuNfKgteVSEOR26zsph0oEFPVvEmSldkvxBHeSpUPOpIVxvrDnRHyKoV9hBuszGvVjHovjnG3aUBw==",
       "dev": true
     },
     "grunt-extract-sourcemap": {
       "version": "0.1.19",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-extract-sourcemap/-/grunt-extract-sourcemap-0.1.19.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-extract-sourcemap/-/grunt-extract-sourcemap-0.1.19.tgz",
       "integrity": "sha1-vUYwEl1Wh1x8s7cAA8owE3JFppI=",
       "dev": true,
       "requires": {
@@ -3153,7 +3147,7 @@
       "dependencies": {
         "coffee-script": {
           "version": "1.10.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/coffee-script/-/coffee-script-1.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
           "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA=",
           "dev": true
         }
@@ -3161,24 +3155,24 @@
     },
     "grunt-filerev": {
       "version": "2.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-filerev/-/grunt-filerev-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-filerev/-/grunt-filerev-2.3.1.tgz",
       "integrity": "sha1-KZAhDwtantxecZiYf9HAKcbV9N8=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "convert-source-map": "1.5.1",
+        "convert-source-map": "1.6.0",
         "each-async": "0.1.3"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3191,7 +3185,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -3199,19 +3193,19 @@
     },
     "grunt-jscs": {
       "version": "3.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-jscs/-/grunt-jscs-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-jscs/-/grunt-jscs-3.0.1.tgz",
       "integrity": "sha1-H65Q4+lV3546nZQlrsIqzK4AgJI=",
       "dev": true,
       "requires": {
         "hooker": "0.2.3",
         "jscs": "3.0.7",
         "lodash": "4.6.1",
-        "vow": "0.4.17"
+        "vow": "0.4.18"
       },
       "dependencies": {
         "lodash": {
           "version": "4.6.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-4.6.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.6.1.tgz",
           "integrity": "sha1-3wDBFkrSNrGDz8OIel6NOMxjy7w=",
           "dev": true
         }
@@ -3219,7 +3213,7 @@
     },
     "grunt-karma": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-karma/-/grunt-karma-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/grunt-karma/-/grunt-karma-2.0.0.tgz",
       "integrity": "sha1-dTWD0RXf3AVf5X5Y+W1rPH5hIRg=",
       "dev": true,
       "requires": {
@@ -3228,16 +3222,16 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }
     },
     "grunt-known-options": {
-      "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
-      "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+      "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
       "dev": true
     },
     "grunt-legacy-log": {
@@ -3249,7 +3243,7 @@
         "colors": "1.1.2",
         "grunt-legacy-log-utils": "2.0.1",
         "hooker": "0.2.3",
-        "lodash": "4.17.5"
+        "lodash": "4.17.10"
       }
     },
     "grunt-legacy-log-utils": {
@@ -3260,14 +3254,6 @@
       "requires": {
         "chalk": "2.4.1",
         "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
       }
     },
     "grunt-legacy-util": {
@@ -3283,34 +3269,17 @@
         "lodash": "4.17.10",
         "underscore.string": "3.3.4",
         "which": "1.3.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        }
       }
     },
     "grunt-middleware-proxy": {
       "version": "1.0.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-middleware-proxy/-/grunt-middleware-proxy-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-middleware-proxy/-/grunt-middleware-proxy-1.0.7.tgz",
       "integrity": "sha1-YUPO05nBrzOlRmgvPUBcp2m6fRg=",
       "dev": true
     },
     "grunt-newer": {
       "version": "1.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-newer/-/grunt-newer-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-newer/-/grunt-newer-1.3.0.tgz",
       "integrity": "sha1-g8y3od2ny9irI7BZAk6+YUrS80I=",
       "dev": true,
       "requires": {
@@ -3320,7 +3289,7 @@
     },
     "grunt-ng-annotate": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-ng-annotate/-/grunt-ng-annotate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-ng-annotate/-/grunt-ng-annotate-3.0.0.tgz",
       "integrity": "sha1-dqKiGha6Y+Vve+G3XuXErZMCeTk=",
       "dev": true,
       "requires": {
@@ -3330,18 +3299,31 @@
     },
     "grunt-postcss": {
       "version": "0.9.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-postcss/-/grunt-postcss-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.9.0.tgz",
       "integrity": "sha512-lglLcVaoOIqH0sFv7RqwUKkEFGQwnlqyAKbatxZderwZGV1nDyKHN7gZS9LUiTx1t5GOvRBx0BEalHMyVwFAIA==",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
         "diff": "3.5.0",
-        "postcss": "6.0.22"
+        "postcss": "6.0.23"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "source-map": "0.6.1",
+            "supports-color": "5.5.0"
+          }
+        }
       }
     },
     "grunt-sass": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-sass/-/grunt-sass-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-2.1.0.tgz",
       "integrity": "sha512-XkexnQt/9rhReNd+Y7T0n/2g5FqYOQKfi2iSlpwDqvgs7EgEaGTxNhnWzHnbW5oNRvzL9AHopBG3AgRxL0d+DA==",
       "dev": true,
       "requires": {
@@ -3352,7 +3334,7 @@
       "dependencies": {
         "each-async": {
           "version": "1.1.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/each-async/-/each-async-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
           "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
           "dev": true,
           "requires": {
@@ -3364,7 +3346,7 @@
     },
     "grunt-usemin": {
       "version": "3.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-usemin/-/grunt-usemin-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-usemin/-/grunt-usemin-3.1.1.tgz",
       "integrity": "sha1-WrZ5UQ1nLOpWbMcXq+i4oAn2QcI=",
       "dev": true,
       "requires": {
@@ -3376,13 +3358,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3395,19 +3377,19 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "path-exists": {
           "version": "1.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/path-exists/-/path-exists-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
           "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -3415,7 +3397,7 @@
     },
     "grunt-wiredep": {
       "version": "3.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/grunt-wiredep/-/grunt-wiredep-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-wiredep/-/grunt-wiredep-3.0.1.tgz",
       "integrity": "sha1-d+dfpw6c+OxqRnnX15r0Q6MgL1U=",
       "dev": true,
       "requires": {
@@ -3424,7 +3406,7 @@
     },
     "gzip-size": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/gzip-size/-/gzip-size-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
       "dev": true,
       "requires": {
@@ -3432,91 +3414,31 @@
       }
     },
     "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
+      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
+        "async": "2.6.1",
         "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "source-map": "0.6.1",
+        "uglify-js": "3.4.9"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
+            "lodash": "4.17.10"
           }
         }
       }
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
@@ -3532,7 +3454,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -3541,7 +3463,7 @@
     },
     "has-binary2": {
       "version": "1.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/has-binary2/-/has-binary2-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
       "dev": true,
       "requires": {
@@ -3550,7 +3472,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -3558,25 +3480,25 @@
     },
     "has-color": {
       "version": "0.1.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/has-color/-/has-color-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "dev": true
     },
     "has-cors": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/has-cors/-/has-cors-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
@@ -3614,7 +3536,7 @@
     },
     "hasha": {
       "version": "2.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/hasha/-/hasha-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
@@ -3622,15 +3544,33 @@
         "pinkie-promise": "2.0.1"
       }
     },
+    "hawk": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+      "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
     "he": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/he/-/he-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
       "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
@@ -3639,34 +3579,45 @@
     },
     "hooker": {
       "version": "0.2.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/hooker/-/hooker-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "html-minifier": {
-      "version": "3.5.15",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/html-minifier/-/html-minifier-3.5.15.tgz",
-      "integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
+      "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
-        "clean-css": "4.1.11",
-        "commander": "2.15.1",
+        "clean-css": "4.2.1",
+        "commander": "2.17.1",
         "he": "1.1.1",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.26"
+        "uglify-js": "3.4.9"
+      },
+      "dependencies": {
+        "clean-css": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+          "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
+          }
+        }
       }
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
@@ -3679,13 +3630,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3697,7 +3648,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -3705,7 +3656,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -3717,7 +3668,7 @@
       "dependencies": {
         "statuses": {
           "version": "1.5.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/statuses/-/statuses-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         }
@@ -3731,35 +3682,35 @@
     },
     "http-proxy": {
       "version": "1.17.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/http-proxy/-/http-proxy-1.17.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
         "eventemitter3": "3.1.0",
-        "follow-redirects": "1.5.7",
+        "follow-redirects": "1.5.8",
         "requires-port": "1.0.0"
       }
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "sshpk": "1.14.2"
       }
     },
     "http2": {
       "version": "3.3.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/http2/-/http2-3.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/http2/-/http2-3.3.7.tgz",
       "integrity": "sha512-puSi8M8WNlFJm9Pk4c/Mbz9Gwparuj3gO9/RRO5zv6piQ0FY+9Qywp0PdWshYgsMJSalixFY7eC6oPu0zRxLAQ==",
       "dev": true
     },
     "i": {
       "version": "0.3.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/i/-/i-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
       "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
       "dev": true
     },
@@ -3774,13 +3725,13 @@
     },
     "in-publish": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/in-publish/-/in-publish-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/indent-string/-/indent-string-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
@@ -3789,13 +3740,13 @@
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -3805,43 +3756,43 @@
     },
     "inherit": {
       "version": "2.2.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/inherit/-/inherit-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.6.tgz",
       "integrity": "sha1-8WFLBshUToEo5CKchjR9tzrZeI0=",
       "dev": true
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ini/-/ini-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "interpret": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/interpret/-/interpret-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/invert-kv/-/invert-kv-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "irregular-plurals": {
       "version": "1.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
       "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
     "is-absolute": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-absolute/-/is-absolute-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
       "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
       "dev": true,
       "requires": {
@@ -3871,13 +3822,13 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -3886,13 +3837,13 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-buffer/-/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3940,7 +3891,7 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
@@ -3952,7 +3903,7 @@
     },
     "is-finite": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-finite/-/is-finite-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
@@ -3961,7 +3912,7 @@
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
@@ -3970,7 +3921,7 @@
     },
     "is-glob": {
       "version": "3.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-glob/-/is-glob-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
@@ -3979,17 +3930,17 @@
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
       "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
+        "generate-function": "2.3.1",
         "generate-object-property": "1.2.0",
         "is-my-ip-valid": "1.0.0",
         "jsonpointer": "4.0.1",
@@ -4018,13 +3969,13 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
@@ -4033,7 +3984,7 @@
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
@@ -4051,13 +4002,13 @@
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
     "is-relative": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-relative/-/is-relative-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
       "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
       "dev": true,
       "requires": {
@@ -4066,19 +4017,19 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-unc-path": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
       "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
       "dev": true,
       "requires": {
@@ -4087,7 +4038,7 @@
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
@@ -4099,7 +4050,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
@@ -4114,7 +4065,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -4126,13 +4077,13 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul": {
       "version": "0.4.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/istanbul/-/istanbul-0.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
@@ -4141,45 +4092,26 @@
         "escodegen": "1.8.1",
         "esprima": "2.7.3",
         "glob": "5.0.15",
-        "handlebars": "4.0.11",
+        "handlebars": "4.0.12",
         "js-yaml": "3.5.5",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "once": "1.4.0",
         "resolve": "1.1.7",
         "supports-color": "3.2.3",
-        "which": "1.2.14",
+        "which": "1.3.1",
         "wordwrap": "1.0.0"
       },
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/abbrev/-/abbrev-1.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
           "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-          "dev": true
-        },
-        "escodegen": {
-          "version": "1.8.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/escodegen/-/escodegen-1.8.1.tgz",
-          "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-          "dev": true,
-          "requires": {
-            "esprima": "2.7.3",
-            "estraverse": "1.9.3",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.2.0"
-          }
-        },
-        "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
           "dev": true
         },
         "glob": {
           "version": "5.0.15",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
@@ -4192,23 +4124,13 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
         "supports-color": {
           "version": "3.2.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
@@ -4217,7 +4139,7 @@
         },
         "wordwrap": {
           "version": "1.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wordwrap/-/wordwrap-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
@@ -4225,25 +4147,25 @@
     },
     "jasmine-core": {
       "version": "2.99.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jasmine-core/-/jasmine-core-2.99.1.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
       "integrity": "sha1-5kAN8ea1bhMLYcS80JPap/boyhU=",
       "dev": true
     },
     "jit-grunt": {
       "version": "0.10.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jit-grunt/-/jit-grunt-0.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/jit-grunt/-/jit-grunt-0.10.0.tgz",
       "integrity": "sha1-AIw6f+Hpa9DYTiYOofoXg0V/ecI=",
       "dev": true
     },
     "js-base64": {
       "version": "2.4.9",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/js-base64/-/js-base64-2.4.9.tgz",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
       "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
       "dev": true
     },
     "js-yaml": {
       "version": "3.5.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/js-yaml/-/js-yaml-3.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
       "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
       "dev": true,
       "requires": {
@@ -4253,14 +4175,14 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
     },
     "jscs": {
       "version": "3.0.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jscs/-/jscs-3.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/jscs/-/jscs-3.0.7.tgz",
       "integrity": "sha1-cUG03/W4bjLQ6Z12S4NnZ8MNIBo=",
       "dev": true,
       "requires": {
@@ -4287,20 +4209,20 @@
         "strip-json-comments": "1.0.4",
         "to-double-quotes": "2.0.0",
         "to-single-quotes": "2.0.1",
-        "vow": "0.4.17",
+        "vow": "0.4.18",
         "vow-fs": "0.3.6",
         "xmlbuilder": "3.1.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4313,7 +4235,7 @@
         },
         "commander": {
           "version": "2.9.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/commander/-/commander-2.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
@@ -4322,7 +4244,7 @@
         },
         "glob": {
           "version": "5.0.15",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
@@ -4335,7 +4257,7 @@
         },
         "js-yaml": {
           "version": "3.4.6",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/js-yaml/-/js-yaml-3.4.6.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
           "integrity": "sha1-a+GyP2JJ9T0pM3D9TRqqY84bTrA=",
           "dev": true,
           "requires": {
@@ -4346,13 +4268,13 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -4360,7 +4282,7 @@
     },
     "jscs-jsdoc": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jscs-jsdoc/-/jscs-jsdoc-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jscs-jsdoc/-/jscs-jsdoc-2.0.0.tgz",
       "integrity": "sha1-9T684CmqMSW9iCkLpQ1k1FEKSHE=",
       "dev": true,
       "requires": {
@@ -4370,13 +4292,13 @@
     },
     "jscs-preset-wikimedia": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jscs-preset-wikimedia/-/jscs-preset-wikimedia-1.0.1.tgz",
       "integrity": "sha512-RWqu6IYSUlnYuCRCF0obCOHjJV0vhpLcvKbauwxmLQoZ0PiXDTWBYlfpsEfdhg7pmREAEwrARfDRz5qWD6qknA==",
       "dev": true
     },
     "jsdoctypeparser": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-1.2.0.tgz",
       "integrity": "sha1-597cFToRhJ/8UUEUSuhqfvDCU5I=",
       "dev": true,
       "requires": {
@@ -4385,39 +4307,34 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
       }
     },
     "jshint": {
-      "version": "2.9.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jshint/-/jshint-2.9.5.tgz",
-      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.6.tgz",
+      "integrity": "sha512-KO9SIAKTlJQOM4lE64GQUtGBRpTOuvbrRrSZw3AhUxMNG266nX9hK2cKA4SBhXOj0irJGyNyGSLT62HGOVDEOA==",
       "dev": true,
       "requires": {
         "cli": "1.0.1",
         "console-browserify": "1.1.0",
         "exit": "0.1.2",
         "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
+        "phantom": "4.0.12",
+        "phantomjs-prebuilt": "2.1.16",
         "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.7.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-3.7.0.tgz",
-          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
-          "dev": true
-        }
+        "strip-json-comments": "1.0.4",
+        "unicode-5.2.0": "0.7.5"
       }
     },
     "jshint-stylish": {
       "version": "2.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jshint-stylish/-/jshint-stylish-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-2.2.1.tgz",
       "integrity": "sha1-JCCCosA1rgP9gQROBXDMQgjPbmE=",
       "dev": true,
       "requires": {
@@ -4431,13 +4348,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4450,7 +4367,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -4458,25 +4375,25 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
@@ -4485,7 +4402,7 @@
     },
     "jsonlint": {
       "version": "1.6.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jsonlint/-/jsonlint-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
       "integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
       "dev": true,
       "requires": {
@@ -4495,13 +4412,13 @@
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -4513,25 +4430,25 @@
     },
     "karma": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/karma/-/karma-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-3.0.0.tgz",
       "integrity": "sha512-ZTjyuDXVXhXsvJ1E4CnZzbCjSxD6sEdzEsFYogLuZM0yqvg/mgz+O+R1jb0J7uAQeuzdY8kJgx6hSNXLwFuHIQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "3.5.2",
         "body-parser": "1.18.3",
         "chokidar": "2.0.4",
         "colors": "1.1.2",
         "combine-lists": "1.0.1",
         "connect": "3.6.6",
-        "core-js": "2.5.5",
+        "core-js": "2.5.7",
         "di": "0.0.1",
         "dom-serialize": "2.2.1",
         "expand-braces": "0.1.2",
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "graceful-fs": "4.1.11",
         "http-proxy": "1.17.0",
         "isbinaryfile": "3.0.3",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "log4js": "3.0.5",
         "mime": "2.3.1",
         "minimatch": "3.0.4",
@@ -4539,7 +4456,7 @@
         "qjobs": "1.2.0",
         "range-parser": "1.2.0",
         "rimraf": "2.6.2",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "socket.io": "2.1.1",
         "source-map": "0.6.1",
         "tmp": "0.0.33",
@@ -4548,7 +4465,7 @@
       "dependencies": {
         "mime": {
           "version": "2.3.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mime/-/mime-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
           "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
           "dev": true
         }
@@ -4556,12 +4473,12 @@
     },
     "karma-chrome-launcher": {
       "version": "2.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz",
       "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
         "fs-access": "1.0.1",
-        "which": "1.2.14"
+        "which": "1.3.1"
       }
     },
     "karma-coverage": {
@@ -4572,14 +4489,14 @@
       "requires": {
         "dateformat": "1.0.12",
         "istanbul": "0.4.5",
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "minimatch": "3.0.4",
         "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -4587,7 +4504,7 @@
     },
     "karma-firefox-launcher": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",
       "integrity": "sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA==",
       "dev": true
     },
@@ -4599,23 +4516,23 @@
     },
     "karma-ng-html2js-preprocessor": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/karma-ng-html2js-preprocessor/-/karma-ng-html2js-preprocessor-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/karma-ng-html2js-preprocessor/-/karma-ng-html2js-preprocessor-1.0.0.tgz",
       "integrity": "sha1-ENjIz6pBNvHIp22RpMvO7evsSjE=",
       "dev": true
     },
     "karma-phantomjs-launcher": {
       "version": "1.0.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5",
+        "lodash": "4.17.10",
         "phantomjs-prebuilt": "2.1.16"
       }
     },
     "kew": {
       "version": "0.7.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/kew/-/kew-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
       "dev": true
     },
@@ -4627,29 +4544,22 @@
     },
     "klaw": {
       "version": "1.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/klaw/-/klaw-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
     },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true,
-      "optional": true
-    },
     "lazy.js": {
       "version": "0.4.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lazy.js/-/lazy.js-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/lazy.js/-/lazy.js-0.4.3.tgz",
       "integrity": "sha1-h/Z6B602VVEh5P/xUg3zG+Znhtg=",
       "dev": true
     },
     "lcid": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lcid/-/lcid-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
@@ -4658,7 +4568,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -4668,7 +4578,7 @@
     },
     "liftoff": {
       "version": "2.5.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/liftoff/-/liftoff-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
       "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
       "dev": true,
       "requires": {
@@ -4684,7 +4594,7 @@
       "dependencies": {
         "findup-sync": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/findup-sync/-/findup-sync-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
           "dev": true,
           "requires": {
@@ -4698,13 +4608,13 @@
     },
     "livereload-js": {
       "version": "2.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/livereload-js/-/livereload-js-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
       "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg==",
       "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -4717,27 +4627,27 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
@@ -4749,13 +4659,13 @@
     },
     "lodash.mergewith": {
       "version": "4.6.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
       "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
       "dev": true
     },
     "log-symbols": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/log-symbols/-/log-symbols-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "dev": true,
       "requires": {
@@ -4764,13 +4674,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4783,7 +4693,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -4791,37 +4701,37 @@
     },
     "log4js": {
       "version": "3.0.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/log4js/-/log4js-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.5.tgz",
       "integrity": "sha512-IX5c3G/7fuTtdr0JjOT2OIR12aTESVhsH6cEsijloYwKgcPRlO6DgOU72v0UFhWcoV1HN6+M3dwT89qVPLXm0w==",
       "dev": true,
       "requires": {
         "circular-json": "0.5.5",
         "date-format": "1.2.0",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "rfdc": "1.1.2",
         "streamroller": "0.7.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -4831,19 +4741,23 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
     "lru-cache": {
-      "version": "2.2.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lru-cache/-/lru-cache-2.2.4.tgz",
-      "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
-      "dev": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "make-iterator": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/make-iterator/-/make-iterator-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
       "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
       "dev": true,
       "requires": {
@@ -4858,7 +4772,7 @@
     },
     "map-obj": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/map-obj/-/map-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
@@ -4873,7 +4787,7 @@
     },
     "maxmin": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/maxmin/-/maxmin-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-2.1.0.tgz",
       "integrity": "sha1-TTsiCQPZXu5+t6x/qGTnLcCaMWY=",
       "dev": true,
       "requires": {
@@ -4885,13 +4799,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4904,7 +4818,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -4912,13 +4826,13 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -4936,7 +4850,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -4965,28 +4879,28 @@
     },
     "mime": {
       "version": "1.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mime/-/mime-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "1.36.0"
       }
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
@@ -4995,7 +4909,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -5022,7 +4936,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5030,9 +4944,9 @@
       }
     },
     "morgan": {
-      "version": "1.9.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/morgan/-/morgan-1.9.0.tgz",
-      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
       "dev": true,
       "requires": {
         "basic-auth": "2.0.0",
@@ -5044,25 +4958,25 @@
     },
     "mout": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mout/-/mout-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
       "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
       "dev": true
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "nan": {
       "version": "2.11.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/nan/-/nan-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
       "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
       "dev": true
     },
@@ -5087,25 +5001,25 @@
     },
     "natural-compare": {
       "version": "1.2.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/natural-compare/-/natural-compare-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.2.2.tgz",
       "integrity": "sha1-H5bWDjFBysG20FZTzg2urHY69qo=",
       "dev": true
     },
     "ncp": {
       "version": "0.4.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ncp/-/ncp-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
       "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
       "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/negotiator/-/negotiator-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
     "ng-annotate": {
       "version": "1.2.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ng-annotate/-/ng-annotate-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/ng-annotate/-/ng-annotate-1.2.2.tgz",
       "integrity": "sha1-3D/FG6Cy+LOF2+BH9NoG9YCh/WE=",
       "dev": true,
       "requires": {
@@ -5125,13 +5039,13 @@
       "dependencies": {
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -5139,7 +5053,7 @@
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/no-case/-/no-case-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
@@ -5148,12 +5062,12 @@
     },
     "node-gyp": {
       "version": "3.8.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/node-gyp/-/node-gyp-3.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
         "fstream": "1.0.11",
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "graceful-fs": "4.1.11",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
@@ -5163,12 +5077,12 @@
         "rimraf": "2.6.2",
         "semver": "5.3.0",
         "tar": "2.2.1",
-        "which": "1.2.14"
+        "which": "1.3.1"
       },
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -5176,25 +5090,25 @@
     },
     "node-releases": {
       "version": "1.0.0-alpha.11",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
       "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
       "dev": true,
       "requires": {
-        "semver": "5.5.0"
+        "semver": "5.5.1"
       }
     },
     "node-sass": {
       "version": "4.9.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/node-sass/-/node-sass-4.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
       "integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
         "chalk": "1.1.3",
         "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
+        "gaze": "1.1.3",
         "get-stdin": "4.0.1",
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "in-publish": "2.0.0",
         "lodash.assign": "4.2.0",
         "lodash.clonedeep": "4.5.0",
@@ -5212,13 +5126,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5231,7 +5145,7 @@
         },
         "har-validator": {
           "version": "5.0.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/har-validator/-/har-validator-5.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
@@ -5239,9 +5153,15 @@
             "har-schema": "2.0.0"
           }
         },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true
+        },
         "request": {
           "version": "2.87.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/request/-/request-2.87.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "dev": true,
           "requires": {
@@ -5257,11 +5177,11 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
+            "mime-types": "2.1.20",
             "oauth-sign": "0.8.2",
             "performance-now": "2.1.0",
             "qs": "6.5.2",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.1.2",
             "tough-cookie": "2.3.4",
             "tunnel-agent": "0.6.0",
             "uuid": "3.3.2"
@@ -5269,15 +5189,24 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         }
       }
     },
     "nomnom": {
       "version": "1.8.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/nomnom/-/nomnom-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
@@ -5287,13 +5216,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
           "dev": true
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -5304,7 +5233,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
@@ -5312,7 +5241,7 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/nopt/-/nopt-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
@@ -5321,19 +5250,19 @@
     },
     "normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
+        "hosted-git-info": "2.7.1",
         "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.3"
+        "semver": "5.5.1",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/normalize-path/-/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
@@ -5342,13 +5271,13 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/npmlog/-/npmlog-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
@@ -5360,37 +5289,37 @@
     },
     "null-check": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/null-check/-/null-check-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
       "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
       "dev": true
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-component": {
       "version": "0.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/object-component/-/object-component-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
@@ -5436,7 +5365,7 @@
     },
     "object.defaults": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/object.defaults/-/object.defaults-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
       "requires": {
@@ -5448,7 +5377,7 @@
     },
     "object.map": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/object.map/-/object.map-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
       "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
       "dev": true,
       "requires": {
@@ -5467,7 +5396,7 @@
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -5476,13 +5405,13 @@
     },
     "on-headers": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/on-headers/-/on-headers-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
       "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -5491,13 +5420,13 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
     "opn": {
       "version": "4.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/opn/-/opn-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "dev": true,
       "requires": {
@@ -5507,7 +5436,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
@@ -5517,7 +5446,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -5531,7 +5460,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wordwrap/-/wordwrap-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
@@ -5539,7 +5468,7 @@
     },
     "ordered-ast-traverse": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ordered-ast-traverse/-/ordered-ast-traverse-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ordered-ast-traverse/-/ordered-ast-traverse-1.1.1.tgz",
       "integrity": "sha1-aEOhcLwO7otSDMjdwd3TqjD6BXw=",
       "dev": true,
       "requires": {
@@ -5548,19 +5477,19 @@
     },
     "ordered-esprima-props": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ordered-esprima-props/-/ordered-esprima-props-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ordered-esprima-props/-/ordered-esprima-props-1.1.0.tgz",
       "integrity": "sha1-qYJwht9fAQqmDpvQK24DNc6i/8s=",
       "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -5569,13 +5498,13 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
       "version": "0.1.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/osenv/-/osenv-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
@@ -5585,18 +5514,18 @@
     },
     "p-map": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/p-map/-/p-map-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
     "pad-stream": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pad-stream/-/pad-stream-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pad-stream/-/pad-stream-1.2.0.tgz",
       "integrity": "sha1-Yx3Mn3mBC3BZZeid7eps/w/B38k=",
       "dev": true,
       "requires": {
         "meow": "3.7.0",
-        "pumpify": "1.4.0",
+        "pumpify": "1.5.1",
         "repeating": "2.0.1",
         "split2": "1.1.1",
         "through2": "2.0.3"
@@ -5604,7 +5533,7 @@
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
@@ -5613,7 +5542,7 @@
     },
     "parse-filepath": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
       "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
       "dev": true,
       "requires": {
@@ -5624,28 +5553,28 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "1.3.2"
       }
     },
     "parse-ms": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/parse-ms/-/parse-ms-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
       "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
       "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "parseqs": {
       "version": "0.0.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/parseqs/-/parseqs-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
@@ -5654,7 +5583,7 @@
     },
     "parseuri": {
       "version": "0.0.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/parseuri/-/parseuri-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
@@ -5663,7 +5592,7 @@
     },
     "parseurl": {
       "version": "1.3.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/parseurl/-/parseurl-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
@@ -5681,7 +5610,7 @@
     },
     "path-exists": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/path-exists/-/path-exists-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
@@ -5690,19 +5619,19 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-root": {
       "version": "0.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/path-root/-/path-root-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
       "dev": true,
       "requires": {
@@ -5711,13 +5640,13 @@
     },
     "path-root-regex": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
     },
     "path-type": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/path-type/-/path-type-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
@@ -5728,7 +5657,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -5736,54 +5665,66 @@
     },
     "pathval": {
       "version": "0.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pathval/-/pathval-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz",
       "integrity": "sha1-CPkRzcqczllCiA2ngXvAtyO2bYI=",
       "dev": true
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "phantom": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz",
+      "integrity": "sha512-Tz82XhtPmwCk1FFPmecy7yRGZG2btpzY2KI9fcoPT7zT9det0CcMyfBFPp1S8DqzsnQnm8ZYEfdy528mwVtksA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "phantomjs-prebuilt": "2.1.16",
+        "split": "1.0.1",
+        "winston": "2.4.4"
+      }
+    },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4",
-        "extract-zip": "1.6.6",
+        "es6-promise": "4.2.5",
+        "extract-zip": "1.6.7",
         "fs-extra": "1.0.0",
         "hasha": "2.2.0",
         "kew": "0.7.0",
         "progress": "1.1.8",
         "request": "2.88.0",
         "request-progress": "2.0.1",
-        "which": "1.2.14"
+        "which": "1.3.1"
       }
     },
     "pify": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pify/-/pify-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -5792,13 +5733,13 @@
     },
     "pkginfo": {
       "version": "0.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pkginfo/-/pkginfo-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
       "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
       "dev": true
     },
     "plur": {
       "version": "2.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/plur/-/plur-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
@@ -5807,7 +5748,7 @@
     },
     "portscanner": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/portscanner/-/portscanner-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.2.0.tgz",
       "integrity": "sha1-sUu9olfRTDEPqcwJaCrwLUCWGAI=",
       "dev": true,
       "requires": {
@@ -5821,31 +5762,31 @@
       "dev": true
     },
     "postcss": {
-      "version": "6.0.22",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/postcss/-/postcss-6.0.22.tgz",
-      "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+      "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
       "dev": true,
       "requires": {
         "chalk": "2.4.1",
         "source-map": "0.6.1",
-        "supports-color": "5.4.0"
+        "supports-color": "5.5.0"
       }
     },
     "postcss-value-parser": {
       "version": "3.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "pretty-bytes": {
       "version": "3.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-3.0.1.tgz",
       "integrity": "sha1-J9AAjXeAY6C0gRuzXHnxvV1fvM8=",
       "dev": true,
       "requires": {
@@ -5854,7 +5795,7 @@
     },
     "pretty-ms": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
@@ -5865,7 +5806,7 @@
       "dependencies": {
         "plur": {
           "version": "1.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/plur/-/plur-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
           "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
           "dev": true
         }
@@ -5873,19 +5814,19 @@
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "progress": {
       "version": "1.1.8",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/progress/-/progress-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
     "prompt": {
       "version": "0.2.14",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/prompt/-/prompt-0.2.14.tgz",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
       "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
       "dev": true,
       "requires": {
@@ -5894,17 +5835,54 @@
         "revalidator": "0.1.8",
         "utile": "0.2.1",
         "winston": "0.8.3"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "colors": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
+          "dev": true
+        },
+        "winston": {
+          "version": "0.8.3",
+          "resolved": "http://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+          "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+          "dev": true,
+          "requires": {
+            "async": "0.2.10",
+            "colors": "0.6.2",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "pkginfo": "0.3.1",
+            "stack-trace": "0.0.10"
+          },
+          "dependencies": {
+            "pkginfo": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+              "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "propprop": {
       "version": "0.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/propprop/-/propprop-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/propprop/-/propprop-0.3.1.tgz",
       "integrity": "sha1-oEmjVouJZEAGfRXY7J8zc15XAXg=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -5916,7 +5894,7 @@
     },
     "pump": {
       "version": "2.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pump/-/pump-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
@@ -5925,25 +5903,25 @@
       }
     },
     "pumpify": {
-      "version": "1.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pumpify/-/pumpify-1.4.0.tgz",
-      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "inherits": "2.0.3",
         "pump": "2.0.1"
       }
     },
     "punycode": {
       "version": "1.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/punycode/-/punycode-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
     "qjobs": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/qjobs/-/qjobs-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
       "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
       "dev": true
     },
@@ -5955,13 +5933,13 @@
     },
     "querystringify": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/querystringify/-/querystringify-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
       "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
       "dev": true
     },
     "range-parser": {
       "version": "1.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/range-parser/-/range-parser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
       "dev": true
     },
@@ -5985,7 +5963,7 @@
     },
     "read": {
       "version": "1.0.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/read/-/read-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
@@ -5994,7 +5972,7 @@
     },
     "read-pkg": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/read-pkg/-/read-pkg-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
@@ -6005,7 +5983,7 @@
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
@@ -6015,7 +5993,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -6023,14 +6001,14 @@
         "inherits": "2.0.3",
         "isarray": "1.0.0",
         "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/readdirp/-/readdirp-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
@@ -6042,7 +6020,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -6051,7 +6029,7 @@
     },
     "redent": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/redent/-/redent-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
@@ -6061,7 +6039,7 @@
     },
     "regenerator-runtime": {
       "version": "0.11.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
@@ -6077,13 +6055,13 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
@@ -6095,13 +6073,13 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -6134,133 +6112,58 @@
         "tough-cookie": "2.4.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.3.2"
-      },
-      "dependencies": {
-        "aws4": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-          "dev": true
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.20",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.36.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
-          "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
-          }
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-          "dev": true
-        }
       }
     },
     "request-digest": {
       "version": "1.0.10",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/request-digest/-/request-digest-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/request-digest/-/request-digest-1.0.10.tgz",
       "integrity": "sha1-PiD2JYm2InoM75Vsvfy2KHVQWIk=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "3.5.2",
         "lodash": "3.9.3",
         "request": "2.57.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "asn1": {
           "version": "0.1.11",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/asn1/-/asn1-0.1.11.tgz",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
           "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
           "dev": true
         },
         "assert-plus": {
           "version": "0.1.5",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/assert-plus/-/assert-plus-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
           "dev": true
         },
         "async": {
           "version": "0.9.2",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/aws-sign2/-/aws-sign2-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
           "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
           "dev": true
         },
-        "bl": {
-          "version": "0.9.5",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/bl/-/bl-0.9.5.tgz",
-          "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
         "caseless": {
           "version": "0.10.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/caseless/-/caseless-0.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz",
           "integrity": "sha1-7WsnGa3NH9GPWNwIHA8aW0OWOQk=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -6271,24 +6174,15 @@
             "supports-color": "2.0.0"
           }
         },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
         "delayed-stream": {
           "version": "0.0.5",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
           "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
           "dev": true
         },
         "form-data": {
           "version": "0.2.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/form-data/-/form-data-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
           "integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
           "dev": true,
           "requires": {
@@ -6299,7 +6193,7 @@
           "dependencies": {
             "combined-stream": {
               "version": "0.0.7",
-              "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/combined-stream/-/combined-stream-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
               "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
               "dev": true,
               "requires": {
@@ -6310,45 +6204,27 @@
         },
         "har-validator": {
           "version": "1.8.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/har-validator/-/har-validator-1.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.8.0.tgz",
           "integrity": "sha1-2DhCsOtMQ1lgrrEIoGejqpTA7rI=",
           "dev": true,
           "requires": {
             "bluebird": "2.11.0",
             "chalk": "1.1.3",
-            "commander": "2.15.1",
-            "is-my-json-valid": "2.17.2"
+            "commander": "2.17.1",
+            "is-my-json-valid": "2.19.0"
           },
           "dependencies": {
             "bluebird": {
               "version": "2.11.0",
-              "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/bluebird/-/bluebird-2.11.0.tgz",
+              "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
               "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
               "dev": true
             }
           }
         },
-        "hawk": {
-          "version": "2.3.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/hawk/-/hawk-2.3.1.tgz",
-          "integrity": "sha1-HnMc45RH+h0PbXB/e87r7A/R7B8=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
         "http-signature": {
           "version": "0.11.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/http-signature/-/http-signature-0.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
           "integrity": "sha1-F5bPZ6ABrVzWhJ3KCZFIXwkIn+Y=",
           "dev": true,
           "requires": {
@@ -6357,27 +6233,21 @@
             "ctype": "0.5.3"
           }
         },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
         "lodash": {
           "version": "3.9.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-3.9.3.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
           "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
           "dev": true
         },
         "mime-db": {
           "version": "1.12.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mime-db/-/mime-db-1.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
           "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
           "dev": true
         },
         "mime-types": {
           "version": "2.0.14",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/mime-types/-/mime-types-2.0.14.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
           "dev": true,
           "requires": {
@@ -6386,31 +6256,25 @@
         },
         "node-uuid": {
           "version": "1.4.8",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/node-uuid/-/node-uuid-1.4.8.tgz",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
           "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true
         },
         "qs": {
           "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/qs/-/qs-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-3.1.0.tgz",
           "integrity": "sha1-0OmudFIzoS3EP7TzBVu6RGJhFTw=",
           "dev": true
         },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
         "request": {
           "version": "2.57.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/request/-/request-2.57.0.tgz",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.57.0.tgz",
           "integrity": "sha1-1EUQWkLQCbnXJCiWM7RJptcj2Yk=",
           "dev": true,
           "requires": {
@@ -6429,35 +6293,20 @@
             "node-uuid": "1.4.8",
             "oauth-sign": "0.8.2",
             "qs": "3.1.0",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.4.3",
             "tunnel-agent": "0.4.3"
           }
         },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "tunnel-agent": {
           "version": "0.4.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
           "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
         }
@@ -6465,7 +6314,7 @@
     },
     "request-progress": {
       "version": "2.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/request-progress/-/request-progress-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
@@ -6474,37 +6323,37 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "reserved-words": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/reserved-words/-/reserved-words-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
       "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
       "dev": true
     },
     "resolve": {
       "version": "1.1.7",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/resolve/-/resolve-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
@@ -6526,39 +6375,29 @@
     },
     "revalidator": {
       "version": "0.1.8",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/revalidator/-/revalidator-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
       "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
       "dev": true
     },
     "rfdc": {
       "version": "1.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/rfdc/-/rfdc-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
       "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==",
       "dev": true
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
-    },
     "rimraf": {
       "version": "2.6.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/rimraf/-/rimraf-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "7.1.3"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safe-json-parse": {
@@ -6578,25 +6417,25 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "sass-graph": {
       "version": "2.2.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/sass-graph/-/sass-graph-2.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.5",
+        "glob": "7.1.3",
+        "lodash": "4.17.10",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
       }
     },
     "scss-tokenizer": {
       "version": "0.2.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
@@ -6606,7 +6445,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -6617,19 +6456,19 @@
     },
     "selenium-server-standalone-jar": {
       "version": "3.8.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/selenium-server-standalone-jar/-/selenium-server-standalone-jar-3.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/selenium-server-standalone-jar/-/selenium-server-standalone-jar-3.8.1.tgz",
       "integrity": "sha512-FEmjGRdCl9xbgSGJiUZv/7lb48c0ewJC3BxsovLnLOk7Wueg80VNvzrWcJHPfHqf8aOxbyAhqUYCScuPOx/lPQ==",
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
       "dev": true
     },
     "send": {
       "version": "0.16.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/send/-/send-0.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "dev": true,
       "requires": {
@@ -6650,7 +6489,7 @@
       "dependencies": {
         "statuses": {
           "version": "1.4.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/statuses/-/statuses-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
@@ -6658,7 +6497,7 @@
     },
     "serve-index": {
       "version": "1.9.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/serve-index/-/serve-index-1.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
@@ -6667,13 +6506,13 @@
         "debug": "2.6.9",
         "escape-html": "1.0.3",
         "http-errors": "1.6.3",
-        "mime-types": "2.1.18",
+        "mime-types": "2.1.20",
         "parseurl": "1.3.2"
       }
     },
     "serve-static": {
       "version": "1.13.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/serve-static/-/serve-static-1.13.2.tgz",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
@@ -6685,13 +6524,13 @@
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
@@ -6720,31 +6559,31 @@
     },
     "setprototypeof": {
       "version": "1.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "simple-fmt": {
       "version": "0.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/simple-fmt/-/simple-fmt-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
       "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
       "dev": true
     },
     "simple-is": {
       "version": "0.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/simple-is/-/simple-is-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
       "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
       "dev": true
     },
@@ -6861,9 +6700,18 @@
         }
       }
     },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
     "socket.io": {
       "version": "2.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/socket.io/-/socket.io-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
@@ -6877,7 +6725,7 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -6888,13 +6736,13 @@
     },
     "socket.io-adapter": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
       "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
       "dev": true
     },
     "socket.io-client": {
       "version": "2.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/socket.io-client/-/socket.io-client-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
       "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
       "dev": true,
       "requires": {
@@ -6916,7 +6764,7 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -6927,7 +6775,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {
@@ -6938,7 +6786,7 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
@@ -6947,7 +6795,7 @@
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -6955,7 +6803,7 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
@@ -6974,7 +6822,7 @@
     },
     "source-map-support": {
       "version": "0.4.18",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map-support/-/source-map-support-0.4.18.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
@@ -6983,7 +6831,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -6997,35 +6845,45 @@
     },
     "spdx-correct": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-exceptions": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
       "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.0"
+        "spdx-license-ids": "3.0.1"
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "through": "2.3.8"
+      }
     },
     "split-string": {
       "version": "3.1.0",
@@ -7038,7 +6896,7 @@
     },
     "split2": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/split2/-/split2-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-1.1.1.tgz",
       "integrity": "sha1-Fi2bGIZfAqsvKtlYVSLbm1TEgfk=",
       "dev": true,
       "requires": {
@@ -7046,36 +6904,37 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
+        "asn1": "0.2.4",
         "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
+        "bcrypt-pbkdf": "1.0.2",
         "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
+        "ecc-jsbn": "0.1.2",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/stable/-/stable-0.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
@@ -7102,13 +6961,13 @@
     },
     "statuses": {
       "version": "1.3.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/statuses/-/statuses-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
     "stdout-stream": {
       "version": "1.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/stdout-stream/-/stdout-stream-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
       "dev": true,
       "requires": {
@@ -7117,36 +6976,42 @@
     },
     "stream-shift": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/stream-shift/-/stream-shift-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "streamroller": {
       "version": "0.7.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/streamroller/-/streamroller-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
       "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
       "dev": true,
       "requires": {
         "date-format": "1.2.0",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "mkdirp": "0.5.1",
         "readable-stream": "2.3.6"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
     "string-length": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/string-length/-/string-length-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "dev": true,
       "requires": {
@@ -7161,7 +7026,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -7172,34 +7037,34 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringmap": {
       "version": "0.2.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/stringmap/-/stringmap-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
       "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
       "dev": true
     },
     "stringset": {
       "version": "0.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/stringset/-/stringset-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
       "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
       "dev": true
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -7208,7 +7073,7 @@
     },
     "strip-bom": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/strip-bom/-/strip-bom-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
@@ -7217,7 +7082,7 @@
     },
     "strip-indent": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/strip-indent/-/strip-indent-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
@@ -7226,14 +7091,14 @@
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
         "has-flag": "3.0.0"
@@ -7241,7 +7106,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/tar/-/tar-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -7252,19 +7117,26 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "throttleit": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/throttleit/-/throttleit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
       "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true,
+      "optional": true
+    },
     "through2": {
       "version": "2.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/through2/-/through2-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
@@ -7274,7 +7146,7 @@
     },
     "time-grunt": {
       "version": "1.4.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/time-grunt/-/time-grunt-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.4.0.tgz",
       "integrity": "sha1-BiIT5mDJB+hvRAVWwB6mWXtxJCA=",
       "dev": true,
       "requires": {
@@ -7289,13 +7161,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -7308,7 +7180,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -7316,7 +7188,7 @@
     },
     "time-zone": {
       "version": "0.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/time-zone/-/time-zone-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-0.1.0.tgz",
       "integrity": "sha1-Sncotqwo2w4Aj1FAQ/1VW9VXO0Y=",
       "dev": true
     },
@@ -7327,7 +7199,7 @@
       "dev": true,
       "requires": {
         "body": "5.1.0",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "faye-websocket": "0.10.0",
         "livereload-js": "2.3.0",
         "object-assign": "4.1.1",
@@ -7335,19 +7207,25 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
@@ -7356,13 +7234,13 @@
     },
     "to-array": {
       "version": "0.1.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/to-array/-/to-array-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
     "to-double-quotes": {
       "version": "2.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
       "integrity": "sha1-qvIx1vqUiUn4GTAburRITYWI5Kc=",
       "dev": true
     },
@@ -7410,59 +7288,60 @@
     },
     "to-single-quotes": {
       "version": "2.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.1.tgz",
       "integrity": "sha1-fMKRUfD18sQZRvEZ9ZMv5VQXASU=",
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
+        "psl": "1.1.29",
         "punycode": "1.4.1"
       }
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
     },
     "true-case-path": {
       "version": "1.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/true-case-path/-/true-case-path-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "7.1.3"
       }
     },
     "tryor": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/tryor/-/tryor-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
       "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -7471,52 +7350,45 @@
     },
     "type-is": {
       "version": "1.6.16",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/type-is/-/type-is-1.6.16.tgz",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "2.1.20"
       }
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.3.26",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/uglify-js/-/uglify-js-3.3.26.tgz",
-      "integrity": "sha512-XHxutZNxbx0UnqNUrjL/wvABLxirEYpbAnjCWGakPfQRJbbAGF2dI+YYw300F5mYKm7zBtgYiw3kOiQFobzglQ==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
       "requires": {
-        "commander": "2.15.1",
+        "commander": "2.17.1",
         "source-map": "0.6.1"
       }
     },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
     "ultron": {
       "version": "1.1.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ultron/-/ultron-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
     "unc-path-regex": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
     "underscore": {
       "version": "1.6.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/underscore/-/underscore-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
     },
@@ -7526,9 +7398,15 @@
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3",
+        "sprintf-js": "1.1.1",
         "util-deprecate": "1.0.2"
       }
+    },
+    "unicode-5.2.0": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unicode-5.2.0/-/unicode-5.2.0-0.7.5.tgz",
+      "integrity": "sha512-KVGLW1Bri30x00yv4HNM8kBxoqFXr0Sbo55735nvrlsx4PYBZol3UtoWgO492fSwmsetzPEZzy73rbU8OGXJcA==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",
@@ -7567,7 +7445,7 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
@@ -7613,7 +7491,7 @@
     },
     "untildify": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/untildify/-/untildify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "dev": true,
       "requires": {
@@ -7628,13 +7506,13 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "uri-path": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/uri-path/-/uri-path-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uri-path/-/uri-path-1.0.0.tgz",
       "integrity": "sha1-l0fwGDWJM8Md4PzP2C0TjmcmLjI=",
       "dev": true
     },
@@ -7646,7 +7524,7 @@
     },
     "url-parse": {
       "version": "1.4.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/url-parse/-/url-parse-1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
       "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "dev": true,
       "requires": {
@@ -7662,23 +7540,31 @@
     },
     "useragent": {
       "version": "2.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/useragent/-/useragent-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
       "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
         "lru-cache": "2.2.4",
         "tmp": "0.0.33"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
+          "dev": true
+        }
       }
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "utile": {
       "version": "0.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/utile/-/utile-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
       "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
       "dev": true,
       "requires": {
@@ -7692,7 +7578,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         }
@@ -7700,19 +7586,19 @@
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
       "version": "3.3.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/uuid/-/uuid-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "v8flags": {
       "version": "3.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/v8flags/-/v8flags-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.2.tgz",
       "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
       "dev": true,
       "requires": {
@@ -7720,9 +7606,9 @@
       }
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "3.0.0",
@@ -7731,7 +7617,7 @@
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -7742,31 +7628,31 @@
     },
     "void-elements": {
       "version": "2.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/void-elements/-/void-elements-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
     "vow": {
-      "version": "0.4.17",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/vow/-/vow-0.4.17.tgz",
-      "integrity": "sha512-A3/9bWFqf6gT0jLR4/+bT+IPTe1mQf+tdsW6+WI5geP9smAp8Kbbu4R6QQCDKZN/8TSCqTlXVQm12QliB4rHfg==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.18.tgz",
+      "integrity": "sha512-7QGozxlOhour77BCQbbyW5XFP8ioIz/DPK67IyO3DnJtF0WXrXueMwqrYFM9yqyfgENcyxL+vktz2oJeZfdWtw==",
       "dev": true
     },
     "vow-fs": {
       "version": "0.3.6",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/vow-fs/-/vow-fs-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.6.tgz",
       "integrity": "sha1-LUxZviLivyYY3fWXq0uqkjvnIA0=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
+        "glob": "7.1.3",
         "uuid": "2.0.3",
-        "vow": "0.4.17",
+        "vow": "0.4.18",
         "vow-queue": "0.4.3"
       },
       "dependencies": {
         "uuid": {
           "version": "2.0.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/uuid/-/uuid-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
           "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
           "dev": true
         }
@@ -7774,16 +7660,16 @@
     },
     "vow-queue": {
       "version": "0.4.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/vow-queue/-/vow-queue-0.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.3.tgz",
       "integrity": "sha512-/poAKDTFL3zYbeQg7cl4BGcfP4sGgXKrHnRFSKj97dteUFu8oyXMwIcdwu8NSx/RmPGIuYx1Bik/y5vU4H/VKw==",
       "dev": true,
       "requires": {
-        "vow": "0.4.17"
+        "vow": "0.4.18"
       }
     },
     "websocket-driver": {
       "version": "0.7.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
@@ -7793,14 +7679,14 @@
     },
     "websocket-extensions": {
       "version": "0.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -7808,70 +7694,59 @@
     },
     "which-module": {
       "version": "1.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/which-module/-/which-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wide-align/-/wide-align-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
-    },
     "winston": {
-      "version": "0.8.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/winston/-/winston-0.8.3.tgz",
-      "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "async": "0.2.10",
-        "colors": "0.6.2",
+        "async": "1.0.0",
+        "colors": "1.0.3",
         "cycle": "1.0.3",
         "eyes": "0.1.8",
         "isstream": "0.1.2",
-        "pkginfo": "0.3.1",
         "stack-trace": "0.0.10"
       },
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+          "dev": true,
+          "optional": true
         },
         "colors": {
-          "version": "0.6.2",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-          "dev": true
-        },
-        "pkginfo": {
-          "version": "0.3.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/pkginfo/-/pkginfo-0.3.1.tgz",
-          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-          "dev": true
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "dev": true,
+          "optional": true
         }
       }
     },
     "wiredep": {
       "version": "4.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wiredep/-/wiredep-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wiredep/-/wiredep-4.0.0.tgz",
       "integrity": "sha1-7pVIqVBN/n6FQBpDXb7SybTqLkQ=",
       "dev": true,
       "requires": {
         "bower-config": "1.4.1",
-        "glob": "7.1.2",
-        "lodash": "4.17.5",
+        "glob": "7.1.3",
+        "lodash": "4.17.10",
         "propprop": "0.3.1",
         "through2": "2.0.3",
         "wiredep-cli": "0.1.0"
@@ -7879,7 +7754,7 @@
     },
     "wiredep-cli": {
       "version": "0.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wiredep-cli/-/wiredep-cli-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wiredep-cli/-/wiredep-cli-0.1.0.tgz",
       "integrity": "sha1-ZCcr/KKUYfvQdEMVix4FZSb2xzk=",
       "dev": true,
       "requires": {
@@ -7890,13 +7765,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -7909,13 +7784,13 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -7923,13 +7798,13 @@
     },
     "wordwrap": {
       "version": "0.0.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wordwrap/-/wordwrap-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -7939,24 +7814,24 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "ws": {
       "version": "3.3.3",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/ws/-/ws-3.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
         "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "ultron": "1.1.1"
       }
     },
     "xmlbuilder": {
       "version": "3.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.1.0.tgz",
       "integrity": "sha1-LIaIjy1OrehQ+jjKf3Ij9yCVFuE=",
       "dev": true,
       "requires": {
@@ -7965,7 +7840,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -7973,31 +7848,31 @@
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/y18n/-/y18n-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {
       "version": "7.1.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/yargs/-/yargs-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
@@ -8018,7 +7893,7 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
@@ -8026,7 +7901,7 @@
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
@@ -8035,7 +7910,7 @@
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/camelcase/-/camelcase-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
@@ -8043,7 +7918,7 @@
     },
     "yauzl": {
       "version": "2.4.1",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/yauzl/-/yauzl-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
@@ -8052,7 +7927,7 @@
     },
     "yeast": {
       "version": "0.1.2",
-      "resolved": "https://nexus.opencast.org/nexus/content/repositories/npmjs/yeast/-/yeast-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     }

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -14,7 +14,6 @@
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
     <skipTests>false</skipTests>
-    <nexus.npm>${opencast.nexus.url}/nexus/content/repositories/npmjs/</nexus.npm>
   </properties>
   <dependencies>
     <!-- osgi support -->
@@ -319,8 +318,6 @@
                   <executable>npm</executable>
                   <arguments>
                     <argument>install</argument>
-                    <argument>--registry</argument>
-                    <argument>${nexus.npm}</argument>
                   </arguments>
                 </configuration>
               </execution>
@@ -372,7 +369,7 @@
                   <goal>npm</goal>
                 </goals>
                 <configuration>
-                  <arguments>install --registry ${nexus.npm}</arguments>
+                  <arguments>install</arguments>
                 </configuration>
               </execution>
               <execution>

--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -76,8 +76,6 @@
                   <executable>npm</executable>
                   <arguments>
                     <argument>install</argument>
-                    <argument>--registry</argument>
-                    <argument>${nexus.npm}</argument>
                   </arguments>
                 </configuration>
               </execution>


### PR DESCRIPTION
Opencast partly uses its own NPM registry for caching JavaScript
libraries used when building the project. When this was introduced, the
idea was to ensure versions would always be the same and that Opencast
could still be build when something happened to the global registry.

- The first goal, fixing versions, which was never ensured by using a
  custom registry but is now ensured using the `package-lock.json`
  files.

- The second goal, ensuring the registry exists, is currently not
  archived since multiple parts of Opencast use the global registry
  anyway. Furthermore, with the ever increasing importance of NPM, its
  highly unlikely for the global registry to just cease to exist without
  a prior notification.