### PR TITLE
MH-13155: Make weekday preselection optional

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -403,6 +403,13 @@ prop.admin.shortcut.general.main_menu=m
 # Note: prop.admin.event.new.duration need not match prop.admin.event.new.interval;
 #       this is to allow short intermissions between consecutive events.
 
+# Preselect an appropriate weekday when scheduling multiple events.
+#
+# Format: Boolean
+# Default: true
+#
+#prop.admin.event.new.preselect_day=true
+
 #
 # Display durations for different notification types in SECONDS.
 #

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -512,7 +512,14 @@ angular.module('adminNg.services')
             minute: parseInt(endDateTime.format('mm'))
           };
 
-          defaults.presentableWeekdays = chosenSlot.format('dd');
+
+          if (!orgProperties.hasOwnProperty('admin.event.new.preselect_day')
+            || orgProperties.hasOwnProperty('admin.event.new.preselect_day')
+            && orgProperties['admin.event.new.preselect_day'] === true) {
+            defaults.presentableWeekdays = chosenSlot.format('dd');
+          } else {
+            defaults.presentableWeekdays = '';
+          }
 
           if (self.captureAgents.length === 0) {
             //No capture agents, so user can only upload files

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -512,13 +512,10 @@ angular.module('adminNg.services')
             minute: parseInt(endDateTime.format('mm'))
           };
 
-
-          if (!orgProperties.hasOwnProperty('admin.event.new.preselect_day')
-            || orgProperties.hasOwnProperty('admin.event.new.preselect_day')
-            && orgProperties['admin.event.new.preselect_day'] === true) {
-            defaults.presentableWeekdays = chosenSlot.format('dd');
-          } else {
+          if (orgProperties['admin.event.new.preselect_day'] === 'false') {
             defaults.presentableWeekdays = '';
+          } else {
+            defaults.presentableWeekdays = chosenSlot.format('dd');
           }
 
           if (self.captureAgents.length === 0) {


### PR DESCRIPTION
When scheduling multiple events, this will make the preselection of the day of the week optional by introducing the ```prop.admin.event.new.preselect_day``` property.

Resolves: [MH-13155](https://opencast.jira.com/browse/MH-13155)