### PR TITLE
MH-13142, Error parsing non-existent schedule

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventSchedulingResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventSchedulingResource.js
@@ -22,7 +22,13 @@
 
 angular.module('adminNg.resources')
 .factory('EventSchedulingResource', ['$resource', 'JsHelper', function ($resource, JsHelper) {
-  var transformResponse = function (data) {
+  var transformResponse = function (data, headers, status) {
+
+        // an event may have no schedule
+        if (status == 404) {
+          return;
+        }
+
         var parsedData,
             startDate,
             endDate,


### PR DESCRIPTION
In some situations (e.g. opening the event details), the admin interface
tries to load and parse scheduling information, even if none exist,
causing the JSON parser to throw an exception since the endpoint does
not return JSON.

This patch stops the data handling if the response code indicates that
there are no information.