### PR TITLE
MH-13134, Concurrency issue when loading admin interface statistics

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/statsService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/statsService.js
@@ -42,10 +42,11 @@ angular.module('adminNg.services')
       };
 
       /**
-         * Retrieve data from the defined API with the given filter values.
-         */
+       * Retrieve data from the defined API with the given filter values.
+       */
       this.fetch = function () {
         if (angular.isUndefined(me.apiService)) {
+          me.refreshScheduler.restartSchedule();
           return;
         }
 
@@ -76,9 +77,9 @@ angular.module('adminNg.services')
           }
 
           /* Workaround:
-                 * We don't want actual data here, but limit 0 does not work (retrieves all data)
-                 * See MH-11892 Implement event counters efficiently
-                 */
+           * We don't want actual data here, but limit 0 does not work (retrieves all data)
+           * See MH-11892 Implement event counters efficiently
+           */
           query.limit = 1;
           me.runningQueries++;
 
@@ -97,8 +98,8 @@ angular.module('adminNg.services')
       };
 
       /**
-         * Scheduler for the refresh of the fetch
-         */
+       * Scheduler for the refresh of the fetch
+       */
       this.refreshScheduler = {
         on: true,
         restartSchedule: function () {


### PR DESCRIPTION
Opencast 6 makes the statistics counter in the admin interface
configurable. This can cause problems when the configuration is not yet
fully applied the first time, the counters are loaded as the refresh
interval is then never set and the counter values fail to load.

This patch simply adds the usual refresh if the configuration is not yet
properly set, ensuring that the values are loaded eventually.