### PR TITLE
MH-13215: WorkflowOperationTagUtil throws a null pointer

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationTagUtil.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationTagUtil.java
@@ -22,6 +22,7 @@
 package org.opencastproject.workflow.api;
 
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.util.data.Collections;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -54,7 +55,8 @@ public final class WorkflowOperationTagUtil {
   private static final String MINUS = "-";
 
   public static TagDiff createTagDiff(final String tagList) {
-    final String[] targetTags = StringUtils.split(tagList, ",");
+    final ArrayList<String> targetTags = new ArrayList<>();
+    ((ArrayList) targetTags).addAll(Collections.toList(StringUtils.split(tagList, ",")));
 
     final List<String> removeTags = new ArrayList<>();
     final List<String> addTags = new ArrayList<>();


### PR DESCRIPTION
Copying from list, this is the stack trace:
```
2018-11-05 15:14:27,152 | ERROR | (WorkflowOperationWorker:180) - Workflow operation 'operation:'prepare-av', position:13, state:'FAILED'' failed
java.lang.NullPointerException
at org.opencastproject.workflow.api.WorkflowOperationTagUtil.createTagDiff(WorkflowOperationTagUtil.java:63)[170:opencast-workflow-service-api:6.0.0.SNAPSHOT]
at org.opencastproject.workflow.handler.composer.PrepareAVWorkflowOperationHandler.mux(PrepareAVWorkflowOperationHandler.java:175)[61:opencast-composer-workflowoperation:6.0.0.SNAPSHOT]
at ...
```
Obvious fix is to make sure the list always exists.