### PR TITLE
MH-13141 Correctly initialize stats service

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -142,10 +142,5 @@ angular.module('adminNg.controllers')
         }
       });
     };
-
-    $scope.$on('$destroy', function() {
-      // stop polling event stats on an inactive tab
-      $scope.stats.refreshScheduler.cancel();
-    });
   }
 ]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/statsDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/statsDirective.js
@@ -58,7 +58,6 @@ angular.module('adminNg.directives')
         stats: '='
       },
       link: function (scope) {
-        scope.stats.fetch();
         scope.statsFilterNumber = -1;
 
         scope.showStatsFilter = function (index) {
@@ -107,6 +106,10 @@ angular.module('adminNg.directives')
           event.preventDefault();
           Storage.remove('filter');
           scope.statsFilterNumber = -1;
+        });
+        
+        scope.$on('$destroy', function() {
+          scope.stats.refreshScheduler.cancel();
         });
       }
     };

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/statsDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/statsDirective.js
@@ -107,7 +107,7 @@ angular.module('adminNg.directives')
           Storage.remove('filter');
           scope.statsFilterNumber = -1;
         });
-        
+
         scope.$on('$destroy', function() {
           scope.stats.refreshScheduler.cancel();
         });

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/statsService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/statsService.js
@@ -28,7 +28,6 @@ angular.module('adminNg.services')
           DEFAULT_REFRESH_DELAY = 5000;
 
       this.stats = [];
-      this.loading = true;
 
       this.configure = function (options) {
         me.resource = options.resource;
@@ -49,7 +48,6 @@ angular.module('adminNg.services')
           return;
         }
 
-        me.loading = true;
         me.runningQueries = 0;
 
         angular.forEach(me.stats, function (stat) {
@@ -83,7 +81,6 @@ angular.module('adminNg.services')
           me.runningQueries++;
 
           me.apiService.query(query).$promise.then(function (data) {
-            me.loading = false;
             stat.counter = data.total;
             stat.index = me.stats.indexOf(stat);
 
@@ -116,13 +113,6 @@ angular.module('adminNg.services')
           }
         }
       };
-
-      // Reload the stats if the language is changed
-      $rootScope.$on('language-changed', function () {
-        if (!me.loading) {
-          me.fetch();
-        }
-      });
 
     };
     return new StatsService();

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/statsService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/statsService.js
@@ -38,16 +38,13 @@ angular.module('adminNg.services')
         me.stats.sort(function(a, b) {
           return a.order - b.order;
         });
+        me.fetch();
       };
 
       /**
-         * Retrieve data from the defined API with the given filter values.
-         */
+        * Retrieve data from the defined API with the given filter values.
+        */
       this.fetch = function () {
-        if (angular.isUndefined(me.apiService)) {
-          return;
-        }
-
         me.runningQueries = 0;
 
         angular.forEach(me.stats, function (stat) {
@@ -74,9 +71,9 @@ angular.module('adminNg.services')
           }
 
           /* Workaround:
-                 * We don't want actual data here, but limit 0 does not work (retrieves all data)
-                 * See MH-11892 Implement event counters efficiently
-                 */
+           * We don't want actual data here, but limit 0 does not work (retrieves all data)
+           * See MH-11892 Implement event counters efficiently
+           */
           query.limit = 1;
           me.runningQueries++;
 
@@ -94,8 +91,8 @@ angular.module('adminNg.services')
       };
 
       /**
-         * Scheduler for the refresh of the fetch
-         */
+        * Scheduler for the refresh of the fetch
+        */
       this.refreshScheduler = {
         on: true,
         restartSchedule: function () {


### PR DESCRIPTION
Steps to reproduce: 
1. Open the Admin UI in your browser 
2. Maybe reload the page (forcing full reload to prevent caching) 
  
Actual Results: 
Sometimes, the Admin UI Counters on the Events page don't work. 
  
Expected Results: 
The counters should work correctly 
  
Workaround (if any): 
Reload page until it works 

Analysis: 
The problem is the result of incorrect component initialization: The statsService is configured asynchronously which causes it to be used before it has been initialised. 