### PR TITLE
MH-13171 Fix workflow configuration settings being displayed incorrectly

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -157,6 +157,8 @@ angular.module('adminNg.controllers')
                 if (el.is('[type=checkbox]') || el.is('[type=radio]')) {
                   if (value === 'true' || value === true) {
                     el.attr('checked','checked');
+                  } else {
+                    el.removeAttr('checked');
                   }
                 } else {
                   el.val(value);


### PR DESCRIPTION
For scheduled events, the workflow configuration settings under event
details -> workflows were displayed incorrectly. If a setting was set to
"false", the default value was displayed which could also be "true",
even though the value was manually changed to "false".

This work is sponsored by SWITCH.