### PR TITLE
MH-13263, Invalid Ingest Encoding

### DIFF
--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
@@ -35,7 +35,6 @@ import org.opencastproject.workflow.api.WorkflowInstanceImpl;
 import org.apache.commons.fileupload.MockHttpServletRequest;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.cxf.jaxrs.impl.MetadataMap;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -50,12 +49,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -253,12 +252,15 @@ public class IngestRestServiceTest {
 
     String mpId = "6f7a7850-3232-4719-9064-24c9bad2832f";
 
-    MultivaluedMap<String, String> metadataMap = new MetadataMap<>();
     Response createMediaPackage = restService.createMediaPackage();
     MediaPackage mp = (MediaPackage) createMediaPackage.getEntity();
-    metadataMap.add("mediaPackage", MediaPackageParser.getAsXml(mp));
-    metadataMap.add(IngestRestService.WORKFLOW_INSTANCE_ID_PARAM, mpId);
-    Response response = restService.ingest(metadataMap);
+    Map<String, String[]> metadataMap = new HashMap<>();
+    metadataMap.put("mediaPackage", new String[] {MediaPackageParser.getAsXml(mp)});
+    metadataMap.put(IngestRestService.WORKFLOW_INSTANCE_ID_PARAM, new String[] {mpId});
+    HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
+    EasyMock.expect(request.getParameterMap()).andReturn(metadataMap).anyTimes();
+    EasyMock.replay(request);
+    Response response = restService.ingest(request);
     Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
     Map<String, String> config = workflowConfigCapture.getValue();
     Assert.assertFalse(config.isEmpty());


### PR DESCRIPTION
The POST /ingest/ingest REST endpoints accept form data encoded as
`application/x-www-form-urlencoded` or as `multipart/form-data`.
Regardless of the encoding however, a url-decoding of all values is
performed. This may lead to corruption of data sent in this request.

A simple example for a problem is attaching an episode access control
list which is expected to have the flavor `security/xacml+episode`.
Ingesting this in a `multipart/form-data` request will force the
url-decoding of the non-encoded data and will convert this flavor to
`security/xacml episode`.

Opencast will now obviously not match this modified flavor anymore when
it is looking for ACLs and is furthermore not at all happy about the
space contained in the flavor causing further problems.

This patch fixes the decoding problems.

*Work sponsored by SWITCH*