### PR TITLE
MH-13191 Improve performance of retrieving groups

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/GroupsEndpoint.java
@@ -73,9 +73,14 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.DELETE;
 import javax.ws.rs.FormParam;
@@ -221,6 +226,12 @@ public class GroupsEndpoint {
       return RestUtil.R.serverError();
     }
 
+    List<String> userNames = Arrays.stream(results.getItems()).flatMap(item -> item.getSource().getMembers().stream())
+      .collect(Collectors.toList());
+
+    final Map<String, User> users = new HashMap<>(userNames.size());
+    userDirectoryService.loadUsers(userNames).forEachRemaining(user -> users.put(user.getUsername(), user));
+
     List<JValue> groupsJSON = new ArrayList<>();
     for (SearchResultItem<Group> item : results.getItems()) {
       Group group = item.getSource();
@@ -229,7 +240,8 @@ public class GroupsEndpoint {
       fields.add(f("name", v(group.getName(), Jsons.BLANK)));
       fields.add(f("description", v(group.getDescription(), Jsons.BLANK)));
       fields.add(f("role", v(group.getRole())));
-      fields.add(f("users", membersToJSON(group.getMembers())));
+      fields.add(
+        f("users", membersToJSON(group.getMembers().stream().map(users::get).filter(Objects::nonNull).iterator())));
       groupsJSON.add(obj(fields));
     }
 
@@ -316,9 +328,10 @@ public class GroupsEndpoint {
       throw new NotFoundException("Group " + groupId + " does not exist.");
 
     Group group = groupOpt.get();
+    Iterator<User> users = userDirectoryService.loadUsers(group.getMembers());
     return RestUtils.okJson(obj(f("id", v(group.getIdentifier())), f("name", v(group.getName(), Jsons.BLANK)),
-            f("description", v(group.getDescription(), Jsons.BLANK)), f("role", v(group.getRole(), Jsons.BLANK)),
-            f("roles", rolesToJSON(group.getRoles())), f("users", membersToJSON(group.getMembers()))));
+      f("description", v(group.getDescription(), Jsons.BLANK)), f("role", v(group.getRole(), Jsons.BLANK)),
+      f("roles", rolesToJSON(group.getRoles())), f("users", membersToJSON(users))));
   }
 
   /**
@@ -344,18 +357,18 @@ public class GroupsEndpoint {
    *          the members source
    * @return a JSON array ({@link JValue}) with the given members
    */
