### PR TITLE
MH-13117, Mark NPM managed modules as private packages

### DIFF
--- a/docs/guides/package-lock.json
+++ b/docs/guides/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "docs",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/docs/guides/package.json
+++ b/docs/guides/package.json
@@ -1,13 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "",
-  "license": "ISC",
+  "private": true,
   "devDependencies": {
     "grunt": "^1.0.3",
     "grunt-markdownlint": "^2.1.0",

--- a/modules/lti/package-lock.json
+++ b/modules/lti/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "opencast-lit-tools",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0",

--- a/modules/lti/package.json
+++ b/modules/lti/package.json
@@ -1,11 +1,10 @@
 {
   "name": "opencast-lit-tools",
-  "version": "1.0.0",
+  "private": true,
   "scripts": {
     "eslint": "eslint src/main/resources/",
     "html-linter": "html-linter --config .html-linter.json 'src/main/resources/**/*.html'"
   },
-  "license": "ECL-2.0",
   "dependencies": {
     "font-awesome": "^4.7.0",
     "jquery": "^3.3.1",

--- a/modules/runtime-info-ui-ng/package.json
+++ b/modules/runtime-info-ui-ng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencast-runtime-info-ui-ng",
-  "license": "ECL-2.0",
+  "private": true,
   "scripts": {
     "eslint": "eslint src/main/resources/ui/"
   },

--- a/modules/runtime-info-ui/package-lock.json
+++ b/modules/runtime-info-ui/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "opencast-runtime-info-ui",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0",

--- a/modules/runtime-info-ui/package.json
+++ b/modules/runtime-info-ui/package.json
@@ -1,7 +1,6 @@
 {
   "name": "opencast-runtime-info-ui",
-  "version": "1.0.0",
-  "license": "ECL-2.0",
+  "private": true,
   "scripts": {
     "eslint": "eslint src/main/resources/ui/"
   },


### PR DESCRIPTION
NPM warns about missing descriptions and scm locations in modules which
include the package manager like lti or runtime-info-ui. This patch
marks these as private to indicate that those are not stand-alone
projects.