### PR TITLE
MH-13211 engage-ui: Fix live schedule bug: event available before schedule

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -675,19 +675,15 @@ function($, bootbox, _, alertify) {
 
                     if (data.mediapackage.media && data.mediapackage.media.track) {
                     	// Check if there's a 'live' track
-                        for (var i = 0; i < data.mediapackage.media.track.length; i++) {
-                            var track = data.mediapackage.media.track[i];
-                            if (track.live) {
-                            	// Is event in progress?
-                            	var start = new Date(data.mediapackage.start);
-                            	var end = new Date(start.getTime() + parseInt (data.mediapackage.duration));
-                            	var now = new Date(); 
-                                if (now < start || now > end) {
-                                	live = msg_live_not_in_progress;
-                                	canLaunch = false;
-                                } else live = msg_live_in_progress;
-                                break;
-                            }
+                        if (data.mediapackage.media.track.live) {
+                            // Is event in progress?
+                            var start = new Date(data.mediapackage.start);
+                            var end = new Date(start.getTime() + parseInt (data.mediapackage.duration));
+                            var now = new Date();
+                            if (now < start || now > end) {
+                               	live = msg_live_not_in_progress;
+                               	canLaunch = false;
+                            } else live = msg_live_in_progress;
                         }
                     }
                     tile = tile + "<div class=\"live\">" + live + "</div>";

--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -674,16 +674,16 @@ function($, bootbox, _, alertify) {
                     };
 
                     if (data.mediapackage.media && data.mediapackage.media.track) {
-                    	// Check if there's a 'live' track
+                        // Check if there's a 'live' track
                         if (data.mediapackage.media.track.live) {
                             // Is event in progress?
                             var start = new Date(data.mediapackage.start);
                             var end = new Date(start.getTime() + parseInt (data.mediapackage.duration));
                             var now = new Date();
-                            if (now < start || now > end) {
-                               	live = msg_live_not_in_progress;
-                               	canLaunch = false;
-                            } else live = msg_live_in_progress;
+                            if (now < start || now >= end) {
+                                live = _.escape(msg_live_not_in_progress);
+                                canLaunch = false;
+                            } else live = _.escape(msg_live_in_progress);
                         }
                     }
                     tile = tile + "<div class=\"live\">" + live + "</div>";


### PR DESCRIPTION
The bug fix in this PR is to avoid the behaviour of allow users to access to the live stream before an event starts.

The problem was the check algorithm only worked if the `data.mediapackage.media.track` variable had an array type. The live streaming events have type dict. Thus the for statement never started.

The fix makes an immediate check considering that the live stream only have live tracks.