### PR TITLE
MH-13221 Improve multi-select metadata fields

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
@@ -8,9 +8,9 @@
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
   <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
 
-  <div class="editable-select" ng-show="editMode">
-    <input type="text" ng-blur="leaveEditMode()" ng-required="params.required" tabindex="{{ params.tabindex }}"
-                                                                               list="{{ data.list.id }}-data-list" ng-keyup="keyUp($event)" name="{{ params.name }}" ng-model="value">
+  <div class="editable-select" ng-if="editMode">
+    <input type="text" ng-blur="onBlur($event)" ng-required="params.required" tabindex="{{ params.tabindex }}"
+                                                                               list="{{ data.list.id }}-data-list" ng-keyup="keyUp($event)" name="{{ params.name }}" ng-model="data.value">
     <datalist id="{{ data.list.id }}-data-list">
       <option ng-repeat="(item, label) in collection"
               value="{{ item }}">


### PR DESCRIPTION
Improve the code and behavior of the multi-select metadata fields (e.g. presenters, contributors, ...): 
* Fix focusing issues in Firefox where one has to click twice to edit
* enter multiple values without leaving edit mode in between
* remove multiple values without leaving edit mode in between
* don't save the entered value when leaving the text field by hitting ESC or clicking somewhere else, instead allowing the user to continue typing when re-entering edit mode
* simplify code and remove unused functionality