### PR TITLE
MH-12332, disable workflows whose tags don't explicitly match the source type, UPLOAD|SCHEDULE 5.x

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1772,7 +1772,8 @@ public abstract class AbstractEventEndpoint {
       for (WorkflowDefinition wflDef : workflowsDefinitions) {
         if (wflDef.containsTag(tags)) {
 
-          workflows.add(obj(f("id", v(wflDef.getId())), f("title", v(nul(wflDef.getTitle()).getOr(""))),
+          workflows.add(obj(f("id", v(wflDef.getId())), f("tags", arr(wflDef.getTags())),
+                  f("title", v(nul(wflDef.getTitle()).getOr(""))),
                   f("description", v(nul(wflDef.getDescription()).getOr(""))),
                   f("configuration_panel", v(nul(wflDef.getConfigurationPanel()).getOr("")))));
         }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -473,7 +473,8 @@
                         data-disable-search-threshold="0"
                         data-search_contains="true"
                         ng-model="wizard.step.ud.workflow"
-                        ng-options="w.title for (obj, w) in wizard.step.workflows"
+                        ng-options="w.title for (obj, w) in wizard.step.workflows |
+                                  filter: wizard.getStateControllerByName('source').ud.type==='UPLOAD' ? 'upload-ng' : 'schedule-ng'"
                         placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW' | translate }}'"
                         no-results-text="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY' | translate }}'"
                     >

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -474,7 +474,7 @@
                         data-search_contains="true"
                         ng-model="wizard.step.ud.workflow"
                         ng-options="w.title for (obj, w) in wizard.step.workflows |
-                                  filter: wizard.getStateControllerByName('source').ud.type==='UPLOAD' ? 'upload-ng' : 'schedule-ng'"
+                                  filter: wizard.getStateControllerByName('source').ud.type==='UPLOAD' ? 'upload' : 'schedule'"
                         placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW' | translate }}'"
                         no-results-text="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY' | translate }}'"
                     >

--- a/modules/admin-ui/src/test/resources/newEventProcessing.json
+++ b/modules/admin-ui/src/test/resources/newEventProcessing.json
@@ -5,12 +5,14 @@
       {
         "id": "full",
         "title": "Full",
+        "tags": [],
         "description": "",
         "configuration_panel": ""
       },
       {
         "id": "full-html5",
         "title": "Full HTML5",
+        "tags": ["quick_actions","test"],
         "description": "Test description",
         "configuration_panel": "<h2>Test</h2>"
       }

--- a/modules/admin-ui/src/test/resources/newEventProcessing2.json
+++ b/modules/admin-ui/src/test/resources/newEventProcessing2.json
@@ -5,6 +5,7 @@
     {
       "id": "full-html5",
       "title": "Full HTML5",
+        "tags": ["quick_actions","test"],
       "description": "Test description",
       "configuration_panel": "<h2>Test</h2>"
     }


### PR DESCRIPTION
ported from the 4.x commit that conflicted with 5.x