### PR TITLE
MH-13257: Fix outdated command line argument for tesseract >= 4.0.0

### DIFF
--- a/docs/guides/admin/docs/modules/textextraction.md
+++ b/docs/guides/admin/docs/modules/textextraction.md
@@ -44,19 +44,19 @@ analysis.
 
 For example, if you want OCR for German content, you want to run something like this:
 
-    tesseract in.tif out.txt -l deu -psm 3
+    tesseract in.tif out.txt -l deu --psm 3
 
 * The arguments `in.tif` and `out.txt` are automatically set by Opencast.
 * The argument `-l` specifies the language files used by Tesseract. `deu` specifies the German language. Multiple
   languages may be specified, separated by plus characters. Please make sure that you have installed the language packs
   you want to use on every worker (E.g. `yum install tesseract-langpack-deu`).
-* Finally `-psm 3` specifies the layout analysis for Tesseract. The value `3` means *Fully automatic page segmentation,
+* Finally `--psm 3` specifies the layout analysis for Tesseract. The value `3` means *Fully automatic page segmentation,
   but no orientation and script detection* which is actually the default. Hence in this case, the argument could simply
   be omitted. If you know more about your input videos, you might want to use different options here (not likely).
 
 In Opencast, you can modify this options in the `custom.properties` file by setting the following option:
 
-    org.opencastproject.textanalyzer.tesseract.options=-l deu -psm 3
+    org.opencastproject.textanalyzer.tesseract.options=-l deu --psm 3
 
 It is highly recommended to configure Tesseract to use your local language. It will improve the recognition a lot and
 only this will enable the recognition of special characters specific to your local language.

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -255,7 +255,7 @@ org.opencastproject.elasticsearch.config.dir=${karaf.etc}/index
 
 # Additional options for Tesseract like language or page segmentation mode.
 # The default are no additional options.
-#org.opencastproject.textanalyzer.tesseract.options=-l eng -psm 3
+#org.opencastproject.textanalyzer.tesseract.options=-l eng --psm 3
 
 # Path to the hunspell binary used by the dictionary-hunspell
 # module. The default ist just "hunspell" which requires hunspell to be in the

--- a/modules/textextractor-tesseract/src/test/java/org/opencastproject/analysis/text/TesseractTextExtractorTest.java
+++ b/modules/textextractor-tesseract/src/test/java/org/opencastproject/analysis/text/TesseractTextExtractorTest.java
@@ -61,7 +61,7 @@ public class TesseractTextExtractorTest {
   protected String text = "Land and Vegetation Key players on the";
 
   /** Additional options for tesseract */
-  protected String addopts = "-psm 3";
+  protected String addopts = "--psm 3";
 
   /** True to run the tests */
   private static boolean tesseractInstalled = true;


### PR DESCRIPTION
As said in [MH-13257](https://opencast.jira.com/browse/MH-13257) tesseract >= 4.0.0 doesn't allow '-psm' as command line argument. Which is causing the tests to fail.

The right spelling is '--psm' which should also be accepted by tesseract 3

Without it, test failed with the following message:
`Error, unknown command line argument '-psm' `