### PR TITLE
MH-13258, Broken User Provider Removal

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -175,7 +175,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
    */
   protected synchronized void removeUserProvider(UserProvider userProvider) {
     logger.debug("Removing {} from the list of user providers", userProvider);
-    roleProviders.remove(userProvider);
+    userProviders.remove(userProvider);
   }
 
   /**


### PR DESCRIPTION
All user providers in Opencast are dynamically bound to the user
directory service which then acts as a unified interface to access all
users in Opencast.

This means that during at runtime, new user providers can dynamically be
added and old ones removed. However, the removal process in the
directory service is broken which can cause references to old user
services being left in the system. This can then lead to effects like
invalid users or multiple references to identical users.

This patch fixes the removal of user providers.

*Work sponsored by SWITCH*