### PR TITLE
NOJIRA: Add Ansible docs

### DIFF
--- a/docs/guides/admin/docs/installation/ansible.md
+++ b/docs/guides/admin/docs/installation/ansible.md
@@ -6,7 +6,8 @@ configuration.  These scripts should handle most common installation setups, and
 quickly and easily set up Opencast for testing.  These scripts are also a good base upon which to build your own, local
 configuration management scripts.
 
-The Ansible scripts are tested on Debian 8+, Ubuntu 16.04+, and CentOS 7+, but may also work on other systems.
+The Ansible scripts are tested on long term stable releases of Debian, Ubuntu, and CentOS.  Currently this is Debian 8,
+Ubuntu 16.04, and 18.04, and CentOS 7.  Other releases, and distributions should work, but are untested.
 
 
 Setup
@@ -30,7 +31,7 @@ get by mail after the registration to successfully complete this manual. The pla
 Testing Use
 -----------
 
-The scripts can be found [here](https://github.com/gregorydlogan/oc-config-management).  If you are familiar with `git`
+The scripts can be found [here](https://github.com/opencast/oc-config-management).  If you are familiar with `git`
 make a local clone, otherwise download a zip file of the scripts.  Read through the documentation, which contains
 additional setup steps.
 
@@ -49,7 +50,7 @@ Similar to testing, you need to read the documentation and perform the additiona
 differences between testing and production use are:
 
  - Setting different passwords for all password options in `group_vars/all.yml`.  These scripts default to the common
-   passwords used worldwide by Opencast.  You do not want to use these passwords in production.
+   passwords used by default by Opencast.  You do not want to use these passwords in production.
  - Changing `install_mariadb` to `false`.  These scripts install MariaDB from your distribution's package manager by
    default, but some institutions may want to use an institution-wide MariaDB instance.  If this is true for you, set
    this value to `false` to prevent installation of MariaDB.  The database schema will still be imported, although you

--- a/docs/guides/admin/docs/installation/ansible.md
+++ b/docs/guides/admin/docs/installation/ansible.md
@@ -1,0 +1,69 @@
+Install via Script using the Repository (Debian, Ubuntu)
+===========================================================================
+
+Installing Opencast can be complex, so we have built a set of Ansible scripts to handle the installation and 
+configuration.  These scripts should handle most common installation setups, and are ideal for someone wishing to 
+quickly and easily set up Opencast for testing.  These scripts are also a good base upon which to build your own, local
+configuration management scripts.
+
+The Ansible scripts are tested on Debian 8+, Ubuntu 16.04+, and CentOS 7+, but may also work on other systems.
+
+
+Setup
+-----
+
+These scripts use [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html), which
+allows you to easily and automatically manage large numbers of machines via SSH.  Install Ansible before continuing
+with this guide.
+
+
+Registration
+------------
+
+Before you can install Opencast you need to get an account for the repository. You will need the credentials that you 
+get by mail after the registration to successfully complete this manual. The placeholders `[your_username]` and 
+`[your_password]` are used in this manual wherever the credentials are needed.
+
+[Please visit https://pkg.opencast.org](https://pkg.opencast.org)
+
+
+Testing Use
+-----------
+
+The scripts can be found [here](https://github.com/gregorydlogan/oc-config-management).  If you are familiar with `git`
+make a local clone, otherwise download a zip file of the scripts.  Read through the documentation, which contains
+additional setup steps.
+
+Once you have set up your host configuration in `hosts`, run 
+`ansible-playbook -K -i hosts opencast.yml --extra-vars "repo_username=[your_username] repo_password=[your_password]"`.
+If you are uncomfortable with your username and password on the commandline, you can set those variables in 
+`group_vars/all.yml`.
+
+If you successfully install Opencast, but notice you have made a mistake in your configuration you can use the `config`
+advanced option.  Read the script documentation for more detail.
+
+Production Use
+--------------
+
+Similar to testing, you need to read the documentation and perform the additional installation steps.  The only
+differences between testing and production use are:
+
+ - Setting different passwords for all password options in `group_vars/all.yml`.  These scripts default to the common
+   passwords used worldwide by Opencast.  You do not want to use these passwords in production.
+ - Changing `install_mariadb` to `false`.  These scripts install MariaDB from your distribution's package manager by
+   default, but some institutions may want to use an institution-wide MariaDB instance.  If this is true for you, set
+   this value to `false` to prevent installation of MariaDB.  The database schema will still be imported, although you
+   may need to create the schema itself manually.
+ - Changing `handle_network_mounts` to `false`.  These scripts install NFS from your distribution's package manager by
+   default, but some institutions may want to use an appliance, or want to manage NFS themselves.  If this is true for
+   you, set this value to `false` to prevent installation of NFS on the fileserver, and the creation of mounts on the 
+   Opencast nodes.
+
+Upgrading Major Versions
+------------------------
+
+These scripts do not attempt to intelligently update your Opencast installation across major versions.  They will
+however upgrade your installation to the newest *minor* version.  For example, if you have Opencast 3.6 installed,
+these scripts will upgrade you to 3.7, but not 4.0.  To upgrade major versions, follow the upgrade steps listed in the
+[RPM](rpm-rhel-sl-centos.md) or [Deb](debs.md) instructions, depending on your installed distribution.
+

--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -183,7 +183,7 @@ Upgrading Major Versions
 ------------------------
 
 While these packages will automatically upgrade you to the latest point version in a release series, they do not
-automatically upgrade you to the latest major version. In other words, if you install `opencast3-admin` you get the
+automatically upgrade you to the latest major version. In other words, if you install `opencast-3-admin` you get the
 latest 3.x release, not the latest 4.x release. To upgrade from one version to another you first stop Opencast:
 
  - On a SysV-init based system

--- a/docs/guides/admin/docs/installation/index.md
+++ b/docs/guides/admin/docs/installation/index.md
@@ -31,6 +31,8 @@ pre-built Opencast installations.
  - [Debian](debs.md)
  - [Ubuntu](debs.md)
 
+We also support [Installation via Ansible](ansible.md), which makes installation and configuration easier.
+
 
 Installation with Docker
 ----------------------------
@@ -48,4 +50,6 @@ For production systems, it is recommended to install Opencast across multiple se
 management and presentation layer, so that, for example, even if the processing layer is under full load, users can
 still watch recordings unaffected since the presentation layer is running on a separate machine.
 
+ - [Installation via Ansible](ansible.md)
  - [Installation Across Multiple Servers](multiple-servers.md)
+

--- a/docs/guides/admin/docs/installation/index.md
+++ b/docs/guides/admin/docs/installation/index.md
@@ -21,7 +21,7 @@ Building on most other Unix-like operating systems should be very much alike.
 Installation from Repository
 ----------------------------
 
-There is an RPM repository available for some operating systems. It provides packages containing pre-configured and
+There is a package repository available for some operating systems. It provides packages containing pre-configured and
 pre-built Opencast installations.
 
  - [RedHat Enterprise Linux](rpm-rhel-sl-centos.md)

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -28,6 +28,7 @@ pages:
       - Debian/Ubuntu: 'installation/debs.md'
       - Fedora: 'installation/rpm-fedora.md'
       - RHEL/CentOS: 'installation/rpm-rhel-sl-centos.md'
+      - Ansible: 'installation/ansible.md'
    - Installation with Docker:
       - Testing Locally: 'installation/docker-local.md'
 - Configuration:


### PR DESCRIPTION
This documentation adds links to the Ansible installation scripts to our mainline documentation.  Aiming at 4.x currently with the idea that it would percolate upwards from there.