### PR TITLE
MH-12816 Make waveform size configurable in WOH

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/waveform-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/waveform-woh.md
@@ -15,12 +15,16 @@ one audio channel.
 Parameter Table
 ---------------
 
-|configuration |example     |description                                                     |
-|--------------|------------|----------------------------------------------------------------|
-|source-flavors|`*/audio`   |Flavor specifying tracks for which a waveform should be created |
-|source-tags   |`edit`      |Tags specifying tracks for which a waveform should be created   |
-|target-flavor |`*/waveform`|Flavor used for the generated waveform                          |
-|target-tags   |`preview`   |Comma-separated list of tags to be added to the waveform        |
+configuration     |example     |description                                                     |default
+------------------|------------|----------------------------------------------------------------|-------
+source-flavors    |`*/audio`   |Flavor specifying tracks for which a waveform should be created |n/a
+source-tags       |`edit`      |Tags specifying tracks for which a waveform should be created   |n/a
+target-flavor     |`*/waveform`|Flavor used for the generated waveform                          |n/a
+target-tags       |`preview`   |Comma-separated list of tags to be added to the waveform        |n/a
+pixels-per-minute |400         |Width of waveform image in pixels per minute                    |200
+min-width         |10000       |Minimum width of waveform image in pixels                       |5000
+max-width         |30000       |Maximum width of waveform image in pixels                       |20000
+height            |60          |Height of waveform image in pixels                              |500
 
 Additional notes:
 
@@ -38,5 +42,9 @@ Operation Example
         <configuration key="source-flavor">*/audio</configuration>
         <configuration key="target-flavor">*/waveform</configuration>
         <configuration key="target-tags">preview</configuration>
+        <configuration key="pixels-per-minute">200</configuration>
+        <configuration key="min-width">5000</configuration>
+        <configuration key="max-width">20000</configuration>
+        <configuration key="height">60</configuration>
       </configurations>
     </operation>

--- a/etc/org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg
+++ b/etc/org.opencastproject.waveform.ffmpeg.WaveformServiceImpl.cfg
@@ -2,22 +2,6 @@
 # Default: 0.1
 #job.load.waveform=0.1
 
-# Waveform output image minimum width in pixels.
-# default: 5000
-#waveform.image.width.min = 5000
-
-# Waveform output image maximum width in pixels.
-# default: 20000
-#waveform.image.width.max = 20000
-
-# Waveform output image width in pixels per minute of video duration.
-# default: 200
-#waveform.image.width.ppm = 200
-
-# Waveform output image height in pixels.
-# default: 500
-#waveform.image.height = 500
-
 # Waveform color. This value can be a predefined color (see https://www.ffmpeg.org/ffmpeg-all.html#Color)
 # or have this format: [0x]RRGGBB[AA]
 # You can define one color per audio channel separated by a whitespace

--- a/etc/workflows/partial-preview.xml
+++ b/etc/workflows/partial-preview.xml
@@ -97,9 +97,6 @@
       </configurations>
     </operation>
 
-    <!-- Once WOH waveform supports setting the image size of the waveform image,
-         those preview images should be way smaller than the preview image used for the timeline
-         as those previews cannot be zoomed -->
     <operation
       id="waveform"
       fail-on-error="false"
@@ -108,6 +105,9 @@
         <configuration key="source-flavor">*/work</configuration>
         <configuration key="target-flavor">*/audio+preview</configuration>
         <configuration key="target-tags">preview</configuration>
+        <configuration key="min-width">688</configuration>
+        <configuration key="max-width">688</configuration>
+        <configuration key="height">58</configuration>
       </configurations>
     </operation>
 

