### PR TITLE
MH-13173, Do not hardcode value of ACL override

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesAccessResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesAccessResource.js
@@ -42,7 +42,7 @@ angular.module('adminNg.resources')
 
         return $.param({
           acl      : angular.toJson({acl: data.acl}),
-          override : true
+          override : data.override
         });
       }
     }


### PR DESCRIPTION
Changing a series ACL in the admin interface will replace all access
rules set in the series' episodes. This behavior is hard-coded in the
logic for handling series ACL changes in the admin interface.

From there, the value is passed to the connection logic to the series
access REST endpoint where it is overwritten again which does not really
make any sense since we wouldn't need that parameter in the first place
if we just replace it again at that point.

This patch removes the second hard-coding of this value and respects the
value of the parameter passed to the logic instead.

*Work sponsored by SWITCH*