### PR TITLE
MH-13116, Fix typo in paella error message

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/05_loader.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/05_loader.js
@@ -29,7 +29,7 @@ function loadOpencastPaella(containerId) {
           var converter = new OpencastToPaellaConverter();
           var data = converter.convertToDataJson(episode);
           if (data.streams.length < 1) {
-            paella.messageBox.showError(paella.dictionary.translate('Error loading video! No video traks found'));
+            paella.messageBox.showError(paella.dictionary.translate('Error loading video! No video tracks found'));
           }
           else {
             resolve(data);

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/en-US.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/en-US.json
@@ -1,7 +1,7 @@
 {
-	"Error loading video! No video traks found": "Error loading video! No video traks found",
+	"Error loading video! No video tracks found": "Error loading video! No video tracks found",
 	"Error loading video {0}": "Error loading video {0}",
-	
+
 	"CAPTIONS_undefined": "Unknown language",
 	"CAPTIONS_es": "Spanish",
 	"CAPTIONS_en": "English",


### PR DESCRIPTION
This patch fixes a typo in the error message telling you that there are
no tracks available.