### PR TITLE
MH-13025: Fix workflow-definitions URL

### DIFF
--- a/docs/guides/admin/docs/configuration/external-api.md
+++ b/docs/guides/admin/docs/configuration/external-api.md
@@ -117,13 +117,13 @@ directly in the Opencast administrative user interface.
 
 **Workflow API**
 
-|ROLE                                |METHOD | URL                                                    |
-|------------------------------------|-------|--------------------------------------------------------|
-|ROLE_API_WORKFLOW_INSTANCE_CREATE   |POST   |/api/workflow                                           |
-|ROLE_API_WORKFLOW_INSTANCE_VIEW     |GET    |/api/workflow<br>/api/workflow/\*                       |
-|ROLE_API_WORKFLOW_INSTANCE_EDIT     |PUT    |/api/workflow/\*                                        |
-|ROLE_API_WORKFLOW_INSTANCE_DELETE   |DELETE |/api/workflow/\*                                        |
-|ROLE_API_WORKFLOW_DEFINITION_VIEW   |GET    |/api/workflow-definition<br>/api/workflow-definition/\* |
+|ROLE                                |METHOD | URL                                                      |
+|------------------------------------|-------|----------------------------------------------------------|
+|ROLE_API_WORKFLOW_INSTANCE_CREATE   |POST   |/api/workflow                                             |
+|ROLE_API_WORKFLOW_INSTANCE_VIEW     |GET    |/api/workflow<br>/api/workflow/\*                         |
+|ROLE_API_WORKFLOW_INSTANCE_EDIT     |PUT    |/api/workflow/\*                                          |
+|ROLE_API_WORKFLOW_INSTANCE_DELETE   |DELETE |/api/workflow/\*                                          |
+|ROLE_API_WORKFLOW_DEFINITION_VIEW   |GET    |/api/workflow-definitions<br>/api/workflow-definitions/\* |
 
 **User- and Role-switching**
 

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -193,8 +193,8 @@
     <sec:intercept-url pattern="/api/version/*" method="GET" access="ROLE_ADMIN, ROLE_API"/>
     <sec:intercept-url pattern="/api/workflows" method="GET" access="ROLE_ADMIN, ROLE_API_WORKFLOW_INSTANCE_VIEW"/>
     <sec:intercept-url pattern="/api/workflows/*" method="GET" access="ROLE_ADMIN, ROLE_API_WORKFLOW_INSTANCE_VIEW"/>
-    <sec:intercept-url pattern="/api/workflow-definition" method="GET" access="ROLE_ADMIN, ROLE_API_WORKFLOW_DEFINITION_VIEW"/>
-    <sec:intercept-url pattern="/api/workflow-definition/*" method="GET" access="ROLE_ADMIN, ROLE_API_WORKFLOW_DEFINITION_VIEW"/>
+    <sec:intercept-url pattern="/api/workflow-definitions" method="GET" access="ROLE_ADMIN, ROLE_API_WORKFLOW_DEFINITION_VIEW"/>
+    <sec:intercept-url pattern="/api/workflow-definitions/*" method="GET" access="ROLE_ADMIN, ROLE_API_WORKFLOW_DEFINITION_VIEW"/>
     <!-- External API PUT Endpoints -->
     <sec:intercept-url pattern="/api/events/*" method="PUT" access="ROLE_ADMIN, ROLE_API_EVENTS_EDIT"/>
     <sec:intercept-url pattern="/api/events/*/acl" method="PUT" access="ROLE_ADMIN, ROLE_API_EVENTS_ACL_EDIT"/>


### PR DESCRIPTION
In #372 I missed that some places use `/api/workflow-definition` instead of the correct `/api/workflow-definitions` endpoint.