### PR TITLE
MH-13127: Make table headers non-interactive by default

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/emailtemplatesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/emailtemplatesController.js
@@ -38,8 +38,7 @@ angular.module('adminNg.controllers')
         label: 'CONFIGURATION.EMAIL_TEMPLATES.TABLE.CREATED'
       }, {
         template: 'modules/configuration/partials/emailtemplateActionsCell.html',
-        label:    'CONFIGURATION.EMAIL_TEMPLATES.TABLE.ACTION',
-        dontSort: true
+        label:    'CONFIGURATION.EMAIL_TEMPLATES.TABLE.ACTION'
       }],
       caption:    'CONFIGURATION.EMAIL_TEMPLATES.TABLE.CAPTION',
       resource:   'emailtemplates',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/themesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/configuration/controllers/themesController.js
@@ -29,16 +29,20 @@ angular.module('adminNg.controllers')
     $scope.table.configure({
       columns: [{
         name:  'name',
-        label: 'CONFIGURATION.THEMES.TABLE.NAME'
+        label: 'CONFIGURATION.THEMES.TABLE.NAME',
+        sortable: true
       }, {
         name:  'description',
-        label: 'CONFIGURATION.THEMES.TABLE.DESCRIPTION'
+        label: 'CONFIGURATION.THEMES.TABLE.DESCRIPTION',
+        sortable: true
       },  {
         name:  'creator',
-        label: 'CONFIGURATION.THEMES.TABLE.CREATOR'
+        label: 'CONFIGURATION.THEMES.TABLE.CREATOR',
+        sortable: true
       }, {
         name:  'creation_date',
-        label: 'CONFIGURATION.THEMES.TABLE.CREATED'
+        label: 'CONFIGURATION.THEMES.TABLE.CREATED',
+        sortable: true
       },
       /*
              * Temporarily disabled
@@ -50,8 +54,7 @@ angular.module('adminNg.controllers')
              */
       {
         template: 'modules/configuration/partials/themesActionsCell.html',
-        label:    'CONFIGURATION.THEMES.TABLE.ACTION',
-        dontSort: true
+        label:    'CONFIGURATION.THEMES.TABLE.ACTION'
       }],
       caption:    'CONFIGURATION.THEMES.TABLE.CAPTION',
       resource:   'themes',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -48,41 +48,47 @@ angular.module('adminNg.controllers')
     $scope.table.configure({
       columns: [{
         name:  'title',
-        label: 'EVENTS.EVENTS.TABLE.TITLE'
+        label: 'EVENTS.EVENTS.TABLE.TITLE',
+        sortable: true
       }, {
         name:  'presenter',
-        label: 'EVENTS.EVENTS.TABLE.PRESENTERS'
+        label: 'EVENTS.EVENTS.TABLE.PRESENTERS',
+        sortable: true
       }, {
         template: 'modules/events/partials/eventsSeriesCell.html',
         name:  'series_name',
-        label: 'EVENTS.EVENTS.TABLE.SERIES'
+        label: 'EVENTS.EVENTS.TABLE.SERIES',
+        sortable: true
       }, {
         template: 'modules/events/partials/eventsTechnicalDateCell.html',
         name:  'technical_date',
-        label: 'EVENTS.EVENTS.TABLE.DATE'
+        label: 'EVENTS.EVENTS.TABLE.DATE',
+        sortable: true
       }, {
         name:  'technical_start',
-        label: 'EVENTS.EVENTS.TABLE.START'
+        label: 'EVENTS.EVENTS.TABLE.START',
+        sortable: true
       }, {
         name:  'technical_end',
-        label: 'EVENTS.EVENTS.TABLE.STOP'
+        label: 'EVENTS.EVENTS.TABLE.STOP',
+        sortable: true
       }, {
         template: 'modules/events/partials/eventsLocationCell.html',
         name:  'location',
-        label: 'EVENTS.EVENTS.TABLE.LOCATION'
+        label: 'EVENTS.EVENTS.TABLE.LOCATION',
+        sortable: true
       }, {
         name:  'published',
         label: 'EVENTS.EVENTS.TABLE.PUBLISHED',
-        template: 'modules/events/partials/publishedCell.html',
-        dontSort: true
+        template: 'modules/events/partials/publishedCell.html'
       }, {
         template: 'modules/events/partials/eventsStatusCell.html',
         name:  'event_status',
-        label: 'EVENTS.EVENTS.TABLE.SCHEDULING_STATUS'
+        label: 'EVENTS.EVENTS.TABLE.SCHEDULING_STATUS',
+        sortable: true
       }, {
         template: 'modules/events/partials/eventActionsCell.html',
-        label:    'EVENTS.EVENTS.TABLE.ACTION',
-        dontSort: true
+        label:    'EVENTS.EVENTS.TABLE.ACTION'
       }],
       caption:    'EVENTS.EVENTS.TABLE.CAPTION',
       resource:   'events',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/seriesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/seriesController.js
@@ -30,20 +30,23 @@ angular.module('adminNg.controllers')
       columns: [{
         template: 'modules/events/partials/seriesTitleCell.html',
         name:  'title',
-        label: 'EVENTS.SERIES.TABLE.TITLE'
+        label: 'EVENTS.SERIES.TABLE.TITLE',
+        sortable: true
       }, {
         name:  'creator',
-        label: 'EVENTS.SERIES.TABLE.CREATORS'
+        label: 'EVENTS.SERIES.TABLE.CREATORS',
+        sortable: true
       }, {
         name:  'contributors',
-        label: 'EVENTS.SERIES.TABLE.CONTRIBUTORS'
+        label: 'EVENTS.SERIES.TABLE.CONTRIBUTORS',
+        sortable: true
       }, {
         name:  'createdDateTime',
-        label: 'EVENTS.SERIES.TABLE.CREATED'
+        label: 'EVENTS.SERIES.TABLE.CREATED',
+        sortable: true
       }, {
         template: 'modules/events/partials/seriesActionsCell.html',
-        label:    'EVENTS.SERIES.TABLE.ACTION',
-        dontSort: true
+        label:    'EVENTS.SERIES.TABLE.ACTION'
       }],
       caption:    'EVENTS.SERIES.TABLE.CAPTION',
       resource: 'series',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/controllers/locationblacklistsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/controllers/locationblacklistsController.js
@@ -30,21 +30,24 @@ angular.module('adminNg.controllers')
     $scope.table.configure({
       columns: [{
         name:  'resourceName',
-        label: 'USERS.BLACKLISTS.TABLE.NAME'
+        label: 'USERS.BLACKLISTS.TABLE.NAME',
+        sortable: true
       }, {
         name:  'date_from',
-        label: 'USERS.BLACKLISTS.TABLE.DATE_FROM'
+        label: 'USERS.BLACKLISTS.TABLE.DATE_FROM',
+        sortable: true
       }, {
         name:  'date_to',
-        label: 'USERS.BLACKLISTS.TABLE.DATE_TO'
+        label: 'USERS.BLACKLISTS.TABLE.DATE_TO',
+        sortable: true
       }, {
         name:  'reason',
         label: 'USERS.BLACKLISTS.TABLE.REASON',
-        translate: true
+        translate: true,
+        sortable: true
       }, {
         template: 'modules/recordings/partials/locationblacklistActionsCell.html',
-        label:    'USERS.BLACKLISTS.TABLE.ACTION',
-        dontSort: true
+        label:    'USERS.BLACKLISTS.TABLE.ACTION'
       }],
       caption:    'RECORDINGS.BLACKLISTS.TABLE.CAPTION',
       resource:   'locationblacklists',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/controllers/recordingsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/controllers/recordingsController.js
@@ -31,14 +31,17 @@ angular.module('adminNg.controllers')
         name:  'status',
         template: 'modules/recordings/partials/recordingStatusCell.html',
         label: 'RECORDINGS.RECORDINGS.TABLE.STATUS',
-        translate: true
+        translate: true,
+        sortable: true
       }, {
         template: 'modules/recordings/partials/recordingsNameCell.html',
         name:  'name',
-        label: 'RECORDINGS.RECORDINGS.TABLE.NAME'
+        label: 'RECORDINGS.RECORDINGS.TABLE.NAME',
+        sortable: true
       }, {
         name:  'updated',
-        label: 'RECORDINGS.RECORDINGS.TABLE.UPDATED'
+        label: 'RECORDINGS.RECORDINGS.TABLE.UPDATED',
+        sortable: true
         //}, {
         //    name:  'blacklist_from',
         //    label: 'USERS.USERS.TABLE.BLACKLIST_FROM'
@@ -47,8 +50,7 @@ angular.module('adminNg.controllers')
         //    label: 'USERS.USERS.TABLE.BLACKLIST_TO'
       }, {
         template: 'modules/recordings/partials/recordingActionsCell.html',
-        label:    'RECORDINGS.RECORDINGS.TABLE.ACTION',
-        dontSort: true
+        label:    'RECORDINGS.RECORDINGS.TABLE.ACTION'
       }],
       caption:    'RECORDINGS.RECORDINGS.TABLE.CAPTION',
       resource:   'recordings',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/systems/controllers/jobsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/systems/controllers/jobsController.js
@@ -26,33 +26,40 @@ angular.module('adminNg.controllers')
     $scope.table.configure({
       columns: [{
         name:  'id',
-        label: 'SYSTEMS.JOBS.TABLE.ID'
+        label: 'SYSTEMS.JOBS.TABLE.ID',
+        sortable: true
       }, {
         name:  'status',
         label: 'SYSTEMS.JOBS.TABLE.STATUS',
-        translate: true
+        translate: true,
+        sortable: true
       }, {
         name:  'operation',
-        label: 'SYSTEMS.JOBS.TABLE.OPERATION'
+        label: 'SYSTEMS.JOBS.TABLE.OPERATION',
+        sortable: true
       }, {
         name:  'type',
-        label: 'SYSTEMS.JOBS.TABLE.TYPE'
+        label: 'SYSTEMS.JOBS.TABLE.TYPE',
+        sortable: true
       }, {
         name:  'processingHost',
-        label: 'SYSTEMS.JOBS.TABLE.HOST_NAME'
+        label: 'SYSTEMS.JOBS.TABLE.HOST_NAME',
+        sortable: true
       }, {
         name:  'submitted',
-        label: 'SYSTEMS.JOBS.TABLE.SUBMITTED'
+        label: 'SYSTEMS.JOBS.TABLE.SUBMITTED',
+        sortable: true
       }, {
         name:  'started',
-        label: 'SYSTEMS.JOBS.TABLE.STARTED'
+        label: 'SYSTEMS.JOBS.TABLE.STARTED',
+        sortable: true
       }, {
         name:  'creator',
-        label: 'SYSTEMS.JOBS.TABLE.CREATOR'
+        label: 'SYSTEMS.JOBS.TABLE.CREATOR',
+        sortable: true
         //}, {
         //    template: 'modules/systems/partials/jobActionsCell.html',
-        //    label:    'SYSTEMS.JOBS.TABLE.ACTION',
-        //    dontSort: true
+        //    label:    'SYSTEMS.JOBS.TABLE.ACTION'
       }],
       caption:    'SYSTEMS.JOBS.TABLE.CAPTION',
       resource:   'jobs',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/systems/controllers/serversController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/systems/controllers/serversController.js
@@ -27,36 +27,44 @@ angular.module('adminNg.controllers')
       columns: [{
         name:     'online',
         template: 'modules/systems/partials/serverStatusCell.html',
-        label:    'SYSTEMS.SERVERS.TABLE.STATUS'
+        label:    'SYSTEMS.SERVERS.TABLE.STATUS',
+        sortable: true
       }, {
         name:  'hostname',
-        label: 'SYSTEMS.SERVERS.TABLE.HOST_NAME'
+        label: 'SYSTEMS.SERVERS.TABLE.HOST_NAME',
+        sortable: true
       }, {
         name:  'cores',
-        label: 'SYSTEMS.SERVERS.TABLE.CORES'
+        label: 'SYSTEMS.SERVERS.TABLE.CORES',
+        sortable: true
       }, {
         name:  'completed',
-        label: 'SYSTEMS.SERVERS.TABLE.COMPLETED'
+        label: 'SYSTEMS.SERVERS.TABLE.COMPLETED',
+        sortable: true
       }, {
         name:  'running',
-        label: 'SYSTEMS.SERVERS.TABLE.RUNNING'
+        label: 'SYSTEMS.SERVERS.TABLE.RUNNING',
+        sortable: true
       }, {
         name:  'queued',
-        label: 'SYSTEMS.SERVERS.TABLE.QUEUED'
+        label: 'SYSTEMS.SERVERS.TABLE.QUEUED',
+        sortable: true
       }, {
         name:  'meanRunTime',
-        label: 'SYSTEMS.SERVERS.TABLE.MEAN_RUN_TIME'
+        label: 'SYSTEMS.SERVERS.TABLE.MEAN_RUN_TIME',
+        sortable: true
       }, {
         name:  'meanQueueTime',
-        label: 'SYSTEMS.SERVERS.TABLE.MEAN_QUEUE_TIME'
+        label: 'SYSTEMS.SERVERS.TABLE.MEAN_QUEUE_TIME',
+        sortable: true
       }, {
         name:     'maintenance',
         template: 'modules/systems/partials/serverMaintenanceCell.html',
-        label:    'SYSTEMS.SERVERS.TABLE.MAINTENANCE'
+        label:    'SYSTEMS.SERVERS.TABLE.MAINTENANCE',
+        sortable: true
         //}, {
         //    template: 'modules/systems/partials/serverActionsCell.html',
-        //    label:    'SYSTEMS.SERVERS.TABLE.ACTION',
-        //    dontSort: true
+        //    label:    'SYSTEMS.SERVERS.TABLE.ACTION'
       }],
       caption:    'SYSTEMS.SERVERS.TABLE.CAPTION',
       resource:   'servers',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/systems/controllers/servicesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/systems/controllers/servicesController.js
@@ -27,32 +27,39 @@ angular.module('adminNg.controllers')
       columns: [{
         name:  'status',
         label: 'SYSTEMS.SERVICES.TABLE.STATUS',
-        translate: true
+        translate: true,
+        sortable: true
       }, {
         name:  'name',
-        label: 'SYSTEMS.SERVICES.TABLE.NAME'
+        label: 'SYSTEMS.SERVICES.TABLE.NAME',
+        sortable: true
       }, {
         name:  'hostname',
-        label: 'SYSTEMS.SERVICES.TABLE.HOST_NAME'
+        label: 'SYSTEMS.SERVICES.TABLE.HOST_NAME',
+        sortable: true
       }, {
         name:  'completed',
-        label: 'SYSTEMS.SERVICES.TABLE.COMPLETED'
+        label: 'SYSTEMS.SERVICES.TABLE.COMPLETED',
+        sortable: true
       }, {
         name:  'running',
-        label: 'SYSTEMS.SERVICES.TABLE.RUNNING'
+        label: 'SYSTEMS.SERVICES.TABLE.RUNNING',
+        sortable: true
       }, {
         name:  'queued',
-        label: 'SYSTEMS.SERVICES.TABLE.QUEUED'
+        label: 'SYSTEMS.SERVICES.TABLE.QUEUED',
+        sortable: true
       }, {
         name:  'meanRunTime',
-        label: 'SYSTEMS.SERVICES.TABLE.MEAN_RUN_TIME'
+        label: 'SYSTEMS.SERVICES.TABLE.MEAN_RUN_TIME',
+        sortable: true
       }, {
         name:  'meanQueueTime',
-        label: 'SYSTEMS.SERVICES.TABLE.MEAN_QUEUE_TIME'
+        label: 'SYSTEMS.SERVICES.TABLE.MEAN_QUEUE_TIME',
+        sortable: true
       }, {
         template: 'modules/systems/partials/serviceActionsCell.html',
-        label:    'SYSTEMS.SERVICES.TABLE.ACTION',
-        dontSort: true
+        label:    'SYSTEMS.SERVICES.TABLE.ACTION'
       }],
       caption:    'SYSTEMS.SERVICES.TABLE.CAPTION',
       resource:   'services',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/aclsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/aclsController.js
@@ -28,7 +28,8 @@ angular.module('adminNg.controllers')
     $scope.table.configure({
       columns: [{
         name:  'name',
-        label: 'USERS.ACLS.TABLE.NAME'
+        label: 'USERS.ACLS.TABLE.NAME',
+        sortable: true
         //}, {
         //    name:  'created',
         //    label: 'USERS.ACLS.TABLE.CREATED'
@@ -40,8 +41,7 @@ angular.module('adminNg.controllers')
         //    label: 'USERS.ACLS.TABLE.IN_USE'
       }, {
         template: 'modules/users/partials/aclActionsCell.html',
-        label:    'USERS.ACLS.TABLE.ACTION',
-        dontSort: true
+        label:    'USERS.ACLS.TABLE.ACTION'
       }],
       caption:    'USERS.ACLS.TABLE.CAPTION',
       resource:   'acls',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupsController.js
@@ -29,17 +29,19 @@ angular.module('adminNg.controllers')
     $scope.table.configure({
       columns: [{
         name:  'name',
-        label: 'USERS.GROUPS.TABLE.NAME'
+        label: 'USERS.GROUPS.TABLE.NAME',
+        sortable: true
       }, {
         name:  'description',
-        label: 'USERS.GROUPS.TABLE.DESCRIPTION'
+        label: 'USERS.GROUPS.TABLE.DESCRIPTION',
+        sortable: true
       }, {
         name:  'role',
-        label: 'USERS.GROUPS.TABLE.ROLE'
+        label: 'USERS.GROUPS.TABLE.ROLE',
+        sortable: true
       }, {
         template: 'modules/users/partials/groupActionsCell.html',
-        label:    'USERS.USERS.TABLE.ACTION',
-        dontSort: true
+        label:    'USERS.USERS.TABLE.ACTION'
       }],
       caption:    'USERS.GROUPS.TABLE.CAPTION',
       resource:   'groups',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userblacklistsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userblacklistsController.js
@@ -28,23 +28,22 @@ angular.module('adminNg.controllers')
     $scope.table.configure({
       columns: [{
         name:  'resourceName',
-        label: 'USERS.BLACKLISTS.TABLE.NAME'
+        label: 'USERS.BLACKLISTS.TABLE.NAME',
+        sortable: true
       }, {
         name:  'date_from',
-        label: 'USERS.BLACKLISTS.TABLE.DATE_FROM',
-        dontSort: true
+        label: 'USERS.BLACKLISTS.TABLE.DATE_FROM'
       }, {
         name:  'date_to',
-        label: 'USERS.BLACKLISTS.TABLE.DATE_TO',
-        dontSort: true
+        label: 'USERS.BLACKLISTS.TABLE.DATE_TO'
       }, {
         name:  'reason',
         label: 'USERS.BLACKLISTS.TABLE.REASON',
-        translate: true
+        translate: true,
+        sortable: true
       }, {
         template: 'modules/users/partials/userblacklistActionsCell.html',
-        label:    'USERS.BLACKLISTS.TABLE.ACTION',
-        dontSort: true
+        label:    'USERS.BLACKLISTS.TABLE.ACTION'
       }],
       caption:    'USERS.BLACKLISTS.TABLE.CAPTION',
       resource:   'userblacklists',

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/usersController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/usersController.js
@@ -29,19 +29,24 @@ angular.module('adminNg.controllers')
     $scope.table.configure({
       columns: [{
         name:  'name',
-        label: 'USERS.USERS.TABLE.NAME'
+        label: 'USERS.USERS.TABLE.NAME',
+        sortable: true
       }, {
         name:  'username',
-        label: 'USERS.USERS.TABLE.USERNAME'
+        label: 'USERS.USERS.TABLE.USERNAME',
+        sortable: true
       }, {
         name:  'email',
-        label: 'USERS.USERS.TABLE.EMAIL'
+        label: 'USERS.USERS.TABLE.EMAIL',
+        sortable: true
       }, {
         name:  'roles',
-        label: 'USERS.USERS.TABLE.ROLES'
+        label: 'USERS.USERS.TABLE.ROLES',
+        sortable: true
       }, {
         name:  'provider',
-        label: 'USERS.USERS.TABLE.PROVIDER'
+        label: 'USERS.USERS.TABLE.PROVIDER',
+        sortable: true
       }, {
         //     name:  'blacklist_from',
         //     label: 'USERS.USERS.TABLE.BLACKLIST_FROM'
@@ -50,8 +55,7 @@ angular.module('adminNg.controllers')
         //     label: 'USERS.USERS.TABLE.BLACKLIST_TO'
         // }, {
         template: 'modules/users/partials/userActionsCell.html',
-        label:    'USERS.USERS.TABLE.ACTION',
-        dontSort: true
+        label:    'USERS.USERS.TABLE.ACTION'
       }],
       caption:    'USERS.USERS.TABLE.CAPTION',
       resource:   'users',

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/table.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/table.html
@@ -16,11 +16,11 @@
           ng-repeat="column in table.columns"
           ng-style="column.style"
           ng-if="!column.deactivated"
-          ng-class="{ 'col-sort': table.predicate === column.name, 'no-sort': column.dontSort }"
+          ng-class="{ 'col-sort': table.predicate === column.name, 'sortable': column.sortable }"
           ng-click="table.sortBy(column)">
         <span>
           {{ column.label | translate }}
-          <i ng-if="!column.dontSort"
+          <i ng-if="column.sortable"
              class="sort"
              ng-class="{ asc: table.predicate === column.name && !table.reverse, desc: table.predicate === column.name && table.reverse }"></i>
         </span>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
@@ -222,7 +222,7 @@ angular.module('adminNg.services')
           for (var i = 0; i < me.columns.length; i++) {
             var column = me.columns[i];
 
-            if (!column.dontSort) {
+            if (column.sortable) {
               me.sortBy(column);
               break;
             }
@@ -239,7 +239,7 @@ angular.module('adminNg.services')
 
       this.sortBy = function (column) {
         // Avoid sorting by action column
-        if (angular.isUndefined(column) || column.dontSort) {
+        if (angular.isUndefined(column) || !column.sortable) {
           return;
         }
 

--- a/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
@@ -46,10 +46,18 @@
     }
 
     th {
+        &.sortable {
+            cursor: pointer;
+            &:hover {
+                @include linear-gradient(top, $off-white, darken(#f1f3f5, 3%));
+            }
+            &:active {
+                box-shadow: inset 0 3px 10px 2px rgba($black, 0.05);
+            }
+        }
         // Layout
         padding-left: 10px;
         padding-right: 10px;
-        cursor: pointer;
 
         &:first-child {
             border-left: none;
@@ -80,13 +88,6 @@
         color: $medium-prim-color;
         text-shadow: 0px 1px 0px #fff;
 
-        &:hover {
-            @include linear-gradient(top, $off-white, darken(#f1f3f5, 3%));
-        }
-
-        &:active {
-            box-shadow: inset 0 3px 10px 2px rgba($black, 0.05);
-        }
 
         // Sort icon
         span .sort {

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/tableServiceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/tableServiceSpec.js
@@ -34,7 +34,8 @@ describe('Table', function () {
         var params = {
             columns: [{
                 name: 'name',
-                label: 'NAME'
+                label: 'NAME',
+                sortable: true
             }],
             caption: 'CAPTION',
             resource: 'tables',
@@ -134,7 +135,7 @@ describe('Table', function () {
         it('sets the sort params', function () {
             $httpBackend.whenGET('/admin-ng/users/users.json?limit=10&offset=0&sort=email:ASC')
                 .respond(JSON.stringify(getJSONFixture('admin-ng/users/users.json')));
-            Table.sortBy({ name: 'email' });
+            Table.sortBy({ name: 'email', sortable: true });
             $httpBackend.flush();
             expect(Table.predicate).toEqual('email');
             expect(Table.reverse).toBe(false);
@@ -144,7 +145,7 @@ describe('Table', function () {
             spyOn(Storage, 'put');
             $httpBackend.whenGET('/admin-ng/users/users.json?limit=10&offset=0&sort=email:DESC')
                 .respond(JSON.stringify(getJSONFixture('admin-ng/users/users.json')));
-            Table.sortBy({ name: 'email' });
+            Table.sortBy({ name: 'email', sortable: true });
             $httpBackend.flush();
             expect(Storage.put).toHaveBeenCalledWith('sorter', 'users', 'email',  { name : 'email', priority : 0, order : 'DESC' });
         });


### PR DESCRIPTION
This will ensure that only table headers with a corresponding _sort by_ action are styled to be interactive.

**Before**
![before](https://user-images.githubusercontent.com/16406401/47740251-9c854a00-dc77-11e8-891f-733f93c58d6d.gif)

**After**
![after](https://user-images.githubusercontent.com/16406401/47740272-a6a74880-dc77-11e8-8f40-fc0ac53e11d3.gif)

Resolves: [MH-13127](https://opencast.jira.com/browse/MH-13127)

Note that this affects all tables in the Admin UI that come with table headers - the tables used in modals and wizards are affected, too.