### PR TITLE
MH-13285, Display workflow description

### DIFF
--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -63,9 +63,11 @@ Start by naming the workflow and giving it a meaningful description:
         <tag>archive</tag>
       </tags>
       <description>
-        Encode to Mp4 and thumbnail.
-        Distribute to local repository.
-        Publish to search index.
+        1. Encode to Mp4 and thumbnail.
+
+        2. Distribute to local repository.
+
+        3. Publish to search index.
       </description>
       <displayOrder>10</displayOrder>
 
@@ -84,6 +86,8 @@ Start by naming the workflow and giving it a meaningful description:
     * *editor*: Usable from the video editor
 * The `displayOrder` is an integer that indicates in what order workflow definitions shall be displayed by clients.
   If ommitted, the `displayOrder` defaults to `0`. Clients are expected to list workflow definitions in descending order.
+* The `description` allows you to describe the workflow in detail. Blank lines are formatted as newlines, while single
+  line breaks are ignored so that the XML remains compact and readable even with long paragraphs.
 
 
 ### Inspect the Media

--- a/etc/workflows/schedule-and-upload.xml
+++ b/etc/workflows/schedule-and-upload.xml
@@ -8,7 +8,10 @@
     <tag>schedule</tag>
   </tags>
   <displayOrder>1000</displayOrder>
