### PR TITLE
MH-13144, only set Job startDate if no set before

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
@@ -584,8 +584,10 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
       job.setDateCreated(now);
     }
     if (Status.RUNNING.equals(status)) {
-      job.setDateStarted(now);
-      job.setQueueTime(now.getTime() - job.getDateCreated().getTime());
+      if (job.getDateStarted() == null) {
+        job.setDateStarted(now);
+        job.setQueueTime(now.getTime() - job.getDateCreated().getTime());
+      }
     } else if (Status.FAILED.equals(status)) {
       // failed jobs may not have even started properly
       job.setDateCompleted(now);

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -1120,12 +1120,14 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       fromDb.setProcessorServiceRegistration(processingService);
     }
     if (Status.RUNNING.equals(status) && !Status.WAITING.equals(fromDbStatus)) {
-      jpaJob.setDateStarted(now);
-      jpaJob.setQueueTime(now.getTime() - job.getDateCreated().getTime());
-      fromDb.setDateStarted(now);
-      fromDb.setQueueTime(now.getTime() - job.getDateCreated().getTime());
-      job.setDateStarted(now);
-      job.setQueueTime(now.getTime() - job.getDateCreated().getTime());
+      if (job.getDateStarted() == null) {
+        jpaJob.setDateStarted(now);
+        jpaJob.setQueueTime(now.getTime() - job.getDateCreated().getTime());
+        fromDb.setDateStarted(now);
+        fromDb.setQueueTime(now.getTime() - job.getDateCreated().getTime());
+        job.setDateStarted(now);
+        job.setQueueTime(now.getTime() - job.getDateCreated().getTime());
+      }
     } else if (Status.FAILED.equals(status)) {
       // failed jobs may not have even started properly
       if (job.getDateCompleted() == null) {


### PR DESCRIPTION
Stops jobs that update while they are running (eg START_WORKFLOW) from having their startDate reset each time