### PR TITLE
MH-13248 Allow hidden workflow parameters

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
@@ -141,7 +141,8 @@ angular.module('adminNg.services')
     // Most of the stuff we do here with input elements doesn't distinguish between
     // input type="text" and input type="number", so we need this getter a few times.
     function elementIsTextual(angularElement) {
-      return angularElement.is('[type=text]') || angularElement.is('[type=number]');
+      return angularElement.is('[type=text]') || angularElement.is('[type=number]') ||
+             angularElement.is('[type=hidden]');
     }
 
     // Gather all input elements used in the workflow configuration HTML into a dictionary:

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-event/proccessingSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-event/proccessingSpec.js
@@ -105,6 +105,18 @@ describe('Processing Step in New Event Wizard', function () {
                     .toEqual({ testID: 'testvalueA' });
             });
         });
+
+        describe('with a hidden field', function () {
+            beforeEach(function () {
+                $('#new-event-workflow-configuration')
+                    .append('<input type="hidden" class="configField" id="testID" value="testvalueA">');
+            });
+
+            it('returns the field value', function () {
+                expect(NewEventProcessing.getWorkflowConfig())
+                    .toEqual({ testID: 'testvalueA' });
+            });
+        });
     });
 
     describe('#getUserEntries', function () {


### PR DESCRIPTION
Workflow parameters in form elements of type "hidden" were ignored
when adding a new event, breaking the default schedule-and-upload
workflow.