### PR TITLE
MH-12819: change extract-text encoding profile for better OCR results…

### DIFF
--- a/etc/encoding/opencast-images.properties
+++ b/etc/encoding/opencast-images.properties
@@ -34,7 +34,7 @@ profile.text-analysis.http.input = visual
 profile.text-analysis.http.output = image
 profile.text-analysis.http.suffix = .#{time}.png
 profile.text-analysis.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
-  -filter:v boxblur=1:1,curves=all=0.4/0#{space}0.6/1 \
+  -filter:v curves=preset=increase_contrast \
   -frames:v 1 -pix_fmt:v gray -r 1 #{out.dir}/#{out.name}#{out.suffix}
 
 


### PR DESCRIPTION
… when using digital documents.

The extract-text encoding profile was originally used for grainy slides/document cameras (see https://groups.google.com/a/opencast.org/forum/#!searchin/users/mh-12819|sort:date/users/xAcxeUFAhSM/0c71zxXRCQAJ). As such, the encoding profile produces miserable results for PDFs, powerpoint slides and the like when those video streams are sourced via HDMI.

This PR proposes a different encoding profile for OCR images which produces better results for digital documents.