### PR TITLE
MH-13111: Fix display of metadata in series creation summary

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-series.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-series.html
@@ -213,7 +213,7 @@
           <table class="main-tbl">
             <tr ng-repeat="userEntry in wizard.states[0].stateController.getUserEntries()" ng-if="userEntry.presentableValue">
               <td>{{ userEntry.label | translate }}</td>
-              <td>{{ userEntry.presentableValue }}</td>
+              <td>{{ userEntry.presentableValue | translate }}</td>
               <tr>
           </table>
         </div>
@@ -263,13 +263,16 @@
         </div>
       </div>
 
-      <div class="obj tbl-list" ng-if="wizard.getStateControllerByName('theme').ud.theme && wizard.getStateControllerByName('theme').ud.theme !== ''">
+      <div class="obj tbl-list" ng-if="wizard.getStateControllerByName('theme').ud.theme 
+          && wizard.getStateControllerByName('theme').themes.hasOwnProperty(wizard.getStateControllerByName('theme').ud.theme)">
         <header class="no-expand" translate="EVENTS.SERIES.NEW.THEME.CAPTION"><!-- Caption --></header>
         <div class="obj-container">
           <table class="main-tbl">
             <tr>
               <td translate="EVENTS.SERIES.NEW.THEME.CAPTION"><!-- Caption --></td>
-              <td ng-if="wizard.getStateControllerByName('theme').ud.theme && wizard.getStateControllerByName('theme').themes[wizard.getStateControllerByName('theme').ud.theme]">{{wizard.getStateControllerByName('theme').themes[wizard.getStateControllerByName('theme').ud.theme].name}}</td>
+              <td ng-if="wizard.getStateControllerByName('theme').ud.theme && wizard.getStateControllerByName('theme').themes[wizard.getStateControllerByName('theme').ud.theme]">
+                {{wizard.getStateControllerByName('theme').themes[wizard.getStateControllerByName('theme').ud.theme].name}}
+              </td>
 
             </tr>
           </table>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
@@ -44,14 +44,20 @@ angular.module('adminNg.services')
       me.ud[mainMetadataName] = mainData;
       if (mainData && mainData.fields) {
         for (i = 0; i < mainData.fields.length; i++) {
+          var field = mainData.fields[i];
+          // preserve default value, if set
+          if (field.hasOwnProperty('value') && field.value) {
+            field.presentableValue = me.extractPresentableValue(field);
+            me.ud[mainMetadataName].fields[field.id] = field;
+          }
           // just hooking the tab index up here, as this is already running through all elements
-          mainData.fields[i].tabindex = i + 1;
-          if (mainData.fields[i].required) {
-            me.updateRequiredMetadata(mainData.fields[i].id, mainData.fields[i].value);
-            if (mainData.fields[i].type === 'boolean') {
+          field.tabindex = i + 1;
+          if (field.required) {
+            me.updateRequiredMetadata(field.id, field.value);
+            if (field.type === 'boolean') {
               // set all boolean fields to false by default
-              mainData.fields[i].value = false;
-              me.requiredMetadata[mainData.fields[i].id] = true;
+              field.value = false;
+              me.requiredMetadata[field.id] = true;
             }
           }
         }
@@ -72,6 +78,36 @@ angular.module('adminNg.services')
       return result;
     };
 
+    this.extractPresentableValue = function (field) {
+      var actualValue = field.value;
+      var presentableValue = '';
+      if (field.collection) {
+        if (angular.isArray(actualValue)) {
+          angular.forEach(actualValue, function (item, index) {
+            presentableValue += item;
+            if ((index + 1) < actualValue.length) {
+              presentableValue += ', ';
+            }
+          });
+          field.presentableValue = presentableValue;
+        } else {
+          if (field.collection.hasOwnProperty(actualValue)) {
+            presentableValue = field.collection[actualValue];
+          } else {
+            // this should work in older browsers, albeit looking clumsy
+            var matchingKey = Object.keys(field.collection)
+              .filter(function(key) {return field.collection[key] === actualValue;})[0];
+            presentableValue = field.type === 'ordered_text'
+              ? JSON.parse(matchingKey)['label']
+              : matchingKey;
+          }
+        }
+      } else {
+        presentableValue = actualValue;
+      }
+      return presentableValue;
+    };
+
     this.save = function (scope) {
       //FIXME: This should be nicer, rather propagate the id and values
       //instead of looking for them in the parent scope.
@@ -79,33 +115,7 @@ angular.module('adminNg.services')
           fieldId = params.id,
           value = params.value;
 
-      if (params.collection) {
-        if (angular.isArray(value)) {
-          var presentableValue = '';
-
-          angular.forEach(value, function (item, index) {
-            presentableValue += item;
-            if ((index + 1) < value.length) {
-              presentableValue += ', ';
-            }
-          });
-
-          params.presentableValue = presentableValue;
-        } else {
-          if (params.collection.hasOwnProperty(value)) {
-            params.presentableValue = params.collection[value];
-          } else {
-            // this should work in older browsers, albeit looking clumsy
-            var matchingKey = Object.keys(params.collection)
-              .filter(function(key) {return params.collection[key] === value;})[0];
-            params.presentableValue = params.type === 'ordered_text'
-              ? JSON.parse(matchingKey)['label']
-              : matchingKey;
-          }
-        }
-      } else {
-        params.presentableValue = value;
-      }
+      params.presentableValue = me.extractPresentableValue(params);
 
       me.ud[mainMetadataName].fields[fieldId] = params;
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
@@ -92,7 +92,16 @@ angular.module('adminNg.services')
 
           params.presentableValue = presentableValue;
         } else {
-          params.presentableValue = params.collection[value];
+          if (params.collection.hasOwnProperty(value)) {
+            params.presentableValue = params.collection[value];
+          } else {
+            // this should work in older browsers, albeit looking clumsy
+            var matchingKey = Object.keys(params.collection)
+              .filter(function(key) {return params.collection[key] === value;})[0];
+            params.presentableValue = params.type === 'ordered_text'
+              ? JSON.parse(matchingKey)['label']
+              : matchingKey;
+          }
         }
       } else {
         params.presentableValue = value;


### PR DESCRIPTION
This will ensure that the summary page of the 'new-series' wizard displays all fields that have an assigned value, also handling cases where a data object key might be of the type 'ordered_text' or desired object values are passed as object keys.

Resolves: [MH-13111](https://opencast.jira.com/browse/MH-13111)