### PR TITLE
MH-13163, Fix empty REST documentation notes

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
@@ -83,7 +83,7 @@ import javax.ws.rs.core.Response;
  */
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0 })
-@RestService(name = "externalapiservice", title = "External API Service", notes = "", abstractText = "Provides a location for external apis to query the current server of the API.")
+@RestService(name = "externalapiservice", title = "External API Service", notes = {}, abstractText = "Provides a location for external apis to query the current server of the API.")
 public class BaseEndpoint {
 
   /** The logging facility */

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
@@ -59,7 +59,7 @@ import javax.ws.rs.core.Response;
 @RestService(
     name = "externalapicaptureagents",
     title = "External API Capture Agents Service",
-    notes = "",
+    notes = {},
     abstractText = "Provides resources and operations related to the capture agents"
 )
 public class CaptureAgentsEndpoint {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -167,7 +167,7 @@ import javax.ws.rs.core.Response.Status;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0 })
-@RestService(name = "externalapievents", title = "External API Events Service", notes = "", abstractText = "Provides resources and operations related to the events")
+@RestService(name = "externalapievents", title = "External API Events Service", notes = {}, abstractText = "Provides resources and operations related to the events")
 public class EventsEndpoint implements ManagedService {
   private static final String METADATA_JSON_KEY = "metadata";
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -71,7 +71,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0 })
-@RestService(name = "externalapigroups", title = "External API Groups Service", notes = "", abstractText = "Provides resources and operations related to the groups")
+@RestService(name = "externalapigroups", title = "External API Groups Service", notes = {}, abstractText = "Provides resources and operations related to the groups")
 public class GroupsEndpoint {
 
   /** The logging facility */

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
@@ -64,7 +64,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0 })
-@RestService(name = "externalapisecurity", title = "External API Security Service", notes = "", abstractText = "Provides security operations related to the external API")
+@RestService(name = "externalapisecurity", title = "External API Security Service", notes = {}, abstractText = "Provides security operations related to the external API")
 public class SecurityEndpoint implements ManagedService {
 
   protected static final String URL_SIGNING_EXPIRES_DURATION_SECONDS_KEY = "url.signing.expires.seconds";

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -121,7 +121,7 @@ import javax.ws.rs.core.Response.Status;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0 })
-@RestService(name = "externalapiseries", title = "External API Series Service", notes = "", abstractText = "Provides resources and operations related to the series")
+@RestService(name = "externalapiseries", title = "External API Series Service", notes = {}, abstractText = "Provides resources and operations related to the series")
 public class SeriesEndpoint {
 
   private static final int CREATED_BY_UI_ORDER = 9;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
@@ -78,7 +78,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0 })
-@RestService(name = "externalapiworkflowdefinitions", title = "External API Workflow Definitions Service", notes = "", abstractText = "Provides resources and operations related to the workflow definitions")
+@RestService(name = "externalapiworkflowdefinitions", title = "External API Workflow Definitions Service", notes = {}, abstractText = "Provides resources and operations related to the workflow definitions")
 public class WorkflowDefinitionsEndpoint {
 
   /**

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
@@ -104,7 +104,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0 })
-@RestService(name = "externalapiworkflowinstances", title = "External API Workflow Instances Service", notes = "", abstractText = "Provides resources and operations related to the workflow instances")
+@RestService(name = "externalapiworkflowinstances", title = "External API Workflow Instances Service", notes = {}, abstractText = "Provides resources and operations related to the workflow instances")
 public class WorkflowsEndpoint {
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(WorkflowsEndpoint.class);

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OsgiOaiPmhServerInfoRestEndpoint.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OsgiOaiPmhServerInfoRestEndpoint.java
@@ -30,7 +30,7 @@ import javax.ws.rs.Path;
         title = "OAI-PMH server info service",
         abstractText = "This service "
                 + "provides system gateway to the OAI-PMH server.",
-        notes = "")
+        notes = {})
 public class OsgiOaiPmhServerInfoRestEndpoint extends AbstractOaiPmhServerInfoRestEndpoint {
   private OaiPmhServerInfo oaiPmhServerInfo;
 


### PR DESCRIPTION
Instead of adding no notes, a few REST interfaced explicitly added one
empty note which would cause a notes section with an empty bullet point
to appear in the REST documentation.