### PR TITLE
MH-13179, Fix Video Editor Preview Mode Default

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
@@ -64,7 +64,7 @@ angular.module('adminNg.directives')
           var ADMIN_EDITOR_PREVIEWMODE_DEFAULT = 'admin.editor.previewmode.default';
           AuthService.getUser().$promise.then(function(user) {
             if (angular.isDefined(user.org.properties[ADMIN_EDITOR_PREVIEWMODE_DEFAULT])) {
-              scope.previewMode = user.org.properties[ADMIN_EDITOR_PREVIEWMODE_DEFAULT].toUpperCase() === 'TRUE';
+              scope.previewMode = user.org.properties[ADMIN_EDITOR_PREVIEWMODE_DEFAULT].toUpperCase() !== 'FALSE';
             }
           });
         }


### PR DESCRIPTION
The documentation claims the default for the video editor preview mode
setting to be `true` which is correct if it is not set at all. However,
if an incorrect value is set, the default incorrectly switches over to
`false`