### PR TITLE
MH-13218, IBM Watson Transcriptions speech-to-text endpoint HTTP-413

### DIFF
--- a/modules/matterhorn-transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
+++ b/modules/matterhorn-transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
@@ -484,7 +484,9 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
                       mpId, additionalParms));
       logger.debug("Url to invoke ibm watson service: {}", httpPost.getURI().toString());
       httpPost.setHeader(HttpHeaders.CONTENT_TYPE, track.getMimeType().toString());
-      httpPost.setEntity(new FileEntity(audioFile));
+      FileEntity fileEntity = new FileEntity(audioFile);
+      fileEntity.setChunked(true);
+      httpPost.setEntity(fileEntity);
       response = httpClient.execute(httpPost);
       int code = response.getStatusLine().getStatusCode();
 


### PR DESCRIPTION
As of 29Oct2018 setChunked hint fix is needed for HttpClient's FileEntity post in the IBM Watson Transcription service. This issue is known to affect the IBM Watson transcriptions in Opencast 4x and 5x. 

If the hint is not set and a large (10MB+) audio file is sent to IBM Watson US https://stream.watsonplatform.net/speech-to-text/api/v1/recognitions endpoint 
The endpoint returns an HTTP 413 file too big response. 

The setChunked is a hint attribute and does not impact smaller uploads. 