### PR TITLE
MH-12290 SAXParserFactory slow to init when called by series listprovider

### DIFF
--- a/assemblies/resources/system.properties.append
+++ b/assemblies/resources/system.properties.append
@@ -5,4 +5,5 @@ org.terracotta.quartz.skipUpdateCheck=true
 
 # Configuring DocumentBuilderFactory and TransformerFactory
 javax.xml.parsers.DocumentBuilderFactory=org.apache.xerces.jaxp.DocumentBuilderFactoryImpl
+javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
 javax.xml.transform.TransformerFactory=org.apache.xalan.processor.TransformerFactoryImpl


### PR DESCRIPTION
Adding a default SAXParserFactoryImpl to the system properties resolves the sluggish SAXParserFactory and SAXParser. This speeds up the series listprovider response back up to minmal lag when a system contains many hundreds of series. 

I tested with both "org.apache.xerces.jaxp.SAXParserFactoryImpl" and "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl". The  first migitates the lag time. But the com.sum inpl was even faster. 

If approved, this patch is applicable to later version branches.