### PR TITLE
MH-13105, Fix minor mattermost notification operation issues

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -151,7 +151,6 @@
   <feature name="opencast-allinone">
     <feature start-level="80">opencast-core</feature>
 
-    <bundle start-level="82">mvn:org.opencastproject/mattermost-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-impl/${project.version}</bundle>
@@ -217,6 +216,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-live-schedule-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-live-schedule-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-lti/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-mattermost-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-messages/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-metadata/${project.version}</bundle>
     <bundle start-level="85">mvn:org.opencastproject/opencast-migration/${project.version}</bundle>
@@ -280,7 +280,6 @@
   <feature name="opencast-admin">
     <feature start-level="80">opencast-core</feature>
 
-    <bundle start-level="82">mvn:org.opencastproject/mattermost-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-remote/${project.version}</bundle>
@@ -327,6 +326,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-live-schedule-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-live-schedule-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-lti/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-mattermost-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-messages/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-metadata/${project.version}</bundle>
     <bundle start-level="85">mvn:org.opencastproject/opencast-migration/${project.version}</bundle>
@@ -385,7 +385,6 @@
   <feature name="opencast-adminpresentation">
     <feature start-level="80">opencast-core</feature>
 
-    <bundle start-level="82">mvn:org.opencastproject/mattermost-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-remote/${project.version}</bundle>
@@ -449,6 +448,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-live-schedule-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-live-schedule-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-lti/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-mattermost-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-messages/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-metadata/${project.version}</bundle>
     <bundle start-level="85">mvn:org.opencastproject/opencast-migration/${project.version}</bundle>
@@ -567,7 +567,6 @@
   <feature name="opencast-adminworker">
     <feature start-level="80">opencast-core</feature>
 
-    <bundle start-level="82">mvn:org.opencastproject/mattermost-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-workflowoperation/${project.version}</bundle>
@@ -616,6 +615,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-live-schedule-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-live-schedule-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-lti/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-mattermost-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-messages/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-metadata/${project.version}</bundle>
     <bundle start-level="85">mvn:org.opencastproject/opencast-migration/${project.version}</bundle>

--- a/modules/mattermost-notification-workflowoperation/pom.xml
+++ b/modules/mattermost-notification-workflowoperation/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>mattermost-notification-workflowoperation</artifactId>
+  <artifactId>opencast-mattermost-notification-workflowoperation</artifactId>
   <packaging>bundle</packaging>
-  <name>mattermost-notification-workflowoperation</name>
+  <name>Opencast :: mattermost-notification-workflowoperation</name>
   <parent>
     <groupId>org.opencastproject</groupId>
     <artifactId>base</artifactId>
@@ -22,36 +22,28 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-kernel</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workflow-service-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.21</version>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <version>${osgi.core.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.7</version>
     </dependency>
   </dependencies>
   <build>

--- a/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
+++ b/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
@@ -40,7 +40,6 @@ import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
@@ -130,11 +129,6 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
   public static final int SLEEP_SCALE_FACTOR = 2;
 
   /**
-   * The http client to use when connecting to remote servers
-   */
-  protected HttpClient client = null;
-
-  /**
    * {@inheritDoc}
    */
   @Override
@@ -164,7 +158,7 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
     }
 
     // Figure out which request method to use
-    HttpEntityEnclosingRequestBase request = null;
+    HttpEntityEnclosingRequestBase request;
     if (StringUtils.equalsIgnoreCase(POST, method)) {
       request = new HttpPost(urlPath);
     } else if (StringUtils.equalsIgnoreCase(PUT, method)) {
@@ -185,8 +179,7 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
 
       request.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (UnsupportedEncodingException e) {
-      throw new WorkflowOperationException(
-              "Error happened during the encoding of the event parameter as form parameter: {}", e);
+      throw new WorkflowOperationException("Error encoding the event parameter as form parameter", e);
     }
 
     // Execute the request
@@ -241,8 +234,7 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
       return s + "not defined";
     }
     if (o instanceof String[]) {
-      String tmp = join((String[]) o, ',');
-      return tmp;
+      return join((String[]) o, ',');
     }
     return o.toString();
 
@@ -270,10 +262,10 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
     try {
       response = httpClient.execute(request);
     } catch (ClientProtocolException e) {
-      logger.error("Protocol error during execution of query on target {}: {} ", request.getURI(), e);
+      logger.error("Protocol error during execution of query on target {}", request.getURI(), e);
       return false;
     } catch (IOException e) {
-      logger.error("I/O error during execution of query on target {}: {}", request.getURI(), e);
+      logger.error("I/O error during execution of query on target {}", request.getURI(), e);
       return false;
     }
 
@@ -288,7 +280,7 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
         Thread.sleep(sleepTime);
         return executeRequest(request, --maxAttempts, timeout, sleepTime * SLEEP_SCALE_FACTOR);
       } catch (InterruptedException e) {
-        logger.error("Error during sleep time before new notification request try: {}", e);
+        logger.error("Error during sleep time before new notification request try", e);
         return false;
       }
     } else {


### PR DESCRIPTION
This patch fixes a few minor issues with the new Mattermost notification
workflow operation handler:

- Use the same module prefix like everyone else
- Correct dependency declaration
- Fix some log statements
- Remove unused variables