-  private JValue membersToJSON(Set<String> members) {
+  private JValue membersToJSON(Iterator<User> members) {
     List<JValue> membersJSON = new ArrayList<>();
 
-    for (String username : members) {
-      User user = userDirectoryService.loadUser(username);
-      String name = username;
+    while (members.hasNext()) {
+      User user = members.next();
+      String name = user.getUsername();
 
-      if (user != null && StringUtils.isNotBlank(user.getName())) {
+      if (StringUtils.isNotBlank(user.getName())) {
         name = user.getName();
       }
 
-      membersJSON.add(obj(f("username", v(username)), f("name", v(name))));
+      membersJSON.add(obj(f("username", v(user.getUsername())), f("name", v(name))));
     }
 
     return arr(membersJSON);

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUser.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUser.java
@@ -58,6 +58,7 @@ import javax.persistence.UniqueConstraint;
   @NamedQuery(name = "User.findByIdAndOrg", query = "select u from JpaUser u where u.id=:id and u.organization.id = :org"),
   @NamedQuery(name = "User.findByUsername", query = "select u from JpaUser u where u.username=:u and u.organization.id = :org"),
   @NamedQuery(name = "User.findAll", query = "select u from JpaUser u where u.organization.id = :org"),
+  @NamedQuery(name = "User.findAllByUserNames", query = "select u from JpaUser u where u.organization.id = :org AND u.username IN :names"),
   @NamedQuery(name = "User.countAll", query = "select COUNT(u) from JpaUser u where u.organization.id = :org") })
 public class JpaUser implements User {
 

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUserReference.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUserReference.java
@@ -61,6 +61,7 @@ import javax.persistence.UniqueConstraint;
   @NamedQuery(name = "UserReference.findByQuery", query = "select u from JpaUserReference u where UPPER(u.username) like :query and u.organization.id = :org"),
   @NamedQuery(name = "UserReference.findByUsername", query = "select u from JpaUserReference u where u.username=:u and u.organization.id = :org"),
   @NamedQuery(name = "UserReference.findAll", query = "select u from JpaUserReference u where u.organization.id = :org"),
+  @NamedQuery(name = "UserReference.findAllByUserNames", query = "select u from JpaUserReference u where u.organization.id = :org and u.username in :names"),
   @NamedQuery(name = "UserReference.countAll", query = "select COUNT(u) from JpaUserReference u where u.organization.id = :org") })
 public class JpaUserReference {
   @Id

--- a/modules/common/src/main/java/org/opencastproject/security/api/UserDirectoryService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/UserDirectoryService.java
@@ -21,7 +21,10 @@
 
 package org.opencastproject.security.api;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * A marker interface for federation of all {@link UserProvider}s.
@@ -45,6 +48,23 @@ public interface UserDirectoryService {
    *           if no organization is set for the current thread
    */
   User loadUser(String userName);
+
+  /**
+   * Loads multiple users by a list of user names.
+   *
+   * @param userNames
+   *          the user names to look for
+   * @return the users
+   * @throws IllegalStateException
+   *           if no organization is set for the current thread
+   */
+  default Iterator<User> loadUsers(Collection<String> userNames) {
+    List<User> result = new ArrayList<>(userNames.size());
+    for (String userName : userNames) {
+      result.add(loadUser(userName));
+    }
+    return result.iterator();
+  }
 
   /**
    * Return the found user's as an iterator.

--- a/modules/common/src/main/java/org/opencastproject/security/api/UserProvider.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/UserProvider.java
@@ -21,7 +21,10 @@
 
 package org.opencastproject.security.api;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Provides access to users and roles.
@@ -84,6 +87,24 @@ public interface UserProvider {
    *           if the query is <code>null</code>
    */
   Iterator<User> findUsers(String query, int offset, int limit);
+
+  /**
+   * Find a list of users by their user names
+   *
+   * Note that the default implementation of this might be slow, as it calls <code>loadUser</code> on every single user.
+   * @param userNames A list of user names
+   * @return A list of resolved user objects
+   */
+  default Iterator<User> findUsers(Collection<String> userNames) {
+    List<User> result = new ArrayList<>(0);
+    for (String name : userNames) {
+      final User e = loadUser(name);
+      if (e != null) {
+        result.add(e);
+      }
+    }
+    return result.iterator();
+  }
 
   /**
    * Discards any cached value for given user name.

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
@@ -87,6 +87,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 
+import javax.xml.bind.Unmarshaller;
+
 public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractSearchIndex.class);
@@ -528,11 +530,12 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
     SearchRequestBuilder requestBuilder = getSearchRequestBuilder(query, new GroupQueryBuilder(query));
 
     try {
+      Unmarshaller unmarshaller = Group.createUnmarshaller();
       return executeQuery(query, requestBuilder, new Fn<SearchMetadataCollection, Group>() {
         @Override
         public Group apply(SearchMetadataCollection metadata) {
           try {
-            return GroupIndexUtils.toGroup(metadata);
+            return GroupIndexUtils.toGroup(metadata, unmarshaller);
           } catch (IOException e) {
             return chuck(e);
           }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/group/Group.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/group/Group.java
@@ -236,6 +236,22 @@ public class Group implements IndexObject {
   }
 
   /**
+   * Create an unmarshaller for groups, which can be re-used for performance (from a single thread)
+   * @return An unmarshaller for groups
+   * @throws IOException if something went from with the creation
+   */
+  public static Unmarshaller createUnmarshaller() throws IOException {
+    try {
+      if (context == null) {
+        createJAXBContext();
+      }
+      return context.createUnmarshaller();
+    } catch (JAXBException e) {
+      throw new IOException(e.getLinkedException() != null ? e.getLinkedException() : e);
+    }
+  }
+
+  /**
    * Reads the group from the input stream.
    *
    * @param xml
@@ -243,12 +259,11 @@ public class Group implements IndexObject {
    * @return the deserialized group
    * @throws IOException
    */
-  public static Group valueOf(InputStream xml) throws IOException {
+  public static Group valueOf(InputStream xml, Unmarshaller unmarshaller) throws IOException {
     try {
       if (context == null) {
         createJAXBContext();
       }
-      Unmarshaller unmarshaller = context.createUnmarshaller();
       return unmarshaller.unmarshal(new StreamSource(xml), Group.class).getValue();
     } catch (JAXBException e) {
       throw new IOException(e.getLinkedException() != null ? e.getLinkedException() : e);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/group/GroupIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/group/GroupIndexUtils.java
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Map;
 
+import javax.xml.bind.Unmarshaller;
+
 /**
  * Utility implementation to deal with the conversion of groups and its corresponding index data structures.
  */
@@ -59,10 +61,10 @@ public final class GroupIndexUtils {
    * @throws IOException
    *           if unmarshalling fails
    */
-  public static Group toGroup(SearchMetadataCollection metadata) throws IOException {
+  public static Group toGroup(SearchMetadataCollection metadata, Unmarshaller unmarshaller) throws IOException {
     Map<String, SearchMetadata<?>> metadataMap = metadata.toMap();
     String groupXml = (String) metadataMap.get(GroupIndexSchema.OBJECT).getValue();
-    return Group.valueOf(IOUtils.toInputStream(groupXml));
+    return Group.valueOf(IOUtils.toInputStream(groupXml), unmarshaller);
   }
 
   /**

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserAndRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserAndRoleProvider.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -164,6 +165,13 @@ public class JpaUserAndRoleProvider implements UserProvider, RoleProvider {
       throw new IllegalArgumentException("Query must be set");
     String orgId = securityService.getOrganization().getId();
     List<JpaUser> users = UserDirectoryPersistenceUtil.findUsersByQuery(orgId, query, limit, offset, emf);
+    return Monadics.mlist(users).map(addProviderName).iterator();
+  }
+
+  @Override
+  public Iterator<User> findUsers(Collection<String> userNames) {
+    String orgId = securityService.getOrganization().getId();
+    List<JpaUser> users = UserDirectoryPersistenceUtil.findUsersByUserName(userNames, orgId, emf);
     return Monadics.mlist(users).map(addProviderName).iterator();
   }
 

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserDirectoryPersistenceUtil.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserDirectoryPersistenceUtil.java
@@ -28,6 +28,7 @@ import org.opencastproject.security.impl.jpa.JpaRole;
 import org.opencastproject.security.impl.jpa.JpaUser;
 import org.opencastproject.util.NotFoundException;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -283,6 +284,27 @@ public final class UserDirectoryPersistenceUtil {
       return (JpaOrganization) query.getSingleResult();
     } catch (NoResultException e) {
       return null;
+    } finally {
+      if (em != null)
+        em.close();
+    }
+  }
+
+  /**
+   * Return specific users by their user names
+   * @param userNames list of user names
+   * @param organizationId organization to search for
+   * @param emf the entity manager factory
+   * @return the list of users that was found
+   */
+  public static List<JpaUser> findUsersByUserName(Collection<String> userNames, String organizationId, EntityManagerFactory emf) {
+    EntityManager em = null;
+    try {
+      em = emf.createEntityManager();
+      Query q = em.createNamedQuery("User.findAllByUserNames");
+      q.setParameter("names", userNames);
+      q.setParameter("org", organizationId);
+      return q.getResultList();
     } finally {
       if (em != null)
         em.close();


### PR DESCRIPTION
When groups have a large number of group members, the performance of the requests

- GET /admin-ng/groups
- GET /admin-ng/groups/ {group_identifier}

gets quite bad.

This is because of three reasons:

1. For each group and for each user in that group, an SQL query of its own is run. So there’s lots of queries, and apparently there are a number of caches involved to mitigate this already. However, as the
number of users in each group grows bigger, the caches don’t help anymore.
2. For each group, along with the actual users in that group, the users roles are retrieved. However, the roles aren’t actually _used_ in the JSON output of the request. So all that work is for nothing.
3. When deserializing the group output from the search index, the XML unmarshaller isn’t shared between runs.

Consequently, this PR does the following:

1. Add a function to retrieve a list of users (by their names) from the data base in bulk. This is used per-group. Currently supported backends for this are the JPA user provider and the JPA user reference
provider. The other backends behave as before. 
2. Don’t retrieve the users roles anymore.
3. Share the unmarshaller between deserialization runs for the group query.

We saw a performance increase from about 40s (!) to about 1s for a group with 1000 members.

This work is sponsored by SWITCH.