### PR TITLE
MH-13192 Improve performance of list requests

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
@@ -87,6 +87,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
 
+import javax.xml.bind.Unmarshaller;
+
 public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractSearchIndex.class);
@@ -498,11 +500,12 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
     SearchRequestBuilder requestBuilder = getSearchRequestBuilder(query, new EventQueryBuilder(query));
 
     try {
+      Unmarshaller unmarshaller = Event.createUnmarshaller();
       return executeQuery(query, requestBuilder, new Fn<SearchMetadataCollection, Event>() {
         @Override
         public Event apply(SearchMetadataCollection metadata) {
           try {
-            return EventIndexUtils.toRecordingEvent(metadata);
+            return EventIndexUtils.toRecordingEvent(metadata, unmarshaller);
           } catch (IOException e) {
             return chuck(e);
           }
@@ -555,11 +558,12 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
     // Create the request builder
     SearchRequestBuilder requestBuilder = getSearchRequestBuilder(query, new SeriesQueryBuilder(query));
     try {
+      Unmarshaller unmarshaller = Series.createUnmarshaller();
       return executeQuery(query, requestBuilder, new Fn<SearchMetadataCollection, Series>() {
         @Override
         public Series apply(SearchMetadataCollection metadata) {
           try {
-            return SeriesIndexUtils.toSeries(metadata);
+            return SeriesIndexUtils.toSeries(metadata, unmarshaller);
           } catch (IOException e) {
             return chuck(e);
           }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
@@ -1352,15 +1352,15 @@ public class Event implements IndexObject {
    *
    * @param xml
    *          the input stream
+   * @param unmarshaller the unmarshaller to use
    * @return the deserialized recording event
    * @throws IOException
    */
-  public static Event valueOf(InputStream xml) throws IOException {
+  public static Event valueOf(InputStream xml, Unmarshaller unmarshaller) throws IOException {
     try {
       if (context == null) {
         createJAXBContext();
       }
-      Unmarshaller unmarshaller = context.createUnmarshaller();
       return unmarshaller.unmarshal(new StreamSource(xml), Event.class).getValue();
     } catch (JAXBException e) {
       throw new IOException(e.getLinkedException() != null ? e.getLinkedException() : e);
@@ -1472,6 +1472,22 @@ public class Event implements IndexObject {
       return writer.toString();
     } catch (JAXBException e) {
       throw new IllegalStateException(e.getLinkedException() != null ? e.getLinkedException() : e);
+    }
+  }
+
+  /**
+   * Create an unmarshaller for events
+   * @return an unmarshaller for events
+   * @throws IOException
+   */
+  public static Unmarshaller createUnmarshaller() throws IOException {
+    try {
+      if (context == null) {
+        createJAXBContext();
+      }
+      return context.createUnmarshaller();
+    } catch (JAXBException e) {
+      throw new IOException(e.getLinkedException() != null ? e.getLinkedException() : e);
     }
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -56,6 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -63,6 +64,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+
+import javax.xml.bind.Unmarshaller;
 
 /**
  * Utility implementation to deal with the conversion of recording events and its corresponding index data structures.
@@ -87,14 +90,15 @@ public final class EventIndexUtils {
    *
    * @param metadata
    *          the search metadata
+   * @param unmarshaller the unmarshaller to use
    * @return the search result item
    * @throws IOException
    *           if unmarshalling fails
    */
-  public static Event toRecordingEvent(SearchMetadataCollection metadata) throws IOException {
+  public static Event toRecordingEvent(SearchMetadataCollection metadata, Unmarshaller unmarshaller) throws IOException {
     Map<String, SearchMetadata<?>> metadataMap = metadata.toMap();
     String eventJson = (String) metadataMap.get(EventIndexSchema.OBJECT).getValue();
-    return Event.valueOf(IOUtils.toInputStream(eventJson));
+    return Event.valueOf(IOUtils.toInputStream(eventJson, Charset.defaultCharset()), unmarshaller);
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/Series.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/Series.java
@@ -169,6 +169,22 @@ public class Series implements IndexObject {
   }
 
   /**
+   * Create an unmarshaller for series
+   * @return an unmarshaller for series
+   * @throws IOException
+   */
+  public static Unmarshaller createUnmarshaller() throws IOException {
+    try {
+      if (context == null) {
+        createJAXBContext();
+      }
+      return context.createUnmarshaller();
+    } catch (JAXBException e) {
+      throw new IOException(e.getLinkedException() != null ? e.getLinkedException() : e);
+    }
+  }
+
+  /**
    * Returns the series identifier.
    *
    * @return the identifier
@@ -523,15 +539,15 @@ public class Series implements IndexObject {
    *
    * @param xml
    *          the input stream
+   * @param unmarshaller the unmarshaller to use
    * @return the deserialized recording event
    * @throws IOException
    */
-  public static Series valueOf(InputStream xml) throws IOException {
+  public static Series valueOf(InputStream xml, Unmarshaller unmarshaller) throws IOException {
     try {
       if (context == null) {
         createJAXBContext();
       }
-      Unmarshaller unmarshaller = context.createUnmarshaller();
       return unmarshaller.unmarshal(new StreamSource(xml), Series.class).getValue();
     } catch (JAXBException e) {
       throw new IOException(e.getLinkedException() != null ? e.getLinkedException() : e);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java
@@ -47,10 +47,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.xml.bind.Unmarshaller;
 
 /**
  * Utility implementation to deal with the conversion of series and its corresponding index data structures.
@@ -70,14 +73,15 @@ public final class SeriesIndexUtils {
    *
    * @param metadata
    *          the search metadata
+   * @param unmarshaller the unmarshaller to use
    * @return the search result item
    * @throws IOException
    *           if unmarshalling fails
    */
-  public static Series toSeries(SearchMetadataCollection metadata) throws IOException {
+  public static Series toSeries(SearchMetadataCollection metadata, Unmarshaller unmarshaller) throws IOException {
     Map<String, SearchMetadata<?>> metadataMap = metadata.toMap();
     String seriesXml = (String) metadataMap.get(SeriesIndexSchema.OBJECT).getValue();
-    return Series.valueOf(IOUtils.toInputStream(seriesXml));
+    return Series.valueOf(IOUtils.toInputStream(seriesXml, Charset.defaultCharset()), unmarshaller);
   }
 
   /**

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/event/EventTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/event/EventTest.java
@@ -129,7 +129,7 @@ public class EventTest {
   @Ignore
   @Test
   public void testValueOf() throws ParseException, IOException, JSONException, XMLStreamException, JAXBException {
-    Event event = Event.valueOf(IOUtils.toInputStream(eventXml));
+    Event event = Event.valueOf(IOUtils.toInputStream(eventXml), Event.createUnmarshaller());
     assertEquals(id, event.getIdentifier());
     assertEquals(title, event.getTitle());
     assertEquals(description, event.getDescription());

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/series/SeriesTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/series/SeriesTest.java
@@ -109,7 +109,7 @@ public class SeriesTest {
   @Ignore
   @Test
   public void testValueOf() throws ParseException, IOException, JSONException, XMLStreamException, JAXBException {
-    Series series = Series.valueOf(IOUtils.toInputStream(seriesXml));
+    Series series = Series.valueOf(IOUtils.toInputStream(seriesXml), Series.createUnmarshaller());
     assertEquals(id, series.getIdentifier());
     assertEquals(title, series.getTitle());
     assertEquals(description, series.getDescription());


### PR DESCRIPTION
The following requests are quite slow when asking for a large number of objects:

- GET /admin-ng/events
- GET /api/events
- GET /admin-ng/series
- GET /api/series

An analysis revealed that most of the time is spent creating JAXB Unmarshaller objects for each single item. This can be sped up by reusing the same Unmarshaller between events/series.

Note that this is not thread-safe, of course, but we’re inside a single thread while deserializing, so this should be fine.

We saw the following performance improvement when displaying 100 items per page:

Events table: From approx. 850ms down to approx. 150ms
Series table: From approx. 900ms down to approx. 250ms

So the re-use of JAXB Unmarshaller objects results in a speedup of roughly 4-5.

This work is sponsored by SWITCH.