### PR TITLE
MH-13176, Bug fix update of Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <karaf.version>4.0.10</karaf.version>
     <pax.web.version>4.3.4</pax.web.version>
     <cxf.version>3.1.12</cxf.version>
-    <jackson.version>2.9.4</jackson.version>
+    <jackson.version>2.9.7</jackson.version>
     <functional.version>1.4.2</functional.version>
     <jdk.version>1.8</jdk.version>
     <mina.version>2.0.19</mina.version>


### PR DESCRIPTION
Several problems have been found and fixed in FasterXML's Jackson
libraries which Opencast uses for generating XML (and party also JSON).
This patch updates to the latest minor version.