### PR TITLE
MH-13170 Fix workflow not selected in event details

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -377,6 +377,11 @@ angular.module('adminNg.controllers')
             }
           });
 
+          $scope.setWorkflowDefinitions = function (workflowDefinitions) {
+            $scope.workflowDefinitions = workflowDefinitions;
+            $scope.workflowDefinitionIds = workflowDefinitions.map(function (w) {return w.id;});
+          };
+
           $scope.workflow = {};
           $scope.workflows = EventWorkflowsResource.get({ id: id }, function () {
             if (angular.isDefined($scope.workflows.workflow)) {
@@ -385,7 +390,7 @@ angular.module('adminNg.controllers')
               $scope.workflowDefinitionsObject = NewEventProcessingResource.get({
                 tags: 'schedule'
               }, function () {
-                $scope.workflowDefinitions = $scope.workflowDefinitionsObject.workflows;
+                $scope.setWorkflowDefinitions($scope.workflowDefinitionsObject.workflows);
                 $scope.changeWorkflow(true);
                 setWorkflowConfig();
               });

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -490,7 +490,7 @@
                         <td>
                           <div class="obj-container padded">
                             <select chosen
-                                    pre-select-from="workflowDefinitions"
+                                    pre-select-from="workflowDefinitionIds"
                                     data-width="'100%'"
                                     ng-model="workflow.id"
                                     ng-change="changeWorkflow(false)"


### PR DESCRIPTION
When there is only one workflow with the "schedule" tag, for scheduled
events the workflow under event details -> workflows is not selected
properly.

This was caused by the preSelectFromDirective being provided with the
wrong options (whole workflow objects instead of just IDs).

This work is sponsored by SWITCH.