### PR TITLE
MH-13221 Open single-select with single click

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
@@ -99,6 +99,8 @@ angular.module('adminNg.directives')
       scope.collection = scope.ordered ? mapToArrayOrdered(scope.collection, scope.params.translatable) :
         mapToArray(scope.collection, scope.params.translatable);
 
+      scope.editMode = false;
+
       scope.submit = function () {
         // Wait until the change of the value propagated to the parent's
         // metadata object.
@@ -124,21 +126,30 @@ angular.module('adminNg.directives')
         $timeout.cancel(scope.submitTimer);
       });
 
+      scope.toggleEditMode = function () {
+
+        if (scope.editMode == false) {
+          scope.enterEditMode();
+        } else {
+          scope.leaveEditMode();
+        }
+      };
+
       scope.enterEditMode = function () {
+
         // Store the original value for later comparision or undo
         if (!angular.isDefined(scope.original)) {
           scope.original = scope.params.value;
         }
         scope.editMode = true;
-        scope.focusTimer = $timeout(function () {
+        $timeout(function () {
           if ($('[chosen]')) {
-            element.find('select').trigger('chosen:activate');
+            element.find('select').trigger('chosen:open');
           }
         });
       };
 
       scope.leaveEditMode = function () {
-        // does not work currently, as angular chose does not support ng-blur yet. But it does not break anything
         scope.editMode = false;
       };
     }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableSingleSelect.html
@@ -1,7 +1,7 @@
-<div ng-form="innerForm" ng-click="enterEditMode()">
-  &nbsp;<span ng-show="!editMode" ng-click="enterEditMode()" translate="{{((params.value === '' || params.value === null || angular.isUndefined(params.value)) ? 'SELECT_NO_OPTIONS' : getLabel(params.value))}}"></span>
+<div ng-form="innerForm" ng-click="toggleEditMode()">
+  &nbsp;<span ng-show="!editMode" translate="{{((params.value === '' || params.value === null || angular.isUndefined(params.value)) ? 'SELECT_NO_OPTIONS' : getLabel(params.value))}}"></span>
 
-  <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-click="enterEditMode()" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
+  <i class="edit fa fa-pencil-square" ng-show="!editMode" tabindex="{{ params.tabindex }}"></i>
   <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
 
   <div class="editable-select" ng-show="editMode">
@@ -10,7 +10,6 @@
             ng-model="params.value"
             name="{{ params.name }}"
             ng-change="submit()"
-            ng-blur="leaveEditMode()"
             ng-required="params.required"
             tabindex="{{ params.tabindex }}"
             data-width="'250px'"
@@ -19,4 +18,3 @@
     </select>
   </div>
 </div>
-

--- a/modules/admin-ui/src/test/resources/test/unit/shared/directives/editableSingleSelectDirectiveSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/directives/editableSingleSelectDirectiveSpec.js
@@ -40,7 +40,7 @@ describe('adminNg.directives.adminNgEditableSingleSelect', function () {
         expect(element.find('span')).not.toHaveClass('ng-hide');
         element.click();
         $timeout.flush();
-        expect(element.find('div')).not.toHaveClass('ng-hide');
+        expect(element.find('div.editable-select')).not.toHaveClass('ng-hide');
         expect(element.find('span')).toHaveClass('ng-hide');
         expect(element.find('select')).not.toHaveClass('ng-hide');
     });


### PR DESCRIPTION
Open a single-select drop-down with a single click instead of having to click twice. No longer react to clicks outside of the span representing the drop-down menu.