### PR TITLE
MH-13149, Timed tiered storage test fails on fast systems

### DIFF
--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/TieredStorageAssetManagerJobProducerTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/TieredStorageAssetManagerJobProducerTest.java
@@ -156,10 +156,13 @@ public class TieredStorageAssetManagerJobProducerTest extends AbstractTieredStor
   }
 
   @Test
-  public void testInternalByDate() throws NotFoundException, ServiceRegistryException {
+  public void testInternalByDate() throws ServiceRegistryException, InterruptedException {
     Date start = new Date();
+    Thread.sleep(1);
     Date before = new Date();
+    Thread.sleep(1);
     String[] mp = createAndAddMediaPackagesSimple(2, 2, 2, Opt.<String>none());
+    Thread.sleep(1);
     Date after = new Date();
     //Non terminal query, but internal test so we create terminal expectations
     createIdAndVersionExpectation(mp[0], 0, 2);


### PR DESCRIPTION
The asset manager tests are testing that certain snapshots are created
within a certain timespan. This may fail on faster systems since it is
not guaranteed that the measured times are not equal.

For example, if the first snapshot gets the same time as the measurement
right before it, the request for snapshots until that date returns a
snapshot while none is expected. That causes the test to fail.

This regularly happened on one of my development set-ups.

This patch ensures the times are not equal by enforcing a millisecond
(the granularity of Date) sleep between the measured operations.