### PR TITLE
MH-13082: Fix LTI security vulnerability and refactor LTI and OAuth classes

### DIFF
--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -14,48 +14,52 @@ More information about the LTI specifications is available at
 [IMS Learning Tools Interoperability](http://www.imsglobal.org/activity/learning-tools-interoperability).
 
 Configure Opencast
-------------------------
+------------------
 
-To enable LTI authentication in Opencast, edit `OPENCAST/etc/security/mh_default_org.xml`
+### Configure OAuth authentication
 
-* In the Authentication Filters section, uncomment the oAuthProtectedResourceFilter:
-````
+LTI uses OAuth to authenticate users. To enable OAuth in Opencast, edit `OPENCAST/etc/security/mh_default_org.xml` and
+uncomment the oAuthProtectedResourceFilter in the Authentication Filters section:
+
+```xml
     <!-- 2-legged OAuth is used by trusted 3rd party applications, including LTI. -->
     <!-- Uncomment the line below to support LTI or other OAuth clients.          -->
     <ref bean="oauthProtectedResourceFilter" />
-````
+```
 
-* Replace CONSUMER_KEY and CONSUMER_SECRET with LTI the key and secret values that you will use in your LMS:
-````
-    <!-- ####################### -->
-    <!-- # OAuth (LTI) Support # -->
-    <!-- ####################### -->
+To configure OAuth consumers (e.g. a LMS), edit
+`OPENCAST/etc/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg` and replace CONSUMERNAME,
+CONSUMERKEY, and CONSUMERSECRET with the values you will use in your LMS:
 
-    <!-- This is required for LTI. If you are using LTI and have enabled the oauthProtectedResourceFilter  -->
-    <!-- in the list of authenticationFilters above, set custom values for CONSUMERKEY and CONSUMERSECRET. -->
+```properties
+oauth.consumer.name.1=CONSUMERNAME
+oauth.consumer.key.1=CONSUMERKEY
+oauth.consumer.secret.1=CONSUMERSECRET
+```
 
-    <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="CONSUMERKEY" />
-    <constructor-arg index="2" value="CONSUMERSECRET" />
-    <constructor-arg index="3" value="constructorName" />
-    </bean>
-````
+### Configure LTI (optional)
 
-* To give LMS users the same username in Opencast as the LMS username, uncomment the constructor arguments
-below and update CONSUMERKEY to the same key used above:
+To give LMS users the same username in Opencast as the LMS username, edit
+`etc/org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler.cfg` and add the configured OAuth consumer key
+to the list of highly trusted keys.
 
-````
-    <!-- Uncomment to trust usernames from the LTI consumer identified by CONSUMERKEY.           -->
-    <!-- Users from untrusted systems will be prefixed with "lti:" and the consumer domain name. -->
+```properties
+lti.oauth.highly_trusted_consumer_key.1=CONSUMERKEY
+```
 
-    <constructor-arg index="1" ref="securityService" />
-    <constructor-arg index="2">
-      <list>
-        <value>CONSUMERKEY</value>
-      </list>
-    </constructor-arg>
-````
+Use can exempt specific users even if a highly trusted consumer is used by configuring a blacklist. Additionally, there
+are settings for excluding the system administrator as well as the digest user (enabled by default).
+
+```properties
+lti.allow_system_administrator=false
+lti.allow_digest_user=false
+lti.blacklist.user.1=myAdminUser
+```
+
+> **Notice:** Marking a consumer key as highly trusted can be a security risk! If the usernames of sensitive Opencast
+> users are not blacklisted, the LMS administrator could create LMS users with the same username and use LTI to grant
+> that user access to Opencast. In the default configuration, that includes the `admin` and `opencast_system_account`
+> users.
 
 Configure and test an LTI tool in the LMS
 -----------------------------------------

--- a/etc/org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler.cfg
+++ b/etc/org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler.cfg
@@ -1,0 +1,42 @@
+# OAuth consumer keys with should be highly trusted.
+#
+# By default OAuth consumer are regarded as untrusted and a user authenticating via such
+# systems receives a rewritten username in the form of "lti:{ltiConsumerGUID}:{ltiUserID}".
+# This user is regarded as a new user temporarily existing for the duration of the session.
+# Opencast roles associated with the original user will not be attached to this user.
+#
+# Usernames of users authenticating via highly trusted systems will not be rewritten except
+# for the cases configured in the additional options below.
+#
+# Multiple consumer keys can be configured, by incrementing the counter. The list is read
+# sequentially incrementing the counter. If you miss any numbers it will stop looking for
+# further consumer keys.
+#lti.oauth.highly_trusted_consumer_key.1=CONSUMERKEY
+
+# Allow the Opencast system administrator user to authenticate as such via LTI.
+#
+# Note that this user may still authenticate via LTI, but the username will be rewritten,
+# even if a trusted OAuth consumer key is used.
+#
+# Note that this option does not apply to custom users having the ROLE_ADMIN. Use the
+# blacklist below instead.
+#
+# Default: false
+#lti.allow_system_administrator=false
+
+# Allow the Opencast digest user to authenticate as such via LTI.
+#
+# Note that this user may still authenticate via LTI, but the username will be rewritten,
+# even if a trusted OAuth consumer key is used.
+#
+# Default: false
+#lti.allow_digest_user=false
+
+# A blacklist of users not allowed to authenticate via LTI as themselves.
+#
+# Note that these users may still authenticate via LTI, but their username will be rewritten,
+# even if a trusted OAuth consumer key is used.
+#
+# Multiple users can be configured, by incrementing the counter. The list is read sequentially
+# incrementing the counter. If you miss any numbers it will stop looking for further users.
+#lti.blacklist.user.1=myAdminUser

--- a/etc/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg
+++ b/etc/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg
@@ -1,0 +1,8 @@
+# OAuth consumer consisting of name, key and secret.
+#
+# Multiple OAuth consumers can be configured, by incrementing the counter. The list is read
+# sequentially incrementing the counter. If you miss any numbers it will stop looking for
+# further consumers.
+#oauth.consumer.name.1=CONSUMERNAME
+#oauth.consumer.key.1=CONSUMERKEY
+#oauth.consumer.secret.1=CONSUMERSECRET

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -462,16 +462,6 @@
   <!-- # OAuth (LTI) Support # -->
   <!-- ####################### -->
 
-  <!-- This is required for LTI. If you are using LTI and have enabled the oauthProtectedResourceFilter  -->
-  <!-- in the list of authenticationFilters above, set custom values for CONSUMERKEY and CONSUMERSECRET. -->
-
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="CONSUMERKEY" />
-    <constructor-arg index="2" value="CONSUMERSECRET" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
-
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
@@ -480,25 +470,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-
-        <!-- Uncomment to trust usernames from the LTI consumer identified by CONSUMERKEY.           -->
-        <!-- Users from untrusted systems will be prefixed with "lti:" and the consumer domain name. -->
-
-        <!--
-        <constructor-arg index="1" ref="securityService" />
-        <constructor-arg index="2">
-          <list>
-            <value>CONSUMERKEY</value>
-          </list>
-        </constructor-arg>
-        <constructor-arg index="3" value="^(admin|opencast_system_account)$" />
-        -->
-
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>
 
   <!-- ###################### -->
@@ -553,6 +525,11 @@
   <osgi:reference id="userDirectoryService" cardinality="1..1"
                   interface="org.opencastproject.security.api.UserDirectoryService" />
 
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->

--- a/etc/security/security_sample_cas.xml-example
+++ b/etc/security/security_sample_cas.xml-example
@@ -172,13 +172,6 @@
   <!-- # OAuth (LTI) Support # -->
   <!-- ####################### -->
 
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="consumerkey" />
-    <constructor-arg index="2" value="consumersecret" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
-
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
@@ -187,19 +180,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-        <!-- Uncomment to allow the included keys to be trusted to provide known user details
-        <constructor-arg index="1">
-          <list>
-            <value>trustedKey</value>
-            <value>trustedKey2</value>
-          </list>
-        </constructor-arg>
-        -->
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>
 
   <!-- ############### -->
@@ -266,6 +247,11 @@
 
   <osgi:reference id="securityService" cardinality="1..1" interface="org.opencastproject.security.api.SecurityService" />
 
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+    interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+    interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->

--- a/etc/security/security_sample_ldap.xml-example
+++ b/etc/security/security_sample_ldap.xml-example
@@ -445,16 +445,6 @@
   <!-- # OAuth (LTI) Support # -->
   <!-- ####################### -->
 
-  <!-- This is required for LTI. If you are using LTI and have enabled the oauthProtectedResourceFilter  -->
-  <!-- in the list of authenticationFilters above, set custom values for CONSUMERKEY and CONSUMERSECRET. -->
-
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="CONSUMERKEY" />
-    <constructor-arg index="2" value="CONSUMERSECRET" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
-
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
@@ -463,25 +453,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-
-        <!-- Uncomment to trust usernames from the LTI consumer identified by CONSUMERKEY.           -->
-        <!-- Users from untrusted systems will be prefixed with "lti:" and the consumer domain name. -->
-
-        <!--
-        <constructor-arg index="1" ref="securityService" />
-        <constructor-arg index="2">
-          <list>
-            <value>CONSUMERKEY</value>
-          </list>
-        </constructor-arg>
-        <constructor-arg index="3" value="^(admin|opencast_system_account)$" />
-        -->
-
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>
 
   <!-- ###################### -->
@@ -586,6 +558,11 @@
                   interface="org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator"
                   filter="(instanceId=theId)"/>
 
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->

--- a/etc/security/security_sample_shibboleth.xml-example
+++ b/etc/security/security_sample_shibboleth.xml-example
@@ -193,13 +193,6 @@
   <!-- # OAuth (LTI) Support # -->
   <!-- ####################### -->
 
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="consumerkey" />
-    <constructor-arg index="2" value="consumersecret" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
-
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
@@ -208,21 +201,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-        <!-- Uncomment to allow the included keys to be trusted to provide known user details
-        <constructor-arg index="1" ref="securityService" />
-        <constructor-arg index="2">
-          <list>
-            <value>trustedKey</value>
-            <value>trustedKey2</value>
-          </list>
-        </constructor-arg>
-        <constructor-arg index="3" value="^(admin|opencast_system_account)$" />
-        -->
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>
 
   <!-- ###################### -->
@@ -271,6 +250,11 @@
   <osgi:reference id="userReferenceProvider" cardinality="1..1"
     interface="org.opencastproject.userdirectory.api.UserReferenceProvider"  />
 
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+    interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+    interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -300,6 +300,8 @@
               OSGI-INF/pingback.xml,
               OSGI-INF/rest.xml,
               OSGI-INF/security-filter.xml,
+              OSGI-INF/security-lti.xml,
+              OSGI-INF/security-oauth.xml,
               OSGI-INF/security-service.xml,
               OSGI-INF/smtp-service.xml,
               OSGI-INF/remote-user-and-role-filter.xml,

--- a/modules/kernel/src/main/resources/OSGI-INF/security-lti.xml
+++ b/modules/kernel/src/main/resources/OSGI-INF/security-lti.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler"
+               immediate="true" activate="activate">
+  <implementation class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler"/>
+  <property name="service.description" value="LTI authentication helper"/>
+  <service>
+    <provide interface="org.osgi.service.cm.ManagedService"/>
+    <provide interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler"/>
+  </service>
+  <reference name="userDetailsService" interface="org.springframework.security.core.userdetails.UserDetailsService"
+             cardinality="1..1" policy="static" bind="setUserDetailsService"/>
+</scr:component>

--- a/modules/kernel/src/main/resources/OSGI-INF/security-oauth.xml
+++ b/modules/kernel/src/main/resources/OSGI-INF/security-oauth.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.kernel.security.OAuthConsumerDetailsService" immediate="true">
+  <implementation class="org.opencastproject.kernel.security.OAuthConsumerDetailsService"/>
+  <property name="service.description" value="OAuth consumer details service"/>
+  <service>
+    <provide interface="org.osgi.service.cm.ManagedService"/>
+    <provide interface="org.springframework.security.oauth.provider.ConsumerDetailsService"/>
+  </service>
+  <reference name="userDetailsService" interface="org.springframework.security.core.userdetails.UserDetailsService"
+             cardinality="1..1" policy="static" bind="setDelegate"/>
+</scr:component>


### PR DESCRIPTION
This refactors LTI and OAuth classes to OSGi services and implements the LTI user blacklist as discussed in #414 and during the developer meeting.

There is a new functionality in that this changes allows to configure multiple OAuth consumers instead of just one, so this might be seen as feature instead of a bug fix. Although, this might be small enough?

@gregorydlogan note that I have a branch ready for 3.x, however since `SecurityUtil` did not have that method back then, it is marginally different. Should I file separately?