### PR TITLE
MH-13228, Homogeneous Width of Shortcut Icons

### DIFF
--- a/modules/admin-ui/src/main/webapp/styles/views/modals/_hotkey-cheat-sheet.scss
+++ b/modules/admin-ui/src/main/webapp/styles/views/modals/_hotkey-cheat-sheet.scss
@@ -7,6 +7,7 @@
     padding: 2px 9px;
     color: $color-white;
     text-shadow: 1px 1px 0 $color-darkgray;
+    min-width: 32px;
 }
 
 .chord:not(:last-child) {


### PR DESCRIPTION
The icons indicating which key to press in the shortcut overview of the
admin interface all have a different width based on the letters used
which looks add.

This patch sets a minimum with which should create a more homogeneous
design by default while not restricting the width for special cases.

<img src="https://user-images.githubusercontent.com/1008395/48305897-084a9b00-e533-11e8-84d3-39c7acb4691e.png" width="300px" />
