### PR TITLE
MH-13160, Send actually required data in workflow messages

### DIFF
--- a/modules/admin-ui/src/main/resources/OSGI-INF/message-receiver-workflow.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/message-receiver-workflow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
                name="org.opencastproject.index.service.message.WorkflowMessageReceiverImpl-Adminui"
-               immediate="true" activate="activate" deactivate="deactivate">
+               immediate="true">
   <implementation
     class="org.opencastproject.index.service.message.WorkflowMessageReceiverImpl"/>
   <property name="service.description" value="Workflow Message Receiver"/>
@@ -11,40 +11,23 @@
   </service>
 
   <reference name="message-broker-sender"
-             cardinality="1..1"
              interface="org.opencastproject.message.broker.api.MessageSender"
-             policy="static"
              bind="setMessageSender"/>
 
   <reference name="message-broker-receiver"
              interface="org.opencastproject.message.broker.api.MessageReceiver"
-             cardinality="1..1"
-             policy="static"
              bind="setMessageReceiver"/>
 
   <reference name="message-receiver-lock-service"
-             cardinality="1..1"
              interface="org.opencastproject.index.service.message.MessageReceiverLockService"
-             policy="static"
              bind="setMessageReceiverLockService"/>
 
   <reference name="search-index"
              interface="org.opencastproject.adminui.impl.index.AdminUISearchIndex"
-             cardinality="1..1"
-             policy="static"
              bind="setSearchIndex"/>
 
-  <reference bind="setWorkspace"
-             cardinality="1..1"
-             interface="org.opencastproject.workspace.api.Workspace"
-             name="workspace"
-             policy="static"/>
-
-  <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
-             cardinality="1..1" policy="static" bind="setSecurityService"/>
-  <reference name="authorization-service" interface="org.opencastproject.security.api.AuthorizationService"
-             cardinality="1..1" policy="static" bind="setAuthorizationService"/>
-  <reference name="aclServiceFactory" interface="org.opencastproject.authorization.xacml.manager.api.AclServiceFactory"
-             cardinality="1..1" policy="dynamic" bind="setAclServiceFactory"/>
+  <reference name="security-service"
+             interface="org.opencastproject.security.api.SecurityService"
+             bind="setSecurityService"/>
 
 </scr:component>

--- a/modules/external-api/src/main/resources/OSGI-INF/message-receiver-workflow.xml
+++ b/modules/external-api/src/main/resources/OSGI-INF/message-receiver-workflow.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
                name="org.opencastproject.index.service.message.WorkflowMessageReceiverImpl-External"
-               immediate="true" activate="activate" deactivate="deactivate">
+               immediate="true">
   <implementation
       class="org.opencastproject.index.service.message.WorkflowMessageReceiverImpl"/>
   <property name="service.description" value="Workflow Message Receiver"/>
@@ -11,41 +11,23 @@
   </service>
 
   <reference name="message-broker-sender"
-             cardinality="1..1"
              interface="org.opencastproject.message.broker.api.MessageSender"
-             policy="static"
              bind="setMessageSender"/>
 
   <reference name="message-broker-receiver"
              interface="org.opencastproject.message.broker.api.MessageReceiver"
-             cardinality="1..1"
-             policy="static"
              bind="setMessageReceiver"/>
 
   <reference name="message-receiver-lock-service"
-             cardinality="1..1"
              interface="org.opencastproject.index.service.message.MessageReceiverLockService"
-             policy="static"
              bind="setMessageReceiverLockService"/>
 
   <reference name="search-index"
              interface="org.opencastproject.external.impl.index.ExternalIndex"
-             cardinality="1..1"
-             policy="static"
              bind="setSearchIndex"/>
 
