### PR TITLE
MH-13190, Factor out JpaGroupRoleProvider JaxRs REST to mitigate load cycle race

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
@@ -26,13 +26,13 @@ import static com.entwinemedia.fn.data.json.Jsons.f;
 import static com.entwinemedia.fn.data.json.Jsons.obj;
 import static com.entwinemedia.fn.data.json.Jsons.v;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
 import static javax.servlet.http.HttpServletResponse.SC_CREATED;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
-import static org.apache.http.HttpStatus.SC_CONFLICT;
-import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.opencastproject.index.service.util.RestUtils.okJsonList;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.INTEGER;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
@@ -260,7 +260,8 @@ public class GroupsEndpoint {
     } catch (UnauthorizedException e) {
       return Response.status(SC_FORBIDDEN).build();
     } catch (Exception e) {
-      throw new WebApplicationException(e);
+      logger.error("Unable to delete group {}", groupId, e);
+      throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
     }
   }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
@@ -51,8 +51,10 @@ import org.opencastproject.matterhorn.search.SearchResult;
 import org.opencastproject.matterhorn.search.SearchResultItem;
 import org.opencastproject.matterhorn.search.SortCriterion;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
+import org.opencastproject.userdirectory.ConflictException;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.RestUtil;
 import org.opencastproject.util.data.Option;
@@ -250,7 +252,16 @@ public class GroupsEndpoint {
       @RestResponse(responseCode = SC_NOT_FOUND, description = "Group not found."),
       @RestResponse(responseCode = SC_INTERNAL_SERVER_ERROR, description = "An internal server error occured.")})
   public Response removeGroup(@PathParam("id") String groupId) throws NotFoundException {
-    return indexService.removeGroup(groupId);
+    try {
+      indexService.removeGroup(groupId);
+      return Response.noContent().build();
+    } catch (NotFoundException e) {
+      return Response.status(SC_NOT_FOUND).build();
+    } catch (UnauthorizedException e) {
+      return Response.status(SC_FORBIDDEN).build();
+    } catch (Exception e) {
+      throw new WebApplicationException(e);
+    }
   }
 
   @POST
@@ -271,7 +282,17 @@ public class GroupsEndpoint {
       @RestResponse(responseCode = SC_CONFLICT, description = "An group with this name already exists.") })
   public Response createGroup(@FormParam("name") String name, @FormParam("description") String description,
           @FormParam("roles") String roles, @FormParam("users") String users) {
-    return indexService.createGroup(name, description, roles, users);
+    try {
+      indexService.createGroup(name, description, roles, users);
+    } catch (IllegalArgumentException e) {
+      logger.warn(e.getMessage());
+      return Response.status(Status.BAD_REQUEST).build();
+    } catch (UnauthorizedException e) {
+      return Response.status(SC_FORBIDDEN).build();
+    } catch (ConflictException e) {
+      return Response.status(SC_CONFLICT).build();
+    }
+    return Response.status(Status.CREATED).build();
   }
 
   @PUT
@@ -295,7 +316,15 @@ public class GroupsEndpoint {
   public Response updateGroup(@PathParam("id") String groupId, @FormParam("name") String name,
           @FormParam("description") String description, @FormParam("roles") String roles,
           @FormParam("users") String users) throws NotFoundException {
-    return indexService.updateGroup(groupId, name, description, roles, users);
+    try {
+      indexService.updateGroup(groupId, name, description, roles, users);
+    } catch (IllegalArgumentException e) {
+      logger.warn(e.getMessage());
+      return Response.status(Status.BAD_REQUEST).build();
+    } catch (UnauthorizedException ex) {
+      return Response.status(SC_FORBIDDEN).build();
+    }
+    return Response.ok().build();
   }
 
   @GET

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -24,12 +24,17 @@ import static com.entwinemedia.fn.data.json.Jsons.arr;
 import static com.entwinemedia.fn.data.json.Jsons.f;
 import static com.entwinemedia.fn.data.json.Jsons.obj;
 import static com.entwinemedia.fn.data.json.Jsons.v;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
+import static javax.servlet.http.HttpServletResponse.SC_CREATED;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getMessage;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
-import static org.apache.http.HttpStatus.SC_CONFLICT;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
 
 import org.opencastproject.external.common.ApiResponses;
@@ -74,7 +79,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 
 @Path("/")
 @RestService(name = "externalapigroups", title = "External API Groups Service", notes = "", abstractText = "Provides resources and operations related to the groups")
@@ -169,7 +173,8 @@ public class GroupsEndpoint {
     } catch (UnauthorizedException e) {
       return Response.status(SC_FORBIDDEN).build();
     } catch (Exception e) {
-      throw new WebApplicationException(e);
+      logger.error("Unable to delete group {}", id, e);
+      throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -191,7 +196,7 @@ public class GroupsEndpoint {
       indexService.updateGroup(id, name, description, roles, members);
     } catch (IllegalArgumentException e) {
       logger.warn(e.getMessage());
-      return Response.status(Status.BAD_REQUEST).build();
+      return Response.status(SC_BAD_REQUEST).build();
     } catch (UnauthorizedException ex) {
       return Response.status(SC_FORBIDDEN).build();
     }
@@ -206,8 +211,8 @@ public class GroupsEndpoint {
           @RestParameter(name = "description", description = "Group Description", isRequired = false, type = STRING),
           @RestParameter(name = "roles", description = "Comma-separated list of roles", isRequired = false, type = STRING),
           @RestParameter(name = "members", description = "Comma-separated list of members", isRequired = false, type = STRING) }, reponses = {
-                  @RestResponse(description = "A new group is created.", responseCode = HttpServletResponse.SC_CREATED),
-                  @RestResponse(description = "The request is invalid or inconsistent.", responseCode = HttpServletResponse.SC_BAD_REQUEST) })
+                  @RestResponse(description = "A new group is created.", responseCode = SC_CREATED),
+                  @RestResponse(description = "The request is invalid or inconsistent.", responseCode = SC_BAD_REQUEST) })
   public Response createGroup(@HeaderParam("Accept") String acceptHeader, @FormParam("name") String name,
           @FormParam("description") String description, @FormParam("roles") String roles,
           @FormParam("members") String members) {
@@ -215,13 +220,13 @@ public class GroupsEndpoint {
       indexService.createGroup(name, description, roles, members);
     } catch (IllegalArgumentException e) {
       logger.warn(e.getMessage());
-      return Response.status(Status.BAD_REQUEST).build();
+      return Response.status(SC_BAD_REQUEST).build();
     } catch (UnauthorizedException e) {
       return Response.status(SC_FORBIDDEN).build();
     } catch (ConflictException e) {
       return Response.status(SC_CONFLICT).build();
     }
-    return Response.status(Status.CREATED).build();
+    return Response.status(SC_CREATED).build();
   }
 
   @POST
