### PR TITLE
MH-13186, Episode and Series ACL Handling

### DIFF
--- a/docs/guides/admin/docs/configuration/acl.md
+++ b/docs/guides/admin/docs/configuration/acl.md
@@ -1,46 +1,152 @@
 Access Control List Configuration
 =================================
 
-This document describes configuration options considering the access control lists (ACL) used by
-Opencast for authorization.
+This document describes how Opencast stores and handles access control settings for series and episodes and what
+configuration options related to this are available.
 
-## ACL Templates
+Access Control Lists
+--------------------
 
-On startup, Opencast loads all ACL templates found in `/opt/opencast/etc/acl/`.
+An access control list (ACL) in the context of Opencast consists of a global deny rule (no one is allowed access) and a
+set of roles with rules attached to define access. Hence, it is effectively a white-listing of roles to grant access and
+it means that all roles and/or actions not defined in an access control list are denied access.
 
-Notes:
+For example, the following rule defines read access for role 1 and read/write access for role 2:
 
-* ACL templates can also be created and managed directly in the Admin UI
+|role |action|access|
+|-----|------|------|
+|ROLE1|read  |true  |
+|ROLE2|read  |true  |
+|     |write |true  |
 
-## Additional ACL Actions
+Opencast can also deny access locally (e.g. deny write access for role 1) which can be interesting if merging of ACLs is
+used. But this is not handled in the user interface and using this should therefore be avoided.
 
-Opencast uses to ACL actions to authorize roles to perform specific actions on a given object:
+System administrators are an exception to these rules. A user with `ROLE_ADMIN` will always be granted access,
+regardless of the rule-set attached to an event. Organizational administrators are also granted access in some cases.
 
-* `read` allows the role to access to object
-* `write` allows the role to modify the object
 
-Those built-in actions are known to Opencast.
+Global Rules
+------------
 
-In case you need other ACL actions, you can configure additional ACL actions in
-`/opt/opencast/etc/listprovides/acl.additional.actions.properties`. Those additional ACL actions are not affecting the way
-Opencast treats objects but are simply just forwarded to publication channels so that third-party applications
-(expecting those specific ACL actions) can implement the respective authorization logic.
+In case an event has no custom access control list defined, a global rule set is associated with the event. The global
+rules consist only of the general deny rule. Hence, no access is allowed to anyone except administrators..
+
+
+Series and Episode Rules
+------------------------
+
+Access control lists can be specified both on series and on episode level. This means that multiple rule sets can be
+attached to an episode which is part of a series. Opencast can handle this in multiple ways.
+
+The handling is specified by the merge mode configured in `etc/org.opencastproject.organization-mh_default_org.cfg`. It
+defines the relationship between series and episode access control lists, if both are attached to an event. If only one
+list is attached, its rules are always active. If multiple lists are attached, the following modes define Opencast's
+behavior:
+
+### Merge Mode “override” (Default)
+
+The episode ACL takes precedence over the series ACL. This means that the series ACL will be completely ignored as soon
+as the episode has an ACL, no matter what rules are set in either. This allows users to define general rules for a
+series which can be completely redefined on an episode and which are not influenced by changes later made to the series.
+This is also a very simple rule and thus easy to understand.
 
 Example:
 
-    list.name=ACL.ACTIONS
-    # This list provider allows you to configure custom actions that can be added
-    # to ACLs. The default actions are read and write.
-    # The pattern for adding them is
-    # UI_LABEL=actionId
-    #
-    Upload=myorg_upload
-    Download=myorg_downlaod
+|         |ROLE1 |       |ROLE2 |       |ROLE3 |       |
+|---------|------|-------|------|-------|------|-------|
+|         |*read*|*write*|*read*|*write*|*read*|*write*|
+|*series* |allow |allow  |allow |allow  |      |       |
+|*episode*|      |       |allow |       |allow |       |
+|*active* |      |       |allow |       |allow |       |
 
-In the example above, the two additional ACL actions `Upload` and `Download` have been configured.
-The ACL editor of the Admin UI will allow the user to set those actions.
+### Merge Mode “roles”
 
-Notes:
+Series and episode ACLs are merged based on the roles defined within. If both the series and the episode define a rule
+for a specific role (user or group), the episode's rule takes precedence. Rules for roles defined in one ACL only are
+always part of the resulting active ACL.
 
