### PR TITLE
MH-13137, Less extensive statistics configuration

### DIFF
--- a/etc/listproviders/adminui.stats.properties
+++ b/etc/listproviders/adminui.stats.properties
@@ -1,21 +1,59 @@
 list.name=STATS
 
+###
 # statistics by start date of event
-YESTERDAY=\
-  {"filters": [{"name": "startDate", "filter":"FILTERS.EVENTS.START_DATE", \
-                "value": {"relativeDateSpan": {"from": "-1", "to": "-1", "unit": "day"}}}],\
-   "description": "DATES.YESTERDAY",\
-   "order":0}
+##
+
 TODAY=\
   {"filters": [{"name": "startDate", "filter":"FILTERS.EVENTS.START_DATE", \
                 "value": {"relativeDateSpan": {"from": "0", "to": "0", "unit": "day"}}}],\
    "description": "DATES.TODAY",\
    "order":1}
-TOMORROW=\
-  {"filters": [{"name": "startDate", "filter":"FILTERS.EVENTS.START_DATE", \
-                "value": {"relativeDateSpan": {"from": "1", "to": "1", "unit": "day"}}}],\
-  "description": "DATES.TOMORROW",\
-  "order":2}
+
+###
+# statistics by event state
+##
+
+SCHEDULED=\
+  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.SCHEDULED"}], \
+  "description": "DASHBOARD.SCHEDULED",\
+  "order":6}
+RECORDING=\
+  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.RECORDING"}],\
+  "description": "DASHBOARD.RECORDING",\
+  "order":7}
+RUNNING=\
+  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSING"}],\
+  "description": "DASHBOARD.RUNNING",\
+  "order":8}
+FAILED=\
+  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSING_FAILURE"}],\
+  "description": "DASHBOARD.FAILED",\
+  "order":10}
+FINISHED_WITH_COMMENTS=\
+  {"filters": [{"name": "comments", "filter": "FILTERS.EVENTS.COMMENTS.LABEL", "value": "OPEN"},\
+               {"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSED"}],\
+  "description": "DASHBOARD.FINISHED_WITH_COMMENTS",\
+  "order":11}
+FINISHED=\
+  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSED"}],\
+  "description": "DASHBOARD.FINISHED",\
+  "order":12}
+
+###
+# examples for more helpful statistic configurations
+##
+
+#YESTERDAY=\
+#  {"filters": [{"name": "startDate", "filter":"FILTERS.EVENTS.START_DATE", \
+#                "value": {"relativeDateSpan": {"from": "-1", "to": "-1", "unit": "day"}}}],\
+#   "description": "DATES.YESTERDAY",\
+#   "order":0}
+#TOMORROW=\
+#  {"filters": [{"name": "startDate", "filter":"FILTERS.EVENTS.START_DATE", \
+#                "value": {"relativeDateSpan": {"from": "1", "to": "1", "unit": "day"}}}],\
+#  "description": "DATES.TOMORROW",\
+#  "order":2}
 #THIS_WEEK=\
 #  {"filters": [{"name": "startDate", "filter":"FILTERS.EVENTS.START_DATE", \
 #                "value": {"relativeDateSpan": {"from": "0", "to": "0", "unit": "week"}}}],\
@@ -31,35 +69,7 @@ TOMORROW=\
 #                "value": {"relativeDateSpan": {"from": "0", "to": "0", "unit": "year"}}}],\
 #  "description": "DATES.THIS_YEAR",\
 #  "order":5}
-
-# statistics by event state
-SCHEDULED=\
-  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.SCHEDULED"}], \
-  "description": "DASHBOARD.SCHEDULED",\
-  "order":6}
-RECORDING=\
-  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.RECORDING"}],\
-  "description": "DASHBOARD.RECORDING",\
-  "order":7}
-RUNNING=\
-  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSING"}],\
-  "description": "DASHBOARD.RUNNING",\
-  "order":8}
-PAUSED=\
-  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PAUSED"}],\
-  "description": "DASHBOARD.PAUSED",\
-  "order":9}
-FAILED=\
-  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSING_FAILURE"}],\
-  "description": "DASHBOARD.FAILED",\
-  "order":10}
-FINISHED_WITH_COMMENTS=\
-  {"filters": [{"name": "comments", "filter": "FILTERS.EVENTS.COMMENTS.LABEL", "value": "OPEN"},\
-               {"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSED"}],\
-  "description": "DASHBOARD.FINISHED_WITH_COMMENTS",\
-  "order":11}
-FINISHED=\
-  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PROCESSED"}],\
-  "description": "DASHBOARD.FINISHED",\
-  "order":12}
-
+#PAUSED=\
+#  {"filters": [{"name": "status", "filter": "FILTERS.EVENTS.STATUS.LABEL", "value": "EVENTS.EVENTS.STATUS.PAUSED"}],\
+#  "description": "DASHBOARD.PAUSED",\
+#  "order":9}


### PR DESCRIPTION
With Opencast 6, the statistic counter in the administrative user
interface are now configurable, making it undesirable to ship less
widely used featured (e.g. paused workflows) by default since
configuring a high amount of counters can have undesired side-effects
like visual overlapping of counters and tabs.

This patch reduces the amount of default configurations to those often
used but still includes a set of pre-defined examples to make it easy
for users to add more if necessary.