### PR TITLE
MH-13206 Use correct mouse cursor in filters

### DIFF
--- a/modules/admin-ui/src/main/webapp/styles/main.scss
+++ b/modules/admin-ui/src/main/webapp/styles/main.scss
@@ -343,7 +343,6 @@ div.table-filter {
     border: 0;
     border-radius: 4px;
     float: left;
-    cursor: text;
     background: #fff;
     background-color: #fafafa;
     min-height: 23px;


### PR DESCRIPTION
Before:
![incorrect_behavior](https://user-images.githubusercontent.com/1590263/47804897-488d6a80-dd36-11e8-8a3c-fcbbef28aecd.gif)

After:
![correct_behavior](https://user-images.githubusercontent.com/1590263/47804901-4aefc480-dd36-11e8-8efe-585027af2460.gif)

Note: Just verified that the cursor does change to the text cursor at mouse over on text with no actions assigned in other web pages, too. Nevertheless, it does not make sense here since there is no text that could be selected. 
