### PR TITLE
MH-13097: Added a configuration parameter to be able to send HTML emails

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -29,6 +29,7 @@ Parameter Table
 |to|The field `to` of the email<br>i.e. the comma separated list of email accounts the email will be sent to.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |cc|The field `cc` of the email<br>i.e. the comma separated list of email accounts that will receive a carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |bcc|The field `bcc` of the email<br>i.e. the comma separated list of email accounts that will receive a blind carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
+|use-html|Flag to indicate that the email content should be displayed as 'text/plain' or 'text/html'|false|true/false|
 
 **Some other email parameters can be customized in the SMTP Service configuration**
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -29,7 +29,7 @@ Parameter Table
 |to|The field `to` of the email<br>i.e. the comma separated list of email accounts the email will be sent to.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |cc|The field `cc` of the email<br>i.e. the comma separated list of email accounts that will receive a carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |bcc|The field `bcc` of the email<br>i.e. the comma separated list of email accounts that will receive a blind carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
-|use-html|Flag to indicate that the email content should be displayed as 'text/plain' or 'text/html'|false|true/false|
+|use-html|Flag to indicate that the email content should be displayed as 'text/html'|false|true/false|
 
 **Some other email parameters can be customized in the SMTP Service configuration**
 

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
@@ -166,10 +166,32 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *           if sending the message failed
    */
   public void send(String to, String subject, String body) throws MessagingException {
+    send(to, subject, body, false);
+  }
+
+  /**
+   * Method to send a message
+   *
+   * @param to
+   *          Recipient of the message
+   * @param subject
+   *          Subject of the message
+   * @param body
+   *          Body of the message
+   * @param isHTML
+   *          Is the body of the message in HTML
+   * @throws MessagingException
+   *           if sending the message failed
+   */
+  public void send(String to, String subject, String body, boolean isHTML) throws MessagingException {
     MimeMessage message = createMessage();
     message.addRecipient(RecipientType.TO, new InternetAddress(to));
     message.setSubject(subject);
-    message.setText(body);
+    if (isHTML) {
+        message.setContent(body, "text/html");
+    } else {
+        message.setText(body);
+    }
     message.saveChanges();
     send(message);
   }
