### PR TITLE
MH-13167, Republishing metadata does not update all metadata

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-engage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-engage-woh.md
@@ -12,7 +12,7 @@ Parameter Table
 
 |configuration keys         |description                                                                   |
 |---------------------------|------------------------------------------------------------------------------|
-|check-availability         |Check if the media if rechable                                                |
+|check-availability         |Check if the media if reachable                                               |
 |download-source-flavors    |Specifies which media should be published for download                        |
 |download-source-tags       |Specifies which media should be published for download                        |
 |download-target-subflavors |Subflavor to use for distributed material                                     |
@@ -24,6 +24,8 @@ Parameter Table
 |streaming-source-tags      |Specifies which media should be published to the streaming server             |
 |streaming-target-tags      |Modify tags of published media                                                |
 |streaming-target-subflavors|Subflavor to use for distributed material                                     |
+|merge-force-flavors        |Flavors of elements for which an update is enforced when mergeing catalogs.   |
+|                           |Defaults to `dublincore/*,security/*`.
 
 Operation Example
 -----------------


### PR DESCRIPTION
The merge option of the `publish-engage` operation is used for
republishing metadata like dublincore catalogs or access control lists.

Merge works in a way that every previously published element which is
not in the new catalog is included in the merged media package. Or in
other words, only newly published catalogs are updated.

This behavior, while technically well defined and implemented correctly,
causes severe usability issues in some edge cases since a metadata
update can include an unexpected removal of an element.

Example 1 (Series Catalog)
--------------------------

Given an episode which is assigned to a series. Both dublincore/episode
and dublincore/series are published to engage. The user updates the
metadata in the admin interface, removes the series and republishes the
metadata.

Since the episode does not contain a series catalog any longer, the
element is not published which causes the merge to republish the old one
(a new catalog is not published after all). Hence you end up with a
published episode without a series which still has a series catalog.

Example 2 (ACL)
---------------

Given an episode with a published episode ACL. A user now removes the
episode ACL, modifies the series ACL and republishes the metadata to
update the access status. Note that switching from episode to series ACL
may happen automatically in some cases.

The publication of the episode ACL is not updated and the merge option
will republish the old access rules which override the less specific
series ACL. Hence the new access rules have no effect at all.

The Fix
-------

This patch introduces a new merge-force-flavor option which can be used
to enforce the update of certain catalogs. By default this is done for
the dublincore catalogs and the ACLs which are usually part of a
metadata republication. This ensures the metadata are updated even when
a catalog is removed.

The default is set in a way that users will usually not need to specify
any other value. Additional values may be set for extended metadata
catalogs (for which the default does not make things worse though) or in
the case that someone republishes parts of the metadata which is rather
unlikely.