### PR TITLE
MH-13227, Update to Apache Karaf 4.2

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -28,7 +28,10 @@
     <bundle>mvn:javax.el/javax.el-api/3.0.0</bundle>
     <bundle>mvn:javax.servlet.jsp/javax.servlet.jsp-api/2.3.1</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+    <bundle>mvn:org.apache.geronimo.specs/geronimo-j2ee-management_1.1_spec/1.0.1</bundle>
     <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr339-api-2.0.1/2.6.0</bundle>
+    <bundle>mvn:org.fusesource.hawtbuf/hawtbuf/1.11</bundle>
 
     <!-- JPA -->
     <feature>jndi</feature>

--- a/modules/inspection-service-ffmpeg/pom.xml
+++ b/modules/inspection-service-ffmpeg/pom.xml
@@ -26,8 +26,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -46,13 +47,20 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -63,14 +71,6 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/assetmanager/AssetManagerItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/assetmanager/AssetManagerItem.java
@@ -66,11 +66,11 @@ public abstract class AssetManagerItem implements MessageItem, Serializable {
   // common fields
 
   private final String mediaPackageId;
-  private final Date date;
+  private final long date;
 
   private AssetManagerItem(String mediaPackageId, Date date) {
     this.mediaPackageId = RequireUtil.notNull(mediaPackageId, "mediaPackageId");
-    this.date = RequireUtil.notNull(date, "date");
+    this.date = RequireUtil.notNull(date, "date").getTime();
   }
 
   public abstract Type getType();
@@ -79,7 +79,7 @@ public abstract class AssetManagerItem implements MessageItem, Serializable {
           Fn<? super DeleteSnapshot, ? extends A> deleteSnapshot, Fn<? super DeleteEpisode, ? extends A> deleteEpisode);
 
   public final Date getDate() {
-    return date;
+    return new Date(date);
   }
 
   @Override

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/scheduler/SchedulerItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/scheduler/SchedulerItem.java
@@ -54,14 +54,14 @@ public class SchedulerItem implements MessageItem, Serializable {
   private final String properties;
   private final String acl;
   private final String agentId;
-  private final Date end;
+  private final long end;
   private final Boolean optOut;
   private final Set<String> presenters;
   private final Boolean blacklisted;
   private final String reviewStatus;
-  private final Date reviewDate;
+  private final long reviewDate;
   private final String recordingState;
-  private final Date start;
+  private final long start;
   private final Long lastHeardFrom;
   private final Type type;
 
@@ -229,13 +229,13 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.optOut = null;
     this.presenters = null;
     this.reviewStatus = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.recordingState = null;
-    this.start = null;
+    this.start = -1;
     this.lastHeardFrom = null;
     this.type = Type.UpdateCatalog;
   }
@@ -255,13 +255,13 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.optOut = null;
     this.presenters = null;
     this.reviewStatus = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.recordingState = null;
-    this.start = null;
+    this.start = -1;
     this.lastHeardFrom = null;
     this.type = Type.UpdateProperties;
   }
@@ -279,13 +279,13 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.optOut = null;
     this.presenters = null;
     this.reviewStatus = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.recordingState = null;
-    this.start = null;
+    this.start = -1;
     this.lastHeardFrom = null;
     this.type = type;
   }
@@ -309,13 +309,13 @@ public class SchedulerItem implements MessageItem, Serializable {
     }
     this.agentId = null;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.optOut = null;
     this.presenters = null;
     this.reviewStatus = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.recordingState = null;
-    this.start = null;
+    this.start = -1;
     this.lastHeardFrom = null;
     this.type = Type.UpdateAcl;
   }
@@ -335,13 +335,13 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.optOut = optOut;
     this.presenters = null;
     this.reviewStatus = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.recordingState = null;
-    this.start = null;
+    this.start = -1;
     this.lastHeardFrom = null;
     this.type = Type.UpdateOptOut;
   }
@@ -361,13 +361,13 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = blacklisted;
-    this.end = null;
+    this.end = -1;
     this.optOut = null;
     this.presenters = null;
     this.reviewStatus = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.recordingState = null;
-    this.start = null;
+    this.start = -1;
     this.lastHeardFrom = null;
     this.type = Type.UpdateBlacklist;
   }
@@ -389,13 +389,13 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.optOut = null;
     this.presenters = null;
     this.reviewStatus = reviewStatus.toString();
-    this.reviewDate = reviewDate;
+    this.reviewDate = reviewDate == null ? -1 : reviewDate.getTime();
     this.recordingState = null;
