### PR TITLE
MH-13110: Fix display of metadata in event creation summary

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/filters/localizeDateFilter.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/filters/localizeDateFilter.js
@@ -30,6 +30,8 @@ angular.module('adminNg.filters')
     switch (type) {
     case 'date':
       return Language.formatDate(format, input);
+    case 'dateRaw':
+      return Language.formatDateRaw(format, input);
     case 'dateTime':
       return Language.formatDateTime(format, input);
     case 'time':

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -673,7 +673,7 @@
             <!-- Start date upload -->
             <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].metadata.start">
               <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_DATE"><!-- Start Date --></td>
-              <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].metadata.start.value | localizeDate:'dateTime' }}</td>
+              <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].metadata.start.value | localizeDate:'dateRaw' }}</td>
             </tr>
 
             <!-- Start date schedule -->

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -679,16 +679,17 @@
             <!-- Start date schedule -->
             <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.date">
               <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_DATE"><!-- Start Date --></td>
-              <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.date | localizeDate:'date' }}</td>
+              <td>{{ wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.date | localizeDate:'dateRaw' }}</td>
             </tr>
 
             <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].start.hour !== undefined">
               <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.START_TIME"><!-- Start Time --></td>
               <td>{{ wizard.getStateControllerByName('source').getFormattedStartTime() | localizeDate:'time' }}</td>
             </tr>
-            <tr ng-if="(wizard.step.ud.type === 'SCHEDULE_MULTIPLE') && wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].end.date">
+            <tr ng-if="(wizard.getStateControllerByName('source').getUserEntries().type === 'SCHEDULE_MULTIPLE')
+                && wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].end.date">
               <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_DATE"><!-- End Date --></td>
-              <td>{{ wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.end.date | localizeDate:'date' }}</td>
+              <td>{{ wizard.getStateControllerByName('source').getUserEntries().SCHEDULE_MULTIPLE.end.date | localizeDate:'dateRaw' }}</td>
             </tr>
             <tr ng-if="wizard.getStateControllerByName('source').getUserEntries()[wizard.getStateControllerByName('source').getUserEntries().type].end.hour !== undefined">
               <td translate="EVENTS.EVENTS.NEW.SOURCE.DATE_TIME.END_TIME"><!-- End Time --></td>
@@ -723,7 +724,7 @@
         <table class="main-tbl">
           <tr>
             <td translate="EVENTS.EVENTS.NEW.PROCESSING.WORKFLOW"><!-- Workflow --></td>
-            <td>{{ wizard.getStateControllerByName('processing').getUserEntries().selection.id }}</td>
+            <td>{{ wizard.getStateControllerByName('processing').getUserEntries().title }}</td>
           </tr>
           <tr ng-repeat="(key, value) in wizard.getStateControllerByName('processing').getUserEntries().selection.configuration">
             <td>{{ key }}</td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
