### PR TITLE
MH-13243, Asset Manager ACL Cache Updates

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
@@ -238,10 +238,17 @@ public class AssetManagerWithSecurity extends AssetManagerDecorator {
   }
 
   private void storeAclAsProperties(Snapshot snapshot, AccessControlList acl) {
+    final String mediaPackageId =  snapshot.getMediaPackage().getIdentifier().toString();
+    // Drop old ACL rules
+    final AQueryBuilder queryBuilder = createQuery();
+    queryBuilder.delete(snapshot.getOwner(), queryBuilder.propertiesOf(SECURITY_NAMESPACE))
+            .where(queryBuilder.mediaPackageId(mediaPackageId))
+            .run();
+    // Set new ACL rules
     for (final AccessControlEntry ace : acl.getEntries()) {
       super.setProperty(Property.mk(
           PropertyId.mk(
-              snapshot.getMediaPackage().getIdentifier().toString(),
+              mediaPackageId,
               SECURITY_NAMESPACE,
               mkPropertyName(ace)),
           Value.mk(ace.isAllow())));


### PR DESCRIPTION
This patch ensures that the internal asset manager ACL cache gets
updated and no old rules are left in the database.

*Work sponsored by SWITCH*