-* To ensure compatibility with future Opencast versions, it is highly recommended to use a prefix for your
-customized additional actions in case later Opencast versions would introduce an action with the same name
+Example:
+
+|         |ROLE1 |       |ROLE2 |       |ROLE3 |       |
+|---------|------|-------|------|-------|------|-------|
+|         |*read*|*write*|*read*|*write*|*read*|*write*|
+|*series* |allow |allow  |allow |allow  |      |       |
+|*episode*|      |       |allow |       |allow |       |
+|*active* |allow |allow  |allow |       |allow |       |
+
+### Merge Mode “actions”
+
+ACLs are merged based on the actions (read, write, …) contained within both ACLs. If a rule is specified for a tuple of
+role and action in both ACLs, the rule specified in the episode ACL takes precedence.
+
+Example:
+
+|         |ROLE1 |       |ROLE2 |       |ROLE3 |       |
+|---------|------|-------|------|-------|------|-------|
+|         |*read*|*write*|*read*|*write*|*read*|*write*|
+|*series* |allow |allow  |allow |allow  |      |       |
+|*episode*|      |       |allow |       |allow |       |
+|*active* |allow |allow  |allow |allow  |allow |       |
+
+### Switching Modes
+
+Switching modes is not necessarily simple since access control lists are cached at several places. Hence, while changing
+this value will have an immediate effect on newly processed videos, an index rebuild is inevitable to update cached data
+and republications to update old events may be necessary.
+
+
+Updating Series Permissions
+---------------------------
+
+Depending on the admin interface configuration in `etc/org.opencastproject.organization-mh_default_org.cfg`, the admin
+interface behaves differently when series access control lists are modified and may also overwrite episode rules of that
+series. Possible modes of operation are:
+
+- *always:*
+  When modifying series permissions, automatically remove all permission rules specific to single episodes belonging to
+  the series. This enforces that every episode has the rules of the series in effect as soon as they are changed.
+- *never:*
+  Only update the series permissions but never replace permissions set on event level. This may mean that updated rules
+  have no effect on already existing events.
+- *optional (default):*
+  Like `never` but present users with a button in the series permission dialog which allows them to replace the event
+  specific permissions easily if they want to.
+
+
+Templates
+---------
+
+Templates of access control lists can be specified for the administrative user interface. They are a convenient way to
+apply a defined set of rules all at once instead of applying each rule one after another. Templates stored in `etc/acl/`
+are loaded at start-up for all organizations. Templates can also be created and managed in the admin interface.
+
+
+Additional Actions
+------------------
+
+Opencast uses two default actions for access authorization on events:
+
+- `read` allows a role to access (read the value of) objects
+- `write` allows a role to modify (write to) objects
+
+More actions can be added but are usually ignored by Opencast. Though they may be handy to specify rules for external
+applications.
+
+In case you need other actions, you can configure the admin interface to allow adding additional ones. These are
+configured in `etc/listprovides/acl.additional.actions.properties`. For example, this would configure the two actions,
+`Upload` and `Download`, to be available in the permission editor of the admin interface:
+
+```properties
+list.name=ACL.ACTIONS
+# This list provider allows you to configure custom actions that can be added
+# to ACLs. The default actions are read and write.
+# The pattern for adding them is
+# UI_LABEL=actionId
+#
+Upload=myorg_upload
+Download=myorg_downlaod
+```
+
+Using a unique prefix for your custom actions like this example did with `myorg_` is recommended to make it unlikely
+that later Opencast versions introduce the same action in a different context.

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -4,8 +4,9 @@ Opencast 7: Release Notes
 New Features
 ------------
 
-- feature 1
-- feature 2
+- Overhaul of the permission management with the newly added possibility to define how access control lists are
+  evaluated and how series permission changes are populated to episodes. For more details take a look at the [access
+  control configuration guide](configuration/acl.md).
 
 Improvements
 ------------

--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -31,6 +31,32 @@ ActiveMQ Migration
 *So gar, this is not required*
 
 
+Removal of Deprecated Access Control Ruleset
+--------------------------------------------
+
+Opencast 7 finally removes the long-since deprecated `security/xacml` flavor for access control lists. This had not been
+used since before Opencast 1.2 (we could not track down its exact deprecation date due to its age). Additionally, all
+rule-sets which had been modified since had also been automnatically been updated to `security/xacml+series` which
+serves as replacement for the old flavor.
+
+In case Opencast still encounters such a rule set, it will now be ignored and access will be denied by default. A simple
+update of the permissions would fix this if that is required.
+
+Due to the extreme unlikeliness of anyone encountering this problem, there is no automatic migration. In case you run a
+system migrated from a pre-1.2 Matterhorn, you can make sure that there are no old rule-sets left using the following
+SQL queries:
+
+```sql
+-- Check OAI-PMH publications:
+select * from oc_oaipmh_elements where flavor = 'security/xacml';
+-- Check engage publications:
+select * from oc_search where mediapackage_xml like '%"security/xacml"%';
+-- Check asset manager:
+select * from oc_assets_snapshot where mediapackage_xml like '%"security/xacml"%';
+```
+
+
+
 Configuration Changes
 ---------------------
 

