### PR TITLE
MH-13233 - add note about the jdk version use for build

### DIFF
--- a/docs/guides/developer/docs/installation/source-linux.md
+++ b/docs/guides/developer/docs/installation/source-linux.md
@@ -21,7 +21,7 @@ Please make sure to install the following dependencies.
 
 Required:
 
-    java-1.8.0-openjdk-devel.x86_64 / openjdk-8-jdk
+    java-1.8.0-openjdk-devel.x86_64 / openjdk-8-jdk (other jdk versions untested / Oracle JDK strongly not recommended)
     ffmpeg >= 3.2.4
     maven >= 3.1
     unzip


### PR DESCRIPTION
[MH-13233](https://opencast.jira.com/browse/MH-13233?filter=-4) -  the Developer docs the build requirement need to add a warning about use different jdk versions, it's can save a lot of question about builds fail