### PR TITLE
MH-12091, Per-Tenant Capture Agent Users

### DIFF
--- a/etc/org.opencastproject.userdirectory.InMemoryUserAndRoleProvider.cfg
+++ b/etc/org.opencastproject.userdirectory.InMemoryUserAndRoleProvider.cfg
@@ -1,0 +1,19 @@
+##############################################################################
+# InMemory User and Role Provider Configuration
+##############################################################################
+
+############### Capture Agent User ###########################################
+
+# This configuration file lets you specify per-tenant digest users with limited privileges meant for to be used by
+# capture agents (they are allowed to access the capture agent API by default)
+#
+# Multiple users can be specified (even for one tenant) by providing a configuration in the following form:
+#
+# capture_agent.user.<organization>.<username> = <password>
+# capture_agent.roles.<organization>.<username> = <extra_role_a>, <extra_role_b>
+#
+# The roles specified are added to the default set of roles for capture agents. Adding roles is completely optional and
+# this configuration can just be left out.
+#
+#capture_agent.user.mh_default_org.opencast_capture_agent = some_password
+#capture_agent.roles.mh_default_org.opencast_capture_agent = ROLE_A, ROLE_B

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
@@ -24,6 +24,7 @@ import static com.entwinemedia.fn.Prelude.chuck;
 import static com.entwinemedia.fn.Stream.$;
 import static java.lang.String.format;
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 
 import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.Availability;
@@ -197,7 +198,10 @@ public class AssetManagerWithSecurity extends AssetManagerDecorator<TieredStorag
     final User user = secSvc.getUser();
     if (user.hasRole(GLOBAL_ADMIN_ROLE)) {
       return AdminRole.GLOBAL;
-    } else if (user.hasRole(secSvc.getOrganization().getAdminRole())) {
+    } else if (user.hasRole(secSvc.getOrganization().getAdminRole())
+            || user.hasRole(GLOBAL_CAPTURE_AGENT_ROLE)) {
+      // In this context, we treat capture agents the same way as organization admins, allowing them access so that
+      // they can ingest new media without requiring them to be explicitly specified in the ACLs.
       return AdminRole.ORGANIZATION;
     } else {
       return AdminRole.NONE;

--- a/modules/userdirectory/src/main/resources/OSGI-INF/user-and-role-provider-inmemory.xml
+++ b/modules/userdirectory/src/main/resources/OSGI-INF/user-and-role-provider-inmemory.xml
@@ -7,6 +7,7 @@
   <service>
     <provide interface="org.opencastproject.security.api.UserProvider"/>
     <provide interface="org.opencastproject.security.api.RoleProvider"/>
+    <provide interface="org.osgi.service.cm.ManagedService"/>
   </service>
   <reference name="securityService" interface="org.opencastproject.security.api.SecurityService"
              bind="setSecurityService"/>


### PR DESCRIPTION
This patch re-implements the feature of per-tenant capture agent users
which can be used with HTTP Digest authentication.

It provides a configuration file in which users can be defined and be
assigned to organizations. Additional roles can be applied as well.

This patch also allows these users access to the asset manager so that
files ingested by a capture agent can be archived as part of the
launched workflow

The commits include pull request #610 which is required for this to work properly.

*Work sponsored by SWITCH*