### PR TITLE
MH-13106: Add Moodle groups to Moodle role provider

### DIFF
--- a/docs/guides/admin/docs/configuration/security.user.moodle.md
+++ b/docs/guides/admin/docs/configuration/security.user.moodle.md
@@ -31,9 +31,10 @@ The values can be arbitrary, if only the Moodle User Provider should be
 configured.
 
 After the installation, a new user with the capabilities
-`webservice/rest:use`, `tool/opencast:externalapi`, `moodle/user:viewalldetails`
-and `moodle/user:viewdetails` has to be created. Then generate a new web service
-token and add that user to the "Opencast web service" service.
+`webservice/rest:use`, `tool/opencast:externalapi`, `moodle/user:viewalldetails`,
+`moodle/user:viewdetails` and `moodle/site:accessallgroups` has to be created.
+Then generate a new web service token and add that user to the "Opencast web
+service" service.
 
 ### Step 1
 

--- a/etc/org.opencastproject.userdirectory.moodle-default.cfg.template
+++ b/etc/org.opencastproject.userdirectory.moodle-default.cfg.template
@@ -13,6 +13,10 @@ org.opencastproject.userdirectory.moodle.token=mytoken1234abcdef
 # The maximum number of minutes to cache a user
 #org.opencastproject.userdirectory.moodle.cache.expiration=60
 
+# Optionally activate Moodle group roles
+#org.opencastproject.userdirectory.moodle.group.roles.enabled=true
+
 # Optional regexp for matching Moodle course and user IDs.
 #org.opencastproject.userdirectory.moodle.course.pattern=^[0-9]+$
 #org.opencastproject.userdirectory.moodle.user.pattern=^[0-9a-zA-Z_]+$
+#org.opencastproject.userdirectory.moodle.group.pattern=^[0-9]+$

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
@@ -86,6 +86,11 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
   private static final String CACHE_EXPIRATION = "org.opencastproject.userdirectory.moodle.cache.expiration";
 
   /**
+   * The key to look up whether to activate group roles
+   */
+  private static final String GROUP_ROLES_KEY = "org.opencastproject.userdirectory.moodle.group.roles.enabled";
+
+  /**
    * The key to look up the regular expression used to validate courses
    */
   private static final String COURSE_PATTERN_KEY = "org.opencastproject.userdirectory.moodle.course.pattern";
@@ -94,6 +99,11 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
    * The key to look up the regular expression used to validate users
    */
   private static final String USER_PATTERN_KEY = "org.opencastproject.userdirectory.moodle.user.pattern";
+
+  /**
+   * The key to look up the regular expression used to validate groups
+   */
+  private static final String GROUP_PATTERN_KEY = "org.opencastproject.userdirectory.moodle.group.pattern";
 
   /**
    * The OSGI bundle context
@@ -176,8 +186,14 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
     if (StringUtils.isBlank(token))
       throw new ConfigurationException(MOODLE_TOKEN_KEY, "is not set");
 
+    boolean groupRoles = false;
+    String groupRolesStr = (String) properties.get(GROUP_ROLES_KEY);
+    if ("true".equals(groupRolesStr))
+      groupRoles = true;
+
     String coursePattern = (String) properties.get(COURSE_PATTERN_KEY);
     String userPattern = (String) properties.get(USER_PATTERN_KEY);
+    String groupPattern = (String) properties.get(GROUP_PATTERN_KEY);
 
     int cacheSize = 1000;
     try {
@@ -210,7 +226,7 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
 
     logger.debug("creating new MoodleUserProviderInstance for pid=" + pid);
     MoodleUserProviderInstance provider = new MoodleUserProviderInstance(pid, new MoodleWebServiceImpl(url, token), org,
-            coursePattern, userPattern, cacheSize, cacheExpiration);
+            coursePattern, userPattern, groupPattern, groupRoles, cacheSize, cacheExpiration);
 
     providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
     providerRegistrations.put(pid, bundleContext.registerService(RoleProvider.class.getName(), provider, null));

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleWebService.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleWebService.java
@@ -34,6 +34,7 @@ public interface MoodleWebService {
   String MOODLE_FUNCTION_CORE_USER_GET_USERS_BY_FIELD = "core_user_get_users_by_field";
   String MOODLE_FUNCTION_TOOL_OPENCAST_GET_COURSES_FOR_INSTRUCTOR = "tool_opencast_get_courses_for_instructor";
   String MOODLE_FUNCTION_TOOL_OPENCAST_GET_COURSES_FOR_LEARNER = "tool_opencast_get_courses_for_learner";
+  String MOODLE_FUNCTION_TOOL_OPENCAST_GET_GROUPS_FOR_LEARNER = "tool_opencast_get_groups_for_learner";
 
   /**
    * Searches for a user in Moodle.
@@ -73,6 +74,19 @@ public interface MoodleWebService {
    * @throws ParseException            In case the Moodle response cannot be parsed.
    */
   List<String> toolOpencastGetCoursesForLearner(String username)