@@ -230,9 +235,9 @@ public class GroupsEndpoint {
   @RestQuery(name = "addgroupmember", description = "Adds a member to a group.", returnDescription = "", pathParameters = {
           @RestParameter(name = "groupId", description = "The group id", isRequired = true, type = STRING) }, restParameters = {
                   @RestParameter(name = "member", description = "Member Name", isRequired = true, type = STRING) }, reponses = {
-                          @RestResponse(description = "The member was already member of the group.", responseCode = HttpServletResponse.SC_OK),
-                          @RestResponse(description = "The member has been added.", responseCode = HttpServletResponse.SC_NO_CONTENT),
-                          @RestResponse(description = "The specified group does not exist.", responseCode = HttpServletResponse.SC_NOT_FOUND) })
+                          @RestResponse(description = "The member was already member of the group.", responseCode = SC_OK),
+                          @RestResponse(description = "The member has been added.", responseCode = SC_NO_CONTENT),
+                          @RestResponse(description = "The specified group does not exist.", responseCode = SC_NOT_FOUND) })
   public Response addGroupMember(@HeaderParam("Accept") String acceptHeader, @PathParam("groupId") String id,
           @FormParam("member") String member) {
     try {
@@ -247,7 +252,7 @@ public class GroupsEndpoint {
                     StringUtils.join(group.getRoles(), ","), StringUtils.join(group.getMembers(), ","));
           } catch (IllegalArgumentException e) {
             logger.warn(e.getMessage());
-            return Response.status(Status.BAD_REQUEST).build();
+            return Response.status(SC_BAD_REQUEST).build();
           } catch (UnauthorizedException ex) {
             return Response.status(SC_FORBIDDEN).build();
           }
@@ -291,7 +296,7 @@ public class GroupsEndpoint {
                     StringUtils.join(group.getRoles(), ","), StringUtils.join(group.getMembers(), ","));
           } catch (IllegalArgumentException e) {
             logger.warn(e.getMessage());
-            return Response.status(Status.BAD_REQUEST).build();
+            return Response.status(SC_BAD_REQUEST).build();
           } catch (UnauthorizedException ex) {
             return Response.status(SC_FORBIDDEN).build();
           }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
@@ -68,7 +68,7 @@ public interface IndexService {
   }
 
   SearchResult<Group> getGroups(String filter, Opt<Integer> limit, Opt<Integer> offset, Opt<String> sort,
-          AbstractSearchIndex index) throws SearchIndexException;
+          AbstractSearchIndex index) throws SearchIndexException, IllegalArgumentException;
 
   /**
    * Get a single group

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
@@ -41,6 +41,7 @@ import org.opencastproject.scheduler.api.SchedulerException;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.series.api.SeriesException;
+import org.opencastproject.userdirectory.ConflictException;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.WorkflowException;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -55,7 +56,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
 
 public interface IndexService {
 
@@ -83,12 +83,25 @@ public interface IndexService {
    */
   Opt<Group> getGroup(String id, AbstractSearchIndex index) throws SearchIndexException;
 
-  Response removeGroup(String id) throws NotFoundException;
+  /**
+   * Remove a group by id
+   *
+   * @param groupId
+   *          the id of the group to remove
+   * @throws NotFoundException
+   *           the group was not found
+   * @throws UnauthorizedException
+   *           user is not authorized to remove this group
+   * @throws Exception
+   *           unexpected error occurred
+   *
+   */
+  void removeGroup(String groupId) throws NotFoundException, UnauthorizedException, Exception;
 
   /**
    * Update a {@link Group} with new data
    *
-   * @param id
+   * @param groupId
    *          The unique id for the group.
    * @param name
    *          The name to use for the group.
@@ -98,12 +111,13 @@ public interface IndexService {
    *          A comma separated list of roles to add to this group.
    * @param members
    *          A comma separated list of roles to add to this group.
-   * @return The Response from the update
    * @throws NotFoundException
    *           Thrown if the group was not found
+   * @throws UnauthorizedException
+   *           Thrown if the user does not have rights to update the group
    */
-  Response updateGroup(String id, String name, String description, String roles, String members)
-          throws NotFoundException;
+  void updateGroup(String groupId, String name, String description, String roles, String members)
+          throws NotFoundException, UnauthorizedException;
 
   /**
    * Create a new {@link Group}
@@ -116,10 +130,13 @@ public interface IndexService {
    *          A comma separated list of roles to add to this group.
    * @param members
    *          A comma separated list of members to add to this group.
-   * @return The Response from the update
+   * @throws UnauthorizedException
+   *           if user does not have rights to create group
+   * @throws ConflictException
+   *           if group already exists
    */
