### PR TITLE
MH-12332, hide workflows whose tags don't explicitly match the source type

### DIFF
--- a/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/matterhorn-admin-ui-ng/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1749,7 +1749,8 @@ public abstract class AbstractEventEndpoint {
       for (WorkflowDefinition wflDef : workflowsDefinitions) {
         if (wflDef.containsTag(tags)) {
 
-          actions.add(obj(f("id", v(wflDef.getId())), f("title", v(nul(wflDef.getTitle()).getOr(""))),
+          actions.add(obj(f("id", v(wflDef.getId())), f("tags", arr(wflDef.getTags())),
+                  f("title", v(nul(wflDef.getTitle()).getOr(""))),
                   f("description", v(nul(wflDef.getDescription()).getOr(""))),
                   f("configuration_panel", v(nul(wflDef.getConfigurationPanel()).getOr("")))));
         }

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -413,10 +413,8 @@
                         data-disable-search-threshold="8"
                         data-search_contains="true"
                         ng-model="wizard.step.ud.workflow"
-                        ng-options="w.title disable when 
-                          ((wizard.getStateControllerByName('source').ud.type==='UPLOAD' && !w.tags.includes('upload-ng')) ||
-                                  (wizard.getStateControllerByName('source').ud.type.startsWith('SCHEDULE') && !w.tags.includes('schedule-ng')))
-                          for (obj, w) in wizard.step.workflows"
+                        ng-options="w.title for (obj, w) in wizard.step.workflows |
+                                  filter: wizard.getStateControllerByName('source').ud.type==='UPLOAD' ? 'upload-ng' : 'schedule-ng'"
                         data-placeholder="{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW' | translate }}"
                         no-results-text="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY' | translate }}'"
                     >

--- a/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/matterhorn-admin-ui-ng/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -413,7 +413,10 @@
                         data-disable-search-threshold="8"
                         data-search_contains="true"
                         ng-model="wizard.step.ud.workflow"
-                        ng-options="w.title for (obj, w) in wizard.step.workflows"
+                        ng-options="w.title disable when 
+                          ((wizard.getStateControllerByName('source').ud.type==='UPLOAD' && !w.tags.includes('upload-ng')) ||
+                                  (wizard.getStateControllerByName('source').ud.type.startsWith('SCHEDULE') && !w.tags.includes('schedule-ng')))
+                          for (obj, w) in wizard.step.workflows"
                         data-placeholder="{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW' | translate }}"
                         no-results-text="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY' | translate }}'"
                     >

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/newEventProcessing.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/newEventProcessing.json
@@ -2,12 +2,14 @@
     {
         "id": "full",
         "title": "Full",
+        "tags": [],
         "description": "",
         "configuration_panel": ""
     },
     {
         "id": "full-html5",
         "title": "Full HTML5",
+        "tags": ["quick_actions","test"],
         "description": "Test description",
         "configuration_panel": "<h2>Test</h2>"
     }

--- a/modules/matterhorn-admin-ui-ng/src/test/resources/newEventProcessing2.json
+++ b/modules/matterhorn-admin-ui-ng/src/test/resources/newEventProcessing2.json
@@ -2,6 +2,7 @@
     {
         "id": "full-html5",
         "title": "Full HTML5",
+        "tags": ["quick_actions","test"],
         "description": "Test description",
         "configuration_panel": "<h2>Test</h2>"
     }


### PR DESCRIPTION
Add the workflow tags to the processing.json response. Use ng-options' "disable when" clause to grey out workflows that don't contain a tag relevant to the current source type.