### PR TITLE
MH-13231: Allow entering multiple metadata values at once

### DIFF
--- a/docs/guides/admin/docs/configuration/metadata.md
+++ b/docs/guides/admin/docs/configuration/metadata.md
@@ -90,6 +90,7 @@ output id to make it easy to find.
 |property.{field-id}.label |"EVENTS.EVENTS.DETAILS.METADATA.TITLE" or "Event Title" |The label to show for this property in the UI. If there is a i18n support for a label that should be the value used so that it will be translated, if you don't mind it being locked to one translation just put that single value in.|
 |property.{field-id}.type |text |The type of the metadata field. |
 |property.{field-id}.pattern |yyyy-MM-dd |Applies to date and time types for now. It is used to format their values using the java DateTimeFormatter values\**|
+|property.{field-id}.delimiter |;|For mixed_text and iterable_text type fields, a string at which inputs into the corresponding fields are split into individual values for easier bulk entry of lists. The default is no delimiter, in which case no splitting takes place.|
 |property.{field-id}.readOnly |false |If the property can be edited in the UI or if it should only be displayed. |
 |property.{field-id}.required |true |If the property has to have a value before the metadata can be saved (the UI's save button will be disabled until all of the required fields are entered)|
 |property.{field-id}.collectionID |USERS |The id of the list provider that will be used to validate the input in the backend. So for example entering a username that doesn't exist will throw an error in this case.|

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableMultiValueDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableMultiValueDirective.js
@@ -33,6 +33,8 @@
  * `required` and `value`.
  * The "save" attribute is a reference to a save function used to persist the
  * values.
+ * The "delimiter" attribute specifies at what character the input string
+ * is to be split into multiple individual values.
  *
  * @example
    <doc:example>
@@ -66,15 +68,22 @@ angular.module('adminNg.directives')
       };
 
       scope.addValue = function (model, value) {
-        if (value && model.indexOf(value) === -1) {
-          model.push(value);
-          scope.editMode = false;
+        if (value) {
+          var newValues = scope.params.delimiter
+            ? value.split(scope.params.delimiter)
+            : [value];
+          angular.forEach(newValues, function (newValue) {
+            newValue = newValue.trim();
+            if (newValue && model.indexOf(newValue) === -1) {
+              model.push(newValue);
+            }
+          });
         }
         scope.submit();
       };
 
-      scope.removeValue = function (model, value) {
-        model.splice(model.indexOf(value), 1);
+      scope.removeValue = function (model, index) {
+        model.splice(index, 1);
         scope.submit();
       };
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
@@ -1,7 +1,7 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
   &nbsp;<ul ng-show="!editMode">
     <li ng-repeat="value in params.value">
-      <span ng-if="value">{{ getText(value) | translate }}</span>
+      <span ng-if="value">{{ getText(value).value | translate }}</span>
     </li>
   </ul>
 
@@ -20,8 +20,8 @@
   </div>
   <span ng-show="editMode" class="ng-multi-value"
                            ng-repeat="value in params.value">
-    {{ getText(value) | translate | limitTo : 70 }}
-    <a ng-mousedown="removeValue(params.value, value)">
+    {{ getText(value).value | translate | limitTo : 70 }}
+    <a ng-mousedown="removeValue($index)">
       <i class="fa fa-times"></i>
     </a>
   </span>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiValue.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiValue.html
@@ -19,7 +19,7 @@
   <span ng-show="editMode" class="ng-multi-value"
                            ng-repeat="value in params.value">
     {{ value | translate }}
-    <a ng-mousedown="removeValue(params.value, value)">
+    <a ng-mousedown="removeValue(params.value, $index)">
       <i class="fa fa-times"></i>
     </a>
   </span>

--- a/modules/admin-ui/src/test/resources/test/unit/shared/directives/editableMultiSelectDirectiveSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/directives/editableMultiSelectDirectiveSpec.js
@@ -40,28 +40,31 @@ describe('adminNg.directives.adminNgEditableMultiSelect', function () {
         expect(element.find('div').length).toBe(1);
     });
 
-    it('saves when adding values', function () {
-        expect(element.scope().params.value).not.toContain('item2');
-
+    function enterValue(value) {
         element.click();
-        element.find('input').val('item2').trigger('change');
+        element.find('input').val(value).trigger('change');
 
         var enter = $.Event('keyup');
         enter.keyCode = 13;
         element.find('input').trigger(enter);
+    }
+
+    it('saves when adding values', function () {
+        expect(element.scope().params.value).not.toContain('Item 2');
+
+        enterValue('item2');
 
         expect($rootScope.save).toHaveBeenCalled();
         expect(element.scope().params.value).toContain('Item 2');
     });
 
     it('saves when removing values', function () {
-        expect(element.scope().params.value).toContain('item1');
+        expect(element.scope().params.value).toContain('Item 1');
 
-        element.click();
         element.find('span.ng-multi-value:first a').mousedown();
 
         expect($rootScope.save).toHaveBeenCalled();
-        expect(element.scope().params.value).not.toContain('item1');
+        expect(element.scope().params.value).not.toContain('Item 1');
     });
 
     xit('autocompletes after entering three characters', function () {
@@ -88,6 +91,35 @@ describe('adminNg.directives.adminNgEditableMultiSelect', function () {
         });
     });
 
+    it('allows entering multiple values at once separated by a given delimiter', function () {
+        element.scope().params.value = ['item1'];
+        element.scope().params.delimiter = ';';
+
+        enterValue('item2;item3');
+
+        expect(element.scope().params.value).toContain('Item 2');
+        expect(element.scope().params.value).toContain('Item 3');
+        expect(element.scope().params.value).not.toContain('item2;item3');
+    });
+
+    it('ignores duplicate values', function () {
+        function count() {
+            var count = 0;
+            angular.forEach(element.scope().params.value, function (value) {
+                if (value == 'Item 2') {
+                    ++count;
+                }
+            });
+            return count;
+        }
+        expect(count()).toBe(0);
+
+        enterValue('item2');
+        enterValue('item2');
+
+        expect(count()).toBe(1);
+    });
+
     describe('#leaveEditMode', function () {
 
         it('leaves edit mode', function () {
@@ -97,18 +129,9 @@ describe('adminNg.directives.adminNgEditableMultiSelect', function () {
 
             scope.leaveEditMode();
 
-            expect(element.scope().params.value).not.toContain('edited')
+            expect(element.scope().params.value).not.toContain('edited');
             expect(scope.editMode).toBe(false);
             expect(scope.data.value).toEqual('edited');
-        });
-    });
-
-    describe('#addValue', function () {
-
-        it('does not save duplicate values', function () {
-            var model = ['unique'];
-            element.find('ul').scope().addValue(model, 'unique');
-            expect(model).toEqual(['unique']);
         });
     });
 
@@ -118,9 +141,8 @@ describe('adminNg.directives.adminNgEditableMultiSelect', function () {
 
         beforeEach(function () {
             event.stopPropagation = jasmine.createSpy();
-            scope = element.find('ul').scope()
+            scope = element.find('ul').scope();
             scope.editMode = true;
-
         });
 
         it('does nothing by default', function () {

--- a/modules/admin-ui/src/test/resources/test/unit/shared/directives/editableMultiValueDirectiveSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/directives/editableMultiValueDirectiveSpec.js
@@ -64,6 +64,22 @@ describe('adminNg.directives.adminNgEditableMultiValue', function () {
         expect(element.scope().params.value).not.toContain('Value 1');
     });
 
+    it('allows entering multiple values at once separated by a given delimiter', function () {
+        element.find('input').scope().params.delimiter = ';';
+
+        element.click();
+        element.find('input').val('a;b;c').trigger('change');
+
+        var enter = $.Event('keyup');
+        enter.keyCode = 13;
+        element.find('input').trigger(enter);
+
+        expect(element.scope().params.value).toContain('a');
+        expect(element.scope().params.value).toContain('b');
+        expect(element.scope().params.value).toContain('c');
+        expect(element.scope().params.value).not.toContain('a;b;c');
+    });
+
     describe('#leaveEditMode', function () {
 
         it('leaves edit mode', function () {

--- a/modules/external-api/src/main/java/org/opencastproject/external/util/ExternalMetadataUtils.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/util/ExternalMetadataUtils.java
@@ -47,7 +47,8 @@ public final class ExternalMetadataUtils {
     MetadataField<Iterable<String>> newSubjects; // = //MetadataUtils.copyMetadataField(subject);
     newSubjects = MetadataField.createIterableStringMetadataField(subject.getInputID(), Opt.some("subjects"),
             subject.getLabel(), subject.isReadOnly(), subject.isRequired(), subject.isTranslatable(),
-            subject.getCollection(), subject.getCollectionID(), subject.getOrder(), subject.getNamespace());
+            subject.getCollection(), subject.getCollectionID(), subject.getDelimiter(), subject.getOrder(),
+            subject.getNamespace());
     List<String> subjectNames = new ArrayList<String>();
     if (subject.getValue().isSome()) {
       subjectNames = com.entwinemedia.fn.Stream.$(subject.getValue().get().toString().split(",")).toList();

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/AbstractMetadataCollection.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/AbstractMetadataCollection.java
@@ -231,8 +231,8 @@ public abstract class AbstractMetadataCollection implements MetadataCollection {
     removeField(current);
     MetadataField<Iterable<String>> field = MetadataField.createIterableStringMetadataField(current.getInputID(),
             Opt.some(current.getOutputID()), current.getLabel(), current.isReadOnly(), current.isRequired(),
-            current.isTranslatable(), current.getCollection(), current.getCollectionID(), current.getOrder(),
-            current.getNamespace());
+            current.isTranslatable(), current.getCollection(), current.getCollectionID(), current.getDelimiter(),
+            current.getOrder(), current.getNamespace());
     field.setValue(value);
     addField(field);
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
@@ -156,7 +156,7 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
                 metadataField.isReadOnly(), metadataField.isRequired(),
                 getCollectionIsTranslatable(metadataField, listProvidersService),
                 getCollection(metadataField, listProvidersService), metadataField.getCollectionID(),
-                metadataField.getOrder(), metadataField.getNamespace());
+                metadataField.getDelimiter(), metadataField.getOrder(), metadataField.getNamespace());
         if (StringUtils.isNotBlank(value)) {
           iterableTextField.setValue(Arrays.asList(value));
         }
@@ -169,7 +169,7 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
                 metadataField.isReadOnly(), metadataField.isRequired(),
                 getCollectionIsTranslatable(metadataField, listProvidersService),
                 getCollection(metadataField, listProvidersService), metadataField.getCollectionID(),
-                metadataField.getOrder(), metadataField.getNamespace());
+                metadataField.getDelimiter(), metadataField.getOrder(), metadataField.getNamespace());
         if (StringUtils.isNotBlank(value)) {
           mixedIterableTextField.setValue(Arrays.asList(value));
         }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/MetadataUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/MetadataUtils.java
@@ -116,6 +116,7 @@ public final class MetadataUtils {
     newField.setNamespace(other.getNamespace());
     newField.setOutputID(Opt.some(other.getOutputID()));
     newField.setPattern(other.getPattern());
+    newField.setDelimiter(other.getDelimiter());
     newField.setOrder(other.getOrder());
     newField.setReadOnly(other.isReadOnly());
     newField.setRequired(other.isRequired());


### PR DESCRIPTION
This is my attempt at implementing [MH-13231](https://opencast.jira.com/browse/MH-13231). With this, you can add a `delimiter` field to any metadata field configuration block in the catalog UI adapter configuration files where the type is `iterable_text` or `mixed_text`. This delimiter is passed to the frontend and the frontend will split inputs into the appropriate fields at this delimiter. If no delimiter is configured, no splitting takes place.

The `editableMulti*Directive` code handling the `iterable_` ad `mixed_text` fields is not the best, unfortunately. I indulged a bit in refactoring it, although one could certainly do more.

In fact, I tried that in the beginning but was running into problems when chaning the structure of the directive too much. It turns out that there is subtle implicit asynchrony going on here leading to race conditions and similar effects all over the place.

Thus, the code I added is unfortunately not of the highest quality, either; if I find some time in the (hopefully) near future, I would like to try again to refactor the whole thing. Until then I hope I didn't make things worse and I can of course fix any major grievances that offend the comitters' taste. :wink: 