### PR TITLE
MH-13132, Fix REST Docs Overview Rendering

### DIFF
--- a/modules/runtime-info-ui-ng/src/main/resources/ui/rest_docs.css
+++ b/modules/runtime-info-ui-ng/src/main/resources/ui/rest_docs.css
@@ -13,7 +13,7 @@ h1 {
   background-color: #2075b1;
   margin: 0px;
   padding: 15px;
-  font-size: larger;
+  font-size: 16px;
   color: white;
 }
 
@@ -44,7 +44,7 @@ li {
 }
 
 ul {
-  font-size: smaller;
+  font-size: 12px;
   color: #333;
   padding: 20px 0;
 }
@@ -59,8 +59,14 @@ a:hover {
   color: gray;
 }
 
-li a span {
+li .path {
   display: inline-block;
   width: 200px;
-    font-family: monospace;
+  font-family: monospace;
+}
+
+li .desc {
+  display: inline-block;
+  min-width: 200px;
+  padding-left: 20px;
 }

--- a/modules/runtime-info-ui-ng/src/main/resources/ui/rest_docs.html
+++ b/modules/runtime-info-ui-ng/src/main/resources/ui/rest_docs.html
@@ -4,6 +4,7 @@
 <html lang=en>
 <head>
 <meta http-equiv=content-type content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="shortcut icon" href="img/favicon.ico" />
 <title>Opencast REST Service Documentation</title>
 
@@ -28,6 +29,10 @@
 </nav>
 
 <ul class=center id=docs> </ul>
+
+<script id=template type=x-tmpl>
+  <li><a><span class=path></span><span class=desc></span></a></li>
+</script>
 
 </body>
 </html>

--- a/modules/runtime-info-ui-ng/src/main/resources/ui/rest_docs.js
+++ b/modules/runtime-info-ui-ng/src/main/resources/ui/rest_docs.js
@@ -33,13 +33,18 @@ $(document).ready(function($) {
   $('input').keyup(search);
 
   $.getJSON('/info/components.json', function(data) {
+    var docs = $('#docs'),
+        tpl = $('#template').html();
     $.each(data, function(section) {
       if ('rest' == section) {
         data.rest.sort((a,b) => a.path > b.path ? 1 : -1);
         $.each(data.rest, function(i) {
-          $('#docs').append('<li><a href="/docs.html?path=' + data.rest[i].path + '">'
-              + '<span>' + data.rest[i].path + '</span>'
-              + data.rest[i].description + '</a></li>');
+          let path = data.rest[i].path,
+              service = $(tpl);
+          $('a', service).attr('href', '/docs.html?path=' + path);
+          $('.path', service).text(path);
+          $('.desc', service).text(data.rest[i].description);
+          docs.append(service);
         });
         return;
       }


### PR DESCRIPTION
The REST documentation overview page interprets special HTML characters
and syntax and does not render correctly on mobile devices.

This patch ensures loaded strings are rendered as Text and the UI is
displayed properly on mobile devices.