-  Response createGroup(String name, String description, String roles, String members);
-
+   void createGroup(String name, String description, String roles, String members)
+          throws IllegalArgumentException, UnauthorizedException, ConflictException;
   /**
    * Get a single event
    *

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -166,8 +166,6 @@ import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response.Status;
 
 public class IndexServiceImpl implements IndexService {
 
@@ -1360,7 +1358,7 @@ public class IndexServiceImpl implements IndexService {
 
   @Override
   public SearchResult<Group> getGroups(String filter, Opt<Integer> optLimit, Opt<Integer> optOffset,
-          Opt<String> optSort, AbstractSearchIndex index) throws SearchIndexException {
+          Opt<String> optSort, AbstractSearchIndex index) throws SearchIndexException, IllegalArgumentException {
     GroupSearchQuery query = new GroupSearchQuery(securityService.getOrganization().getId(), securityService.getUser());
 
     // Parse the filters
@@ -1400,7 +1398,7 @@ public class IndexServiceImpl implements IndexService {
             query.sortByRoles(criterion.getOrder());
             break;
           default:
-            throw new WebApplicationException(Status.BAD_REQUEST);
+            throw new IllegalArgumentException("Unknown group index " + criterion.getFieldName());
         }
       }
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -101,6 +101,7 @@ import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.security.util.SecurityContext;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
+import org.opencastproject.userdirectory.ConflictException;
 import org.opencastproject.userdirectory.JpaGroupRoleProvider;
 import org.opencastproject.util.Checksum;
 import org.opencastproject.util.ChecksumType;
@@ -166,7 +167,6 @@ import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 public class IndexServiceImpl implements IndexService {
@@ -1428,23 +1428,24 @@ public class IndexServiceImpl implements IndexService {
   }
 
   @Override
-  public Response removeGroup(String id) throws NotFoundException {
-    return jpaGroupRoleProvider.removeGroup(id);
+  public void removeGroup(String id) throws NotFoundException, UnauthorizedException, Exception {
+    jpaGroupRoleProvider.removeGroup(id);
   }
 
   @Override
-  public Response updateGroup(String id, String name, String description, String roles, String members)
-          throws NotFoundException {
-    return jpaGroupRoleProvider.updateGroup(id, name, description, roles, members);
+  public void updateGroup(String id, String name, String description, String roles, String members)
+          throws NotFoundException, UnauthorizedException {
+    jpaGroupRoleProvider.updateGroup(id, name, description, roles, members);
   }
 
   @Override
-  public Response createGroup(String name, String description, String roles, String members) {
+  public void createGroup(String name, String description, String roles, String members)
+          throws IllegalArgumentException, UnauthorizedException, ConflictException {
     if (StringUtils.isEmpty(roles))
       roles = "";
     if (StringUtils.isEmpty(members))
       members = "";
-    return jpaGroupRoleProvider.createGroup(name, description, roles, members);
+    jpaGroupRoleProvider.createGroup(name, description, roles, members);
   }
 
   @Override

--- a/modules/textanalyzer-impl/src/main/resources/OSGI-INF/textanalyzer.xml
+++ b/modules/textanalyzer-impl/src/main/resources/OSGI-INF/textanalyzer.xml
@@ -28,7 +28,7 @@
       interface="org.opencastproject.util.ReadinessIndicator" target="(artifact=dictionary)" />
   </scr:component>
 
-  <scr:component name="org.opencastproject.textanalyzer.impl.endpoint.TextAnalysisRestEndpoint" immediate="true"
+  <scr:component name="org.opencastproject.textanalyzer.impl.endpoint.TextAnalysisRestEndpoint" immediate="false"
     activate="activate">
     <implementation class="org.opencastproject.textanalyzer.impl.endpoint.TextAnalysisRestEndpoint" />
     <property name="service.description" value="Text Analysis REST Endpoint" />

--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -145,6 +145,7 @@
               OSGI-INF/admin-user-and-group-loader.xml,
               OSGI-INF/custom-role-provider.xml,
               OSGI-INF/group-role-provider.xml,
+              OSGI-INF/group-role-endpoint.xml,
               OSGI-INF/organization-role-provider.xml,
               OSGI-INF/user-and-role-directory-service.xml,
               OSGI-INF/user-reference-provider.xml,

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/ConflictException.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/ConflictException.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.userdirectory;
+
+
+/**
+ * An exception thrown when something is being created has been created. For example a group id that is already being
+ * used.
+ *
+ */
+public class ConflictException extends Exception {
+
+  /** The serial version ui */
+  private static final long serialVersionUID = 898989376281407395L;
+
+  /**
+   * @param message
+   */
+  public ConflictException(String message) {
+    super(message);
+  }
+
+  /**
+   * @param cause
+   */
+  public ConflictException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * @param message
+   * @param cause
+   */
+  public ConflictException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * @param message
+   * @param cause
+   * @param enableSuppression
+   * @param writableStackTrace
+   */
+  public ConflictException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+    super(message, cause, enableSuppression, writableStackTrace);
+  }
+
+}

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -21,14 +21,6 @@
 
 package org.opencastproject.userdirectory;
 
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_CREATED;
-import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
-import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static org.apache.http.HttpStatus.SC_CONFLICT;
-
 import org.opencastproject.index.IndexProducer;
 import org.opencastproject.message.broker.api.MessageReceiver;
 import org.opencastproject.message.broker.api.MessageSender;
@@ -58,11 +50,6 @@ import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.userdirectory.utils.UserDirectoryUtils;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Effect0;
-import org.opencastproject.util.doc.rest.RestParameter;
-import org.opencastproject.util.doc.rest.RestParameter.Type;
-import org.opencastproject.util.doc.rest.RestQuery;
-import org.opencastproject.util.doc.rest.RestResponse;
-import org.opencastproject.util.doc.rest.RestService;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
@@ -81,33 +68,10 @@ import java.util.regex.Pattern;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 
 /**
- * Manages and locates users using JPA. Note that this also provides a REST endpoint to manage user roles. Since this is
- * not intended to be production code, the REST concerns have not be factored into a separate class. Feel free to
- * refactor.
+ * Manages and locates users using JPA. The REST concerns have been refactored to the GroupRoleEndpoint
  */
