### PR TITLE
MH-13161, Simplify log statements

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -158,7 +158,6 @@ import net.fortuna.ical4j.model.property.RRule;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.codehaus.jettison.json.JSONException;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -421,10 +420,10 @@ public abstract class AbstractEventEndpoint {
     try {
       eventIdsJsonArray = (JSONArray) parser.parse(eventIdsContent);
     } catch (org.json.simple.parser.ParseException e) {
-      logger.error("Unable to parse '{}' because: {}", eventIdsContent, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to parse '{}'", eventIdsContent, e);
       return Response.status(Response.Status.BAD_REQUEST).build();
     } catch (ClassCastException e) {
-      logger.error("Unable to cast '{}' because: {}", eventIdsContent, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to cast '{}'", eventIdsContent, e);
       return Response.status(Response.Status.BAD_REQUEST).build();
     }
 
@@ -539,14 +538,14 @@ public abstract class AbstractEventEndpoint {
         fields.add(technicalMetadataToJson.apply(getSchedulerService().getTechnicalMetadata(eventId)));
       } catch (final NotFoundException e) {
         if (!ignoreNonScheduled) {
-          logger.warn("Unable to find id {}", eventId, ExceptionUtils.getStackTrace(e));
+          logger.warn("Unable to find id {}", eventId, e);
           return notFound("Cannot find an event with id '%s'.", eventId);
         }
       } catch (final UnauthorizedException e) {
-        logger.warn("Unauthorized access to event ID {}", eventId, ExceptionUtils.getStackTrace(e));
+        logger.warn("Unauthorized access to event ID {}", eventId, e);
         return Response.status(Status.BAD_REQUEST).build();
       } catch (final SchedulerException e) {
-        logger.warn("Scheduler exception accessing event ID {}", eventId, ExceptionUtils.getStackTrace(e));
+        logger.warn("Scheduler exception accessing event ID {}", eventId, e);
         return Response.status(Status.BAD_REQUEST).build();
       }
     }
@@ -576,8 +575,7 @@ public abstract class AbstractEventEndpoint {
     } catch (ParseException e) {
       return RestUtil.R.badRequest("The UTC dates in the scheduling object is not valid");
     } catch (SchedulerException e) {
-      logger.error("Unable to update scheduling technical metadata of event {}: {}", eventId,
-              ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to update scheduling technical metadata of event {}", eventId, e);
       throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
     } catch (IllegalStateException e) {
       return RestUtil.R.badRequest(e.getMessage());
@@ -673,7 +671,7 @@ public abstract class AbstractEventEndpoint {
       return Response.ok(org.opencastproject.util.Jsons.arr(commentArr).toJson(), MediaType.APPLICATION_JSON_TYPE)
               .build();
     } catch (EventCommentException e) {
-      logger.error("Unable to get comments from event {}: {}", eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get comments from event {}", eventId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -721,7 +719,7 @@ public abstract class AbstractEventEndpoint {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not retrieve comment {}: {}", commentId, ExceptionUtils.getStackTrace(e));
+      logger.error("Could not retrieve comment {}", commentId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -772,7 +770,7 @@ public abstract class AbstractEventEndpoint {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Unable to update the comments catalog on event {}: {}", eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to update the comments catalog on event {}", eventId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -829,11 +827,10 @@ public abstract class AbstractEventEndpoint {
         return ok();
       }
     } catch (AclServiceException e) {
-      logger.error("Error applying acl '{}' to event '{}' because: {}",
-              accessControlList, eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Error applying acl '{}' to event '{}'", accessControlList, eventId, e);
       return serverError();
     } catch (SchedulerException e) {
-      logger.error("Error applying ACL to scheduled event {} because {}", eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Error applying ACL to scheduled event {}", eventId, e);
       return serverError();
     }
   }
@@ -868,7 +865,7 @@ public abstract class AbstractEventEndpoint {
       return Response.created(getCommentUrl(eventId, createdComment.getId().get()))
               .entity(createdComment.toJson().toJson()).build();
     } catch (Exception e) {
-      logger.error("Unable to create a comment on the event {}: {}", eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to create a comment on the event {}", eventId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -899,7 +896,7 @@ public abstract class AbstractEventEndpoint {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not resolve comment {}: {}", commentId, ExceptionUtils.getStackTrace(e));
+      logger.error("Could not resolve comment {}", commentId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -926,8 +923,7 @@ public abstract class AbstractEventEndpoint {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Unable to delete comment {} on event {}: {}",
-              commentId, eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to delete comment {} on event {}", commentId, eventId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -969,8 +965,7 @@ public abstract class AbstractEventEndpoint {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.warn("Could not remove event comment reply {} from comment {}: {}",
-              replyId, commentId, ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not remove event comment reply {} from comment {}", replyId, commentId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -1020,8 +1015,7 @@ public abstract class AbstractEventEndpoint {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.warn("Could not update event comment reply {} from comment {}: {}",
-              replyId, commentId, ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not update event comment reply {} from comment {}", replyId, commentId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -1068,7 +1062,7 @@ public abstract class AbstractEventEndpoint {
       getIndexService().updateCommentCatalog(optEvent.get(), comments);
       return Response.ok(updatedComment.toJson().toJson()).build();
     } catch (Exception e) {
-      logger.warn("Could not create event comment reply on comment {}: {}", comment, ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not create event comment reply on comment {}", comment, e);
       throw new WebApplicationException(e);
     }
   }
@@ -1764,9 +1758,8 @@ public abstract class AbstractEventEndpoint {
         transitionsJson.add(AccessInformationUtil.serializeEpisodeACLTransition(trans));
       }
     } catch (AclServiceException e) {
-      logger.error(
-              "There was an error while trying to get the ACL transitions for series '{}' from the ACL service: {}",
-              eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("There was an error while trying to get the ACL transitions for series '{}' from the ACL service",
+        eventId, e);
       return RestUtil.R.serverError();
     }
 
@@ -1775,7 +1768,7 @@ public abstract class AbstractEventEndpoint {
       if (optEvent.get().getAccessPolicy() != null)
         activeAcl = AccessControlParser.parseAcl(optEvent.get().getAccessPolicy());
     } catch (Exception e) {
-      logger.error("Unable to parse access policy because: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to parse access policy", e);
     }
     Option<ManagedAcl> currentAcl = AccessInformationUtil.matchAcls(acls, activeAcl);
 
@@ -1880,15 +1873,11 @@ public abstract class AbstractEventEndpoint {
       return Response.noContent().build();
     } catch (JSONException e) {
       return RestUtil.R.badRequest("The transition object is not valid");
-    } catch (IllegalStateException e) {
+    } catch (IllegalStateException | ParseException e) {
       // That should never happen
       throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
     } catch (AclServiceException e) {
-      logger.error("Unable to update transtion {} of event {}: {}",
-              transitionId, eventId, ExceptionUtils.getStackTrace(e));
-      throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
-    } catch (ParseException e) {
-      // That should never happen
+      logger.error("Unable to update transition {} of event {}", transitionId, eventId, e);
       throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
     }
   }
@@ -1959,14 +1948,13 @@ public abstract class AbstractEventEndpoint {
     try {
       eventIdsArray = (JSONArray) parser.parse(eventIds);
     } catch (org.json.simple.parser.ParseException e) {
-      logger.warn("Unable to parse event ids {} : {}", eventIds, ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to parse event ids {} ", eventIds, e);
       return Response.status(Status.BAD_REQUEST).build();
     } catch (NullPointerException e) {
       logger.warn("Unable to parse event ids because it was null {}", eventIds);
       return Response.status(Status.BAD_REQUEST).build();
     } catch (ClassCastException e) {
-      logger.warn("Unable to parse event ids because it was the wrong class {} : {}", eventIds,
-              ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to parse event ids because it was the wrong class {}", eventIds, e);
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -1981,7 +1969,7 @@ public abstract class AbstractEventEndpoint {
       } catch (NotFoundException e) {
         result.addNotFound(eventId);
       } catch (Exception e) {
-        logger.error("Could not update opt out status of event {}: {}", eventId, ExceptionUtils.getStackTrace(e));
+        logger.error("Could not update opt out status of event {}", eventId, e);
         result.addServerError(eventId);
       }
     }
@@ -2005,8 +1993,7 @@ public abstract class AbstractEventEndpoint {
       getAclService().deleteEpisodeTransition(transitionId);
       return Response.noContent().build();
     } catch (AclServiceException e) {
-      logger.error("Error while trying to delete transition '{}' from event '{}': {}",
-              transitionId, eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Error while trying to delete transition '{}' from event '{}'", transitionId, eventId, e);
       throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
     }
   }
@@ -2079,7 +2066,7 @@ public abstract class AbstractEventEndpoint {
         }
       }
     } catch (WorkflowDatabaseException e) {
-      logger.error("Unable to get available workflow definitions: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get available workflow definitions", e);
       return RestUtil.R.serverError();
     }
 
@@ -2190,8 +2177,8 @@ public abstract class AbstractEventEndpoint {
       }
       return Response.noContent().build();
     } catch (Exception e) {
-      logger.error("Unable to find conflicting events for {}, {}, {}: {}",
-              device, startDate, endDate, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to find conflicting events for {}, {}, {}",
+              device, startDate, endDate, e);
       return RestUtil.R.serverError();
     }
   }
@@ -2562,7 +2549,7 @@ public abstract class AbstractEventEndpoint {
         }
         return URI.create(getUrlSigningService().sign(url.toString(), getUrlSigningExpireDuration(), null, clientIP));
       } catch (UrlSigningException e) {
-        logger.warn("Unable to sign url '{}': {}", url, ExceptionUtils.getStackTrace(e));
+        logger.warn("Unable to sign url '{}'", url, e);
       }
     }
     return url;

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/PresetsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/PresetsEndpoint.java
@@ -35,7 +35,6 @@ import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +93,7 @@ public class PresetsEndpoint {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.warn("Could not perform search query: {}", ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not perform search query", e);
     }
     throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
   }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -112,7 +112,6 @@ import com.entwinemedia.fn.data.json.Jsons.Functions;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -291,7 +290,7 @@ public class SeriesEndpoint implements ManagedService {
       seriesAccessJson.put("transitions", transitionsJson);
       seriesAccessJson.put("locked", hasProcessingEvents);
     } catch (SeriesException e) {
-      logger.error("Unable to get ACL from series {}: {}", seriesId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get ACL from series {}", seriesId, e);
       return RestUtil.R.serverError();
     }
 
@@ -358,14 +357,13 @@ public class SeriesEndpoint implements ManagedService {
     try {
       seriesIdsArray = (JSONArray) parser.parse(seriesIds);
     } catch (org.json.simple.parser.ParseException e) {
-      logger.warn("Unable to parse series ids {} : {}", seriesIds, ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to parse series ids {} ", seriesIds, e);
       return Response.status(Status.BAD_REQUEST).build();
     } catch (NullPointerException e) {
       logger.warn("Unable to parse series ids because it was null {}", seriesIds);
       return Response.status(Status.BAD_REQUEST).build();
     } catch (ClassCastException e) {
-      logger.warn("Unable to parse series ids because it was the wrong class {} : {}", seriesIds,
-              ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to parse series ids because it was the wrong class {}", seriesIds, e);
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -377,8 +375,7 @@ public class SeriesEndpoint implements ManagedService {
       } catch (NotFoundException e) {
         result.addNotFound(seriesId.toString());
       } catch (Exception e) {
-        logger.error("Could not update opt out status of series {}: {}", seriesId.toString(),
-                ExceptionUtils.getStackTrace(e));
+        logger.error("Could not update opt out status of series {}", seriesId.toString(), e);
         result.addServerError(seriesId.toString());
       }
     }
@@ -547,7 +544,7 @@ public class SeriesEndpoint implements ManagedService {
     try {
       results = searchIndex.getByQuery(query);
     } catch (SearchIndexException e) {
-      logger.error("The admin UI Search Index was not able to get the themes: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("The admin UI Search Index was not able to get the themes", e);
       return RestUtil.R.serverError();
     }
 
@@ -594,7 +591,7 @@ public class SeriesEndpoint implements ManagedService {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Unable to delete the series '{}' due to: {}", id, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to delete the series '{}' due to", id, e);
       return Response.serverError().build();
     }
   }
@@ -615,10 +612,10 @@ public class SeriesEndpoint implements ManagedService {
     try {
       seriesIdsArray = (JSONArray) parser.parse(seriesIdsContent);
     } catch (org.json.simple.parser.ParseException e) {
-      logger.error("Unable to parse '{}' because: {}", seriesIdsContent, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to parse '{}'", seriesIdsContent, e);
       return Response.status(Status.BAD_REQUEST).build();
     } catch (ClassCastException e) {
-      logger.error("Unable to cast '{}' to a JSON array because: {}", seriesIdsContent, ExceptionUtils.getMessage(e));
+      logger.error("Unable to cast '{}' to a JSON array", seriesIdsContent, e);
       return Response.status(Status.BAD_REQUEST).build();
     }
 
@@ -630,7 +627,7 @@ public class SeriesEndpoint implements ManagedService {
       } catch (NotFoundException e) {
         result.addNotFound(seriesId.toString());
       } catch (Exception e) {
-        logger.error("Unable to remove the series '{}': {}", seriesId.toString(), ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to remove the series '{}'", seriesId.toString(), e);
         result.addServerError(seriesId.toString());
       }
     }
@@ -774,7 +771,7 @@ public class SeriesEndpoint implements ManagedService {
 
       return okJsonList(series, offset, limit, result.getHitCount());
     } catch (Exception e) {
-      logger.warn("Could not perform search query: {}", ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not perform search query", e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
   }
@@ -871,7 +868,7 @@ public class SeriesEndpoint implements ManagedService {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.warn("Could not perform search query: {}", ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not perform search query", e);
     }
     throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
   }
@@ -905,8 +902,7 @@ public class SeriesEndpoint implements ManagedService {
     } catch (NotFoundException e) {
       return Response.status(NOT_FOUND).build();
     } catch (SeriesException e) {
-      logger.warn("Could not update series property for series {} property {}:{} : {}", seriesId, name,
-              value, ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not update series property for series {} property {}:{}", seriesId, name, value, e);
     }
     throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
   }
@@ -932,13 +928,10 @@ public class SeriesEndpoint implements ManagedService {
     try {
       seriesService.deleteSeriesProperty(seriesId, propertyName);
       return Response.status(NO_CONTENT).build();
-    } catch (UnauthorizedException e) {
-      throw e;
-    } catch (NotFoundException e) {
+    } catch (UnauthorizedException | NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.warn("Could not delete series '{}' property '{}' query: {}", seriesId, propertyName,
-              ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not delete series '{}' property '{}' query", seriesId, propertyName, e);
     }
     throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
   }
@@ -969,7 +962,7 @@ public class SeriesEndpoint implements ManagedService {
 
       themeId = series.get().getTheme();
     } catch (SearchIndexException e) {
-      logger.error("Unable to get series {}: {}", seriesId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get series {}", seriesId, e);
       throw new WebApplicationException(e);
     }
 
@@ -984,7 +977,7 @@ public class SeriesEndpoint implements ManagedService {
 
       return getSimpleThemeJsonResponse(themeOpt.get());
     } catch (SearchIndexException e) {
-      logger.error("Unable to get theme {}: {}", themeId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get theme {}", themeId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -1005,10 +998,10 @@ public class SeriesEndpoint implements ManagedService {
       seriesService.updateSeriesProperty(seriesID, THEME_KEY, Long.toString(themeId));
       return getSimpleThemeJsonResponse(themeOpt.get());
     } catch (SeriesException e) {
-      logger.error("Unable to update series theme {}: {}", themeId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to update series theme {}", themeId, e);
       throw new WebApplicationException(e);
     } catch (SearchIndexException e) {
-      logger.error("Unable to get theme {}: {}", themeId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get theme {}", themeId, e);
       throw new WebApplicationException(e);
     }
   }
@@ -1025,7 +1018,7 @@ public class SeriesEndpoint implements ManagedService {
       seriesService.deleteSeriesProperty(seriesID, THEME_KEY);
       return Response.noContent().build();
     } catch (SeriesException e) {
-      logger.error("Unable to remove theme from series {}: {}", seriesID, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to remove theme from series {}", seriesID, e);
       throw new WebApplicationException(e);
     }
   }
@@ -1093,7 +1086,7 @@ public class SeriesEndpoint implements ManagedService {
       events = searchIndex.getByQuery(query);
       elementsCount += events.getHitCount();
     } catch (SearchIndexException e) {
-      logger.warn("Could not perform search query: {}", ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not perform search query", e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/TasksEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/TasksEndpoint.java
@@ -54,7 +54,6 @@ import com.entwinemedia.fn.data.json.JValue;
 import com.google.gson.Gson;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,7 +134,7 @@ public class TasksEndpoint {
         }
       }
     } catch (WorkflowDatabaseException e) {
-      logger.error("Unable to get available workflow definitions: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get available workflow definitions", e);
       return RestUtil.R.serverError();
     }
 
@@ -175,7 +174,7 @@ public class TasksEndpoint {
     try {
       wfd = workflowService.getWorkflowDefinitionById(workflowId);
     } catch (WorkflowDatabaseException e) {
-      logger.error("Unable to get workflow definition {}: {}", workflowId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get workflow definition {}", workflowId, e);
       return RestUtil.R.serverError();
     }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ThemesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ThemesEndpoint.java
@@ -453,7 +453,7 @@ public class ThemesEndpoint {
       Theme updatedTheme = themesServiceDatabase.updateTheme(theme);
       return RestUtils.okJson(themeToJSON(updatedTheme));
     } catch (ThemesServiceDatabaseException e) {
-      logger.error("Unable to update theme {}: {}", themeId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to update theme {}", themeId, e);
       return RestUtil.R.serverError();
     }
   }
@@ -512,7 +512,7 @@ public class ThemesEndpoint {
       } catch (NotFoundException e) {
         logger.warn("Theme {} already deleted on series {}", themeId, seriesId);
       } catch (SeriesException e) {
-        logger.error("Unable to remove theme from series {}: {}", seriesId, ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to remove theme from series {}", seriesId, e);
         throw new WebApplicationException(e, Status.INTERNAL_SERVER_ERROR);
       }
     }
@@ -583,7 +583,7 @@ public class ThemesEndpoint {
         fields.add(f(fieldName.concat("Name"), v(staticFileService.getFileName(staticFileId))));
         fields.add(f(fieldName.concat("Url"), v(staticFileRestService.getStaticFileURL(staticFileId).toString(), Jsons.BLANK)));
       } catch (IllegalStateException | NotFoundException e) {
-        logger.error("Error retreiving static file '{}' : {}", staticFileId, ExceptionUtils.getStackTrace(e));
+        logger.error("Error retreiving static file '{}' ", staticFileId, e);
       }
     }
   }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -109,7 +109,6 @@ import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -606,7 +605,7 @@ public class ToolsEndpoint implements ManagedService {
       JSONObject detailsJSON = (JSONObject) parser.parse(details);
       editingInfo = EditingInfo.parse(detailsJSON);
     } catch (Exception e) {
-      logger.warn("Unable to parse concat information ({}): {}", details, ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to parse concat information ({})", details, e);
       return R.badRequest("Unable to parse details");
     }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/userdirectory/UIRolesRoleProvider.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/userdirectory/UIRolesRoleProvider.java
@@ -35,7 +35,6 @@ import com.entwinemedia.fn.Stream;
 import com.entwinemedia.fn.StreamOp;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +75,7 @@ public class UIRolesRoleProvider implements RoleProvider {
       in = getClass().getResourceAsStream("/roles.txt");
       roles = new TreeSet<String>(IOUtils.readLines(in, "UTF-8"));
     } catch (IOException e) {
-      logger.error("Unable to read available roles: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to read available roles", e);
     } finally {
       IOUtils.closeQuietly(in);
     }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/UserSettingsService.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/UserSettingsService.java
@@ -251,7 +251,7 @@ public class UserSettingsService {
 
       return result;
     } catch (Exception e) {
-      logger.error("Could not get user setting: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get user setting", e);
       throw new UserSettingsServiceException(e);
     } finally {
       if (em != null)

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclScanner.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclScanner.java
@@ -36,7 +36,6 @@ import org.opencastproject.util.data.Option;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.felix.fileinstall.ArtifactInstaller;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -215,7 +214,7 @@ public class AclScanner implements ArtifactInstaller {
         } catch (NotFoundException e) {
           logger.warn("Unable to delete managec acl {}: Managed acl already deleted!", id);
         } catch (AclServiceException e) {
-          logger.error("Unable to delete managed acl {}: {}", id, ExceptionUtils.getStackTrace(e));
+          logger.error("Unable to delete managed acl {}", id, e);
         }
       } else {
         logger.debug("No Acl found with the id {}.", id);

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
@@ -49,7 +49,6 @@ import com.google.gson.JsonSyntaxException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -403,7 +402,7 @@ public class CaptureAgentStateRestService {
         return Response.ok(new RecordingStateUpdate(rec)).type(MediaType.TEXT_XML).build();
       }
     } catch (SchedulerException e) {
-      logger.debug("Unable to get recording state of {}: {}", id, ExceptionUtils.getStackTrace(e));
+      logger.debug("Unable to get recording state of {}", id, e);
       return Response.serverError().build();
     }
   }
@@ -435,7 +434,7 @@ public class CaptureAgentStateRestService {
         return Response.status(Response.Status.BAD_REQUEST).build();
       }
     } catch (SchedulerException e) {
-      logger.debug("Unable to set recording state of {}: {}", id, ExceptionUtils.getStackTrace(e));
+      logger.debug("Unable to set recording state of {}", id, e);
       return Response.serverError().build();
     }
   }
@@ -460,7 +459,7 @@ public class CaptureAgentStateRestService {
       schedulerService.removeRecording(id);
       return Response.ok(id + " removed").build();
     } catch (SchedulerException e) {
-      logger.debug("Unable to remove recording with id '{}': {}", id, ExceptionUtils.getStackTrace(e));
+      logger.debug("Unable to remove recording with id '{}'", id, e);
       return Response.serverError().build();
     }
   }
@@ -482,7 +481,7 @@ public class CaptureAgentStateRestService {
       }
       return update;
     } catch (SchedulerException e) {
-      logger.debug("Unable to get all recordings: {}", ExceptionUtils.getStackTrace(e));
+      logger.debug("Unable to get all recordings", e);
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
     }
   }

--- a/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaAdaptiveStreamingDistributionService.java
+++ b/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaAdaptiveStreamingDistributionService.java
@@ -243,7 +243,7 @@ public class WowzaAdaptiveStreamingDistributionService extends AbstractDistribut
                 DEFAULT_STREAMING_SCHEME, DEFAULT_STREAMING_URL);
         logger.info("Streaming URL set to \"{}\"", streamingUri);
       } catch (URISyntaxException e) {
-        logger.warn("Streaming URL {} could not be parsed: {}", readStreamingUrl, ExceptionUtils.getStackTrace(e));
+        logger.warn("Streaming URL {} could not be parsed", readStreamingUrl, e);
       }
 
       try {

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
@@ -20,8 +20,6 @@
  */
 package org.opencastproject.workflow.handler.distribution;
 
-import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
-
 import org.opencastproject.distribution.api.DistributionException;
 import org.opencastproject.distribution.api.DownloadDistributionService;
 import org.opencastproject.job.api.Job;
@@ -48,7 +46,6 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -292,8 +289,8 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
         Job job = distributionService.distribute(channelId, mediapackage, bulkElementIds, checkAvailability);
         jobs.add(job);
       } catch (DistributionException | MediaPackageException e) {
-        logger.error("Creating the distribution job for {} elements of media package '{}' failed: {}",
-                bulkElementIds.size(), mediapackage, getStackTrace(e));
+        logger.error("Creating the distribution job for {} elements of media package '{}' failed",
+                bulkElementIds.size(), mediapackage, e);
         throw new WorkflowOperationException(e);
       }
     }
@@ -305,8 +302,8 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
           Job job = distributionService.distribute(channelId, mediapackage, elementId, checkAvailability);
           jobs.add(job);
         } catch (DistributionException | MediaPackageException e) {
-          logger.error("Creating the distribution job for element '{}' of media package '{}' failed: {}", elementId,
-                  mediapackage, getStackTrace(e));
+          logger.error("Creating the distribution job for element '{}' of media package '{}' failed", elementId,
+                  mediapackage, e);
           throw new WorkflowOperationException(e);
         }
       }
@@ -321,8 +318,8 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
           List<? extends MediaPackageElement> elems = MediaPackageElementParser.getArrayFromXml(job.getPayload());
           result.addAll(elems);
         } catch (MediaPackageException e) {
-          logger.error("Job '{}' returned payload ({}) that could not be parsed to media package elements: {}", job,
-                  job.getPayload(), ExceptionUtils.getStackTrace(e));
+          logger.error("Job '{}' returned payload ({}) that could not be parsed to media package elements", job,
+                  job.getPayload(), e);
           throw new WorkflowOperationException(e);
         }
       }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
@@ -36,7 +36,6 @@ import com.entwinemedia.fn.data.json.JValue;
 import com.entwinemedia.fn.data.json.Jsons;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
@@ -1063,8 +1062,7 @@ public class MetadataField<A> {
           Integer orderValue = Integer.parseInt(value);
           this.order = Opt.some(orderValue);
         } catch (NumberFormatException e) {
-          logger.warn("Unable to parse order value {} of metadata field {} because:{}",
-                  value, this.getInputID(), ExceptionUtils.getStackTrace(e));
+          logger.warn("Unable to parse order value {} of metadata field {}", value, this.getInputID(), e);
           this.order = Opt.none();
         }
         break;

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -45,7 +45,6 @@ import org.opencastproject.util.persistencefn.PersistenceEnvs;
 import com.entwinemedia.fn.Fn;
 import com.entwinemedia.fn.Stream;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.text.WordUtils;
 import org.osgi.framework.ServiceException;
 import org.osgi.service.component.ComponentContext;
@@ -170,7 +169,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
       q.setParameter("org", securityService.getOrganization().getId());
       return q.getResultList();
     } catch (Exception e) {
-      logger.error("Could not get reasons: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get reasons", e);
       throw new EventCommentDatabaseException(e);
     } finally {
       if (em != null)
@@ -190,7 +189,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not get event comment {}: {}", commentId, ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get event comment {}", commentId, e);
       throw new EventCommentDatabaseException(e);
     } finally {
       if (em != null)
@@ -214,7 +213,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not delete event comment: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not delete event comment", e);
       if (tx.isActive())
         tx.rollback();
 
@@ -248,7 +247,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not delete event comments: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not delete event comments", e);
       if (tx.isActive())
         tx.rollback();
 
@@ -314,7 +313,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
               }).value();
       return new ArrayList<>(comments);
     } catch (Exception e) {
-      logger.error("Could not retreive comments for event {}: {}", eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Could not retreive comments for event {}", eventId, e);
       throw new EventCommentDatabaseException(e);
     } finally {
       if (em != null)
@@ -329,7 +328,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
       Query q = em.createNamedQuery("EventComment.findAll");
       return new ArrayList<EventCommentDto>(q.getResultList()).iterator();
     } catch (Exception e) {
-      logger.error("Could not retreive event comments: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not retreive event comments", e);
       throw new EventCommentDatabaseException(e);
     } finally {
       if (em != null)

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -116,7 +116,6 @@ import com.entwinemedia.fn.data.json.Jsons;
 import com.entwinemedia.fn.data.json.Jsons.Functions;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.json.simple.JSONArray;
@@ -472,14 +471,13 @@ public class EventsEndpoint implements ManagedService {
     } catch (UnauthorizedException e) {
       return Response.status(Status.UNAUTHORIZED).build();
     } catch (IllegalArgumentException e) {
-      logger.debug("Unable to update event '{}' because: {}", eventId, ExceptionUtils.getStackTrace(e));
+      logger.debug("Unable to update event '{}'", eventId, e);
       return RestUtil.R.badRequest(e.getMessage());
     } catch (IndexServiceException e) {
-      logger.error("Unable to get multi part fields or file for event '{}' because: {}", eventId,
-              ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get multi part fields or file for event '{}'", eventId, e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     } catch (SearchIndexException e) {
-      logger.error("Unable to update event '{}' because: {}", eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to update event '{}'", eventId, e);
       throw new WebApplicationException(e, Status.INTERNAL_SERVER_ERROR);
     } catch (Exception e) {
       throw new WebApplicationException(e, Status.INTERNAL_SERVER_ERROR);
@@ -520,19 +518,19 @@ public class EventsEndpoint implements ManagedService {
       String eventId = indexService.createEvent(eventHttpServletRequest);
       return ApiResponses.Json.created(requestedVersion, URI.create(getEventUrl(eventId)), obj(f("identifier", v(eventId))));
     } catch (IllegalArgumentException | DateTimeParseException e) {
-      logger.debug("Unable to create event because: {}", ExceptionUtils.getStackTrace(e));
+      logger.debug("Unable to create event", e);
       return RestUtil.R.badRequest(e.getMessage());
     } catch (IndexServiceException e) {
       if (e.getCause() != null && e.getCause() instanceof NotFoundException
               || e.getCause() instanceof IllegalArgumentException) {
-        logger.debug("Unable to create event because: {}", ExceptionUtils.getStackTrace(e));
+        logger.debug("Unable to create event", e);
         return RestUtil.R.badRequest(e.getCause().getMessage());
       } else {
-        logger.error("Unable to create event because: {}", ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to create event", e);
         throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
       }
     } catch (Exception e) {
-      logger.error("Unable to create event because: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to create event", e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
   }
@@ -757,8 +755,7 @@ public class EventsEndpoint implements ManagedService {
     try {
       results = externalIndex.getByQuery(query);
     } catch (SearchIndexException e) {
-      logger.error("The External Search Index was not able to get the events list: {}",
-              ExceptionUtils.getStackTrace(e));
+      logger.error("The External Search Index was not able to get the events list", e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
 
@@ -773,7 +770,7 @@ public class EventsEndpoint implements ManagedService {
       return getJsonEvents(
           acceptHeader, events, withAcl, withMetadata, withScheduling, withPublications, sign, requestedVersion);
     } catch (Exception e) {
-      logger.error("Unable to get events because: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get events", e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
   }
@@ -885,8 +882,7 @@ public class EventsEndpoint implements ManagedService {
           fields.add(f("metadata", metadata.get().toJSON()));
         }
       } catch (Exception e) {
-        logger.error("Unable to get metadata for event '{}' because: {}", event.getIdentifier(),
-                ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to get metadata for event '{}'", event.getIdentifier(), e);
         throw new IndexServiceException("Unable to add metadata to event", e);
       }
     }
@@ -938,17 +934,16 @@ public class EventsEndpoint implements ManagedService {
       try {
         accessControlList = AclUtils.deserializeJsonToAcl(acl, false);
       } catch (ParseException e) {
-        logger.debug("Unable to update event acl to '{}' because: {}", acl, ExceptionUtils.getStackTrace(e));
+        logger.debug("Unable to update event acl to '{}'", acl, e);
         return R.badRequest(String.format("Unable to parse acl '%s' because '%s'", acl, e.getMessage()));
       } catch (IllegalArgumentException e) {
-        logger.debug("Unable to update event acl to '{}' because: {}", acl, ExceptionUtils.getStackTrace(e));
+        logger.debug("Unable to update event acl to '{}'", acl, e);
         return R.badRequest(e.getMessage());
       }
       try {
         accessControlList = indexService.updateEventAcl(id, accessControlList, externalIndex);
       } catch (IllegalArgumentException e) {
-        logger.error("Unable to update event '{}' acl with '{}' because: {}",
-                id, acl, ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to update event '{}' acl with '{}'", id, acl, e);
         return Response.status(Status.FORBIDDEN).build();
       }
       return Response.noContent().build();
@@ -995,8 +990,7 @@ public class EventsEndpoint implements ManagedService {
       try {
         withNewAce = indexService.updateEventAcl(id, withNewAce, externalIndex);
       } catch (IllegalArgumentException e) {
-        logger.error("Unable to update event '{}' acl entry with action '{}' and role '{}' because: {}",
-                id, action, role, ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to update event '{}' acl entry with action '{}' and role '{}'", id, action, role, e);
         return Response.status(Status.FORBIDDEN).build();
       }
       return Response.noContent().build();
@@ -1035,8 +1029,7 @@ public class EventsEndpoint implements ManagedService {
       try {
         withoutDeleted = indexService.updateEventAcl(id, withoutDeleted, externalIndex);
       } catch (IllegalArgumentException e) {
-        logger.error("Unable to delete event's '{}' acl entry with action '{}' and role '{}' because: {}",
-                id, action, role, ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to delete event's '{}' acl entry with action '{}' and role '{}'", id, action, role, e);
         return Response.status(Status.FORBIDDEN).build();
       }
       return Response.noContent().build();
@@ -1207,13 +1200,10 @@ public class EventsEndpoint implements ManagedService {
     try {
       updatedFields = RequestUtils.getKeyValueMap(metadataJSON);
     } catch (ParseException e) {
-      logger.debug("Unable to update event '{}' with metadata type '{}' and content '{}' because: {}",
-              id, type, metadataJSON, ExceptionUtils.getStackTrace(e));
-      return RestUtil.R.badRequest(String.format("Unable to parse metadata fields as json from '%s' because '%s'",
-              metadataJSON, ExceptionUtils.getStackTrace(e)));
+      logger.debug("Unable to update event '{}' with metadata type '{}' and content '{}'", id, type, metadataJSON, e);
+      return RestUtil.R.badRequest(String.format("Unable to parse metadata fields as json from '%s'", metadataJSON));
     } catch (IllegalArgumentException e) {
-      logger.debug("Unable to update event '{}' with metadata type '{}' and content '{}' because: {}",
-              id, type, metadataJSON, ExceptionUtils.getStackTrace(e));
+      logger.debug("Unable to update event '{}' with metadata type '{}' and content '{}'", id, type, metadataJSON, e);
       return RestUtil.R.badRequest(e.getMessage());
     }
 
@@ -1369,12 +1359,10 @@ public class EventsEndpoint implements ManagedService {
       } catch (NotFoundException e) {
         return ApiResponses.notFound(e.getMessage());
       } catch (IndexServiceException e) {
-        logger.error("Unable to remove metadata catalog with type '{}' from event '{}' because {}",
-                type, id, ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to remove metadata catalog with type '{}' from event '{}'", type, id, e);
         throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
       } catch (IllegalStateException e) {
-        logger.debug("Unable to remove metadata catalog with type '{}' from event '{}' because {}",
-                type, id, ExceptionUtils.getStackTrace(e));
+        logger.debug("Unable to remove metadata catalog with type '{}' from event '{}'", type, id, e);
         throw new WebApplicationException(e, Status.BAD_REQUEST);
       } catch (UnauthorizedException e) {
         return Response.status(Status.UNAUTHORIZED).build();
@@ -1400,8 +1388,7 @@ public class EventsEndpoint implements ManagedService {
         return ApiResponses.notFound(String.format("Unable to find event with id '%s'", id));
       }
     } catch (SearchIndexException e) {
-      logger.error("Unable to get list of publications from event with id '{}' because {}", id,
-              ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get list of publications from event with id '{}'", id, e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
   }
@@ -1437,7 +1424,7 @@ public class EventsEndpoint implements ManagedService {
         try {
           location = urlSigningService.sign(location, expireSeconds, null, null);
         } catch (UrlSigningException e) {
-          logger.error("Unable to sign URI {} because: {}", uri, ExceptionUtils.getStackTrace(e));
+          logger.error("Unable to sign URI {}", uri, e);
           return uri.toString();
         }
       }
@@ -1523,8 +1510,7 @@ public class EventsEndpoint implements ManagedService {
     } catch (NotFoundException e) {
       return ApiResponses.notFound(e.getMessage());
     } catch (SearchIndexException e) {
-      logger.error("Unable to get list of publications from event with id '{}' because {}", eventId,
-              ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get list of publications from event with id '{}'", eventId, e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
   }
@@ -1614,7 +1600,7 @@ public class EventsEndpoint implements ManagedService {
       if (event.getAccessPolicy() != null)
         activeAcl = AccessControlParser.parseAcl(event.getAccessPolicy());
     } catch (Exception e) {
-      logger.error("Unable to parse access policy because: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to parse access policy", e);
     }
     return activeAcl;
   }
@@ -1714,8 +1700,7 @@ public class EventsEndpoint implements ManagedService {
       }
       return Response.noContent().build();
     } catch (SearchIndexException e) {
-      logger.error("Unable to get list of publications from event with id '{}' because {}", id,
-          ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to get list of publications from event with id '{}'", id, e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
@@ -28,8 +28,6 @@ import static com.entwinemedia.fn.data.json.Jsons.obj;
 import static com.entwinemedia.fn.data.json.Jsons.v;
 import static java.time.ZoneOffset.UTC;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
-import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
 import static org.elasticsearch.common.lang3.StringUtils.isNoneBlank;
 import static org.opencastproject.util.RestUtil.getEndpointUrl;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.BOOLEAN;
@@ -305,8 +303,8 @@ public class WorkflowsEndpoint {
     try {
       workflowInstances = workflowService.getWorkflowInstances(query);
     } catch (Exception e) {
-      logger.error("The workflow service was not able to get the workflow instances: {}", getStackTrace(e));
-      return ApiResponses.serverError("Could not retrieve workflow instances, reason: '%s'", getMessage(e));
+      logger.error("The workflow service was not able to get the workflow instances", e);
+      return ApiResponses.serverError("Could not retrieve workflow instances, reason: '%s'", e.getMessage());
     }
 
     List<JValue> json = Arrays.stream(workflowInstances.getItems())
@@ -373,10 +371,10 @@ public class WorkflowsEndpoint {
               workflowInstanceToJSON(wi, withOperations, withConfiguration));
     } catch (IllegalStateException e) {
       final ApiVersion requestedVersion = ApiMediaType.parse(acceptHeader).getVersion();
-      return ApiResponses.Json.conflict(requestedVersion, obj(f("message", v(getMessage(e), BLANK))));
+      return ApiResponses.Json.conflict(requestedVersion, obj(f("message", v(e.getMessage(), BLANK))));
     } catch (Exception e) {
-      logger.error("Could not create workflow instances: {}", getStackTrace(e));
-      return ApiResponses.serverError("Could not create workflow instances, reason: '%s'", getMessage(e));
+      logger.error("Could not create workflow instances", e);
+      return ApiResponses.serverError("Could not create workflow instances, reason: '%s'", e.getMessage());
     }
   }
 
@@ -400,8 +398,8 @@ public class WorkflowsEndpoint {
     } catch (UnauthorizedException e) {
       return Response.status(Response.Status.FORBIDDEN).build();
     } catch (Exception e) {
-      logger.error("The workflow service was not able to get the workflow instance: {}", getStackTrace(e));
-      return ApiResponses.serverError("Could not retrieve workflow instance, reason: '%s'", getMessage(e));
+      logger.error("The workflow service was not able to get the workflow instance", e);
+      return ApiResponses.serverError("Could not retrieve workflow instance, reason: '%s'", e.getMessage());
     }
 
     return ApiResponses.Json.ok(acceptHeader, workflowInstanceToJSON(wi, withOperations, withConfiguration));
@@ -502,8 +500,8 @@ public class WorkflowsEndpoint {
     } catch (UnauthorizedException e) {
       return Response.status(Response.Status.FORBIDDEN).build();
     } catch (Exception e) {
-      logger.error("The workflow service was not able to get the workflow instance: {}", getStackTrace(e));
-      return ApiResponses.serverError("Could not retrieve workflow instance, reason: '%s'", getMessage(e));
+      logger.error("The workflow service was not able to get the workflow instance", e);
+      return ApiResponses.serverError("Could not retrieve workflow instance, reason: '%s'", e.getMessage());
     }
   }
 
@@ -526,8 +524,8 @@ public class WorkflowsEndpoint {
     } catch (UnauthorizedException e) {
       return Response.status(Response.Status.FORBIDDEN).build();
     } catch (Exception e) {
-      logger.error("Could not delete workflow instances: {}", getStackTrace(e));
-      return ApiResponses.serverError("Could not delete workflow instances, reason: '%s'", getMessage(e));
+      logger.error("Could not delete workflow instances", e);
+      return ApiResponses.serverError("Could not delete workflow instances, reason: '%s'", e.getMessage());
     }
 
     return Response.noContent().build();

--- a/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalApiRoleProvider.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalApiRoleProvider.java
@@ -35,7 +35,6 @@ import com.entwinemedia.fn.Stream;
 import com.entwinemedia.fn.StreamOp;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +77,7 @@ public class ExternalApiRoleProvider implements RoleProvider {
       in = getClass().getResourceAsStream(rolesFile);
       roles = new TreeSet<>(IOUtils.readLines(in, "UTF-8"));
     } catch (IOException e) {
-      logger.error("Unable to read available roles: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to read available roles", e);
     } finally {
       IOUtils.closeQuietly(in);
     }

--- a/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalGroupLoader.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalGroupLoader.java
@@ -34,7 +34,6 @@ import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.UrlSupport;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,7 +136,7 @@ public class ExternalGroupLoader {
             groupRoleProvider.addGroup(externalApplicationGroup);
           }
         } catch (NotFoundException | IllegalStateException | IOException | UnauthorizedException e) {
-          logger.error("Unable to load external API groups because {}", ExceptionUtils.getStackTrace(e));
+          logger.error("Unable to load external API groups", e);
         }
       });
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/events/ConfigurableEventDCCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/events/ConfigurableEventDCCatalogUIAdapter.java
@@ -110,7 +110,7 @@ public class ConfigurableEventDCCatalogUIAdapter implements EventCatalogUIAdapte
       try {
         dublinCoreMetadata.addField(dublinCoreProperties.get(field), "", getListProvidersService());
       } catch (Exception e) {
-        logger.error("Skipping metadata field '{}' because of error: {}", field, ExceptionUtils.getStackTrace(e));
+        logger.error("Skipping metadata field '{}' because of error", field, e);
       }
     }
   }
@@ -194,7 +194,7 @@ public class ConfigurableEventDCCatalogUIAdapter implements EventCatalogUIAdapte
       // setting the URI to a new source so the checksum will most like be invalid
       catalog.setChecksum(null);
     } catch (IOException e) {
-      logger.error("Unable to store catalog {} metadata to workspace: {}", catalog, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to store catalog {} metadata to workspace", catalog, e);
     } finally {
       IoSupport.closeQuietly(inputStream);
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/series/CommonSeriesCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/series/CommonSeriesCatalogUIAdapter.java
@@ -74,7 +74,7 @@ public class CommonSeriesCatalogUIAdapter extends ConfigurableSeriesDCCatalogUIA
     try {
       getSeriesService().updateSeries(dc);
     } catch (SeriesException e) {
-      logger.warn("Error while updating series DublinCore: {}", ExceptionUtils.getStackTrace(e));
+      logger.warn("Error while updating series DublinCore", e);
       return false;
     } catch (UnauthorizedException e) {
       logger.warn("User is not authorized to change series DublinCore");

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/series/ConfigurableSeriesDCCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/series/ConfigurableSeriesDCCatalogUIAdapter.java
@@ -224,10 +224,10 @@ public class ConfigurableSeriesDCCatalogUIAdapter implements SeriesCatalogUIAdap
         return getSeriesService().addSeriesElement(seriesId, flavor.getType(), dcData);
       }
     } catch (IOException e) {
-      logger.error("Error while serializing the dublin core catalog to XML: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Error while serializing the dublin core catalog to XML", e);
       return false;
     } catch (SeriesException e) {
-      logger.error("Error while saving the series element: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Error while saving the series element", e);
       return false;
     }
   }
@@ -241,7 +241,7 @@ public class ConfigurableSeriesDCCatalogUIAdapter implements SeriesCatalogUIAdap
       try {
         dublinCoreMetadata.addField(dublinCoreProperties.get(field), "", listProvidersService);
       } catch (Exception e) {
-        logger.error("Skipping metadata field '{}' because of error: {}", field, ExceptionUtils.getStackTrace(e));
+        logger.error("Skipping metadata field '{}' because of error", field, e);
       }
     }
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -51,7 +51,6 @@ import org.opencastproject.util.NotFoundException;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -599,14 +598,13 @@ public final class EventIndexUtils {
           event.setSeriesName(result.getItems()[0].getSource().getTitle());
           break;
         } else {
-          Integer triesLeft = new Integer(tries - i);
+          Integer triesLeft = tries - i;
           logger.debug("Not able to find the series {} in the search index for the event {}. Will try {} more times.",
                   event.getSeriesId(), event.getIdentifier(), triesLeft);
           try {
             Thread.sleep(sleep);
           } catch (InterruptedException e) {
-            logger.warn("Interupted while sleeping before checking for the series being added to the index {}",
-                    ExceptionUtils.getStackTrace(e));
+            logger.warn("Interrupted while sleeping before checking for the series being added to the index", e);
           }
         }
 
@@ -652,7 +650,7 @@ public final class EventIndexUtils {
     try {
       searchIndex.addOrUpdate(event);
     } catch (SearchIndexException e) {
-      logger.warn("Unable to update event '{}': {}", event, ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to update event '{}'", event, e);
     }
   }
 
@@ -677,8 +675,8 @@ public final class EventIndexUtils {
       result = searchIndex
               .getByQuery(new EventSearchQuery(organization, user).withoutActions().withManagedAcl(currentManagedAcl));
     } catch (SearchIndexException e) {
-      logger.error("Unable to find the events in org '{}' with current managed acl name '{}' for event because {}",
-              organization, currentManagedAcl, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to find the events in org '{}' with current managed acl name '{}' for event",
+              organization, currentManagedAcl, e);
     }
     if (result != null && result.getHitCount() > 0) {
       for (SearchResultItem<Event> eventItem : result.getItems()) {
@@ -688,8 +686,8 @@ public final class EventIndexUtils {
           searchIndex.addOrUpdate(event);
         } catch (SearchIndexException e) {
           logger.warn(
-                  "Unable to update event '{}' from current managed acl '{}' to new managed acl name '{}' because {}",
-                  event, currentManagedAcl, newManagedAcl, ExceptionUtils.getStackTrace(e));
+                  "Unable to update event '{}' from current managed acl '{}' to new managed acl name '{}'",
+                  event, currentManagedAcl, newManagedAcl, e);
         }
       }
     }
@@ -714,8 +712,8 @@ public final class EventIndexUtils {
       result = searchIndex
               .getByQuery(new EventSearchQuery(organization, user).withoutActions().withManagedAcl(managedAcl));
     } catch (SearchIndexException e) {
-      logger.error("Unable to find the events in org '{}' with current managed acl name '{}' for event because {}",
-              organization, managedAcl, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to find the events in org '{}' with current managed acl name '{}' for event",
+              organization, managedAcl, e);
     }
     if (result != null && result.getHitCount() > 0) {
       for (SearchResultItem<Event> eventItem : result.getItems()) {
@@ -724,8 +722,7 @@ public final class EventIndexUtils {
         try {
           searchIndex.addOrUpdate(event);
         } catch (SearchIndexException e) {
-          logger.warn("Unable to update event '{}' to remove managed acl '{}' because {}",
-                  event, managedAcl, ExceptionUtils.getStackTrace(e));
+          logger.warn("Unable to update event '{}' to remove managed acl '{}'", event, managedAcl, e);
         }
       }
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java
@@ -42,7 +42,6 @@ import org.opencastproject.util.DateTimeSupport;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -270,8 +269,8 @@ public final class SeriesIndexUtils {
       result = searchIndex
               .getByQuery(new SeriesSearchQuery(organization, user).withoutActions().withManagedAcl(currentManagedAcl));
     } catch (SearchIndexException e) {
-      logger.error("Unable to find the series in org '{}' with current managed acl name '{}' because {}",
-              organization, currentManagedAcl, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to find the series in org '{}' with current managed acl name '{}'", organization,
+              currentManagedAcl, e);
     }
     if (result != null && result.getHitCount() > 0) {
       for (SearchResultItem<Series> seriesItem : result.getItems()) {
@@ -281,8 +280,8 @@ public final class SeriesIndexUtils {
           searchIndex.addOrUpdate(series);
         } catch (SearchIndexException e) {
           logger.warn(
-                  "Unable to update event '{}' from current managed acl '{}' to new managed acl name '{}' because {}",
-                  series, currentManagedAcl, newManagedAcl, ExceptionUtils.getStackTrace(e));
+                  "Unable to update event '{}' from current managed acl '{}' to new managed acl name '{}'",
+                  series, currentManagedAcl, newManagedAcl, e);
         }
       }
     }
@@ -307,8 +306,8 @@ public final class SeriesIndexUtils {
       result = searchIndex
               .getByQuery(new SeriesSearchQuery(organization, user).withoutActions().withManagedAcl(managedAcl));
     } catch (SearchIndexException e) {
-      logger.error("Unable to find the series in org '{}' with current managed acl name '{}' because {}",
-              organization, managedAcl, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to find the series in org '{}' with current managed acl name '{}'", organization,
+              managedAcl, e);
     }
     if (result != null && result.getHitCount() > 0) {
       for (SearchResultItem<Series> seriesItem : result.getItems()) {
@@ -317,8 +316,7 @@ public final class SeriesIndexUtils {
         try {
           searchIndex.addOrUpdate(series);
         } catch (SearchIndexException e) {
-          logger.warn("Unable to update series '{}' to remove managed acl '{}' because {}",
-                  series, managedAcl, ExceptionUtils.getStackTrace(e));
+          logger.warn("Unable to update series '{}' to remove managed acl '{}'", series, managedAcl, e);
         }
       }
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImpl.java
@@ -109,7 +109,7 @@ public class AssetManagerMessageReceiverImpl extends BaseMessageReceiverImpl<Ass
     try {
       EventIndexUtils.updateSeriesName(event, organization, user, getSearchIndex());
     } catch (SearchIndexException e) {
-      logger.error("Error updating the series name of the event to index: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Error updating the series name of the event to index", e);
     }
 
     // Persist the scheduling event

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/GroupMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/GroupMessageReceiverImpl.java
@@ -29,7 +29,6 @@ import org.opencastproject.message.broker.api.group.GroupItem;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.User;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,8 +70,7 @@ public class GroupMessageReceiverImpl extends BaseMessageReceiverImpl<GroupItem>
           group.setRoles(roles);
           getSearchIndex().addOrUpdate(group);
         } catch (SearchIndexException e) {
-          logger.error("Error storing the group {} to the search index: {}", jaxbGroup.getGroupId(),
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error storing the group {} to the search index", jaxbGroup.getGroupId(), e);
           return;
         }
         break;
@@ -84,8 +82,7 @@ public class GroupMessageReceiverImpl extends BaseMessageReceiverImpl<GroupItem>
           getSearchIndex().delete(Group.DOCUMENT_TYPE, groupItem.getGroupId().concat(organization));
           logger.debug("Group {} removed from external search index", groupItem.getGroupId());
         } catch (SearchIndexException e) {
-          logger.error("Error deleting the group {} from the search index: {}", groupItem.getGroupId(),
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error deleting the group {} from the search index", groupItem.getGroupId(), e);
           return;
         }
         return;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/SeriesMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/SeriesMessageReceiverImpl.java
@@ -37,7 +37,6 @@ import org.opencastproject.util.data.Option;
 import com.entwinemedia.fn.data.Opt;
 import com.entwinemedia.fn.fns.Strings;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,8 +75,7 @@ public class SeriesMessageReceiverImpl extends BaseMessageReceiverImpl<SeriesIte
           series.setCreator(getSecurityService().getUser().getName());
           SeriesIndexUtils.updateSeries(series, dc);
         } catch (SearchIndexException e) {
-          logger.error("Error retrieving series {} from the search index: {}", seriesId,
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error retrieving series {} from the search index", seriesId, e);
           return;
         }
 
@@ -86,8 +84,8 @@ public class SeriesMessageReceiverImpl extends BaseMessageReceiverImpl<SeriesIte
           SeriesIndexUtils.updateEventSeriesTitles(series, organization, getSecurityService().getUser(),
                   getSearchIndex());
         } catch (SearchIndexException e) {
-          logger.error("Error updating the series name of series {} from the associated events: {}",
-                  series.getIdentifier(), ExceptionUtils.getStackTrace(e));
+          logger.error("Error updating the series name of series {} from the associated events",
+                  series.getIdentifier(), e);
         }
 
         // Persist the series
@@ -107,8 +105,7 @@ public class SeriesMessageReceiverImpl extends BaseMessageReceiverImpl<SeriesIte
 
           series.setAccessPolicy(AccessControlParser.toJsonSilent(seriesItem.getAcl()));
         } catch (SearchIndexException e) {
-          logger.error("Error retrieving series {} from the search index: {}", seriesItem.getSeriesId(),
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error retrieving series {} from the search index", seriesItem.getSeriesId(), e);
           return;
         }
 
@@ -123,8 +120,7 @@ public class SeriesMessageReceiverImpl extends BaseMessageReceiverImpl<SeriesIte
           series = SeriesIndexUtils.getOrCreate(seriesItem.getSeriesId(), organization, user, getSearchIndex());
           series.setOptOut(seriesItem.getOptOut());
         } catch (SearchIndexException e) {
-          logger.error("Error retrieving series {} from the search index: {}", seriesItem.getSeriesId(),
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error retrieving series {} from the search index", seriesItem.getSeriesId(), e);
           return;
         }
 
@@ -142,8 +138,7 @@ public class SeriesMessageReceiverImpl extends BaseMessageReceiverImpl<SeriesIte
           series = SeriesIndexUtils.getOrCreate(seriesItem.getSeriesId(), organization, user, getSearchIndex());
           series.setTheme(Opt.nul(seriesItem.getPropertyValue()).bind(Strings.toLong).orNull());
         } catch (SearchIndexException e) {
-          logger.error("Error retrieving series {} from the search index: {}", seriesItem.getSeriesId(),
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error retrieving series {} from the search index", seriesItem.getSeriesId(), e);
           return;
         }
 
@@ -158,8 +153,7 @@ public class SeriesMessageReceiverImpl extends BaseMessageReceiverImpl<SeriesIte
           getSearchIndex().delete(Series.DOCUMENT_TYPE, seriesItem.getSeriesId().concat(organization));
           logger.debug("Series {} removed from search index", seriesItem.getSeriesId());
         } catch (SearchIndexException e) {
-          logger.error("Error deleting the series {} from the search index: {}", seriesItem.getSeriesId(),
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error deleting the series {} from the search index", seriesItem.getSeriesId(), e);
           return;
         }
         return;
@@ -176,7 +170,7 @@ public class SeriesMessageReceiverImpl extends BaseMessageReceiverImpl<SeriesIte
       getSearchIndex().addOrUpdate(series);
       logger.debug("Series {} updated in the search index", seriesId);
     } catch (SearchIndexException e) {
-      logger.error("Error storing the series {} to the search index: {}", seriesId, ExceptionUtils.getStackTrace(e));
+      logger.error("Error storing the series {} to the search index", seriesId, e);
     }
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/ThemeMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/ThemeMessageReceiverImpl.java
@@ -29,7 +29,6 @@ import org.opencastproject.message.broker.api.theme.SerializableTheme;
 import org.opencastproject.message.broker.api.theme.ThemeItem;
 import org.opencastproject.security.api.User;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,8 +76,7 @@ public class ThemeMessageReceiverImpl extends BaseMessageReceiverImpl<ThemeItem>
           theme.setWatermarkPosition(serializableTheme.getWatermarkPosition());
           getSearchIndex().addOrUpdate(theme);
         } catch (SearchIndexException e) {
-          logger.error("Error storing the theme {} to the search index: {}", serializableTheme.getId(),
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error storing the theme {} to the search index", serializableTheme.getId(), e);
           return;
         }
         break;
@@ -91,8 +89,7 @@ public class ThemeMessageReceiverImpl extends BaseMessageReceiverImpl<ThemeItem>
           logger.debug("Theme {} removed from {} search index", themeItem.getThemeId(),
                   getSearchIndex().getIndexName());
         } catch (SearchIndexException e) {
-          logger.error("Error deleting the group {} from the search index: {}", themeItem.getThemeId(),
-                  ExceptionUtils.getStackTrace(e));
+          logger.error("Error deleting the group {} from the search index", themeItem.getThemeId(), e);
           return;
         }
         return;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EmailListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EmailListProvider.java
@@ -30,7 +30,6 @@ import org.opencastproject.messages.MailServiceException;
 import org.opencastproject.messages.MessageTemplate;
 import org.opencastproject.security.api.Organization;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,7 +110,7 @@ public class EmailListProvider implements ResourceListProvider {
           messageTemplateList = mailService.getMessageTemplates();
         }
       } catch (MailServiceException e) {
-        logger.error("Error retreiving message templates from mail service: {}", ExceptionUtils.getStackTrace(e));
+        logger.error("Error retreiving message templates from mail service", e);
         throw new ListProviderException("Error retreiving message templates from mail service", e);
       }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventCommentsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventCommentsListProvider.java
@@ -28,7 +28,6 @@ import org.opencastproject.index.service.resources.list.api.ResourceListProvider
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.security.api.Organization;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,7 +87,7 @@ public class EventCommentsListProvider implements ResourceListProvider {
       try {
         reasons = eventCommentService.getReasons();
       } catch (EventCommentException e) {
-        logger.error("Error retreiving reasons from event comment service: {}", ExceptionUtils.getStackTrace(e));
+        logger.error("Error retreiving reasons from event comment service", e);
         throw new ListProviderException("Error retreiving reasons from event comment service", e);
       }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ThemesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ThemesListProvider.java
@@ -34,7 +34,6 @@ import org.opencastproject.matterhorn.search.SearchResultItem;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,7 +90,7 @@ public class ThemesListProvider implements ResourceListProvider {
       try {
         results = searchIndex.getByQuery(themeQuery);
       } catch (SearchIndexException e) {
-        logger.error("The admin UI Search Index was not able to get the themes: {}", ExceptionUtils.getStackTrace(e));
+        logger.error("The admin UI Search Index was not able to get the themes", e);
         throw new ListProviderException("No themes list for list name " + listName + " found!");
       }
 
@@ -111,7 +110,7 @@ public class ThemesListProvider implements ResourceListProvider {
       try {
         results = searchIndex.getByQuery(themeQuery);
       } catch (SearchIndexException e) {
-        logger.error("The admin UI Search Index was not able to get the themes: {}", ExceptionUtils.getStackTrace(e));
+        logger.error("The admin UI Search Index was not able to get the themes", e);
         throw new ListProviderException("No themes list for list name " + listName + " found!");
       }
 

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -96,7 +96,6 @@ import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.cxf.jaxrs.ext.multipart.ContentDisposition;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -1282,8 +1281,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       logger.debug("Restoring workflow properties from scheduler event {}", mediaPackageId);
       mergedProperties.putAll(recordingProperties);
     } catch (SchedulerException e) {
-      logger.warn("Unable to get workflow properties from scheduler event {}: {}", mediaPackageId,
-              ExceptionUtils.getMessage(e));
+      logger.warn("Unable to get workflow properties from scheduler event {}", mediaPackageId, e);
     } catch (NotFoundException e) {
       logger.info("No capture event found for id {}", mediaPackageId);
     } catch (UnauthorizedException e) {
@@ -1419,8 +1417,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
         } catch (UnauthorizedException e) {
           throw new IllegalStateException(e);
         } catch (SchedulerException e) {
-          logger.warn("Unable to get the workflow definition id from scheduler event {}: {}", mediaPackageId,
-                  ExceptionUtils.getMessage(e));
+          logger.warn("Unable to get the workflow definition id from scheduler event {}", mediaPackageId, e);
           throw new IngestException(e);
         }
       } else {

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/FFmpegAnalyzer.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/FFmpegAnalyzer.java
@@ -31,7 +31,6 @@ import org.opencastproject.util.ProcessRunner.ProcessInfo;
 import com.entwinemedia.fn.Pred;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -121,7 +120,7 @@ public class FFmpegAnalyzer implements MediaAnalyzer {
       if (exitCode != -1 && exitCode != 0 && exitCode != 255)
         throw new MediaAnalyzerException("Frame analyzer " + binary + " exited with code " + exitCode);
     } catch (IOException e) {
-      logger.error("Error executing ffprobe: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Error executing ffprobe", e);
       throw new MediaAnalyzerException("Error while running ffprobe " + binary, e);
     }
 

--- a/modules/messages/src/main/java/org/opencastproject/messages/MailService.java
+++ b/modules/messages/src/main/java/org/opencastproject/messages/MailService.java
@@ -40,7 +40,6 @@ import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Option;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -229,7 +228,7 @@ public class MailService {
       }
       return templates;
     } catch (Exception e) {
-      logger.error("Could not get message templates: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get message templates", e);
       throw new MailServiceException(e);
     } finally {
       if (em != null)
@@ -252,7 +251,7 @@ public class MailService {
       }
       return templates;
     } catch (Exception e) {
-      logger.error("Could not get message templates: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get message templates", e);
       throw new MailServiceException(e);
     } finally {
       if (em != null)
@@ -275,7 +274,7 @@ public class MailService {
       }
       return templates;
     } catch (Exception e) {
-      logger.error("Could not get message templates: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get message templates", e);
       throw new MailServiceException(e);
     } finally {
       if (em != null)
@@ -371,7 +370,7 @@ public class MailService {
       }
       return signatures;
     } catch (Exception e) {
-      logger.error("Could not get message signatures: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get message signatures", e);
       throw new MailServiceException(e);
     } finally {
       if (em != null) {
@@ -398,7 +397,7 @@ public class MailService {
     } catch (NoResultException e) {
       throw new NotFoundException(e);
     } catch (Exception e) {
-      logger.error("Could not get message signatures: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get message signatures", e);
       throw new MailServiceException(e);
     } finally {
       if (em != null)
@@ -421,7 +420,7 @@ public class MailService {
       Number countResult = (Number) q.getSingleResult();
       return countResult.intValue();
     } catch (Exception e) {
-      logger.error("Could not count message signatures: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not count message signatures", e);
       throw new MailServiceException(e);
     } finally {
       if (em != null)
@@ -547,13 +546,13 @@ public class MailService {
     try {
       mimeMessage = toMimeMessage(mail);
     } catch (Exception e) {
-      logger.error("Unable to create mime message: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to create mime message", e);
       throw new MailServiceException(e);
     }
     try {
       smtpService.send(mimeMessage);
     } catch (MessagingException e) {
-      logger.error("Unable to send the email: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to send the email", e);
       throw new MailServiceException(e);
     }
   }

--- a/modules/migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
+++ b/modules/migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
@@ -23,7 +23,6 @@ package org.opencastproject.migration;
 import static com.entwinemedia.fn.Equality.eq;
 import static com.entwinemedia.fn.Prelude.chuck;
 import static com.entwinemedia.fn.data.Opt.none;
-import static java.lang.String.format;
 
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
@@ -60,7 +59,6 @@ import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.osgi.service.cm.ConfigurationException;
@@ -217,15 +215,13 @@ public class SchedulerMigrationService {
       }
       logger.info("Scheduler transaction | end");
     } catch (Exception e) {
-      final String stackTrace = ExceptionUtils.getStackTrace(e);
-      logger.error(format("Scheduler transaction | error\n%s", stackTrace));
+      logger.error("Scheduler transaction | error", e);
       if (tx != null) {
         logger.error("Scheduler transaction | rollback transaction");
         try {
           tx.rollback();
         } catch (Exception e2) {
-          final String stackTrace2 = ExceptionUtils.getStackTrace(e2);
-          logger.error(format("Scheduler transaction | error doing rollback\n%s", stackTrace2));
+          logger.error("Scheduler transaction | error doing rollback", e2);
         }
       }
     } finally {

--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/impl/AbstractOaiPmhDatabase.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/impl/AbstractOaiPmhDatabase.java
@@ -38,7 +38,6 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +97,7 @@ public abstract class AbstractOaiPmhDatabase implements OaiPmhDatabase {
         tx.commit();
         success = true;
       } catch (Exception e) {
-        final String message = ExceptionUtils.getMessage(e.getCause()).toLowerCase();
+        final String message = e.getCause().getMessage().toLowerCase();
         if (message.contains("unique") || message.contains("duplicate")) {
           try {
             Thread.sleep(1100L);
@@ -106,11 +105,11 @@ public abstract class AbstractOaiPmhDatabase implements OaiPmhDatabase {
             throw new OaiPmhDatabaseException(e1);
           }
           i++;
-          logger.info("Storing OAI-PMH entry '{}' from  repository '{}' failed, retry {} times.", new String[] {
-                  mediaPackage.getIdentifier().toString(), repository, Integer.toString(i) });
+          logger.info("Storing OAI-PMH entry '{}' from  repository '{}' failed, retry {} times.",
+                  mediaPackage.getIdentifier(), repository, i);
         } else {
-          logger.error("Could not store mediapackage '{}' to OAI-PMH repository '{}': {}", new String[] {
-                  mediaPackage.getIdentifier().toString(), repository, ExceptionUtils.getStackTrace(e) });
+          logger.error("Could not store mediapackage '{}' to OAI-PMH repository '{}'", mediaPackage.getIdentifier(),
+                  repository, e);
           if (tx != null && tx.isActive())
             tx.rollback();
 
@@ -193,7 +192,7 @@ public abstract class AbstractOaiPmhDatabase implements OaiPmhDatabase {
       } catch (NotFoundException e) {
         throw e;
       } catch (Exception e) {
-        final String message = ExceptionUtils.getMessage(e.getCause()).toLowerCase();
+        final String message = e.getCause().getMessage().toLowerCase();
         if (message.contains("unique") || message.contains("duplicate")) {
           try {
             Thread.sleep(1100L);
@@ -202,10 +201,10 @@ public abstract class AbstractOaiPmhDatabase implements OaiPmhDatabase {
           }
           i++;
           logger.info("Deleting OAI-PMH entry '{}' from  repository '{}' failed, retry {} times.",
-                  new String[] { mediaPackageId, repository, Integer.toString(i) });
+                  mediaPackageId, repository, i);
         } else {
-          logger.error("Could not delete mediapackage '{}' from OAI-PMH repository '{}': {}",
-                  new String[] { mediaPackageId, repository, ExceptionUtils.getStackTrace(e) });
+          logger.error("Could not delete mediapackage '{}' from OAI-PMH repository '{}'",
+                  mediaPackageId, repository, e);
           if (tx != null && tx.isActive())
             tx.rollback();
 

--- a/modules/scheduler-conflict-notifier-email/src/main/java/org/opencastproject/scheduler/conflict/notifier/email/EmailSchedulerConflictNotifier.java
+++ b/modules/scheduler-conflict-notifier-email/src/main/java/org/opencastproject/scheduler/conflict/notifier/email/EmailSchedulerConflictNotifier.java
@@ -40,7 +40,6 @@ import com.entwinemedia.fn.Stream;
 
 import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.osgi.service.component.ComponentContext;
@@ -184,7 +183,7 @@ public class EmailSchedulerConflictNotifier implements ConflictNotifier, Managed
       smptService.send(message);
       logger.info("E-mail scheduler conflict notification sent to {}", recipient);
     } catch (MessagingException e) {
-      logger.error("Unable to send email scheduler conflict notification: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to send email scheduler conflict notification", e);
     }
   }
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/CalendarGenerator.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/CalendarGenerator.java
@@ -50,7 +50,6 @@ import net.fortuna.ical4j.model.property.Uid;
 import net.fortuna.ical4j.model.property.Version;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -199,7 +198,7 @@ public class CalendarGenerator {
       event.getProperties().add(agentsAttachment);
 
     } catch (Exception e) {
-      logger.error("Unable to add event '{}' to recording calendar: {}", eventId, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to add event '{}' to recording calendar", eventId, e);
       return false;
     }
 
@@ -235,7 +234,7 @@ public class CalendarGenerator {
         seriesDC = seriesService.getSeries(seriesID);
         series.put(seriesID, seriesDC);
       } catch (SeriesException e) {
-        logger.error("Error loading DublinCoreCatalog for series '{}': {}", seriesID, ExceptionUtils.getStackTrace(e));
+        logger.error("Error loading DublinCoreCatalog for series '{}'", seriesID, e);
         return null;
       }
     }
@@ -243,7 +242,7 @@ public class CalendarGenerator {
     try {
       return seriesDC.toXmlString();
     } catch (IOException e) {
-      logger.error("Error serializing DublinCoreCatalog of series '{}': {}", seriesID, ExceptionUtils.getStackTrace(e));
+      logger.error("Error serializing DublinCoreCatalog of series '{}'", seriesID, e);
       return null;
     }
   }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerUtil.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerUtil.java
@@ -52,7 +52,6 @@ import com.entwinemedia.fn.Fn2;
 import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.lang3.CharUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,7 +225,7 @@ public final class SchedulerUtil {
       try {
         dublinCore = DublinCoreUtil.loadDublinCore(workspace, c);
       } catch (Exception e) {
-        logger.error("Unable to read event dublincore: {}", ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to read event dublincore", e);
         continue;
       }
 

--- a/modules/search/src/main/java/org/opencastproject/matterhorn/search/impl/AbstractElasticsearchIndex.java
+++ b/modules/search/src/main/java/org/opencastproject/matterhorn/search/impl/AbstractElasticsearchIndex.java
@@ -34,7 +34,6 @@ import org.opencastproject.util.data.Option;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
@@ -184,7 +183,7 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
     try {
       createIndex(index);
     } catch (SearchIndexException e) {
-      logger.error("Unable to re-create the index after a clear: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to re-create the index after a clear", e);
     }
   }
 

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
@@ -374,7 +374,7 @@ public class SeriesRestService {
       logger.warn("Series with id '{}' does not exist.", seriesId);
       return Response.status(Status.NOT_FOUND).build();
     } catch (Exception e) {
-      logger.warn("Unable to get series opt out status with id '{}': {}", seriesId, ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to get series opt out status with id '{}'", seriesId, e);
       throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
     }
   }
@@ -567,7 +567,7 @@ public class SeriesRestService {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.warn("Could not perform search query: {}", ExceptionUtils.getStackTrace(e));
+      logger.warn("Could not perform search query", e);
     }
     throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
   }
@@ -793,7 +793,7 @@ public class SeriesRestService {
         return R.notFound();
       }
     } catch (SeriesException e) {
-      logger.warn("Error while retrieving elements for sieres '{}': {}", seriesId, ExceptionUtils.getStackTrace(e));
+      logger.warn("Error while retrieving elements for sieres '{}'", seriesId, e);
       return R.serverError();
     }
   }
@@ -850,10 +850,10 @@ public class SeriesRestService {
         }
       }
     } catch (IOException e) {
-      logger.error("Error while trying to read from request: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Error while trying to read from request", e);
       return R.serverError();
     } catch (SeriesException e) {
-      logger.warn("Error while adding element to series '{}': {}", seriesId, ExceptionUtils.getStackTrace(e));
+      logger.warn("Error while adding element to series '{}'", seriesId, e);
       return R.serverError();
     } finally {
       IOUtils.closeQuietly(is);

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -61,7 +61,6 @@ import org.opencastproject.util.data.Option;
 import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.framework.ServiceException;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
@@ -407,8 +406,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     try {
       return index.isOptOut(seriesId);
     } catch (SeriesServiceDatabaseException e) {
-      logger.error("Exception occured while getting opt out status of series '{}': {}", seriesId,
-              ExceptionUtils.getStackTrace(e));
+      logger.error("Exception occurred while getting opt out status of series '{}'", seriesId, e);
       throw new SeriesException(e);
     }
   }
@@ -421,8 +419,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       messageSender.sendObjectMessage(SeriesItem.SERIES_QUEUE, MessageSender.DestinationType.Queue,
               SeriesItem.updateOptOut(seriesId, optOut));
     } catch (SeriesServiceDatabaseException e) {
-      logger.error("Failed to update opt out status of series with id '{}': {}", seriesId,
-              ExceptionUtils.getStackTrace(e));
+      logger.error("Failed to update opt out status of series with id '{}'", seriesId, e);
       throw new SeriesException(e);
     }
   }
@@ -433,8 +430,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     try {
       return persistence.getSeriesProperties(seriesID);
     } catch (SeriesServiceDatabaseException e) {
-      logger.error("Failed to get series properties for series with id '{}': {}", seriesID,
-              ExceptionUtils.getStackTrace(e));
+      logger.error("Failed to get series properties for series with id '{}'", seriesID, e);
       throw new SeriesException(e);
     }
   }
@@ -445,8 +441,8 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     try {
       return persistence.getSeriesProperty(seriesID, propertyName);
     } catch (SeriesServiceDatabaseException e) {
-      logger.error("Failed to get series property for series with series id '{}' and property name '{}': {}", seriesID,
-              propertyName, ExceptionUtils.getStackTrace(e));
+      logger.error("Failed to get series property for series with series id '{}' and property name '{}'", seriesID,
+              propertyName, e);
       throw new SeriesException(e);
     }
   }
@@ -460,8 +456,8 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
               SeriesItem.updateProperty(seriesID, propertyName, propertyValue));
     } catch (SeriesServiceDatabaseException e) {
       logger.error(
-              "Failed to get series property for series with series id '{}' and property name '{}' and value '{}': {}",
-              seriesID, propertyName, propertyValue, ExceptionUtils.getStackTrace(e));
+              "Failed to get series property for series with series id '{}' and property name '{}' and value '{}'",
+              seriesID, propertyName, propertyValue, e);
       throw new SeriesException(e);
     }
   }
@@ -474,8 +470,8 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       messageSender.sendObjectMessage(SeriesItem.SERIES_QUEUE, MessageSender.DestinationType.Queue,
               SeriesItem.updateProperty(seriesID, propertyName, null));
     } catch (SeriesServiceDatabaseException e) {
-      logger.error("Failed to delete series property for series with series id '{}' and property name '{}': {}",
-              seriesID, propertyName, ExceptionUtils.getStackTrace(e));
+      logger.error("Failed to delete series property for series with series id '{}' and property name '{}'",
+              seriesID, propertyName, e);
       throw new SeriesException(e);
     }
   }

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -573,7 +573,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not retrieve opt out status for series '{}': {}", seriesId, ExceptionUtils.getStackTrace(e));
+      logger.error("Could not retrieve opt out status for series '{}'", seriesId, e);
       throw new SeriesServiceDatabaseException(e);
     } finally {
       if (em != null)

--- a/modules/smil-api/src/main/java/org/opencastproject/smil/api/util/SmilUtil.java
+++ b/modules/smil-api/src/main/java/org/opencastproject/smil/api/util/SmilUtil.java
@@ -40,7 +40,6 @@ import com.entwinemedia.fn.FnX;
 
 import org.apache.commons.httpclient.util.URIUtil;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -108,7 +107,7 @@ public final class SmilUtil {
 
       throw eitherDocument.left().value();
     } catch (Exception e) {
-      logger.warn("Unable to load smil document from catalog '{}': {}", mpe, ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to load smil document from catalog '{}'", mpe, e);
       return Misc.chuck(e);
     }
   }

--- a/modules/static-file-service-api/src/main/java/org/opencastproject/staticfiles/endpoint/StaticFileRestService.java
+++ b/modules/static-file-service-api/src/main/java/org/opencastproject/staticfiles/endpoint/StaticFileRestService.java
@@ -166,7 +166,7 @@ public class StaticFileRestService {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.warn("Unable to retrieve file with uuid {} because: {}", uuid, ExceptionUtils.getStackTrace(e));
+      logger.warn("Unable to retrieve file with uuid {}", uuid, e);
       return Response.serverError().build();
     }
   }
@@ -239,7 +239,7 @@ public class StaticFileRestService {
     } catch (WebApplicationException e) {
       return e.getResponse();
     } catch (Exception e) {
-      logger.error("Unable to store file because: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to store file", e);
       return Response.serverError().build();
     } finally {
       IOUtils.closeQuietly(inputStream);
@@ -273,7 +273,7 @@ public class StaticFileRestService {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Unable to retrieve static file URL from {} because: {}", uuid, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to retrieve static file URL from {}", uuid, e);
       return Response.serverError().build();
     }
   }
@@ -290,7 +290,7 @@ public class StaticFileRestService {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Unable to delete static file {} because: {}", uuid, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to delete static file {}", uuid, e);
       return Response.serverError().build();
     }
   }

