### PR TITLE
MH-13245: Paella player does not show a single presentation video

### DIFF
--- a/modules/engage-paella-player/package-lock.json
+++ b/modules/engage-paella-player/package-lock.json
@@ -1119,7 +1119,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -2113,7 +2113,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2317,8 +2317,8 @@
       "dev": true
     },
     "paellaplayer": {
-      "version": "github:polimediaupv/paella#49f3f264d0e81b210f1f22833484d4e88c844451",
-      "from": "github:polimediaupv/paella#6.0.3",
+      "version": "github:polimediaupv/paella#a50e194aec43ece9f67c2e01b736ebf60d6c88e1",
+      "from": "github:polimediaupv/paella#6.0.4",
       "dev": true
     },
     "parse-filepath": {
@@ -2448,7 +2448,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
@@ -3250,7 +3250,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {

--- a/modules/engage-paella-player/package.json
+++ b/modules/engage-paella-player/package.json
@@ -10,6 +10,6 @@
     "eslint-plugin-header": "^2.0.0",
     "gulp": "^3.9.1",
     "merge-stream": "^1.0.1",
-    "paellaplayer": "github:polimediaupv/paella#6.0.3"
+    "paellaplayer": "github:polimediaupv/paella#6.0.4"
   }
 }


### PR DESCRIPTION
Jira ticket: [MH-13245](https://opencast.jira.com/browse/MH-13245)

Paella player 6 <= 6.0.3 only plays single videos when flavored as `presenter/delivery`.
Upgrading to paella 6.0.4 solves this issue. 