-    this.start = null;
+    this.start = -1;
     this.lastHeardFrom = null;
     this.type = Type.UpdateReviewStatus;
   }
@@ -417,13 +417,13 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.optOut = null;
     this.presenters = null;
     this.reviewStatus = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.recordingState = state;
-    this.start = null;
+    this.start = -1;
     this.lastHeardFrom = lastHeardFrom;
     this.type = Type.UpdateRecordingStatus;
   }
@@ -434,15 +434,15 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = null;
-    this.end = end;
+    this.end = end == null ? -1 : end.getTime();
     this.lastHeardFrom = null;
     this.optOut = null;
     this.presenters = null;
     this.properties = null;
     this.recordingState = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.reviewStatus = null;
-    this.start = start;
+    this.start = start == null ? -1 : start.getTime();
     this.type = type;
   }
 
@@ -452,15 +452,15 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = agentId;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.lastHeardFrom = null;
     this.optOut = null;
     this.presenters = null;
     this.properties = null;
     this.recordingState = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.reviewStatus = null;
-    this.start = null;
+    this.start = -1;
     this.type = Type.UpdateAgentId;
   }
 
@@ -470,15 +470,15 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.acl = null;
     this.agentId = null;
     this.blacklisted = null;
-    this.end = null;
+    this.end = -1;
     this.lastHeardFrom = null;
     this.optOut = null;
     this.presenters = presenters;
     this.properties = null;
     this.recordingState = null;
-    this.reviewDate = null;
+    this.reviewDate = -1;
     this.reviewStatus = null;
-    this.start = null;
+    this.start = -1;
     this.type = Type.UpdatePresenters;
   }
 