--- a/etc/org.opencastproject.authorization.xacml.XACMLAuthorizationService.cfg
+++ b/etc/org.opencastproject.authorization.xacml.XACMLAuthorizationService.cfg
@@ -1,0 +1,43 @@
+# Merge mode defining the relationship between series and episode ACLs, if both are attached to an event. If only one
+# ACL is attached, its rules are always active. If multiple ACLs are attached, the following modes define Opencast's
+# behavior:
+#
+# - override:
+#   The episode ACL takes precedence over the series ACL. This means that the series ACL will be completely ignored as
+#   soon as the episode has an ACL, no matter what rules are set in either. This allows users to define general rules
+#   for a series which can be completely redefined on an episode and which are not influenced by changes later made to
+#   the series.
+#   Example:
+#             ROLE_USER1   ROLE_USER2   ROLE_USER3
+#             read  write  read  write  read  write
+#     series   ok    ok     ok    ok
+#     episode               ok           ok
+#     active                ok           ok
+#
+# - roles:
+#   Series and episode ACLs are merged based on the roles defined within. If both the series and the episode define a
+#   rule for a specific role (user or group), the episode's rule takes precedence. Rules for roles defined in one ACL
+#   only are always part of the resulting active ACL.
+#   Example:
+#             ROLE_USER1   ROLE_USER2   ROLE_USER3
+#             read  write  read  write  read  write
+#     series   ok    ok     ok    ok
+#     episode               ok           ok
+#     active   ok    ok     ok           ok
+#
+# - actions
+#   ACLs are merged based on the actions (read, write, …) contained within both ACLs. If a rule is specified for a tuple
+#   of role and action in both ACLs, the rule specified in the episode ACL takes precedence.
+#   Example:
+#             ROLE_USER1   ROLE_USER2   ROLE_USER3
+#             read  write  read  write  read  write
+#     series   ok    ok     ok    ok
+#     episode               ok           ok
+#     active   ok    ok     ok    ok     ok
+#
+# Note that ACLs are cached at several places. Hence, while changing this value will have an immediate effect on newly
+# processed videos, an index rebuild is inevitable to rebuild all search indexes and in some cases may require
+# republications to update old events.
+#
+# Default: override
+#merge.mode = override

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -434,3 +434,15 @@ prop.admin.shortcut.general.main_menu=m
 # Default: true
 #
 #prop.admin.editor.previewmode.default=true
+
+# Event access control update mode when modifying series permissions.
+# Possible modes are:
+# - always:   When modifying series permissions, automatically remove all permission rules specific to single episodes
+#             belonging to the series. This enforces every episode has the rules of the series in effect as soon as they
+#             are changed.
+# - never:    Only update the series permissions but never replace permissions set on event level. This can mean that
+#             updated rules have no effect on already existing events.
+# - optional: Like `never` but present users with a button in the series permission dialog which allows them to
+#             replace the event specific permissions if they want to.
+# Default: optional
+#prop.admin.series.acl.event.update.mode=optional

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -98,6 +98,7 @@ import org.opencastproject.mediapackage.AudioStream;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.VideoStream;
@@ -826,7 +827,7 @@ public abstract class AbstractEventEndpoint {
                 Opt.<Map<String, String>> none(), Opt.<Opt<Boolean>> none(), SchedulerService.ORIGIN);
         return ok();
       }
