### PR TITLE
MH-13295 Handle null for presentable value extraction

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
@@ -86,29 +86,32 @@ angular.module('adminNg.services')
     this.extractPresentableValue = function (field) {
       var actualValue = field.value;
       var presentableValue = '';
-      if (field.collection) {
-        if (angular.isArray(actualValue)) {
-          angular.forEach(actualValue, function (item, index) {
-            presentableValue += item;
-            if ((index + 1) < actualValue.length) {
-              presentableValue += ', ';
-            }
-          });
-          field.presentableValue = presentableValue;
-        } else {
-          if (field.collection.hasOwnProperty(actualValue)) {
-            presentableValue = field.collection[actualValue];
+
+      if (actualValue !== undefined && actualValue !== '' && actualValue !== null) {
+        if (field.collection) {
+          if (angular.isArray(actualValue)) {
+            angular.forEach(actualValue, function (item, index) {
+              presentableValue += item;
+              if ((index + 1) < actualValue.length) {
+                presentableValue += ', ';
+              }
+            });
+            field.presentableValue = presentableValue;
           } else {
-            // this should work in older browsers, albeit looking clumsy
-            var matchingKey = Object.keys(field.collection)
-              .filter(function(key) {return field.collection[key] === actualValue;})[0];
-            presentableValue = field.type === 'ordered_text'
-              ? JSON.parse(matchingKey)['label']
-              : matchingKey;
+            if (field.collection.hasOwnProperty(actualValue)) {
+              presentableValue = field.collection[actualValue];
+            } else {
+              // this should work in older browsers, albeit looking clumsy
+              var matchingKey = Object.keys(field.collection)
+                .filter(function(key) {return field.collection[key] === actualValue;})[0];
+              presentableValue = field.type === 'ordered_text'
+                ? JSON.parse(matchingKey)['label']
+                : matchingKey;
+            }
           }
+        } else {
+          presentableValue = actualValue;
         }
-      } else {
-        presentableValue = actualValue;
       }
       return presentableValue;
     };

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
@@ -81,29 +81,32 @@ angular.module('adminNg.services')
     this.extractPresentableValue = function (field) {
       var actualValue = field.value;
       var presentableValue = '';
-      if (field.collection) {
-        if (angular.isArray(actualValue)) {
-          angular.forEach(actualValue, function (item, index) {
-            presentableValue += item;
-            if ((index + 1) < actualValue.length) {
-              presentableValue += ', ';
-            }
-          });
-          field.presentableValue = presentableValue;
-        } else {
-          if (field.collection.hasOwnProperty(actualValue)) {
-            presentableValue = field.collection[actualValue];
+
+      if (actualValue !== undefined && actualValue !== '' && actualValue !== null) {
+        if (field.collection) {
+          if (angular.isArray(actualValue)) {
+            angular.forEach(actualValue, function (item, index) {
+              presentableValue += item;
+              if ((index + 1) < actualValue.length) {
+                presentableValue += ', ';
+              }
+            });
+            field.presentableValue = presentableValue;
           } else {
-            // this should work in older browsers, albeit looking clumsy
-            var matchingKey = Object.keys(field.collection)
-              .filter(function(key) {return field.collection[key] === actualValue;})[0];
-            presentableValue = field.type === 'ordered_text'
-              ? JSON.parse(matchingKey)['label']
-              : matchingKey;
+            if (field.collection.hasOwnProperty(actualValue)) {
+              presentableValue = field.collection[actualValue];
+            } else {
+              // this should work in older browsers, albeit looking clumsy
+              var matchingKey = Object.keys(field.collection)
+                .filter(function(key) {return field.collection[key] === actualValue;})[0];
+              presentableValue = field.type === 'ordered_text'
+                ? JSON.parse(matchingKey)['label']
+                : matchingKey;
+            }
           }
+        } else {
+          presentableValue = actualValue;
         }
-      } else {
-        presentableValue = actualValue;
       }
       return presentableValue;
     };


### PR DESCRIPTION
Handle the possibility that the value of a field is undefined, empty or null when extracting the presentable value.