### PR TITLE
MH-13099, Warn when default credentials are being used

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
@@ -124,6 +124,20 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
     adminEmail = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_EMAIL));
     adminRoles = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_ROLES));
 
+    if ("opencast".equals(adminPassword)) {
+    logger.warn("\n"
+            + "######################################################\n"
+            + "#                                                    #\n"
+            + "# WARNING: Opencast still uses the default admin     #\n"
+            + "#          credentials. Never do this in production. #\n"
+            + "#                                                    #\n"
+            + "#          To change the password, edit the key      #\n"
+            + "#          org.opencastproject.security.admin.pass   #\n"
+            + "#          in custom.properties.                     #\n"
+            + "#                                                    #\n"
+            + "######################################################");
+    }
+
     // Keep a reference to the component context
     componentCtx = cc;
 

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
@@ -68,6 +68,12 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
   /** The administrator password configuration option */
   public static final String OPT_ADMIN_PASSWORD = "org.opencastproject.security.admin.pass";
 
+  /**
+   * The administrator password set by default in the configuration file.
+   * Note that this is not set if it is not defined in the configuration file.
+   **/
+  private static final String DEFAULT_ADMIN_PASSWORD_CONFIGURATION = "opencast";
+
   /** The administrator email configuration option */
   public static final String OPT_ADMIN_EMAIL = "org.opencastproject.admin.email";
 
@@ -124,7 +130,7 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
     adminEmail = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_EMAIL));
     adminRoles = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_ROLES));
 
-    if ("opencast".equals(adminPassword)) {
+    if (DEFAULT_ADMIN_PASSWORD_CONFIGURATION.equals(adminPassword)) {
     logger.warn("\n"
             + "######################################################\n"
             + "#                                                    #\n"

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
@@ -99,11 +99,26 @@ public class InMemoryUserAndRoleProvider implements UserProvider, RoleProvider {
    */
   protected void activate(ComponentContext cc) {
     digestUsername = StringUtils.trimToNull(cc.getBundleContext().getProperty(DIGEST_USER_KEY));
-    if (digestUsername == null)
+    if (digestUsername == null) {
       logger.warn("Digest username has not been configured ({})", DIGEST_USER_KEY);
+    }
+
     digestUserPass = StringUtils.trimToNull(cc.getBundleContext().getProperty(DIGEST_PASSWORD_KEY));
-    if (digestUsername == null)
+    if (digestUserPass == null) {
       logger.warn("Digest password has not been configured ({})", DIGEST_PASSWORD_KEY);
+    } else if ("CHANGE_ME".equals(digestUserPass)) {
+      logger.warn("\n"
+              + "######################################################\n"
+              + "#                                                    #\n"
+              + "# WARNING: Opencast still uses the default system    #\n"
+              + "#          credentials. Never do this in production. #\n"
+              + "#                                                    #\n"
+              + "#          To change the password, edit the key      #\n"
+              + "#          org.opencastproject.security.digest.pass  #\n"
+              + "#          in custom.properties.                     #\n"
+              + "#                                                    #\n"
+              + "######################################################");
+    }
 
     // Create the digest user
     createSystemUsers();

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
@@ -76,6 +76,12 @@ public class InMemoryUserAndRoleProvider implements UserProvider, RoleProvider {
   public static final String DIGEST_PASSWORD_KEY = "org.opencastproject.security.digest.pass";
   public static final String CAPTURE_AGENT_PASSWORD_KEY = "org.opencastproject.security.capture_agent.pass";
 
+  /**
+   * System password set by default in the configuration file.
+   * Note that this is not set if it is not defined in the configuration file.
+   * */
+  private static final String DIGEST_PASSWORD_DEFAULT_CONFIGURATION = "CHANGE_ME";
+
   /** Configuration key for optional additional roles for the capture agent user */
   public static final String CAPTURE_AGENT_EXTRA_ROLES_KEY = "org.opencastproject.security.capture_agent.roles";
 
@@ -106,7 +112,7 @@ public class InMemoryUserAndRoleProvider implements UserProvider, RoleProvider {
     digestUserPass = StringUtils.trimToNull(cc.getBundleContext().getProperty(DIGEST_PASSWORD_KEY));
     if (digestUserPass == null) {
       logger.warn("Digest password has not been configured ({})", DIGEST_PASSWORD_KEY);
-    } else if ("CHANGE_ME".equals(digestUserPass)) {
+    } else if (DIGEST_PASSWORD_DEFAULT_CONFIGURATION.equals(digestUserPass)) {
       logger.warn("\n"
               + "######################################################\n"
               + "#                                                    #\n"


### PR DESCRIPTION
Using default credentials in production is bad and users should never do
that but we have still seen that happening.

This patch will cause Opencast to print a big warning if the passwords
are not changed. Everything will run as usual (important for testing)
but it's now more likely that users will notice they have a problem.