### PR TITLE
MH-13096: Set workflow variables with duplicated media package IDs

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
@@ -12,6 +12,12 @@ seperate events for each presentation, the original recording can be copied and 
 one presentation. If the original event was already published, the duplicate won't be published right away. The user will
 have to publish it manually when he is done editing it.
 
+For each duplicated event the new media package ID is stored as a workflow property:
+
+|Name                                    |Example                                                             |Description                                    |
+|----------------------------------------|--------------------------------------------------------------------|-----------------------------------------------|
+|duplicate\_media\_package\_*number*\_id |`duplicate_media_package_1_id=e72f2265-472a-49ae-bc04-8301d94b4b1a` |Media package ID of the duplicated event       |
+
 Parameter Table
 ---------------
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -66,8 +66,10 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -218,6 +220,8 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
           + originalEpisodeDc.length + " episode dublin cores while it is expected to have exactly 1. Aborting.");
     }
 
+    Map<String, String> properties = new HashMap<>();
+
     for (int i = 0; i < numberOfEvents; i++) {
       final List<URI> temporaryFiles = new ArrayList<>();
       MediaPackage newMp = null;
@@ -248,11 +252,14 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
         for (String namespace : propertyNamespaces) {
           copyProperties(namespace, mediaPackage, newMp);
         }
+
+        // Store media package ID as workflow property
+        properties.put("duplicate_media_package_" + (i + 1) + "_id", newMp.getIdentifier().toString());
       } finally {
         cleanup(temporaryFiles, Optional.ofNullable(newMp));
       }
     }
-    return createResult(mediaPackage, Action.CONTINUE);
+    return createResult(mediaPackage, properties, Action.CONTINUE, 0);
   }
 
   private void cleanup(List<URI> temporaryFiles, Optional<MediaPackage> newMp) {


### PR DESCRIPTION
This PR changes the `duplicate-event` WOH such that the IDs of the new media packages are exposed as new workflow properties.

Use case: We want to automatically start a new workflow for the duplicated event (expect a new PR for starting new workflows soon 😄).