### PR TITLE
MH-13251: Remove duplicate dependency

### DIFF
--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -66,11 +66,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-asset-manager-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.entwinemedia.common</groupId>
       <artifactId>functional</artifactId>
     </dependency>


### PR DESCRIPTION
The `workflow-service-impl` declared its dependency to the `opencast-asset-manager-api` twice, which Maven was (rightfully) complaining about.

See also [MH-13251](https://opencast.jira.com/browse/MH-13251).