### PR TITLE
MH-13238, don't throw related services straight into ERROR state just because job succeeded on current service

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -2477,6 +2477,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
           if (currentService.equals(relatedService))
             continue;
 
+          // De-escalate the state of related services as the issue is most likely with the job not the service
           // Reset the WARNING job to NORMAL
           if (relatedService.getServiceState() == WARNING) {
             logger.info("State reset to NORMAL for related service {} on host {}", relatedService.getServiceType(),
@@ -2527,17 +2528,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
                 currentService.getHost());
         currentService.setServiceState(NORMAL);
         updateServiceState(em, currentService);
-      }
-
-      // Services in WARNING state triggered by current job
-      List<ServiceRegistrationJpaImpl> relatedWarningServices = getRelatedWarningServices(job);
-
-      // Sets all related services to error state
-      for (ServiceRegistrationJpaImpl relatedService : relatedWarningServices) {
-        logger.info("State set to ERROR for related service {} on host {}", currentService.getServiceType(),
-                currentService.getHost());
-        relatedService.setServiceState(ERROR, job.toJob().getSignature());
-        updateServiceState(em, relatedService);
       }
 
     }

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
@@ -391,7 +391,7 @@ public class ServiceRegistrationTest {
     updatedService3 = getUpdatedService(regType1Remotehost2);
     Assert.assertEquals(ServiceState.NORMAL, updatedService1.getServiceState());
     Assert.assertEquals(ServiceState.NORMAL, updatedService2.getServiceState());
-    Assert.assertEquals(ServiceState.ERROR, updatedService3.getServiceState());
+    Assert.assertEquals(ServiceState.WARNING, updatedService3.getServiceState());
   }
 
   /**


### PR DESCRIPTION
Moved from 4.x due to EoL https://github.com/opencast/opencast/pull/569