@@ -523,7 +523,7 @@ public class SchedulerItem implements MessageItem, Serializable {
   }
 
   public Date getEnd() {
-    return end;
+    return end < 0 ? null : new Date(end);
   }
 
   public Long getLastHeardFrom() {
@@ -543,7 +543,7 @@ public class SchedulerItem implements MessageItem, Serializable {
   }
 
   public Date getReviewDate() {
-    return reviewDate;
+    return reviewDate < 0 ? null : new Date(reviewDate);
   }
 
   public String getRecordingState() {
@@ -551,7 +551,7 @@ public class SchedulerItem implements MessageItem, Serializable {
   }
 
   public Date getStart() {
-    return start;
+    return start < 0 ? null : new Date(start);
   }
 
   public Type getType() {

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/theme/SerializableTheme.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/theme/SerializableTheme.java
@@ -32,7 +32,7 @@ public class SerializableTheme implements Serializable {
   private static final long serialVersionUID = 618342361307578393L;
 
   private final long id;
-  private final Date creationDate;
+  private final long creationDate;
   private final boolean isDefault;
   private final String creator;
   private final String name;
@@ -58,7 +58,7 @@ public class SerializableTheme implements Serializable {
           String licenseSlideBackground, String licenseSlideDescription, boolean watermarkActive, String watermarkFile,
           String watermarkPosition) {
     this.id = id;
-    this.creationDate = creationDate;
+    this.creationDate = creationDate.getTime();
     this.isDefault = isDefault;
     this.creator = creator;
     this.name = name;
@@ -83,7 +83,7 @@ public class SerializableTheme implements Serializable {
   }
 
   public Date getCreationDate() {
-    return creationDate;
+    return new Date(creationDate);
   }
 
   public String getCreator() {

--- a/modules/message-broker-impl/pom.xml
+++ b/modules/message-broker-impl/pom.xml
@@ -28,20 +28,16 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-metadata-api</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
     <!-- 3rd party dependencies -->
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-all</artifactId>
+      <artifactId>activemq-client</artifactId>
+      <version>5.15.7</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jms_1.1_spec</artifactId>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activeio-core</artifactId>
+      <version>3.1.4</version>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
@@ -52,16 +48,20 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-jms_1.1_spec</artifactId>
     </dependency>
     <!-- Logging -->
     <dependency>
@@ -69,26 +69,10 @@
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <scope>test</scope>
-    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.xerces</groupId>
-      <artifactId>com.springsource.org.apache.xerces</artifactId>
-      <version>2.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -108,8 +92,18 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
-              !com.thoughtworks.xstream.*,
+              !bsh,
+              !com.barchart.*,
+              !com.fasterxml.*,
+              !com.google.protobuf*,
+              !com.jcraft*;
+              !com.ibm.*,
+              !com.ning.*,
+              !com.sun.jdmk.comm,
+              !com.sun.net.httpserver,
+              !com.thoughtworks.*,
               !javax.ejb.*,
+              !javax.jmdns,
               !junit.framework,
               !org.apache.activeio.*,
               !org.apache.axis.*,
@@ -124,6 +118,7 @@
               !org.codehaus.jam.*,
               !org.josql,
               !org.mortbay.jetty.*,
+              !org.objectweb.*,
               !org.springframework.jms.connection,
               !org.springframework.oxm,
               !org.springframework.xml.transform,
@@ -143,7 +138,8 @@
               *
             </Import-Package>
             <Embed-Dependency>
-              activemq-all;inline=true
+              activemq-client;inline=true,
+              activeio-core;inline=true
             </Embed-Dependency>
             <Private-Package>
               org.opencastproject.message.broker.endpoint
@@ -152,7 +148,6 @@
               org.opencastproject.message.broker.impl;version=${project.version}
             </Export-Package>
             <_exportcontents>
-              javax.jms,
               javax.transaction,
               javax.transaction.xa
             </_exportcontents>

--- a/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageBaseFacility.java
+++ b/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageBaseFacility.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.jms.Connection;
@@ -105,6 +106,7 @@ public class MessageBaseFacility {
     try {
       /* Create a ConnectionFactory for establishing connections to the Active MQ broker */
       ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(url);
+      connectionFactory.setTrustedPackages(Arrays.asList("org.opencastproject.message.broker.api", "java.util"));
       if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
         connectionFactory.setUserName(username);
         connectionFactory.setPassword(password);

--- a/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageBaseFacility.java
+++ b/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageBaseFacility.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.jms.Connection;
@@ -106,7 +106,7 @@ public class MessageBaseFacility {
     try {
       /* Create a ConnectionFactory for establishing connections to the Active MQ broker */
       ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(url);
-      connectionFactory.setTrustedPackages(Arrays.asList("org.opencastproject.message.broker.api", "java.util"));
+      connectionFactory.setTrustedPackages(Collections.singletonList("org.opencastproject.message.broker.api"));
       if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
         connectionFactory.setUserName(username);
         connectionFactory.setPassword(password);

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,11 @@
 
     <!-- library version specifications -->
     <aws.version>1.11.49_1</aws.version>
+    <commons-beanutils.version>1.9.3</commons-beanutils.version>
     <commons-collections.version>4.2</commons-collections.version>
     <commons-compress.version>1.18</commons-compress.version>
     <cxf.version>3.2.6</cxf.version>
-    <eclipselink.version>2.6.4</eclipselink.version>
+    <eclipselink.version>2.7.1</eclipselink.version>
     <functional.version>1.4.2</functional.version>
     <guava.version>23.0</guava.version>
     <httpcomponents-httpclient.version>4.5.6</httpcomponents-httpclient.version>
@@ -30,14 +31,14 @@
     <jackson.version>2.9.7</jackson.version>
     <jdk.version>1.8</jdk.version>
     <json-simple.version>1.1.1</json-simple.version>
-    <karaf.version>4.1.6</karaf.version>
+    <karaf.version>4.2.0</karaf.version>
     <mina.version>2.0.19</mina.version>
     <node.version>v8.12.0</node.version>
     <npm.version>6.4.1</npm.version>
     <osgi.compendium.version>5.0.0</osgi.compendium.version>
     <osgi.core.version>5.0.0</osgi.core.version>
     <osgi.enterprise.version>5.0.0</osgi.enterprise.version>
-    <pax.web.version>6.0.11</pax.web.version>
+    <pax.web.version>7.0.0</pax.web.version>
   </properties>
   <modules>
     <module>modules/admin-ui</module>
@@ -652,9 +653,9 @@
           <version>2.5.2</version>
         </plugin>
         <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>1.6.0</version>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.6.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -668,8 +669,13 @@
       </dependency>
       <dependency>
         <groupId>org.apache.activemq</groupId>
-        <artifactId>activemq-all</artifactId>
-        <version>5.3.1</version>
+        <artifactId>activemq-client</artifactId>
+        <version>5.15.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>activeio-core</artifactId>
+        <version>3.1.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.geronimo.specs</groupId>


### PR DESCRIPTION
This patch updates Opencast to Apache Karaf 4.2 which is the latest
stable branch of Karaf right now. It updates a number of libraries in
the process with the ActiveMQ client library being the most notably
one.

ActiveMQ was hardened against exploitation of Java object
(de-)serialization in the meantime. Something Opencast utterly relies on
for messaging. This patch now allows Opencast's messages explicitly,
preventing any other objects from being sent.