### PR TITLE
MH-13152, Reduce Workflow Messages

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1397,8 +1397,15 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
       // Update both workflow and workflow job
       try {
         job = serviceRegistry.updateJob(job);
-        messageSender.sendObjectMessage(WorkflowItem.WORKFLOW_QUEUE, MessageSender.DestinationType.Queue,
-                WorkflowItem.updateInstance(workflowInstance));
+
+        WorkflowOperationInstance op = workflowInstance.getCurrentOperation();
+
+        // Update index used for UI. Note that we only need certain metadata and we can safely filter out workflow
+        // updates for running operations since we updated the metadata right before these operations and will do so
+        // again right after those operations.
+        if (op == null || op.getState() != OperationState.RUNNING) {
+          messageSender.sendObjectMessage(WorkflowItem.WORKFLOW_QUEUE, MessageSender.DestinationType.Queue, WorkflowItem.updateInstance(workflowInstance));
+        }
         index(workflowInstance);
       } catch (ServiceRegistryException e) {
         logger.error(


### PR DESCRIPTION
The high amount of messages sent while workflows are processed can
easily cause performance issues and reduce parallel throughput.

Workflow messages contain metadata about the event and they are used to
update information in Opencast's administrative user interface and in
the external API. These information may change within workflow
operations and need to be updated after each operation as well as on
general workflow state changes (e.g. starting a workflow).

Updates are unnecessary, however, when new operations are launched since
they have been updated right before that operation already and noting
has changed since. Not sending those messages will cut the total amount
of workflow messages almost in half.