--- a/modules/static-file-service-impl/src/main/java/org/opencastproject/staticfiles/impl/StaticFileServiceImpl.java
+++ b/modules/static-file-service-impl/src/main/java/org/opencastproject/staticfiles/impl/StaticFileServiceImpl.java
@@ -42,7 +42,6 @@ import com.google.common.util.concurrent.Service.State;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.ComponentException;
 import org.slf4j.Logger;
@@ -164,7 +163,7 @@ public class StaticFileServiceImpl implements StaticFileService {
       Files.createDirectories(file.getParent());
       Files.copy(progressInputStream, file);
     } catch (IOException e) {
-      logger.error("Unable to save file '{}' to {} because: {}", filename, file, ExceptionUtils.getStackTrace(e));
+      logger.error("Unable to save file '{}' to {}", filename, file, e);
       throw e;
     }
 

--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
@@ -40,7 +40,6 @@ import org.opencastproject.themes.ThemesServiceDatabase;
 import org.opencastproject.util.NotFoundException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.text.WordUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
@@ -160,7 +159,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not get theme: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get theme", e);
       throw new ThemesServiceDatabaseException(e);
     } finally {
       if (em != null)
@@ -182,7 +181,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
       }
       return themes;
     } catch (Exception e) {
-      logger.error("Could not get themes: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not get themes", e);
       throw new ThemesServiceDatabaseException(e);
     } finally {
       if (em != null)
@@ -219,7 +218,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
               ThemeItem.update(toSerializableTheme(theme)));
       return theme;
     } catch (Exception e) {
-      logger.error("Could not update theme {}: {}", theme, ExceptionUtils.getStackTrace(e));
+      logger.error("Could not update theme {}", theme, e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -270,7 +269,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not delete theme '{}': {}", id, ExceptionUtils.getStackTrace(e));
+      logger.error("Could not delete theme '{}'", id, e);
       if (tx.isActive())
         tx.rollback();
       throw new ThemesServiceDatabaseException(e);
@@ -290,7 +289,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
       Number countResult = (Number) q.getSingleResult();
       return countResult.intValue();
     } catch (Exception e) {
-      logger.error("Could not count themes: {}", ExceptionUtils.getStackTrace(e));
+      logger.error("Could not count themes", e);
       throw new ThemesServiceDatabaseException(e);
     } finally {
       if (em != null) {
@@ -356,7 +355,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
             current++;
           }
         } catch (ThemesServiceDatabaseException e) {
-          logger.error("Unable to get themes from the database because", e);
+          logger.error("Unable to get themes from the database", e);
           throw new IllegalStateException(e);
         }
       });

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/AbstractUrlSigningProvider.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/AbstractUrlSigningProvider.java
@@ -242,7 +242,7 @@ public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, 
       return ((keyEntry != null) && (StringUtils.equals(keyEntry.getOrganization(), ANY_ORGANIZATION)
               || StringUtils.equals(keyEntry.getOrganization(), orgId)));
     } catch (URISyntaxException e) {
-      getLogger().debug("Unable to support url {} because: {}", baseUrl, ExceptionUtils.getStackTrace(e));
+      getLogger().debug("Unable to support url {} because", baseUrl, e);
       return false;
     }
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
@@ -268,7 +268,7 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
         }
 
       } catch (Throwable t) {
-        logger.error("Unable to load system administrator group because", t);
+        logger.error("Unable to load system administrator group", t);
       }
     });
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
@@ -280,7 +280,7 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
         // setting the URI to a new source so the checksum will most like be invalid
         episodeCatalog.setChecksum(null);
       } catch (Exception e) {
-        logger.error("Unable to update episode catalog isPartOf field: {}", ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to update episode catalog isPartOf field", e);
         throw new WorkflowOperationException(e);
       }
     }
@@ -342,7 +342,7 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
         if (acl != null)
           authorizationService.setAcl(mediaPackage, AclScope.Series, acl);
       } catch (Exception e) {
-        logger.error("Unable to update series ACL: {}", ExceptionUtils.getStackTrace(e));
+        logger.error("Unable to update series ACL", e);
         throw new WorkflowOperationException(e);
       }
     }


### PR DESCRIPTION
This patch reduces the complexity of some log statements, in particular
by replacing the use of ExceptionUtils#getStackTrace by the same
functionality built into the logger used by Opencast.