### PR TITLE
MH-13129 More Configuration Options For Thumbnails

### DIFF
--- a/etc/org.opencastproject.adminui.cfg
+++ b/etc/org.opencastproject.adminui.cfg
@@ -81,16 +81,6 @@
 # Default: thumbnail
 #thumbnail.source.flavor.type=thumbnail
 
-# Flavor for published thumbnails. This flavor will be used when publishing
-# thumbnails to OAI-PMH or other channels.
-#
-# The default workflow will produce and publish thumbnail artifacts
-# like 'presenter/search+preview', therefore '*/search+preview' is the
-# recommended default value.
-#
-# Default: */search+preview
-#thumbnail.publish.flavor=*/search+preview
-
 # Tags to tag published thumbnails with. This can be a comma-separated list.
 #
 # The default workflow will tag published thumbnails with 'engage-download',
@@ -150,6 +140,11 @@
 # Default: <nothing>
 #oaipmh.profiles=
 
+# Flavor to use for thumbnails distributed via OAI-PMH.
+#
+# Default: */search+preview
+#oaipmh.flavor=*/search+preview
+
 # Flavor that identifies the left hand stream, for use in the "Tracks" and "Thumbnail"
 # panels of the video editor.
 #
@@ -199,3 +194,7 @@
 # Default: <nothing>
 #api.profiles=
 
+# Flavor to use for thumbnails distributed via external API.
+#
+# Default: */search+preview
+#api.flavor=*/search+preview

--- a/etc/org.opencastproject.adminui.cfg
+++ b/etc/org.opencastproject.adminui.cfg
@@ -142,6 +142,14 @@
 # Default: default
 #oaipmh.channel=default
 
+# Encoding profiles to use for generating thumbnails to distribute on OAI-PMH.
+# If no profile is specified, the thumbnail is published in full resolution. Specifying
+# multiple profiles (comma-separated) leads to the thumbnail being published in multiple
+# qualities.
+#
+# Default: <nothing>
+#oaipmh.profiles=
+
 # Flavor that identifies the left hand stream, for use in the "Tracks" and "Thumbnail"
 # panels of the video editor.
 #
@@ -177,3 +185,17 @@
 #
 # Default: video+preview
 #preview.video.subtype=video+preview
+
+# External API channel to distribute thumbnails to
+#
+# Default: api
+#api.channel=api
+
+# Encoding profiles to use for generating thumbnails to distribute on external API.
+# If no profile is specified, the thumbnail is published in full resolution. Specifying
+# multiple profiles (comma-separated) leads to the thumbnail being published in multiple
+# qualities.
+#
+# Default: <nothing>
+#api.profiles=
+

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -662,7 +662,8 @@ public class ToolsEndpoint implements ManagedService {
         } catch (UrlSigningException | URISyntaxException e) {
           logger.error("Error while trying to serialize the thumbnail url because: {}", getStackTrace(e));
           return R.serverError();
-        } catch (IOException | EncoderException | PublicationException | UnknownFileTypeException | MediaPackageException e) {
+        } catch (IOException | EncoderException | PublicationException | UnknownFileTypeException
+          | DistributionException | MediaPackageException e) {
           logger.error("Error while updating default thumbnail because: {}", getStackTrace(e));
           return R.serverError();
         }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