@@ -191,6 +213,28 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *           if sending the message failed
    */
   public void send(String to, String cc, String bcc, String subject, String body) throws MessagingException {
+    send(to, cc, bcc, subject, body, false);
+  }
+
+  /**
+   * Send a message to multiple recipients
+   *
+   * @param to
+   *          "To:" message recipient(s), separated by commas and/or spaces
+   * @param cc
+   *          "CC:" message recipient(s), separated by commas and/or spaces
+   * @param bcc
+   *          "BCC:" message recipient(s), separated by commas and/or spaces
+   * @param subject
+   *          Subject of the message
+   * @param body
+   *          Body of the message
+   * @param isHTML
+   *          Is the body of the message in HTML
+   * @throws MessagingException
+   *           if sending the message failed
+   */
+  public void send(String to, String cc, String bcc, String subject, String body, boolean isHTML) throws MessagingException {
     String[] toArray = null;
     String[] ccArray = null;
     String[] bccArray = null;
@@ -204,7 +248,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
     if (bcc != null)
       bccArray = bcc.trim().split(SPLIT_PATTERN, 0);
 
-    send(toArray, ccArray, bccArray, subject, body);
+    send(toArray, ccArray, bccArray, subject, body, isHTML);
   }
 
   /**
@@ -224,12 +268,38 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *           if sending the message failed
    */
   public void send(String[] to, String[] cc, String[] bcc, String subject, String body) throws MessagingException {
+    send(to, cc, bcc, subject, body, false);
+  }
+
+  /**
+   * Send a message to multiple recipients
+   *
+   * @param to
+   *          Array with the "To:" recipients of the message
+   * @param cc
+   *          Array with the "CC:" recipients of the message
+   * @param bcc
+   *          Array with the "BCC:" recipients of the message
+   * @param subject
+   *          Subject of the message
+   * @param body
+   *          Body of the message
+   * @param isHTML
+   *          Is the body of the message in HTML
+   * @throws MessagingException
+   *           if sending the message failed
+   */
+  public void send(String[] to, String[] cc, String[] bcc, String subject, String body, boolean isHTML) throws MessagingException {
     MimeMessage message = createMessage();
     addRecipients(message, RecipientType.TO, to);
     addRecipients(message, RecipientType.CC, cc);
     addRecipients(message, RecipientType.BCC, bcc);
     message.setSubject(subject);
-    message.setText(body);
+    if (isHTML) {
+        message.setContent(body, "text/html");
+    } else {
+        message.setText(body);
+    }
     message.saveChanges();
     send(message);
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
@@ -54,6 +54,9 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    */
   private static final String SPLIT_PATTERN = "[\\s,]+";
 
+  /** Define the MIME type for HTML mail content */
+  private static final String TEXT_HTML = "text/html";
+
   /**
    * Callback from the OSGi <code>ConfigurationAdmin</code> on configuration changes.
    *
@@ -188,7 +191,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
     message.addRecipient(RecipientType.TO, new InternetAddress(to));
     message.setSubject(subject);
     if (isHTML) {
-        message.setContent(body, "text/html");
+        message.setContent(body, TEXT_HTML);
     } else {
         message.setText(body);
     }
@@ -296,7 +299,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
     addRecipients(message, RecipientType.BCC, bcc);
     message.setSubject(subject);
     if (isHTML) {
-        message.setContent(body, "text/html");
+        message.setContent(body, TEXT_HTML);
     } else {
         message.setText(body);
     }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
@@ -183,7 +183,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String to, String subject, String body, boolean isHTML) throws MessagingException {
+  public void send(String to, String subject, String body, Boolean isHTML) throws MessagingException {
     MimeMessage message = createMessage();
     message.addRecipient(RecipientType.TO, new InternetAddress(to));
     message.setSubject(subject);
@@ -234,7 +234,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String to, String cc, String bcc, String subject, String body, boolean isHTML) throws MessagingException {
+  public void send(String to, String cc, String bcc, String subject, String body, Boolean isHTML) throws MessagingException {
     String[] toArray = null;
     String[] ccArray = null;
     String[] bccArray = null;
@@ -289,7 +289,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String[] to, String[] cc, String[] bcc, String subject, String body, boolean isHTML) throws MessagingException {
+  public void send(String[] to, String[] cc, String[] bcc, String subject, String body, Boolean isHTML) throws MessagingException {
     MimeMessage message = createMessage();
     addRecipients(message, RecipientType.TO, to);
     addRecipients(message, RecipientType.CC, cc);

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -106,7 +106,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
     String subject = applyTemplateIfNecessary(workflowInstance, operation, SUBJECT_PROPERTY);
     String bodyText = null;
     String body = operation.getConfiguration(BODY_PROPERTY);
-    boolean isHTML = "true".equals(operation.getConfiguration(IS_HTML));
+    Boolean isHTML = "true".equals(operation.getConfiguration(IS_HTML));
     // If specified, templateFile is a file that contains the Freemarker template
     String bodyTemplateFile = operation.getConfiguration(BODY_TEMPLATE_FILE_PROPERTY);
     // Body informed? If not, use the default.

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -66,6 +66,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
   static final String SUBJECT_PROPERTY = "subject";
   static final String BODY_PROPERTY = "body";
   static final String BODY_TEMPLATE_FILE_PROPERTY = "body-template-file";
+  static final String IS_HTML = "use-html";
 
   /*
    * (non-Javadoc)
@@ -82,6 +83,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
     addConfigurationOption(SUBJECT_PROPERTY, "The subject line");
     addConfigurationOption(BODY_PROPERTY, "The email body text (or email template)");
     addConfigurationOption(BODY_TEMPLATE_FILE_PROPERTY, "The file name of the Freemarker template for the email body");
+    addConfigurationOption(IS_HTML, "Is the body text (or email template) in HTML");
   }
 
   /**
@@ -104,6 +106,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
     String subject = applyTemplateIfNecessary(workflowInstance, operation, SUBJECT_PROPERTY);
     String bodyText = null;
     String body = operation.getConfiguration(BODY_PROPERTY);
+    boolean isHTML = "true".equals(operation.getConfiguration(IS_HTML));
     // If specified, templateFile is a file that contains the Freemarker template
     String bodyTemplateFile = operation.getConfiguration(BODY_TEMPLATE_FILE_PROPERTY);
     // Body informed? If not, use the default.
@@ -121,7 +124,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
               "Sending e-mail notification with subject {} and body {} to {}, CC addresses {} and BCC addresses {}",
               subject, bodyText, to, cc, bcc);
       // "To", "CC" and "BCC" can be comma- or space-separated lists of emails
-      smtpService.send(to, cc, bcc, subject, bodyText);
+      smtpService.send(to, cc, bcc, subject, bodyText, isHTML);
       logger.info("E-mail notification sent to {}, CC addresses {} and BCC addresses {}", to, cc, bcc);
     } catch (MessagingException e) {
       throw new WorkflowOperationException(e);

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -34,6 +34,7 @@ import org.opencastproject.workflow.api.WorkflowOperationInstance;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
@@ -106,7 +107,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
     String subject = applyTemplateIfNecessary(workflowInstance, operation, SUBJECT_PROPERTY);
     String bodyText = null;
     String body = operation.getConfiguration(BODY_PROPERTY);
-    Boolean isHTML = "true".equals(operation.getConfiguration(IS_HTML));
+    Boolean isHTML = BooleanUtils.toBoolean(operation.getConfiguration(IS_HTML));
     // If specified, templateFile is a file that contains the Freemarker template
     String bodyTemplateFile = operation.getConfiguration(BODY_TEMPLATE_FILE_PROPERTY);
     // Body informed? If not, use the default.

--- a/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
+++ b/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
@@ -95,7 +95,7 @@ public class EmailWorkflowOperationHandlerTest {
     capturedSubject = Capture.newInstance();
     capturedBody = Capture.newInstance();
     smtpService.send(EasyMock.capture(capturedTo), EasyMock.capture(capturedCC), EasyMock.capture(capturedBCC),
-            EasyMock.capture(capturedSubject), EasyMock.capture(capturedBody));
+            EasyMock.capture(capturedSubject), EasyMock.capture(capturedBody), EasyMock.anyBoolean());
     EasyMock.expectLastCall().once();
     EasyMock.replay(smtpService);
     operationHandler.setSmtpService(smtpService);


### PR DESCRIPTION
Extend the configuration of the email WOH (EmailWorkflowOperationHandler) to include an optional configuration key (default: false):

<configuration key="use-html">true</configuration>

In this way we can extent the existing functionality and create better end-user experience (HTML formatted mails can be sent out).
