### PR TITLE
MH-13159: Fix mattermost notification operation issues

### DIFF
--- a/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
+++ b/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
@@ -101,8 +101,6 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
    */
   public static final String PUT = "put";
 
-
-
   /**
    * The logging facility
    */
@@ -127,6 +125,11 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
    * The scale factor to the sleep time between two notification attempts
    */
   public static final int SLEEP_SCALE_FACTOR = 2;
+
+  /**
+   * Gson instance for JSON serialization.
+   */
+  private static Gson gson = new GsonBuilder().create();
 
   /**
    * {@inheritDoc}
@@ -215,8 +218,6 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
 
     JsonObject json = new JsonObject();
     json.addProperty("text", s);
-    GsonBuilder builder = new GsonBuilder();
-    Gson gson = builder.create();
     return gson.toJson(json);
   }
 

--- a/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
+++ b/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
@@ -217,7 +217,7 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
     json.addProperty("text", s);
     GsonBuilder builder = new GsonBuilder();
     Gson gson = builder.create();
-    return gson.toJson(s);
+    return gson.toJson(json);
   }
 
   /**

--- a/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
+++ b/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
@@ -254,9 +254,15 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
 
     logger.debug("Executing notification request on target {}, {} attempts left", request.getURI(), maxAttempts);
 
-    RequestConfig config = RequestConfig.custom().setConnectTimeout(timeout).setConnectionRequestTimeout(timeout)
-            .setSocketTimeout(timeout).build();
-    CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+    RequestConfig config = RequestConfig.custom()
+                                        .setConnectTimeout(timeout)
+                                        .setConnectionRequestTimeout(timeout)
+                                        .setSocketTimeout(timeout)
+                                        .build();
+    CloseableHttpClient httpClient = HttpClientBuilder.create()
+                                                      .useSystemProperties()
+                                                      .setDefaultRequestConfig(config)
+                                                      .build();
 
     HttpResponse response;
     try {


### PR DESCRIPTION
This fixes these issues in the Mattermost WOH:

1.  wrong construction of the JSON request
2. add call to `useSystemProperties` in the HTTP client construction (e.g. to use the configured HTTP proxy which is otherwise ignored)
3. extract Gson object to static object