### PR TITLE
MH-13198, Properly Display Multiple Presenters

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -51,7 +51,8 @@ angular.module('adminNg.controllers')
         label: 'EVENTS.EVENTS.TABLE.TITLE',
         sortable: true
       }, {
-        name:  'presenter',
+        template: 'modules/events/partials/eventsPresentersCell.html',
+        name:  'presenters',
         label: 'EVENTS.EVENTS.TABLE.PRESENTERS',
         sortable: true
       }, {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/seriesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/seriesController.js
@@ -33,10 +33,12 @@ angular.module('adminNg.controllers')
         label: 'EVENTS.SERIES.TABLE.TITLE',
         sortable: true
       }, {
-        name:  'creator',
+        template: 'modules/events/partials/seriesCreatorsCell.html',
+        name:  'creators',
         label: 'EVENTS.SERIES.TABLE.CREATORS',
         sortable: true
       }, {
+        template: 'modules/events/partials/seriesContributorsCell.html',
         name:  'contributors',
         label: 'EVENTS.SERIES.TABLE.CONTRIBUTORS',
         sortable: true

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsPresentersCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsPresentersCell.html
@@ -1,0 +1,4 @@
+<span ng-repeat="presenter in row.presenters"
+      class=metadata-entry>
+  {{presenter}}
+</span>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesContributorsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesContributorsCell.html
@@ -1,0 +1,4 @@
+<span ng-repeat="contributor in row.contributors"
+      class=metadata-entry>
+  {{contributor}}
+</span>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesCreatorsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesCreatorsCell.html
@@ -1,0 +1,4 @@
+<span ng-repeat="creator in row.creators"
+      class=metadata-entry>
+  {{creator}}
+</span>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsResource.js
@@ -45,7 +45,7 @@ angular.module('adminNg.resources')
         var row = {};
         row.id = r.id;
         row.title = r.title;
-        row.presenter = r.presenters.join(', ');
+        row.presenters = r.presenters;
         row.technical_presenter = r.technical_presenters.join(', ');
         if (angular.isDefined(r.series)) {
           row.series_name = r.series.title;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesResource.js
@@ -34,8 +34,8 @@ angular.module('adminNg.resources')
           var row = {};
           row.id = r.id;
           row.title = r.title;
-          row.creator = r.organizers.join(', ');
-          row.contributors = r.contributors.join(', ');
+          row.creators = r.organizers;
+          row.contributors = r.contributors;
           row.createdDateTime = Language.formatDate('short', r.creation_date);
           row.managed_acl = r.managedAcl;
           row.type = 'SERIES';

--- a/modules/admin-ui/src/main/webapp/styles/extensions/components/_tables.scss
+++ b/modules/admin-ui/src/main/webapp/styles/extensions/components/_tables.scss
@@ -25,6 +25,14 @@
     .main-tbl {
         border-top-left-radius: 0;
         border-top-right-radius: 0;
+
+        .metadata-entry {
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            padding: 0 5px;
+            margin-right: 5px;
+        }
+
     }
 }
 

--- a/modules/admin-ui/src/test/resources/test/unit/shared/resources/eventsResourceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/resources/eventsResourceSpec.js
@@ -94,7 +94,7 @@ describe('Events API Resource', function () {
             $httpBackend.flush();
             expect(data.rows.length).toBe(2);
             expect(data.rows[0].title).toBe(sampleJSON.results[0].title);
-            expect(data.rows[0].presenter).toEqual(sampleJSON.results[0].presenters.join(', '));
+            expect(data.rows[0].presenters).toEqual(sampleJSON.results[0].presenters);
             expect(data.rows[0].date).toBe(sampleJSON.results[0].start_date);
             expect(data.rows[0].start_date).toBe('2012-12-02T10:00:00Z');
             expect(data.rows[0].end_date).toBe('2012-12-02T11:15:00Z');

--- a/modules/admin-ui/src/test/resources/test/unit/shared/resources/seriesResourceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/resources/seriesResourceSpec.js
@@ -35,8 +35,8 @@ describe('Series API Resource', function () {
             $httpBackend.flush();
             expect(data.rows.length).toBe(2);
             expect(data.rows[0].title).toEqual('Mock Series');
-            expect(data.rows[0].creator).toEqual('Ophelia Organizer');
-            expect(data.rows[0].contributors).toEqual('Carl Contributor, Carmen Contributor');
+            expect(data.rows[0].creators).toEqual(['Ophelia Organizer']);
+            expect(data.rows[0].contributors).toEqual(['Carl Contributor', 'Carmen Contributor']);
             expect(data.rows[0].createdDateTime).toEqual('2018-08-13T07:20:41Z');
         });
     });


### PR DESCRIPTION
If an event has multiple presenters, the main event table will display
them as one string, separated by comma. This can be a real usability
issue if the name format is in the form of “Doe, Jane”, where users will
end up with lines like “Doe, Jane, Doe, John, Mustermann, Max” which is
very confusing.

This patch tries to make the separate metadata entries visually distinct
by containing each entry in its own element, surrounded by a
lightweight border.

<img src=https://user-images.githubusercontent.com/1008395/47608529-59d13100-da2f-11e8-94aa-dc5561496bf2.png width=400px/>
