### PR TITLE
MH-13174 Simplify class MediaPackageElementFlavor

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/Attachment.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/Attachment.java
@@ -38,7 +38,7 @@ public interface Attachment extends MediaPackageElement {
   Type TYPE = Type.Attachment;
 
   /** Element flavor definition */
-  MediaPackageElementFlavor FLAVOR = new MediaPackageElementFlavor("attachment", "(unkown)", "Unspecified attachment");
+  MediaPackageElementFlavor FLAVOR = new MediaPackageElementFlavor("attachment", "(unkown)");
 
   /**
    * Returns a map containing the properties for this media package element or an empty map if there are no properties.

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElementFlavor.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElementFlavor.java
@@ -68,14 +68,12 @@ public class MediaPackageElementFlavor implements Cloneable, Comparable<MediaPac
   }
 
   /**
-   * Creates a new element type with the given type and subtype.
+   * Creates a new flavor with the given type and subtype.
    *
    * @param type
-   *          the major type
+   *          the type of the flavor
    * @param subtype
-   *          minor type
-   * @param description
-   *          an optional description
+   *          the subtype of the flavor
    */
   public MediaPackageElementFlavor(String type, String subtype) {
     this.type = checkPartSyntax(type);
@@ -115,24 +113,24 @@ public class MediaPackageElementFlavor implements Cloneable, Comparable<MediaPac
   }
 
   /**
-   * Returns the major type of this element type. Major types are more of a technical description.
-   * The major type is never null.
+   * Returns the type of this flavor.
+   * The type is never <code>null</code>.
    * <p>
-   * For example, if the element type is a presentation movie which is represented as <code>presentation/source</code>,
-   * this method will return <code>track</code>.
+   * For example, if the type is a presentation movie which is represented as <code>presentation/source</code>,
+   * this method will return <code>presentation</code>.
    *
-   * @return the type
+   * @return the type of this flavor
    */
   public String getType() {
     return type;
   }
 
   /**
-   * Returns the minor type of this element type. Minor types define the meaning.
-   * The minor type is never null.
+   * Returns the subtype of this flavor.
+   * The subtype is never <code>null</code>.
    * <p>
-   * For example, if the element type is a presentation movie which is represented as <code>presentation/source</code>,
-   * this method will return <code>presentation</code>.
+   * For example, if the subtype is a presentation movie which is represented as <code>presentation/source</code>,
+   * this method will return <code>source</code>.
    *
    * @return the subtype
    */
@@ -150,13 +148,13 @@ public class MediaPackageElementFlavor implements Cloneable, Comparable<MediaPac
    * @return The resulting flavor.
    */
   public MediaPackageElementFlavor applyTo(MediaPackageElementFlavor target) {
-    String subtype = this.subtype;
     String type = this.type;
-    if ("*".equals(this.subtype)) {
-      subtype = target.getSubtype();
-    }
-    if ("*".equals(this.type)) {
+    String subtype = this.subtype;
+    if (WILDCARD.equals(this.type)) {
       type = target.getType();
+    }
+    if (WILDCARD.equals(this.subtype)) {
+      subtype = target.getSubtype();
     }
     return new MediaPackageElementFlavor(type, subtype);
   }
@@ -228,11 +226,6 @@ public class MediaPackageElementFlavor implements Cloneable, Comparable<MediaPac
     return WILDCARD.equals(type);
   }
 
-  /** Check if type or subtype of <code>flavor</code> is a wildcard. */
-  public static boolean hasWildcard(MediaPackageElementFlavor flavor) {
-    return isWildcard(flavor.getType()) || isWildcard(flavor.getSubtype());
-  }
-
   /**
    * JAXB adapter implementation.
    */
@@ -248,31 +241,27 @@ public class MediaPackageElementFlavor implements Cloneable, Comparable<MediaPac
 
     @Override
     public MediaPackageElementFlavor unmarshal(String str) throws Exception {
-      MediaPackageElementFlavor f = parseFlavor(str);
-      return f;
+      return parseFlavor(str);
     }
   }
 
   public boolean matches(MediaPackageElementFlavor other) {
-    return (other != null) && matchParts(type, other.type) && matchParts(subtype, other.subtype);
-  }
-
-  private boolean matchParts(String part1, String part2) {
-    return part1.equals(part2) || isWildcard(part1) || isWildcard(part2);
+    return (other != null)
+      && (type.equals(other.type) || isWildcard(type) || isWildcard(other.type))
+      && (subtype.equals(other.subtype) || isWildcard(subtype) || isWildcard(other.subtype));
   }
 
   @Override
   public int hashCode() {
     final int prime = 31;
-    int result = 1;
-    result = prime * result + subtype.hashCode();
+    int result = prime + subtype.hashCode();
     result = prime * result + type.hashCode();
     return result;
   }
 
   @Override
   public boolean equals(Object other) {
-    return (other != null) && (other instanceof MediaPackageElementFlavor)
+    return (other instanceof MediaPackageElementFlavor)
       && type.equals(((MediaPackageElementFlavor) other).type)
       && subtype.equals(((MediaPackageElementFlavor) other).subtype);
   }

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElements.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElements.java
@@ -32,7 +32,7 @@ public interface MediaPackageElements {
   String MANIFEST_FILENAME = "index.xml";
 
   /** Cover art flavor */
-  MediaPackageElementFlavor MEDIAPACKAGE_COVER_FLAVOR = new MediaPackageElementFlavor("cover", "source", "Cover art");
+  MediaPackageElementFlavor MEDIAPACKAGE_COVER_FLAVOR = new MediaPackageElementFlavor("cover", "source");
 
   // Track flavors
 
@@ -77,54 +77,48 @@ public interface MediaPackageElements {
   /** The flavor produced by speech recognition */
   MediaPackageElementFlavor SPEECH = new MediaPackageElementFlavor("mpeg-7", "speech");
 
-  /** A flavor for chapters */
-  MediaPackageElementFlavor CHAPTERING = new MediaPackageElementFlavor("mpeg-7", "chapter", "MPEG-7 chapters catalog");
+  /** A flavor for MPEG-7 chapter catalogs */
+  MediaPackageElementFlavor CHAPTERING = new MediaPackageElementFlavor("mpeg-7", "chapter");
 
   // Engage flavors
 
   /** Presenter player preview image flavor */
-  MediaPackageElementFlavor PRESENTER_PLAYER_PREVIEW = new MediaPackageElementFlavor("presenter", "player+preview",
-          "Presenter player preview image");
+  MediaPackageElementFlavor PRESENTER_PLAYER_PREVIEW = new MediaPackageElementFlavor("presenter", "player+preview");
 
   /** Presentation player preview image flavor */
   MediaPackageElementFlavor PRESENTATION_PLAYER_PREVIEW = new MediaPackageElementFlavor("presentation",
-          "player+preview", "Presentation player preview image");
+    "player+preview");
 
   /** Presenter search result preview image flavor */
   MediaPackageElementFlavor PRESENTER_SEARCHRESULT_PREVIEW = new MediaPackageElementFlavor("presenter",
-          "search+preview", "Presenter search result preview image");
+          "search+preview");
 
   /** Presentation search result preview image flavor */
   MediaPackageElementFlavor PRESENTATION_SEARCHRESULT_PREVIEW = new MediaPackageElementFlavor("presentation",
-          "search+preview", "Presentation search result preview image");
+          "search+preview");
 
   /** Presenter segment preview image flavor */
