### PR TITLE
MH-13249, Invalid Group Endpoint Registration

### DIFF
--- a/modules/userdirectory/src/main/resources/OSGI-INF/group-role-provider.xml
+++ b/modules/userdirectory/src/main/resources/OSGI-INF/group-role-provider.xml
@@ -5,11 +5,6 @@
   <implementation class="org.opencastproject.userdirectory.JpaGroupRoleProvider"/>
   <property name="service.description" value="Provides a group role directory"/>
 
-  <!-- Also register as a REST endpoint -->
-  <property name="opencast.service.type" value="org.opencastproject.groups"/>
-  <property name="opencast.service.jobproducer" value="false"/>
-  <property name="opencast.service.path" value="/groups"/>
-
   <service>
     <provide interface="org.opencastproject.security.api.RoleProvider"/>
     <provide interface="org.opencastproject.userdirectory.JpaGroupRoleProvider"/>


### PR DESCRIPTION
The JPA group and role provider declares that it provides a /groups REST
endpoint including JAX-RS annotation which it does not. This causes the
/groups endpoint to appear twice in the REST docs, possibly breaking the
endpoints docs if the invalid one is chosen.