### PR TITLE
MH-13209, Put CAS Feature In Distributions

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -117,6 +117,9 @@
             </libraries>
             <archiveZip>false</archiveZip>
             <archiveTarGz>false</archiveTarGz>
+            <installedFeatures>
+              <feature>opencast-security-cas</feature>
+            </installedFeatures>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This patch ensures that Opencast's CAS security feature is contained in
all distributions and can easily be installed/enabled without enabling
it by default or making it a core dependency.

*This is an alternative solution to pull request #543*