-    } catch (AclServiceException e) {
+    } catch (AclServiceException | MediaPackageException e) {
       logger.error("Error applying acl '{}' to event '{}'", accessControlList, eventId, e);
       return serverError();
     } catch (SchedulerException e) {

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1071,7 +1071,9 @@
              "ADDITIONAL_ACTIONS" : "Additional Actions",
              "ACTION"      : "Actions",
              "NEW"         : "New policy",
-             "DETAILS"     : "Details"
+             "DETAILS"     : "Details",
+             "REPLACE_EVENT_ACLS": "Update event permissions",
+             "REPLACE_EVENT_ACLS_HINT": "Ensure all events of this series have these permissions in effect"
            },
            "ROLES": {
               "LABEL": "Select a role",

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
@@ -207,14 +207,14 @@
                             <input type="checkbox"
                                    ng-disabled="aclLocked"
                                    ng-model="policy.read"
-                                   ng-change="accessSave(policy)"
+                                   ng-change="accessSave()"
                                    ng-disabled="!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT')"/>
                           </td>
                           <td class="fit text-center">
                             <input type="checkbox"
                                    ng-disabled="aclLocked"
                                    ng-model="policy.write"
-                                   ng-change="accessSave(policy)"
+                                   ng-change="accessSave()"
                                    ng-disabled="!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT')"/>
                           </td>
                           <td class="fit editable" ng-if="hasActions">
@@ -246,6 +246,16 @@
                   </div>
                 </div>
               </div>
+              <footer ng-if="updateMode === 'optional'">
+                <!-- Button to remove all episode ACLs to ensure only the series ACL applies -->
+                <a ng-click="accessSave(true)"
+                   class="submit"
+                   ng-class="{disabled: !validAcl}"
+                   translate="EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.REPLACE_EVENT_ACLS"
+                   title="{{'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.REPLACE_EVENT_ACLS_HINT' | translate}}">
+                  <!-- Submit -->
+                </a>
+              </footer>
             </div>
           </li>
         </ul>

--- a/modules/admin-ui/src/test/resources/app/GET/info/me.json
+++ b/modules/admin-ui/src/test/resources/app/GET/info/me.json
@@ -91,6 +91,7 @@
       "org.opencastproject.admin.help.restdocs.url": "/rest_docs.html",
       "org.opencastproject.admin.mediamodule.url": "/engage/ui",
       "player": "/engage/theodul/ui/core.html",
+      "admin.series.acl.event.update.mode": "optional",
       "admin.shortcut.editor.split_at_current_time": "v",
       "admin.shortcut.editor.play_ending_of_current_segment": "n",
       "admin.shortcut.editor.clear_list": "ctrl+backspace",

--- a/modules/admin-ui/src/test/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/test/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1025,7 +1025,9 @@
             "ADDITIONAL_ACTIONS" : "Additional Actions",
             "ACTION"      : "Actions",
             "NEW"         : "New policy",
-            "DETAILS"     : "Details"
+            "DETAILS"     : "Details",
+            "REPLACE_EVENT_ACLS": "Update event permissions",
+            "REPLACE_EVENT_ACLS_HINT": "Ensure all events of this series have these permissions in effect"
           },
           "ROLES": {
             "LABEL": "Select a role",

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/serieControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/serieControllerSpec.js
@@ -41,6 +41,7 @@ describe('Serie controller', function () {
         $httpBackend.whenGET('/admin-ng/resources/ACL.ACTIONS.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=100&offset=0').respond('{"ROLE_ANONYMOUS": "ROLE_ANONYMOUS"}');
         $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=100&offset=2').respond('{}');
+        $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
 
         $controller('SerieCtrl', {$scope: $scope});
     });
@@ -174,7 +175,7 @@ describe('Serie controller', function () {
             expect(SeriesAccessResource.save).toHaveBeenCalledWith({ id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c' },
                 {
                     acl : { ace : [ { action : 'read', allow : true, role : 'admin' }, { action : 'write', allow : true, role : 'admin' } ] },
-                    override: true
+                    override: false
                 }
             );
         });

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
@@ -39,6 +39,7 @@ import org.opencastproject.authorization.xacml.manager.api.SeriesACLTransition;
 import org.opencastproject.authorization.xacml.manager.api.TransitionQuery;
 import org.opencastproject.authorization.xacml.manager.api.TransitionResult;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.MediaPackageSupport;
 import org.opencastproject.message.broker.api.MessageSender;
 import org.opencastproject.message.broker.api.acl.AclItem;
@@ -178,9 +179,13 @@ public final class AclServiceImpl implements AclService {
           @Override
           public void esome(final AccessControlList acl) {
             // update in episode service
-            MediaPackage mp = authorizationService.setAcl(episodeSvcMp, AclScope.Episode, acl).getA();
-            if (assetManager != null)
-              assetManager.takeSnapshot(mp);
+            try {
+              MediaPackage mp = authorizationService.setAcl(episodeSvcMp, AclScope.Episode, acl).getA();
+              if (assetManager != null)
+                assetManager.takeSnapshot(mp);
+            } catch (MediaPackageException e) {
+              logger.error("Error getting ACL from media package", e);
+            }
           }
 
           // if none EpisodeACLTransition#isDelete returns true so delete the episode ACL

--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
@@ -165,8 +165,15 @@ public class TestRestService extends AbstractAclServiceRestEndpoint {
     AuthorizationService authorizationService = EasyMock.createNiceMock(AuthorizationService.class);
     EasyMock.expect(authorizationService.getActiveAcl((MediaPackage) EasyMock.anyObject()))
             .andReturn(Tuple.tuple(acl, AclScope.Series)).anyTimes();
-    EasyMock.expect(authorizationService.setAcl((MediaPackage) EasyMock.anyObject(), (AclScope) EasyMock.anyObject(),
-            (AccessControlList) EasyMock.anyObject())).andReturn(Tuple.tuple(mediapackage, attachment));
+    try {
+      EasyMock.expect(authorizationService.setAcl(
+                EasyMock.anyObject(MediaPackage.class),
+                EasyMock.anyObject(AclScope.class),
+                EasyMock.anyObject(AccessControlList.class)))
+              .andReturn(Tuple.tuple(mediapackage, attachment));
+    } catch (MediaPackageException e) {
+      throw new RuntimeException(e);
+    }
     EasyMock.replay(authorizationService);
 
     return authorizationService;

--- a/modules/authorization-xacml/pom.xml
+++ b/modules/authorization-xacml/pom.xml
@@ -97,6 +97,11 @@
       <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.compendium</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/authorization-xacml/src/main/resources/OSGI-INF/authorization-service.xml
+++ b/modules/authorization-xacml/src/main/resources/OSGI-INF/authorization-service.xml
@@ -6,6 +6,7 @@
             value="Provides translation between access control entries and xacml documents"/>
   <service>
     <provide interface="org.opencastproject.security.api.AuthorizationService"/>
+    <provide interface="org.osgi.service.cm.ManagedService"/>
   </service>
   <reference name="workspace" interface="org.opencastproject.workspace.api.Workspace"
              bind="setWorkspace"/>

--- a/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
+++ b/modules/authorization-xacml/src/test/java/org/opencastproject/authorization/xacml/XACMLSecurityTest.java
@@ -174,7 +174,7 @@ public class XACMLSecurityTest {
     currentRoles.add(new JaxbRole("admin", organization));
 
     mediapackage = authzService.setAcl(mediapackage, AclScope.Episode, aclEpisode).getA();
-    Assert.assertEquals(AclScope.Episode, authzService.getActiveAcl(mediapackage).getB());
+    Assert.assertEquals(AclScope.Merged, authzService.getActiveAcl(mediapackage).getB());
     Assert.assertFalse(authzService.hasPermission(mediapackage, "delete"));
     Assert.assertFalse(authzService.hasPermission(mediapackage, "read"));
     Assert.assertFalse(authzService.hasPermission(mediapackage, "comment"));

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElements.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElements.java
@@ -120,17 +120,6 @@ public interface MediaPackageElements {
   /** Series bound XACML policy flavor */
   MediaPackageElementFlavor XACML_POLICY_SERIES = new MediaPackageElementFlavor("security", "xacml+series");
 
-  /**
-   * XACML policy flavor.
-   *
-   * @deprecated use {@link #XACML_POLICY_SERIES} instead.
-   */
-  @Deprecated
-  MediaPackageElementFlavor XACML_POLICY = new MediaPackageElementFlavor("security", "xacml");
-
-  /** Export Files Policy flavor */
-  MediaPackageElementFlavor EXPORT_POLICY = new MediaPackageElementFlavor("security", "acl");
-
   // Other flavors
 
   /** A default flavor for DFXP captions catalogs" */

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageSupport.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageSupport.java
@@ -422,25 +422,6 @@ public final class MediaPackageSupport {
       };
     }
 
-    /**
-     * Return true if the element has a flavor that matches any of the <code>flavors</code>.
-     *
-     * @see MediaPackageElementFlavor#matches(MediaPackageElementFlavor)
-     */
-    public static Function<MediaPackageElement, Boolean> matchesFlavorAny(final List<MediaPackageElementFlavor> flavors) {
-      return new Function<MediaPackageElement, Boolean>() {
-        @Override
-        public Boolean apply(MediaPackageElement mpe) {
-          for (MediaPackageElementFlavor f : flavors) {
-            if (f.matches(mpe.getFlavor())) {
-              return true;
-            }
-          }
-          return false;
-        }
-      };
-    }
-
     public static final Function<MediaPackageElementFlavor, Function<MediaPackageElement, Boolean>> matchesFlavor = new Function<MediaPackageElementFlavor, Function<MediaPackageElement, Boolean>>() {
       @Override
       public Function<MediaPackageElement, Boolean> apply(final MediaPackageElementFlavor flavor) {
@@ -457,10 +438,6 @@ public final class MediaPackageSupport {
         }
       };
     }
-
-    public static final Function<MediaPackageElement, Boolean> isXACML = MediaPackageSupport.Filters
-            .matchesFlavorAny(list(MediaPackageElements.XACML_POLICY, MediaPackageElements.XACML_POLICY_EPISODE,
-                    MediaPackageElements.XACML_POLICY_SERIES));
 
     public static final Function<MediaPackageElement, Boolean> isEpisodeAcl = new Function<MediaPackageElement, Boolean>() {
       @Override

--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlList.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlList.java
@@ -21,8 +21,11 @@
 
 package org.opencastproject.security.api;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -47,15 +50,15 @@ public final class AccessControlList {
    * No-arg constructor needed by JAXB
    */
   public AccessControlList() {
-    this.entries = new ArrayList<AccessControlEntry>();
+    this.entries = new ArrayList<>();
   }
 
   public AccessControlList(AccessControlEntry... entries) {
-    this.entries = new ArrayList<AccessControlEntry>(Arrays.asList(entries));
+    this.entries = new ArrayList<>(Arrays.asList(entries));
   }
 
   public AccessControlList(List<AccessControlEntry> entries) {
-    this.entries = new ArrayList<AccessControlEntry>(entries);
+    this.entries = new ArrayList<>(entries);
   }
 
   /**
@@ -73,6 +76,74 @@ public final class AccessControlList {
   @Override
   public String toString() {
     return entries.toString();
+  }
+
+  /**
+   * Merge this access control list with another one based on roles specified within. In case both lists specify
+   * rules for a specific role, the set of rules from the access control list passed as argument to this method will
+   * take precedence over the internal set of rules.
+   *
+   * Example:
+   * <pre>
+   *          ROLE_USER1   ROLE_USER2   ROLE_USER3
+   *          read  write  read  write  read  write
+   * this     ok    ok     ok    ok
+   * argument              ok           ok
+   * result   ok    ok     ok           ok
+   * </pre>
+   *
+   * @param acl
+   *        Access control list to merge with
+   * @return Merged access control list
+   */
+  public AccessControlList merge(AccessControlList acl) {
+    HashSet<String> roles = new HashSet<>();
+    ArrayList<AccessControlEntry> newEntries = new ArrayList<>(acl.getEntries());
+    // Get list of new roles
+    for (AccessControlEntry entry : newEntries) {
+      roles.add(entry.getRole());
+    }
+    // Apply old rules if no new rules for a role exist
+    for (AccessControlEntry entry : this.entries) {
+      if (!roles.contains(entry.getRole())) {
+        newEntries.add(entry);
+      }
+    }
+    this.entries = newEntries;
+    return this;
+  }
+
+  /**
+   * Merge this access control list with another one based on actions specified within. In case both lists specify
+   * rules for a specific action, the rules from the access control list passed as argument to this method will take
+   * precedence over the internal rules.
+   *
+   * Example:
+   * <pre>
+   *          ROLE_USER1   ROLE_USER2   ROLE_USER3
+   *          read  write  read  write  read  write
+   * this     ok    ok     ok    ok
+   * argument              ok           ok
+   * result   ok    ok     ok    ok     ok
+   * </pre>
+   *
+   * @param acl
+   *        Access control list to merge with
+   * @return Merged access control list
+   */
+  public AccessControlList mergeActions(AccessControlList acl) {
+    HashMap<SimpleEntry<String, String>, AccessControlEntry> rules = new HashMap<>();
+    SimpleEntry<String, String> key;
+    for (AccessControlEntry entry : this.entries) {
+      key = new SimpleEntry<>(entry.getRole(), entry.getAction());
+      rules.put(key, entry);
+    }
+    for (AccessControlEntry entry : acl.getEntries()) {
+      key = new SimpleEntry<>(entry.getRole(), entry.getAction());
+      rules.put(key, entry);
+    }
+    this.entries = new ArrayList<>(rules.values());
+    return this;
   }
 
 }

--- a/modules/common/src/main/java/org/opencastproject/security/api/AclScope.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AclScope.java
@@ -23,5 +23,5 @@ package org.opencastproject.security.api;
 
 /** Scopes of an ACL. */
 public enum AclScope {
-  Series, Episode, Global
+  Series, Episode, Global, Merged
 }

--- a/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AuthorizationService.java
@@ -23,6 +23,7 @@ package org.opencastproject.security.api;
 
 import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.util.data.Tuple;
 
 import java.io.IOException;
@@ -33,15 +34,6 @@ import java.io.InputStream;
  * Provides generation and interpretation of policy documents in media packages
  */
 public interface AuthorizationService {
-
-  /**
-   * Determines whether the current media package contains a security policy.
-   *
-   * @param mp
-   *          the media package
-   * @return whether the current media package contains a security policy
-   */
-  boolean hasPolicy(MediaPackage mp);
 
   /**
    * Determines whether the current user can take the specified action on the media package.
@@ -117,7 +109,8 @@ public interface AuthorizationService {
    *          the tuples of roles to actions
    * @return the mutated (!) media package with attached XACML policy and the XACML attachment
    */
-  Tuple<MediaPackage, Attachment> setAcl(MediaPackage mp, AclScope scope, AccessControlList acl);
+  Tuple<MediaPackage, Attachment> setAcl(MediaPackage mp, AclScope scope, AccessControlList acl)
+          throws MediaPackageException;
 
   /**
    * Remove the XACML of the given scope.

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
@@ -32,6 +32,7 @@ import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElements;
+import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.message.broker.api.series.SeriesItem;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
@@ -170,7 +171,11 @@ public class AssetManagerUpdatedEventHandler {
         // Update the series XACML file
         if (SeriesItem.Type.UpdateAcl.equals(seriesItem.getType())) {
           // Build a new XACML file for this mediapackage
-          authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl());
+          try {
+            authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl());
+          } catch (MediaPackageException e) {
+            logger.error("Error setting ACL for media package {}", mp.getIdentifier(), e);
+          }
         }
 
         // Update the series dublin core or extended metadata

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
@@ -24,6 +24,7 @@ package org.opencastproject.event.handler;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElements;
+import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.message.broker.api.series.SeriesItem;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
@@ -167,7 +168,11 @@ public class WorkflowPermissionsUpdatedEventHandler {
           // Update the series XACML file
           if (SeriesItem.Type.UpdateAcl.equals(seriesItem.getType())) {
             // Build a new XACML file for this mediapackage
-            authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl());
+            try {
+              authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl());
+            } catch (MediaPackageException e) {
+              logger.error("Error setting ACL for media package {}", mp.getIdentifier(), e);
+            }
           }
 
           // Update the series dublin core

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -33,12 +33,10 @@ import org.opencastproject.distribution.api.DistributionService;
 import org.opencastproject.distribution.api.DownloadDistributionService;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobContext;
-import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
-import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.MediaPackageReference;
 import org.opencastproject.mediapackage.MediaPackageReferenceImpl;
@@ -312,18 +310,6 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
       }
       for (MediaPackageElement elem : streamingElements) {
         streamingElementIds.add(elem.getIdentifier());
-      }
-
-      // Also distribute the security configuration
-      // -----
-      // This was removed in the meantime by a fix for MH-8515, but could now be used again.
-      // -----
-      Attachment[] securityAttachments = mediaPackage.getAttachments(MediaPackageElements.XACML_POLICY);
-      if (securityAttachments != null && securityAttachments.length > 0) {
-        for (Attachment a : securityAttachments) {
-          downloadElementIds.add(a.getIdentifier());
-          streamingElementIds.add(a.getIdentifier());
-        }
       }
 
       removePublicationElement(mediaPackage);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishOaiPmhWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishOaiPmhWorkflowOperationHandler.java
@@ -29,12 +29,10 @@ import static org.opencastproject.util.data.functions.Strings.trimToNone;
 
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobContext;
-import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
-import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.mediapackage.PublicationImpl;
@@ -217,18 +215,6 @@ public class PublishOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
       }
       for (MediaPackageElement elem : streamingElements) {
         streamingElementIds.add(elem.getIdentifier());
-      }
-
-      // Also distribute the security configuration
-      // -----
-      // This was removed in the meantime by a fix for MH-8515, but could now be used again.
-      // -----
-      Attachment[] securityAttachments = mediaPackage.getAttachments(MediaPackageElements.XACML_POLICY);
-      if (securityAttachments != null && securityAttachments.length > 0) {
-        for (Attachment a : securityAttachments) {
-          downloadElementIds.add(a.getIdentifier());
-          streamingElementIds.add(a.getIdentifier());
-        }
       }
 
       Job publishJob = null;

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -588,9 +588,13 @@ public class IndexServiceImplTest {
     // Setup Authorization Service
     Tuple<MediaPackage, Attachment> returnValue = new Tuple<>(mediapackage, null);
     AuthorizationService authorizationService = EasyMock.createMock(AuthorizationService.class);
-    EasyMock.expect(authorizationService.setAcl(EasyMock.anyObject(MediaPackage.class),
-            EasyMock.anyObject(AclScope.class), EasyMock.anyObject(AccessControlList.class))).andReturn(returnValue)
-            .anyTimes();
+    try {
+      EasyMock.expect(authorizationService.setAcl(EasyMock.anyObject(MediaPackage.class),
+              EasyMock.anyObject(AclScope.class), EasyMock.anyObject(AccessControlList.class)))
+              .andReturn(returnValue).anyTimes();
+    } catch (MediaPackageException e) {
+      throw new RuntimeException(e);
+    }
     EasyMock.replay(authorizationService);
     return authorizationService;
   }

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -872,11 +872,6 @@ public class LiveScheduleServiceImplTest {
     }
 
     @Override
-    public boolean hasPolicy(MediaPackage mp) {
-      return false;
-    }
-
-    @Override
     public boolean hasPermission(MediaPackage mp, String action) {
       return false;
     }

--- a/modules/migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
+++ b/modules/migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
@@ -246,7 +246,11 @@ public class SchedulerMigrationService {
     mp.add(dc);
     // add acl to the media package
     for (AccessControlList acl : event.accessControlList) {
-      authorizationService.setAcl(mp, AclScope.Episode, acl);
+      try {
+        authorizationService.setAcl(mp, AclScope.Episode, acl);
+      } catch (MediaPackageException e) {
+        logger.error("Error setting ACL for media package {}", mp.getIdentifier(), e);
+      }
     }
     //
     // add to scheduler service


### PR DESCRIPTION
Opencast's handling of access control lists always felt like a magic
black box from which you would get a defined output for each input but
no one (with a few exceptions) really knew what the output was or even
should be, especially when it comes to the relationship and handling of
series and episode rules.

This is an attempt to finally solve the issue by introducing ACL merge
modes and a well defined, configurable behavior of the admin interface
when it comes to modifications of series acl.

This task consists of three parts:

- Defining the admin interface's behavior for series acl changes
- Defining the permission handling in case multiple rule-sets (e.g.
  series and episode acl) are attached to an event.
- Document how access control lists work and how they are evaluated
  given different settings.

Additional to these primary tasks, this also includes a general code
cleanup for the access control management which most notably collapses
several evaluation paths to ensure that evaluation of access control
always behaves similar and which also removes the evaluation of the
`security/xacml` flavor which was deprecated and not used anymore since
before Opencast 1.2 (see discussion on list).


Series ACL Changes In The Admin Interface
-----------------------------------------

Until now, the admin interface would always automatically remove all
episode acls whenever a series' permissions where modified to ensure
these new permissions apply for all episodes.

Now, this behavior can be configured with the following modes of
operation being available. Note that the default has changed compared to
the previous behavior in the hope that it is easier to userstand.

- *always:*
  When modifying series permissions, automatically remove all permission
  rules specific to single episodes belonging to the series. This
  enforces that every episode has the rules of the series in effect as
  soon as they are changed.
- *never:*
  Only update the series permissions but never replace permissions set
  on event level. This may mean that updated rules have no effect on
  already existing events.
- *optional (default):*
  Like `never` but present users with a button in the series permission
  dialog which allows them to replace the event specific permissions
  easily if they want to.


Handling/Merging Series and Episode Rules
-----------------------------------------

Access control lists can be specified both on series and on episode
level. This means that multiple rule sets can be attaches to an episode
which is part of a series. Opencast can now handle this in multiple
ways. If multiple lists are attached, the following modes define
Opencast's behavior:


### Merge Mode “override” (Default)

The episode ACL takes precedence over the series ACL. This means that
the series ACL will be completely ignored as soon as the episode has an
ACL, no matter what rules are set in either. This allows users to define
general rules for a series which can be completely redefined on an
episode and which are not influenced by changes later made to the
series.  This is also a very simple rule and thus easy to understand.

Example:

|         |ROLE1 |       |ROLE2 |       |ROLE3 |       |
|---------|------|-------|------|-------|------|-------|
|         |*read*|*write*|*read*|*write*|*read*|*write*|
|*series* |allow |allow  |allow |allow  |      |       |
|*episode*|      |       |allow |       |allow |       |
|*active* |      |       |allow |       |allow |       |


### Merge Mode “roles”

Series and episode ACLs are merged based on the roles defined within. If
both the series and the episode define a rule for a specific role (user
or group), the episode's rule takes precedence. Rules for roles defined
in one ACL only are always part of the resulting active ACL.

Example:

|         |ROLE1 |       |ROLE2 |       |ROLE3 |       |
|---------|------|-------|------|-------|------|-------|
|         |*read*|*write*|*read*|*write*|*read*|*write*|
|*series* |allow |allow  |allow |allow  |      |       |
|*episode*|      |       |allow |       |allow |       |
|*active* |allow |allow  |allow |       |allow |       |


### Merge Mode “actions”

ACLs are merged based on the actions (read, write, …) contained within
both ACLs. If a rule is specified for a tuple of role and action in both
ACLs, the rule specified in the episode ACL takes precedence.

Example:

|         |ROLE1 |       |ROLE2 |       |ROLE3 |       |
|---------|------|-------|------|-------|------|-------|
|         |*read*|*write*|*read*|*write*|*read*|*write*|
|*series* |allow |allow  |allow |allow  |      |       |
|*episode*|      |       |allow |       |allow |       |
|*active* |allow |allow  |allow |allow  |allow |       |

Pull Request
-----------------

Frontend, backend, cleanup and documentation are contained in separate commits which should be relatively easy to review by itself.

*Work sponsored by SWITCH*