@@ -97,7 +97,16 @@ angular.module('adminNg.services')
 
           params.presentableValue = presentableValue;
         } else {
-          params.presentableValue = params.collection[value];
+          if (params.collection.hasOwnProperty(value)) {
+            params.presentableValue = params.collection[value];
+          } else {
+            // this should work in older browsers, albeit looking clumsy
+            var matchingKey = Object.keys(params.collection)
+              .filter(function(key) {return params.collection[key] === value;})[0];
+            params.presentableValue = params.type === 'ordered_text'
+              ? JSON.parse(matchingKey)['label']
+              : matchingKey;
+          }
         }
       } else {
         params.presentableValue = value;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
@@ -47,14 +47,20 @@ angular.module('adminNg.services')
       me.ud[mainMetadataName] = mainData;
       if (mainData && mainData.fields) {
         for (i = 0; i < mainData.fields.length; i++) {
+          var field = mainData.fields[i];
+          // preserve default value, if set
+          if (field.hasOwnProperty('value') && field.value) {
+            field.presentableValue = me.extractPresentableValue(field);
+            me.ud[mainMetadataName].fields[field.id] = field;
+          }
           // just hooking the tab index up here, as this is already running through all elements
-          mainData.fields[i].tabindex = i + 1;
-          if (mainData.fields[i].required) {
-            me.updateRequiredMetadata(mainData.fields[i].id, mainData.fields[i].value);
-            if (mainData.fields[i].type === 'boolean') {
+          field.tabindex = i + 1;
+          if (field.required) {
+            me.updateRequiredMetadata(field.id, field.value);
+            if (field.type === 'boolean') {
               // set all boolean fields to false by default
-              mainData.fields[i].value = false;
-              me.requiredMetadata[mainData.fields[i].id] = true;
+              field.value = false;
+              me.requiredMetadata[field.id] = true;
             }
           }
         }
@@ -77,6 +83,36 @@ angular.module('adminNg.services')
       return result;
     };
 
+    this.extractPresentableValue = function (field) {
+      var actualValue = field.value;
+      var presentableValue = '';
+      if (field.collection) {
+        if (angular.isArray(actualValue)) {
+          angular.forEach(actualValue, function (item, index) {
+            presentableValue += item;
+            if ((index + 1) < actualValue.length) {
+              presentableValue += ', ';
+            }
+          });
+          field.presentableValue = presentableValue;
+        } else {
+          if (field.collection.hasOwnProperty(actualValue)) {
+            presentableValue = field.collection[actualValue];
+          } else {
+            // this should work in older browsers, albeit looking clumsy
+            var matchingKey = Object.keys(field.collection)
+              .filter(function(key) {return field.collection[key] === actualValue;})[0];
+            presentableValue = field.type === 'ordered_text'
+              ? JSON.parse(matchingKey)['label']
+              : matchingKey;
+          }
+        }
+      } else {
+        presentableValue = actualValue;
+      }
+      return presentableValue;
+    };
+
     this.save = function (scope) {
       //FIXME: This should be nicer, rather propagate the id and values
       //instead of looking for them in the parent scope.
@@ -84,33 +120,7 @@ angular.module('adminNg.services')
           fieldId = params.id,
           value = params.value;
 
-      if (params.collection) {
-        if (angular.isArray(value)) {
-          var presentableValue = '';
-
-          angular.forEach(value, function (item, index) {
-            presentableValue += item;
-            if ((index + 1) < value.length) {
-              presentableValue += ', ';
-            }
-          });
-
-          params.presentableValue = presentableValue;
-        } else {
-          if (params.collection.hasOwnProperty(value)) {
-            params.presentableValue = params.collection[value];
-          } else {
-            // this should work in older browsers, albeit looking clumsy
-            var matchingKey = Object.keys(params.collection)
-              .filter(function(key) {return params.collection[key] === value;})[0];
-            params.presentableValue = params.type === 'ordered_text'
-              ? JSON.parse(matchingKey)['label']
-              : matchingKey;
-          }
-        }
-      } else {
-        params.presentableValue = value;
-      }
+      params.presentableValue = me.extractPresentableValue(params);
 
       me.ud[mainMetadataName].fields[fieldId] = params;
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -31,7 +31,7 @@ angular.module('adminNg.services')
     var NOTIFICATION_CONTEXT = 'events-form';
     var SCHEDULE_SINGLE = 'SCHEDULE_SINGLE';
     var SCHEDULE_MULTIPLE = 'SCHEDULE_MULTIPLE';
-    var WEEKDAY_PREFIX = 'EVENTS.EVENTS.NEW.WEEKDAYS.';
+    var WEEKDAY_PREFIX = 'EVENTS.EVENTS.NEW.WEEKDAYSLONG.';
     var UPLOAD = 'UPLOAD';
 
     var WEEKDAYS = {
@@ -153,7 +153,7 @@ angular.module('adminNg.services')
       };
 
       this.sortedWeekdays = _.map(self.weekdays, function(day, index) {
-        return { key: index, translation: day };
+        return { key: index, translation: day.replace('LONG', '') };
       });
 
       this.hours = JsHelper.initArray(24);
@@ -383,7 +383,7 @@ angular.module('adminNg.services')
             translatedWeekdays.push(t);
           });
 
-          self.ud[SCHEDULE_MULTIPLE].presentableWeekdays = translatedWeekdays.join(',');
+          self.ud[SCHEDULE_MULTIPLE].presentableWeekdays = translatedWeekdays.join(', ');
         });
       };
 


### PR DESCRIPTION
This will ensure that the summary page of the 'new-event' wizard displays all fields that have an assigned value, also handling cases where a data object key might be of the type 'ordered_text' or desired object values are passed as object keys.

Resolves: [MH-13110](https://opencast.jira.com/browse/MH-13110)