### PR TITLE
MH-13082: Fix LTI security vulnerability and refactor LTI and OAuth classes

### DIFF
--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -13,49 +13,53 @@ and can play back videos in an Opencast series set up for the course.
 More information about the LTI specifications is available at 
 [IMS Learning Tools Interoperability](http://www.imsglobal.org/activity/learning-tools-interoperability).
 
-Configure Opencast 
-------------------------
+Configure Opencast
+------------------
 
-To enable LTI authentication in Opencast, edit `OPENCAST/etc/security/mh_default_org.xml`
+### Configure OAuth authentication
 
-* In the Authentication Filters section, uncomment the oAuthProtectedResourceFilter: 
-````
+LTI uses OAuth to authenticate users. To enable OAuth in Opencast, edit `OPENCAST/etc/security/mh_default_org.xml` and
+uncomment the oAuthProtectedResourceFilter in the Authentication Filters section:
+
+```xml
     <!-- 2-legged OAuth is used by trusted 3rd party applications, including LTI. -->
     <!-- Uncomment the line below to support LTI or other OAuth clients.          -->
     <ref bean="oauthProtectedResourceFilter" />
-````
+```
 
-* Replace CONSUMER_KEY and CONSUMER_SECRET with LTI the key and secret values that you will use in your LMS:
-````
-    <!-- ####################### -->
-    <!-- # OAuth (LTI) Support # -->
-    <!-- ####################### -->
+To configure an OAuth consumer (e.g. a LMS), edit
+`OPENCAST/etc/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg` and replace CONSUMERNAME,
+CONSUMERKEY, and CONSUMERSECRET with the values you will use in your LMS:
 
-    <!-- This is required for LTI. If you are using LTI and have enabled the oauthProtectedResourceFilter  -->
-    <!-- in the list of authenticationFilters above, set custom values for CONSUMERKEY and CONSUMERSECRET. -->
+```properties
+oauth.consumer.name=CONSUMERNAME
+oauth.consumer.key=CONSUMERKEY
+oauth.consumer.secret=CONSUMERSECRET
+```
 
-    <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="CONSUMERKEY" />
-    <constructor-arg index="2" value="CONSUMERSECRET" />
-    <constructor-arg index="3" value="constructorName" />
-    </bean>
-````
+### Configure LTI (optional)
 
-* To give LMS users the same username in Opencast as the LMS username, uncomment the constructor arguments 
-below and update CONSUMERKEY to the same key used above:
+To give LMS users the same username in Opencast as the LMS username, edit
+`etc/org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler.cfg` and add the configured OAuth consumer key
+to the list of highly trusted keys.
 
-````
-    <!-- Uncomment to trust usernames from the LTI consumer identified by CONSUMERKEY.           -->
-    <!-- Users from untrusted systems will be prefixed with "lti:" and the consumer domain name. -->
+```properties
+lti.oauth.highly_trusted_consumer_key.1=CONSUMERKEY
+```
 
-    <constructor-arg index="1" ref="securityService" />
-    <constructor-arg index="2">
-      <list>
-        <value>CONSUMERKEY</value>
-      </list>
-    </constructor-arg>
-````
+Use can exempt specific users even if a highly trusted consumer is used by configuring a blacklist. Additionally, there
+are settings for excluding the system administrator as well as the digest user (enabled by default).
+
+```properties
+lti.allow_system_administrator=false
+lti.allow_digest_user=false
+lti.blacklist.user.1=myAdminUser
+```
+
+> **Notice:** Marking a consumer key as highly trusted can be a security risk! If the usernames of sensitive Opencast
+> users are not blacklisted, the LMS administrator could create LMS users with the same username and use LTI to grant
+> that user access to Opencast. In the default configuration, that includes the `admin` and `opencast_system_account`
+> users.
 
 Configure and test an LTI tool in the LMS
 -----------------------------------------

--- a/etc/org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler.cfg
+++ b/etc/org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler.cfg
@@ -1,0 +1,42 @@
+# OAuth consumer keys with should be highly trusted.
+#
+# By default OAuth consumer are regarded as untrusted and a user authenticating via such
+# systems receives a rewritten username in the form of "lti:{ltiConsumerGUID}:{ltiUserID}".
+# This user is regarded as a new user temporarily existing for the duration of the session.
+# Opencast roles associated with the original user will not be attached to this user.
+#
+# Usernames of users authenticating via highly trusted systems will not be rewritten except
+# for the cases configured in the additional options below.
+#
+# Multiple consumer keys can be configured, by incrementing the counter. The list is read
+# sequentially incrementing the counter. If you miss any numbers it will stop looking for
+# further consumer keys.
+#lti.oauth.highly_trusted_consumer_key.1=CONSUMERKEY
+
+# Allow the Opencast system administrator user to authenticate as such via LTI.
+#
+# Note that this user may still authenticate via LTI, but the username will be rewritten,
+# even if a trusted OAuth consumer key is used.
+#
+# Note that this option does not apply to custom users having the ROLE_ADMIN. Use the
+# blacklist below instead.
+#
+# Default: false
+#lti.allow_system_administrator=false
+
+# Allow the Opencast digest user to authenticate as such via LTI.
+#
+# Note that this user may still authenticate via LTI, but the username will be rewritten,
+# even if a trusted OAuth consumer key is used.
+#
+# Default: false
+#lti.allow_digest_user=false
+
+# A blacklist of users not allowed to authenticate via LTI as themselves.
+#
+# Note that these users may still authenticate via LTI, but their username will be rewritten,
+# even if a trusted OAuth consumer key is used.
+#
+# Multiple users can be configured, by incrementing the counter. The list is read sequentially
+# incrementing the counter. If you miss any numbers it will stop looking for further users.
+#lti.blacklist.user.1=myAdminUser

--- a/etc/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg
+++ b/etc/org.opencastproject.kernel.security.OAuthConsumerDetailsService.cfg
@@ -1,0 +1,4 @@
+# OAuth consumer consisting of name, key and secret.
+#oauth.consumer.name=CONSUMERNAME
+#oauth.consumer.key=CONSUMERKEY
+#oauth.consumer.secret=CONSUMERSECRET

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -431,16 +431,6 @@
   <!-- # OAuth (LTI) Support # -->
   <!-- ####################### -->
 
-  <!-- This is required for LTI. If you are using LTI and have enabled the oauthProtectedResourceFilter  -->
-  <!-- in the list of authenticationFilters above, set custom values for CONSUMERKEY and CONSUMERSECRET. -->
-
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="CONSUMERKEY" />
-    <constructor-arg index="2" value="CONSUMERSECRET" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
-
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
@@ -449,25 +439,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-
-        <!-- Uncomment to trust usernames from the LTI consumer identified by CONSUMERKEY.           -->
-        <!-- Users from untrusted systems will be prefixed with "lti:" and the consumer domain name. -->
-
-        <!--
-        <constructor-arg index="1" ref="securityService" />
-        <constructor-arg index="2">
-          <list>
-            <value>CONSUMERKEY</value>
-          </list>
-        </constructor-arg>
-        <constructor-arg index="3" value="^(admin|opencast_system_account)$" />
-        -->
-
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>
 
   <!-- ###################### -->
@@ -522,6 +494,11 @@
   <osgi:reference id="userDirectoryService" cardinality="1..1"
                   interface="org.opencastproject.security.api.UserDirectoryService" />
 
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->

--- a/etc/security/security_sample_cas.xml-example
+++ b/etc/security/security_sample_cas.xml-example
@@ -172,13 +172,6 @@
   <!-- # OAuth (LTI) Support # -->
   <!-- ####################### -->
 
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="consumerkey" />
-    <constructor-arg index="2" value="consumersecret" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
-
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
@@ -187,20 +180,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-	      <!-- Uncomment to allow the included keys to be trusted to provide known user details
-	      <constructor-arg index="1">
-	        <list>
-            <value>trustedKey</value>
-            <value>trustedKey2</value>
-          </list>
-	      </constructor-arg>
-              <constructor-arg index="3" value="^(admin|opencast_system_account)$" />
-	      -->
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>
 
   <!-- ############### -->
@@ -267,6 +247,11 @@
 
   <osgi:reference id="securityService" cardinality="1..1" interface="org.opencastproject.security.api.SecurityService" />
 
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+    interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+    interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->

--- a/etc/security/security_sample_ldap.xml-example
+++ b/etc/security/security_sample_ldap.xml-example
@@ -418,12 +418,6 @@
 
   <!-- This is required for LTI. If you plan to use LTI, uncomment this and set
        custom values for consumerkey and consumersecret:
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="consumerkey" />
-    <constructor-arg index="2" value="consumersecret" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
 
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
@@ -433,21 +427,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-        < ! - - Uncomment to allow the included keys to be trusted to provide known user details
-        <constructor-arg index="1" ref="securityService" />
-        <constructor-arg index="2">
-          <list>
-            <value>trustedKey</value>
-            <value>trustedKey2</value>
-          </list>
-        </constructor-arg>
-        <constructor-arg index="3" value="^(admin|opencast_system_account)$" />
-        - - >
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>
   -->
 
@@ -551,6 +531,11 @@
   <osgi:reference id="userDirectoryService" cardinality="1..1"
                   interface="org.opencastproject.security.api.UserDirectoryService" />
 
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+                  interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->

--- a/etc/security/security_sample_shibboleth.xml-example
+++ b/etc/security/security_sample_shibboleth.xml-example
@@ -193,13 +193,6 @@
   <!-- # OAuth (LTI) Support # -->
   <!-- ####################### -->
 
-  <bean name="oAuthConsumerDetailsService" class="org.opencastproject.kernel.security.OAuthSingleConsumerDetailsService">
-    <constructor-arg index="0" ref="userDetailsService" />
-    <constructor-arg index="1" value="consumerkey" />
-    <constructor-arg index="2" value="consumersecret" />
-    <constructor-arg index="3" value="constructorName" />
-  </bean>
-
   <bean name="oauthProtectedResourceFilter" class="org.opencastproject.kernel.security.LtiProcessingFilter">
     <property name="consumerDetailsService" ref="oAuthConsumerDetailsService" />
     <property name="tokenServices">
@@ -208,21 +201,7 @@
     <property name="nonceServices">
       <bean class="org.springframework.security.oauth.provider.nonce.InMemoryNonceServices" />
     </property>
-    <property name="authHandler">
-      <bean class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler">
-        <constructor-arg index="0" ref="userDetailsService" />
-        <!-- Uncomment to allow the included keys to be trusted to provide known user details
-        <constructor-arg index="1" ref="securityService" />
-        <constructor-arg index="2">
-          <list>
-            <value>trustedKey</value>
-            <value>trustedKey2</value>
-          </list>
-        </constructor-arg>
-        <constructor-arg index="3" value="^(admin|opencast_system_account)$" />
-        -->
-      </bean>
-    </property>
+    <property name="authHandler" ref="ltiLaunchAuthenticationHandler" />
   </bean>
 
   <!-- ###################### -->
@@ -271,6 +250,11 @@
   <osgi:reference id="userReferenceProvider" cardinality="1..1"
 	  interface="org.opencastproject.userdirectory.api.UserReferenceProvider"  />
 
+  <osgi:reference id="oAuthConsumerDetailsService" cardinality="1..1"
+    interface="org.springframework.security.oauth.provider.ConsumerDetailsService" />
+
+  <osgi:reference id="ltiLaunchAuthenticationHandler" cardinality="1..1"
+    interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler" />
 
   <!-- ############################# -->
   <!-- # Spring Security Internals # -->

--- a/modules/matterhorn-kernel/pom.xml
+++ b/modules/matterhorn-kernel/pom.xml
@@ -334,6 +334,8 @@
               OSGI-INF/pingback.xml,
               OSGI-INF/rest.xml,
               OSGI-INF/security-filter.xml,
+              OSGI-INF/security-lti.xml,
+              OSGI-INF/security-oauth.xml,
               OSGI-INF/security-service.xml,
               OSGI-INF/smtp-service.xml,
               OSGI-INF/remote-user-and-role-filter.xml,

--- a/modules/matterhorn-kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
+++ b/modules/matterhorn-kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
@@ -21,9 +21,11 @@
 
 package org.opencastproject.kernel.security;
 
-import org.opencastproject.security.api.SecurityService;
-
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
+import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
@@ -35,16 +37,14 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth.provider.ConsumerAuthentication;
+import org.springframework.security.oauth.provider.OAuthAuthenticationHandler;
 import org.springframework.security.oauth.provider.token.OAuthAccessProviderToken;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Dictionary;
 import java.util.HashSet;
-import java.util.List;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -52,91 +52,123 @@ import javax.servlet.http.HttpServletRequest;
  * Callback interface for handing authentication details that are used when an authenticated request for a protected
  * resource is received.
  */
-public class LtiLaunchAuthenticationHandler
-        implements org.springframework.security.oauth.provider.OAuthAuthenticationHandler {
+public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandler, ManagedService {
 
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(LtiLaunchAuthenticationHandler.class);
 
   /** The Http request parameter, sent by the LTI consumer, containing the user ID. */
-  public static final String LTI_USER_ID_PARAM = "user_id";
+  private static final String LTI_USER_ID_PARAM = "user_id";
 
-  /** The http request paramater containing the Consumer GUI **/
-  public static final String LTI_CONSUMER_GUID = "tool_consumer_instance_guid";
+  /** The http request parameter containing the Consumer GUI **/
+  private static final String LTI_CONSUMER_GUID = "tool_consumer_instance_guid";
 
-  /** LTI field containing a comma delimeted list of roles */
-  public static final String ROLES = "roles";
+  /** LTI field containing a comma delimited list of roles */
+  private static final String ROLES = "roles";
 
   /** The LTI field containing the context_id */
-  public static final String CONTEXT_ID = "context_id";
+  private static final String CONTEXT_ID = "context_id";
 
   /** The prefix for LTI user ids */
-  public static final String LTI_USER_ID_PREFIX = "lti";
+  private static final String LTI_USER_ID_PREFIX = "lti";
 
   /** The delimiter to use in generated OAUTH id's **/
-  public static final String LTI_ID_DELIMITER = ":";
+  private static final String LTI_ID_DELIMITER = ":";
 
-  /** The Matterhorn Role for OAUTH users **/
+  /** The Opencast Role for OAUTH users **/
   private static final String ROLE_OAUTH_USER = "ROLE_OAUTH_USER";
 
-  /** The default context for LTI x **/
+  /** The default context for LTI **/
   private static final String DEFAULT_CONTEXT = "LTI";
 
   /** The default learner for LTI **/
   private static final String DEFAULT_LEARNER = "USER";
 
+  /** The key to look up the admin username **/
+  private static final String ADMIN_USER_KEY = "org.opencastproject.security.admin.user";
+
+  /** The key to look up the digest username **/
+  private static final String DIGEST_USER_KEY = "org.opencastproject.security.digest.user";
+
+  /** The prefix of the key to look up a consumer key. */
+  private static final String HIGHLY_TRUSTED_CONSUMER_KEY_PREFIX = "lti.oauth.highly_trusted_consumer_key.";
+
+  /** The prefix of the key to look up a blacklisted user. */
+  private static final String BLACKLIST_USER_PREFIX = "lti.blacklist.user.";
+
+  /** The key to look up whether the admin user should be able to authenticate via LTI **/
+  private static final String ALLOW_SYSTEM_ADMINISTRATOR_KEY = "lti.allow_system_administrator";
+
+  /** The key to look up whether the digest user should be able to authenticate via LTI **/
+  private static final String ALLOW_DIGIST_USER_KEY = "lti.allow_digest_user";
+
   /** The user details service */
-  protected UserDetailsService userDetailsService;
+  private UserDetailsService userDetailsService;
 
-  /** the Security Service **/
-  protected SecurityService securityService;
+  /** OSGi component context */
+  private ComponentContext componentContext;
 
-  /** list of keys that will be highly */
-  protected List<String> highlyTrustedKeys;
+  /** Set of OAuth consumer keys that are highly trusted */
+  private Set<String> highlyTrustedConsumerKeys = new HashSet<>();
 
-  /** Pattern that matches user names, which should not be trusted from LTI */
-  protected Pattern untrustedUsersPattern;
-
-  /**
-   * Constructs a new LTI authentication handler, using the supplied user details service for performing user lookups.
-   *
-   * @param userDetailsService
-   *          the user details service used to map user identifiers to more detailed information
-   */
-  public LtiLaunchAuthenticationHandler(UserDetailsService userDetailsService) {
-    this(userDetailsService, null, new ArrayList<String>());
-  }
+  /** Set of usernames that should not authenticated as themselves even if the OAuth consumer keys is trusted */
+  private Set<String> usernameBlacklist = new HashSet<>();
 
   /**
-   * Constructor for a LTI authentication handler that includes a list of highly trusted keys
-   *
-   * @param userDetailsService
-   * @param highlyTrustedkeys
+   * OSGi DI
    */
-  public LtiLaunchAuthenticationHandler(UserDetailsService userDetailsService, SecurityService securityService,
-          List<String> highlyTrustedkeys) {
-    this(userDetailsService, securityService, highlyTrustedkeys, null);
-  }
-
-  /**
-   * Full constructor for a LTI authentication handler that includes a list of highly trusted keys with exceptions.
-   *
-   * @param userDetailsService
-   * @param highlyTrustedkeys
-   * @param untrustedUsersPattern
-   */
-  public LtiLaunchAuthenticationHandler(UserDetailsService userDetailsService, SecurityService securityService,
-          List<String> highlyTrustedkeys, String untrustedUsersPattern) {
+  public void setUserDetailsService(UserDetailsService userDetailsService) {
     this.userDetailsService = userDetailsService;
-    this.securityService = securityService;
-    this.highlyTrustedKeys = highlyTrustedkeys;
+  }
 
-    if (StringUtils.isNotBlank(untrustedUsersPattern)) {
-      try {
-        this.untrustedUsersPattern = Pattern.compile(untrustedUsersPattern);
-      } catch (PatternSyntaxException e) {
-        logger.warn("The configured untrusted users pattern is invalid - disabling checks:", e);
+  public void activate(ComponentContext cc) {
+    logger.info("Activating LtiLaunchAuthenticationHandler");
+    componentContext = cc;
+  }
+
+  @Override
+  public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+    logger.debug("Updating LtiLaunchAuthenticationHandler");
+
+    highlyTrustedConsumerKeys.clear();
+    usernameBlacklist.clear();
+
+    if (properties == null) {
+      logger.warn("LtiLaunchAuthenticationHandler is not configured");
+      return;
+    }
+
+    // Highly trusted OAuth consumer keys
+    for (int i = 1; true; i++) {
+      logger.debug("Looking for configuration of {}", HIGHLY_TRUSTED_CONSUMER_KEY_PREFIX + i);
+      String consumerKey = StringUtils.trimToNull((String) properties.get(HIGHLY_TRUSTED_CONSUMER_KEY_PREFIX + i));
+      if (consumerKey == null) {
+        break;
       }
+      highlyTrustedConsumerKeys.add(consumerKey);
+    }
+
+    // User blacklist
+    if (!BooleanUtils.toBoolean(StringUtils.trimToNull((String) properties.get(ALLOW_SYSTEM_ADMINISTRATOR_KEY)))) {
+      String adminUsername = StringUtils.trimToNull(componentContext.getBundleContext().getProperty(ADMIN_USER_KEY));
+      if (adminUsername != null) {
+        usernameBlacklist.add(adminUsername);
+      }
+    }
+    if (!BooleanUtils.toBoolean(StringUtils.trimToNull((String) properties.get(ALLOW_DIGIST_USER_KEY)))) {
+      String digestUsername = StringUtils.trimToNull(componentContext.getBundleContext().getProperty(DIGEST_USER_KEY));
+      if (digestUsername != null) {
+        usernameBlacklist.add(digestUsername);
+      }
+    }
+
+    for (int i = 1; true; i++) {
+      logger.debug("Looking for configuration of {}", BLACKLIST_USER_PREFIX + i);
+      String username = StringUtils.trimToNull((String) properties.get(BLACKLIST_USER_PREFIX + i));
+      if (username == null) {
+        break;
+      }
+      usernameBlacklist.add(username);
     }
   }
 
@@ -158,11 +190,11 @@ public class LtiLaunchAuthenticationHandler
       return null;
     }
 
-    // Get the comser guid if provided
+    // Get the consumer guid if provided
     String consumerGUID = request.getParameter(LTI_CONSUMER_GUID);
-    // This is an optional field it could be blank
+    // This is an optional field, so it could be blank
     if (StringUtils.isBlank(consumerGUID)) {
-      consumerGUID = "UknownConsumer";
+      consumerGUID = "UnknownConsumer";
     }
 
     // We need to construct a complex ID to avoid confusion
@@ -170,7 +202,7 @@ public class LtiLaunchAuthenticationHandler
 
     // if this is a trusted consumer we trust their details
     String oaAuthKey = request.getParameter("oauth_consumer_key");
-    if (highlyTrustedKeys.contains(oaAuthKey)) {
+    if (highlyTrustedConsumerKeys.contains(oaAuthKey)) {
       logger.debug("{} is a trusted key", oaAuthKey);
 
       // If supplied we use the human readable name coming from:
@@ -186,9 +218,9 @@ public class LtiLaunchAuthenticationHandler
       }
 
       // Check if the provided username should be trusted
-      if (untrustedUsersPattern != null && untrustedUsersPattern.matcher(ltiUsername).matches()) {
+      if (usernameBlacklist.contains(ltiUsername)) {
         // Do not trust the username
-        logger.debug("{} is an untrusted username", ltiUsername);
+        logger.debug("{} is blacklisted", ltiUsername);
       } else {
         username = ltiUsername;
       }
@@ -198,8 +230,8 @@ public class LtiLaunchAuthenticationHandler
       logger.debug("LTI user id is : {}", username);
     }
 
-    UserDetails userDetails = null;
-    Collection<GrantedAuthority> userAuthorities = null;
+    UserDetails userDetails;
+    Collection<GrantedAuthority> userAuthorities;
     try {
       userDetails = userDetailsService.loadUserByUsername(username);
 
@@ -208,7 +240,7 @@ public class LtiLaunchAuthenticationHandler
       // On the other hand, one cannot add non-null elements or modify the existing ones in a Collection<? extends
       // GrantedAuthority>. Therefore, we *must* instantiate a new Collection<GrantedAuthority> (an ArrayList in this
       // case) and populate it with whatever elements are returned by getAuthorities()
-      userAuthorities = new HashSet<GrantedAuthority>(userDetails.getAuthorities());
+      userAuthorities = new HashSet<>(userDetails.getAuthorities());
 
       // we still need to enrich this user with the LTI Roles
       String roles = request.getParameter(ROLES);
@@ -216,7 +248,7 @@ public class LtiLaunchAuthenticationHandler
       enrichRoleGrants(roles, context, userAuthorities);
     } catch (UsernameNotFoundException e) {
       // This user is known to the tool consumer, but not to Opencast. Create a user "on the fly"
-      userAuthorities = new HashSet<GrantedAuthority>();
+      userAuthorities = new HashSet<>();
       // We should add the authorities passed in from the tool consumer?
       String roles = request.getParameter(ROLES);
       String context = request.getParameter(CONTEXT_ID);
@@ -239,23 +271,25 @@ public class LtiLaunchAuthenticationHandler
   }
 
   /**
-   * Enrich A collection of role grants with specified LTI memberships
+   * Enrich A collection of role grants with specified LTI memberships.
    *
    * @param roles
+   *          String of LTI roles.
    * @param context
+   *          LTI context ID.
    * @param userAuthorities
+   *          Collection to append to.
    */
   private void enrichRoleGrants(String roles, String context, Collection<GrantedAuthority> userAuthorities) {
     // Roles could be a list
     if (roles != null) {
-      List<String> roleList = Arrays.asList(roles.split(","));
+      String[] roleList = roles.split(",");
 
-      /* Use a generic context and learner if none is given: */
+      // Use a generic context and learner if none is given:
       context = StringUtils.isBlank(context) ? DEFAULT_CONTEXT : context;
 
       for (String learner : roleList) {
-
-        /* Build the role */
+        // Build the role
         String role;
         if (StringUtils.isBlank(learner)) {
           role = context + "_" + DEFAULT_LEARNER;
@@ -263,17 +297,16 @@ public class LtiLaunchAuthenticationHandler
           role = context + "_" + learner;
         }
 
-        /* Make sure to not accept ROLE_… */
+        // Make sure to not accept ROLE_…
         if (role.trim().toUpperCase().startsWith("ROLE_")) {
           logger.warn("Discarding attempt to acquire role “{}”", role);
           continue;
         }
 
-        /* Add this role */
+        // Add this role
         logger.debug("Adding role: {}", role);
         userAuthorities.add(new SimpleGrantedAuthority(role));
       }
     }
   }
-
 }

--- a/modules/matterhorn-kernel/src/main/java/org/opencastproject/kernel/security/OAuthConsumerDetailsService.java
+++ b/modules/matterhorn-kernel/src/main/java/org/opencastproject/kernel/security/OAuthConsumerDetailsService.java
@@ -21,11 +21,14 @@
 
 package org.opencastproject.kernel.security;
 
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.GrantedAuthorityImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -37,67 +40,87 @@ import org.springframework.security.oauth.provider.ConsumerDetailsService;
 import org.springframework.security.oauth.provider.ExtraTrustConsumerDetails;
 
 import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * A sample OAuth consumer details service, hard coded to authenticate a consumer with the following information:
- *
- * <ul>
- *  <li>key=consumerkey</li>
- *  <li>name=consumername</li>
- *  <li>secret=consumersecret</li>
- * </ul>
- *
- * A UserDetailsService must be provided for delegating user lookup requests.
+ * A OAuth consumer details service with multiple consumers. UserDetailsService is used for delegating user
+ * lookup requests.
  */
-public class OAuthSingleConsumerDetailsService implements ConsumerDetailsService, UserDetailsService {
+public class OAuthConsumerDetailsService implements ConsumerDetailsService, UserDetailsService, ManagedService {
 
   /** The logger */
-  private static final Logger logger = LoggerFactory.getLogger(OAuthSingleConsumerDetailsService.class);
+  private static final Logger logger = LoggerFactory.getLogger(OAuthConsumerDetailsService.class);
 
-  /** The single hard-coded OAuth consumer. To be replaced later. */
-  private ConsumerDetails consumer;
+  /** The prefix of the key to look up a consumer name. */
+  private static final String CONSUMER_NAME_KEY = "oauth.consumer.name";
+
+  /** The prefix of the key to look up a consumer key. */
+  private static final String CONSUMER_KEY_KEY = "oauth.consumer.key";
+
+  /** The prefix of the key to look up a consumer secret. */
+  private static final String CONSUMER_SECRET_KEY = "oauth.consumer.secret";
 
   /** The user details service to use as a delegate for user lookups */
   private UserDetailsService delegate;
 
+  /** A map associating consumer keys to OAuth consumers. */
+  private Map<String, ConsumerDetails> consumers = new HashMap<>();
+
   /**
-   * Full constructor that accepts all the consumer details
-   *
-   * @param delegate
-   *          the user detail service to handle user lookups
-   * @param consumerKey
-   *          The consumer's secret key
-   * @param consumerSecret
-   *          The shared secret for the consumer
-   * @param consumerName
-   *          The consumer's name
+   * OSGi DI
    */
-  public OAuthSingleConsumerDetailsService(UserDetailsService delegate, String consumerKey, String consumerSecret,
-          String consumerName) {
+  public void setDelegate(UserDetailsService delegate) {
     this.delegate = delegate;
-    consumer = createConsumerDetails(consumerKey, consumerName, consumerSecret);
+  }
+
+  @Override
+  public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+    logger.debug("Updating OAuthConsumerDetailsService");
+
+    consumers.clear();
+
+    if (properties == null) {
+      logger.warn("OAuthConsumerDetailsService has no configured OAuth consumers");
+      return;
+    }
+
+    String consumerName = StringUtils.trimToNull((String) properties.get(CONSUMER_NAME_KEY));
+    String consumerKey = StringUtils.trimToNull((String) properties.get(CONSUMER_KEY_KEY));
+    String consumerSecret = StringUtils.trimToNull((String) properties.get(CONSUMER_SECRET_KEY));
+
+    // Has the consumer been fully configured
+    if (consumerName == null || consumerKey == null || consumerSecret == null) {
+      logger.debug("Unable to configure OAuth consumer with name'{}' because the name, key or secret is missing.",
+              consumerName);
+      return;
+    }
+
+    consumers.put(consumerKey, createConsumerDetails(consumerName, consumerKey, consumerSecret));
   }
 
   /**
    * Creates a spring security consumer details object, suitable to achieve two-legged OAuth.
    *
-   * @param consumerKey
-   *          the consumer key
    * @param consumerName
    *          the consumer name
+   * @param consumerKey
+   *          the consumer key
    * @param consumerSecret
    *          the consumer secret
    * @return the consumer details
    */
-  private ExtraTrustConsumerDetails createConsumerDetails(String consumerKey, String consumerName, String consumerSecret) {
+  private ExtraTrustConsumerDetails createConsumerDetails(String consumerName, String consumerKey,
+          String consumerSecret) {
     SharedConsumerSecret secret = new SharedConsumerSecret(consumerSecret);
     BaseConsumerDetails bcd = new BaseConsumerDetails();
     bcd.setConsumerKey(consumerKey);
     bcd.setConsumerName(consumerName);
     bcd.setSignatureSecret(secret);
-    List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-    authorities.add(new GrantedAuthorityImpl("ROLE_OAUTH_USER"));
+    List<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority("ROLE_OAUTH_USER"));
     bcd.setAuthorities(authorities);
     bcd.setRequiredToObtainAuthenticatedToken(false); // false for 2 legged OAuth
     return bcd;
@@ -106,7 +129,8 @@ public class OAuthSingleConsumerDetailsService implements ConsumerDetailsService
   @Override
   public ConsumerDetails loadConsumerByConsumerKey(String key) throws OAuthException {
     logger.debug("Request received to find consumer for consumerKey=[" + key + "]");
-    if (!consumer.getConsumerKey().equals(key)) {
+    ConsumerDetails consumer = consumers.get(key);
+    if (consumer == null) {
       logger.debug("Result: No consumer found for [" + key + "]");
       throw new OAuthException("No consumer found for key " + key);
     }
@@ -118,5 +142,4 @@ public class OAuthSingleConsumerDetailsService implements ConsumerDetailsService
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
     return delegate.loadUserByUsername(username);
   }
-
 }

--- a/modules/matterhorn-kernel/src/main/resources/OSGI-INF/security-lti.xml
+++ b/modules/matterhorn-kernel/src/main/resources/OSGI-INF/security-lti.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler"
+               immediate="true" activate="activate">
+  <implementation class="org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler"/>
+  <property name="service.description" value="LTI authentication helper"/>
+  <service>
+    <provide interface="org.osgi.service.cm.ManagedService"/>
+    <provide interface="org.springframework.security.oauth.provider.OAuthAuthenticationHandler"/>
+  </service>
+  <reference name="userDetailsService" interface="org.springframework.security.core.userdetails.UserDetailsService"
+             cardinality="1..1" policy="static" bind="setUserDetailsService"/>
+</scr:component>

--- a/modules/matterhorn-kernel/src/main/resources/OSGI-INF/security-oauth.xml
+++ b/modules/matterhorn-kernel/src/main/resources/OSGI-INF/security-oauth.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.kernel.security.OAuthConsumerDetailsService" immediate="true">
+  <implementation class="org.opencastproject.kernel.security.OAuthConsumerDetailsService"/>
+  <property name="service.description" value="OAuth consumer details service"/>
+  <service>
+    <provide interface="org.osgi.service.cm.ManagedService"/>
+    <provide interface="org.springframework.security.oauth.provider.ConsumerDetailsService"/>
+  </service>
+  <reference name="userDetailsService" interface="org.springframework.security.core.userdetails.UserDetailsService"
+             cardinality="1..1" policy="static" bind="setDelegate"/>
+</scr:component>


### PR DESCRIPTION
Same as #440, but for 3.x to 5.x. The only functional difference is the missing support for configuring multiple OAuth consumers.