### PR TITLE
MH-13241, Filter Fileinstall Artifacts

### DIFF
--- a/etc/org.apache.felix.fileinstall-acl.cfg
+++ b/etc/org.apache.felix.fileinstall-acl.cfg
@@ -1,6 +1,9 @@
 # The name of the directory to watch.
 felix.fileinstall.dir=${karaf.etc}/acl
 
+# Filter accepted files (only allow xml files)
+felix.fileinstall.filter=.*\\.xml
+
 # Number of milliseconds between 2 polls of the directory
 felix.fileinstall.poll=5000
 

--- a/etc/org.apache.felix.fileinstall-encoding.cfg
+++ b/etc/org.apache.felix.fileinstall-encoding.cfg
@@ -1,6 +1,9 @@
 # The name of the directory to watch.
 felix.fileinstall.dir=${karaf.etc}/encoding
 
+# Filter accepted files (only allow .properties files)
+felix.fileinstall.filter=.*\\.properties
+
 # Number of milliseconds between 2 polls of the directory
 felix.fileinstall.poll=5000
 

--- a/etc/org.apache.felix.fileinstall-feeds.cfg
+++ b/etc/org.apache.felix.fileinstall-feeds.cfg
@@ -1,6 +1,9 @@
 # The name of the directory to watch.
 felix.fileinstall.dir=${karaf.etc}/feeds
 
+# Filter accepted files (only allow .properties files)
+felix.fileinstall.filter=.*\\.properties
+
 # Number of milliseconds between 2 polls of the directory
 felix.fileinstall.poll=5000
 

--- a/etc/org.apache.felix.fileinstall-listproviders.cfg
+++ b/etc/org.apache.felix.fileinstall-listproviders.cfg
@@ -1,6 +1,9 @@
 # The name of the directory to watch.
 felix.fileinstall.dir=${karaf.etc}/listproviders
 
+# Filter accepted files (only allow .properties files)
+felix.fileinstall.filter=.*\\.properties
+
 # Number of milliseconds between 2 polls of the directory
 felix.fileinstall.poll=5000
 

--- a/etc/org.apache.felix.fileinstall-security.cfg
+++ b/etc/org.apache.felix.fileinstall-security.cfg
@@ -1,6 +1,9 @@
 # The name of the directory to watch.
 felix.fileinstall.dir=${karaf.etc}/security
 
+# Filter accepted files (only allow xml files)
+felix.fileinstall.filter=.*\\.xml
+
 # Number of milliseconds between 2 polls of the directory
 felix.fileinstall.poll=5000
 

--- a/etc/org.apache.felix.fileinstall-workflows.cfg
+++ b/etc/org.apache.felix.fileinstall-workflows.cfg
@@ -1,6 +1,9 @@
 # The name of the directory to watch.
 felix.fileinstall.dir=${karaf.etc}/workflows
 
+# Filter accepted files (only allow xml files)
+felix.fileinstall.filter=.*\\.xml
+
 # Number of milliseconds between 2 polls of the directory
 felix.fileinstall.poll=5000
 


### PR DESCRIPTION
Instead of loading all files, let fileinstall filter artifacts by their
file extension to avoid unnecessary loading.