### PR TITLE
MH-13289 Introduce Metadatafield Copy Constructor

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -77,7 +77,6 @@ import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.api.IndexService.Source;
 import org.opencastproject.index.service.catalog.adapter.MetadataList;
 import org.opencastproject.index.service.catalog.adapter.MetadataList.Locked;
-import org.opencastproject.index.service.catalog.adapter.MetadataUtils;
 import org.opencastproject.index.service.exception.IndexServiceException;
 import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.index.service.impl.index.event.EventIndexSchema;
@@ -1159,7 +1158,7 @@ public abstract class AbstractEventEndpoint {
       mc.removeField(series);
       Map<String, String> seriesAccessEventModal = getSeriesService().getUserSeriesByAccess(true);
       Opt<Map<String, String>> map = Opt.some(seriesAccessEventModal);
-      MetadataField<String> newSeries = MetadataUtils.copyMetadataField(series);
+      MetadataField<String> newSeries = new MetadataField(series);
       newSeries.setCollection(map);
       newSeries.setValue(optEvent.get().getSeriesId());
       mc.addField(newSeries);

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -60,7 +60,6 @@ import org.opencastproject.authorization.xacml.manager.api.SeriesACLTransition;
 import org.opencastproject.authorization.xacml.manager.api.TransitionQuery;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.catalog.adapter.MetadataList;
-import org.opencastproject.index.service.catalog.adapter.MetadataUtils;
 import org.opencastproject.index.service.exception.IndexServiceException;
 import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.index.service.impl.index.event.EventSearchQuery;
@@ -421,55 +420,55 @@ public class SeriesEndpoint implements ManagedService {
 
     MetadataField<?> title = metadata.getOutputFields().get(DublinCore.PROPERTY_TITLE.getLocalName());
     metadata.removeField(title);
-    MetadataField<String> newTitle = MetadataUtils.copyMetadataField(title);
+    MetadataField<String> newTitle = new MetadataField(title);
     newTitle.setValue(series.getTitle());
     metadata.addField(newTitle);
 
     MetadataField<?> subject = metadata.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
     metadata.removeField(subject);
-    MetadataField<String> newSubject = MetadataUtils.copyMetadataField(subject);
+    MetadataField<String> newSubject = new MetadataField(subject);
     newSubject.setValue(series.getSubject());
     metadata.addField(newSubject);
 
     MetadataField<?> description = metadata.getOutputFields().get(DublinCore.PROPERTY_DESCRIPTION.getLocalName());
     metadata.removeField(description);
-    MetadataField<String> newDescription = MetadataUtils.copyMetadataField(description);
+    MetadataField<String> newDescription = new MetadataField(description);
     newDescription.setValue(series.getDescription());
     metadata.addField(newDescription);
 
     MetadataField<?> language = metadata.getOutputFields().get(DublinCore.PROPERTY_LANGUAGE.getLocalName());
     metadata.removeField(language);
-    MetadataField<String> newLanguage = MetadataUtils.copyMetadataField(language);
+    MetadataField<String> newLanguage = new MetadataField(language);
     newLanguage.setValue(series.getLanguage());
     metadata.addField(newLanguage);
 
     MetadataField<?> rightsHolder = metadata.getOutputFields().get(DublinCore.PROPERTY_RIGHTS_HOLDER.getLocalName());
     metadata.removeField(rightsHolder);
-    MetadataField<String> newRightsHolder = MetadataUtils.copyMetadataField(rightsHolder);
+    MetadataField<String> newRightsHolder = new MetadataField(rightsHolder);
     newRightsHolder.setValue(series.getRightsHolder());
     metadata.addField(newRightsHolder);
 
     MetadataField<?> license = metadata.getOutputFields().get(DublinCore.PROPERTY_LICENSE.getLocalName());
     metadata.removeField(license);
-    MetadataField<String> newLicense = MetadataUtils.copyMetadataField(license);
+    MetadataField<String> newLicense = new MetadataField(license);
     newLicense.setValue(series.getLicense());
     metadata.addField(newLicense);
 
     MetadataField<?> organizers = metadata.getOutputFields().get(DublinCore.PROPERTY_CREATOR.getLocalName());
     metadata.removeField(organizers);
-    MetadataField<List<String>> newOrganizers = MetadataUtils.copyMetadataField(organizers);
+    MetadataField<List<String>> newOrganizers = new MetadataField(organizers);
     newOrganizers.setValue(series.getOrganizers());
     metadata.addField(newOrganizers);
 
     MetadataField<?> contributors = metadata.getOutputFields().get(DublinCore.PROPERTY_CONTRIBUTOR.getLocalName());
     metadata.removeField(contributors);
-    MetadataField<List<String>> newContributors = MetadataUtils.copyMetadataField(contributors);
+    MetadataField<List<String>> newContributors = new MetadataField(contributors);
     newContributors.setValue(series.getContributors());
     metadata.addField(newContributors);
 
     MetadataField<?> publishers = metadata.getOutputFields().get(DublinCore.PROPERTY_PUBLISHER.getLocalName());
     metadata.removeField(publishers);
-    MetadataField<List<String>> newPublishers = MetadataUtils.copyMetadataField(publishers);
+    MetadataField<List<String>> newPublishers = new MetadataField(publishers);
     newPublishers.setValue(series.getPublishers());
     metadata.addField(newPublishers);
 
@@ -482,7 +481,7 @@ public class SeriesEndpoint implements ManagedService {
 
     MetadataField<?> uid = metadata.getOutputFields().get(DublinCore.PROPERTY_IDENTIFIER.getLocalName());
     metadata.removeField(uid);
-    MetadataField<String> newUID = MetadataUtils.copyMetadataField(uid);
+    MetadataField<String> newUID = new MetadataField(uid);
     newUID.setValue(series.getIdentifier());
     metadata.addField(newUID);
 

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
@@ -60,7 +60,7 @@ import java.util.TimeZone;
  * @param <A>
  *          Defines the type of the metadata value
  */
-public final class MetadataField<A> {
+public class MetadataField<A> {
 
   private static final Logger logger = LoggerFactory.getLogger(MetadataField.class);
 
@@ -143,6 +143,35 @@ public final class MetadataField<A> {
   private Opt<Map<String, String>> collection = Opt.none();
   private Fn<Opt<A>, JValue> valueToJSON;
   private Fn<Object, A> jsonToValue;
+
+  /**
+   * Copy constructor
+   *
+   * @param other
+   *          Other metadata field
+   */
+  public MetadataField(MetadataField<A> other) {
+
+    this.inputID = other.inputID;
+    this.outputID = other.outputID;
+    this.label = other.label;
+    this.readOnly = other.readOnly;
+    this.required = other.required;
+    this.value = other.value;
+    this.translatable = other.translatable;
+    this.type = other.type;
+    this.jsonType = other.jsonType;
+    this.collection = other.collection;
+    this.collectionID = other.collectionID;
+    this.valueToJSON = other.valueToJSON;
+    this.jsonToValue = other.jsonToValue;
+    this.order = other.order;
+    this.namespace = other.namespace;
+    this.updated = other.updated;
+    this.pattern = other.pattern;
+    this.delimiter = other.delimiter;
+    this.listprovider = other.listprovider;
+  }
 
   /**
    * Metadata field constructor
@@ -344,83 +373,9 @@ public final class MetadataField<A> {
    * @return A new {@link MetadataField} with the value set
    */
   public static MetadataField<?> copyMetadataFieldWithValue(MetadataField<?> oldField, String value) {
-    MetadataField<?> newField = null;
-    switch (oldField.getType()) {
-      case BOOLEAN:
-        MetadataField<Boolean> booleanField = MetadataField.createBooleanMetadata(oldField.getInputID(),
-                Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-                oldField.getOrder(), oldField.getNamespace());
-        booleanField.fromJSON(value);
-        return booleanField;
-      case DATE:
-        MetadataField<Date> dateField = MetadataField.createDateMetadata(oldField.getInputID(),
-                Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-                oldField.getPattern().get(), oldField.getOrder(), oldField.getNamespace());
-        dateField.fromJSON(value);
-        return dateField;
-      case DURATION:
-        MetadataField<String> durationField = MetadataField.createDurationMetadataField(oldField.getInputID(),
-                Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-                oldField.getOrder(), oldField.getNamespace());
-        durationField.fromJSON(value);
-        return durationField;
-      case ITERABLE_TEXT:
-        MetadataField<Iterable<String>> iterableTextField = MetadataField.createIterableStringMetadataField(
-                oldField.getInputID(), Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(),
-                oldField.isRequired(), oldField.isTranslatable(), oldField.getCollection(), oldField.getCollectionID(),
-                oldField.getDelimiter(), oldField.getOrder(), oldField.getNamespace());
-        iterableTextField.fromJSON(value);
-        return iterableTextField;
-      case LONG:
-        MetadataField<Long> longField = MetadataField.createLongMetadataField(oldField.getInputID(),
-                Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-                oldField.isTranslatable(), oldField.getCollection(), oldField.getCollectionID(), oldField.getOrder(),
-                oldField.getNamespace());
-        longField.fromJSON(value);
-        return longField;
-      case MIXED_TEXT:
-        MetadataField<Iterable<String>> mixedField = MetadataField.createMixedIterableStringMetadataField(
-                oldField.getInputID(), Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(),
-                oldField.isRequired(), oldField.isTranslatable(), oldField.getCollection(), oldField.getCollectionID(),
-                oldField.getDelimiter(), oldField.getOrder(), oldField.getNamespace());
-        mixedField.fromJSON(value);
-        return mixedField;
-      case START_DATE:
-        MetadataField<String> startDateField = MetadataField.createTemporalStartDateMetadata(oldField.getInputID(),
-                Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-                oldField.getPattern().get(), oldField.getOrder(), oldField.getNamespace());
-        startDateField.fromJSON(value);
-        return startDateField;
-      case START_TIME:
-        MetadataField<String> startTimeField = MetadataField.createTemporalStartTimeMetadata(oldField.getInputID(),
-                Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-                oldField.getPattern().get(), oldField.getOrder(), oldField.getNamespace());
-        startTimeField.fromJSON(value);
-        return startTimeField;
-      case TEXT:
-        MetadataField<String> textField = MetadataField.createTextMetadataField(oldField.getInputID(),
-                Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-                oldField.isTranslatable(), oldField.getCollection(), oldField.getCollectionID(), oldField.getOrder(),
-                oldField.getNamespace());
-        textField.fromJSON(value);
-        return textField;
-      case TEXT_LONG:
-        MetadataField<String> textLongField = MetadataField.createTextLongMetadataField(oldField.getInputID(),
-                Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-                oldField.isTranslatable(), oldField.getCollection(), oldField.getCollectionID(), oldField.getOrder(),
-                oldField.getNamespace());
-        textLongField.fromJSON(value);
-        return textLongField;
-      case ORDERED_TEXT:
-        MetadataField<String> orderedTextField = MetadataField.createOrderedTextMetadataField(oldField.getInputID(),
-            Opt.some(oldField.getOutputID()), oldField.getLabel(), oldField.isReadOnly(), oldField.isRequired(),
-            oldField.isTranslatable(), oldField.getCollection(), oldField.getCollectionID(), oldField.getOrder(),
-            oldField.getNamespace());
-        orderedTextField.fromJSON(value);
-        return orderedTextField;
-      default:
-        return newField;
-    }
+    MetadataField<?> newField = new MetadataField(oldField);
+    newField.fromJSON(value);
+    return newField;
   }
 
   /**
@@ -958,28 +913,26 @@ public final class MetadataField<A> {
   }
 
   public static MetadataField createMetadataField(Map<String,String> configuration) {
-    Opt<String> collectionID = configuration.containsKey(CONFIG_COLLECTION_ID_KEY)
-            ? Opt.some(configuration.get(CONFIG_COLLECTION_ID_KEY)) : Opt.none();
-    String pattern = configuration.containsKey(CONFIG_PATTERN_KEY)
-            ? configuration.get(CONFIG_PATTERN_KEY) : "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-    Opt<String> delimiter = configuration.containsKey(CONFIG_DELIMITER_KEY)
-            ? Opt.some(configuration.get(CONFIG_DELIMITER_KEY)) : Opt.none();
-    String inputID = configuration.containsKey(CONFIG_INPUT_ID_KEY)
-            ? configuration.get(CONFIG_INPUT_ID_KEY) : null;
-    String label = configuration.containsKey(CONFIG_LABEL_KEY)
-            ? configuration.get(CONFIG_LABEL_KEY) : null;
-    Opt<String> listprovider = configuration.containsKey(CONFIG_LIST_PROVIDER_KEY)
-            ? Opt.some(configuration.get(CONFIG_LIST_PROVIDER_KEY)) : Opt.none();
-    Opt<String> namespace = configuration.containsKey(CONFIG_NAMESPACE_KEY)
-            ? Opt.some(configuration.get(CONFIG_NAMESPACE_KEY)) : Opt.none();
+
+    String inputID = configuration.get(CONFIG_INPUT_ID_KEY);
+    String label = configuration.get(CONFIG_LABEL_KEY);
+
+    Opt<String> collectionID = Opt.nul(configuration.get(CONFIG_COLLECTION_ID_KEY));
+    Opt<String> delimiter = Opt.nul(configuration.get(CONFIG_DELIMITER_KEY));
+    Opt<String> outputID = Opt.nul(configuration.get(CONFIG_OUTPUT_ID_KEY));
+    Opt<String> listprovider = Opt.nul(configuration.get(CONFIG_LIST_PROVIDER_KEY));
+    Opt<String> namespace = Opt.nul(configuration.get(CONFIG_NAMESPACE_KEY));
+
     Type type = configuration.containsKey(CONFIG_TYPE_KEY)
             ? Type.valueOf(configuration.get(CONFIG_TYPE_KEY).toUpperCase()) : null;
     Boolean required = configuration.containsKey(CONFIG_REQUIRED_KEY)
             ? Boolean.valueOf(configuration.get(CONFIG_REQUIRED_KEY).toUpperCase()) : null;
     Boolean readOnly = configuration.containsKey(CONFIG_READ_ONLY_KEY)
             ? Boolean.valueOf(configuration.get(CONFIG_READ_ONLY_KEY).toUpperCase()) : null;
-    Opt<String> outputID = configuration.containsKey(CONFIG_OUTPUT_ID_KEY)
-            ? Opt.some(configuration.get(CONFIG_OUTPUT_ID_KEY)) : Opt.none();
+
+    String pattern = configuration.containsKey(CONFIG_PATTERN_KEY)
+            ? configuration.get(CONFIG_PATTERN_KEY) : "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
     Opt<Integer> order = Opt.none();
     if (configuration.containsKey(CONFIG_ORDER_KEY)) {
       try {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -41,7 +41,6 @@ import org.opencastproject.external.util.AclUtils;
 import org.opencastproject.external.util.ExternalMetadataUtils;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.catalog.adapter.MetadataList;
-import org.opencastproject.index.service.catalog.adapter.MetadataUtils;
 import org.opencastproject.index.service.exception.IndexServiceException;
 import org.opencastproject.index.service.impl.index.event.EventIndexSchema;
 import org.opencastproject.index.service.impl.index.series.Series;
@@ -477,55 +476,55 @@ public class SeriesEndpoint {
 
     MetadataField<?> title = metadata.getOutputFields().get(DublinCore.PROPERTY_TITLE.getLocalName());
     metadata.removeField(title);
-    MetadataField<String> newTitle = MetadataUtils.copyMetadataField(title);
+    MetadataField<String> newTitle = new MetadataField(title);
     newTitle.setValue(series.getTitle());
     metadata.addField(newTitle);
 
     MetadataField<?> subject = metadata.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
     metadata.removeField(subject);
-    MetadataField<String> newSubject = MetadataUtils.copyMetadataField(subject);
+    MetadataField<String> newSubject = new MetadataField(subject);
     newSubject.setValue(series.getSubject());
     metadata.addField(newSubject);
 
     MetadataField<?> description = metadata.getOutputFields().get(DublinCore.PROPERTY_DESCRIPTION.getLocalName());
     metadata.removeField(description);
-    MetadataField<String> newDescription = MetadataUtils.copyMetadataField(description);
+    MetadataField<String> newDescription = new MetadataField(description);
     newDescription.setValue(series.getDescription());
     metadata.addField(newDescription);
 
     MetadataField<?> language = metadata.getOutputFields().get(DublinCore.PROPERTY_LANGUAGE.getLocalName());
     metadata.removeField(language);
-    MetadataField<String> newLanguage = MetadataUtils.copyMetadataField(language);
+    MetadataField<String> newLanguage = new MetadataField(language);
     newLanguage.setValue(series.getLanguage());
     metadata.addField(newLanguage);
 
     MetadataField<?> rightsHolder = metadata.getOutputFields().get(DublinCore.PROPERTY_RIGHTS_HOLDER.getLocalName());
     metadata.removeField(rightsHolder);
-    MetadataField<String> newRightsHolder = MetadataUtils.copyMetadataField(rightsHolder);
+    MetadataField<String> newRightsHolder = new MetadataField(rightsHolder);
     newRightsHolder.setValue(series.getRightsHolder());
     metadata.addField(newRightsHolder);
 
     MetadataField<?> license = metadata.getOutputFields().get(DublinCore.PROPERTY_LICENSE.getLocalName());
     metadata.removeField(license);
-    MetadataField<String> newLicense = MetadataUtils.copyMetadataField(license);
+    MetadataField<String> newLicense = new MetadataField(license);
     newLicense.setValue(series.getLicense());
     metadata.addField(newLicense);
 
     MetadataField<?> organizers = metadata.getOutputFields().get(DublinCore.PROPERTY_CREATOR.getLocalName());
     metadata.removeField(organizers);
-    MetadataField<String> newOrganizers = MetadataUtils.copyMetadataField(organizers);
+    MetadataField<String> newOrganizers = new MetadataField(organizers);
     newOrganizers.setValue(StringUtils.join(series.getOrganizers(), ", "));
     metadata.addField(newOrganizers);
 
     MetadataField<?> contributors = metadata.getOutputFields().get(DublinCore.PROPERTY_CONTRIBUTOR.getLocalName());
     metadata.removeField(contributors);
-    MetadataField<String> newContributors = MetadataUtils.copyMetadataField(contributors);
+    MetadataField<String> newContributors = new MetadataField(contributors);
     newContributors.setValue(StringUtils.join(series.getContributors(), ", "));
     metadata.addField(newContributors);
 
     MetadataField<?> publishers = metadata.getOutputFields().get(DublinCore.PROPERTY_PUBLISHER.getLocalName());
     metadata.removeField(publishers);
-    MetadataField<String> newPublishers = MetadataUtils.copyMetadataField(publishers);
+    MetadataField<String> newPublishers = new MetadataField(publishers);
     newPublishers.setValue(StringUtils.join(series.getPublishers(), ", "));
     metadata.addField(newPublishers);
 
@@ -538,7 +537,7 @@ public class SeriesEndpoint {
 
     MetadataField<?> uid = metadata.getOutputFields().get(DublinCore.PROPERTY_IDENTIFIER.getLocalName());
     metadata.removeField(uid);
-    MetadataField<String> newUID = MetadataUtils.copyMetadataField(uid);
+    MetadataField<String> newUID = new MetadataField(uid);
     newUID.setValue(series.getIdentifier());
     metadata.addField(newUID);
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/util/ExternalMetadataUtils.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/util/ExternalMetadataUtils.java
@@ -44,11 +44,10 @@ public final class ExternalMetadataUtils {
     // Change subject to subjects.
     MetadataField<?> subject = collection.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
     collection.removeField(subject);
-    MetadataField<Iterable<String>> newSubjects; // = //MetadataUtils.copyMetadataField(subject);
-    newSubjects = MetadataField.createIterableStringMetadataField(subject.getInputID(), Opt.some("subjects"),
-            subject.getLabel(), subject.isReadOnly(), subject.isRequired(), subject.isTranslatable(),
-            subject.getCollection(), subject.getCollectionID(), subject.getDelimiter(), subject.getOrder(),
-            subject.getNamespace());
+    MetadataField<Iterable<String>> newSubjects = MetadataField.createIterableStringMetadataField(subject.getInputID(),
+            Opt.some("subjects"), subject.getLabel(), subject.isReadOnly(), subject.isRequired(),
+            subject.isTranslatable(), subject.getCollection(), subject.getCollectionID(), subject.getDelimiter(),
+            subject.getOrder(), subject.getNamespace());
     List<String> subjectNames = new ArrayList<String>();
     if (subject.getValue().isSome()) {
       subjectNames = com.entwinemedia.fn.Stream.$(subject.getValue().get().toString().split(",")).toList();

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
@@ -292,14 +292,8 @@ public final class DublinCoreMetadataUtil {
         String propertyName = propertyNameOpt.get();
         String propertyKey = propertyKeyOpt.get();
 
-        Map metadataFieldProperties;
-        if (!allProperties.containsKey(propertyName)) {
-          metadataFieldProperties = new HashMap();
-          allProperties.put(propertyName, metadataFieldProperties);
-        }
-        else {
-          metadataFieldProperties = allProperties.get(propertyName);
-        }
+        Map<String,String> metadataFieldProperties = allProperties.computeIfAbsent(propertyName,
+                key -> new HashMap<>());
         metadataFieldProperties.put(propertyKey, configProperties.get(property).toString());
       }
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
@@ -278,25 +278,39 @@ public final class DublinCoreMetadataUtil {
 
   @SuppressWarnings("unchecked")
   public static Map<String, MetadataField<?>> getDublinCoreProperties(Dictionary configProperties) {
-    Map<String, MetadataField<?>> dublinCorePropertyMapByConfigurationName = new HashMap<String, MetadataField<?>>();
+
+    Map<String,Map<String, String>> allProperties = new HashMap();
+
     for (Object configObject : Collections.list(configProperties.keys())) {
       String property = configObject.toString();
-      if (getDublinCorePropertyName(property).isSome()) {
-        MetadataField<?> dublinCoreProperty = dublinCorePropertyMapByConfigurationName
-                .get(getDublinCorePropertyName(property).get());
-        if (dublinCoreProperty == null) {
-          dublinCoreProperty = new MetadataField();
+
+      Opt<String> propertyNameOpt = getDublinCorePropertyName(property);
+      Opt<String> propertyKeyOpt = getDublinCorePropertyKey(property);
+
+      if (propertyNameOpt.isSome() && propertyKeyOpt.isSome()) {
+
+        String propertyName = propertyNameOpt.get();
+        String propertyKey = propertyKeyOpt.get();
+
+        Map metadataFieldProperties;
+        if (!allProperties.containsKey(propertyName)) {
+          metadataFieldProperties = new HashMap();
+          allProperties.put(propertyName, metadataFieldProperties);
         }
-        dublinCoreProperty.setValue(getDublinCorePropertyKey(property).get(),
-                configProperties.get(property).toString());
-        dublinCorePropertyMapByConfigurationName.put(getDublinCorePropertyName(property).get(), dublinCoreProperty);
+        else {
+          metadataFieldProperties = allProperties.get(propertyName);
+        }
+        metadataFieldProperties.put(propertyKey, configProperties.get(property).toString());
       }
     }
-    Map<String, MetadataField<?>> dublinCorePropertyMap = new TreeMap<String, MetadataField<?>>();
-    for (MetadataField dublinCoreProperty : dublinCorePropertyMapByConfigurationName.values()) {
-      dublinCorePropertyMap.put(dublinCoreProperty.getOutputID(), dublinCoreProperty);
+
+    Map<String, MetadataField<?>> metadataFieldsMap = new TreeMap<String, MetadataField<?>>();
+    for (Map<String, String> metadataFieldPropertiesMap : allProperties.values()) {
+      MetadataField metadataField = MetadataField.createMetadataField(metadataFieldPropertiesMap);
+      metadataFieldsMap.put(metadataField.getOutputID(), metadataField);
     }
-    return dublinCorePropertyMap;
+
+    return metadataFieldsMap;
   }
 
   static boolean isDublinCoreProperty(String propertyKey) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/MetadataUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/MetadataUtils.java
@@ -106,24 +106,17 @@ public final class MetadataUtils {
    */
   @SuppressWarnings({ "rawtypes", "unchecked" })
   public static MetadataField copyMetadataField(MetadataField other) {
-    MetadataField newField = new MetadataField();
-    newField.setCollection(other.getCollection());
-    newField.setCollectionID(other.getCollectionID());
-    newField.setInputId(other.getInputID());
-    newField.setIsTranslatable(other.isTranslatable());
-    newField.setLabel(other.getLabel());
+
+    MetadataField newField = MetadataField.createMetadataField(other.getInputID(),
+            other.getOutputID() != null ? Opt.some(other.getOutputID()) : Opt.none(),
+            other.getLabel(), other.isReadOnly(), other.isRequired(), other.isTranslatable(), other.getType(),
+            other.getCollection(), other.getCollectionID(), other.getOrder(), other.getNamespace(),
+            other.getDelimiter(), other.getPattern().isSome() ? (String) other.getPattern().get() : null);
+
     newField.setListprovider(other.getListprovider());
-    newField.setNamespace(other.getNamespace());
-    newField.setOutputID(Opt.some(other.getOutputID()));
-    newField.setPattern(other.getPattern());
-    newField.setDelimiter(other.getDelimiter());
-    newField.setOrder(other.getOrder());
-    newField.setReadOnly(other.isReadOnly());
-    newField.setRequired(other.isRequired());
     newField.setJsonType(other.getJsonType());
     newField.setJsonToValue(other.getJsonToValue());
     newField.setValueToJSON(other.getValueToJSON());
-    newField.setType(other.getType());
     if (other.getValue().isSome()) {
       newField.setValue(other.getValue().get());
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/MetadataUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/MetadataUtils.java
@@ -98,32 +98,6 @@ public final class MetadataUtils {
   }
 
   /**
-   * Copy a {@link MetadataField} into a new field.
-   *
-   * @param other
-   *          The other {@link MetadataField} to copy the state from.
-   * @return A new {@link MetadataField} with the same settings as the passed in {@link MetadataField}
-   */
-  @SuppressWarnings({ "rawtypes", "unchecked" })
-  public static MetadataField copyMetadataField(MetadataField other) {
-
-    MetadataField newField = MetadataField.createMetadataField(other.getInputID(),
-            other.getOutputID() != null ? Opt.some(other.getOutputID()) : Opt.none(),
-            other.getLabel(), other.isReadOnly(), other.isRequired(), other.isTranslatable(), other.getType(),
-            other.getCollection(), other.getCollectionID(), other.getOrder(), other.getNamespace(),
-            other.getDelimiter(), other.getPattern().isSome() ? (String) other.getPattern().get() : null);
-
-    newField.setListprovider(other.getListprovider());
-    newField.setJsonType(other.getJsonType());
-    newField.setJsonToValue(other.getJsonToValue());
-    newField.setValueToJSON(other.getValueToJSON());
-    if (other.getValue().isSome()) {
-      newField.setValue(other.getValue().get());
-    }
-    return newField;
-  }
-
-  /**
    * Returns the {@link String} value of a {@link MetadataField} if updated and available.
    *
    * @param collection

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -850,7 +850,7 @@ public class IndexServiceImpl implements IndexService {
       currentStartDate = sdf.parse((String) startDate.getValue().get());
     } else if (currentStartDate != null) {
       eventMetadata.removeField(startDate);
-      MetadataField<String> newStartDate = MetadataUtils.copyMetadataField(startDate);
+      MetadataField<String> newStartDate = new MetadataField(startDate);
       newStartDate.setValue(EncodingSchemeUtils.encodeDate(currentStartDate, Precision.Fraction).getValue());
       eventMetadata.addField(newStartDate);
     }
@@ -858,7 +858,7 @@ public class IndexServiceImpl implements IndexService {
     MetadataField<?> created = eventMetadata.getOutputFields().get(DublinCore.PROPERTY_CREATED.getLocalName());
     if (created == null || !created.isUpdated() || created.getValue().isNone()) {
       eventMetadata.removeField(created);
-      MetadataField<String> newCreated = MetadataUtils.copyMetadataField(created);
+      MetadataField<String> newCreated = new MetadataField(created);
       if (currentStartDate != null) {
         newCreated.setValue(EncodingSchemeUtils.encodeDate(currentStartDate, Precision.Second).getValue());
       } else {
@@ -1020,8 +1020,7 @@ public class IndexServiceImpl implements IndexService {
       Tuple<List<String>, Set<String>> updatedPresenters = getTechnicalPresenters(eventMetadata);
       presenterUsernames = updatedPresenters.getB();
       eventMetadata.removeField(presentersMetadataField);
-      MetadataField<Iterable<String>> newPresentersMetadataField = MetadataUtils
-              .copyMetadataField(presentersMetadataField);
+      MetadataField<Iterable<String>> newPresentersMetadataField = new MetadataField(presentersMetadataField);
       newPresentersMetadataField.setValue(updatedPresenters.getA());
       eventMetadata.addField(newPresentersMetadataField);
       return Opt.some(presenterUsernames);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.index.service.impl.index.event;
 
-import org.opencastproject.index.service.catalog.adapter.MetadataUtils;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.EventCatalogUIAdapter;
@@ -75,7 +74,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_TITLE.getLocalName())) {
       MetadataField<?> title = metadata.getOutputFields().get(DublinCore.PROPERTY_TITLE.getLocalName());
       metadata.removeField(title);
-      MetadataField<String> newTitle = MetadataUtils.copyMetadataField(title);
+      MetadataField<String> newTitle = new MetadataField(title);
       newTitle.setValue(event.getTitle());
       metadata.addField(newTitle);
     }
@@ -83,7 +82,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_SUBJECT.getLocalName())) {
       MetadataField<?> subject = metadata.getOutputFields().get(DublinCore.PROPERTY_SUBJECT.getLocalName());
       metadata.removeField(subject);
-      MetadataField<String> newSubject = MetadataUtils.copyMetadataField(subject);
+      MetadataField<String> newSubject = new MetadataField(subject);
       newSubject.setValue(event.getSubject());
       metadata.addField(newSubject);
     }
@@ -91,7 +90,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_DESCRIPTION.getLocalName())) {
       MetadataField<?> description = metadata.getOutputFields().get(DublinCore.PROPERTY_DESCRIPTION.getLocalName());
       metadata.removeField(description);
-      MetadataField<String> newDescription = MetadataUtils.copyMetadataField(description);
+      MetadataField<String> newDescription = new MetadataField(description);
       newDescription.setValue(event.getDescription());
       metadata.addField(newDescription);
     }
@@ -99,7 +98,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_LANGUAGE.getLocalName())) {
       MetadataField<?> language = metadata.getOutputFields().get(DublinCore.PROPERTY_LANGUAGE.getLocalName());
       metadata.removeField(language);
-      MetadataField<String> newLanguage = MetadataUtils.copyMetadataField(language);
+      MetadataField<String> newLanguage = new MetadataField(language);
       newLanguage.setValue(event.getLanguage());
       metadata.addField(newLanguage);
     }
@@ -107,7 +106,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_RIGHTS_HOLDER.getLocalName())) {
       MetadataField<?> rightsHolder = metadata.getOutputFields().get(DublinCore.PROPERTY_RIGHTS_HOLDER.getLocalName());
       metadata.removeField(rightsHolder);
-      MetadataField<String> newRightsHolder = MetadataUtils.copyMetadataField(rightsHolder);
+      MetadataField<String> newRightsHolder = new MetadataField(rightsHolder);
       newRightsHolder.setValue(event.getRights());
       metadata.addField(newRightsHolder);
     }
@@ -115,7 +114,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_LICENSE.getLocalName())) {
       MetadataField<?> license = metadata.getOutputFields().get(DublinCore.PROPERTY_LICENSE.getLocalName());
       metadata.removeField(license);
-      MetadataField<String> newLicense = MetadataUtils.copyMetadataField(license);
+      MetadataField<String> newLicense = new MetadataField(license);
       newLicense.setValue(event.getLicense());
       metadata.addField(newLicense);
     }
@@ -123,7 +122,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_IS_PART_OF.getLocalName())) {
       MetadataField<?> series = metadata.getOutputFields().get(DublinCore.PROPERTY_IS_PART_OF.getLocalName());
       metadata.removeField(series);
-      MetadataField<String> newSeries = MetadataUtils.copyMetadataField(series);
+      MetadataField<String> newSeries = new MetadataField(series);
       newSeries.setValue(event.getSeriesId());
       metadata.addField(newSeries);
     }
@@ -131,7 +130,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_CREATOR.getLocalName())) {
       MetadataField<?> presenters = metadata.getOutputFields().get(DublinCore.PROPERTY_CREATOR.getLocalName());
       metadata.removeField(presenters);
-      MetadataField<List<String>> newPresenters = MetadataUtils.copyMetadataField(presenters);
+      MetadataField<List<String>> newPresenters = new MetadataField(presenters);
       newPresenters.setValue(event.getPresenters());
       metadata.addField(newPresenters);
     }
@@ -139,7 +138,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_CONTRIBUTOR.getLocalName())) {
       MetadataField<?> contributors = metadata.getOutputFields().get(DublinCore.PROPERTY_CONTRIBUTOR.getLocalName());
       metadata.removeField(contributors);
-      MetadataField<List<String>> newContributors = MetadataUtils.copyMetadataField(contributors);
+      MetadataField<List<String>> newContributors = new MetadataField(contributors);
       newContributors.setValue(event.getContributors());
       metadata.addField(newContributors);
     }
@@ -151,7 +150,7 @@ public final class EventUtils {
       if (metadata.getOutputFields().containsKey("startDate")) {
         MetadataField<?> startDate = metadata.getOutputFields().get("startDate");
         metadata.removeField(startDate);
-        MetadataField<String> newStartDate = MetadataUtils.copyMetadataField(startDate);
+        MetadataField<String> newStartDate = new MetadataField(startDate);
         SimpleDateFormat sdf = new SimpleDateFormat(startDate.getPattern().get());
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         newStartDate.setValue(sdf.format(startDateTime));
@@ -162,7 +161,7 @@ public final class EventUtils {
     if (event.getDuration() != null) {
       MetadataField<?> duration = metadata.getOutputFields().get("duration");
       metadata.removeField(duration);
-      MetadataField<String> newDuration = MetadataUtils.copyMetadataField(duration);
+      MetadataField<String> newDuration = new MetadataField(duration);
       newDuration.setValue(event.getDuration().toString());
       metadata.addField(newDuration);
     }
@@ -170,7 +169,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey("location")) {
       MetadataField<?> agent = metadata.getOutputFields().get("location");
       metadata.removeField(agent);
-      MetadataField<String> newAgent = MetadataUtils.copyMetadataField(agent);
+      MetadataField<String> newAgent = new MetadataField(agent);
       newAgent.setValue(event.getLocation());
       metadata.addField(newAgent);
     }
@@ -178,7 +177,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_SOURCE.getLocalName())) {
       MetadataField<?> source = metadata.getOutputFields().get(DublinCore.PROPERTY_SOURCE.getLocalName());
       metadata.removeField(source);
-      MetadataField<String> newSource = MetadataUtils.copyMetadataField(source);
+      MetadataField<String> newSource = new MetadataField(source);
       newSource.setValue(event.getSource());
       metadata.addField(newSource);
     }
@@ -188,7 +187,7 @@ public final class EventUtils {
       if (StringUtils.isNotBlank(createdDate)) {
         MetadataField<?> created = metadata.getOutputFields().get(DublinCore.PROPERTY_CREATED.getLocalName());
         metadata.removeField(created);
-        MetadataField<Date> newCreated = MetadataUtils.copyMetadataField(created);
+        MetadataField<Date> newCreated = new MetadataField(created);
         newCreated.setValue(new Date(DateTimeSupport.fromUTC(createdDate)));
         metadata.addField(newCreated);
       }
@@ -197,7 +196,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_IDENTIFIER.getLocalName())) {
       MetadataField<?> uid = metadata.getOutputFields().get(DublinCore.PROPERTY_IDENTIFIER.getLocalName());
       metadata.removeField(uid);
-      MetadataField<String> newUID = MetadataUtils.copyMetadataField(uid);
+      MetadataField<String> newUID = new MetadataField(uid);
       newUID.setValue(event.getIdentifier());
       metadata.addField(newUID);
     }
@@ -205,7 +204,7 @@ public final class EventUtils {
     if (metadata.getOutputFields().containsKey(DublinCore.PROPERTY_PUBLISHER.getLocalName())) {
       MetadataField<?> publisher = metadata.getOutputFields().get(DublinCore.PROPERTY_PUBLISHER.getLocalName());
       metadata.removeField(publisher);
-      MetadataField<String> newPublisher = MetadataUtils.copyMetadataField(publisher);
+      MetadataField<String> newPublisher = new MetadataField(publisher);
       newPublisher.setValue(event.getPublisher());
       metadata.addField(newPublisher);
     }

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -959,8 +959,9 @@ public class IndexServiceImplTest {
   }
 
   private MetadataField<Iterable<String>> createCreatorMetadataField(Iterable<String> value) {
-    MetadataField<Iterable<String>> creator = new MetadataField<>();
-    creator.setInputId(DublinCore.PROPERTY_CREATOR.getLocalName());
+    MetadataField<Iterable<String>> creator = MetadataField.createMetadataField(
+            DublinCore.PROPERTY_CREATOR.getLocalName(), Opt.none(), "creator", false, false, Opt.none(),
+            MetadataField.Type.TEXT, Opt.none(), Opt.none(), Opt.none(), Opt.none(), Opt.none(), null);
     creator.setValue(value);
     return creator;
   }


### PR DESCRIPTION
Introduce a copy constructor for MetadataField so other copy methods can be simplified or removed completely.

This PR includes the PRs #630  ~~and #629~~.  