### PR TITLE
MH-13232: Fix potentially negative fade-out start

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -811,8 +811,8 @@ public class EncoderEngine implements AutoCloseable {
         int fileindx = vclip.getSrc(); // get source file by index
         double inpt = vclip.getStart(); // get in points
         double duration = vclip.getDuration();
-        double vend = duration - vfade;
-        double aend = duration - afade;
+        double vend = Math.max(duration - vfade, 0);
+        double aend = Math.max(duration - afade, 0);
         if (hasVideo) {
           String vvclip;
           vvclip = "[" + fileindx + ":v]trim=" + f.format(inpt) + ":duration=" + f.format(duration)
@@ -843,8 +843,8 @@ public class EncoderEngine implements AutoCloseable {
       int fileindx = vclip.getSrc(); // get source file by index
       double inpt = vclip.getStart(); // get in points
       double duration = vclip.getDuration();
-      double vend = duration - vfade;
-      double aend = duration - afade;
+      double vend = Math.max(duration - vfade, 0);
+      double aend = Math.max(duration - afade, 0);
 
       if (hasVideo) {
         String vvclip;


### PR DESCRIPTION
As said in [MH-13232](https://opencast.jira.com/browse/MH-13232), `ffmpeg >= 4.1` does not accept negative values for some parameters anymore. This PR fixes one incarnation of that. Unfortunately I have neither the time, nor the `ffmpeg` knowledge to check for more. But at least the tests should run through again with this patch.

Without it, they failed with the following message:

```
[ERROR] testProcessSmilMultiSegment(org.opencastproject.composer.impl.ProcessSmilTest)  Time elapsed: 0.341 s  <<< ERROR!
org.opencastproject.composer.api.EncoderException: Unable to create a job - Exception processing XML in ProcessSmil
	at org.opencastproject.composer.impl.ProcessSmilTest.testProcessSmilMultiSegment(ProcessSmilTest.java:797)
Caused by: org.opencastproject.composer.api.EncoderException: Unable to create a job
	at org.opencastproject.composer.impl.ProcessSmilTest.testProcessSmilMultiSegment(ProcessSmilTest.java:797)
Caused by: org.opencastproject.serviceregistry.api.ServiceRegistryException: Error handling operation 'ProcessSmil'
	at org.opencastproject.composer.impl.ProcessSmilTest.lambda$setUp$0(ProcessSmilTest.java:289)
	at org.opencastproject.composer.impl.ProcessSmilTest.testProcessSmilMultiSegment(ProcessSmilTest.java:797)
Caused by: org.opencastproject.composer.api.EncoderException: ProcessSmil operation failed to run 
	at org.opencastproject.composer.impl.ProcessSmilTest.lambda$setUp$0(ProcessSmilTest.java:289)
	at org.opencastproject.composer.impl.ProcessSmilTest.testProcessSmilMultiSegment(ProcessSmilTest.java:797)
Caused by: org.opencastproject.composer.api.EncoderException: Cannot encode the inputs
	at org.opencastproject.composer.impl.ProcessSmilTest.lambda$setUp$0(ProcessSmilTest.java:289)
	at org.opencastproject.composer.impl.ProcessSmilTest.testProcessSmilMultiSegment(ProcessSmilTest.java:797)
Caused by: org.opencastproject.composer.api.EncoderException: org.opencastproject.composer.api.EncoderException: Encoder exited abnormally with status 1
	at org.opencastproject.composer.impl.ProcessSmilTest.lambda$setUp$0(ProcessSmilTest.java:289)
	at org.opencastproject.composer.impl.ProcessSmilTest.testProcessSmilMultiSegment(ProcessSmilTest.java:797)
Caused by: org.opencastproject.composer.api.EncoderException: Encoder exited abnormally with status 1
	at org.opencastproject.composer.impl.ProcessSmilTest.lambda$setUp$0(ProcessSmilTest.java:289)
	at org.opencastproject.composer.impl.ProcessSmilTest.testProcessSmilMultiSegment(ProcessSmilTest.java:797)
```