### PR TITLE
MH-13239: Docs: Fix 'Edit on GitHub' link

### DIFF
--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Opencast - Administration Guide
-repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/admin/docs
+repo_url: https://github.com/opencast/opencast
+edit_uri: edit/develop/docs/guides/admin/docs/
 
 # Default theme used is readthedocs
 theme: readthedocs

--- a/docs/guides/developer/mkdocs.yml
+++ b/docs/guides/developer/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Opencast - Developer Guide
-repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/developer/docs
+repo_url: https://github.com/opencast/opencast
+edit_uri: edit/develop/docs/guides/developer/docs/
 
 # Default theme used is readthedocs
 theme: readthedocs

--- a/docs/guides/user/mkdocs.yml
+++ b/docs/guides/user/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Opencast - Users Guide
-repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/user/docs
+repo_url: https://github.com/opencast/opencast
+edit_uri: edit/develop/docs/guides/user/docs/
 
 # Default theme used is readthedocs
 theme: readthedocs


### PR DESCRIPTION
C.f. https://www.mkdocs.org/user-guide/configuration/

repo_url
When set, provides a link to your repository.

edit_uri
To use a different URI than the default (for example a
different branch), simply set the edit_uri to your desired
string.

Fixes:
![oc-docs](https://user-images.githubusercontent.com/6669916/48662792-4b52c400-ea87-11e8-8ab7-ad400a08d795.png)
