### PR TITLE
MH-13162 Show all series in edit-scheduled-events

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -646,7 +646,7 @@ public class SeriesEndpoint implements ManagedService {
           @RestParameter(name = "filter", isRequired = false, description = "The filter used for the query. They should be formated like that: 'filter1:value1,filter2,value2'", type = STRING),
           @RestParameter(name = "offset", isRequired = false, description = "The page offset", type = INTEGER, defaultValue = "0"),
           @RestParameter(name = "optedOut", isRequired = false, description = "Whether this series is opted out", type = BOOLEAN),
-          @RestParameter(name = "limit", isRequired = false, description = "Results per page (max 100)", type = INTEGER, defaultValue = "100") }, reponses = {
+          @RestParameter(name = "limit", isRequired = false, description = "The limit to define the number of returned results (-1 for all)", type = INTEGER, defaultValue = "100") }, reponses = {
           @RestResponse(responseCode = SC_OK, description = "The access control list."),
           @RestResponse(responseCode = SC_UNAUTHORIZED, description = "If the current user is not authorized to perform this action") })
   public Response getSeries(@QueryParam("filter") String filter, @QueryParam("sort") String sort,

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/SERIES.json
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/SERIES.json
@@ -1,0 +1,7 @@
+{
+  "3ba1297f-05cf-4496-a1ef-b978c361a738": "testseries1",
+  "509a35f5-8bfb-4afb-99db-040a99f1595f": "testseries2",
+  "ba874b1f-3898-4eac-b634-2340643985c2": "testseries3",
+  "aca461f3-92d0-4cbe-955e-67d61b3215c9": "testseries4",
+  "29b4d859-24dd-42b8-a594-8b5fcd71abf4": "testseries5"
+}

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/editEventsControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/editEventsControllerSpec.js
@@ -43,11 +43,12 @@ describe('Edit events controller', function () {
         $controller('EditEventsCtrl', {$scope: $scope});
         jasmine.getJSONFixtures().fixturesPath = 'base/app/GET';
         // These are the requests that are necessary to construct the modal.
-        $httpBackend.expectGET('/admin-ng/series/series.json').respond(JSON.stringify(getJSONFixture('admin-ng/series/series.json')));
+        $httpBackend.expectGET('/admin-ng/resources/SERIES.json').respond(JSON.stringify(getJSONFixture('admin-ng/resources/SERIES.json')));
         $httpBackend.expectGET('/admin-ng/capture-agents/agents.json?inputs=true').respond(JSON.stringify(getJSONFixture('admin-ng/capture-agents/agents.json')));
         $httpBackend.expectPOST('/admin-ng/event/scheduling.json').respond(JSON.stringify(getJSONFixture('admin-ng/event/scheduling.json')));
         $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
         $httpBackend.flush();
+        spyOn($scope, 'nextWizardStep');
     });
 
     describe('basic functionality', function () {
@@ -70,19 +71,31 @@ describe('Edit events controller', function () {
     });
 
     describe('wizard edit step', function () {
-        it('is correctly instantiated', function () {
+        it('is correctly instantiated', function (done) {
+
             spyOn(JsHelper, 'getTimeZoneName').and.returnValue("UTC");
-            $scope.clearFormAndContinue();
-            expect($scope.conflictCheckingEnabled).toBe(true);
-            expect($scope.metadataRows).not.toBe([]);
-            // Title is ambiguous
-            expect($scope.metadataRows[0].value).toBe("");
-            // Series is non-ambiguous
-            expect($scope.metadataRows[1].value).toBe("4581");
-            expect($scope.scheduling).not.toBe({});
-            // Agent is non-ambiguous
-            expect($scope.scheduling.location.id).toBe("agent1");
-            // Yadda yadda, test the rest of the data. :)
+
+            $scope.clearFormAndContinue().then(function() {
+
+                expect($scope.scheduling).not.toBe({});
+                // Agent is non-ambiguous
+                expect($scope.scheduling.location.id).toBe("agent1");
+                // Yadda yadda, test the rest of the data. :)
+
+                expect($scope.conflictCheckingEnabled).toBe(true);
+
+                expect($scope.metadataRows).not.toBe([]);
+                // Title is ambiguous
+                expect($scope.metadataRows[0].value).toBe("");
+                // Series is non-ambiguous
+                expect($scope.metadataRows[1].value).toBe("4581");
+
+                expect($scope.nextWizardStep).toHaveBeenCalled();
+
+                done();
+            });
+
+            $scope.$apply();
         });
     });
 


### PR DESCRIPTION
Show all series in the edit-scheduled-events modal instead of only the first 100. Use the listprovider endpoint since the request is significantly faster compared to the series endpoint of the admin UI.
Only switch to the second tab once the series have been loaded, otherwise the dropdown will be empty. Update the rest docs of the series endpoint.

(Updated version from #485.)