### PR TITLE
MH-13214, Fix HTTP Digest Authentication

### DIFF
--- a/modules/userdirectory/src/main/resources/OSGI-INF/user-and-role-directory-service.xml
+++ b/modules/userdirectory/src/main/resources/OSGI-INF/user-and-role-directory-service.xml
@@ -27,8 +27,6 @@
     </service>
     <reference name="securityService" interface="org.opencastproject.security.api.SecurityService"
                cardinality="1..1" policy="static" bind="setSecurityService"/>
-    <reference name="orgDirectory" interface="org.opencastproject.security.api.OrganizationDirectoryService"
-               cardinality="1..1" policy="static" bind="setOrganizationDirectoryService"/>
   </scr:component>
 
   <scr:component name="org.opencastproject.userdirectory.RoleEndpoint" immediate="true">


### PR DESCRIPTION
On the first start of Opencast, sometimes, everything appears normal but
digest authentication does not function, including service heartbeats.
This causes Opencast to fail to perform any processing, as well as
disabling communication with capture agents, and other
digest-integrators.

The problem is basically that when the in-memory user-provider is
initialized, it will create a system user for every registered
organization allowing the system access we want.

But the initialization of the organizations is happening in parallel
and nothing guarantees that all, or in fact any, organizations are
created by the time the user is created. This means that it may always
happen that there is no digest user for some (or all) of the
organizations which then means that the system digest requests will
fail for that organization.

This patch changes the behavior to create the organization specific
users the first time that organization is requested, thus guaranteeing
the organizations existence even for organizations created at runtime.

It also switches to a more performant storage of these users (access
always happens on an organizational basis and it hence make sense to use
an organization based storage instead of one global list) and a
modern, less obscure delivery of users (removing Entwine's functional
library).