### PR TITLE
MH-13169, Update bibliographic metadata when technical metadata changes

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -569,6 +569,8 @@ angular.module('adminNg.controllers')
           EventSchedulingResource.save({
             id: $scope.resourceId,
             entries: $scope.source
+          }, function () {
+            fetchChildResources($scope.resourceId);
           });
         }, me.conflictsDetected);
       }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -87,7 +87,7 @@
           <header><span translate="EVENTS.EVENTS.DETAILS.METADATA.CAPTION"><!-- Event details --></span></header>
           <div class="obj-container">
             <table class="main-tbl">
-              <tr ng-repeat="row in episodeCatalog.fields track by $index">
+              <tr ng-repeat="(idx, row) in episodeCatalog.fields">
                 <td>
                   <span translate="{{ row.label }}"></span>
                   <i ng-show="row.required" class="required">*</i>

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
@@ -129,7 +129,7 @@ public final class DublinCoreMetadataUtil {
     List<DublinCoreValue> periodStrings = dc.get(ename);
     Opt<DCMIPeriod> p = Opt.<DCMIPeriod> none();
     for (DublinCoreValue periodString : periodStrings) {
-      p = Opt.some(EncodingSchemeUtils.decodePeriod(periodString.getValue()));
+      p = Opt.nul(EncodingSchemeUtils.decodePeriod(periodString.getValue()));
     }
     return p;
   }


### PR DESCRIPTION
When scheduling a new event, the bibliographic meta data (as it can
be seen under event details -> meta data) is initialized with the
technical meta data specified while scheduling the event. However, when
changing the technical meta data of an existing event, the bibliographic
meta data is not updated accordingly. This is quite confusing for the
user. What makes things worse is the fact that the events table reflects
the change to the start/end date while it doesn't display the new
location.

To overcome this confusing behavior, this patch updates the
bibliographic meta data whenever the technical meta data is changed.
Changing the bibliographic meta data, however, doesn't affect the
technical meta data.

This work is sponsored by SWITCH.