### PR TITLE
MH-13284, Update Elasticsearch to 2.x

### DIFF
--- a/docs/guides/admin/docs/modules/searchindex/elasticsearch.md
+++ b/docs/guides/admin/docs/modules/searchindex/elasticsearch.md
@@ -19,14 +19,27 @@ When running Elasticsearch, it is recommended to deploy the same version Opencas
 otherwise not match the server. To check the version, take a look at [the maven dependency declaration for the
 elasticsearch bundle in the search module](https://github.com/opencast/opencast/blob/develop/modules/search/pom.xml).
 
-For example, to quickly spin up an external Elasticsearch matching the current version using Docker, run:
+For example, to quickly spin up an external Elasticsearch matching the current version using Docker, create a simple
+Elasticsearch configuration file called `elasticsearch.yml`:
 
-```sh
-% docker run -p 9200:9200 -p 9300:9300 -e discovery.type=single-node  elasticsearch:1.7.6
+```yml
+cluster.name: opencast
+node.name: opencast-elasticsearch-single-node
+index.max_result_window: 2147483647
+network.host: 0.0.0.0
 ```
 
-This will already give you a running cluster with the name `elasticsearch`. Note that the cluster name is important and
-you will need it later for the configuration.
+…and run
+
+```sh
+% docker run -p 9200:9200 -p 9300:9300 \
+    -e "discovery.type=single-node" \
+    -v "$(pwd)/elasticsearch.yml":/usr/share/elasticsearch/config/elasticsearch.yml \
+    elasticsearch:2.4.6
+```
+
+This will already give you a running cluster with the cluster name `opencast`. Note that the cluster name is important
+and you will need this to match Opencast's configuration.
 
 
 Configuring External Nodes

--- a/etc/index/adminui/event-mapping.json
+++ b/etc/index/adminui/event-mapping.json
@@ -37,7 +37,7 @@
 
             "agent_id": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "agent_configuration": { "type" : "object", "index" : "not_analyzed", "store" : "no"},
+            "agent_configuration": { "type" : "object" },
 
             "language": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
@@ -105,7 +105,6 @@
 
             "publication": {
                 "type" : "nested",
-                "index" : "not_analyzed",
                 "properties": {
                     "channel": { "type": "string"},
                     "mimetype": { "type": "string"},

--- a/etc/index/adminui/group-mapping.json
+++ b/etc/index/adminui/group-mapping.json
@@ -17,12 +17,12 @@
 
             "role": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "roles": { "index_name" : "role", "type" : "string", "index" : "not_analyzed", "store" : "no" },
+            "roles": { "copy_to" : "role", "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "members": { "index_name" : "member", "type" : "string", "index" : "not_analyzed", "store" : "no" },
+            "members": { "copy_to" : "member", "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "text": { "type" : "string", "index" : "analyzed", "store" : "no" },
-            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no" }
+            "text": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" },
+            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
 
         },
         "dynamic_templates" : [
@@ -30,7 +30,7 @@
              "text" : {
                  "match" : "text_*",
                  "match_mapping_type" : "string",
-                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no" }
+                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
                  }
              }
          ]

--- a/etc/index/adminui/series-mapping.json
+++ b/etc/index/adminui/series-mapping.json
@@ -33,9 +33,9 @@
 
             "createdDateTime": { "type" : "date", "format" : "yyyy-MM-dd'T'HH:mm:ssZ", "store" : "no" },
 
-            "organizers": { "index_name" : "organizer", "type" : "string", "index" : "not_analyzed", "store" : "no" },
+            "organizers": { "copy_to" : "organizer", "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "contributors": { "index_name" : "contributor", "type" : "string", "index" : "not_analyzed", "store" : "no" },
+            "contributors": { "copy_to" : "contributor", "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
             "publisher": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
@@ -61,7 +61,7 @@
              "text" : {
                  "match" : "text_*",
                  "match_mapping_type" : "string",
-                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no" }
+                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
                  }
              },
              {

--- a/etc/index/adminui/settings.yml
+++ b/etc/index/adminui/settings.yml
@@ -140,6 +140,8 @@ index.number_of_replicas: 0
 
 #################################### Paths ####################################
 
+path.home: ${karaf.home}/
+
 # Path to directory containing configuration (this file and logging.yml):
 #
 path.conf: ${karaf.etc}/index/adminui
@@ -166,6 +168,7 @@ path.logs: ${karaf.data}/log/elasticsearch.log
 #
 #path.plugins: /path/to/plugins
 
+index.max_result_window: 2147483647
 
 #################################### Plugin ###################################
 

--- a/etc/index/adminui/theme-mapping.json
+++ b/etc/index/adminui/theme-mapping.json
@@ -5,7 +5,7 @@
         "dynamic": "true",
         "properties" : {
 
-            "uid": { "type" : "long", "index" : "not_analyzed", "store" : "yes" },
+            "id": { "type" : "long", "index" : "not_analyzed", "store" : "yes" },
 
             "organization": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
 
@@ -47,8 +47,8 @@
 
             "watermark_position": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "text": { "type" : "string", "index" : "analyzed", "store" : "no" },
-            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no" }
+            "text": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" },
+            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
 
         },
         "dynamic_templates" : [
@@ -56,7 +56,7 @@
              "text" : {
                  "match" : "text_*",
                  "match_mapping_type" : "string",
-                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no" }
+                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
                  }
              }
          ]

--- a/etc/index/externalapi/event-mapping.json
+++ b/etc/index/externalapi/event-mapping.json
@@ -37,7 +37,7 @@
 
             "agent_id": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "agent_configuration": { "type" : "object", "index" : "not_analyzed", "store" : "no"},
+            "agent_configuration": { "type" : "object" },
 
             "language": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
@@ -105,7 +105,6 @@
 
             "publication": {
                 "type" : "nested",
-                "index" : "not_analyzed",
                 "properties": {
                     "channel": { "type": "string"},
                     "mimetype": { "type": "string"},
@@ -181,7 +180,7 @@
             },
 
             "text": { "type" : "string", "index" : "analyzed", "analyzer": "lowercasespaceanalyzer", "store" : "no" },
-            "text_fuzzy": { "type" : "string", "index" : "analyzed", "analyzer": "lowercasespaceanalyzer", "store" : "no" }
+            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
 
         },
         "dynamic_templates" : [

--- a/etc/index/externalapi/group-mapping.json
+++ b/etc/index/externalapi/group-mapping.json
@@ -17,12 +17,12 @@
 
             "role": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "roles": { "index_name" : "role", "type" : "string", "index" : "not_analyzed", "store" : "no" },
+            "roles": { "copy_to" : "role", "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "members": { "index_name" : "member", "type" : "string", "index" : "not_analyzed", "store" : "no" },
+            "members": { "copy_to" : "member", "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "text": { "type" : "string", "index" : "analyzed", "store" : "no" },
-            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no" }
+            "text": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" },
+            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
 
         },
         "dynamic_templates" : [
@@ -30,7 +30,7 @@
              "text" : {
                  "match" : "text_*",
                  "match_mapping_type" : "string",
-                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no" }
+                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
                  }
              }
          ]

--- a/etc/index/externalapi/series-mapping.json
+++ b/etc/index/externalapi/series-mapping.json
@@ -33,9 +33,9 @@
 
             "createdDateTime": { "type" : "date", "format" : "yyyy-MM-dd'T'HH:mm:ssZ", "store" : "no" },
 
-            "organizers": { "index_name" : "organizer", "type" : "string", "index" : "not_analyzed", "store" : "no" },
+            "organizers": { "copy_to" : "organizer", "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "contributors": { "index_name" : "contributor", "type" : "string", "index" : "not_analyzed", "store" : "no" },
+            "contributors": { "copy_to" : "contributor", "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
             "publisher": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
@@ -61,7 +61,7 @@
              "text" : {
                  "match" : "text_*",
                  "match_mapping_type" : "string",
-                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no" }
+                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
                  }
              },
              {

--- a/etc/index/externalapi/settings.yml
+++ b/etc/index/externalapi/settings.yml
@@ -140,6 +140,8 @@ index.number_of_replicas: 0
 
 #################################### Paths ####################################
 
+path.home: ${karaf.home}/
+
 # Path to directory containing configuration (this file and logging.yml):
 #
 path.conf: ${karaf.etc}/index/externalapi
@@ -166,6 +168,7 @@ path.logs: ${karaf.data}/log/elasticsearch.log
 #
 #path.plugins: /path/to/plugins
 
+index.max_result_window: 2147483647
 
 #################################### Plugin ###################################
 

--- a/etc/index/externalapi/theme-mapping.json
+++ b/etc/index/externalapi/theme-mapping.json
@@ -5,7 +5,7 @@
         "dynamic": "true",
         "properties" : {
 
-            "uid": { "type" : "long", "index" : "not_analyzed", "store" : "yes" },
+            "id": { "type" : "long", "index" : "not_analyzed", "store" : "yes" },
 
             "organization": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
 
@@ -47,8 +47,8 @@
 
             "watermark_position": { "type" : "string", "index" : "not_analyzed", "store" : "no" },
 
-            "text": { "type" : "string", "index" : "analyzed", "store" : "no" },
-            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no" }
+            "text": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" },
+            "text_fuzzy": { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
 
         },
         "dynamic_templates" : [
@@ -56,7 +56,7 @@
              "text" : {
                  "match" : "text_*",
                  "match_mapping_type" : "string",
-                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no" }
+                 "mapping" : { "type" : "string", "index" : "analyzed", "store" : "no", "analyzer": "lowercasespaceanalyzer" }
                  }
              }
          ]

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
@@ -28,7 +28,7 @@ import static com.entwinemedia.fn.data.json.Jsons.obj;
 import static com.entwinemedia.fn.data.json.Jsons.v;
 import static java.time.ZoneOffset.UTC;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.elasticsearch.common.lang3.StringUtils.isNoneBlank;
+import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.opencastproject.util.RestUtil.getEndpointUrl;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.BOOLEAN;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.INTEGER;
@@ -242,7 +242,7 @@ public class WorkflowsEndpoint {
 
     // Apply sort
     // TODO: this only uses the last sorting criteria
-    if (StringUtils.isNoneBlank(sort)) {
+    if (isNoneBlank(sort)) {
       Set<SortCriterion> sortCriteria = RestUtils.parseSortQueryParameter(sort);
       for (SortCriterion criterion : sortCriteria) {
         boolean isASC = criterion.getOrder() != SearchQuery.Order.Descending;

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -144,10 +144,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -197,6 +193,10 @@
     <dependency>
       <groupId>net.fortuna.ical4j</groupId>
       <artifactId>ical4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
     </dependency>
     <!-- Logging -->
     <dependency>

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
@@ -626,7 +626,7 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
     Terms aggs = response.getAggregations().get(facetName);
 
     for (Bucket bucket : aggs.getBuckets()) {
-      terms.add(bucket.getKey());
+      terms.add(bucket.getKey().toString());
     }
 
     return terms;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventQueryBuilder.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventQueryBuilder.java
@@ -62,21 +62,21 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
     if (query.getOrganization() == null)
       throw new IllegalStateException("No organization set on the event search query!");
 
-    and(EventIndexSchema.ORGANIZATION, query.getOrganization(), true);
+    and(EventIndexSchema.ORGANIZATION, query.getOrganization());
 
     // Recording identifier
     if (query.getIdentifier().length > 0) {
-      and(EventIndexSchema.UID, query.getIdentifier(), true);
+      and(EventIndexSchema.UID, query.getIdentifier());
     }
 
     // Title
     if (query.getTitle() != null) {
-      and(EventIndexSchema.TITLE, query.getTitle(), true);
+      and(EventIndexSchema.TITLE, query.getTitle());
     }
 
     // Description
     if (query.getDescription() != null) {
-      and(EventIndexSchema.DESCRIPTION, query.getDescription(), true);
+      and(EventIndexSchema.DESCRIPTION, query.getDescription());
     }
 
     // Action
@@ -85,7 +85,7 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
       if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
         for (Role role : user.getRoles()) {
           for (String action : query.getActions()) {
-            and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName(), true);
+            and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());
           }
         }
       }
@@ -94,142 +94,142 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
     // Presenter
     if (query.getPresenters() != null) {
       for (String presenter : query.getPresenters())
-        and(EventIndexSchema.PRESENTER, presenter, true);
+        and(EventIndexSchema.PRESENTER, presenter);
     }
 
     // Contributors
     if (query.getContributors().length > 0) {
-      and(EventIndexSchema.CONTRIBUTOR, query.getContributors(), true);
+      and(EventIndexSchema.CONTRIBUTOR, query.getContributors());
     }
 
     // Subject
     if (query.getSubject() != null) {
-      and(EventIndexSchema.SUBJECT, query.getSubject(), true);
+      and(EventIndexSchema.SUBJECT, query.getSubject());
     }
 
     // Location
     if (query.getLocation() != null) {
-      and(EventIndexSchema.LOCATION, query.getLocation(), true);
+      and(EventIndexSchema.LOCATION, query.getLocation());
     }
 
     // Series Id
     if (query.getSeriesId() != null) {
-      and(EventIndexSchema.SERIES_ID, query.getSeriesId(), true);
+      and(EventIndexSchema.SERIES_ID, query.getSeriesId());
     }
 
     // Series Name
     if (query.getSeriesName() != null) {
-      and(EventIndexSchema.SERIES_NAME, query.getSeriesName(), true);
+      and(EventIndexSchema.SERIES_NAME, query.getSeriesName());
     }
 
     // Language
     if (query.getLanguage() != null) {
-      and(EventIndexSchema.LANGUAGE, query.getLanguage(), true);
+      and(EventIndexSchema.LANGUAGE, query.getLanguage());
     }
 
     // Source
     if (query.getSource() != null) {
-      and(EventIndexSchema.SOURCE, query.getSource(), true);
+      and(EventIndexSchema.SOURCE, query.getSource());
     }
 
     // Created
     if (query.getCreated() != null) {
-      and(EventIndexSchema.CREATED, query.getCreated(), true);
+      and(EventIndexSchema.CREATED, query.getCreated());
     }
 
     // Creator
     if (query.getCreator() != null) {
-      and(EventIndexSchema.CREATOR, query.getCreator(), true);
+      and(EventIndexSchema.CREATOR, query.getCreator());
     }
 
     // Publisher
     if (query.getPublisher() != null) {
-      and(EventIndexSchema.PUBLISHER, query.getPublisher(), true);
+      and(EventIndexSchema.PUBLISHER, query.getPublisher());
     }
 
     // License
     if (query.getLicense() != null) {
-      and(EventIndexSchema.LICENSE, query.getLicense(), true);
+      and(EventIndexSchema.LICENSE, query.getLicense());
     }
 
     // Rights
     if (query.getRights() != null) {
-      and(EventIndexSchema.RIGHTS, query.getRights(), true);
+      and(EventIndexSchema.RIGHTS, query.getRights());
     }
 
     // Track mime types
     if (query.getTrackMimetypes().length > 0) {
-      and(EventIndexSchema.TRACK_MIMETYPE, query.getTrackMimetypes(), true);
+      and(EventIndexSchema.TRACK_MIMETYPE, query.getTrackMimetypes());
     }
 
     // Track stream resolutions
     if (query.getTrackStreamResolution().length > 0) {
-      and(EventIndexSchema.TRACK_STREAM_RESOLUTION, query.getTrackStreamResolution(), true);
+      and(EventIndexSchema.TRACK_STREAM_RESOLUTION, query.getTrackStreamResolution());
     }
 
     // Track flavors
     if (query.getTrackFlavor().length > 0) {
-      and(EventIndexSchema.TRACK_FLAVOR, query.getTrackFlavor(), true);
+      and(EventIndexSchema.TRACK_FLAVOR, query.getTrackFlavor());
     }
 
     // Metadata flavors
     if (query.getMetadataFlavor().length > 0) {
-      and(EventIndexSchema.METADATA_FLAVOR, query.getMetadataFlavor(), true);
+      and(EventIndexSchema.METADATA_FLAVOR, query.getMetadataFlavor());
     }
 
     // Metadata mime types
     if (query.getMetadataMimetype().length > 0) {
-      and(EventIndexSchema.METADATA_MIMETYPE, query.getMetadataMimetype(), true);
+      and(EventIndexSchema.METADATA_MIMETYPE, query.getMetadataMimetype());
     }
 
     // Attachment flavors
     if (query.getAttachmentFlavor().length > 0) {
-      and(EventIndexSchema.ATTACHMENT_FLAVOR, query.getAttachmentFlavor(), true);
+      and(EventIndexSchema.ATTACHMENT_FLAVOR, query.getAttachmentFlavor());
     }
 
     // Access policy
     if (query.getAccessPolicy() != null) {
-      and(EventIndexSchema.ACCESS_POLICY, query.getAccessPolicy(), true);
+      and(EventIndexSchema.ACCESS_POLICY, query.getAccessPolicy());
     }
 
     // Managed ACL
     if (query.getManagedAcl() != null) {
-      and(EventIndexSchema.MANAGED_ACL, query.getManagedAcl(), true);
+      and(EventIndexSchema.MANAGED_ACL, query.getManagedAcl());
     }
 
     // Workflow state
     if (query.getWorkflowState() != null) {
-      and(EventIndexSchema.WORKFLOW_STATE, query.getWorkflowState(), true);
+      and(EventIndexSchema.WORKFLOW_STATE, query.getWorkflowState());
     }
 
     // Workflow id
     if (query.getWorkflowId() != null) {
-      and(EventIndexSchema.WORKFLOW_ID, query.getWorkflowId(), true);
+      and(EventIndexSchema.WORKFLOW_ID, query.getWorkflowId());
     }
 
     // Workflow definition id
     if (query.getWorkflowDefinition() != null) {
-      and(EventIndexSchema.WORKFLOW_DEFINITION_ID, query.getWorkflowDefinition(), true);
+      and(EventIndexSchema.WORKFLOW_DEFINITION_ID, query.getWorkflowDefinition());
     }
 
     // Workflow scheduled date
     if (query.getWorkflowScheduledDate() != null) {
-      and(EventIndexSchema.WORKFLOW_SCHEDULED_DATETIME, query.getWorkflowScheduledDate(), true);
+      and(EventIndexSchema.WORKFLOW_SCHEDULED_DATETIME, query.getWorkflowScheduledDate());
     }
 
     // Event status
     if (query.getEventStatus() != null) {
-      and(EventIndexSchema.EVENT_STATUS, query.getEventStatus(), true);
+      and(EventIndexSchema.EVENT_STATUS, query.getEventStatus());
     }
 
     // Review status
     if (query.getReviewStatus() != null) {
-      and(EventIndexSchema.REVIEW_STATUS, query.getReviewStatus(), true);
+      and(EventIndexSchema.REVIEW_STATUS, query.getReviewStatus());
     }
 
     // Scheduling status
     if (query.getSchedulingStatus() != null) {
-      and(EventIndexSchema.SCHEDULING_STATUS, query.getSchedulingStatus(), true);
+      and(EventIndexSchema.SCHEDULING_STATUS, query.getSchedulingStatus());
     }
 
     // Recording start date period
@@ -239,53 +239,53 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
 
     // Recording start date
     if (query.getStartDate() != null) {
-      and(EventIndexSchema.START_DATE, query.getStartDate(), true);
+      and(EventIndexSchema.START_DATE, query.getStartDate());
     }
 
     // Recording duration
     if (query.getDuration() != null) {
-      and(EventIndexSchema.DURATION, query.getDuration(), true);
+      and(EventIndexSchema.DURATION, query.getDuration());
     }
 
     // Opt out
     if (query.getOptedOut() != null) {
-      and(EventIndexSchema.OPTED_OUT, query.getOptedOut(), true);
+      and(EventIndexSchema.OPTED_OUT, query.getOptedOut());
     }
 
     // Review date
     if (query.getReviewDate() != null) {
-      and(EventIndexSchema.REVIEW_DATE, query.getReviewDate(), true);
+      and(EventIndexSchema.REVIEW_DATE, query.getReviewDate());
     }
 
     // Blacklisted
     if (query.getBlacklisted() != null) {
-      and(EventIndexSchema.BLACKLISTED, query.getBlacklisted(), true);
+      and(EventIndexSchema.BLACKLISTED, query.getBlacklisted());
     }
 
     // Has comments
     if (query.getHasComments() != null) {
-      and(EventIndexSchema.HAS_COMMENTS, query.getHasComments(), true);
+      and(EventIndexSchema.HAS_COMMENTS, query.getHasComments());
     }
 
     // Has open comments
     if (query.getHasOpenComments() != null) {
-      and(EventIndexSchema.HAS_OPEN_COMMENTS, query.getHasOpenComments(), true);
+      and(EventIndexSchema.HAS_OPEN_COMMENTS, query.getHasOpenComments());
     }
 
     // Publications
     if (query.getPublications() != null) {
       for (String publication : query.getPublications())
-        and(EventIndexSchema.PUBLICATION, publication, true);
+        and(EventIndexSchema.PUBLICATION, publication);
     }
 
     // Archive version
     if (query.getArchiveVersion() != null) {
-      and(EventIndexSchema.ARCHIVE_VERSION, query.getArchiveVersion(), true);
+      and(EventIndexSchema.ARCHIVE_VERSION, query.getArchiveVersion());
     }
 
     // Technical agent identifier
     if (query.getAgentId() != null) {
-      and(EventIndexSchema.AGENT_ID, query.getAgentId(), true);
+      and(EventIndexSchema.AGENT_ID, query.getAgentId());
     }
 
     // Technical start date period
@@ -295,17 +295,17 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
 
     // Technical start date
     if (query.getTechnicalStartTime() != null) {
-      and(EventIndexSchema.TECHNICAL_START, query.getTechnicalStartTime(), true);
+      and(EventIndexSchema.TECHNICAL_START, query.getTechnicalStartTime());
     }
 
     // Technical end date
     if (query.getTechnicalEndTime() != null) {
-      and(EventIndexSchema.TECHNICAL_END, query.getTechnicalEndTime(), true);
+      and(EventIndexSchema.TECHNICAL_END, query.getTechnicalEndTime());
     }
 
     // Technical presenters
     if (query.getTechnicalPresenters().length > 0) {
-      and(EventIndexSchema.TECHNICAL_PRESENTERS, query.getTechnicalPresenters(), true);
+      and(EventIndexSchema.TECHNICAL_PRESENTERS, query.getTechnicalPresenters());
     }
 
     // Text

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/group/GroupQueryBuilder.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/group/GroupQueryBuilder.java
@@ -63,11 +63,11 @@ public class GroupQueryBuilder extends AbstractElasticsearchQueryBuilder<GroupSe
     if (query.getOrganization() == null)
       throw new IllegalStateException("No organization set on the group search query!");
 
-    and(GroupIndexSchema.ORGANIZATION, query.getOrganization(), true);
+    and(GroupIndexSchema.ORGANIZATION, query.getOrganization());
 
     // group identifier
     if (query.getIdentifier().length > 0) {
-      and(GroupIndexSchema.UID, query.getIdentifier(), true);
+      and(GroupIndexSchema.UID, query.getIdentifier());
     }
 
     // Action
@@ -76,30 +76,30 @@ public class GroupQueryBuilder extends AbstractElasticsearchQueryBuilder<GroupSe
       if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
         for (Role role : user.getRoles()) {
           for (String action : query.getActions()) {
-            and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName(), true);
+            and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());
           }
         }
       }
     }
 
     if (query.getRole() != null) {
-      and(GroupIndexSchema.ROLE, query.getRole(), true);
+      and(GroupIndexSchema.ROLE, query.getRole());
     }
 
     if (query.getName() != null) {
-      and(GroupIndexSchema.NAME, query.getName(), true);
+      and(GroupIndexSchema.NAME, query.getName());
     }
 
     if (query.getDescription() != null) {
-      and(GroupIndexSchema.DESCRIPTION, query.getDescription(), true);
+      and(GroupIndexSchema.DESCRIPTION, query.getDescription());
     }
 
     if (query.getRoles().length > 0) {
-      and(GroupIndexSchema.ROLES, query.getRoles(), true);
+      and(GroupIndexSchema.ROLES, query.getRoles());
     }
 
     if (query.getMembers().length > 0) {
-      and(GroupIndexSchema.MEMBERS, query.getMembers(), true);
+      and(GroupIndexSchema.MEMBERS, query.getMembers());
     }
 
     // Text

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesQueryBuilder.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesQueryBuilder.java
@@ -63,16 +63,16 @@ public class SeriesQueryBuilder extends AbstractElasticsearchQueryBuilder<Series
     if (query.getOrganization() == null)
       throw new IllegalStateException("No organization set on the series search query!");
 
-    and(SeriesIndexSchema.ORGANIZATION, query.getOrganization(), true);
+    and(SeriesIndexSchema.ORGANIZATION, query.getOrganization());
 
     // Series identifier
     if (query.getIdentifier().length > 0) {
-      and(SeriesIndexSchema.UID, query.getIdentifier(), true);
+      and(SeriesIndexSchema.UID, query.getIdentifier());
     }
 
     // Title
     if (query.getTitle() != null) {
-      and(SeriesIndexSchema.TITLE, query.getTitle(), true);
+      and(SeriesIndexSchema.TITLE, query.getTitle());
     }
 
     // Action
@@ -81,34 +81,34 @@ public class SeriesQueryBuilder extends AbstractElasticsearchQueryBuilder<Series
       if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
         for (Role role : user.getRoles()) {
           for (String action : query.getActions()) {
-            and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName(), true);
+            and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());
           }
         }
       }
     }
 
     if (query.getDescription() != null) {
-      and(SeriesIndexSchema.DESCRIPTION, query.getDescription(), true);
+      and(SeriesIndexSchema.DESCRIPTION, query.getDescription());
     }
 
     if (query.getSubjects().length > 0) {
-      and(SeriesIndexSchema.SUBJECT, query.getSubjects(), true);
+      and(SeriesIndexSchema.SUBJECT, query.getSubjects());
     }
 
     if (query.getLanguage() != null) {
-      and(SeriesIndexSchema.LANGUAGE, query.getLanguage(), true);
+      and(SeriesIndexSchema.LANGUAGE, query.getLanguage());
     }
 
     if (query.getCreator() != null) {
-      and(SeriesIndexSchema.CREATOR, query.getCreator(), true);
+      and(SeriesIndexSchema.CREATOR, query.getCreator());
     }
 
     if (query.getLicense() != null) {
-      and(SeriesIndexSchema.LICENSE, query.getLicense(), true);
+      and(SeriesIndexSchema.LICENSE, query.getLicense());
     }
 
     if (query.getAccessPolicy() != null) {
-      and(SeriesIndexSchema.ACCESS_POLICY, query.getAccessPolicy(), true);
+      and(SeriesIndexSchema.ACCESS_POLICY, query.getAccessPolicy());
     }
 
     if (query.getCreatedFrom() != null && query.getCreatedTo() != null) {
@@ -116,31 +116,31 @@ public class SeriesQueryBuilder extends AbstractElasticsearchQueryBuilder<Series
     }
 
     if (query.getOrganizers().length > 0) {
-      and(SeriesIndexSchema.ORGANIZERS, query.getOrganizers(), true);
+      and(SeriesIndexSchema.ORGANIZERS, query.getOrganizers());
     }
 
     if (query.getContributors().length > 0) {
-      and(SeriesIndexSchema.CONTRIBUTORS, query.getContributors(), true);
+      and(SeriesIndexSchema.CONTRIBUTORS, query.getContributors());
     }
 
     if (query.getPublishers().length > 0) {
-      and(SeriesIndexSchema.PUBLISHERS, query.getPublishers(), true);
+      and(SeriesIndexSchema.PUBLISHERS, query.getPublishers());
     }
 
     if (query.getManagedAcl() != null) {
-      and(SeriesIndexSchema.MANAGED_ACL, query.getManagedAcl(), true);
+      and(SeriesIndexSchema.MANAGED_ACL, query.getManagedAcl());
     }
 
     if (query.getRightsHolder() != null) {
-      and(SeriesIndexSchema.RIGHTS_HOLDER, query.getRightsHolder(), true);
+      and(SeriesIndexSchema.RIGHTS_HOLDER, query.getRightsHolder());
     }
 
     if (query.getOptedOut() != null) {
-      and(SeriesIndexSchema.OPT_OUT, query.getOptedOut(), true);
+      and(SeriesIndexSchema.OPT_OUT, query.getOptedOut());
     }
 
     if (query.getTheme() != null) {
-      and(SeriesIndexSchema.THEME, query.getTheme(), true);
+      and(SeriesIndexSchema.THEME, query.getTheme());
     }
 
     if (query.getCreatedFrom() != null && query.getCreatedTo() != null) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/theme/ThemeIndexSchema.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/theme/ThemeIndexSchema.java
@@ -30,7 +30,7 @@ import org.opencastproject.matterhorn.search.impl.IndexSchema;
 public interface ThemeIndexSchema extends IndexSchema {
 
   /** The unique identifier */
-  String UID = "uid";
+  String ID = "id";
 
   /** The organization that owns this theme. */
   String ORGANIZATION = "organization";

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/theme/ThemeIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/theme/ThemeIndexUtils.java
@@ -76,7 +76,7 @@ public final class ThemeIndexUtils {
     SearchMetadataCollection metadata = new SearchMetadataCollection(Long.toString(theme.getIdentifier()).concat(
             theme.getOrganization()), Theme.DOCUMENT_TYPE);
     // Mandatory fields
-    metadata.addField(ThemeIndexSchema.UID, theme.getIdentifier(), true);
+    metadata.addField(ThemeIndexSchema.ID, theme.getIdentifier(), true);
     metadata.addField(ThemeIndexSchema.ORGANIZATION, theme.getOrganization(), false);
     metadata.addField(ThemeIndexSchema.OBJECT, theme.toXML(), false);
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/theme/ThemeQueryBuilder.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/theme/ThemeQueryBuilder.java
@@ -58,15 +58,15 @@ public class ThemeQueryBuilder extends AbstractElasticsearchQueryBuilder<ThemeSe
     if (query.getOrganization() == null)
       throw new IllegalStateException("No organization set on the theme search query!");
 
-    and(ThemeIndexSchema.ORGANIZATION, query.getOrganization(), true);
+    and(ThemeIndexSchema.ORGANIZATION, query.getOrganization());
 
     // theme identifier
     if (query.getIdentifiers().length > 0) {
-      and(ThemeIndexSchema.UID, query.getIdentifiers(), true);
+      and(ThemeIndexSchema.ID, query.getIdentifiers());
     }
 
     if (query.getCreator() != null) {
-      and(ThemeIndexSchema.CREATOR, query.getCreator(), true);
+      and(ThemeIndexSchema.CREATOR, query.getCreator());
     }
 
     if (query.getCreatedFrom() != null && query.getCreatedTo() != null) {
@@ -74,73 +74,73 @@ public class ThemeQueryBuilder extends AbstractElasticsearchQueryBuilder<ThemeSe
     }
 
     if (query.getIsDefault() != null) {
-      and(ThemeIndexSchema.DEFAULT, query.getIsDefault(), true);
+      and(ThemeIndexSchema.DEFAULT, query.getIsDefault());
     }
 
     if (query.getDescription() != null) {
-      and(ThemeIndexSchema.DESCRIPTION, query.getDescription(), true);
+      and(ThemeIndexSchema.DESCRIPTION, query.getDescription());
     }
 
     if (query.getName() != null) {
-      and(ThemeIndexSchema.NAME, query.getName(), true);
+      and(ThemeIndexSchema.NAME, query.getName());
     }
 
     if (query.getBumperActive() != null) {
-      and(ThemeIndexSchema.BUMPER_ACTIVE, query.getBumperActive(), true);
+      and(ThemeIndexSchema.BUMPER_ACTIVE, query.getBumperActive());
     }
 
     if (query.getBumperFile() != null) {
-      and(ThemeIndexSchema.BUMPER_FILE, query.getBumperFile(), true);
+      and(ThemeIndexSchema.BUMPER_FILE, query.getBumperFile());
     }
 
     if (query.getLicenseSlideActive() != null) {
-      and(ThemeIndexSchema.LICENSE_SLIDE_ACTIVE, query.getLicenseSlideActive(), true);
+      and(ThemeIndexSchema.LICENSE_SLIDE_ACTIVE, query.getLicenseSlideActive());
     }
 
     if (query.getLicenseSlideBackground() != null) {
-      and(ThemeIndexSchema.LICENSE_SLIDE_BACKGROUND, query.getLicenseSlideBackground(), true);
+      and(ThemeIndexSchema.LICENSE_SLIDE_BACKGROUND, query.getLicenseSlideBackground());
     }
 
     if (query.getLicenseSlideDescription() != null) {
-      and(ThemeIndexSchema.LICENSE_SLIDE_DESCRIPTION, query.getLicenseSlideDescription(), true);
+      and(ThemeIndexSchema.LICENSE_SLIDE_DESCRIPTION, query.getLicenseSlideDescription());
     }
 
     if (query.getTrailerActive() != null) {
-      and(ThemeIndexSchema.TRAILER_ACTIVE, query.getTrailerActive(), true);
+      and(ThemeIndexSchema.TRAILER_ACTIVE, query.getTrailerActive());
     }
 
     if (query.getTrailerFile() != null) {
-      and(ThemeIndexSchema.TRAILER_FILE, query.getTrailerFile(), true);
+      and(ThemeIndexSchema.TRAILER_FILE, query.getTrailerFile());
     }
 
     if (query.getTitleSlideActive() != null) {
-      and(ThemeIndexSchema.TITLE_SLIDE_ACTIVE, query.getTitleSlideActive(), true);
+      and(ThemeIndexSchema.TITLE_SLIDE_ACTIVE, query.getTitleSlideActive());
     }
 
     if (query.getTitleSlideBackground() != null) {
-      and(ThemeIndexSchema.TITLE_SLIDE_BACKGROUND, query.getTitleSlideBackground(), true);
+      and(ThemeIndexSchema.TITLE_SLIDE_BACKGROUND, query.getTitleSlideBackground());
     }
 
     if (query.getTitleSlideMetadata() != null) {
-      and(ThemeIndexSchema.TITLE_SLIDE_METADATA, query.getTitleSlideMetadata(), true);
+      and(ThemeIndexSchema.TITLE_SLIDE_METADATA, query.getTitleSlideMetadata());
     }
 
     if (query.getWatermarkActive() != null) {
-      and(ThemeIndexSchema.WATERMARK_ACTIVE, query.getWatermarkActive(), true);
+      and(ThemeIndexSchema.WATERMARK_ACTIVE, query.getWatermarkActive());
     }
 
     if (query.getWatermarkFile() != null) {
-      and(ThemeIndexSchema.WATERMARK_FILE, query.getWatermarkFile(), true);
+      and(ThemeIndexSchema.WATERMARK_FILE, query.getWatermarkFile());
     }
 
     if (query.getWatermarkPosition() != null) {
-      and(ThemeIndexSchema.WATERMARK_POSITION, query.getWatermarkPosition(), true);
+      and(ThemeIndexSchema.WATERMARK_POSITION, query.getWatermarkPosition());
     }
 
     // Text
     if (query.getTerms() != null) {
       for (SearchTerms<String> terms : query.getTerms()) {
-        StringBuffer queryText = new StringBuffer();
+        StringBuilder queryText = new StringBuilder();
         for (String term : terms.getTerms()) {
           if (queryText.length() > 0)
             queryText.append(" ");

--- a/modules/search/pom.xml
+++ b/modules/search/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <lucene.version>5.5.4</lucene.version>
   </properties>
   <dependencies>
     <dependency>
@@ -38,7 +39,7 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.7.6</version>
+      <version>2.4.6</version>
     </dependency>
     <!-- elasticsearch dependencies -->
     <dependency>
@@ -49,83 +50,83 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-codecs</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-expressions</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-grouping</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-highlighter</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-join</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-memory</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-misc</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-queries</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-queryparser</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-sandbox</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-spatial</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-suggest</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -158,6 +159,66 @@
       <version>4.1</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>com.carrotsearch</groupId>
+      <artifactId>hppc</artifactId>
+      <version>0.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-smile</artifactId>
+      <version>2.8.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>2.8.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ning</groupId>
+      <artifactId>compress-lzf</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.tdunning</groupId>
+      <artifactId>t-digest</artifactId>
+      <version>3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+      <version>2.1.6</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>1.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty</artifactId>
+      <version>3.10.6.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.15</version>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.joda</groupId>
+      <artifactId>joda-convert</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>jsr166e</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+
     <!-- thirdparty -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -199,6 +260,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              !com.github.mustachejava*,
               !com.google.protobuf,
               !groovy.lang,
               !org.antlr.*,
@@ -219,11 +281,20 @@
               org.opencastproject.matterhorn.search.impl;version=${project.version}
             </Export-Package>
             <Embed-Dependency>
+              HdrHistogram,
               asm,
               asm-commons,
               asm-tree,
+              commons-cli,
+              compress-lzf,
               elasticsearch,
+              hppc,
+              jackson-dataformat-smile,
+              jackson-dataformat-yaml,
               jna,
+              joda-time,
+              joda-convert,
+              jsr166e,
               jts,
               lucene-analyzers-common,
               lucene-codecs,
@@ -239,10 +310,17 @@
               lucene-sandbox,
               lucene-spatial,
               lucene-suggest,
-              spatial4j
+              netty,
+              snakeyaml,
+              spatial4j,
+              t-digest
             </Embed-Dependency>
             <_exportcontents>
               com.spatial4j.*;version=0.4,
+              com.carrotsearch.*,
+              org.jboss.netty.*,
+              org.apache.commons.cli,
+              org.joda.*,
               com.vividsolutions.*,
               org.apache.lucene.*,
               org.elasticsearch.*,

--- a/modules/search/src/main/java/org/opencastproject/matterhorn/search/impl/SearchTermsImpl.java
+++ b/modules/search/src/main/java/org/opencastproject/matterhorn/search/impl/SearchTermsImpl.java
@@ -31,23 +31,13 @@ import java.util.List;
 /**
  * Implementation of a list of search terms.
  */
-public class SearchTermsImpl<T extends Object> implements SearchTerms<T> {
+public class SearchTermsImpl<T> implements SearchTerms<T> {
 
   /** The quantifier */
-  protected Quantifier quantifier = Quantifier.Any;
+  protected Quantifier quantifier;
 
   /** The search terms */
-  protected List<T> terms = new ArrayList<T>();
-
-  /**
-   * Creates a list of search terms, to be queried using the given quantifier.
-   * 
-   * @param quantifier
-   *          the quantifier
-   */
-  public SearchTermsImpl(Quantifier quantifier) {
-    this.quantifier = quantifier;
-  }
+  protected List<T> terms = new ArrayList<>();
 
   /**
    * Creates a list of search terms, to be queried using the given quantifier.

--- a/modules/search/src/test/resources/elasticsearch/test/settings.yml
+++ b/modules/search/src/test/resources/elasticsearch/test/settings.yml
@@ -140,6 +140,8 @@ index.number_of_replicas: 0
 
 #################################### Paths ####################################
 
+path.home: ${opencast.home}/
+
 # Path to directory containing configuration (this file and logging.yml):
 #
 path.conf: ${opencast.home}/etc/index


### PR DESCRIPTION
As a first step in the process of bringing Elasticsearch to the latest
stable version, this patch updates Elasticsearch and its client
libraries to the latest 2.x version.

Unnecessary changes in how Opencast and Elasticsearch are avoided if
possible to make the update as smooth as possible though some queries
had to be replaces and the structure had to be adjusted slightly.

*This requires an index rebuild*