### PR TITLE
Documentation: Opencast 5.2 was released in Nov

### DIFF
--- a/docs/guides/admin/docs/changelog.md
+++ b/docs/guides/admin/docs/changelog.md
@@ -6,7 +6,7 @@ Opencast 5
 
 ### Opencast 5.2
 
-*Released on September 13, 2018*
+*Released on November 13, 2018*
 
 - [[MH-13144](https://opencast.jira.com/browse/MH-13144)][[#553](https://github.com/opencast/opencast/pull/553)] -
   only set Job startDate if no set before


### PR DESCRIPTION
Documentation: Changelog: Opencast 5.2 was released in November 2018, not in September.