+          throws URISyntaxException, IOException, MoodleWebServiceException, ParseException;
+
+  /**
+   * Returns the list of Moodle group IDs where the given user has the learner capability.
+   *
+   * @param username The username to search for.
+   * @return A list of Moodle group IDs.
+   * @throws URISyntaxException        In case the URL cannot be constructed.
+   * @throws IOException               In case of an IO error.
+   * @throws MoodleWebServiceException In case Moodle returns an error.
+   * @throws ParseException            In case the Moodle response cannot be parsed.
+   */
+  List<String> toolOpencastGetGroupsForLearner(String username)
           throws URISyntaxException, IOException, MoodleWebServiceException, ParseException;
 
   /**

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleWebServiceImpl.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleWebServiceImpl.java
@@ -142,7 +142,7 @@ public class MoodleWebServiceImpl implements MoodleWebService {
     List<NameValuePair> params = Collections
             .singletonList((NameValuePair) new BasicNameValuePair("username", username));
 
-    return parseCourseList(executeMoodleRequest(MOODLE_FUNCTION_TOOL_OPENCAST_GET_COURSES_FOR_INSTRUCTOR, params));
+    return parseIdList(executeMoodleRequest(MOODLE_FUNCTION_TOOL_OPENCAST_GET_COURSES_FOR_INSTRUCTOR, params));
   }
 
   /**
@@ -158,7 +158,18 @@ public class MoodleWebServiceImpl implements MoodleWebService {
     List<NameValuePair> params = Collections
             .singletonList((NameValuePair) new BasicNameValuePair("username", username));
 
-    return parseCourseList(executeMoodleRequest(MOODLE_FUNCTION_TOOL_OPENCAST_GET_COURSES_FOR_LEARNER, params));
+    return parseIdList(executeMoodleRequest(MOODLE_FUNCTION_TOOL_OPENCAST_GET_COURSES_FOR_LEARNER, params));
+  }
+
+  @Override
+  public List<String> toolOpencastGetGroupsForLearner(String username)
+          throws URISyntaxException, IOException, MoodleWebServiceException, ParseException {
+    logger.debug("toolOpencastGetGroupsForLearner({})", username);
+
+    List<NameValuePair> params = Collections
+            .singletonList((NameValuePair) new BasicNameValuePair("username", username));
+
+    return parseIdList(executeMoodleRequest(MOODLE_FUNCTION_TOOL_OPENCAST_GET_GROUPS_FOR_LEARNER, params));
   }
 
   /**
@@ -172,13 +183,13 @@ public class MoodleWebServiceImpl implements MoodleWebService {
   }
 
   /**
-   * Parses the returned Moodle response for a list of courses.
+   * Parses the returned Moodle response for a list of IDs.
    *
-   * @param resp The Moodle response as. It should be of type {@link JSONArray}.
-   * @return A list of Moodle course IDs.
+   * @param resp The Moodle response. It should be of type {@link JSONArray}.
+   * @return A list of Moodle IDs.
    * @throws MoodleWebServiceException If the parsing failed because the response format was unexpected.
    */
-  private List<String> parseCourseList(Object resp) throws MoodleWebServiceException {
+  private List<String> parseIdList(Object resp) throws MoodleWebServiceException {
     if (resp == null)
       return new LinkedList<>();
 
@@ -186,16 +197,16 @@ public class MoodleWebServiceImpl implements MoodleWebService {
       throw new MoodleWebServiceException("Moodle responded in unexpected format");
 
     JSONArray respArray = (JSONArray) resp;
-    List<String> courses = new ArrayList<>(respArray.size());
+    List<String> ids = new ArrayList<>(respArray.size());
 
     for (Object courseObj : respArray) {
       if (!(courseObj instanceof JSONObject) || ((JSONObject) courseObj).get("id") == null)
         throw new MoodleWebServiceException("Moodle responded in unexpected format");
 
-      courses.add(((JSONObject) courseObj).get("id").toString());
+      ids.add(((JSONObject) courseObj).get("id").toString());
     }
 
-    return courses;
+    return ids;
   }
 
   /**

--- a/modules/userdirectory-moodle/src/test/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderTest.java
+++ b/modules/userdirectory-moodle/src/test/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderTest.java
@@ -45,7 +45,7 @@ public class MoodleUserProviderTest {
   public void setUp() throws Exception {
     moodleProvider = new MoodleUserProviderInstance("sample_pid",
             new MoodleWebServiceImpl(new URI("http://moodle/webservice/rest/server.php"), "myToken"),
-            new DefaultOrganization(), "^[0-9]+$", "^[0-9a-zA-Z_]+$", 100, 10);
+            new DefaultOrganization(), "^[0-9]+$", "^[0-9a-zA-Z_]+$", "^[0-9]+$", true, 100, 10);
   }
 
   @Test


### PR DESCRIPTION
This extends the Moodle role provider to make it aware of Moodle groups. Additionally to the learner und instructor roles, group roles in the form of `G{GROUP_ID}_Learner` will be added. It is thus possible to restrict access to certain groups instead of a whole course.

This extension requires a recent version of the [`moodle-tool_opencast`](https://github.com/unirz-tu-ilmenau/moodle-tool_opencast) Moodle Plugin.