### PR TITLE
MH-13188: Update paella player 6.0.3

### DIFF
--- a/modules/engage-paella-player/package-lock.json
+++ b/modules/engage-paella-player/package-lock.json
@@ -2317,8 +2317,8 @@
       "dev": true
     },
     "paellaplayer": {
-      "version": "github:polimediaupv/paella#03423846856d8e13ba09dd16585b058e738dcee3",
-      "from": "github:polimediaupv/paella#6.0.2",
+      "version": "github:polimediaupv/paella#49f3f264d0e81b210f1f22833484d4e88c844451",
+      "from": "github:polimediaupv/paella#6.0.3",
       "dev": true
     },
     "parse-filepath": {

--- a/modules/engage-paella-player/package.json
+++ b/modules/engage-paella-player/package.json
@@ -10,6 +10,6 @@
     "eslint-plugin-header": "^2.0.0",
     "gulp": "^3.9.1",
     "merge-stream": "^1.0.1",
-    "paellaplayer": "github:polimediaupv/paella#6.0.2"
+    "paellaplayer": "github:polimediaupv/paella#6.0.3"
   }
 }


### PR DESCRIPTION
This PR Update Paella player to 6.0.3
Jira ticket: https://opencast.jira.com/browse/MH-13188

Paella 6.0.3 fix these issues:
  * Zoom in/out button are not hidden when the mouse cursor leaves the player (https://github.com/polimediaupv/paella/issues/364)
  * Fix Matomo Media Analytics scan (https://github.com/polimediaupv/paella/pull/365)

