### PR TITLE
MH-12727, Augument the suspendWaiterJob catch with RollbackException

### DIFF
--- a/modules/matterhorn-common/src/main/java/org/opencastproject/job/api/JobBarrier.java
+++ b/modules/matterhorn-common/src/main/java/org/opencastproject/job/api/JobBarrier.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.persistence.OptimisticLockException;
+import javax.persistence.RollbackException;
 
 /**
  * This class is a utility implementation that will wait for all given jobs to change their status to either one of:
@@ -159,7 +160,9 @@ public final class JobBarrier {
             if (setBlockerJob(j, waiter)) {
               blockedForJobs.add(j.getId());
             }
-          } catch (OptimisticLockException e) {
+          } catch (OptimisticLockException | RollbackException e) {
+            // Catch javax.persistence.RollbackException: javax.persistence.OptimisticLockException
+            // from tx.commit()
             // Try again, this happens if the job finishes before we get here
             // If the same exception happens again then we're in a very weird state
             if (setBlockerJob(j, waiter)) {


### PR DESCRIPTION
The suspendWaiterJob currently has an OptimisticLock catch for the job complete race condition described in MH-12727. The RollbackException appears to be wrapping the OptimisticLockException  in cases at our site. This pull is to include the RollbackException to the existing catch to cover that case. 

This was logged moments after the inspect job had completed, implying that the OptimisticLockException was not caught because it was wrapped in the RollbackException (from a tx.commit())
``
JobBarrier.suspendWaiterJob - Unable to put Some(240757) into a waiting state, this may cause a deadlock: javax.persistence.RollbackException: javax.persistence.OptimisticLockException: Exception [EclipseLink-5006] (Eclipse Persistence Services - 2.6.4.v20160829-44060b6): org.eclipse.persistence.exceptions.OptimisticLockException#012Exception Description: The object [Job {id:240759, operation:Inspect, status:QUEUED}] cannot be updated because it has changed or been deleted since it was last read. #012Class> org.opencastproject.job.jpa.JpaJob Primary Key
``