### PR TITLE
MH-13098: Add start-workflow WOH

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -82,6 +82,7 @@ The following table contains the workflow operations that are available in an ou
 |silence             |Silence detection on audio of the mediapackage                 |[Documentation](silence-woh.md)|
 |snapshot            |Archive the current state of the mediapackage                  |[Documentation](snapshot-woh.md)|
 |start-watson-transcription|Starts automated transcription provided by IBM Watson    |[Documentation](start-watson-transcription-woh.md)|
+|start-workflow      |Start a new workflow for given media package ID                |[Documentation](start-workflow-woh.md)|
 |tag                 |Modify the tag sets of media package elements                  |[Documentation](tag-woh.md)|
 |tag-by-dcterm       |Modify the tags if dublincore term matches value               |[Documentation](tag-by-dcterm-woh.md)|
 |theme               |Make settings of themes available to processing                |[Documentation](theme-woh.md)|

--- a/docs/guides/admin/docs/workflowoperationhandlers/start-workflow-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/start-workflow-woh.md
@@ -1,0 +1,28 @@
+# StartWorkflowWorkflowOperationHandler
+
+## Description
+
+The StartWorkflowWorkflowOperationHandler can be used to start a new workflow for given media package and workflow definition.
+
+## Parameter Table
+
+|Configuration Key         |Example                              |Description                                     |
+|--------------------------|-------------------------------------|------------------------------------------------|
+|media-package\*           |e72f2265-472a-49ae-bc04-8301d94b4b1a |The ID of the media package that should be used |
+|workflow-definition\*     |fast                                 |The workflow definition that should be used     |
+|*configProperty*          |abc / false                          |Workflow configuration property                 |
+
+\* mandatory configuration key
+
+## Operation Example
+
+```xml
+<operation id="start-workflow">
+  <configurations>
+    <configuration key="workflow-definition">fast</configuration>
+    <configuration key="media-package">e72f2265-472a-49ae-bc04-8301d94b4b1a</configuration>
+    <configuration key="key">value</configuration>
+    <configuration key="publish">true</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -148,6 +148,7 @@ pages:
    - Series: 'workflowoperationhandlers/series-woh.md'
    - Silence: 'workflowoperationhandlers/silence-woh.md'
    - Start Watson Transcription: 'workflowoperationhandlers/start-watson-transcription-woh.md'
+   - Start Workflow: 'workflowoperationhandlers/start-workflow-woh.md'
    - Tag: 'workflowoperationhandlers/tag-woh.md'
    - Tag-By-DCTerm: 'workflowoperationhandlers/tag-by-dcterm-woh.md'
    - Timelinepreviews: 'workflowoperationhandlers/timelinepreviews-woh.md'

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -154,6 +154,7 @@
               OSGI-INF/operations/include.xml,
               OSGI-INF/operations/probe-resolution.xml,
               OSGI-INF/operations/series.xml,
+              OSGI-INF/operations/start-workflow.xml,
               OSGI-INF/operations/tag.xml,
               OSGI-INF/operations/tag-by-dcterm.xml,
               OSGI-INF/operations/zip.xml

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandler.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowDefinition;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This WOH starts a new workflow for given media package.
+ */
+public class StartWorkflowWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+  private static final Logger logger = LoggerFactory.getLogger(StartWorkflowWorkflowOperationHandler.class);
+
+  /** Name of the configuration option that provides the media package ID */
+  public static final String MEDIA_PACKAGE_ID = "media-package";
+
+  /** Name of the configuration option that provides the workflow definition ID */
+  public static final String WORKFLOW_DEFINITION = "workflow-definition";
+
+  private AssetManager assetManager;
+
+  private WorkflowService workflowService;
+
+  /**
+   * Callback for the OSGi declarative services configuration.
+   *
+   * @param assetManager
+   *          the asset manager
+   */
+  public void setAssetManager(AssetManager assetManager) {
+    this.assetManager = assetManager;
+  }
+
+  /**
+   * Callback for the OSGi declarative services configuration.
+   *
+   * @param workflowService
+   *          the workflow service
+   */
+  public void setWorkflowService(WorkflowService workflowService) {
+    this.workflowService = workflowService;
+  }
+
+  @Override
+  public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
+          throws WorkflowOperationException {
+
+    final WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
+    final String configuredMediaPackageID = trimToEmpty(operation.getConfiguration(MEDIA_PACKAGE_ID));
+    final String configuredWorkflowDefinition = trimToEmpty(operation.getConfiguration(WORKFLOW_DEFINITION));
+
+    // Get media package
+    final AQueryBuilder q = assetManager.createQuery();
+    final AResult r = q.select(q.snapshot())
+                       .where(q.mediaPackageId(configuredMediaPackageID).and(q.version().isLatest()))
+                       .run();
+    if (r.getSize() != 1) {
+      throw new WorkflowOperationException(format("Media package %s not found", configuredMediaPackageID));
+    }
+    final MediaPackage mp = r.getRecords().head().get().getSnapshot().get().getMediaPackage();
+
+    // Get workflow parameter
+    final Map<String, String> properties = new HashMap<>();
+    for (String key : operation.getConfigurationKeys()) {
+      if (MEDIA_PACKAGE_ID.equals(key) || WORKFLOW_DEFINITION.equals(key)) {
+        continue;
+      }
+      properties.put(key, operation.getConfiguration(key));
+    }
+
+    try {
+      // Get workflow definition
+      final WorkflowDefinition workflowDefinition = workflowService.getWorkflowDefinitionById(
+              configuredWorkflowDefinition);
+
+      // Start workflow
+      logger.info("Starting '{}' workflow for media package '{}'", configuredWorkflowDefinition,
+              configuredMediaPackageID);
+      workflowService.start(workflowDefinition, mp, properties);
+
+    } catch (NotFoundException e) {
+      throw new WorkflowOperationException(format("Workflow Definition '%s' not found", configuredWorkflowDefinition));
+    } catch (Exception e) {
+      throw new WorkflowOperationException(e);
+    }
+
+    return createResult(WorkflowOperationResult.Action.CONTINUE);
+  }
+}

--- a/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/start-workflow.xml
+++ b/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/start-workflow.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+ name="org.opencastproject.workflow.handler.workflow.StartWorkflowWorkflowOperationHandler" immediate="true">
+  <implementation class="org.opencastproject.workflow.handler.workflow.StartWorkflowWorkflowOperationHandler" />
+  <property name="service.description" value="Start Workflow Workflow Operation Handler" />
+  <property name="workflow.operation" value="start-workflow" />
+  <service>
+    <provide interface="org.opencastproject.workflow.api.WorkflowOperationHandler" />
+  </service>
+  <reference name="asset-manager" interface="org.opencastproject.assetmanager.api.AssetManager"
+             cardinality="1..1" policy="static" bind="setAssetManager" />
+  <reference name="workflowService" interface="org.opencastproject.workflow.api.WorkflowService"
+             cardinality="1..1" policy="static" bind="setWorkflowService" />
+</scr:component>

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandlerTest.java
@@ -1,0 +1,257 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.newCapture;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertEquals;
+import static org.opencastproject.workflow.handler.workflow.StartWorkflowWorkflowOperationHandler.MEDIA_PACKAGE_ID;
+import static org.opencastproject.workflow.handler.workflow.StartWorkflowWorkflowOperationHandler.WORKFLOW_DEFINITION;
+
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.Snapshot;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
+import org.opencastproject.mediapackage.identifier.IdImpl;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.WorkflowDefinition;
+import org.opencastproject.workflow.api.WorkflowDefinitionImpl;
+import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
+import org.opencastproject.workflow.api.WorkflowInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance.OperationState;
+import org.opencastproject.workflow.api.WorkflowOperationInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowService;
+
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
+import com.google.common.collect.Lists;
+
+import org.easymock.Capture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class StartWorkflowWorkflowOperationHandlerTest {
+
+  private StartWorkflowWorkflowOperationHandler operationHandler;
+  private AssetManager assetManager;
+  private WorkflowService workflowService;
+  private WorkflowOperationInstanceImpl operation;
+  private WorkflowInstanceImpl workflowInstance;
+  private static final String MP_ID = "c3066908-39e3-44b1-842a-9ae93ef8d314";
+  private static final String WD_ID = "test-workflow";
+
+  @Before
+  public void setUp() throws Exception {
+    assetManager = createNiceMock(AssetManager.class);
+    workflowService = createNiceMock(WorkflowService.class);
+
+    operationHandler = new StartWorkflowWorkflowOperationHandler();
+    operationHandler.setAssetManager(assetManager);
+    operationHandler.setWorkflowService(workflowService);
+
+    operation = new WorkflowOperationInstanceImpl("op", OperationState.RUNNING);
+    operation.setTemplate("start-workflow");
+    operation.setState(OperationState.RUNNING);
+    operation.setConfiguration(MEDIA_PACKAGE_ID, MP_ID);
+    operation.setConfiguration(WORKFLOW_DEFINITION, WD_ID);
+    operation.setConfiguration("workflowConfigurations", "true");
+    operation.setConfiguration("key", "value");
+
+    workflowInstance = new WorkflowInstanceImpl();
+    workflowInstance.setMediaPackage(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());
+    workflowInstance.setState(WorkflowState.RUNNING);
+    workflowInstance.setOperations(Lists.newArrayList(operation));
+  }
+
+  @Test(expected = WorkflowOperationException.class)
+  public void testNoMediaPackage() throws Exception {
+    // Query
+    Target t = createNiceMock(Target.class);
+
+    Predicate p = createNiceMock(Predicate.class);
+    expect(p.and(p)).andReturn(p);
+
+    VersionField v = createNiceMock(VersionField.class);
+    expect(v.isLatest()).andReturn(p);
+
+    ASelectQuery selectQuery = createNiceMock(ASelectQuery.class);
+    expect(selectQuery.where(p)).andReturn(selectQuery);
+
+    AQueryBuilder query = createNiceMock(AQueryBuilder.class);
+    expect(query.snapshot()).andReturn(t);
+    expect(query.select(t)).andReturn(selectQuery);
+    expect(query.mediaPackageId(MP_ID)).andReturn(p);
+    expect(query.version()).andReturn(v);
+
+    // Asset Manager
+    reset(assetManager);
+    expect(assetManager.createQuery()).andReturn(query);
+
+    // Result
+    AResult r = createNiceMock(AResult.class);
+    expect(r.getSize()).andReturn(0L);
+
+    expect(selectQuery.run()).andReturn(r);
+
+    // Workflow Service
+    reset(workflowService);
+
+    replay(assetManager, workflowService, query, t, selectQuery, p, v, r);
+
+    // Run Operation
+    operationHandler.start(workflowInstance, null);
+  }
+
+  @Test(expected = WorkflowOperationException.class)
+  public void testNoWorkflowDefinition() throws Exception {
+    // Media Package
+    MediaPackage mp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
+    mp.setIdentifier(new IdImpl(MP_ID));
+
+    // Snapshot
+    Snapshot snapshot = createNiceMock(Snapshot.class);
+    expect(snapshot.getMediaPackage()).andReturn(mp);
+
+    // Query
+    Target t = createNiceMock(Target.class);
+
+    Predicate p = createNiceMock(Predicate.class);
+    expect(p.and(p)).andReturn(p);
+
+    VersionField v = createNiceMock(VersionField.class);
+    expect(v.isLatest()).andReturn(p);
+
+    ASelectQuery selectQuery = createNiceMock(ASelectQuery.class);
+    expect(selectQuery.where(p)).andReturn(selectQuery);
+
+    AQueryBuilder query = createNiceMock(AQueryBuilder.class);
+    expect(query.snapshot()).andReturn(t);
+    expect(query.select(t)).andReturn(selectQuery);
+    expect(query.mediaPackageId(MP_ID)).andReturn(p);
+    expect(query.version()).andReturn(v);
+
+    // Asset Manager
+    reset(assetManager);
+    expect(assetManager.createQuery()).andReturn(query);
+
+    // Result
+    ARecord aRec = createNiceMock(ARecord.class);
+    expect(aRec.getSnapshot()).andReturn(Opt.some(snapshot));
+
+    AResult r = createNiceMock(AResult.class);
+    expect(r.getSize()).andReturn(1L);
+    expect(r.getRecords()).andReturn(Stream.mk(aRec));
+
+    expect(selectQuery.run()).andReturn(r);
+
+    // Workflow Service
+    reset(workflowService);
+    expect(workflowService.getWorkflowDefinitionById(WD_ID)).andThrow(new NotFoundException());
+
+    replay(assetManager, workflowService, query, t, selectQuery, p, v, snapshot, aRec, r);
+
+    // Run Operation
+    operationHandler.start(workflowInstance, null);
+  }
+
+  @Test
+  public void testStartWorkflow() throws Exception {
+    // Media Package
+    MediaPackage mp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
+    mp.setIdentifier(new IdImpl(MP_ID));
+
+    // Snapshot
+    Snapshot snapshot = createNiceMock(Snapshot.class);
+    expect(snapshot.getMediaPackage()).andReturn(mp);
+
+    // Query
+    Target t = createNiceMock(Target.class);
+
+    Predicate p = createNiceMock(Predicate.class);
+    expect(p.and(p)).andReturn(p);
+
+    VersionField v = createNiceMock(VersionField.class);
+    expect(v.isLatest()).andReturn(p);
+
+    ASelectQuery selectQuery = createNiceMock(ASelectQuery.class);
+    expect(selectQuery.where(p)).andReturn(selectQuery);
+
+    AQueryBuilder query = createNiceMock(AQueryBuilder.class);
+    expect(query.snapshot()).andReturn(t);
+    expect(query.select(t)).andReturn(selectQuery);
+    expect(query.mediaPackageId(MP_ID)).andReturn(p);
+    expect(query.version()).andReturn(v);
+
+    // Asset Manager
+    reset(assetManager);
+    expect(assetManager.createQuery()).andReturn(query);
+
+    // Result
+    ARecord aRec = createNiceMock(ARecord.class);
+    expect(aRec.getSnapshot()).andReturn(Opt.some(snapshot));
+
+    AResult r = createNiceMock(AResult.class);
+    expect(r.getSize()).andReturn(1L);
+    expect(r.getRecords()).andReturn(Stream.mk(aRec));
+
+    expect(selectQuery.run()).andReturn(r);
+
+    // Workflow Service
+    WorkflowDefinition wd = new WorkflowDefinitionImpl();
+    wd.setId(WD_ID);
+
+    Capture<Map<String, String>> wProperties = newCapture();
+
+    reset(workflowService);
+    expect(workflowService.getWorkflowDefinitionById(WD_ID)).andReturn(wd);
+    expect(workflowService.start(eq(wd), eq(mp), capture(wProperties))).andReturn(null);
+
+    replay(assetManager, workflowService, query, t, selectQuery, p, v, snapshot, aRec, r);
+
+    // Run Operation
+    WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
+
+    verify(assetManager, workflowService, query, t, selectQuery, p, v, snapshot, aRec, r);
+
+    assertEquals(WorkflowOperationResult.Action.CONTINUE, result.getAction());
+    assertEquals(2, wProperties.getValue().size());
+    assertEquals("true", wProperties.getValue().get("workflowConfigurations"));
+    assertEquals("value", wProperties.getValue().get("key"));
+  }
+}


### PR DESCRIPTION
This PR adds the new WOH `start-workflow` which starts a new workflow for given media package, workflow definition, and workflow properties.

Use case: In combination with #425 we want to automatically run a workflow on a duplicated event.