### PR TITLE
MH-13166, OAI-PMH Message Handler Performance

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/OaiPmhUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/OaiPmhUpdatedEventHandler.java
@@ -123,8 +123,7 @@ public class OaiPmhUpdatedEventHandler implements ManagedService {
     }
 
     //An episode or its ACL has been updated. Construct the MediaPackage and publish it to OAI-PMH.
-    logger.debug("Handling update event for media package {}",
-            snapshotItem.getMediapackage().getIdentifier().compact());
+    logger.debug("Handling update event for media package {}", snapshotItem.getId());
 
     // We must be an administrative user to make a query to the OaiPmhPublicationService
     final User prevUser = securityService.getUser();
@@ -158,7 +157,7 @@ public class OaiPmhUpdatedEventHandler implements ManagedService {
           // we don't want to wait for job completion here because it will block the message queue
         } catch (Exception e) {
           logger.error("Unable to update OAI-PMH publication for the media package {} in repository {}",
-                  snapshotItem.getMediapackage().getIdentifier().compact(), searchResultItem.getRepository(), e);
+                  snapshotItem.getId(), searchResultItem.getRepository(), e);
         }
       }
     } finally {


### PR DESCRIPTION
Instead of parsing the media package XML multiple times, just to log the
event id, we can just use the event id stored in the message directly.