--- a/modules/waveform-api/src/main/java/org/opencastproject/waveform/api/WaveformService.java
+++ b/modules/waveform-api/src/main/java/org/opencastproject/waveform/api/WaveformService.java
@@ -36,9 +36,14 @@ public interface WaveformService {
    * Takes the given track and returns the job that will create a waveform image.
    *
    * @param sourceTrack the track to create waveform image from
+   * @param pixelPerMinute the width of the waveform image in pixels per minute
+   * @param minWidth the minimum width of the waveform image
+   * @param maxWidth the maximum width of the waveform image
+   * @param height the height of the waveform image
    * @return a job that will create a waveform image
    * @throws MediaPackageException if the serialization of the given track fails
    * @throws WaveformServiceException if the job can't be created for any reason
    */
-  Job createWaveformImage(Track sourceTrack) throws MediaPackageException, WaveformServiceException;
+  Job createWaveformImage(Track sourceTrack, int pixelPerMinute, int minWidth, int maxWidth, int height)
+    throws MediaPackageException, WaveformServiceException;
 }

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/endpoint/WaveformServiceEndpoint.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/endpoint/WaveformServiceEndpoint.java
@@ -65,7 +65,15 @@ public class WaveformServiceEndpoint extends AbstractJobProducerEndpoint {
           returnDescription = "Media package attachment for the generated waveform.",
           restParameters = {
             @RestParameter(name = "track", type = RestParameter.Type.TEXT,
-                    description = "Track with at least one audio channel.", isRequired = true)
+                    description = "Track with at least one audio channel.", isRequired = true),
+            @RestParameter(name = "pixelsPerMinute", type = RestParameter.Type.INTEGER,
+                    description = "Width of waveform image in pixels per minute.", isRequired = true),
+            @RestParameter(name = "minWidth", type = RestParameter.Type.INTEGER,
+                    description = "Minimum width of waveform image.", isRequired = true),
+            @RestParameter(name = "maxWidth", type = RestParameter.Type.INTEGER,
+                    description = "Maximum width of waveform image.", isRequired = true),
+            @RestParameter(name = "height", type = RestParameter.Type.INTEGER,
+                    description = "Height of waveform image.", isRequired = true)
           },
           reponses = {
             @RestResponse(description = "Waveform generation job successfully created.",
@@ -75,13 +83,15 @@ public class WaveformServiceEndpoint extends AbstractJobProducerEndpoint {
             @RestResponse(description = "Internal server error.",
                     responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
   })
-  public Response createWaveformImage(@FormParam("track") String track) {
+  public Response createWaveformImage(@FormParam("track") String track,
+    @FormParam("pixelsPerMinute") int pixelsPerMinute, @FormParam("minWidth") int minWidth,
+    @FormParam("maxWidth") int maxWidth, @FormParam("height") int height) {
     try {
       MediaPackageElement sourceTrack = MediaPackageElementParser.getFromXml(track);
       if (!Track.TYPE.equals(sourceTrack.getElementType()))
         return Response.status(Response.Status.BAD_REQUEST).entity("Track element must be of type track").build();
 
-      Job job = waveformService.createWaveformImage((Track) sourceTrack);
+      Job job = waveformService.createWaveformImage((Track) sourceTrack, pixelsPerMinute, minWidth, maxWidth, height);
       return Response.ok().entity(new JaxbJob(job)).build();
     } catch (WaveformServiceException ex) {
       logger.error("Creating waveform job for track {} failed: {}", track, ExceptionUtils.getStackTrace(ex));

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -59,7 +59,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -88,30 +87,6 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
 
   /** The default path to the ffmpeg binary */
   public static final String DEFAULT_FFMPEG_BINARY = "ffmpeg";
-
-  /** The default minimum waveform image width in pixels */
-  public static final int DEFAULT_WAVEFORM_IMAGE_WIDTH_MIN = 5000;
-
-  /** The default maximum waveform image width in pixels */
-  public static final int DEFAULT_WAVEFORM_IMAGE_WIDTH_MAX = 20000;
-
-  /** The default waveform image width per minute of video in pixels */
-  public static final int DEFAULT_WAVEFORM_IMAGE_WIDTH_PIXEL_PER_MINUTE = 200;
-
-  /** The key to look for in the service configuration file to override the DEFAULT_WAVEFORM_IMAGE_WIDTH_MIN */
-  public static final String WAVEFORM_IMAGE_WIDTH_MIN_CONFIG_KEY = "waveform.image.width.min";
-
-  /** The key to look for in the service configuration file to override the DEFAULT_WAVEFORM_IMAGE_WIDTH_MAX */
-  public static final String WAVEFORM_IMAGE_WIDTH_MAX_CONFIG_KEY = "waveform.image.width.max";
-
-  /** The key to look for in the service configuration file to override the DEFAULT_WAVEFORM_IMAGE_WIDTH_PIXEL_PER_MINUTE */
-  public static final String WAVEFORM_IMAGE_WIDTH_PPM_CONFIG_KEY = "waveform.image.width.ppm";
-
-  /** The default waveform image height in pixels */
-  public static final int DEFAULT_WAVEFORM_IMAGE_HEIGHT = 500;
-
-  /** The key to look for in the service configuration file to override the DEFAULT_WAVEFORM_IMAGE_HEIGHT */
-  public static final String WAVEFORM_IMAGE_HEIGHT_CONFIG_KEY = "waveform.image.height";
 
   /** The default waveform image scale algorithm */
   public static final String DEFAULT_WAVEFORM_SCALE = "lin";
@@ -154,18 +129,6 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
 
   /** The waveform job load */
   private float waveformJobLoad = DEFAULT_WAVEFORM_JOB_LOAD;
-
-  /** The minimum waveform image width in pixels */
-  private int waveformImageWidthMin = DEFAULT_WAVEFORM_IMAGE_WIDTH_MIN;
-
-  /** The maximum waveform image width in pixels */
-  private int waveformImageWidthMax = DEFAULT_WAVEFORM_IMAGE_WIDTH_MAX;
-
-  /** The waveform image width per minute of video in pixels */
-  private int waveformImageWidthPPM = DEFAULT_WAVEFORM_IMAGE_WIDTH_PIXEL_PER_MINUTE;
-
-  /** The waveform image height in pixels */
-  private int waveformImageHeight = DEFAULT_WAVEFORM_IMAGE_HEIGHT;
 
   /** The waveform image scale algorithm */
   private String waveformScale = DEFAULT_WAVEFORM_SCALE;
@@ -220,47 +183,7 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
     waveformJobLoad = LoadUtil.getConfiguredLoadValue(properties,
             WAVEFORM_JOB_LOAD_CONFIG_KEY, DEFAULT_WAVEFORM_JOB_LOAD, serviceRegistry);
 
-    Object val = properties.get(WAVEFORM_IMAGE_WIDTH_MIN_CONFIG_KEY);
-    if (val != null) {
-      try {
-        waveformImageWidthMin = Integer.parseInt((String) val);
-      } catch (NumberFormatException ex) {
-        logger.warn("The configuration value for {} should be an integer but is {}",
-                WAVEFORM_IMAGE_WIDTH_MIN_CONFIG_KEY, val);
-      }
-    }
-
-    val = properties.get(WAVEFORM_IMAGE_WIDTH_MAX_CONFIG_KEY);
-    if (val != null) {
-      try {
-        waveformImageWidthMax = Integer.parseInt((String) val);
-      } catch (NumberFormatException ex) {
-        logger.warn("The configuration value for {} should be an integer but is {}",
-                WAVEFORM_IMAGE_WIDTH_MAX_CONFIG_KEY, val);
-      }
-    }
-
-    val = properties.get(WAVEFORM_IMAGE_WIDTH_PPM_CONFIG_KEY);
-    if (val != null) {
-      try {
-        waveformImageWidthPPM = Integer.parseInt((String) val);
-      } catch (NumberFormatException ex) {
-        logger.warn("The configuration value for {} should be an integer but is {}",
-                WAVEFORM_IMAGE_WIDTH_PPM_CONFIG_KEY, val);
-      }
-    }
-
-    val = properties.get(WAVEFORM_IMAGE_HEIGHT_CONFIG_KEY);
-    if (val != null) {
-      try {
-        waveformImageHeight = Integer.parseInt((String) val);
-      } catch (NumberFormatException ex) {
-        logger.warn("The configuration value for {} should be an integer but is {}",
-                WAVEFORM_IMAGE_HEIGHT_CONFIG_KEY, val);
-      }
-    }
-
-    val = properties.get(WAVEFORM_SCALE_CONFIG_KEY);
+    Object val = properties.get(WAVEFORM_SCALE_CONFIG_KEY);
     if (val != null) {
       if (StringUtils.isNotEmpty((String) val)) {
         if (!"lin".equals(val) && !"log".equals(val)) {
@@ -305,10 +228,12 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
    * @see org.opencastproject.waveform.api.WaveformService#createWaveformImage(org.opencastproject.mediapackage.Track)
    */
   @Override
-  public Job createWaveformImage(Track sourceTrack) throws MediaPackageException, WaveformServiceException {
+  public Job createWaveformImage(Track sourceTrack, int pixelsPerMinute, int minWidth, int maxWidth, int height)
+      throws MediaPackageException, WaveformServiceException {
     try {
       return serviceRegistry.createJob(jobType, Operation.Waveform.toString(),
-              Collections.singletonList(MediaPackageElementParser.getAsXml(sourceTrack)), waveformJobLoad);
+              Arrays.asList(MediaPackageElementParser.getAsXml(sourceTrack), Integer.toString(pixelsPerMinute),
+                Integer.toString(minWidth), Integer.toString(maxWidth), Integer.toString(height)), waveformJobLoad);
     } catch (ServiceRegistryException ex) {
       throw new WaveformServiceException("Unable to create waveform job", ex);
     }
@@ -329,7 +254,11 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
       switch (op) {
         case Waveform:
           Track track = (Track) MediaPackageElementParser.getFromXml(arguments.get(0));
-          Attachment waveformMpe = extractWaveform(track);
+          int pixelsPerMinute = Integer.parseInt(arguments.get(1));
+          int minWidth = Integer.parseInt(arguments.get(2));
+          int maxWidth = Integer.parseInt(arguments.get(3));
+          int height = Integer.parseInt(arguments.get(4));
+          Attachment waveformMpe = extractWaveform(track, pixelsPerMinute, minWidth, maxWidth, height);
           return MediaPackageElementParser.getAsXml(waveformMpe);
         default:
           throw new ServiceRegistryException("This service can't handle operations of type '" + op + "'");
@@ -345,10 +274,15 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
    * Create and run waveform extraction ffmpeg command.
    *
    * @param track source audio/video track with at least one audio channel
+   * @param pixelsPerMinute width of waveform image in pixels per minute
+   * @param minWidth minimum width of waveform image
+   * @param maxWidth maximum width of waveform image
+   * @param height height of waveform image
    * @return waveform image attachment
    * @throws WaveformServiceException if processing fails
    */
-  private Attachment extractWaveform(Track track) throws WaveformServiceException {
+  private Attachment extractWaveform(Track track, int pixelsPerMinute, int minWidth, int maxWidth, int height)
+    throws WaveformServiceException {
     if (!track.hasAudio()) {
       throw new WaveformServiceException("Track has no audio");
     }
@@ -368,12 +302,14 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
     String waveformFilePath = FilenameUtils.removeExtension(mediaFile.getAbsolutePath())
             .concat('-' + track.getIdentifier()).concat("-waveform.png");
 
+    int width = getWaveformImageWidth(track, pixelsPerMinute, minWidth, maxWidth);
+
     // create ffmpeg command
     String[] command = new String[] {
       binary,
       "-nostats",
       "-i", mediaFile.getAbsolutePath(),
-      "-lavfi", createWaveformFilter(track),
+      "-lavfi", createWaveformFilter(track, width, height),
       "-an", "-vn", "-sn", "-y",
       waveformFilePath
     };
@@ -450,9 +386,13 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
    * Create an ffmpeg waveform filter with parameters based on input track and service configuration.
    *
    * @param track source audio/video track with at least one audio channel
+   * @param pixelsPerMinute width of waveform image in pixels per minute
+   * @param minWidth minimum width of waveform image
+   * @param maxWidth maximum width of waveform image
+   * @param height height of waveform image
    * @return ffmpeg filter parameter
    */
-  private String createWaveformFilter(Track track) {
+  private String createWaveformFilter(Track track, int width, int height) {
     StringBuilder filterBuilder = new StringBuilder("");
     if (waveformFilterPre != null) {
       filterBuilder.append(waveformFilterPre);
@@ -462,9 +402,9 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
     filterBuilder.append("split_channels=");
     filterBuilder.append(waveformSplitChannels ? 1 : 0);
     filterBuilder.append(":s=");
-    filterBuilder.append(getWaveformImageWidth(track));
+    filterBuilder.append(width);
     filterBuilder.append("x");
-    filterBuilder.append(waveformImageHeight);
+    filterBuilder.append(height);
     filterBuilder.append(":scale=");
     filterBuilder.append(waveformScale);
     filterBuilder.append(":colors=");
@@ -480,15 +420,18 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
    * Return the waveform image width build from input track and service configuration.
    *
    * @param track source audio/video track with at least one audio channel
+   * @param pixelsPerMinute width of waveform image in pixels per minute
+   * @param minWidth minimum width of waveform image
+   * @param maxWidth maximum width of waveform image
    * @return waveform image width
    */
-  private int getWaveformImageWidth(Track track) {
-    int imageWidth = waveformImageWidthMin;
+  private int getWaveformImageWidth(Track track, int pixelsPerMinute, int minWidth, int maxWidth) {
+    int imageWidth = minWidth;
     if (track.getDuration() > 0) {
       int trackDurationMinutes = (int) TimeUnit.MILLISECONDS.toMinutes(track.getDuration());
-      if (waveformImageWidthPPM > 0 && trackDurationMinutes > 0) {
-        imageWidth = Math.max(waveformImageWidthMin, trackDurationMinutes * waveformImageWidthPPM);
-        imageWidth = Math.min(waveformImageWidthMax, imageWidth);
+      if (pixelsPerMinute > 0 && trackDurationMinutes > 0) {
+        imageWidth = Math.max(minWidth, trackDurationMinutes * pixelsPerMinute);
+        imageWidth = Math.min(maxWidth, imageWidth);
       }
     }
     return imageWidth;

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -387,9 +387,7 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
    * Create an ffmpeg waveform filter with parameters based on input track and service configuration.
    *
    * @param track source audio/video track with at least one audio channel
-   * @param pixelsPerMinute width of waveform image in pixels per minute
-   * @param minWidth minimum width of waveform image
-   * @param maxWidth maximum width of waveform image
+   * @param width width of waveform image
    * @param height height of waveform image
    * @return ffmpeg filter parameter
    */

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -225,7 +225,8 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
   /**
    * {@inheritDoc}
    *
-   * @see org.opencastproject.waveform.api.WaveformService#createWaveformImage(org.opencastproject.mediapackage.Track)
+   * @see org.opencastproject.waveform.api.WaveformService#createWaveformImage(org.opencastproject.mediapackage.Track,
+   *         int, int, int, int)
    */
   @Override
   public Job createWaveformImage(Track sourceTrack, int pixelsPerMinute, int minWidth, int maxWidth, int height)

--- a/modules/waveform-ffmpeg/src/test/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImplTest.java
+++ b/modules/waveform-ffmpeg/src/test/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImplTest.java
@@ -96,10 +96,6 @@ public class WaveformServiceImplTest {
   @Test
   public void testUpdated() throws Exception {
     Dictionary<String, String> properties = new Hashtable<>();
-    properties.put(WaveformServiceImpl.WAVEFORM_IMAGE_WIDTH_MIN_CONFIG_KEY, "1000");
-    properties.put(WaveformServiceImpl.WAVEFORM_IMAGE_WIDTH_MAX_CONFIG_KEY, "2000");
-    properties.put(WaveformServiceImpl.WAVEFORM_IMAGE_WIDTH_PPM_CONFIG_KEY, "100");
-    properties.put(WaveformServiceImpl.WAVEFORM_IMAGE_HEIGHT_CONFIG_KEY, "480");
     properties.put(WaveformServiceImpl.WAVEFORM_COLOR_CONFIG_KEY, "blue green 0x2A2A2A 323232CC");
     properties.put(WaveformServiceImpl.WAVEFORM_SPLIT_CHANNELS_CONFIG_KEY, "false");
     properties.put(WaveformServiceImpl.WAVEFORM_SCALE_CONFIG_KEY, "lin");
@@ -134,7 +130,7 @@ public class WaveformServiceImplTest {
 
     WaveformServiceImpl instance = new WaveformServiceImpl();
     instance.setServiceRegistry(serviceRegistry);
-    Job job = instance.createWaveformImage(dummyTrack);
+    Job job = instance.createWaveformImage(dummyTrack, 200, 5000, 20000, 500);
     assertEquals(expectedJob, job);
   }
 
@@ -159,7 +155,7 @@ public class WaveformServiceImplTest {
     Job job = new JobImpl(1);
     job.setJobType(WaveformServiceImpl.JOB_TYPE);
     job.setOperation(WaveformServiceImpl.Operation.Waveform.toString());
-    job.setArguments(Arrays.asList(audioTrackXml));
+    job.setArguments(Arrays.asList(audioTrackXml, "200", "5000", "20000", "500"));
     String result = instance.process(job);
     assertNotNull(result);
 

--- a/modules/waveform-remote/src/main/java/org/opencastproject/waveform/remote/WaveformServiceRemote.java
+++ b/modules/waveform-remote/src/main/java/org/opencastproject/waveform/remote/WaveformServiceRemote.java
@@ -55,16 +55,25 @@ public class WaveformServiceRemote extends RemoteBase implements WaveformService
    * Takes the given track and returns the job that will create an waveform image using a remote service.
    *
    * @param sourceTrack the track to create waveform image from
+   * @param pixelsPerMinute the width of the waveform image in pixels per minute
+   * @param minWidth the minimum width of the waveform image
+   * @param maxWidth the maximum width of the waveform image
+   * @param height the height of the waveform image
    * @return a job that will create a waveform image
    * @throws MediaPackageException if the serialization of the given track fails
    * @throws WaveformServiceException if the job can't be created for any reason
    */
   @Override
-  public Job createWaveformImage(Track sourceTrack) throws MediaPackageException, WaveformServiceException {
+  public Job createWaveformImage(Track sourceTrack, int pixelsPerMinute, int minWidth, int maxWidth, int height)
+    throws MediaPackageException, WaveformServiceException {
     HttpPost post = new HttpPost("/create");
     try {
       List<BasicNameValuePair> params = new ArrayList<>();
       params.add(new BasicNameValuePair("track", MediaPackageElementParser.getAsXml(sourceTrack)));
+      params.add(new BasicNameValuePair("pixelsPerMinute", Integer.toString(pixelsPerMinute)));
+      params.add(new BasicNameValuePair("minWidth", Integer.toString(minWidth)));
+      params.add(new BasicNameValuePair("maxWidth", Integer.toString(maxWidth)));
+      params.add(new BasicNameValuePair("height", Integer.toString(height)));
       post.setEntity(new UrlEncodedFormEntity(params));
     } catch (Exception e) {
       throw new WaveformServiceException(e);

--- a/modules/waveform-workflowoperation/src/test/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandlerTest.java
+++ b/modules/waveform-workflowoperation/src/test/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandlerTest.java
@@ -92,7 +92,8 @@ public class WaveformWorkflowOperationHandlerTest {
     job.setPayload(MediaPackageElementParser.getAsXml(payload));
 
     WaveformService waveformService = EasyMock.createNiceMock(WaveformService.class);
-    EasyMock.expect(waveformService.createWaveformImage(EasyMock.anyObject())).andReturn(job);
+    EasyMock.expect(waveformService.createWaveformImage(EasyMock.anyObject(), EasyMock.anyInt(), EasyMock.anyInt(),
+      EasyMock.anyInt(), EasyMock.anyInt())).andReturn(job);
 
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
 


### PR DESCRIPTION
The size of the waveform image that is produced by the waveform service can currently only be configured globally.
This patch moves the configuration parameters relevant for waveform image size from the waveform service
configuration to the workflow operation configuration so that Opencast can produce different waveform sizes.