-  MediaPackageElementFlavor PRESENTER_SEGMENT_PREVIEW = new MediaPackageElementFlavor("presenter", "segment+preview",
-          "Presenter segment preview image");
+  MediaPackageElementFlavor PRESENTER_SEGMENT_PREVIEW = new MediaPackageElementFlavor("presenter", "segment+preview");
 
   /** Presentation segment preview image flavor */
   MediaPackageElementFlavor PRESENTATION_SEGMENT_PREVIEW = new MediaPackageElementFlavor("presentation",
-          "segment+preview", "Presentation segment preview image");
+          "segment+preview");
 
   // Feed flavors
 
   /** Presenter feed preview image flavor */
-  MediaPackageElementFlavor PRESENTER_FEED_PREVIEW = new MediaPackageElementFlavor("presenter", "feed+preview",
-          "Presenter feed preview image");
+  MediaPackageElementFlavor PRESENTER_FEED_PREVIEW = new MediaPackageElementFlavor("presenter", "feed+preview");
 
   /** Presentation feed preview image flavor */
-  MediaPackageElementFlavor PRESENTATION_FEED_PREVIEW = new MediaPackageElementFlavor("presentation", "feed+preview",
-          "Presentation feed preview image");
+  MediaPackageElementFlavor PRESENTATION_FEED_PREVIEW = new MediaPackageElementFlavor("presentation", "feed+preview");
 
   // Security flavors
 
   /** Episode bound XACML policy flavor */
