### PR TITLE
MH-13269, Handle Authorization Errors

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -728,8 +728,10 @@ public abstract class AbstractEventEndpoint {
         return ok();
       }
     } catch (AclServiceException e) {
-      logger.error("Error applying acl '{}' to event '{}' because: {}",
-              accessControlList, eventId, ExceptionUtils.getStackTrace(e));
+      if (e.getCause() instanceof UnauthorizedException) {
+        return forbidden();
+      }
+      logger.error("Error applying acl '{}' to event '{}'", accessControlList, eventId, e);
       return serverError();
     } catch (SchedulerException e) {
       logger.error("Error applying ACL to scheduled event {} because {}", eventId, ExceptionUtils.getStackTrace(e));

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
@@ -201,7 +201,6 @@ public final class AclServiceImpl implements AclService {
       // not found
       return false;
     } catch (Exception e) {
-      logger.error("Error applying episode ACL", e);
       throw new AclServiceException(e);
     }
   }


### PR DESCRIPTION
A user trying to modify an ACL to which he does not have access causes
an internal server error in Opencast. This patch converts it to result
in a “forbidden” user error instead.