### PR TITLE
MH-13266 Start date cross link does not work correctly

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -124,9 +124,9 @@ angular.module('adminNg.controllers')
     $scope.publicationChannels = ResourcesListResource.get({ resource: 'PUBLICATION.CHANNELS' });
 
     $scope.table.dateToFilterValue = function(dateString) {
-
-      var from = RelativeDatesService.relativeToAbsoluteDate(0, 'days', true);
-      var to = RelativeDatesService.relativeToAbsoluteDate(0, 'days', false);
+      var date = new Date(dateString),
+          from = new Date(date.setHours(0, 0, 0, 0)),
+          to = new Date(date.setHours(23, 59, 59, 999));
       return from.toISOString() + '/' + to.toISOString();
     };
 

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -124,10 +124,10 @@ angular.module('adminNg.controllers')
     $scope.publicationChannels = ResourcesListResource.get({ resource: 'PUBLICATION.CHANNELS' });
 
     $scope.table.dateToFilterValue = function(dateString) {
-
-      var from = RelativeDatesService.relativeToAbsoluteDate(0, 'days', true);
-      var to = RelativeDatesService.relativeToAbsoluteDate(0, 'days', false);
-      return from.toISOString() + '/' + to.toISOString();
+      var date = new Date(dateString),
+          from = new Date(date.setHours(0, 0, 0, 0)),
+          to = new Date(date.setHours(23, 59, 59, 999));
+      return from.toISOString() + "/" + to.toISOString();
     };
 
     $scope.table.delete = function (row) {


### PR DESCRIPTION
Left-clicking a date in the column "Date" in the table "Events" is supposed to enable the filter "Start date" for the date that has been clicked.

This feature has been recently broken: Left-clicking any date in the column "Date" will just activate the filter "Start date" for the current date of the day.

Steps to reproduce:
1. Left-click on the start date in the events table for a start date that is not "Today"
 
 Actual Results:
The crosslink for the start date will always enable the filter for the date "today". 
 
 Expected Results:
 The crosslink for the start date should enable the filter for the date "start date"
 
 Workaround (if any):