-  MediaPackageElementFlavor XACML_POLICY_EPISODE = new MediaPackageElementFlavor("security", "xacml+episode",
-          "Security policy for the mediapackage");
+  MediaPackageElementFlavor XACML_POLICY_EPISODE = new MediaPackageElementFlavor("security", "xacml+episode");
 
   /** Series bound XACML policy flavor */
-  MediaPackageElementFlavor XACML_POLICY_SERIES = new MediaPackageElementFlavor("security", "xacml+series",
-          "Security policy for the series");
+  MediaPackageElementFlavor XACML_POLICY_SERIES = new MediaPackageElementFlavor("security", "xacml+series");
 
   /**
    * XACML policy flavor.
@@ -132,22 +126,18 @@ public interface MediaPackageElements {
    * @deprecated use {@link #XACML_POLICY_SERIES} instead.
    */
   @Deprecated
-  MediaPackageElementFlavor XACML_POLICY = new MediaPackageElementFlavor("security", "xacml",
-          "Security policy for the mediapackage");
+  MediaPackageElementFlavor XACML_POLICY = new MediaPackageElementFlavor("security", "xacml");
 
   /** Export Files Policy flavor */
-  MediaPackageElementFlavor EXPORT_POLICY = new MediaPackageElementFlavor("security", "acl",
-          "Security policy for the export files");
+  MediaPackageElementFlavor EXPORT_POLICY = new MediaPackageElementFlavor("security", "acl");
 
   // Other flavors
 
-  /** A default flavor for caption files */
-  MediaPackageElementFlavor CAPTION_GENERAL = new MediaPackageElementFlavor("captions", "timedtext",
-          "DFXP Captions catalog");
+  /** A default flavor for DFXP captions catalogs" */
+  MediaPackageElementFlavor CAPTION_GENERAL = new MediaPackageElementFlavor("captions", "timedtext");
 
   /** A flavor for DFXP caption files */
-  MediaPackageElementFlavor CAPTION_DFXP_FLAVOR = new MediaPackageElementFlavor("caption", "dfxp",
-          "DFXP Captions catalog");
+  MediaPackageElementFlavor CAPTION_DFXP_FLAVOR = new MediaPackageElementFlavor("caption", "dfxp");
 
   /** OAI-PMH subtype flavor */
   MediaPackageElementFlavor OAIPMH = new MediaPackageElementFlavor("*", "oaipmh");


### PR DESCRIPTION
- Make default constructor private to ensure that type and subtype are never null
- Don't handle the cases type == null and subtype == null to simplify the boolean expressions
- Remove description and related functionality since unused
- Remove the ElementTypeEquivalent logic as unused