### PR TITLE
MH-13256 Waveform operation fails

### DIFF
--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -374,6 +374,7 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
       "-nostats",
       "-i", mediaFile.getAbsolutePath(),
       "-lavfi", createWaveformFilter(track),
+      "-frames:v", "1",
       "-an", "-vn", "-sn", "-y",
       waveformFilePath
     };


### PR DESCRIPTION
The ffmpeg command to generate the waveform png image fails with some videos (see the Jira ticket for more info). This PR fix this issue.

Jira Ticket: https://opencast.jira.com/browse/MH-13256
Info from: https://trac.ffmpeg.org/wiki/Waveform

The ffmpeg command to generate the waveform outputs this error:

> [image2 @ 0x563637106740] Could not get frame filename number 2 from pattern '576-475e48c1-a72c-4bb3-b261-bab8bd92e2a8-waveform.png' (either set updatefirst or use a pattern like %03d within the filename pattern) 

The [ffmpeg errors guide](https://trac.ffmpeg.org/wiki/Errors) says:

> This usually occurs because the output name is incorrect or some option was omitted.
> 
> - If outputting a single image you need to include -frames:v 1.
> - If outputting a series of images you need to use the proper naming pattern as described in the image muxer documentation. For example, output_%03d.png will make a series named output_001.png, output_002.png, output_003.png, etc.
> - If outputting a single image that is continuously overwritten with new images, add -update 1.

This PR adds the `-frames:v 1` to the ffmpeg command to solve the problem.