-  <description/>
+  <description>
+    A complex workflow, showcasing most of Opencast's features.
+  </description>
+
   <configuration_panel>
     <![CDATA[
       <div id="workflow-configuration">

--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -280,6 +280,7 @@
     <script src="scripts/shared/directives/navDirective.js"></script>
     <script src="scripts/shared/directives/tableDirective.js"></script>
     <script src="scripts/shared/directives/statsDirective.js"></script>
+    <script src="scripts/shared/directives/collapsibleBoxDirective.js"></script>
     <script src="scripts/shared/directives/confirmationModalDirective.js"></script>
     <script src="scripts/shared/directives/deleteSingleSeriesModalDirective.js"></script>
     <script src="scripts/shared/directives/resourceModalDirective.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/collapsibleBoxDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/collapsibleBoxDirective.js
@@ -1,0 +1,129 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name adminNg.directives.collapsibleBox
+ * @description
+ * Generates a collapsible/expandable text field
+ *
+ * The collapsible box displays a text in a div with a max-height. If the content
+ * is too large to fit within the max-height the collapsible box becomes expandable/
+ * collapsible. The text overflow is hidden while collapsed.
+ *
+ * Single linebreaks, intendentions or multiple intendations will be removed. Empty
+ * lines will be replaced by single line break.
+ *
+ * @example
+ * <div class="collapsible-box" input=inputStringFromScope maxheight=100 />
+ */
+angular.module('adminNg.directives')
+.directive(
+  'collapsibleBox',
+  function() {
+    return {
+      restrict : 'C',
+      templateUrl : 'shared/partials/collapsibleBox.html',
+      scope : {
+        input : '=',
+        maxheight : '@'
+      },
+      controller : [
+        '$scope',
+        '$element',
+        '$filter',
+        '$timeout',
+        '$window',
+        function($scope, $element, $filter, $timeout, $window) {
+
+          $scope.initCollapsibleBox = function() {
+            $scope.angleUp = false;
+            $scope.angleDown = true;
+            $scope.collapsibleStyle = { 'max-height' : $scope.maxheight + 'px' };
+            $scope.isCollapsed = true;
+            $timeout(function() {
+              $scope.isOverflown = $scope.getIsOverflown();
+              $scope.calcStyleProperties();
+            }, 0);
+
+            $scope.$watch('isOverflown', function() {
+              $scope.calcStyleProperties();
+            });
+
+            $scope.$watch('input', function() {
+              $scope.hasInput = !($scope.input == '' || $scope.input == undefined);
+              if($scope.hasInput) {
+                $scope.formatInput();
+              } else {
+                $scope.inputFormatted = '';
+              }
+              $timeout(function() {
+                $scope.isOverflown = $scope.getIsOverflown();
+                $scope.calcStyleProperties();
+              });
+            });
+
+            angular.element($window).bind('resize', function() {
+              $scope.$apply(function() {
+                $scope.isOverflown = $scope.getIsOverflown();
+              });
+            });
+          };
+
+          $scope.getIsOverflown = function() {
+            return $element.children().first()[0].scrollHeight > $scope.maxheight;
+          };
+
+          $scope.calcStyleProperties = function() {
+            var overlayPadding = $scope.isOverflown ? $scope.maxheight / 4 : 0;
+            $scope.collapsibleOverlayStyle = { padding : overlayPadding + 'px 0' };
+          };
+
+          $scope.toggle = function() {
+            if ($scope.isOverflown
+                && $window.getSelection().toString() == '') {
+              $scope.isCollapsed = !$scope.isCollapsed;
+              $scope.angleUp = !$scope.angleUp;
+              $scope.angleDown = !$scope.angleDown;
+              $scope.collapsibleTransparentOverlay = !$scope.collapsibleTransparentOverlay;
+              if($scope.collapsibleStyle['max-height'] === $scope.maxheight + 'px') {
+                $scope.collapsibleStyle['max-height'] = 'auto';
+              } else {
+                $scope.collapsibleStyle['max-height'] = $scope.maxheight + 'px';
+              }
+            }
+          };
+
+          $scope.formatInput = function(){
+            var reEmptyLines = /\n^[\r\t\f ]*$/gm;
+            var reWhitespaceChars = /[\r\t\f\n]|/g;
+            var reMltplSpaces = /[ ]{2,}/g;
+            var inputArr = $scope.input.split(reEmptyLines);
+            for(var i = 0; i < inputArr.length; i++) {
+              inputArr[i] = inputArr[i].replace(reWhitespaceChars, '').replace(reMltplSpaces, ' ');
+            }
+            $scope.inputFormatted = inputArr.join('\n');
+          };
+          $scope.initCollapsibleBox();
+        }]
+    };
+  });

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/collapsibleBox.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/collapsibleBox.html
@@ -1,0 +1,19 @@
+<div ng-show="hasInput"
+  ng-class="
+  {
+    'cb-box':true,
+    'cb-overflown':isOverflown,
+    'cb-collapsed':isCollapsed
+  }"
+  ng-style="collapsibleStyle"
+  ng-click="toggle()">
+  <div class="cb-text">{{inputFormatted}}</div>
+  <div class="cb-transparent-overlay" ng-show="isOverflown && isCollapsed" ng-style="collapsibleOverlayStyle">
+  </div>
+</div>
+<div ng-show="isOverflown" class="cb-arrow-box" ng-click="toggle()">
+  <div class="cb-angle">
+    <i ng-show="angleDown" class="fa fa-angle-down"></i>
+    <i ng-show="angleUp" class="fa fa-angle-up"></i>
+  </div>
+</div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
@@ -89,7 +89,7 @@
                       >
                       <option value=""></option>
               </select>
-
+              <div class="collapsible-box" input="processing.workflowDescription" maxheight=45></div>
               <div id="new-event-workflow-configuration"
                    class="checkbox-container"
                    ng-click="processing.save()"

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -462,7 +462,7 @@
                          >
                          <option value=""></option>
           </select>
-
+		  <div class="collapsible-box" input="wizard.step.workflowDescription" maxheight=45></div>
           <div id="new-event-workflow-configuration"
                class="checkbox-container"
                ng-click="wizard.step.save()"

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/processing.js
@@ -26,11 +26,19 @@ angular.module('adminNg.services')
   var Processing = function (use) {
     // Update the content of the configuration panel with the given HTML
     var me = this, queryParams,
-        updateConfigurationPanel = function (html) {
-          if (angular.isUndefined(html)) {
-            html = '';
+        updateConfigurationPanel = function (workflow) {
+          var html = '';
+          var description = '';
+          if (angular.isDefined(workflow)){
+            if(angular.isDefined(workflow.configuration_panel)) {
+              html = workflow.configuration_panel;
+            }
+            if(angular.isDefined(workflow.description)) {
+              description = workflow.description;
+            }
           }
           me.workflowConfiguration = $sce.trustAsHtml(html);
+          me.workflowDescription = description;
         },
         isWorkflowSet = function () {
           return angular.isDefined(me.ud.workflow) && angular.isDefined(me.ud.workflow.id);
@@ -275,7 +283,7 @@ angular.module('adminNg.services')
 
           if (workflow.id === me.default_workflow_id){
             me.ud.workflow = workflow;
-            updateConfigurationPanel(me.ud.workflow.configuration_panel);
+            updateConfigurationPanel(me.ud.workflow);
             this.applyWorkflowProperties(workflowProperties, selectedIds);
             me.save();
             break;
@@ -292,7 +300,7 @@ angular.module('adminNg.services')
       originalValues = {};
       me.changingWorkflow = true;
       if (angular.isDefined(me.ud.workflow)) {
-        updateConfigurationPanel(me.ud.workflow.configuration_panel);
+        updateConfigurationPanel(me.ud.workflow);
       } else {
         updateConfigurationPanel();
       }

--- a/modules/admin-ui/src/main/webapp/styles/components/_collapsible-box.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_collapsible-box.scss
@@ -1,0 +1,47 @@
+.cb-box {
+  margin: 15px 0 0 0;
+
+  position: relative;
+  border: solid #c9d0d3;
+
+  border-width: 1px 1px 1px 1px;
+  background-color: #fafafa;
+  overflow: hidden;
+  border-radius: 4px 4px 4px 4px;
+}
+
+.cb-overflown {
+  border-radius: 4px 4px 0px 0px;
+  cursor: pointer;
+}
+
+.collapsible-box .cb-transparent-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  margin: 0;
+  background-image: linear-gradient(to bottom, transparent, #fafafa);
+}
+
+.cb-text {
+  margin: 10px;
+  font-family: "Open Sans",Helvetica,sans-serif;
+  font-size: 12px;
+  white-space: pre-line;
+}
+
+.cb-arrow-box {
+  cursor: pointer;
+  border: solid #c9d0d3;
+  border-radius: 0px 0px 4px 4px;
+  border-width: 0 1px 1px 1px;
+  background-color: #e1e1e1;
+  background-image: linear-gradient(to bottom, #fafafa, #e1e1e1);
+  bottom: 0;
+}
+
+.cb-angle {
+  text-align: center;
+}

--- a/modules/admin-ui/src/main/webapp/styles/components/_components-config.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_components-config.scss
@@ -39,6 +39,7 @@
 @import "inputs";
 @import "stats";
 @import "popover";
+@import "collapsible-box";
 
 // Integrated From Extensions
 @import "labels";


### PR DESCRIPTION
As described in [MH-13285](https://opencast.jira.com/browse/MH-13285) we wanted to display the workflow description when selecting a workflow.

Since a description could be a very long text and will likely be ignored by an admin who is familiar with the workflow, the description it is contained in a div that becomes "expandable"/"collapsible" when it overflows the defined max-height.

I created a directive called "collapsible-box" that takes two parameters: 
- `input`: displayed text
- `maxheight`: maximum height in px

The directive reacts to window resize (in theory... the two modals in which this directive is used do not resize)

An empty line in the input will be formatted to a line break, while a single line break will be ignored. (Single line breaks are keeping the xml clean and compact and shouldn't be displayed).

The max-height in this implementation is 45px and allows to display two lines before becoming overflowed.

**Example 1: Workflow with fitting workflow description:**
![3](https://user-images.githubusercontent.com/20987894/50168557-00c5a100-02ec-11e9-9f3a-36f4c914dba0.png)

**Example 2: Workflow with fitting workflow description:**
![4](https://user-images.githubusercontent.com/20987894/50168767-792c6200-02ec-11e9-9868-0b35e0214ee8.png)

**Example 3: Workflow with overflowing description (collapsed)**:
![5](https://user-images.githubusercontent.com/20987894/50169366-be9d5f00-02ed-11e9-81e7-6b78aedf387c.png)


**Example 4: Workflow with overflowing description (expanded)**:
![6](https://user-images.githubusercontent.com/20987894/50169376-c3faa980-02ed-11e9-8b22-fea8fbf53aba.png)

**Example 5: No description (collapsible-box becomes hidden)**:
![8](https://user-images.githubusercontent.com/20987894/50170407-23f24f80-02f0-11e9-9ad6-6d032878a1ea.png)