-@Path("/")
-@RestService(name = "groups", title = "Internal group manager", abstractText = "This service offers the ability to manage the groups for internal accounts.", notes = {
-        "All paths above are relative to the REST endpoint base (something like http://your.server/files)",
-        "If the service is down or not working it will return a status 503, this means the the underlying service is "
-                + "not working and is either restarting or has failed",
-                "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
-                        + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
 public class JpaGroupRoleProvider extends AbstractIndexProducer implements RoleProvider, GroupProvider {
 
   /** The logger */
@@ -448,24 +412,35 @@ public class JpaGroupRoleProvider extends AbstractIndexProducer implements RoleP
     return p.matcher(str).matches();
   }
 
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("groups.json")
-  @RestQuery(name = "allgroupsasjson", description = "Returns a list of groups", returnDescription = "Returns a JSON representation of the list of groups available the current user's organization", restParameters = {
-          @RestParameter(defaultValue = "100", description = "The maximum number of items to return per page.", isRequired = false, name = "limit", type = RestParameter.Type.STRING),
-          @RestParameter(defaultValue = "0", description = "The page number.", isRequired = false, name = "offset", type = RestParameter.Type.STRING) }, reponses = { @RestResponse(responseCode = SC_OK, description = "The groups.") })
-  public JaxbGroupList getGroupsAsJson(@QueryParam("limit") int limit, @QueryParam("offset") int offset)
+  /**
+   * Retrieves a group list based on input constraints. Called by GroupRoleEndpoint.
+   *
+   * @param limit
+   *          the int amount to limit the results
+   * @param offset
+   *          the offset to start this result set at
+   * @return the JaxbGroupList of results
+   * @throws IOException
+   *           if unexpected IO exception occurs
+   */
+  public JaxbGroupList getGroupsAsJson(int limit, int offset)
           throws IOException {
     return getGroupsAsXml(limit, offset);
   }
 
-  @GET
-  @Produces(MediaType.APPLICATION_XML)
-  @Path("groups.xml")
-  @RestQuery(name = "allgroupsasxml", description = "Returns a list of groups", returnDescription = "Returns a XML representation of the list of groups available the current user's organization", restParameters = {
-          @RestParameter(defaultValue = "100", description = "The maximum number of items to return per page.", isRequired = false, name = "limit", type = RestParameter.Type.STRING),
-          @RestParameter(defaultValue = "0", description = "The page number.", isRequired = false, name = "offset", type = RestParameter.Type.STRING) }, reponses = { @RestResponse(responseCode = SC_OK, description = "The groups.") })
-  public JaxbGroupList getGroupsAsXml(@QueryParam("limit") int limit, @QueryParam("offset") int offset)
+  /**
+   * Returns a XML representation of the list of groups available the current user's organization. Used by
+   * GroupRoleEndpoint.
+   *
+   * @param limit
+   *          the int amount to limit the results
+   * @param offset
+   *          the offset to start this result set at
+   * @return the JaxbGroupList of results
+   * @throws IOException
+   *           if unexpected IO exception occurs
+   */
+  public JaxbGroupList getGroupsAsXml(int limit, int offset)
           throws IOException {
     if (limit < 1)
       limit = 100;
@@ -478,40 +453,43 @@ public class JpaGroupRoleProvider extends AbstractIndexProducer implements RoleP
     return groupList;
   }
 
-  @DELETE
-  @Path("{id}")
-  @RestQuery(name = "removegrouop", description = "Remove a group", returnDescription = "Return no content", pathParameters = { @RestParameter(name = "id", description = "The group identifier", isRequired = true, type = Type.STRING) }, reponses = {
-          @RestResponse(responseCode = SC_OK, description = "Group deleted"),
-          @RestResponse(responseCode = SC_FORBIDDEN, description = "Not enough permissions to remove a group with the admin role."),
-          @RestResponse(responseCode = SC_NOT_FOUND, description = "Group not found."),
-          @RestResponse(responseCode = SC_INTERNAL_SERVER_ERROR, description = "An internal server error occured.") })
-  public Response removeGroup(@PathParam("id") String groupId) {
+  /**
+   * Remove a group by id
+   *
+   * @param groupId
+   *          the id of the group to remove
+   * @throws Exception
+   *           unexpected error occurred
+   * @throws UnauthorizedException
+   *           user is not authorized to remove this group
+   * @throws NotFoundException
+   *           the group was not found
+   */
+  public void removeGroup(String groupId) throws NotFoundException, UnauthorizedException, Exception {
     String orgId = securityService.getOrganization().getId();
-    try {
-      removeGroup(groupId, orgId);
-      return Response.noContent().build();
-    } catch (NotFoundException e) {
-      return Response.status(SC_NOT_FOUND).build();
-    } catch (UnauthorizedException e) {
-      return Response.status(SC_FORBIDDEN).build();
-    } catch (Exception e) {
-      throw new WebApplicationException(e);
-    }
+    removeGroup(groupId, orgId);
   }
 
-  @POST
-  @Path("")
-  @RestQuery(name = "createGroup", description = "Add a group", returnDescription = "Return the status codes", restParameters = {
-          @RestParameter(name = "name", description = "The group name", isRequired = true, type = Type.STRING),
-          @RestParameter(name = "description", description = "The group description", isRequired = false, type = Type.STRING),
-          @RestParameter(name = "roles", description = "A comma seperated string of additional group roles", isRequired = false, type = Type.TEXT),
-          @RestParameter(name = "users", description = "A comma seperated string of group members", isRequired = false, type = Type.TEXT) }, reponses = {
-                  @RestResponse(responseCode = SC_CREATED, description = "Group created"),
-                  @RestResponse(responseCode = SC_BAD_REQUEST, description = "Name too long"),
-                  @RestResponse(responseCode = SC_FORBIDDEN, description = "Not enough permissions to create a group with the admin role."),
-                  @RestResponse(responseCode = SC_CONFLICT, description = "An group with this name already exists.") })
-  public Response createGroup(@FormParam("name") String name, @FormParam("description") String description,
-          @FormParam("roles") String roles, @FormParam("users") String users) {
+  /**
+   * Create a new group
+   *
+   * @param name
+   *          the name of the group
+   * @param description
+   *          a description of the group
+   * @param roles
+   *          the roles of the group
+   * @param users
+   *          the users in the group
+   * @throws IllegalArgumentException
+   *           if missing or bad parameters
+   * @throws UnauthorizedException
+   *           if user does not have rights to create group
+   * @throws ConflictException
+   *           if group already exists
+   */
+  public void createGroup(String name, String description, String roles, String users)
+          throws IllegalArgumentException, UnauthorizedException, ConflictException {
     JpaOrganization organization = (JpaOrganization) securityService.getOrganization();
 
     HashSet<JpaRole> roleSet = new HashSet<JpaRole>();
@@ -532,33 +510,32 @@ public class JpaGroupRoleProvider extends AbstractIndexProducer implements RoleP
 
     JpaGroup existingGroup = UserDirectoryPersistenceUtil.findGroup(groupId, organization.getId(), emf);
     if (existingGroup != null)
-      return Response.status(SC_CONFLICT).build();
+      throw new ConflictException("group already exists");
 
-    try {
-      addGroup(new JpaGroup(groupId, organization, name, description, roleSet, members));
-    } catch (IllegalArgumentException e) {
-      logger.warn(e.getMessage());
-      return Response.status(Status.BAD_REQUEST).build();
-    } catch (UnauthorizedException e) {
-      return Response.status(SC_FORBIDDEN).build();
-    }
-    return Response.status(Status.CREATED).build();
+    addGroup(new JpaGroup(groupId, organization, name, description, roleSet, members));
+
   }
 
-  @PUT
-  @Path("{id}")
-  @RestQuery(name = "updateGroup", description = "Update a group", returnDescription = "Return the status codes", pathParameters = { @RestParameter(name = "id", description = "The group identifier", isRequired = true, type = Type.STRING) }, restParameters = {
-          @RestParameter(name = "name", description = "The group name", isRequired = true, type = Type.STRING),
-          @RestParameter(name = "description", description = "The group description", isRequired = false, type = Type.STRING),
-          @RestParameter(name = "roles", description = "A comma seperated string of additional group roles", isRequired = false, type = Type.TEXT),
-          @RestParameter(name = "users", description = "A comma seperated string of group members", isRequired = true, type = Type.TEXT) }, reponses = {
-          @RestResponse(responseCode = SC_OK, description = "Group updated"),
-          @RestResponse(responseCode = SC_FORBIDDEN, description = "Not enough permissions to update a group with the admin role."),
-          @RestResponse(responseCode = SC_NOT_FOUND, description = "Group not found"),
-          @RestResponse(responseCode = SC_BAD_REQUEST, description = "Name too long") })
-  public Response updateGroup(@PathParam("id") String groupId, @FormParam("name") String name,
-          @FormParam("description") String description, @FormParam("roles") String roles,
-          @FormParam("users") String users) throws NotFoundException {
+  /**
+   * Update a group
+   *
+   * @param groupId
+   *          the id of the group to update
+   * @param name
+   *          the name to update
+   * @param description
+   *          the description to update
+   * @param roles
+   *          the roles to update
+   * @param users
+   *          the users to update
+   * @throws NotFoundException
+   *           if the group is not found
+   * @throws UnauthorizedException
+   *           if the user does not have rights to update the group
+   */
+  public void updateGroup(String groupId, String name, String description, String roles, String users)
+          throws NotFoundException, UnauthorizedException {
     JpaOrganization organization = (JpaOrganization) securityService.getOrganization();
 
     JpaGroup group = UserDirectoryPersistenceUtil.findGroup(groupId, organization.getId(), emf);
@@ -609,17 +586,7 @@ public class JpaGroupRoleProvider extends AbstractIndexProducer implements RoleP
         userDirectoryService.invalidate(member);
       }
     }
-
-    try {
-      addGroup(group);
-    } catch (IllegalArgumentException e) {
-      logger.warn(e.getMessage());
-      return Response.status(Status.BAD_REQUEST).build();
-    } catch (UnauthorizedException ex) {
-      return Response.status(SC_FORBIDDEN).build();
-    }
-
-    return Response.ok().build();
+    addGroup(group);
   }
 
   @Override

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -70,7 +70,7 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
 
 /**
- * Manages and locates users using JPA. The REST concerns have been refactored to the GroupRoleEndpoint
+ * Manages and locates users using JPA.
  */
 public class JpaGroupRoleProvider extends AbstractIndexProducer implements RoleProvider, GroupProvider {
 
@@ -413,7 +413,7 @@ public class JpaGroupRoleProvider extends AbstractIndexProducer implements RoleP
   }
 
   /**
-   * Retrieves a group list based on input constraints. Called by GroupRoleEndpoint.
+   * Retrieves a group list based on input constraints.
    *
    * @param limit
    *          the int amount to limit the results
@@ -429,8 +429,7 @@ public class JpaGroupRoleProvider extends AbstractIndexProducer implements RoleP
   }
 
   /**
-   * Returns a XML representation of the list of groups available the current user's organization. Used by
-   * GroupRoleEndpoint.
+   * Returns a XML representation of the list of groups available the current user's organization.
    *
    * @param limit
    *          the int amount to limit the results

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/GroupRoleEndpoint.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/GroupRoleEndpoint.java
@@ -1,0 +1,192 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.userdirectory.endpoint;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_CREATED;
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.apache.http.HttpStatus.SC_CONFLICT;
+
+import org.opencastproject.security.api.JaxbGroupList;
+import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.userdirectory.ConflictException;
+import org.opencastproject.userdirectory.JpaGroupRoleProvider;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.util.doc.rest.RestParameter;
+import org.opencastproject.util.doc.rest.RestParameter.Type;
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
+import org.opencastproject.util.doc.rest.RestService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+/**
+ * A REST EndPoint for JpaGroupRoleProvider. This endpoint class factors out the REST concerns of the
+ * JpaGroupRoleProvider.
+ */
+@Path("/")
+@RestService(name = "groups", title = "Internal group manager", abstractText = "This service offers the ability to manage the groups for internal accounts.", notes = {
+        "All paths above are relative to the REST endpoint base (something like http://your.server/files)",
+        "If the service is down or not working it will return a status 503, this means the the underlying service is "
+                + "not working and is either restarting or has failed",
+                "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
+                        + "other words, there is a bug! You should file an error report with your server logs from the time when the "
+                        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+public class GroupRoleEndpoint {
+
+  /** The logger */
+  private static final Logger logger = LoggerFactory.getLogger(GroupRoleEndpoint.class);
+
+  /** The JPA persistence unit name */
+  public static final String PERSISTENCE_UNIT = "org.opencastproject.common";
+
+  /** the jpaGroupRoleProvider Impl service */
+  private JpaGroupRoleProvider jpaGroupRoleProvider;
+
+  /**
+   * @param jpaGroupRoleProvider
+   *          the jpaGroupRoleProvider to set
+   */
+  public void setJpaGroupRoleProvider(JpaGroupRoleProvider jpaGroupRoleProvider) {
+    this.jpaGroupRoleProvider = jpaGroupRoleProvider;
+  }
+
+  /**
+   * Callback for activation of this component.
+   */
+  public void activate() {
+    logger.info("Activating  {}", getClass().getName());
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("groups.json")
+  @RestQuery(name = "allgroupsasjson", description = "Returns a list of groups", returnDescription = "Returns a JSON representation of the list of groups available the current user's organization", restParameters = {
+          @RestParameter(defaultValue = "100", description = "The maximum number of items to return per page.", isRequired = false, name = "limit", type = RestParameter.Type.STRING),
+          @RestParameter(defaultValue = "0", description = "The page number.", isRequired = false, name = "offset", type = RestParameter.Type.STRING) }, reponses = { @RestResponse(responseCode = SC_OK, description = "The groups.") })
+  public JaxbGroupList getGroupsAsJson(@QueryParam("limit") int limit, @QueryParam("offset") int offset)
+          throws IOException {
+    return jpaGroupRoleProvider.getGroupsAsXml(limit, offset);
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_XML)
+  @Path("groups.xml")
+  @RestQuery(name = "allgroupsasxml", description = "Returns a list of groups", returnDescription = "Returns a XML representation of the list of groups available the current user's organization", restParameters = {
+          @RestParameter(defaultValue = "100", description = "The maximum number of items to return per page.", isRequired = false, name = "limit", type = RestParameter.Type.STRING),
+          @RestParameter(defaultValue = "0", description = "The page number.", isRequired = false, name = "offset", type = RestParameter.Type.STRING) }, reponses = { @RestResponse(responseCode = SC_OK, description = "The groups.") })
+  public JaxbGroupList getGroupsAsXml(@QueryParam("limit") int limit, @QueryParam("offset") int offset)
+          throws IOException {
+    return jpaGroupRoleProvider.getGroupsAsXml(limit, offset);
+  }
+
+  @DELETE
+  @Path("{id}")
+  @RestQuery(name = "removegrouop", description = "Remove a group", returnDescription = "Return no content", pathParameters = { @RestParameter(name = "id", description = "The group identifier", isRequired = true, type = Type.STRING) }, reponses = {
+          @RestResponse(responseCode = SC_OK, description = "Group deleted"),
+          @RestResponse(responseCode = SC_FORBIDDEN, description = "Not enough permissions to remove a group with the admin role."),
+          @RestResponse(responseCode = SC_NOT_FOUND, description = "Group not found."),
+          @RestResponse(responseCode = SC_INTERNAL_SERVER_ERROR, description = "An internal server error occured.") })
+  public Response removeGroup(@PathParam("id") String groupId) {
+    try {
+      jpaGroupRoleProvider.removeGroup(groupId);
+      return Response.noContent().build();
+    } catch (NotFoundException e) {
+      return Response.status(SC_NOT_FOUND).build();
+    } catch (UnauthorizedException e) {
+      return Response.status(SC_FORBIDDEN).build();
+    } catch (Exception e) {
+      throw new WebApplicationException(e);
+    }
+  }
+
+  @POST
+  @Path("")
+  @RestQuery(name = "createGroup", description = "Add a group", returnDescription = "Return the status codes", restParameters = {
+          @RestParameter(name = "name", description = "The group name", isRequired = true, type = Type.STRING),
+          @RestParameter(name = "description", description = "The group description", isRequired = false, type = Type.STRING),
+          @RestParameter(name = "roles", description = "A comma seperated string of additional group roles", isRequired = false, type = Type.TEXT),
+          @RestParameter(name = "users", description = "A comma seperated string of group members", isRequired = false, type = Type.TEXT) }, reponses = {
+                  @RestResponse(responseCode = SC_CREATED, description = "Group created"),
+                  @RestResponse(responseCode = SC_BAD_REQUEST, description = "Name too long"),
+                  @RestResponse(responseCode = SC_FORBIDDEN, description = "Not enough permissions to create a group with the admin role."),
+                  @RestResponse(responseCode = SC_CONFLICT, description = "An group with this name already exists.") })
+  public Response createGroup(@FormParam("name") String name, @FormParam("description") String description,
+          @FormParam("roles") String roles, @FormParam("users") String users) {
+    try {
+      jpaGroupRoleProvider.createGroup(name, description, roles, users);
+    } catch (IllegalArgumentException e) {
+      logger.warn(e.getMessage());
+      return Response.status(Status.BAD_REQUEST).build();
+    } catch (UnauthorizedException e) {
+      return Response.status(SC_FORBIDDEN).build();
+    } catch (ConflictException e) {
+      return Response.status(SC_CONFLICT).build();
+    }
+    return Response.status(Status.CREATED).build();
+  }
+
+  @PUT
+  @Path("{id}")
+  @RestQuery(name = "updateGroup", description = "Update a group", returnDescription = "Return the status codes", pathParameters = { @RestParameter(name = "id", description = "The group identifier", isRequired = true, type = Type.STRING) }, restParameters = {
+          @RestParameter(name = "name", description = "The group name", isRequired = true, type = Type.STRING),
+          @RestParameter(name = "description", description = "The group description", isRequired = false, type = Type.STRING),
+          @RestParameter(name = "roles", description = "A comma seperated string of additional group roles", isRequired = false, type = Type.TEXT),
+          @RestParameter(name = "users", description = "A comma seperated string of group members", isRequired = true, type = Type.TEXT) }, reponses = {
+          @RestResponse(responseCode = SC_OK, description = "Group updated"),
+          @RestResponse(responseCode = SC_FORBIDDEN, description = "Not enough permissions to update a group with the admin role."),
+          @RestResponse(responseCode = SC_NOT_FOUND, description = "Group not found"),
+          @RestResponse(responseCode = SC_BAD_REQUEST, description = "Name too long") })
+  public Response updateGroup(@PathParam("id") String groupId, @FormParam("name") String name,
+          @FormParam("description") String description, @FormParam("roles") String roles,
+          @FormParam("users") String users) throws NotFoundException {
+    try {
+      jpaGroupRoleProvider.updateGroup(groupId, name, description, roles, users);
+    } catch (IllegalArgumentException e) {
+      logger.warn(e.getMessage());
+      return Response.status(Status.BAD_REQUEST).build();
+    } catch (UnauthorizedException ex) {
+      return Response.status(SC_FORBIDDEN).build();
+    }
+    return Response.ok().build();
+  }
+}

--- a/modules/userdirectory/src/main/resources/OSGI-INF/group-role-endpoint.xml
+++ b/modules/userdirectory/src/main/resources/OSGI-INF/group-role-endpoint.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+  name="org.opencastproject.userdirectory.endpoint.GroupRoleEndpoint" 
+  immediate="true" activate="activate">
+  <implementation class="org.opencastproject.userdirectory.endpoint.GroupRoleEndpoint" />
+
+  <!-- Register as a REST endpoint -->
+  <property name="service.description" value="Group Role REST EndPoint" />
+
+  <property name="opencast.service.type" value="org.opencastproject.userdirectory.endpoint.GroupRoleEndpoint" />
+  <property name="opencast.service.jobproducer" value="false" />
+  <property name="opencast.service.path" value="/groups" />
+
+  <service>
+    <provide interface="org.opencastproject.userdirectory.endpoint.GroupRoleEndpoint" />
+  </service>
+
+  <reference name="JpaGroupRoleProvider" interface="org.opencastproject.userdirectory.JpaGroupRoleProvider"
+    cardinality="1..1" policy="static" bind="setJpaGroupRoleProvider" />
+
+</scr:component>

--- a/modules/userdirectory/src/main/resources/OSGI-INF/group-role-endpoint.xml
+++ b/modules/userdirectory/src/main/resources/OSGI-INF/group-role-endpoint.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
   name="org.opencastproject.userdirectory.endpoint.GroupRoleEndpoint" 
-  immediate="true" activate="activate">
+  immediate="false" activate="activate">
   <implementation class="org.opencastproject.userdirectory.endpoint.GroupRoleEndpoint" />
 
   <!-- Register as a REST endpoint -->

--- a/modules/userdirectory/src/main/resources/OSGI-INF/group-role-provider.xml
+++ b/modules/userdirectory/src/main/resources/OSGI-INF/group-role-provider.xml
@@ -5,11 +5,6 @@
   <implementation class="org.opencastproject.userdirectory.JpaGroupRoleProvider" />
   <property name="service.description" value="Provides a group role directory" />
   
-  <!-- Also register as a REST endpoint -->
-  <property name="opencast.service.type" value="org.opencastproject.groups" />
-  <property name="opencast.service.jobproducer" value="false" />
-  <property name="opencast.service.path" value="/groups" />
-
   <service>
     <provide interface="org.opencastproject.security.api.RoleProvider" />
     <provide interface="org.opencastproject.userdirectory.JpaGroupRoleProvider" />

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
@@ -37,6 +37,7 @@ import org.opencastproject.security.impl.jpa.JpaGroup;
 import org.opencastproject.security.impl.jpa.JpaOrganization;
 import org.opencastproject.security.impl.jpa.JpaRole;
 import org.opencastproject.security.impl.jpa.JpaUser;
+import org.opencastproject.userdirectory.endpoint.GroupRoleEndpoint;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Collections;
 
@@ -58,6 +59,7 @@ import javax.ws.rs.core.Response;
 public class JpaGroupRoleProviderTest {
 
   private JpaGroupRoleProvider provider = null;
+  private GroupRoleEndpoint endpoint = null;
   private static JpaOrganization org1 = new JpaOrganization("org1", "org1", "localhost", 80, "admin", "anon", null);
   private static JpaOrganization org2 = new JpaOrganization("org2", "org2", "127.0.0.1", 80, "admin", "anon", null);
 
@@ -84,6 +86,10 @@ public class JpaGroupRoleProviderTest {
     provider.setMessageSender(messageSender);
     provider.setEntityManagerFactory(newTestEntityManagerFactory(JpaUserAndRoleProvider.PERSISTENCE_UNIT));
     provider.activate(null);
+
+    endpoint = new GroupRoleEndpoint();
+    endpoint.setJpaGroupRoleProvider(provider);
+
   }
 
   @After
@@ -159,13 +165,13 @@ public class JpaGroupRoleProviderTest {
 
     try {
       // try add ROLE_USER
-      Response updateGroupResponse = provider.updateGroup(group.getGroupId(), group.getName(), group.getDescription(),
+      Response updateGroupResponse = endpoint.updateGroup(group.getGroupId(), group.getName(), group.getDescription(),
               "ROLE_USER, " + SecurityConstants.GLOBAL_ADMIN_ROLE, null);
       assertNotNull(updateGroupResponse);
       assertEquals(HttpStatus.SC_FORBIDDEN, updateGroupResponse.getStatus());
 
       // try remove ROLE_ADMIN
-      updateGroupResponse = provider.updateGroup(group.getGroupId(), group.getName(), group.getDescription(),
+      updateGroupResponse = endpoint.updateGroup(group.getGroupId(), group.getName(), group.getDescription(),
               "ROLE_USER", null);
       assertNotNull(updateGroupResponse);
       assertEquals(HttpStatus.SC_FORBIDDEN, updateGroupResponse.getStatus());
@@ -197,16 +203,16 @@ public class JpaGroupRoleProviderTest {
     EasyMock.replay(securityService);
     provider.setSecurityService(securityService);
 
-    Response removeGroupResponse = provider.removeGroup(group.getGroupId());
+    Response removeGroupResponse = endpoint.removeGroup(group.getGroupId());
     assertNotNull(removeGroupResponse);
     assertEquals(HttpStatus.SC_FORBIDDEN, removeGroupResponse.getStatus());
   }
 
   @Test
   public void testDuplicateGroupCreation() {
-    Response response = provider.createGroup("Test 1", "Test group", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
+    Response response = endpoint.createGroup("Test 1", "Test group", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
     assertEquals(HttpStatus.SC_CREATED, response.getStatus());
-    response = provider.createGroup("Test 1", "Test group 2", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
+    response = endpoint.createGroup("Test 1", "Test group 2", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
     assertEquals(HttpStatus.SC_CONFLICT, response.getStatus());
   }
 

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
@@ -37,29 +37,28 @@ import org.opencastproject.security.impl.jpa.JpaGroup;
 import org.opencastproject.security.impl.jpa.JpaOrganization;
 import org.opencastproject.security.impl.jpa.JpaRole;
 import org.opencastproject.security.impl.jpa.JpaUser;
-import org.opencastproject.userdirectory.endpoint.GroupRoleEndpoint;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Collections;
 
 import org.apache.commons.collections4.IteratorUtils;
-import org.apache.http.HttpStatus;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.ws.rs.core.Response;
-
 public class JpaGroupRoleProviderTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   private JpaGroupRoleProvider provider = null;
-  private GroupRoleEndpoint endpoint = null;
   private static JpaOrganization org1 = new JpaOrganization("org1", "org1", "localhost", 80, "admin", "anon", null);
   private static JpaOrganization org2 = new JpaOrganization("org2", "org2", "127.0.0.1", 80, "admin", "anon", null);
 
@@ -86,9 +85,6 @@ public class JpaGroupRoleProviderTest {
     provider.setMessageSender(messageSender);
     provider.setEntityManagerFactory(newTestEntityManagerFactory(JpaUserAndRoleProvider.PERSISTENCE_UNIT));
     provider.activate(null);
-
-    endpoint = new GroupRoleEndpoint();
-    endpoint.setJpaGroupRoleProvider(provider);
 
   }
 
@@ -156,7 +152,7 @@ public class JpaGroupRoleProviderTest {
     JpaUser user = new JpaUser("user", "pass1", org1, "User", "user@localhost", "opencast", true,
             Collections.set(new JpaRole("ROLE_USER", org1)));
 
-    // Set the security sevice
+    // Set the security service
     SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
     EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
     EasyMock.expect(securityService.getOrganization()).andReturn(org1).anyTimes();
@@ -165,23 +161,21 @@ public class JpaGroupRoleProviderTest {
 
     try {
       // try add ROLE_USER
-      Response updateGroupResponse = endpoint.updateGroup(group.getGroupId(), group.getName(), group.getDescription(),
-              "ROLE_USER, " + SecurityConstants.GLOBAL_ADMIN_ROLE, null);
-      assertNotNull(updateGroupResponse);
-      assertEquals(HttpStatus.SC_FORBIDDEN, updateGroupResponse.getStatus());
+      thrown.expect(UnauthorizedException.class);
+      provider.updateGroup(group.getGroupId(),
+              group.getName(), group.getDescription(), "ROLE_USER, " + SecurityConstants.GLOBAL_ADMIN_ROLE, null);
 
       // try remove ROLE_ADMIN
-      updateGroupResponse = endpoint.updateGroup(group.getGroupId(), group.getName(), group.getDescription(),
-              "ROLE_USER", null);
-      assertNotNull(updateGroupResponse);
-      assertEquals(HttpStatus.SC_FORBIDDEN, updateGroupResponse.getStatus());
+      thrown.expect(UnauthorizedException.class);
+      provider.updateGroup(group.getGroupId(), group.getName(), group.getDescription(), "ROLE_USER", null);
+
     } catch (NotFoundException e) {
       fail("The existing group isn't found");
     }
   }
 
   @Test
-  public void testRemoveGroupNotAllowedAsNonAdminUser() throws UnauthorizedException {
+  public void testRemoveGroupNotAllowedAsNonAdminUser() throws NotFoundException, Exception {
     JpaGroup group = new JpaGroup("test", org1, "Test", "Test group", Collections.set(
             new JpaRole(SecurityConstants.GLOBAL_ADMIN_ROLE, org1)));
     try {
@@ -203,17 +197,17 @@ public class JpaGroupRoleProviderTest {
     EasyMock.replay(securityService);
     provider.setSecurityService(securityService);
 
-    Response removeGroupResponse = endpoint.removeGroup(group.getGroupId());
-    assertNotNull(removeGroupResponse);
-    assertEquals(HttpStatus.SC_FORBIDDEN, removeGroupResponse.getStatus());
+    thrown.expect(UnauthorizedException.class);
+    provider.removeGroup(group.getGroupId());
   }
 
   @Test
-  public void testDuplicateGroupCreation() {
-    Response response = endpoint.createGroup("Test 1", "Test group", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
-    assertEquals(HttpStatus.SC_CREATED, response.getStatus());
-    response = endpoint.createGroup("Test 1", "Test group 2", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
-    assertEquals(HttpStatus.SC_CONFLICT, response.getStatus());
+  public void testDuplicateGroupCreation() throws IllegalArgumentException, UnauthorizedException, ConflictException {
+    // create the group, not exception thrown
+    provider.createGroup("Test 1", "Test group", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
+    // try create again and expect a conflict
+    thrown.expect(ConflictException.class);
+    provider.createGroup("Test 1", "Test group 2", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
   }
 
   @Test

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/endpoint/GroupRoleEndpointTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/endpoint/GroupRoleEndpointTest.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.userdirectory.endpoint;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.opencastproject.util.persistence.PersistenceUtil.newTestEntityManagerFactory;
+
+import org.opencastproject.message.broker.api.MessageSender;
+import org.opencastproject.security.api.Group;
+import org.opencastproject.security.api.SecurityConstants;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.security.impl.jpa.JpaGroup;
+import org.opencastproject.security.impl.jpa.JpaOrganization;
+import org.opencastproject.security.impl.jpa.JpaRole;
+import org.opencastproject.security.impl.jpa.JpaUser;
+import org.opencastproject.userdirectory.JpaGroupRoleProvider;
+import org.opencastproject.userdirectory.JpaUserAndRoleProvider;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.util.data.Collections;
+
+import org.apache.http.HttpStatus;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import javax.ws.rs.core.Response;
+
+public class GroupRoleEndpointTest {
+
+  private JpaGroupRoleProvider provider = null;
+  private GroupRoleEndpoint endpoint = null;
+  private static JpaOrganization org1 = new JpaOrganization("org1", "org1", "localhost", 80, "admin", "anon", null);
+  private static JpaOrganization org2 = new JpaOrganization("org2", "org2", "127.0.0.1", 80, "admin", "anon", null);
+
+  @Before
+  public void setUp() throws Exception {
+    JpaUser adminUser = new JpaUser("admin", "pass1", org1, "Admin", "admin@localhost", "opencast", true,
+            Collections.set(new JpaRole(SecurityConstants.GLOBAL_ADMIN_ROLE, org1)));
+
+    // Set the security sevice
+    SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
+    EasyMock.expect(securityService.getUser()).andReturn(adminUser).anyTimes();
+    EasyMock.expect(securityService.getOrganization()).andReturn(org1).anyTimes();
+    EasyMock.replay(securityService);
+
+    // Create the message sender service
+    MessageSender messageSender = EasyMock.createNiceMock(MessageSender.class);
+    messageSender.sendObjectMessage(EasyMock.anyObject(String.class),
+            EasyMock.anyObject(MessageSender.DestinationType.class), EasyMock.anyObject(Serializable.class));
+    EasyMock.expectLastCall();
+    EasyMock.replay(messageSender);
+
+    provider = new JpaGroupRoleProvider();
+    provider.setSecurityService(securityService);
+    provider.setMessageSender(messageSender);
+    provider.setEntityManagerFactory(newTestEntityManagerFactory(JpaUserAndRoleProvider.PERSISTENCE_UNIT));
+    provider.activate(null);
+
+    endpoint = new GroupRoleEndpoint();
+    endpoint.setJpaGroupRoleProvider(provider);
+
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    provider.deactivate();
+  }
+
+  @Test
+  public void testUpdateGroupNotAllowedAsNonAdminUser() throws UnauthorizedException {
+    JpaGroup group = new JpaGroup("test", org1, "Test", "Test group", Collections.set(
+            new JpaRole(SecurityConstants.GLOBAL_ADMIN_ROLE, org1)));
+    try {
+      provider.addGroup(group);
+      Group loadGroup = provider.loadGroup(group.getGroupId(), group.getOrganization().getId());
+      assertNotNull(loadGroup);
+      assertEquals(loadGroup.getGroupId(), loadGroup.getGroupId());
+    } catch (Exception e) {
+      fail("The group schould be added");
+    }
+
+    JpaUser user = new JpaUser("user", "pass1", org1, "User", "user@localhost", "opencast", true,
+            Collections.set(new JpaRole("ROLE_USER", org1)));
+
+    // Set the security sevice
+    SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
+    EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
+    EasyMock.expect(securityService.getOrganization()).andReturn(org1).anyTimes();
+    EasyMock.replay(securityService);
+    provider.setSecurityService(securityService);
+
+    try {
+      // try add ROLE_USER
+      Response updateGroupResponse = endpoint.updateGroup(group.getGroupId(), group.getName(), group.getDescription(),
+              "ROLE_USER, " + SecurityConstants.GLOBAL_ADMIN_ROLE, null);
+      assertNotNull(updateGroupResponse);
+      assertEquals(HttpStatus.SC_FORBIDDEN, updateGroupResponse.getStatus());
+
+      // try remove ROLE_ADMIN
+      updateGroupResponse = endpoint.updateGroup(group.getGroupId(), group.getName(), group.getDescription(),
+              "ROLE_USER", null);
+      assertNotNull(updateGroupResponse);
+      assertEquals(HttpStatus.SC_FORBIDDEN, updateGroupResponse.getStatus());
+    } catch (NotFoundException e) {
+      fail("The existing group isn't found");
+    }
+  }
+
+  @Test
+  public void testRemoveGroupNotAllowedAsNonAdminUser() throws UnauthorizedException {
+    JpaGroup group = new JpaGroup("test", org1, "Test", "Test group", Collections.set(
+            new JpaRole(SecurityConstants.GLOBAL_ADMIN_ROLE, org1)));
+    try {
+      provider.addGroup(group);
+      Group loadGroup = provider.loadGroup(group.getGroupId(), group.getOrganization().getId());
+      assertNotNull(loadGroup);
+      assertEquals(group.getGroupId(), loadGroup.getGroupId());
+    } catch (Exception e) {
+      fail("The group should be added");
+    }
+
+    JpaUser user = new JpaUser("user", "pass1", org1, "User", "user@localhost", "opencast", true,
+            Collections.set(new JpaRole("ROLE_USER", org1)));
+
+    // Set the security sevice
+    SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
+    EasyMock.expect(securityService.getUser()).andReturn(user).anyTimes();
+    EasyMock.expect(securityService.getOrganization()).andReturn(org1).anyTimes();
+    EasyMock.replay(securityService);
+    provider.setSecurityService(securityService);
+
+    Response removeGroupResponse = endpoint.removeGroup(group.getGroupId());
+    assertNotNull(removeGroupResponse);
+    assertEquals(HttpStatus.SC_FORBIDDEN, removeGroupResponse.getStatus());
+  }
+
+  @Test
+  public void testDuplicateGroupCreation() {
+    Response response = endpoint.createGroup("Test 1", "Test group", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
+    assertEquals(HttpStatus.SC_CREATED, response.getStatus());
+    response = endpoint.createGroup("Test 1", "Test group 2", "ROLE_ASTRO_101_SPRING_2011_STUDENT", "admin");
+    assertEquals(HttpStatus.SC_CONFLICT, response.getStatus());
+  }
+}


### PR DESCRIPTION
-  Move JpaGroupRoleProvider's REST concerns into a separate class to simplify the load of the JpaGroupRoleProvider OSGI service, simply the Group Role REST component, and mitigate the opencast-userdirectory getService load cycle race condition with JaxRsServiceTracker.addingService (/groups).
- Give external-api control of its API response

This pull does not add or remove any existing functionality. However, it forces the admin-ui, external-api, and index service to take resonsibility of their own REST API Response handling from now on.