### PR TITLE
MH-13121: Fix usertracking plugin in paella player

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.userTrackingSaverPlugIn/mh_usertracking_saver.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.userTrackingSaverPlugIn/mh_usertracking_saver.js
@@ -39,15 +39,20 @@ paella.addPlugin(function() {
     }
 
     log(event, params) {
-      paella.player.videoContainer.currentTime().then(function(ct){
-        var videoCurrentTime = parseInt(ct + paella.player.videoContainer.trimStart());
+      var videoCurrentTime;
+      paella.player.videoContainer.currentTime()
+      .then((ct) => {
+        videoCurrentTime = parseInt(ct + paella.player.videoContainer.trimStart());
+        return paella.player.videoContainer.paused();
+      })
+      .then((paused) => {
         var opencastLog = {
           _method: 'PUT',
           'id': paella.player.videoIdentifier,
           'type': undefined,
           'in': videoCurrentTime,
           'out': videoCurrentTime,
-          'playing': !paella.player.videoContainer.paused()
+          'playing': !paused
         };
 
         switch (event) {


### PR DESCRIPTION
Jira ticket: https://opencast.jira.com/browse/MH-13121

paella usertracking plugin is using paella.player.videoContainer.paused().
This function returns a promise, but the plugin is using a direct value return. So, paella is not sending the usertracking data correctly to opencast.