-  <reference bind="setWorkspace"
-             cardinality="1..1"
-             interface="org.opencastproject.workspace.api.Workspace"
-             name="workspace"
-             policy="static"/>
-
-  <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
-             cardinality="1..1" policy="static" bind="setSecurityService"/>
-  <reference name="authorization-service" interface="org.opencastproject.security.api.AuthorizationService"
-             cardinality="1..1" policy="static" bind="setAuthorizationService"/>
-  <reference name="aclServiceFactory"
-             interface="org.opencastproject.authorization.xacml.manager.api.AclServiceFactory"
-             cardinality="1..1" policy="dynamic" bind="setAclServiceFactory"/>
+  <reference name="security-service"
+             interface="org.opencastproject.security.api.SecurityService"
+             bind="setSecurityService"/>
 
 </scr:component>

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -505,9 +506,9 @@ public final class EventIndexUtils {
    */
   public static Event updateEvent(Event event, MediaPackage mp) {
     // Tracks
-    List<String> trackMimeTypes = new ArrayList<String>();
-    List<String> trackStreamResolutions = new ArrayList<String>();
-    List<String> trackFlavors = new ArrayList<String>();
+    List<String> trackMimeTypes = new ArrayList<>();
+    List<String> trackStreamResolutions = new ArrayList<>();
+    List<String> trackFlavors = new ArrayList<>();
     for (Track t : mp.getTracks()) {
       if (t.getMimeType() != null)
         trackMimeTypes.add(t.getMimeType().toString());
@@ -523,8 +524,8 @@ public final class EventIndexUtils {
     event.setTrackFlavors(trackFlavors);
 
     // Metadata
-    List<String> metadataFlavors = new ArrayList<String>();
-    List<String> metadataMimetypes = new ArrayList<String>();
+    List<String> metadataFlavors = new ArrayList<>();
+    List<String> metadataMimetypes = new ArrayList<>();
     for (Catalog c : mp.getCatalogs()) {
       if (c.getFlavor() != null)
         metadataFlavors.add(c.getFlavor().toString());
@@ -535,7 +536,7 @@ public final class EventIndexUtils {
     event.setMetadataMimetypes(metadataMimetypes);
 
     // Attachments
-    List<String> attachmentFlavors = new ArrayList<String>();
+    List<String> attachmentFlavors = new ArrayList<>();
     for (Attachment a : mp.getAttachments()) {
       if (a.getFlavor() != null)
         attachmentFlavors.add(a.getFlavor().toString());
@@ -543,11 +544,7 @@ public final class EventIndexUtils {
     event.setAttachmentFlavors(attachmentFlavors);
 
     // Publications
-    List<Publication> publications = new ArrayList<Publication>();
-    for (Publication p : mp.getPublications()) {
-      publications.add(p);
-    }
-    event.setPublications(publications);
+    event.setPublications(Arrays.asList(mp.getPublications()));
 
     event.setSeriesName(mp.getSeriesTitle());
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImpl.java
@@ -86,7 +86,7 @@ public class AssetManagerMessageReceiverImpl extends BaseMessageReceiverImpl<Ass
     // Load or create the corresponding recording event
     final Event event;
     try {
-      event = getOrCreateEvent(mp.getIdentifier().toString(), organization, user, getSearchIndex());
+      event = getOrCreateEvent(msg.getId(), organization, user, getSearchIndex());
       final AccessControlList acl = msg.getAcl();
       List<ManagedAcl> acls = aclServiceFactory.serviceFor(getSecurityService().getOrganization()).getAcls();
       for (final ManagedAcl managedAcl : AccessInformationUtil.matchAcls(acls, acl)) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/WorkflowMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/WorkflowMessageReceiverImpl.java
@@ -24,43 +24,21 @@ package org.opencastproject.index.service.message;
 import static org.opencastproject.index.service.impl.index.event.EventIndexUtils.getOrCreateEvent;
 import static org.opencastproject.index.service.impl.index.event.EventIndexUtils.updateEvent;
 
-import org.opencastproject.authorization.xacml.manager.api.AclServiceFactory;
-import org.opencastproject.authorization.xacml.manager.api.ManagedAcl;
 import org.opencastproject.index.service.impl.index.event.Event;
-import org.opencastproject.index.service.impl.index.event.EventIndexUtils;
-import org.opencastproject.index.service.util.AccessInformationUtil;
 import org.opencastproject.matterhorn.search.SearchIndexException;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.message.broker.api.MessageSender;
 import org.opencastproject.message.broker.api.workflow.WorkflowItem;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
-import org.opencastproject.metadata.dublincore.DublinCoreUtil;
-import org.opencastproject.security.api.AccessControlList;
-import org.opencastproject.security.api.AccessControlParser;
-import org.opencastproject.security.api.AclScope;
-import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.User;
 import org.opencastproject.util.NotFoundException;
-import org.opencastproject.util.data.Option;
-import org.opencastproject.util.data.Tuple;
-import org.opencastproject.workflow.api.WorkflowInstance;
-import org.opencastproject.workspace.api.Workspace;
 
-import com.entwinemedia.fn.data.Opt;
-
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 public class WorkflowMessageReceiverImpl extends BaseMessageReceiverImpl<WorkflowItem> {
 
   private static final Logger logger = LoggerFactory.getLogger(WorkflowMessageReceiverImpl.class);
-
-  private Workspace workspace;
-  private AuthorizationService authorizationService;
-  private AclServiceFactory aclServiceFactory;
 
   /**
    * Creates a new message receiver that is listening to the admin ui destination of the workflow queue.
@@ -71,110 +49,68 @@ public class WorkflowMessageReceiverImpl extends BaseMessageReceiverImpl<Workflo
 
   @Override
   protected void execute(WorkflowItem workflowItem) {
-    String organization = getSecurityService().getOrganization().getId();
-    User user = getSecurityService().getUser();
-    String eventId = null;
+    logger.debug("Received workflow item of type '{}'", workflowItem.getType());
     switch (workflowItem.getType()) {
       case UpdateInstance:
-
-        logger.debug("Received Update Workflow instance Entry for index {}", getSearchIndex().getIndexName());
-
-        WorkflowInstance wf = workflowItem.getWorkflowInstance();
-        MediaPackage mp = wf.getMediaPackage();
-        eventId = mp.getIdentifier().toString();
-
-        // Load or create the corresponding recording event
-        Event event = null;
-        try {
-          event = getOrCreateEvent(eventId, organization, user, getSearchIndex());
-          event.setCreator(getSecurityService().getUser().getName());
-          event.setWorkflowId(wf.getId());
-          event.setWorkflowDefinitionId(wf.getTemplate());
-          event.setWorkflowState(wf.getState());
-          WorkflowInstance.WorkflowState state = wf.getState();
-
-          if (!state.isTerminated()) {
-            Tuple<AccessControlList, AclScope> activeAcl = authorizationService.getActiveAcl(mp);
-            List<ManagedAcl> acls = aclServiceFactory.serviceFor(getSecurityService().getOrganization()).getAcls();
-            Option<ManagedAcl> managedAcl = AccessInformationUtil.matchAcls(acls, activeAcl.getA());
-
-            if (managedAcl.isSome()) {
-              event.setManagedAcl(managedAcl.get().getName());
-            }
-            event.setAccessPolicy(AccessControlParser.toJsonSilent(activeAcl.getA()));
-
-            try {
-              Opt<DublinCoreCatalog> loadedDC = DublinCoreUtil.loadEpisodeDublinCore(workspace, mp);
-              if (loadedDC.isSome())
-                updateEvent(event, loadedDC.get());
-            } catch (Throwable t) {
-              logger.warn("Unable to load dublincore catalog for the workflow {}, mp {}", wf.getId(),
-                      mp.getIdentifier().compact(), t);
-            }
-
-          }
-          updateEvent(event, mp);
-        } catch (SearchIndexException e) {
-          logger.error("Error retrieving the recording event from the search index: {}", e.getMessage());
-          return;
-        }
-
-        // Update series name if not already done
-        try {
-          EventIndexUtils.updateSeriesName(event, organization, user, getSearchIndex());
-        } catch (SearchIndexException e) {
-          logger.error("Error updating the series name of the event to index: {}", ExceptionUtils.getStackTrace(e));
-        }
-
-        // Persist the scheduling event
-        try {
-          getSearchIndex().addOrUpdate(event);
-          logger.debug("Workflow instance {} updated in the search index", event.getIdentifier());
-        } catch (SearchIndexException e) {
-          logger.error("Error retrieving the recording event from the search index: {}", e.getMessage());
-          return;
-        }
-
-        return;
+        updateWorkflowInstance(workflowItem);
+        break;
       case DeleteInstance:
-        logger.debug("Received Delete Workflow instance Entry {}", eventId);
-        eventId = workflowItem.getWorkflowInstance().getMediaPackage().getIdentifier().toString();
-
-        // Remove the Workflow instance entry from the search index
-        try {
-          getSearchIndex().deleteWorkflow(organization, user, eventId, workflowItem.getWorkflowInstanceId());
-          logger.debug("Workflow instance mediapackage {} removed from search index", eventId);
-        } catch (NotFoundException e) {
-          logger.warn("Workflow instance mediapackage {} not found for deletion", eventId);
-        } catch (SearchIndexException e) {
-          logger.error("Error deleting the Workflow instance entry {} from the search index: {}", eventId,
-                  ExceptionUtils.getStackTrace(e));
-        }
-        return;
-      case AddDefinition:
-        // TODO: Update the index with it as soon as the definition are part of it
-        return;
-      case DeleteDefinition:
-        // TODO: Update the index with it as soon as the definition are part of it
-        return;
+        deleteWorkflowInstance(workflowItem);
+        break;
       default:
         throw new IllegalArgumentException("Unhandled type of WorkflowItem");
     }
   }
 
-  /** OSGi DI. */
-  public void setWorkspace(Workspace workspace) {
-    this.workspace = workspace;
+  private void deleteWorkflowInstance(WorkflowItem workflowItem) {
+    final String organization = getSecurityService().getOrganization().getId();
+    final User user = getSecurityService().getUser();
+    final String eventId = workflowItem.getId();
+    logger.debug("Received Delete Workflow instance Entry {}", eventId);
+
+    // Remove the Workflow instance entry from the search index
+    try {
+      getSearchIndex().deleteWorkflow(organization, user, eventId, workflowItem.getWorkflowInstanceId());
+      logger.debug("Workflow instance media package {} removed from search index", eventId);
+    } catch (NotFoundException e) {
+      logger.warn("Workflow instance media package {} not found for deletion", eventId);
+    } catch (SearchIndexException e) {
+      logger.error("Error deleting the Workflow instance entry {} from the search index", eventId, e);
+    }
   }
 
-  /** OSGi DI. */
-  public void setAuthorizationService(AuthorizationService authorizationService) {
-    this.authorizationService = authorizationService;
-  }
+  private void updateWorkflowInstance(WorkflowItem workflowItem) {
+    logger.debug("Received Update Workflow instance Entry for index {}", getSearchIndex().getIndexName());
+    final String organization = getSecurityService().getOrganization().getId();
+    final User user = getSecurityService().getUser();
+    final String eventId = workflowItem.getId();
+    final MediaPackage mediaPackage = workflowItem.getMediaPackage();
 
-  /** OSGi callback for acl services. */
-  public void setAclServiceFactory(AclServiceFactory aclServiceFactory) {
-    this.aclServiceFactory = aclServiceFactory;
+    // Load or create the corresponding recording event
+    try {
+      Event event = getOrCreateEvent(eventId, organization, user, getSearchIndex());
+      event.setCreator(user.getName());
+      event.setWorkflowId(workflowItem.getWorkflowInstanceId());
+      event.setWorkflowDefinitionId(workflowItem.getWorkflowDefinitionId());
+      event.setWorkflowState(workflowItem.getState());
+      event.setAccessPolicy(workflowItem.getAccessControlListJSON());
+
+      // Update metadata
+      DublinCoreCatalog dcCatalog = workflowItem.getEpisodeDublincoreCatalog();
+      if (dcCatalog != null) {
+        updateEvent(event, dcCatalog);
+      }
+
+      // update publications
+      updateEvent(event, mediaPackage);
+
+
+      // Persist event
+      getSearchIndex().addOrUpdate(event);
+      logger.debug("Workflow instance {} updated in the search index", eventId);
+    } catch (SearchIndexException e) {
+      logger.error("Error retrieving the recording event from the search index", e);
+    }
   }
 
 }

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/workflow/WorkflowItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/workflow/WorkflowItem.java
@@ -21,13 +21,22 @@
 
 package org.opencastproject.message.broker.api.workflow;
 
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.message.broker.api.MessageItem;
-import org.opencastproject.workflow.api.WorkflowDefinition;
+import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
+import org.opencastproject.metadata.dublincore.DublinCoreXmlFormat;
+import org.opencastproject.security.api.AccessControlList;
+import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.workflow.api.WorkflowInstance;
-import org.opencastproject.workflow.api.WorkflowParser;
-import org.opencastproject.workflow.api.WorkflowParsingException;
 
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
 import java.io.Serializable;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * {@link Serializable} class that represents all of the possible messages sent through a WorkflowService queue.
@@ -41,35 +50,29 @@ public class WorkflowItem implements MessageItem, Serializable {
   public static final String WORKFLOW_QUEUE = WORKFLOW_QUEUE_PREFIX + "QUEUE";
 
   private final String id;
-
   private final String workflowDefinitionId;
-  private final String workflowDefinition;
-
   private final long workflowInstanceId;
-  private final String workflowInstance;
+  private final String episodeDublincoreCatalog;
+  private final String mediaPackage;
+  private final String state;
+  private final String accessControlListJSON;
 
   private final Type type;
 
   public enum Type {
-    AddDefinition, DeleteDefinition, UpdateInstance, DeleteInstance
+    DeleteInstance, UpdateInstance
   };
-
-  /**
-   * @param workflowDefinition
-   *          The workflow definition to add.
-   * @return Builds a {@link WorkflowItem} for adding a workflow definition.
-   */
-  public static WorkflowItem addDefinition(WorkflowDefinition workflowDefinition) {
-    return new WorkflowItem(workflowDefinition);
-  }
 
   /**
    * @param workflowInstance
    *          The workflow instance to update.
+   * @param dublincoreXml
+   *          The episode dublincore catalog used for metadata updates
    * @return Builds {@link WorkflowItem} for updating a workflow instance.
    */
-  public static WorkflowItem updateInstance(WorkflowInstance workflowInstance) {
-    return new WorkflowItem(workflowInstance);
+  public static WorkflowItem updateInstance(WorkflowInstance workflowInstance, String dublincoreXml,
+          AccessControlList accessControlList) {
+    return new WorkflowItem(workflowInstance, dublincoreXml, accessControlList);
   }
 
   /**
@@ -84,67 +87,20 @@ public class WorkflowItem implements MessageItem, Serializable {
   }
 
   /**
-   * @param workflowDefinitionId
-   *          The unique id of the workflow definition to delete.
-   * @return Builds {@link WorkflowItem} for deleting a workflow definition.
-   */
-  public static WorkflowItem deleteDefinition(String workflowDefinitionId) {
-    return new WorkflowItem(workflowDefinitionId);
-  }
-
-  /**
-   * Constructor to build an add workflow definition {@link WorkflowItem}.
-   *
-   * @param workflowDefinition
-   *          The workflow definition to add.
-   */
-  public WorkflowItem(WorkflowDefinition workflowDefinition) {
-    this.id = workflowDefinition.getId();
-    this.workflowDefinitionId = null;
-    try {
-      this.workflowDefinition = WorkflowParser.toXml(workflowDefinition);
-    } catch (WorkflowParsingException e) {
-      throw new IllegalStateException(
-              String.format("Not able to serialize the given workflow definition %s.", workflowDefinition), e);
-    }
-    this.workflowInstanceId = -1;
-    this.workflowInstance = null;
-    this.type = Type.AddDefinition;
-  }
-
-  /**
    * Constructor to build an update workflow instance {@link WorkflowItem}.
    *
    * @param workflowInstance
    *          The workflow instance to update.
    */
-  public WorkflowItem(WorkflowInstance workflowInstance) {
+  public WorkflowItem(WorkflowInstance workflowInstance, String dublincoreXml, AccessControlList accessControlList) {
     this.id = workflowInstance.getMediaPackage().getIdentifier().compact();
-    this.workflowDefinitionId = null;
-    this.workflowDefinition = null;
-    this.workflowInstanceId = -1;
-    try {
-      this.workflowInstance = WorkflowParser.toXml(workflowInstance);
-    } catch (WorkflowParsingException e) {
-      throw new IllegalStateException(
-              String.format("Not able to serialize the given workflow instance %s.", workflowInstance), e);
-    }
+    this.workflowDefinitionId = workflowInstance.getTemplate();
+    this.workflowInstanceId = workflowInstance.getId();
+    this.episodeDublincoreCatalog = dublincoreXml;
+    this.mediaPackage = MediaPackageParser.getAsXml(workflowInstance.getMediaPackage());
+    this.state = workflowInstance.getState().toString();
+    this.accessControlListJSON = AccessControlParser.toJsonSilent(accessControlList);
     this.type = Type.UpdateInstance;
-  }
-
-  /**
-   * Constructor to build a delete workflow {@link WorkflowItem}.
-   *
-   * @param workflowDefinitionId
-   *          The id of the workflow definition to delete.
-   */
-  public WorkflowItem(String workflowDefinitionId) {
-    this.id = workflowDefinitionId;
-    this.workflowDefinitionId = workflowDefinitionId;
-    this.workflowDefinition = null;
-    this.workflowInstanceId = -1;
-    this.workflowInstance = null;
-    this.type = Type.DeleteDefinition;
   }
 
   /**
@@ -156,16 +112,14 @@ public class WorkflowItem implements MessageItem, Serializable {
    *          The workflow instance to update.
    */
   public WorkflowItem(long workflowInstanceId, WorkflowInstance workflowInstance) {
+    // We just need the media package id and workflow id
     this.id = workflowInstance.getMediaPackage().getIdentifier().compact();
-    this.workflowDefinitionId = null;
-    this.workflowDefinition = null;
     this.workflowInstanceId = workflowInstanceId;
-    try {
-      this.workflowInstance = WorkflowParser.toXml(workflowInstance);
-    } catch (WorkflowParsingException e) {
-      throw new IllegalStateException(
-              String.format("Not able to serialize the given workflow instance %s.", workflowInstance), e);
-    }
+    this.workflowDefinitionId = null;
+    this.episodeDublincoreCatalog = null;
+    this.mediaPackage = null;
+    this.state = null;
+    this.accessControlListJSON = null;
     this.type = Type.DeleteInstance;
   }
 
@@ -178,29 +132,41 @@ public class WorkflowItem implements MessageItem, Serializable {
     return workflowDefinitionId;
   }
 
-  public WorkflowDefinition getWorkflowDefinition() {
-    try {
-      return WorkflowParser.parseWorkflowDefinition(workflowDefinition);
-    } catch (WorkflowParsingException e) {
-      throw new IllegalStateException(
-              String.format("Not able to serialize the workflow definition %s.", workflowDefinition), e);
-    }
-  }
-
   public long getWorkflowInstanceId() {
     return workflowInstanceId;
-  }
-
-  public WorkflowInstance getWorkflowInstance() {
-    try {
-      return workflowInstance == null ? null : WorkflowParser.parseWorkflowInstance(workflowInstance);
-    } catch (WorkflowParsingException e) {
-      throw new IllegalStateException("Not able to parse the workflow instance.", e);
-    }
   }
 
   public Type getType() {
     return type;
   }
 
+  public DublinCoreCatalog getEpisodeDublincoreCatalog() {
+    if (episodeDublincoreCatalog == null) {
+      return null;
+    }
+    try {
+      return DublinCoreXmlFormat.read(episodeDublincoreCatalog);
+    } catch (IOException | ParserConfigurationException | SAXException e) {
+      throw new IllegalStateException("Unable to parse dublincore catalog", e);
+    }
+  }
+
+  public MediaPackage getMediaPackage() {
+    if (mediaPackage == null) {
+      return null;
+    }
+    try {
+      return MediaPackageParser.getFromXml(mediaPackage);
+    } catch (MediaPackageException e) {
+      throw new IllegalStateException("Could not parse media package XML", e);
+    }
+  }
+
+  public WorkflowInstance.WorkflowState getState() {
+    return WorkflowInstance.WorkflowState.valueOf(state);
+  }
+
+  public String getAccessControlListJSON() {
+    return accessControlListJSON;
+  }
 }


### PR DESCRIPTION
Instead of sending a serialized workflow instance (which can be huge)
and later retrieving additional data from somewhere else about which we
do not know if it is still there or if it has been modified since, this
patch will send the required data–and only that–directly included in the
workflow messages.