### PR TITLE
MH-13193 Improve performance of event deletion (2)

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -18,7 +18,12 @@ How to Upgrade
 Database Migration
 ------------------
 
-*So far, this is not required*
+As part of performance optimizations, a foreign key constraint was added to one table. This requires a database schema
+update. As with all database migrations, we recommend to create a database backup before attempting the upgrade.
+
+You can find the database upgrade script in `docs/upgrade/6_to_7/`. This script is suitable for both, MariaDB and
+MySQL.
+
 
 ActiveMQ Migration
 ------------------

--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -384,6 +384,7 @@ CREATE TABLE oc_assets_asset (
   size BIGINT NOT NULL,
   storage_id VARCHAR(256) NOT NULL DEFAULT 'local-filesystem',
   --
+  CONSTRAINT FK_oc_assets_asset_snapshot_id FOREIGN KEY (snapshot_id) REFERENCES oc_assets_snapshot (id) ON DELETE CASCADE,
   INDEX IX_oc_assets_asset_checksum (checksum),
   INDEX IX_oc_assets_asset_mediapackage_element_id (mediapackage_element_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/docs/upgrade/6_to_7/mysql5.sql
+++ b/docs/upgrade/6_to_7/mysql5.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oc_assets_asset ADD CONSTRAINT FK_oc_assets_asset_snapshot_id FOREIGN KEY (snapshot_id) REFERENCES oc_assets_snapshot (id) ON DELETE CASCADE; 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/AssetDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/AssetDto.java
@@ -31,6 +31,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 
@@ -50,8 +52,9 @@ public class AssetDto {
   private Long id;
 
   // foreign key referencing SnapshotDto.id
-  @Column(name = "snapshot_id", nullable = false)
-  private Long snapshotId;
+  @ManyToOne(targetEntity = SnapshotDto.class)
+  @JoinColumn(name = "snapshot_id", referencedColumnName = "id", nullable = false)
+  private SnapshotDto snapshot;
 
   @Column(name = "mediapackage_element_id", nullable = false, length = 128)
   private String mediaPackageElementId;
@@ -71,9 +74,9 @@ public class AssetDto {
   /**
    * Create a new DTO.
    */
-  public static AssetDto mk(String mediaPackageElementId, long snapshotId, String checksum, Opt<MimeType> mimeType, String storeageId, long size) {
+  public static AssetDto mk(String mediaPackageElementId, SnapshotDto snapshot, String checksum, Opt<MimeType> mimeType, String storeageId, long size) {
     final AssetDto dto = new AssetDto();
-    dto.snapshotId = snapshotId;
+    dto.snapshot = snapshot;
     dto.mediaPackageElementId = mediaPackageElementId;
     dto.checksum = checksum;
     dto.mimeType = mimeType.isSome() ? mimeType.get().toString() : null;
@@ -104,6 +107,14 @@ public class AssetDto {
 
   void setStorageId(String storage) {
     this.storageId = storage;
+  }
+
+  public SnapshotDto getSnapshot() {
+    return snapshot;
+  }
+
+  public void setSnapshot(SnapshotDto snapshot) {
+    this.snapshot = snapshot;
   }
 }
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/AssetDtos.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/AssetDtos.java
@@ -21,6 +21,7 @@
 package org.opencastproject.assetmanager.impl.persistence;
 
 import static com.entwinemedia.fn.Stream.$;
+import static com.mysema.query.types.PathMetadataFactory.forVariable;
 
 import org.opencastproject.assetmanager.api.Availability;
 import org.opencastproject.assetmanager.impl.VersionImpl;
@@ -30,6 +31,7 @@ import com.entwinemedia.fn.data.ListBuilders;
 import com.mysema.query.Tuple;
 import com.mysema.query.jpa.impl.JPAQuery;
 import com.mysema.query.types.Expression;
+import com.mysema.query.types.path.PathInits;
 
 import javax.persistence.EntityManager;
 
@@ -44,11 +46,11 @@ public final class AssetDtos {
    * Create base join for a {@link AssetDtos} query.
    */
   public static JPAQuery baseJoin(EntityManager em) {
-    final QAssetDto assetDto = QAssetDto.assetDto;
+    final QAssetDto assetDto = new QAssetDto(AssetDto.class, forVariable("assetDto"), new PathInits("snapshot"));
     final QSnapshotDto snapshotDto = QSnapshotDto.snapshotDto;
     return new JPAQuery(em, Database.TEMPLATES)
             .from(assetDto)
-            .leftJoin(snapshotDto).on(snapshotDto.id.eq(assetDto.snapshotId));
+            .innerJoin(snapshotDto).on(snapshotDto.id.eq(assetDto.snapshot.id));
   }
 
   /**

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SnapshotDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SnapshotDto.java
@@ -29,14 +29,20 @@ import org.opencastproject.assetmanager.impl.VersionImpl;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageParser;
 
-import java.util.Date;
+import org.eclipse.persistence.annotations.CascadeOnDelete;
 
+import java.util.Date;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 import javax.persistence.Temporal;
@@ -85,6 +91,10 @@ public class SnapshotDto {
   @Lob
   @Column(name = "mediapackage_xml", length = 65535, nullable = false)
   private String mediaPackageXml;
+
+  @CascadeOnDelete
+  @OneToMany(targetEntity = AssetDto.class, fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "snapshot")
+  private Set<AssetDto> assets;
 
   public static SnapshotDto mk(
           MediaPackage mediaPackage,
@@ -147,6 +157,14 @@ public class SnapshotDto {
 
   void setStorageId(String id) {
     this.storageId = id;
+  }
+
+  public boolean addAsset(AssetDto asset) {
+    return this.assets.add(asset);
+  }
+
+  public boolean removeAsset(AssetDto asset) {
+    return this.assets.remove(asset);
   }
 
   public Snapshot toSnapshot() {

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
@@ -180,13 +180,6 @@ HAVING v = (SELECT count(*)
 //                              .count()))
 //              .list(e2.mediaPackageId);
 // </BLOCK>
-      // delete assets from database
-      final JPADeleteClause qAssets = jpa
-              .delete(Q_ASSET)
-              .where(Q_ASSET.snapshotId.in(
-                      new JPASubQuery().from(Q_SNAPSHOT).where(where).list(Q_SNAPSHOT.id)));
-      am.getDb().logDelete(formatQueryName(c.name, "delete assets"), qAssets);
-      qAssets.execute();
       // main delete query
       final JPADeleteClause qMain = jpa.delete(Q_SNAPSHOT).where(where);
       am.getDb().logDelete(formatQueryName(c.name, "main"), qMain);

--- a/modules/asset-manager-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/asset-manager-impl/src/main/resources/META-INF/persistence.xml
@@ -8,10 +8,11 @@
   <persistence-unit name="org.opencastproject.assetmanager.impl" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
     <non-jta-data-source>osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=jdbc/opencast)</non-jta-data-source>
+
     <class>org.opencastproject.assetmanager.impl.persistence.PropertyDto</class>
+    <class>org.opencastproject.assetmanager.impl.persistence.SnapshotDto</class>
     <class>org.opencastproject.assetmanager.impl.persistence.AssetDto</class>
     <class>org.opencastproject.assetmanager.impl.persistence.VersionClaimDto</class>
-    <class>org.opencastproject.assetmanager.impl.persistence.SnapshotDto</class>
     <shared-cache-mode>NONE</shared-cache-mode>
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables" />

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AbstractAssetManagerDeleteSnapshotTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AbstractAssetManagerDeleteSnapshotTest.java
@@ -69,7 +69,7 @@ public class AbstractAssetManagerDeleteSnapshotTest extends AbstractAssetManager
     assertStoreSize(mpCount * versionCount * 2);
     if (RUN_RAW_QUERIES) {
       delete(Q_PROPERTY, Q_PROPERTY.mediaPackageId.eq(mp[0]));
-      delete(Q_ASSET, Q_ASSET.snapshotId.in(new JPASubQuery().from(Q_SNAPSHOT).where(Q_SNAPSHOT.mediaPackageId.eq(mp[0])).list(Q_SNAPSHOT.id)));
+      delete(Q_ASSET, Q_ASSET.snapshot.id.in(new JPASubQuery().from(Q_SNAPSHOT).where(Q_SNAPSHOT.mediaPackageId.eq(mp[0])).list(Q_SNAPSHOT.id)));
       delete(Q_SNAPSHOT, Q_SNAPSHOT.mediaPackageId.eq(mp[0]));
     } else {
       assertEquals(versionCount, q.delete(OWNER, q.snapshot()).where(q.mediaPackageId(mp[0])).run());
@@ -92,7 +92,7 @@ public class AbstractAssetManagerDeleteSnapshotTest extends AbstractAssetManager
     assertStoreSize(6 * 2);
     if (RUN_RAW_QUERIES) {
       assertEquals(3, delete(Q_ASSET,
-                             Q_ASSET.snapshotId.in(
+                             Q_ASSET.snapshot.id.in(
                                      new JPASubQuery().from(Q_SNAPSHOT).where(
                                              Q_SNAPSHOT.version.eq(
                                                      new JPASubQuery().from(Q_SNAPSHOT).unique(Q_SNAPSHOT.version.min())))
@@ -149,7 +149,7 @@ public class AbstractAssetManagerDeleteSnapshotTest extends AbstractAssetManager
       */
       assertEquals(2, delete(
               Q_ASSET,
-              Q_ASSET.snapshotId.in(
+              Q_ASSET.snapshot.id.in(
                       new JPASubQuery()
                               .from(Q_SNAPSHOT, Q_PROPERTY)
                               .where(Q_PROPERTY.mediaPackageId.eq(Q_SNAPSHOT.mediaPackageId)


### PR DESCRIPTION
The AssetManager used to "manually" control the relation between
snapshots and assets. I.e. assets actually have references to snapshots,
but this relationship was only handled on application level. On database
level, there was not explicitly declared relationship between assets and
snapshots.

So when deleting snapshots, the AssetManager had to first figure out,
which snapshots were going to be deleted by the given query and then
"manually" remove all assets referencing the snapshots to be deleted,
before actually deleting the snapshots.

With this patch, the relationship between assets and snapshots is
modeled explicitly on the database level by changing the shema
accordingly. This allows for ON DELETE CASCADE to be used resulting in
only one query being necessary when removing snapshots.

This work is sponsored by SWITCH.