### PR TITLE
MH-13222: Some fixes to tiered storage asset manager

### DIFF
--- a/etc/org.opencastproject.assetmanager.impl.TimedMediaArchiver.cfg
+++ b/etc/org.opencastproject.assetmanager.impl.TimedMediaArchiver.cfg
@@ -9,7 +9,7 @@ enabled = false
 cron-expression =
 
 # Set where to archive the offloaded media to.  This must match the store type
-store-type =
+store-id =
 
 # Set the maximum age in hours that a mediapackage can have in local storage
 max-age =

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
@@ -254,16 +254,10 @@ public abstract class AbstractAssetManager implements AssetManager {
     }
   }
 
-  /** Check if element <code>e</code> is already part of the history and in the local store. */
+  /** Check if element <code>e</code> is already part of the history. */
   private Opt<StoragePath> findAssetInVersions(final String checksum) throws Exception {
-    return getDb().findAssetByChecksum(checksum).filter(new Fn<AssetDtos.Full, Boolean>() {
-      @Override public Boolean apply(AssetDtos.Full dto) {
-        if (getLocalAssetStore().getStoreType().equals(dto.getStorageId())) {
-          return true;
-        }
-        return false;
-      }
-    }).map(new Fn<AssetDtos.Full, StoragePath>() {
+    return getDb().findAssetByChecksumAndStore(checksum, getLocalAssetStore().getStoreType())
+            .map(new Fn<AssetDtos.Full, StoragePath>() {
       @Override public StoragePath apply(AssetDtos.Full dto) {
         return StoragePath.mk(dto.getOrganizationId(), dto.getMediaPackageId(), dto.getVersion(), dto.getAssetDto().getMediaPackageElementId());
       }


### PR DESCRIPTION
Fixes:
- Typo in timed media archiver configuration
- Typo in logger name
- Added copy of manifest file: manifests are stored in the file system and should be copied to remote store too, especially now that snapshots are deleted from the database (before they were just marked as deleted)
- Fixed search in local store to find elements with same checksum when archiving