### PR TITLE
MH-13157: Add multi-tenant support for all list providers

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
@@ -124,7 +124,7 @@ public class ListProvidersEndpoint {
     addRequestFiltersToQuery(filter, query);
     Map<String, String> autocompleteList;
     try {
-      autocompleteList = listProvidersService.getList(source, query, securityService.getOrganization(), false);
+      autocompleteList = listProvidersService.getList(source, query, false);
     } catch (ListProviderNotFoundException e) {
       logger.error("No list found for {}: {}", source, e);
       return NOT_FOUND;
@@ -160,8 +160,7 @@ public class ListProvidersEndpoint {
       if (listProvidersService.hasProvider(source)) {
         JSONObject subList;
         try {
-          subList = generateJSONObject(listProvidersService.getList(source, query, securityService.getOrganization(),
-                  true));
+          subList = generateJSONObject(listProvidersService.getList(source, query, true));
           list.put(source, subList);
         } catch (JsonCreationException e) {
           logger.error("Not able to generate resources list JSON from source {}: {}", source, e);

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
@@ -26,6 +26,7 @@ import static org.opencastproject.adminui.endpoint.EndpointUtil.generateJSONObje
 
 import org.opencastproject.adminui.exception.JsonCreationException;
 import org.opencastproject.index.service.exception.ListProviderException;
+import org.opencastproject.index.service.exception.ListProviderNotFoundException;
 import org.opencastproject.index.service.resources.list.api.ListProvidersService;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.query.AclsListQuery;
@@ -116,31 +117,31 @@ public class ListProvidersEndpoint {
   public Response getList(@PathParam("source") final String source, @QueryParam("limit") final int limit,
           @QueryParam("filter") final String filter, @QueryParam("offset") final int offset,
           @Context HttpHeaders headers) {
-    if (listProvidersService.hasProvider(source)) {
-      ResourceListQueryImpl query = new ResourceListQueryImpl();
-      query.setLimit(limit);
-      query.setOffset(offset);
-      addRequestFiltersToQuery(filter, query);
-      Map<String, String> autocompleteList;
-      try {
-        autocompleteList = listProvidersService.getList(source, query, securityService.getOrganization(), false);
-      } catch (ListProviderException e) {
-        logger.error("Not able to get list from provider {}: {}", source, e);
-        return SERVER_ERROR;
-      }
 
-      JSONObject jsonList;
-      try {
-        jsonList = generateJSONObject(autocompleteList);
-      } catch (JsonCreationException e) {
-        logger.error("Not able to generate resources list JSON from source {}: {}", source, e);
-        return SERVER_ERROR;
-      }
-
-      return Response.ok(jsonList.toString()).build();
+    ResourceListQueryImpl query = new ResourceListQueryImpl();
+    query.setLimit(limit);
+    query.setOffset(offset);
+    addRequestFiltersToQuery(filter, query);
+    Map<String, String> autocompleteList;
+    try {
+      autocompleteList = listProvidersService.getList(source, query, securityService.getOrganization(), false);
+    } catch (ListProviderNotFoundException e) {
+      logger.error("No list found for {}: {}", source, e);
+      return NOT_FOUND;
+    } catch (ListProviderException e) {
+      logger.error("Server error when getting list from provider {}: {}", source, e);
+      return SERVER_ERROR;
     }
 
-    return NOT_FOUND;
+    JSONObject jsonList;
+    try {
+      jsonList = generateJSONObject(autocompleteList);
+    } catch (JsonCreationException e) {
+      logger.error("Not able to generate resources list JSON from source {}: {}", source, e);
+      return SERVER_ERROR;
+    }
+
+    return Response.ok(jsonList.toString()).build();
   }
 
   @GET

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
@@ -126,10 +126,10 @@ public class ListProvidersEndpoint {
     try {
       autocompleteList = listProvidersService.getList(source, query, false);
     } catch (ListProviderNotFoundException e) {
-      logger.error("No list found for {}: {}", source, e);
+      logger.debug("No list found for {}", source, e);
       return NOT_FOUND;
     } catch (ListProviderException e) {
-      logger.error("Server error when getting list from provider {}: {}", source, e);
+      logger.error("Server error when getting list from provider {}", source, e);
       return SERVER_ERROR;
     }
 
@@ -137,7 +137,7 @@ public class ListProvidersEndpoint {
     try {
       jsonList = generateJSONObject(autocompleteList);
     } catch (JsonCreationException e) {
-      logger.error("Not able to generate resources list JSON from source {}: {}", source, e);
+      logger.error("Not able to generate resources list JSON from source {}", source, e);
       return SERVER_ERROR;
     }
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -101,7 +101,6 @@ import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.JaxbOrganization;
 import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
@@ -449,7 +448,7 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
 
     ListProvidersService listProvidersService = EasyMock.createNiceMock(ListProvidersService.class);
     EasyMock.expect(listProvidersService.getList(EasyMock.anyString(), EasyMock.anyObject(ResourceListQuery.class),
-            EasyMock.anyObject(Organization.class), EasyMock.anyBoolean())).andReturn(licences).anyTimes();
+      EasyMock.anyBoolean())).andReturn(licences).anyTimes();
     EasyMock.replay(listProvidersService);
 
     final IncidentTree r = new IncidentTreeImpl(

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestListProvidersEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestListProvidersEndpoint.java
@@ -55,8 +55,7 @@ public class TestListProvidersEndpoint extends ListProvidersEndpoint {
     organization = EasyMock.createNiceMock(Organization.class);
     EasyMock.expect(securityService.getOrganization()).andReturn(organization).anyTimes();
     EasyMock.expect(organization.getId()).andReturn("mh_default_org").anyTimes();
-    EasyMock.replay(organization);
-    EasyMock.replay(securityService);
+    EasyMock.replay(organization, securityService);
     listProvidersService.setSecurityService(securityService);
 
     for (int i = 0; i < PROVIDER_VALUES.length; i++) {

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestListProvidersEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestListProvidersEndpoint.java
@@ -27,7 +27,6 @@ import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.impl.ListProvidersServiceImpl;
 import org.opencastproject.index.service.resources.list.provider.ServersListProvider;
 import org.opencastproject.index.service.util.ListProviderUtil;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 
 import org.easymock.EasyMock;
@@ -64,7 +63,7 @@ public class TestListProvidersEndpoint extends ListProvidersEndpoint {
       }
 
       @Override
-      public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+      public Map<String, String> getList(String listName, ResourceListQuery query) {
         return ListProviderUtil.filterMap(baseMap, query);
       }
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestListProvidersEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestListProvidersEndpoint.java
@@ -27,6 +27,7 @@ import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.impl.ListProvidersServiceImpl;
 import org.opencastproject.index.service.resources.list.provider.ServersListProvider;
 import org.opencastproject.index.service.util.ListProviderUtil;
+import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 
 import org.easymock.EasyMock;
@@ -47,10 +48,16 @@ public class TestListProvidersEndpoint extends ListProvidersEndpoint {
 
   private ListProvidersServiceImpl listProvidersService = new ListProvidersServiceImpl();
   private SecurityService securityService;
+  private Organization organization;
 
   public TestListProvidersEndpoint() {
     this.securityService = EasyMock.createNiceMock(SecurityService.class);
-    EasyMock.expect(securityService.getOrganization()).andReturn(null);
+    organization = EasyMock.createNiceMock(Organization.class);
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization).anyTimes();
+    EasyMock.expect(organization.getId()).andReturn("mh_default_org").anyTimes();
+    EasyMock.replay(organization);
+    EasyMock.replay(securityService);
+    listProvidersService.setSecurityService(securityService);
 
     for (int i = 0; i < PROVIDER_VALUES.length; i++) {
       baseMap.put(Integer.toString(i), PROVIDER_VALUES[i]);

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestSeriesEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestSeriesEndpoint.java
@@ -64,7 +64,6 @@ import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.JaxbOrganization;
 import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
@@ -126,7 +125,7 @@ public class TestSeriesEndpoint extends SeriesEndpoint {
       }
 
       @Override
-      public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+      public Map<String, String> getList(String listName, ResourceListQuery query) {
         return new HashMap<>();
       }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/AbstractMetadataCollection.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/AbstractMetadataCollection.java
@@ -257,7 +257,7 @@ public abstract class AbstractMetadataCollection implements MetadataCollection {
 
     Opt<Map<String, String>> list;
     try {
-      list = Opt.some(listProviderService.getList(name, new ResourceListQueryImpl(), null, true));
+      list = Opt.some(listProviderService.getList(name, new ResourceListQueryImpl(), true));
     } catch (ListProviderException e) {
       logger.warn("Not able to find a value list with the name {}", name);
       list = Opt.none();

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
@@ -75,7 +75,7 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
     try {
       if (listProvidersService != null && metadataField.getListprovider().isSome()) {
         Map<String, String> collection = listProvidersService.getList(metadataField.getListprovider().get(),
-                new ResourceListQueryImpl(), null, true);
+                new ResourceListQueryImpl(), true);
         if (collection != null) {
           return Opt.some(collection);
         }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/exception/ListProviderNotFoundException.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/exception/ListProviderNotFoundException.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.index.service.exception;
+
+/**
+ * This exception indicates that the queried list provider resource could not be found.
+ */
+public class ListProviderNotFoundException extends ListProviderException {
+
+    /**
+     * Constructs an exception with a simple message.
+     *
+     * @param message the simple message
+     */
+    public ListProviderNotFoundException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs an exception with its cause and a simple message.
+     *
+     * @param message the simple message
+     * @param cause the cause
+     */
+    public ListProviderNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/exception/ListProviderNotFoundException.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/exception/ListProviderNotFoundException.java
@@ -26,22 +26,22 @@ package org.opencastproject.index.service.exception;
  */
 public class ListProviderNotFoundException extends ListProviderException {
 
-    /**
-     * Constructs an exception with a simple message.
-     *
-     * @param message the simple message
-     */
-    public ListProviderNotFoundException(String message) {
-        super(message);
-    }
+  /**
+   * Constructs an exception with a simple message.
+   *
+   * @param message the simple message
+   */
+  public ListProviderNotFoundException(String message) {
+    super(message);
+  }
 
-    /**
-     * Constructs an exception with its cause and a simple message.
-     *
-     * @param message the simple message
-     * @param cause the cause
-     */
-    public ListProviderNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  /**
+   * Constructs an exception with its cause and a simple message.
+   *
+   * @param message the simple message
+   * @param cause the cause
+   */
+  public ListProviderNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/api/ListProvidersService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/api/ListProvidersService.java
@@ -22,7 +22,6 @@
 package org.opencastproject.index.service.resources.list.api;
 
 import org.opencastproject.index.service.exception.ListProviderException;
-import org.opencastproject.security.api.Organization;
 
 import java.util.List;
 import java.util.Map;
@@ -39,12 +38,10 @@ public interface ListProvidersService {
    *          The name of the source
    * @param query
    *          The query for the list
-   * @param organization
-   *          The organization context
    * @return a list of tuple id - value from the given source
    */
-  Map<String, String> getList(String providerName, ResourceListQuery query, Organization organization,
-                              boolean inverseValueKey) throws ListProviderException;
+  Map<String, String> getList(String providerName, ResourceListQuery query, boolean inverseValueKey)
+          throws ListProviderException;
 
   /**
    * Defines if keys and values of the given list should be translated in the administrative user interface.
@@ -56,7 +53,6 @@ public interface ListProvidersService {
    *              if no list provider found for the given list name
    */
   boolean isTranslatable(String listName) throws ListProviderException;
-  boolean isTranslatable(String listName, String organizationId) throws ListProviderException;
 
   /**
    * Defines the key of a default value in the given list.
@@ -68,7 +64,6 @@ public interface ListProvidersService {
    *              if no list provider found for the given list name
    */
   String getDefault(String listName) throws ListProviderException;
-  String getDefault(String listName, String organizationId) throws ListProviderException;
 
   /**
    * Adds an source to the service

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/api/ListProvidersService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/api/ListProvidersService.java
@@ -44,7 +44,7 @@ public interface ListProvidersService {
    * @return a list of tuple id - value from the given source
    */
   Map<String, String> getList(String providerName, ResourceListQuery query, Organization organization,
-          boolean inverseValueKey) throws ListProviderException;
+                              boolean inverseValueKey) throws ListProviderException;
 
   /**
    * Defines if keys and values of the given list should be translated in the administrative user interface.
@@ -56,6 +56,7 @@ public interface ListProvidersService {
    *              if no list provider found for the given list name
    */
   boolean isTranslatable(String listName) throws ListProviderException;
+  boolean isTranslatable(String listName, String organizationId) throws ListProviderException;
 
   /**
    * Defines the key of a default value in the given list.
@@ -67,6 +68,7 @@ public interface ListProvidersService {
    *              if no list provider found for the given list name
    */
   String getDefault(String listName) throws ListProviderException;
+  String getDefault(String listName, String organizationId) throws ListProviderException;
 
   /**
    * Adds an source to the service
@@ -78,6 +80,8 @@ public interface ListProvidersService {
    */
   void addProvider(String name, ResourceListProvider provider);
 
+  void addProvider(String name, ResourceListProvider provider, String organizationId);
+
   /**
    * Removes the given source
    *
@@ -85,6 +89,8 @@ public interface ListProvidersService {
    *          The provider to remove
    */
   void removeProvider(String name);
+
+  void removeProvider(String name, String organizationId);
 
   /**
    * Returns if the given source name is or not available
@@ -94,6 +100,8 @@ public interface ListProvidersService {
    * @return true if a source with the given name is available in the service
    */
   boolean hasProvider(String name);
+
+  boolean hasProvider(String name, String organizationId);
 
   /**
    * Returns the resources list providers available

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/api/ResourceListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/api/ResourceListProvider.java
@@ -22,7 +22,6 @@
 package org.opencastproject.index.service.resources.list.api;
 
 import org.opencastproject.index.service.exception.ListProviderException;
-import org.opencastproject.security.api.Organization;
 
 import java.util.Map;
 
@@ -43,11 +42,9 @@ public interface ResourceListProvider {
    *          the list name
    * @param query
    *          the list query
-   * @param organization
-   *          the organization context
    * @return the key-value list for the generator resource
    */
-  Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+  Map<String, String> getList(String listName, ResourceListQuery query)
           throws ListProviderException;
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/impl/ListProvidersScanner.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/impl/ListProvidersScanner.java
@@ -43,6 +43,7 @@ import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 public class ListProvidersScanner implements ArtifactInstaller {
@@ -117,7 +118,7 @@ public class ListProvidersScanner implements ArtifactInstaller {
     @Override
     public Map<String, String> getList(String listName, ResourceListQuery query)
             throws ListProviderNotFoundException {
-      logger.debug("Getting list " + listName + " query " + query + " org " + orgId);
+      logger.debug("Getting list {} with query {} for org {}", listName, query, orgId);
       if (this.listName.equals(listName)) return Collections.unmodifiableMap(list);
       else throw new ListProviderNotFoundException("Unable to read list data from file");
     }
@@ -152,7 +153,7 @@ public class ListProvidersScanner implements ArtifactInstaller {
     }
     String defaultKey = properties.getProperty(LIST_DEFAULT_KEY);
     boolean translatable = BooleanUtils.toBoolean(properties.getProperty(LIST_TRANSLATABLE_KEY));
-    String orgId = properties.getProperty(LIST_ORG_KEY) != null ? properties.getProperty(LIST_ORG_KEY) : ALL_ORGANIZATIONS;
+    String orgId = Objects.toString(properties.getProperty(LIST_ORG_KEY), ALL_ORGANIZATIONS);
 
     logger.info("Adding {} for {}", listName, orgId);
 
@@ -229,7 +230,7 @@ public class ListProvidersScanner implements ArtifactInstaller {
       logger.error("Unable to read file " + filePath);
       return;
     }
-    String orgId = properties.getProperty(LIST_ORG_KEY) != null ? properties.getProperty(LIST_ORG_KEY) : ALL_ORGANIZATIONS;
+    String orgId = Objects.toString(properties.getProperty(LIST_ORG_KEY), ALL_ORGANIZATIONS);
     if (resource != null && !orgId.equals(resource.getOrganizationId())) { // the org ID was changed
       removeResourceListProvider(artifact);
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/impl/ListProvidersServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/impl/ListProvidersServiceImpl.java
@@ -68,10 +68,9 @@ public class ListProvidersServiceImpl implements ListProvidersService {
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      ResourceTuple that = (ResourceTuple) o;
-      return Objects.equals(resourceName, that.resourceName)
-              && Objects.equals(organizationId, that.organizationId);
+      return o instanceof ResourceTuple
+              && Objects.equals(resourceName, ((ResourceTuple) o).resourceName)
+              && Objects.equals(organizationId, ((ResourceTuple) o).organizationId);
     }
 
     @Override
@@ -178,8 +177,8 @@ public class ListProvidersServiceImpl implements ListProvidersService {
   @Override
   public List<String> getAvailableProviders() {
     List<String> sources = new ArrayList<>();
-    for (Map.Entry<ResourceTuple, ResourceListProvider> entry : providers.entrySet()) {
-      sources.add(entry.getKey().getResourceName());
+    for (ResourceTuple key : providers.keySet()) {
+      sources.add(key.getResourceName());
     }
     return sources;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AclListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AclListProvider.java
@@ -26,7 +26,7 @@ import org.opencastproject.authorization.xacml.manager.api.ManagedAcl;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.util.ListProviderUtil;
-import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
 
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -47,6 +47,7 @@ public class AclListProvider implements ResourceListProvider {
   private static final Logger logger = LoggerFactory.getLogger(AclListProvider.class);
 
   private AclServiceFactory aclServiceFactory;
+  private SecurityService securityService;
 
   protected void activate(BundleContext bundleContext) {
     logger.info("ACL list provider activated!");
@@ -57,16 +58,25 @@ public class AclListProvider implements ResourceListProvider {
     this.aclServiceFactory = aclServiceFactory;
   }
 
+  /**
+   * OSGI callback to get the security service
+   *
+   * @param securityService the security service
+   */
+  public void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
+  }
+
   @Override
   public String[] getListNames() {
     return NAMES;
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
     Map<String, String> aclsList = new HashMap<String, String>();
 
-    List<ManagedAcl> acls = aclServiceFactory.serviceFor(organization).getAcls();
+    List<ManagedAcl> acls = aclServiceFactory.serviceFor(securityService.getOrganization()).getAcls();
     for (ManagedAcl a : acls) {
       if (ID.equals(listName)) {
         aclsList.put(a.getId().toString(), a.getId().toString());

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AgentsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AgentsListProvider.java
@@ -26,7 +26,6 @@ import org.opencastproject.capture.admin.api.AgentState;
 import org.opencastproject.capture.admin.api.CaptureAgentStateService;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
-import org.opencastproject.security.api.Organization;
 
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -62,7 +61,7 @@ public class AgentsListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
     Map<String, String> result = new TreeMap<String, String>();
 
     if (STATUS.equals(listName)) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/BooleanListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/BooleanListProvider.java
@@ -21,10 +21,8 @@
 
 package org.opencastproject.index.service.resources.list.provider;
 
-import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.util.data.Option;
 
 import org.apache.commons.lang3.StringUtils;
@@ -50,7 +48,7 @@ public class BooleanListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) throws ListProviderException {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
     Map<String, String> result = new HashMap<String, String>();
 
     String listNameTrimmed = StringUtils.trimToEmpty(listName);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
@@ -30,7 +30,6 @@ import org.opencastproject.index.service.impl.index.series.SeriesIndexSchema;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.util.ListProviderUtil;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.util.data.Option;
@@ -89,7 +88,7 @@ public class ContributorsListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
     if (listName.equalsIgnoreCase(USERNAMES)) {
       return getListWithUserNames(query);
     } else if (listName.equalsIgnoreCase(NAMES_TO_USERNAMES)) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EmailListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EmailListProvider.java
@@ -28,7 +28,6 @@ import org.opencastproject.index.service.util.ListProviderUtil;
 import org.opencastproject.messages.MailService;
 import org.opencastproject.messages.MailServiceException;
 import org.opencastproject.messages.MessageTemplate;
-import org.opencastproject.security.api.Organization;
 
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -83,7 +82,7 @@ public class EmailListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+  public Map<String, String> getList(String listName, ResourceListQuery query)
           throws ListProviderException {
     Map<String, String> result = new HashMap<String, String>();
     if (getListNameFromFilter(EmailFilterList.TEMPLATE_NAMES).equals(listName)) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventCommentsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventCommentsListProvider.java
@@ -26,7 +26,6 @@ import org.opencastproject.event.comment.EventCommentService;
 import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
-import org.opencastproject.security.api.Organization;
 
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -78,7 +77,7 @@ public class EventCommentsListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+  public Map<String, String> getList(String listName, ResourceListQuery query)
           throws ListProviderException {
     Map<String, String> result = new HashMap<String, String>();
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
@@ -22,11 +22,9 @@
 package org.opencastproject.index.service.resources.list.provider;
 
 import org.opencastproject.index.service.api.EventIndex;
-import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.scheduler.api.SchedulerService.ReviewStatus;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 
 import org.osgi.framework.BundleContext;
@@ -77,8 +75,7 @@ public class EventsListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
-          throws ListProviderException {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
     Map<String, String> list = new HashMap<String, String>();
 
     if (CONTRIBUTORS.equals(listName)) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/GroupsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/GroupsListProvider.java
@@ -24,7 +24,6 @@ package org.opencastproject.index.service.resources.list.provider;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.security.api.JaxbGroup;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.userdirectory.JpaGroupRoleProvider;
 
 import org.osgi.framework.BundleContext;
@@ -63,7 +62,7 @@ public class GroupsListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
     Map<String, String> groupsList = new HashMap<String, String>();
     List<JaxbGroup> groups = null;
     int limit = 0;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/JobsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/JobsListProvider.java
@@ -21,11 +21,9 @@
 
 package org.opencastproject.index.service.resources.list.provider;
 
-import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.job.api.Job;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.workflow.api.WorkflowDatabaseException;
 import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowService;
@@ -67,8 +65,7 @@ public class JobsListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
-          throws ListProviderException {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
 
     String listNameTrimmed = StringUtils.trimToEmpty(listName);
     Map<String, String> jobList = new HashMap<String, String>();

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/RolesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/RolesListProvider.java
@@ -23,7 +23,6 @@ package org.opencastproject.index.service.resources.list.provider;
 
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.RoleDirectoryService;
 
@@ -61,7 +60,7 @@ public class RolesListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
 
     // Preserve the ordering of roles from the providers
     Map<String, String> rolesList = new LinkedHashMap<String, String>();

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
@@ -28,7 +28,6 @@ import org.opencastproject.index.service.resources.list.query.StringListFilter;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesQuery;
@@ -83,7 +82,7 @@ public class SeriesListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+  public Map<String, String> getList(String listName, ResourceListQuery query)
           throws ListProviderException {
 
     Map<String, String> series = new HashMap<String, String>();

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServersListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServersListProvider.java
@@ -26,7 +26,6 @@ import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.query.ServersListQuery;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.serviceregistry.api.HostRegistration;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
@@ -82,7 +81,7 @@ public class ServersListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+  public Map<String, String> getList(String listName, ResourceListQuery query)
           throws ListProviderException {
     Map<String, String> list = new HashMap<String, String>();
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServicesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServicesListProvider.java
@@ -26,7 +26,6 @@ import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.query.ServicesListQuery;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.serviceregistry.api.ServiceRegistration;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
@@ -73,7 +72,7 @@ public class ServicesListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+  public Map<String, String> getList(String listName, ResourceListQuery query)
           throws ListProviderException {
 
     ServicesListQuery servicesQuery;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ThemesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ThemesListProvider.java
@@ -31,7 +31,6 @@ import org.opencastproject.matterhorn.search.SearchIndexException;
 import org.opencastproject.matterhorn.search.SearchQuery;
 import org.opencastproject.matterhorn.search.SearchResult;
 import org.opencastproject.matterhorn.search.SearchResultItem;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 
 import org.osgi.framework.BundleContext;
@@ -75,7 +74,7 @@ public class ThemesListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+  public Map<String, String> getList(String listName, ResourceListQuery query)
           throws ListProviderException {
     Map<String, String> list = new HashMap<String, String>();
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/UsersListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/UsersListProvider.java
@@ -23,7 +23,6 @@ package org.opencastproject.index.service.resources.list.provider;
 
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
@@ -75,7 +74,7 @@ public class UsersListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+  public Map<String, String> getList(String listName, ResourceListQuery query) {
     Map<String, String> usersList = new HashMap<String, String>();
     int offset = 0;
     int limit = 0;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/WorkflowsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/WorkflowsListProvider.java
@@ -24,7 +24,6 @@ package org.opencastproject.index.service.resources.list.provider;
 import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.workflow.api.WorkflowDatabaseException;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowQuery;
@@ -59,7 +58,7 @@ public class WorkflowsListProvider implements ResourceListProvider {
   }
 
   @Override
-  public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+  public Map<String, String> getList(String listName, ResourceListQuery query)
           throws ListProviderException {
     Map<String, String> workflowsList = new HashMap<String, String>();
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/JSONUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/JSONUtils.java
@@ -176,10 +176,11 @@ public final class JSONUtils {
         Map<String, String> values = null;
         boolean translatable = false;
 
-        if (!listProvidersService.hasProvider(listProviderName.get())) {
+        if (org != null && !listProvidersService.hasProvider(listProviderName.get(), org.getId())
+                && !listProvidersService.hasProvider(listProviderName.get())) {
           values = new HashMap<String, String>();
         } else {
-          values = listProvidersService.getList(listProviderName.get(), query, org, false);
+          values = listProvidersService.getList(listProviderName.get(), query, false);
           translatable = listProvidersService.isTranslatable(listProviderName.get());
         }
 
@@ -238,7 +239,7 @@ public final class JSONUtils {
               valuesJSON.add(f(entry.getValue(), v(entry.getKey(), Jsons.BLANK)));
             }
           } else {
-            Map<String, String> values = listProvidersService.getList(listProviderName.get(), query, org, false);
+            Map<String, String> values = listProvidersService.getList(listProviderName.get(), query, false);
             for (Entry<String, String> entry : values.entrySet()) {
               valuesJSON.add(f(entry.getKey(), v(entry.getValue(), Jsons.BLANK)));
             }

--- a/modules/index-service/src/main/resources/OSGI-INF/list-providers/acl.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/list-providers/acl.xml
@@ -11,6 +11,9 @@
              interface="org.opencastproject.authorization.xacml.manager.api.AclServiceFactory"
              cardinality="1..1" policy="dynamic" bind="setAclServiceFactory"/>
 
+  <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
+             cardinality="1..1" policy="static" bind="setSecurityService"/>
+
   <service>
     <provide interface="org.opencastproject.index.service.resources.list.api.ResourceListProvider"/>
   </service>

--- a/modules/index-service/src/main/resources/OSGI-INF/list_providers_service.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/list_providers_service.xml
@@ -10,7 +10,7 @@
              cardinality="0..n" policy="dynamic" bind="addProvider" unbind="removeProvider"/>
 
   <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
-           cardinality="1..1" policy="static" bind="setSecurityService"/>
+             bind="setSecurityService"/>
 
   <service>
     <provide interface="org.opencastproject.index.service.resources.list.api.ListProvidersService"/>

--- a/modules/index-service/src/main/resources/OSGI-INF/list_providers_service.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/list_providers_service.xml
@@ -9,6 +9,9 @@
   <reference name="provider" interface="org.opencastproject.index.service.resources.list.api.ResourceListProvider"
              cardinality="0..n" policy="dynamic" bind="addProvider" unbind="removeProvider"/>
 
+  <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
+           cardinality="1..1" policy="static" bind="setSecurityService"/>
+
   <service>
     <provide interface="org.opencastproject.index.service.resources.list.api.ListProvidersService"/>
   </service>

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/DublinCoreCatalogUIAdapterTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/DublinCoreCatalogUIAdapterTest.java
@@ -42,7 +42,6 @@ import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreValue;
 import org.opencastproject.metadata.dublincore.DublinCores;
 import org.opencastproject.metadata.dublincore.MetadataField;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.PropertiesUtil;
 import org.opencastproject.workspace.api.Workspace;
@@ -140,7 +139,7 @@ public class DublinCoreCatalogUIAdapterTest {
     listProvidersService = EasyMock.createMock(ListProvidersService.class);
     EasyMock.expect(
             listProvidersService.getList(EasyMock.anyString(), EasyMock.anyObject(ResourceListQueryImpl.class),
-                    EasyMock.anyObject(Organization.class), EasyMock.anyBoolean())).andReturn(collection).anyTimes();
+                    EasyMock.anyBoolean())).andReturn(collection).anyTimes();
     EasyMock.replay(listProvidersService);
 
     Properties props = new Properties();

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/EventCatalogUIAdapterTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/EventCatalogUIAdapterTest.java
@@ -36,7 +36,6 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.metadata.dublincore.MetadataCollection;
 import org.opencastproject.metadata.dublincore.MetadataField;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.PropertiesUtil;
 import org.opencastproject.workspace.api.Workspace;
@@ -94,7 +93,7 @@ public class EventCatalogUIAdapterTest {
     listProvidersService = EasyMock.createMock(ListProvidersService.class);
     EasyMock.expect(
             listProvidersService.getList(EasyMock.anyString(), EasyMock.anyObject(ResourceListQueryImpl.class),
-                    EasyMock.anyObject(Organization.class), EasyMock.anyBoolean())).andReturn(collection).anyTimes();
+                    EasyMock.anyBoolean())).andReturn(collection).anyTimes();
     EasyMock.expect(
             listProvidersService.isTranslatable(EasyMock.anyString()))
             .andThrow(new ListProviderException("not implemented")).anyTimes();

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/MetadataFieldTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/MetadataFieldTest.java
@@ -32,7 +32,6 @@ import org.opencastproject.index.service.resources.list.api.ListProvidersService
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.util.RestUtils;
 import org.opencastproject.metadata.dublincore.MetadataField;
-import org.opencastproject.security.api.Organization;
 
 import com.entwinemedia.fn.data.Opt;
 
@@ -81,7 +80,7 @@ public class MetadataFieldTest {
     listProvidersService = EasyMock.createMock(ListProvidersService.class);
     EasyMock.expect(
             listProvidersService.getList(EasyMock.anyString(), EasyMock.anyObject(ResourceListQuery.class),
-                    EasyMock.anyObject(Organization.class), EasyMock.anyBoolean())).andReturn(collection).anyTimes();
+                    EasyMock.anyBoolean())).andReturn(collection).anyTimes();
     EasyMock.expect(
             listProvidersService.isTranslatable(EasyMock.anyString())).andReturn(isTranslatable).anyTimes();
     EasyMock.replay(listProvidersService);

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/impl/ListProvidersScannerTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/impl/ListProvidersScannerTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.opencastproject.index.service.exception.ListProviderException;
-import org.opencastproject.index.service.resources.list.api.ListProvidersService;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.query.ResourceListQueryImpl;
 import org.opencastproject.security.api.Organization;
@@ -47,7 +46,7 @@ public class ListProvidersScannerTest {
   private Organization defaultOrg;
   private Organization specificOrg;
   private ListProvidersScanner listProvidersScanner;
-  private ListProvidersService listProvidersService;
+  private ListProvidersServiceImpl listProvidersService;
   private SecurityService securityService;
 
   private static File getResourceFile(String resourcePath) throws Exception {
@@ -62,7 +61,7 @@ public class ListProvidersScannerTest {
     listProvidersService = new ListProvidersServiceImpl();
     listProvidersScanner = new ListProvidersScanner();
     securityService = EasyMock.createNiceMock(SecurityService.class);
-    ((ListProvidersServiceImpl) listProvidersService).setSecurityService(securityService);
+    listProvidersService.setSecurityService(securityService);
     listProvidersScanner.setListProvidersService(listProvidersService);
   }
 
@@ -225,9 +224,6 @@ public class ListProvidersScannerTest {
     assertEquals("org1", org1.getId());
     assertTrue("Provider is not registered", listProvidersService.hasProvider(listName, org1.getId()));
     Map<String, String> dictionary = listProvidersService.getList(listName, query, false);
-    for (String key : dictionary.keySet()) {
-      logger.info("Key: {}, Value {}.", key, dictionary.get(key));
-    }
 
     assertEquals(3, dictionary.size());
 

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/impl/ListProvidersScannerTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/impl/ListProvidersScannerTest.java
@@ -23,17 +23,17 @@ package org.opencastproject.index.service.resources.list.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ListProvidersService;
-import org.opencastproject.index.service.resources.list.api.ResourceListProvider;
 import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.query.ResourceListQueryImpl;
+import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.Organization;
 
-import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +43,21 @@ import java.util.Map;
 
 public class ListProvidersScannerTest {
   private static final Logger logger = LoggerFactory.getLogger(ListProvidersScannerTest.class);
+  private String listName;
+  private ListProvidersService listProvidersService;
+  private ListProvidersScanner listProvidersScanner;
+
+  private static File getResourceFile(String resourcePath) throws Exception {
+    return new File(ListProvidersScannerTest.class.getResource(resourcePath).toURI());
+  }
+
+  @Before
+  public void setUp() {
+    listName = "BLACKLISTS.USERS.REASONS";
+    listProvidersService = new ListProvidersServiceImpl();
+    listProvidersScanner = new ListProvidersScanner();
+    listProvidersScanner.setListProvidersService(listProvidersService);
+  }
 
   @Test
   public void testCanHandle() {
@@ -61,95 +76,100 @@ public class ListProvidersScannerTest {
   }
 
   @Test
-  public void testInstall() throws Exception {
-    String listName = "BLACKLISTS.USERS.REASONS";
-    File file = new File(
-            ListProvidersScannerTest.class.getResource("/ListProvidersScannerTest-GoodProperties.properties").toURI());
-    Capture<ResourceListProvider> resourceListProvider = Capture.newInstance();
-    Capture<String> captureListName = Capture.newInstance();
-    ListProvidersService listProvidersService = EasyMock.createNiceMock(ListProvidersService.class);
-    listProvidersService.addProvider(EasyMock.capture(captureListName), EasyMock.capture(resourceListProvider));
-    EasyMock.expectLastCall();
-    EasyMock.replay(listProvidersService);
-
-    ListProvidersScanner listProvidersScanner = new ListProvidersScanner();
-    listProvidersScanner.setListProvidersService(listProvidersService);
+  public void testDefaultInstall() throws Exception {
+    File file = getResourceFile("/ListProvidersScannerTest-GoodProperties.properties");
     listProvidersScanner.install(file);
 
-    assertEquals(1, resourceListProvider.getValues().size());
-    assertEquals(listName, resourceListProvider.getValue().getListNames()[0]);
-    assertEquals("Sick Leave",
-            resourceListProvider.getValue().getList(listName, null, null).get("PM.BLACKLIST.REASONS.SICK_LEAVE"));
-    assertEquals("Leave",
-            resourceListProvider.getValue().getList(listName, null, null).get("PM.BLACKLIST.REASONS.LEAVE"));
-    assertEquals("Family Emergency",
-            resourceListProvider.getValue().getList(listName, null, null).get("PM.BLACKLIST.REASONS.FAMILY_EMERGENCY"));
-    assertNull(resourceListProvider.getValue().getList("Wrong List Name", null, null));
+    assertTrue("Provider has not been registered", listProvidersService.hasProvider(listName));
+    assertEquals(1, listProvidersService.getAvailableProviders().size());
+    assertEquals(3, listProvidersService
+            .getList(listName, null, new DefaultOrganization(), false).size()
+    );
+    assertEquals(listName, listProvidersService.getAvailableProviders().get(0));
+    assertEquals("Sick Leave", listProvidersService
+            .getList(listName, null, new DefaultOrganization(), false)
+            .get("PM.BLACKLIST.REASONS.SICK_LEAVE")
+    );
   }
 
   @Test
-  public void testUpdate() throws Exception {
-    String listName = "BLACKLISTS.USERS.REASONS";
-    File file = new File(
-            ListProvidersScannerTest.class.getResource("/ListProvidersScannerTest-GoodProperties.properties").toURI());
-    Capture<ResourceListProvider> resourceListProvider = Capture.newInstance();
-    Capture<String> captureListName = Capture.newInstance();
-    ListProvidersService listProvidersService = EasyMock.createNiceMock(ListProvidersService.class);
-    listProvidersService.addProvider(EasyMock.capture(captureListName), EasyMock.capture(resourceListProvider));
-    EasyMock.expectLastCall();
-    EasyMock.replay(listProvidersService);
-
-    ListProvidersScanner listProvidersScanner = new ListProvidersScanner();
-    listProvidersScanner.setListProvidersService(listProvidersService);
+  public void testDefaultUpdate() throws Exception {
+    File file = getResourceFile("/ListProvidersScannerTest-GoodProperties.properties");
     listProvidersScanner.update(file);
+    Map<String, String> dictionary = listProvidersService.getList(listName, null, new DefaultOrganization(), false);
 
-    assertEquals(1, resourceListProvider.getValues().size());
-    assertEquals(listName, resourceListProvider.getValue().getListNames()[0]);
-    assertEquals("Sick Leave",
-            resourceListProvider.getValue().getList(listName, null, null).get("PM.BLACKLIST.REASONS.SICK_LEAVE"));
-    assertEquals("Leave",
-            resourceListProvider.getValue().getList(listName, null, null).get("PM.BLACKLIST.REASONS.LEAVE"));
-    assertEquals("Family Emergency",
-            resourceListProvider.getValue().getList(listName, null, null).get("PM.BLACKLIST.REASONS.FAMILY_EMERGENCY"));
+    assertEquals("Sick Leave", dictionary.get("PM.BLACKLIST.REASONS.SICK_LEAVE"));
+    assertEquals("Leave", dictionary.get("PM.BLACKLIST.REASONS.LEAVE"));
+    assertEquals("Family Emergency", dictionary.get("PM.BLACKLIST.REASONS.FAMILY_EMERGENCY"));
   }
 
   @Test
-  public void testUninstall() throws Exception {
-    String listName = "BLACKLISTS.USERS.REASONS";
-    File file = new File(
-            ListProvidersScannerTest.class.getResource("/ListProvidersScannerTest-GoodProperties.properties").toURI());
-    ListProvidersService listProvidersService = EasyMock.createNiceMock(ListProvidersService.class);
-    listProvidersService.removeProvider(listName);
-    EasyMock.expectLastCall();
-    EasyMock.replay(listProvidersService);
-
-    ListProvidersScanner listProvidersScanner = new ListProvidersScanner();
-    listProvidersScanner.setListProvidersService(listProvidersService);
+  public void testDefaultUninstall() throws Exception {
+    File file = getResourceFile("/ListProvidersScannerTest-GoodProperties.properties");
     listProvidersScanner.uninstall(file);
+    assertTrue("Provider was not removed", !listProvidersService.hasProvider(listName));
+  }
+
+  @Test
+  public void testSpecificOrgInstall() throws Exception {
+    listName = "DEBUG";
+    File file = getResourceFile("/ListProvidersScannerTest-AllProperties.properties");
+    listProvidersScanner.install(file);
+    assertTrue("Provider has not been registered", listProvidersService.hasProvider(listName, "ch-switch"));
+  }
+
+  @Test
+  public void testSpecificOrgUninstall() throws Exception {
+    listName = "DEBUG";
+    File file = getResourceFile("/ListProvidersScannerTest-AllProperties.properties");
+    listProvidersScanner.uninstall(file);
+    assertTrue("Provider was not removed", !listProvidersService.hasProvider(listName, "ch-switch"));
+  }
+
+  @Test
+  public void testIsTranslatable() throws Exception {
+    listName = "DEBUG";
+    File file = getResourceFile("/ListProvidersScannerTest-AllProperties.properties");
+    listProvidersScanner.install(file);
+
+    assertTrue("Translatable property not read correctly", listProvidersService.isTranslatable(listName, "ch-switch"));
+  }
+
+  @Test
+  public void testGetDefault() throws Exception {
+    listName = "DEBUG";
+    File fileWithDefault = getResourceFile("/ListProvidersScannerTest-AllProperties.properties");
+    listProvidersScanner.install(fileWithDefault);
+
+    assertEquals("dokay", listProvidersService.getDefault(listName, "ch-switch"));
+  }
+
+  @Test
+  public void testThrowsExceptions() throws Exception {
+    File fileWithDefault = getResourceFile("/ListProvidersScannerTest-GoodProperties.properties");
+    listProvidersScanner.install(fileWithDefault);
+
+    try {
+      String defaultValue = listProvidersService.getDefault(listName, "ch-switch");
+    } catch (ListProviderException e) {
+      assertEquals("No provider found for organisation <ch-switch> with the name " + listName, e.getMessage());
+    }
   }
 
   @Test
   public void testInstallInputMissingListNameInPropertiesFileExpectsNotAddedToService() throws Exception {
-    File file = new File(
-            ListProvidersScannerTest.class.getResource("/ListProvidersScannerTest-MissingListName.properties").toURI());
-    ListProvidersService listProvidersService = EasyMock.createMock(ListProvidersService.class);
-    EasyMock.replay(listProvidersService);
-
-    ListProvidersScanner listProvidersScanner = new ListProvidersScanner();
-    listProvidersScanner.setListProvidersService(listProvidersService);
+    File file = getResourceFile("/ListProvidersScannerTest-MissingListName.properties");
     listProvidersScanner.install(file);
+
+    assertFalse("Provider should not be added without a name", listProvidersService.hasProvider(listName));
   }
 
   @Test
   public void testInstallInputEmptyListNameInPropertiesFileExpectsNotAddedToService() throws Exception {
-    File file = new File(
-            ListProvidersScannerTest.class.getResource("/ListProvidersScannerTest-EmptyListName.properties").toURI());
-    ListProvidersService listProvidersService = EasyMock.createMock(ListProvidersService.class);
-    EasyMock.replay(listProvidersService);
-
-    ListProvidersScanner listProvidersScanner = new ListProvidersScanner();
-    listProvidersScanner.setListProvidersService(listProvidersService);
+    File file = getResourceFile("/ListProvidersScannerTest-EmptyListName.properties");
     listProvidersScanner.install(file);
+
+    assertFalse("Provider should not be added without a name", listProvidersService.hasProvider(listName));
   }
 
   @Test
@@ -162,36 +182,24 @@ public class ListProvidersScannerTest {
     EasyMock.expect(org2.getId()).andReturn("org2").anyTimes();
     EasyMock.replay(org2);
 
-    String listName = "BLACKLISTS.USERS.REASONS";
-    File file = new File(
-            ListProvidersScannerTest.class.getResource("/ListProvidersScannerTest-WithOrg.properties").toURI());
-    Capture<ResourceListProvider> resourceListProvider = Capture.newInstance();
-    Capture<String> captureListName = Capture.newInstance();
-    ListProvidersService listProvidersService = EasyMock.createNiceMock(ListProvidersService.class);
-    listProvidersService.addProvider(EasyMock.capture(captureListName), EasyMock.capture(resourceListProvider));
-    EasyMock.expectLastCall();
-    EasyMock.replay(listProvidersService);
-
-    ListProvidersScanner listProvidersScanner = new ListProvidersScanner();
-    listProvidersScanner.setListProvidersService(listProvidersService);
+    File file = getResourceFile("/ListProvidersScannerTest-WithOrg.properties");
     listProvidersScanner.install(file);
 
     ResourceListQuery query = new ResourceListQueryImpl();
 
-    assertEquals(1, resourceListProvider.getValues().size());
-    assertEquals(listName, resourceListProvider.getValue().getListNames()[0]);
-    Map<String, String> stuff = resourceListProvider.getValue().getList(listName, query, org1);
-    for (String key : stuff.keySet()) {
-      logger.info("Key: {}, Value {}.", key, stuff.get(key));
+    assertEquals(1, listProvidersService.getAvailableProviders().size());
+    assertEquals(listName, listProvidersService.getAvailableProviders().get(0));
+    assertEquals("org1", org1.getId());
+    assertTrue("Provider is not registered", listProvidersService.hasProvider(listName, org1.getId()));
+    Map<String, String> dictionary = listProvidersService.getList(listName, query, org1, false);
+    for (String key : dictionary.keySet()) {
+      logger.info("Key: {}, Value {}.", key, dictionary.get(key));
     }
-    assertEquals(3, resourceListProvider.getValue().getList(listName, query, org1).size());
-    assertNull(resourceListProvider.getValue().getList(listName, query, org2));
-    assertNull(resourceListProvider.getValue().getList(listName, query, null));
-    assertEquals("Sick Leave",
-            resourceListProvider.getValue().getList(listName, null, org1).get("PM.BLACKLIST.REASONS.SICK_LEAVE"));
-    assertEquals("Leave",
-            resourceListProvider.getValue().getList(listName, null, org1).get("PM.BLACKLIST.REASONS.LEAVE"));
-    assertEquals("Family Emergency",
-            resourceListProvider.getValue().getList(listName, null, org1).get("PM.BLACKLIST.REASONS.FAMILY_EMERGENCY"));
+
+    assertEquals(3, dictionary.size());
+
+    assertEquals("Sick Leave", dictionary.get("PM.BLACKLIST.REASONS.SICK_LEAVE"));
+    assertEquals("Leave", dictionary.get("PM.BLACKLIST.REASONS.LEAVE"));
+    assertEquals("Family Emergency", dictionary.get("PM.BLACKLIST.REASONS.FAMILY_EMERGENCY"));
   }
 }

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/impl/ListProvidersServiceTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/impl/ListProvidersServiceTest.java
@@ -27,7 +27,6 @@ import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.query.ResourceListQueryImpl;
 import org.opencastproject.index.service.resources.list.query.StringListFilter;
 import org.opencastproject.index.service.util.ListProviderUtil;
-import org.opencastproject.security.api.Organization;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -56,7 +55,7 @@ public class ListProvidersServiceTest {
       }
 
       @Override
-      public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization) {
+      public Map<String, String> getList(String listName, ResourceListQuery query) {
 
         Map<String, String> filteredList = new HashMap<String, String>();
 

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/impl/ListProvidersServiceTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/impl/ListProvidersServiceTest.java
@@ -27,7 +27,10 @@ import org.opencastproject.index.service.resources.list.api.ResourceListQuery;
 import org.opencastproject.index.service.resources.list.query.ResourceListQueryImpl;
 import org.opencastproject.index.service.resources.list.query.StringListFilter;
 import org.opencastproject.index.service.util.ListProviderUtil;
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
 
+import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,6 +45,8 @@ public class ListProvidersServiceTest {
   private static final String TEST_SORTBY = "value";
 
   private ListProvidersServiceImpl listProviderService;
+  private Organization organization;
+  private SecurityService securityService;
 
   /**
    * Returns a map for the example with default filtering
@@ -95,6 +100,13 @@ public class ListProvidersServiceTest {
   @Before
   public void setUp() {
     listProviderService = new ListProvidersServiceImpl();
+    securityService = EasyMock.createNiceMock(SecurityService.class);
+    organization = EasyMock.createNiceMock(Organization.class);
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization).anyTimes();
+    EasyMock.expect(organization.getId()).andReturn("mh_default_org").anyTimes();
+    EasyMock.replay(organization);
+    EasyMock.replay(securityService);
+    listProviderService.setSecurityService(securityService);
   }
 
   @Test
@@ -121,8 +133,8 @@ public class ListProvidersServiceTest {
     Assert.assertEquals(baseNumber + 2, listProviderService.getAvailableProviders().size());
     Assert.assertTrue(listProviderService.hasProvider(providerName1));
     Assert.assertTrue(listProviderService.hasProvider(providerName2));
-    Assert.assertEquals(list1, listProviderService.getList(providerName1, query, null, false));
-    Assert.assertEquals(list2, listProviderService.getList(providerName2, query, null, false));
+    Assert.assertEquals(list1, listProviderService.getList(providerName1, query, false));
+    Assert.assertEquals(list2, listProviderService.getList(providerName2, query, false));
 
     listProviderService.removeProvider(providerName2);
     Assert.assertEquals(baseNumber + 1, listProviderService.getAvailableProviders().size());
@@ -143,20 +155,20 @@ public class ListProvidersServiceTest {
 
     query.setLimit(2);
     query.setOffset(1);
-    Assert.assertEquals(2, listProviderService.getList(providerName1, query, null, false).size());
+    Assert.assertEquals(2, listProviderService.getList(providerName1, query, false).size());
 
     query.setLimit(1);
     query.setOffset(5);
-    Assert.assertEquals(0, listProviderService.getList(providerName1, query, null, false).size());
+    Assert.assertEquals(0, listProviderService.getList(providerName1, query, false).size());
 
     query.setLimit(2);
     query.setOffset(1);
-    Assert.assertEquals(2, listProviderService.getList(providerName1, query, null, false).size());
+    Assert.assertEquals(2, listProviderService.getList(providerName1, query, false).size());
 
     query.setLimit(12);
     query.setOffset(0);
     query.addFilter(new StringListFilter(TEST_FILTER_NAME, "test"));
-    Assert.assertEquals(3, listProviderService.getList(providerName1, query, null, false).size());
+    Assert.assertEquals(3, listProviderService.getList(providerName1, query, false).size());
 
     // query.setSortedBy(TEST_SORTBY);
     // Map<String, String> list = listProviderService.getList(providerName1, query, null);

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProviderTest.java
@@ -135,7 +135,7 @@ public class ContributorsListProviderTest {
 
   @Test
   public void testUsernamesList() {
-    Map<String, String> list = contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, null, null);
+    Map<String, String> list = contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, null);
 
     Assert.assertTrue(list.containsKey(user1.getUsername()));
     Assert.assertTrue(list.containsKey(user2.getUsername()));
@@ -153,7 +153,7 @@ public class ContributorsListProviderTest {
 
   @Test
   public void testListSimple() throws ListProviderException {
-    Map<String, String> list = contributorsListProvider.getList(ContributorsListProvider.DEFAULT, null, null);
+    Map<String, String> list = contributorsListProvider.getList(ContributorsListProvider.DEFAULT, null);
 
     Assert.assertTrue(list.containsKey(user1.getName()));
     Assert.assertTrue(list.containsKey(user2.getName()));
@@ -172,11 +172,11 @@ public class ContributorsListProviderTest {
     ResourceListQueryImpl query = new ResourceListQueryImpl();
     query.setLimit(0);
     query.setOffset(0);
-    Assert.assertEquals(5, contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, query, null).size());
+    Assert.assertEquals(5, contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, query).size());
     query.setOffset(3);
-    Assert.assertEquals(2, contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, query, null).size());
+    Assert.assertEquals(2, contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, query).size());
     query.setOffset(0);
     query.setLimit(1);
-    Assert.assertEquals(1, contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, query, null).size());
+    Assert.assertEquals(1, contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, query).size());
   }
 }

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/JobsListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/JobsListProviderTest.java
@@ -79,8 +79,8 @@ public class JobsListProviderTest {
   public void testStatusListName() throws ListProviderException, WorkflowDatabaseException {
     ResourceListQuery query = new JobsListQuery();
 
-    assertEquals(4, jobsListProvider.getList(JobsListProvider.LIST_STATUS, query, null).size());
-    for (Entry<String, String> entry : jobsListProvider.getList(JobsListProvider.LIST_STATUS, query, null).entrySet()) {
+    assertEquals(4, jobsListProvider.getList(JobsListProvider.LIST_STATUS, query).size());
+    for (Entry<String, String> entry : jobsListProvider.getList(JobsListProvider.LIST_STATUS, query).entrySet()) {
       try {
         Job.Status.valueOf(entry.getKey());
       } catch (IllegalArgumentException ex) {
@@ -96,10 +96,10 @@ public class JobsListProviderTest {
     ResourceListQuery query = new JobsListQuery();
 
     assertEquals(workflowDefinitions.size(),
-            jobsListProvider.getList(JobsListProvider.LIST_WORKFLOW, query, null).size());
+            jobsListProvider.getList(JobsListProvider.LIST_WORKFLOW, query).size());
 
     for (Entry<String, String> entry : jobsListProvider.getList(
-            JobsListProvider.LIST_WORKFLOW, query, null).entrySet()) {
+            JobsListProvider.LIST_WORKFLOW, query).entrySet()) {
 
       boolean match = false;
       for (WorkflowDefinition wfD : workflowDefinitions) {

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ServersListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ServersListProviderTest.java
@@ -72,16 +72,16 @@ public class ServersListProviderTest {
   public void testListNames() throws ListProviderException {
     ResourceListQuery query = new ServersListQuery();
 
-    assertEquals(4, serverListProvider.getList("non-existing-name", query, null).size());
-    assertEquals(4, serverListProvider.getList(ServersListProvider.LIST_HOSTNAME, query, null).size());
-    assertEquals(3, serverListProvider.getList(ServersListProvider.LIST_STATUS, query, null).size());
+    assertEquals(4, serverListProvider.getList("non-existing-name", query).size());
+    assertEquals(4, serverListProvider.getList(ServersListProvider.LIST_HOSTNAME, query).size());
+    assertEquals(3, serverListProvider.getList(ServersListProvider.LIST_STATUS, query).size());
   }
 
   @Test
   public void testHostnameList() throws ListProviderException {
     ResourceListQuery query = new ServersListQuery();
 
-    Map<String, String> list = serverListProvider.getList(ServersListProvider.LIST_HOSTNAME, query, null);
+    Map<String, String> list = serverListProvider.getList(ServersListProvider.LIST_HOSTNAME, query);
     assertEquals(HOST1, list.get(HOST1));
     assertEquals(HOST2, list.get(HOST2));
     assertEquals(HOST3, list.get(HOST3));
@@ -92,7 +92,7 @@ public class ServersListProviderTest {
   public void testStatusList() throws ListProviderException {
     ResourceListQuery query = new ServersListQuery();
 
-    Map<String, String> list = serverListProvider.getList(ServersListProvider.LIST_STATUS, query, null);
+    Map<String, String> list = serverListProvider.getList(ServersListProvider.LIST_STATUS, query);
     assertEquals(ServersListProvider.SERVER_STATUS_LABEL_ONLINE, list.get(ServersListProvider.SERVER_STATUS_ONLINE));
     assertEquals(ServersListProvider.SERVER_STATUS_LABEL_OFFLINE, list.get(ServersListProvider.SERVER_STATUS_OFFLINE));
     assertEquals(ServersListProvider.SERVER_STATUS_LABEL_MAINTENANCE, list.get(ServersListProvider.SERVER_STATUS_MAINTENANCE));

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ServicesListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ServicesListProviderTest.java
@@ -67,14 +67,14 @@ public class ServicesListProviderTest {
 
   @Test
   public void testListNames() throws ListProviderException {
-    assertEquals(3, servicesListProvider.getList("", servicesQuery, null).size());
-    assertEquals(3, servicesListProvider.getList(ServicesListProvider.LIST_NAME, servicesQuery, null).size());
-    assertEquals(3, servicesListProvider.getList(ServicesListProvider.LIST_STATUS, servicesQuery, null).size());
+    assertEquals(3, servicesListProvider.getList("", servicesQuery).size());
+    assertEquals(3, servicesListProvider.getList(ServicesListProvider.LIST_NAME, servicesQuery).size());
+    assertEquals(3, servicesListProvider.getList(ServicesListProvider.LIST_STATUS, servicesQuery).size());
   }
 
   @Test
   public void testNameList() throws ListProviderException {
-    Map<String, String> list = servicesListProvider.getList(ServicesListProvider.LIST_NAME, servicesQuery, null);
+    Map<String, String> list = servicesListProvider.getList(ServicesListProvider.LIST_NAME, servicesQuery);
     assertEquals(SERVICE_TYPE_1, list.get(SERVICE_TYPE_1));
     assertEquals(SERVICE_TYPE_2, list.get(SERVICE_TYPE_2));
     assertEquals(SERVICE_TYPE_3, list.get(SERVICE_TYPE_3));
@@ -82,7 +82,7 @@ public class ServicesListProviderTest {
 
   @Test
   public void testStatusList() throws ListProviderException {
-    Map<String, String> list = servicesListProvider.getList(ServicesListProvider.LIST_STATUS, servicesQuery, null);
+    Map<String, String> list = servicesListProvider.getList(ServicesListProvider.LIST_STATUS, servicesQuery);
     for (ServiceState state : ServiceState.values()) {
       assertEquals(ServicesListProvider.SERVICE_STATUS_FILTER_PREFIX + state.toString(), list.get(state.toString()));
     }

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/UsersListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/UsersListProviderTest.java
@@ -114,25 +114,25 @@ public class UsersListProviderTest {
 
   @Test
   public void testListSimple() throws ListProviderException {
-    Map<String, String> list = usersListProvider.getList(UsersListProvider.NAME, null, null);
+    Map<String, String> list = usersListProvider.getList(UsersListProvider.NAME, null);
     Assert.assertTrue(list.containsKey(user1.getName()));
     Assert.assertTrue(list.containsKey(user2.getName()));
     Assert.assertTrue(list.containsKey(user3.getName()));
     Assert.assertEquals(3, list.size());
 
-    list = usersListProvider.getList(UsersListProvider.USERNAME, null, null);
+    list = usersListProvider.getList(UsersListProvider.USERNAME, null);
     Assert.assertTrue(list.containsKey(user1.getUsername()));
     Assert.assertTrue(list.containsKey(user2.getUsername()));
     Assert.assertTrue(list.containsKey(user3.getUsername()));
     Assert.assertTrue(list.containsKey(user4.getUsername()));
     Assert.assertEquals(4, list.size());
 
-    list = usersListProvider.getList(UsersListProvider.EMAIL, null, null);
+    list = usersListProvider.getList(UsersListProvider.EMAIL, null);
     Assert.assertTrue(list.containsKey(user1.getEmail()));
     Assert.assertTrue(list.containsKey(user4.getEmail()));
     Assert.assertEquals(2, list.size());
 
-    list = usersListProvider.getList(UsersListProvider.USERDIRECTORY, null, null);
+    list = usersListProvider.getList(UsersListProvider.USERDIRECTORY, null);
     Assert.assertTrue(list.containsKey(user1.getProvider()));
     Assert.assertEquals(1, list.size());
   }
@@ -142,11 +142,11 @@ public class UsersListProviderTest {
     ResourceListQueryImpl query = new ResourceListQueryImpl();
     query.setLimit(0);
     query.setOffset(0);
-    Assert.assertEquals(4, usersListProvider.getList(UsersListProvider.USERNAME, query, null).size());
+    Assert.assertEquals(4, usersListProvider.getList(UsersListProvider.USERNAME, query).size());
     query.setOffset(3);
-    Assert.assertEquals(1, usersListProvider.getList(UsersListProvider.USERNAME, query, null).size());
+    Assert.assertEquals(1, usersListProvider.getList(UsersListProvider.USERNAME, query).size());
     query.setOffset(0);
     query.setLimit(1);
-    Assert.assertEquals(1, usersListProvider.getList(UsersListProvider.USERNAME, query, null).size());
+    Assert.assertEquals(1, usersListProvider.getList(UsersListProvider.USERNAME, query).size());
   }
 }

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/util/JSONUtilsTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/util/JSONUtilsTest.java
@@ -33,8 +33,8 @@ import org.opencastproject.index.service.resources.list.provider.ContributorsLis
 import org.opencastproject.index.service.resources.list.query.ResourceListQueryImpl;
 import org.opencastproject.index.service.resources.list.query.SeriesListQuery;
 import org.opencastproject.index.service.resources.list.query.StringListFilter;
-import org.opencastproject.security.api.DefaultOrganization;
-import org.opencastproject.security.api.JaxbOrganization;
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.util.data.Option;
 
 import com.entwinemedia.fn.data.json.JValue;
@@ -121,9 +121,17 @@ public class JSONUtilsTest {
   public void testFiltersToJSON() throws Exception {
     String expectedJSON = IOUtils.toString(getClass().getResource("/filters.json"));
 
-    JaxbOrganization defaultOrganization = new DefaultOrganization();
+    SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
+    Organization organization = EasyMock.createNiceMock(Organization.class);
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization).anyTimes();
+    EasyMock.expect(organization.getId()).andReturn("mh_default_org").anyTimes();
+    EasyMock.replay(organization);
+    EasyMock.replay(securityService);
+
     ListProvidersServiceImpl listProvidersService = new ListProvidersServiceImpl();
     SimpleSerializer serializer = new SimpleSerializer();
+
+    listProvidersService.setSecurityService(securityService);
 
     final Map<String, String> license = new HashMap<String, String>();
     license.put("contributor1", "My first contributor");
@@ -131,7 +139,7 @@ public class JSONUtilsTest {
     license.put("contributor3", "My third contributor");
 
     // Create test list provider
-    listProvidersService.addProvider(new ResourceListProvider() {
+    listProvidersService.addProvider(ContributorsListProvider.DEFAULT, new ResourceListProvider() {
 
       @Override
       public String[] getListNames() {
@@ -153,7 +161,7 @@ public class JSONUtilsTest {
       public String getDefault() {
         return null;
       }
-    });
+    }, organization.getId());
 
     // Prepare mock query
     List<ResourceListFilter<?>> filters = new ArrayList<ResourceListFilter<?>>();
@@ -166,7 +174,7 @@ public class JSONUtilsTest {
     EasyMock.expect(query.getOffset()).andReturn(Option.<Integer> none()).anyTimes();
     EasyMock.replay(query);
 
-    JValue result = JSONUtils.filtersToJSON(query, listProvidersService, defaultOrganization);
+    JValue result = JSONUtils.filtersToJSON(query, listProvidersService, organization);
 
     StreamingOutput stream = RestUtils.stream(serializer.fn.toJson(result));
     ByteArrayOutputStream resultStream = new ByteArrayOutputStream();

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/util/JSONUtilsTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/util/JSONUtilsTest.java
@@ -35,7 +35,6 @@ import org.opencastproject.index.service.resources.list.query.SeriesListQuery;
 import org.opencastproject.index.service.resources.list.query.StringListFilter;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.JaxbOrganization;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.util.data.Option;
 
 import com.entwinemedia.fn.data.json.JValue;
@@ -140,7 +139,7 @@ public class JSONUtilsTest {
       }
 
       @Override
-      public Map<String, String> getList(String listName, ResourceListQuery query, Organization organization)
+      public Map<String, String> getList(String listName, ResourceListQuery query)
               throws ListProviderException {
         return ListProviderUtil.filterMap(license, query);
       }

--- a/modules/index-service/src/test/resources/ListProvidersScannerTest-AllProperties.properties
+++ b/modules/index-service/src/test/resources/ListProvidersScannerTest-AllProperties.properties
@@ -1,0 +1,7 @@
+list.name=DEBUG
+list.org=ch-switch
+list.translatable=true
+list.default=dokay
+DEBUG.OKAY=okay
+DEBUG.NOKAY=nokay
+DEBUG.GOKAY=gokay


### PR DESCRIPTION
This will allow Opencast service providers to set different tenant-specific properties for lists located at ```etc/listproviders/```. For a given list, if the ```list.org``` property is set, a resource provider specific to this organisation is registered in the list providers service. If said property is not set, a default resource provider is registered instead. 

When a client wants to retrieve a list, the list providers service first checks if there is a provider registered for the current organisation (determined via the security context) that provides the queried list. If so, the specific list is returned, otherwise, the list providers service checks if there is a default provider for the queried list, returning it. (See example below.)

Resolves: [MH-13157](https://opencast.jira.com/browse/MH-13157)

#### Default:
<img width="100%" alt="default" src="https://user-images.githubusercontent.com/16406401/49235346-37e61800-f3fa-11e8-836d-6e8257b0b898.png">

![default](https://user-images.githubusercontent.com/16406401/49235374-43394380-f3fa-11e8-9231-9574f0bd3b33.gif)

#### Specific:
<img width="100%" alt="specific" src="https://user-images.githubusercontent.com/16406401/49235434-63690280-f3fa-11e8-9abd-5b1885c9f753.png">

![specific](https://user-images.githubusercontent.com/16406401/49235449-69f77a00-f3fa-11e8-8bc9-3452366e5bba.gif)
