### PR TITLE
MH-13196, Unregister Resource Servlets of Bundles to be Removed

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/RestPublisher.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/RestPublisher.java
@@ -137,7 +137,7 @@ public class RestPublisher implements RestConstants {
   private Server server;
 
   /** The map of JAX-RS resource providers */
-  private Map<ServiceReference<?>, ResourceProvider> resourceProviders = new HashMap<>();
+  private Map<ServiceReference<?>, ResourceProvider> resourceProviders = new ConcurrentHashMap<>();
 
   /** A token to store in the miss cache */
   private Object nullToken = new Object();
@@ -173,18 +173,16 @@ public class RestPublisher implements RestConstants {
     jsonProvider.setNamespaceMap(NAMESPACE_MAP);
 
     providers.add(jsonProvider);
-    providers.add(new ExceptionMapper<NotFoundException>() {
-      @Override
-      public Response toResponse(NotFoundException e) {
-        return Response.status(404).entity(fourOhFour).type(MediaType.TEXT_PLAIN).build();
-      }
-    });
-    providers.add(new ExceptionMapper<UnauthorizedException>() {
-      @Override
-      public Response toResponse(UnauthorizedException e) {
-        return Response.status(HttpStatus.SC_UNAUTHORIZED).entity("unauthorized").type(MediaType.TEXT_PLAIN).build();
-      };
-    });
+    providers.add((ExceptionMapper<NotFoundException>) e -> Response
+            .status(404)
+            .entity(fourOhFour)
+            .type(MediaType.TEXT_PLAIN)
+            .build());
+    providers.add((ExceptionMapper<UnauthorizedException>) e -> Response
+            .status(HttpStatus.SC_UNAUTHORIZED)
+            .entity("unauthorized")
+            .type(MediaType.TEXT_PLAIN)
+            .build());
 
     try {
       jaxRsTracker = new JaxRsServiceTracker();
@@ -452,6 +450,8 @@ public class RestPublisher implements RestConstants {
    */
   class StaticResourceBundleTracker extends BundleTracker<Object> {
 
+    private HashMap<Bundle, ServiceRegistration> servlets = new HashMap<>();
+
     /**
      * Creates a new StaticResourceBundleTracker.
      *
@@ -485,10 +485,28 @@ public class RestPublisher implements RestConstants {
         // We use the newly added bundle's context to register this service, so when that bundle shuts down, it brings
         // down this servlet with it
         logger.debug("Registering servlet with alias {}", alias);
-        componentContext.getBundleContext().registerService(Servlet.class.getName(), servlet, props);
+
+        ServiceRegistration serviceRegistration = componentContext.getBundleContext()
+                .registerService(Servlet.class.getName(), servlet, props);
+        servlets.put(bundle, serviceRegistration);
       }
 
       return super.addingBundle(bundle, event);
+    }
+
+    @Override
+    public void removedBundle(Bundle bundle, BundleEvent event, Object object) {
+      String classpath = bundle.getHeaders().get(RestConstants.HTTP_CLASSPATH);
+      String alias = bundle.getHeaders().get(RestConstants.HTTP_ALIAS);
+      if (classpath != null && alias != null) {
+        ServiceRegistration serviceRegistration = servlets.get(bundle);
+        if (serviceRegistration != null) {
+          serviceRegistration.unregister();
+          servlets.remove(bundle);
+        }
+      }
+
+      super.removedBundle(bundle, event, object);
     }
   }
 


### PR DESCRIPTION
Trying to replace a bundle with a static resource servelet registered by
Opencast (e.g. runtime-info-ui-ng or admin-ui) will result in an
org.osgi.service.http.NamespaceException when the updates bundle is
registered again since the servlet registered by the first bundle never
got removed and its alias is hence already in use.

Example:

[![asciicast](https://asciinema.org/a/208822.png)](https://asciinema.org/a/208822)

This patch ensures that servlets are unregistered as soon as the
associated bundle is unloaded. This makes it easily possible to
live-deploy a new version of that bundle, e.g. using Karaf's
`bundle:watch` feature without the need for restarting Opencast in the
process.

*Work sponsored by SWITCH*