### PR TITLE
MH-13138, Fix media module language configuration

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -93,43 +93,23 @@ function($, bootbox, _, alertify) {
             var lang = language.substring(0, language.indexOf("-"));
 	    if (!lang || lang.length <= 0) lang = language;
 
-            switch (lang) {
-                case "en":
-                    return "en-US";
-                case "de":
-                    return "de-DE";
-                case "es":
-                    return "es-ES";
-                case "fr":
-                    return "fr-FR";
-                case "gl":
-                    return "gl-ES";
-                case "nl":
-                    return "nl-NL";
-                case "fi":
-                    return "fi-FI";
-                case "it":
-                    return "it-IT";
-                case "ja":
-                    return "ja-JA";
-                case "tlh":
-                    return "tlh-AA";
-                case "no":
-                    return "no-NO";
-                case "pt":
-                    return "pt-BR";
-                case "ru":
-                    return "ru-RU";
-                case "sv":
-                    return "sv-SE";
-                case "tr":
-                    return "tr-TR";
-                case "zh":
-                    return "zh-CN";
-                case "el":
-                    return "el-GR";
-                default:
-                    return null;
+          switch (lang) {
+              case "de": return "de-DE";
+              case "el": return "el-GR";
+              case "en": return "en-US";
+              case "es": return "es-ES";
+              case "fil": return "fil-PH";
+              case "fr": return "fr-FR";
+              case "gl": return "gl-ES";
+              case "he": return "he-IL";
+              case "nl": return "nl-NL";
+              case "pl": return "pl-PL";
+              case "sl": return "sl-SI";
+              case "sv": return "sv-SE";
+              case "tl": return "tl-PH";
+              case "tr": return "tr-TR";
+              case "zh": return "zh-CN";
+              default: return null;
             }
         }
 


### PR DESCRIPTION
The media module translation file selection work similar to the players
by having a fixed mapping encoded:

  https://github.com/opencast/opencast/blob/r/5.x/modules/engage-theodul-core/src/main/resources/ui/js/engage/core.js#L169

This mapping was never updated for 5.x.