### PR TITLE
MH-13209: Add CAS security bundles to opencast distrubution packages

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -146,6 +146,8 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-working-file-repository-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-workspace-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-workspace-impl/${project.version}</bundle>
+
+    <feature start-level="80">opencast-security-cas</feature>
   </feature>
 
   <feature name="opencast-allinone">


### PR DESCRIPTION
CAS security bundles are not added to the distribution packages. 
If you try to enable the CAS authentication you get an error.