### PR TITLE
MH-13193 Improve performance of event deletion (1)

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/ADeleteQuery.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/ADeleteQuery.java
@@ -29,6 +29,13 @@ public interface ADeleteQuery {
   ADeleteQuery name(String queryName);
 
   /**
+   * When this is called with true, the AssetManager will assume that the whole media package will be removed. This is
+   * faster, but then it is your responsibility to remove all properties associated with the media package since no
+   * orphan removal will take place.
+   */
+  ADeleteQuery willRemoveWholeMediaPackage(boolean willRemoveWholeMediaPackage);
+
+  /**
    * Delete the selected items.
    *
    * @return the number of affected items

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/ADeleteQueryDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/ADeleteQueryDecorator.java
@@ -38,6 +38,11 @@ public class ADeleteQueryDecorator implements ADeleteQuery {
     return mkDecorator(delegate.name(queryName));
   }
 
+  @Override
+  public ADeleteQuery willRemoveWholeMediaPackage(boolean willRemoveWholeMediaPackage) {
+    return mkDecorator(delegate.willRemoveWholeMediaPackage(willRemoveWholeMediaPackage));
+  }
+
   @Override public long run() {
     return delegate.run();
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
@@ -93,6 +93,16 @@ public abstract class AbstractADeleteQuery implements ADeleteQuery, DeleteQueryC
     };
   }
 
+  @Override public ADeleteQuery willRemoveWholeMediaPackage(boolean willRemoveWholeMediaPackage) {
+    return new AbstractADeleteQuery(am, owner) {
+      @Override
+      public DeleteQueryContribution contributeDelete(String owner) {
+        final DeleteQueryContribution cParent = AbstractADeleteQuery.this.contributeDelete(owner);
+        return DeleteQueryContribution.mk(cParent).willRemoveWholeMediaPackage(willRemoveWholeMediaPackage);
+      }
+    };
+  }
+
   public long run(DeleteSnapshotHandler deleteSnapshotHandler) {
     // run query and map the result to records
     final long startTime = System.nanoTime();
@@ -192,7 +202,9 @@ HAVING v = (SELECT count(*)
       am.getDb().logDelete(formatQueryName(c.name, "main"), qMain);
       final long deletedItems = qMain.execute();
       // delete orphaned properties
-      deleteOrphanedProperties();
+      if (!c.willRemoveWholeMediaPackage) {
+        deleteOrphanedProperties();
+      }
       // <BLOCK>
       // TODO Bad solution. Yields all media package IDs which can easily be thousands
       // TODO The above SQL solution does not work with H2 so I suspect the query is not 100% clean
@@ -220,7 +232,7 @@ HAVING v = (SELECT count(*)
       final BooleanExpression where;
       {
         final BooleanExpression w = c.where.apply(Q_PROPERTY);
-        if (w != null) {
+        if (w != null && !c.willRemoveWholeMediaPackage) {
           /* The original sub query used an "ON" clause to filter the join by mediapackage id [1].
              Unfortunately Eclipse link drops this clause completely when transforming the query
              into SQL. It creates a cross join instead of the inner join, which is perfectly legal
@@ -248,7 +260,7 @@ HAVING v = (SELECT count(*)
                           .distinct()
                           .list(Q_PROPERTY.mediaPackageId));
         } else {
-          where = null;
+          where = w;
         }
       }
       final JPADeleteClause qProperties = jpa.delete(from).where(Expressions.allOf(c.targetPredicate.orNull(), where));

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/DeleteQueryContribution.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/DeleteQueryContribution.java
@@ -51,6 +51,8 @@ public final class DeleteQueryContribution {
 
   final String name;
 
+  final boolean willRemoveWholeMediaPackage;
+
   private static final Fn<EntityPath<?>, BooleanExpression> NO_WHERE = new Fn<EntityPath<?>, BooleanExpression>() {
     @Override public BooleanExpression apply(EntityPath<?> entityPathBase) {
       return null;
@@ -67,6 +69,20 @@ public final class DeleteQueryContribution {
     this.where = where;
     this.targetPredicate = targetPredicate;
     this.name = name;
+    this.willRemoveWholeMediaPackage = false;
+  }
+
+  private DeleteQueryContribution(
+      Stream<EntityPath<?>> from,
+      Fn<EntityPath<?>, BooleanExpression> where,
+      Opt<BooleanExpression> targetPredicate,
+      String name,
+      boolean willRemoveWholeMediaPackage) {
+    this.from = from;
+    this.where = where;
+    this.targetPredicate = targetPredicate;
+    this.name = name;
+    this.willRemoveWholeMediaPackage = willRemoveWholeMediaPackage;
   }
 
   /**
@@ -110,6 +126,11 @@ public final class DeleteQueryContribution {
       }
     };
     return new DeleteQueryContribution(from, w, targetPredicate, name);
+  }
+
+
+  DeleteQueryContribution willRemoveWholeMediaPackage(final boolean willRemoveWholeMediaPackage) {
+    return new DeleteQueryContribution(from, where, targetPredicate, name, willRemoveWholeMediaPackage);
   }
 
   DeleteQueryContribution name(String name) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1532,9 +1532,8 @@ public class IndexServiceImpl implements IndexService {
     try {
       final AQueryBuilder q = assetManager.createQuery();
       final Predicate p = q.organizationId().eq(securityService.getOrganization().getId()).and(q.mediaPackageId(id));
-      final AResult r = q.select(q.nothing()).where(p).run();
-      if (r.getSize() > 0)
-        q.delete(DEFAULT_OWNER, q.snapshot()).where(p).run();
+      q.delete(DEFAULT_OWNER, q.propertiesOf()).where(q.mediaPackageId(id)).willRemoveWholeMediaPackage(true).run();
+      q.delete(DEFAULT_OWNER, q.snapshot()).where(p).willRemoveWholeMediaPackage(true).run();
     } catch (AssetManagerException e) {
       if (e.getCause() instanceof UnauthorizedException) {
         unauthorizedArchive = true;

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1085,7 +1085,9 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
         // Delete all properties
         deletedProperties = query.delete(SNAPSHOT_OWNER, query.propertiesOf(p.namespace(), WORKFLOW_NAMESPACE, CA_NAMESPACE))
-                .where(withOrganization(query).and(query.mediaPackageId(mediaPackageId))).name("delete all properties")
+                .where(withOrganization(query).and(query.mediaPackageId(mediaPackageId)))
+                .name("delete all properties")
+                .willRemoveWholeMediaPackage(true)
                 .run();
 
         if (StringUtils.isNotEmpty(agentId))
@@ -1095,8 +1097,9 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       // Delete scheduler snapshot
       long deletedSnapshots = query.delete(SNAPSHOT_OWNER, query.snapshot())
               .where(withOrganization(query).and(query.mediaPackageId(mediaPackageId)))
-              .name("delete episode").run();
-
+              .name("delete episode")
+              .willRemoveWholeMediaPackage(true)
+              .run();
       if (deletedProperties + deletedSnapshots == 0)
         throw new NotFoundException();
 


### PR DESCRIPTION
When deleting events from the scheduler service, some unnecessary
queries related to properties are executed:

- Since we know, that we are deleting the whole episode, we do not have
to check whether there are snapshots for the properties to be deleted. I
am not sure anyway, why this is necessary at all.

- Since we know, that we take care of deleting all properties related to
the episode, we do not have to remove orphaned properties (because we are
not producing any).

It turned out to be quiet hard to control the behavior of the code
executed in AbstractADeleteQuery.runQueries() and I am not happy with
the flag attached to DeleteQueryContribution. However, I could not find a
better solution in the available time.

All in all, these changes seem to improve event deletion by about 50 or
60%, according to our measurements.

This work is sponsored by SWITCH.