### PR TITLE
MH-13175, Remove Apache Tika for Generating Mimetypes

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -68,8 +68,6 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlbeans/2.6.0_2</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
-    <bundle>mvn:org.apache.tika/tika-bundle/1.1</bundle>
-    <bundle>mvn:org.apache.tika/tika-core/1.1</bundle>
     <bundle>mvn:org.codehaus.jettison/jettison/1.3.1</bundle>
     <bundle>mvn:org.codehaus.groovy/groovy/2.4.3</bundle>
     <!-- At least ingest-service-impl need JDOM in version 1.x -->

--- a/modules/inspection-service-ffmpeg/pom.xml
+++ b/modules/inspection-service-ffmpeg/pom.xml
@@ -50,18 +50,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-bundle</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImpl.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImpl.java
@@ -37,7 +37,6 @@ import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.util.LoadUtil;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.tika.parser.Parser;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.osgi.service.component.ComponentContext;
@@ -83,18 +82,8 @@ public class MediaInspectionServiceImpl extends AbstractJobProducer implements M
   private SecurityService securityService = null;
   private UserDirectoryService userDirectoryService = null;
   private OrganizationDirectoryService organizationDirectoryService = null;
-  private Parser tikaParser;
 
   private volatile MediaInspector inspector;
-
-  /**
-   * Sets the Apache Tika parser.
-   *
-   * @param tikaParser
-   */
-  public void setTikaParser(Parser tikaParser) {
-    this.tikaParser = tikaParser;
-  }
 
   /** Creates a new media inspection service instance. */
   public MediaInspectionServiceImpl() {
@@ -114,7 +103,7 @@ public class MediaInspectionServiceImpl extends AbstractJobProducer implements M
       logger.debug("FFprobe config binary: {}", path);
       ffprobeBinary = path;
     }
-    inspector = new MediaInspector(workspace, tikaParser, ffprobeBinary);
+    inspector = new MediaInspector(workspace, ffprobeBinary);
   }
 
   @Override

--- a/modules/inspection-service-ffmpeg/src/main/resources/OSGI-INF/inspection-service.xml
+++ b/modules/inspection-service-ffmpeg/src/main/resources/OSGI-INF/inspection-service.xml
@@ -20,8 +20,6 @@
                cardinality="1..1" policy="static" bind="setUserDirectoryService"/>
     <reference name="orgDirectory" interface="org.opencastproject.security.api.OrganizationDirectoryService"
                cardinality="1..1" policy="static" bind="setOrganizationDirectoryService"/>
-    <reference name="tikaOSGIParser" interface="org.apache.tika.parser.Parser"
-               cardinality="1..1" policy="static" bind="setTikaParser"/>
   </scr:component>
 
   <scr:component activate="activate" immediate="true"

--- a/modules/inspection-service-ffmpeg/src/test/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImplTest.java
+++ b/modules/inspection-service-ffmpeg/src/test/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImplTest.java
@@ -44,7 +44,6 @@ import org.opencastproject.util.StreamHelper;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.tika.parser.audio.AudioParser;
 import org.easymock.EasyMock;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -101,7 +100,7 @@ public class MediaInspectionServiceImplTest {
       EasyMock.expect(workspace.get(resource)).andReturn(f);
       EasyMock.expect(workspace.get(resource)).andReturn(f);
       EasyMock.replay(workspace);
-      return some(new MediaInspector(workspace, new AudioParser(), binary));
+      return some(new MediaInspector(workspace, binary));
     }
     return none();
   }

--- a/modules/working-file-repository-service-impl/pom.xml
+++ b/modules/working-file-repository-service-impl/pom.xml
@@ -54,18 +54,6 @@
       <artifactId>commons-fileupload</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-bundle</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-parsers</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/modules/working-file-repository-service-impl/src/main/resources/OSGI-INF/working-file-repo.xml
+++ b/modules/working-file-repository-service-impl/src/main/resources/OSGI-INF/working-file-repo.xml
@@ -19,8 +19,6 @@
 
   <reference name="remoteServiceManager" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
              cardinality="1..1" policy="static" bind="setRemoteServiceManager"/>
-  <reference name="tikaOSGIParser" interface="org.apache.tika.parser.Parser" cardinality="1..1" policy="static"
-             bind="setTikaParser"/>
   <reference name="securityService" interface="org.opencastproject.security.api.SecurityService" cardinality="1..1"
              policy="static" bind="setSecurityService"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -696,21 +696,6 @@
         <version>${mina.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.tika</groupId>
-        <artifactId>tika-bundle</artifactId>
-        <version>1.18</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tika</groupId>
-        <artifactId>tika-core</artifactId>
-        <version>1.18</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tika</groupId>
-        <artifactId>tika-parsers</artifactId>
-        <version>1.18</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.solr</groupId>
         <artifactId>solr-core</artifactId>
         <exclusions>


### PR DESCRIPTION
Opencast comes with a lot of methods to determine mime types for
content. While the number of methods has been reduced over the years,
there are still multiple ways and Apache Tika is one of them.

By removing Tika and replacing it with the MimeTypes class, we not only
reduce dependencies but also reduce OSGI services we run.