### PR TITLE
MH-13244 Improve concurrency of OAIPMH republication

### DIFF
--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
@@ -223,7 +223,8 @@ public class TestRestService extends AbstractAclServiceRestEndpoint {
     try {
       EasyMock.expect(seriesService.getSeriesAccessControl((String) EasyMock.anyObject())).andReturn(acl).anyTimes();
       EasyMock.expect(seriesService.updateAccessControl((String) EasyMock.anyObject(),
-              (AccessControlList) EasyMock.anyObject())).andThrow(new NotFoundException()).andReturn(true);
+              (AccessControlList) EasyMock.anyObject(), EasyMock.anyBoolean())).andThrow(new NotFoundException())
+              .andReturn(true);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
@@ -169,7 +169,9 @@ public class AssetManagerUpdatedEventHandler {
 
         // Update the series XACML file
         if (SeriesItem.Type.UpdateAcl.equals(seriesItem.getType())) {
-          // Build a new XACML file for this mediapackage
+          if (seriesItem.getOverrideEpisodeAcl()) {
+            authorizationService.removeAcl(mp, AclScope.Episode);
+          }
           authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl());
         }
 

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
@@ -166,7 +166,9 @@ public class WorkflowPermissionsUpdatedEventHandler {
 
           // Update the series XACML file
           if (SeriesItem.Type.UpdateAcl.equals(seriesItem.getType())) {
-            // Build a new XACML file for this mediapackage
+            if (seriesItem.getOverrideEpisodeAcl()) {
+              authorizationService.removeAcl(mp, AclScope.Episode);
+            }
             authorizationService.setAcl(mp, AclScope.Series, seriesItem.getAcl());
           }
 

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/series/SeriesItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/series/SeriesItem.java
@@ -51,6 +51,7 @@ public final class SeriesItem implements MessageItem, Serializable {
   private final Boolean optOut;
   private final String element;
   private final String elementType;
+  private final Boolean overrideEpisodeAcl;
 
   public enum Type {
     UpdateCatalog, UpdateElement, UpdateAcl, UpdateOptOut, UpdateProperty, Delete
@@ -62,7 +63,7 @@ public final class SeriesItem implements MessageItem, Serializable {
    * @return Builds {@link SeriesItem} for updating a series.
    */
   public static SeriesItem updateCatalog(DublinCoreCatalog series) {
-    return new SeriesItem(Type.UpdateCatalog, null, series, null, null, null, null, null, null);
+    return new SeriesItem(Type.UpdateCatalog, null, series, null, null, null, null, null, null, null);
   }
 
   /**
@@ -75,7 +76,7 @@ public final class SeriesItem implements MessageItem, Serializable {
    * @return Builds {@link SeriesItem} for updating series element.
    */
   public static SeriesItem updateElement(String seriesId, String type, String data) {
-    return new SeriesItem(Type.UpdateElement, seriesId, null, null, null, null, null, type, data);
+    return new SeriesItem(Type.UpdateElement, seriesId, null, null, null, null, null, type, data, null);
   }
 
   /**
@@ -83,11 +84,13 @@ public final class SeriesItem implements MessageItem, Serializable {
    *          The unique id for the series to update.
    * @param acl
    *          The new access control list to update to.
+   * @param overrideEpisodeAcl
+   *          Whether to override the episode ACL.
    * @return Builds {@link SeriesItem} for updating the access control list of a series.
    */
-  public static SeriesItem updateAcl(String seriesId, AccessControlList acl) {
-    return new SeriesItem(Type.UpdateAcl, seriesId, null, AccessControlParser.toJsonSilent(acl),
-            null, null, null, null, null);
+  public static SeriesItem updateAcl(String seriesId, AccessControlList acl, boolean overrideEpisodeAcl) {
+    return new SeriesItem(Type.UpdateAcl, seriesId, null, AccessControlParser.toJsonSilent(acl), null, null, null,
+            null, null, overrideEpisodeAcl);
   }
 
   /**
@@ -98,7 +101,7 @@ public final class SeriesItem implements MessageItem, Serializable {
    * @return Builds {@link SeriesItem} for updating the opt out status.
    */
   public static SeriesItem updateOptOut(String seriesId, boolean optOut) {
-    return new SeriesItem(Type.UpdateOptOut, seriesId, null, null, null, null, optOut, null, null);
+    return new SeriesItem(Type.UpdateOptOut, seriesId, null, null, null, null, optOut, null, null, null);
   }
 
   /**
@@ -111,7 +114,8 @@ public final class SeriesItem implements MessageItem, Serializable {
    * @return Builds {@link SeriesItem} for updating a series property.
    */
   public static SeriesItem updateProperty(String seriesId, String propertyName, String propertyValue) {
-    return new SeriesItem(Type.UpdateProperty, seriesId, null, null, propertyName, propertyValue, null, null, null);
+    return new SeriesItem(Type.UpdateProperty, seriesId, null, null, propertyName, propertyValue, null, null, null,
+            null);
   }
 
   /**
@@ -122,7 +126,7 @@ public final class SeriesItem implements MessageItem, Serializable {
    * @return Builds {@link SeriesItem} for updating the opt out status of a series.
    */
   public static SeriesItem delete(String seriesId, boolean optedOut) {
-    return new SeriesItem(Type.UpdateOptOut, seriesId, null, null, null, null, optedOut, null, null);
+    return new SeriesItem(Type.UpdateOptOut, seriesId, null, null, null, null, optedOut, null, null, null);
   }
 
   /**
@@ -131,7 +135,7 @@ public final class SeriesItem implements MessageItem, Serializable {
    * @return Builds {@link SeriesItem} for deleting a series.
    */
   public static SeriesItem delete(String seriesId) {
-    return new SeriesItem(Type.Delete, seriesId, null, null, null, null, null, null, null);
+    return new SeriesItem(Type.Delete, seriesId, null, null, null, null, null, null, null, null);
   }
 
   /**
@@ -163,7 +167,8 @@ public final class SeriesItem implements MessageItem, Serializable {
    *          {@link DublinCore.PROPERTY_IDENTIFIER} in the series catalog does not match.
    */
   private SeriesItem(Type type, String seriesId, DublinCoreCatalog series, String acl,
-          String propertyName, String propertyValue, Boolean optOut, String elementType, String element) {
+          String propertyName, String propertyValue, Boolean optOut, String elementType, String element,
+          Boolean overrideEpisodeAcl) {
     if (seriesId != null && series != null && !seriesId.equals(series.getFirst(DublinCore.PROPERTY_IDENTIFIER)))
       throw new IllegalStateException("Provided series ID and dublincore series ID does not match");
 
@@ -189,6 +194,7 @@ public final class SeriesItem implements MessageItem, Serializable {
     this.optOut = optOut;
     this.elementType = elementType;
     this.element = element;
+    this.overrideEpisodeAcl = overrideEpisodeAcl;
   }
 
   @Override
@@ -243,5 +249,9 @@ public final class SeriesItem implements MessageItem, Serializable {
 
   public String getElementType() {
     return elementType;
+  }
+
+  public Boolean getOverrideEpisodeAcl() {
+    return overrideEpisodeAcl;
   }
 }

--- a/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
+++ b/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
@@ -55,6 +55,7 @@ public interface SeriesService {
    */
   DublinCoreCatalog updateSeries(DublinCoreCatalog dc) throws SeriesException, UnauthorizedException;
 
+
   /**
    * Updates access control rules for specified series. Not specifying series ID or trying to update series with null
    * value will throw IllegalArgumentException.
@@ -73,6 +74,28 @@ public interface SeriesService {
    */
   boolean updateAccessControl(String seriesID, AccessControlList accessControl) throws NotFoundException,
           SeriesException, UnauthorizedException;
+
+  /**
+   * Updates access control rules for specified series. Allows to set the override parameter that controls whether the
+   * episode ACLs of the contained media packages will be removed on update. Not specifying series ID or trying to update series with null
+   * value will throw IllegalArgumentException.
+   *
+   * @param seriesID
+   *          series to be updated
+   * @param accessControl
+   *          {@link AccessControlList} defining access control rules
+   * @param overrideEpisodeAcl
+   *          Whether the new series acl should override the episode acl
+   * @return true if ACL was updated and false it if was created
+   * @throws NotFoundException
+   *           if series with given ID cannot be found
+   * @throws UnauthorizedException
+   *           if the current user is not authorized to perform this action
+   * @throws SeriesException
+   *           if exception occurred
+   */
+  boolean updateAccessControl(String seriesID, AccessControlList accessControl, boolean overrideEpisodeAcl)
+          throws NotFoundException, SeriesException, UnauthorizedException;
 
   /**
    * Removes series

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -159,11 +159,18 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
   @Override
   public boolean updateAccessControl(String seriesID, AccessControlList accessControl)
           throws NotFoundException, SeriesException, UnauthorizedException {
+    return updateAccessControl(seriesID, accessControl, false);
+  }
+
+  @Override
+  public boolean updateAccessControl(String seriesID, AccessControlList accessControl, boolean overrideEpisodeAcl)
+          throws NotFoundException, SeriesException, UnauthorizedException {
     HttpPost post = new HttpPost(seriesID + "/accesscontrol");
     try {
       List<BasicNameValuePair> params = new ArrayList<>();
       params.add(new BasicNameValuePair("seriesID", seriesID));
       params.add(new BasicNameValuePair("acl", AccessControlParser.toXml(accessControl)));
+      params.add(new BasicNameValuePair("overrideEpisodeAcl", Boolean.toString(overrideEpisodeAcl)));
       post.setEntity(new UrlEncodedFormEntity(params));
     } catch (Exception e) {
       throw new SeriesException("Unable to assemble a remote series request for updating an ACL " + accessControl, e);


### PR DESCRIPTION
Remove the snapshot after removing the episode ACL and move the whole step to the AssetManagerUpdatedEventHandler so that the likelihood that two OAIPMH distribution jobs run concurrently for the same mediapackage (which can result in a lost update) is minimized. (See [MH-13233](https://opencast.jira.com/browse/MH-13244).)