@@ -55,6 +55,9 @@ public class AdminUIConfiguration implements ManagedService {
   public static final String OPT_THUMBNAIL_DEFAULT_TRACK_SECONDARY = "thumbnail.default.track.secondary";
   public static final String OPT_THUMBNAIL_AUTO_DISTRIBUTION = "thumbnail.auto.distribution";
   public static final String OPT_OAIPMH_CHANNEL = "oaipmh.channel";
+  public static final String OPT_OAIPMH_PROFILES = "oaipmh.profiles";
+  public static final String OPT_API_CHANNEL = "api.channel";
+  public static final String OPT_API_PROFILES = "api.profiles";
   public static final String OPT_SOURCE_TRACK_LEFT_FLAVOR = "sourcetrack.left.flavor";
   public static final String OPT_SOURCE_TRACK_RIGHT_FLAVOR = "sourcetrack.right.flavor";
   public static final String OPT_PREVIEW_AUDIO_SUBTYPE = "preview.audio.subtype";
@@ -76,6 +79,9 @@ public class AdminUIConfiguration implements ManagedService {
   private static final String DEFAULT_THUMBNAIL_DEFAULT_TRACK_SECONDARY = "presentation";
   private static final Boolean DEFAULT_THUMBNAIL_AUTO_DISTRIBUTION = false;
   private static final String DEFAULT_OAIPMH_CHANNEL = "default";
+  private static final String DEFAULT_OAIPMH_PROFILES = "";
+  private static final String DEFAULT_API_CHANNEL = "api";
+  private static final String DEFAULT_API_PROFILES = "";
   private static final String DEFAULT_PREVIEW_VIDEO_SUBTYPE = "video+preview";
   private static final String DEFAULT_PREVIEW_AUDIO_SUBTYPE = "audio+preview";
   private static final String DEFAULT_SOURCE_TRACK_LEFT_FLAVOR = "presenter/source";
@@ -97,6 +103,9 @@ public class AdminUIConfiguration implements ManagedService {
   private String thumbnailDefaultTrackSecondary = DEFAULT_THUMBNAIL_DEFAULT_TRACK_SECONDARY;
   private boolean thumbnailAutoDistribution = DEFAULT_THUMBNAIL_AUTO_DISTRIBUTION;
   private String oaipmhChannel = DEFAULT_OAIPMH_CHANNEL;
+  private String[] oaipmhProfiles = {};
+  private String apiChannel = DEFAULT_API_CHANNEL;
+  private String[] apiProfiles = {};
   private String previewVideoSubtype = DEFAULT_PREVIEW_VIDEO_SUBTYPE;
   private String previewAudioSubtype = DEFAULT_PREVIEW_AUDIO_SUBTYPE;
   private MediaPackageElementFlavor sourceTrackLeftFlavor = MediaPackageElementFlavor.parseFlavor(
@@ -166,6 +175,18 @@ public class AdminUIConfiguration implements ManagedService {
 
   public String getOaipmhChannel() {
     return oaipmhChannel;
+  }
+
+  public String[] getOaipmhProfiles() {
+    return oaipmhProfiles;
+  }
+
+  public String getApiChannel() {
+    return apiChannel;
+  }
+
+  public String[] getApiProfiles() {
+    return apiProfiles;
   }
 
   public String getPreviewVideoSubtype() {
@@ -269,6 +290,23 @@ public class AdminUIConfiguration implements ManagedService {
     oaipmhChannel = StringUtils.defaultString(
       (String) properties.get(OPT_OAIPMH_CHANNEL), DEFAULT_OAIPMH_CHANNEL);
     logger.debug("OAI-PMH channel set to '{}", oaipmhChannel);
+
+    // OAI-PMH profiles
+    final String oaipmhProfilesStr = StringUtils.defaultString(
+      (String) properties.get(OPT_OAIPMH_PROFILES), DEFAULT_OAIPMH_PROFILES);
+    oaipmhProfiles = oaipmhProfilesStr.trim().isEmpty() ? new String[] {} : oaipmhProfilesStr.split(",");
+    logger.debug("OAI-PMH profiles set to '{}", Arrays.toString(oaipmhProfiles));
+
+    // API channel
+    apiChannel = StringUtils.defaultString(
+      (String) properties.get(OPT_API_CHANNEL), DEFAULT_API_CHANNEL);
+    logger.debug("API channel set to '{}", apiChannel);
+
+    // API profiles
+    final String apiProfilesStr = StringUtils.defaultString(
+      (String) properties.get(OPT_API_PROFILES), DEFAULT_API_PROFILES);
+    apiProfiles = apiProfilesStr.trim().isEmpty() ? new String[] {} : apiProfilesStr.split(",");
+    logger.debug("API profiles set to '{}", Arrays.toString(apiProfiles));
 
     // Preview Video subtype
     previewVideoSubtype = StringUtils.defaultString((String) properties.get(OPT_PREVIEW_VIDEO_SUBTYPE),

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
@@ -44,7 +44,6 @@ public class AdminUIConfiguration implements ManagedService {
   public static final String OPT_SMIL_CATALOG_FLAVOR = "smil.catalog.flavor";
   public static final String OPT_SMIL_CATALOG_TAGS = "smil.catalog.tags";
   public static final String OPT_SMIL_SILENCE_FLAVOR = "smil.silence.flavor";
-  public static final String OPT_THUMBNAIL_PUBLISH_FLAVOR = "thumbnail.publish.flavor";
   public static final String OPT_THUMBNAIL_PREVIEW_FLAVOR = "thumbnail.preview.flavor";
   public static final String OPT_THUMBNAIL_SOURCE_FLAVOR_TYPE = "thumbnail.source.flavor.type";
   public static final String OPT_THUMBNAIL_SOURCE_FLAVOR_SUBTYPE = "thumbnail.source.flavor.subtype";
@@ -56,8 +55,10 @@ public class AdminUIConfiguration implements ManagedService {
   public static final String OPT_THUMBNAIL_AUTO_DISTRIBUTION = "thumbnail.auto.distribution";
   public static final String OPT_OAIPMH_CHANNEL = "oaipmh.channel";
   public static final String OPT_OAIPMH_PROFILES = "oaipmh.profiles";
+  public static final String OPT_OAIPMH_FLAVOR = "oaipmh.flavor";
   public static final String OPT_API_CHANNEL = "api.channel";
   public static final String OPT_API_PROFILES = "api.profiles";
+  public static final String OPT_API_FLAVOR = "api.flavor";
   public static final String OPT_SOURCE_TRACK_LEFT_FLAVOR = "sourcetrack.left.flavor";
   public static final String OPT_SOURCE_TRACK_RIGHT_FLAVOR = "sourcetrack.right.flavor";
   public static final String OPT_PREVIEW_AUDIO_SUBTYPE = "preview.audio.subtype";
@@ -68,7 +69,6 @@ public class AdminUIConfiguration implements ManagedService {
   private static final String DEFAULT_SMIL_CATALOG_FLAVOR = "smil/cutting";
   private static final String DEFAULT_SMIL_CATALOG_TAGS = "archive";
   private static final String DEFAULT_SMIL_SILENCE_FLAVOR = "*/silence";
-  private static final String DEFAULT_THUMBNAIL_PUBLISH_FLAVOR = "*/search+preview";
   private static final String DEFAULT_THUMBNAIL_PREVIEW_FLAVOR = "thumbnail/preview";
   private static final String DEFAULT_THUMBNAIL_SOURCE_FLAVOR_TYPE = "thumbnail";
   private static final String DEFAULT_THUMBNAIL_SOURCE_FLAVOR_SUBTYPE = "source";
@@ -80,8 +80,10 @@ public class AdminUIConfiguration implements ManagedService {
   private static final Boolean DEFAULT_THUMBNAIL_AUTO_DISTRIBUTION = false;
   private static final String DEFAULT_OAIPMH_CHANNEL = "default";
   private static final String DEFAULT_OAIPMH_PROFILES = "";
+  private static final String DEFAULT_OAIPMH_FLAVOR = "*/search+preview";
   private static final String DEFAULT_API_CHANNEL = "api";
   private static final String DEFAULT_API_PROFILES = "";
+  private static final String DEFAULT_API_FLAVOR = "*/search+preview";
   private static final String DEFAULT_PREVIEW_VIDEO_SUBTYPE = "video+preview";
   private static final String DEFAULT_PREVIEW_AUDIO_SUBTYPE = "audio+preview";
   private static final String DEFAULT_SOURCE_TRACK_LEFT_FLAVOR = "presenter/source";
@@ -92,7 +94,6 @@ public class AdminUIConfiguration implements ManagedService {
   private Set<String> smilCatalogTagSet = new HashSet<>();
   private MediaPackageElementFlavor smilCatalogFlavor = MediaPackageElementFlavor.parseFlavor(DEFAULT_SMIL_CATALOG_FLAVOR);
   private MediaPackageElementFlavor smilSilenceFlavor = MediaPackageElementFlavor.parseFlavor(DEFAULT_SMIL_SILENCE_FLAVOR);
-  private String thumbnailPublishFlavor = DEFAULT_THUMBNAIL_PUBLISH_FLAVOR;
   private String thumbnailPreviewFlavor = DEFAULT_THUMBNAIL_PREVIEW_FLAVOR;
   private String thumbnailSourceFlavorType = DEFAULT_THUMBNAIL_SOURCE_FLAVOR_TYPE;
   private String thumbnailSourceFlavorSubtype = DEFAULT_THUMBNAIL_SOURCE_FLAVOR_SUBTYPE;
@@ -104,8 +105,10 @@ public class AdminUIConfiguration implements ManagedService {
   private boolean thumbnailAutoDistribution = DEFAULT_THUMBNAIL_AUTO_DISTRIBUTION;
   private String oaipmhChannel = DEFAULT_OAIPMH_CHANNEL;
   private String[] oaipmhProfiles = {};
+  private String oaipmhFlavor = DEFAULT_OAIPMH_FLAVOR;
   private String apiChannel = DEFAULT_API_CHANNEL;
   private String[] apiProfiles = {};
+  private String apiFlavor = DEFAULT_API_FLAVOR;
   private String previewVideoSubtype = DEFAULT_PREVIEW_VIDEO_SUBTYPE;
   private String previewAudioSubtype = DEFAULT_PREVIEW_AUDIO_SUBTYPE;
   private MediaPackageElementFlavor sourceTrackLeftFlavor = MediaPackageElementFlavor.parseFlavor(
@@ -131,10 +134,6 @@ public class AdminUIConfiguration implements ManagedService {
 
   public MediaPackageElementFlavor getSmilSilenceFlavor() {
     return smilSilenceFlavor;
-  }
-
-  public String getThumbnailPublishFlavor() {
-    return thumbnailPublishFlavor;
   }
 
   public String getThumbnailPreviewFlavor() {
@@ -181,12 +180,20 @@ public class AdminUIConfiguration implements ManagedService {
     return oaipmhProfiles;
   }
 
+  public String getOaipmhFlavor() {
+    return oaipmhFlavor;
+  }
+
   public String getApiChannel() {
     return apiChannel;
   }
 
   public String[] getApiProfiles() {
     return apiProfiles;
+  }
+
+  public String getApiFlavor() {
+    return apiFlavor;
   }
 
   public String getPreviewVideoSubtype() {
@@ -236,11 +243,6 @@ public class AdminUIConfiguration implements ManagedService {
     smilSilenceFlavor = MediaPackageElementFlavor.parseFlavor(
       StringUtils.defaultString((String) properties.get(OPT_SMIL_SILENCE_FLAVOR), DEFAULT_SMIL_SILENCE_FLAVOR));
     logger.debug("Smil silence flavor configuration set to '{}'", smilSilenceFlavor);
-
-    // Thumbnail publish flavor
-    thumbnailPublishFlavor = StringUtils.defaultString(
-      (String) properties.get(OPT_THUMBNAIL_PUBLISH_FLAVOR), DEFAULT_THUMBNAIL_PUBLISH_FLAVOR);
-    logger.debug("Thumbnail publish flavor set to '{}'", thumbnailPublishFlavor);
 
     // Thumbnail preview flavor
     thumbnailPreviewFlavor = StringUtils.defaultString(
@@ -297,6 +299,11 @@ public class AdminUIConfiguration implements ManagedService {
     oaipmhProfiles = oaipmhProfilesStr.trim().isEmpty() ? new String[] {} : oaipmhProfilesStr.split(",");
     logger.debug("OAI-PMH profiles set to '{}", Arrays.toString(oaipmhProfiles));
 
+    // OAI-PMH flavor
+    oaipmhFlavor = StringUtils.defaultString(
+      (String) properties.get(OPT_OAIPMH_FLAVOR), DEFAULT_OAIPMH_FLAVOR);
+    logger.debug("OAI-PMH flavor set to '{}'", oaipmhFlavor);
+
     // API channel
     apiChannel = StringUtils.defaultString(
       (String) properties.get(OPT_API_CHANNEL), DEFAULT_API_CHANNEL);
@@ -307,6 +314,11 @@ public class AdminUIConfiguration implements ManagedService {
       (String) properties.get(OPT_API_PROFILES), DEFAULT_API_PROFILES);
     apiProfiles = apiProfilesStr.trim().isEmpty() ? new String[] {} : apiProfilesStr.split(",");
     logger.debug("API profiles set to '{}", Arrays.toString(apiProfiles));
+
+    // API flavor
+    apiFlavor = StringUtils.defaultString(
+      (String) properties.get(OPT_API_FLAVOR), DEFAULT_API_FLAVOR);
+    logger.debug("API flavor set to '{}'", apiFlavor);
 
     // Preview Video subtype
     previewVideoSubtype = StringUtils.defaultString((String) properties.get(OPT_PREVIEW_VIDEO_SUBTYPE),

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -817,8 +817,8 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
    *
    * @param sourceImageXml
    *          The source image
-   * @param profileId
-   *          The profile to use in image conversion
+   * @param profileIds
+   *          The profiles to use in image conversion
    * @return A {@link Response} with the resulting image in the response body
    * @throws Exception
    */
@@ -830,10 +830,10 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
       @RestParameter(description = "The encoding profile to use", isRequired = true, name = "profileId", type = Type.STRING, defaultValue = "image-conversion.http") }, reponses = {
       @RestResponse(description = "Results in an xml document containing the image attachment", responseCode = HttpServletResponse.SC_OK),
       @RestResponse(description = "If required parameters aren't set or if sourceImage isn't from the type Attachment", responseCode = HttpServletResponse.SC_BAD_REQUEST) }, returnDescription = "")
-  public Response convertImageSync(@FormParam("sourceImage") String sourceImageXml, @FormParam("profileId") String profileId)
+  public Response convertImageSync(@FormParam("sourceImage") String sourceImageXml, @FormParam("profileIds") String profileIds)
       throws Exception {
     // Ensure that the POST parameters are present
-    if (StringUtils.isBlank(sourceImageXml) || StringUtils.isBlank(profileId))
+    if (StringUtils.isBlank(sourceImageXml) || StringUtils.isBlank(profileIds))
       return Response.status(Response.Status.BAD_REQUEST).entity("sourceImage and profileId must not be null").build();
 
     // Deserialize the source track
@@ -842,8 +842,8 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
       return Response.status(Response.Status.BAD_REQUEST).entity("sourceImage element must be of type track").build();
 
     try {
-      Attachment result = composerService.convertImageSync((Attachment) sourceImage, profileId);
-      return Response.ok().entity(MediaPackageElementParser.getAsXml(result)).build();
+      List<Attachment> result = composerService.convertImageSync((Attachment) sourceImage, StringUtils.split(profileIds, ','));
+      return Response.ok().entity(MediaPackageElementParser.getArrayAsXml(result)).build();
     } catch (EncoderException e) {
       logger.warn("Unable to convert image: " + e.getMessage());
       return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/ComposerService.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/ComposerService.java
@@ -248,20 +248,20 @@ public interface ComposerService {
 
 
   /**
-   * Synchronously converts the given image to a different image format using the specified image profile. Please note that
+   * Synchronously converts the given image to a different image format using the specified image profiles. Please note that
    * synchronously doing this means, that the workload cannot be distributed amongst all nodes.
    *
    * @param image
    *          the image
-   * @param profileId
-   *          the profile to use for conversion
-   * @return the converted image
+   * @param profileIds
+   *          the profiles to use for conversion
+   * @return the converted images
    * @throws EncoderException
    *           if image conversion fails
    * @throws MediaPackageException
    *           if the mediapackage is invalid
    */
-  Attachment convertImageSync(Attachment image, String profileId) throws EncoderException, MediaPackageException;
+  List<Attachment> convertImageSync(Attachment image, String... profileIds) throws EncoderException, MediaPackageException;
 
 
   /**

--- a/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
+++ b/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
@@ -365,12 +365,12 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
   }
 
   @Override
-  public Attachment convertImageSync(Attachment image, String profileId) throws EncoderException, MediaPackageException {
+  public List<Attachment> convertImageSync(Attachment image, String... profileIds) throws EncoderException, MediaPackageException {
     HttpPost post = new HttpPost("/convertimagesync");
     try {
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("sourceImage", MediaPackageElementParser.getAsXml(image)));
-      params.add(new BasicNameValuePair("profileId", profileId));
+      params.add(new BasicNameValuePair("profileIds", StringUtils.join(profileIds, ',')));
       post.setEntity(new UrlEncodedFormEntity(params));
     } catch (Exception e) {
       throw new EncoderException(e);
@@ -380,7 +380,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       response = getResponse(post);
       if (response != null) {
         final String xml = IOUtils.toString(response.getEntity().getContent(), Charset.forName("utf-8"));
-        return (Attachment) MediaPackageElementParser.getFromXml(xml);
+        return MediaPackageElementParser.getArrayFromXml(xml).stream().map(a -> (Attachment) a).collect(Collectors.toList());
       }
     } catch (Exception e) {
       throw new EncoderException(e);


### PR DESCRIPTION
This PR consists of two commits. The first one adds the possibility to specify multiple encoding profiles to generate thumbnails in different qualities.

The second commit adds configuration options for the flavors to use when publishing to OAI-PMH and external API.

This work is sponsored by SWITCH.