### PR TITLE
MH-13108, Prevent permission problem in Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
 # Do not cache the opencast artifacts to detect dependency problems
 before_cache:
   - rm -rf ~/.m2/repository/org/opencastproject
+  - sudo chown -R travis:travis ~/.m2 ~/.cache/pip docs/guides/node_modules/
 
 # Shorten some commands
 # - A simple download command for synfig packages


### PR DESCRIPTION
Travis sometimes seems to have issues with incorrect permissions set on
some maven artifacts causing build failures. This patch enforces correct
permission before updating a cache.