### PR TITLE
MH-13154: Unify vertical spacing in wizards

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -988,14 +988,12 @@
          },
          "METADATA_EXTENDED": {
            "CAPTION": "Extended metadata",
-           "DESCRIPTION": "",
            "METADATA": {
              "TITLE": "Extended metadata"
            }
          },
          "ACCESS": {
            "CAPTION": "Access policy",
-           "DESCRIPTION": "",
             "TEMPLATES": {
              "TITLE": "Templates"
             },

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -551,7 +551,6 @@
   </div>
 
   <div class="modal-content" data-modal-tab-content="access">
-    <p class="tab-desc"></p>
     <div class="modal-body">
       <div data-admin-ng-notification="" type="warning" show="access.episode_access.locked" message="{{ metadata.locked }}"></div>
       <div data-admin-ng-notifications="" type="error" context="event-acl"></div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
@@ -27,7 +27,6 @@
   <a ng-click="showAdjacent()" ng-if="hasAdjacent()"><i class="arrow fa fa-chevron-right"></i></a>
 
   <div class="modal-content" data-modal-tab-content="metadata">
-    <p class="tab-desc"></p>
     <div class="modal-body">
       <div data-admin-ng-notification="" type="warning" show="metadata.locked" message="{{ metadata.locked }}"></div>
       <div class="full-col">
@@ -53,7 +52,6 @@
   </div>
 
   <div class="modal-content" data-modal-tab-content="extended-metadata" ng-if="metadata.entries.length > 0">
-    <p class="tab-desc"></p>
     <div class="modal-body">
       <div data-admin-ng-notification="" type="warning" show="metadata.locked" message="{{ metadata.locked }}"></div>
       <div class="full-col">
@@ -170,7 +168,6 @@
     </div> -->
 
     <div class="modal-content" data-modal-tab-content="permissions" data-level="1">
-      <p class="tab-desc"></p>
       <div class="modal-body">
 
         <div data-admin-ng-notifications="" context="series-acl"></div>
@@ -290,7 +287,6 @@
     <div class="modal-content" data-modal-tab-content="theme" data-level="1">
       <div class="modal-body">
         <div data-admin-ng-notifications="" type="warning" context="series-theme"></div>
-        <p class="tab-desc"></p>
         <div class="full-col">
           <div class="obj quick-actions">
             <header translate="CONFIGURATION.NAVIGATION.THEMES"><!-- Theme --></header>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-series.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-series.html
@@ -1,5 +1,4 @@
 <div class="modal-content" ng-class="{active: isCurrentTab('metadata')}" data-modal-tab-content="metadata" data-level="1">
-  <p class="tab-description" translate="EVENTS.SERIES.NEW.METADATA.DESCRIPTION"><!-- Description --></p>
   <div class="modal-body">
     <div class="full-col">
       <div class="obj tbl-list">
@@ -51,7 +50,6 @@
 <div class="modal-content" data-modal-tab-content="access" data-level="1">
   <div class="modal-body">
 
-    <p class="tab-description" translate="EVENTS.SERIES.NEW.ACCESS.DESCRIPTION"><!-- Description --></p>
     <div data-admin-ng-notifications="" context="series-acl"></div>
     <div data-admin-ng-notifications="" type="warning" context="series-acl"></div>
 


### PR DESCRIPTION
This will remove paragraph elements with no content that were causing the UI to behave inconsistently.

Resolves: [MH-13154](https://opencast.jira.com/browse/MH-13154)

Reproduction of one example:

1. Go to https://stable.opencast.org
2. Open the event details for any event
3. Navigate through the different tabs of the event details model

Did you notice that the table moves few pixels down in the tab "Access Policy"? That is what this patch addresses...
