### PR TITLE
MH-13201 Convert uploaded images to appropriate size and format

### DIFF
--- a/etc/encoding/engage-images.properties
+++ b/etc/encoding/engage-images.properties
@@ -48,3 +48,10 @@ profile.search-cover.http.input = visual
 profile.search-cover.http.output = image
 profile.search-cover.http.suffix = -search.jpg
 profile.search-cover.http.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=160:-1 #{out.dir}/#{out.name}#{out.suffix}
+
+profile.search-cover.http.downscale.name = Downscale to cover image for engage
+profile.search-cover.http.downscale.input = visual
+profile.search-cover.http.downscale.output = image
+profile.search-cover.http.downscale.suffix = -search.jpg
+profile.search-cover.http.downscale.ffmpeg.command = -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=160:-1 #{out.dir}/#{out.name}#{out.suffix}
+

--- a/etc/workflows/partial-preview.xml
+++ b/etc/workflows/partial-preview.xml
@@ -159,13 +159,13 @@
          to a resolution optimized for the video editor here -->
 
     <operation
-      id="tag"
-      description="Tag uploaded thumbnail for publication">
+      id="image-convert"
+      description="Convert uploaded thumbnail to thumbnail preview image">
       <configurations>
         <configuration key="source-flavors">thumbnail/source</configuration>
         <configuration key="target-flavor">thumbnail/preview</configuration>
         <configuration key="target-tags">preview</configuration>
-        <configuration key="copy">true</configuration>
+        <configuration key="encoding-profiles">editor.thumbnail.preview.downscale</configuration>
       </configurations>
     </operation>
 

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -123,28 +123,28 @@
     </operation>
 
     <operation
-      id="tag"
+      id="image-convert"
       if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==1 AND ${presenter_work_video}"
       exception-handler-workflow="partial-error"
-      description="Tagging uploaded thumbnail for presenter track">
+      description="Convert uploaded thumbnail to search result thumbnail (presenter track)">
       <configurations>
         <configuration key="source-flavors">thumbnail/source</configuration>
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="target-flavor">presenter/search+preview</configuration>
-        <configuration key="copy">true</configuration>
+        <configuration key="encoding-profiles">search-cover.http.downscale</configuration>
       </configurations>
     </operation>
 
     <operation
-        id="tag"
-        if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==1 AND ${presentation_work_video}"
-        exception-handler-workflow="partial-error"
-        description="Tagging uploaded thumbnail for presentation track">
+      id="image-convert"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==1 AND ${presentation_work_video}"
+      exception-handler-workflow="partial-error"
+      description="Convert uploaded thumbnail to search result thumbnail (presentation track)">
       <configurations>
         <configuration key="source-flavors">thumbnail/source</configuration>
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="target-flavor">presentation/search+preview</configuration>
-        <configuration key="copy">true</configuration>
+        <configuration key="encoding-profiles">search-cover.http.downscale</configuration>
       </configurations>
     </operation>
 


### PR DESCRIPTION
When the thumbnail feature was merged, WOH image-convert was not yet available. 

Converting the images has two advantages:
- Reducing the size of the image (a user can upload whatever ffmpeg supports in whatever resolution and format)
- Ensuring a defined format that is suitable for web pages