### PR TITLE
MH-12290 prevent SAXParserFactory and SAXParser class load lag in series listprovider

### DIFF
--- a/assemblies/resources/system.properties.append
+++ b/assemblies/resources/system.properties.append
@@ -3,6 +3,7 @@
 net.sf.ehcache.skipUpdateCheck=true
 org.terracotta.quartz.skipUpdateCheck=true
 
-# Configuring DocumentBuilderFactory and TransformerFactory
-javax.xml.parsers.DocumentBuilderFactory=org.apache.xerces.jaxp.DocumentBuilderFactoryImpl
-javax.xml.transform.TransformerFactory=org.apache.xalan.processor.TransformerFactoryImpl
+# Configure for native JDK Impls
+javax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl
+javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
+javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl

--- a/modules/capture-admin-service-impl/pom.xml
+++ b/modules/capture-admin-service-impl/pom.xml
@@ -51,10 +51,6 @@
       <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.xerces</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
     </dependency>

--- a/modules/message-broker-impl/pom.xml
+++ b/modules/message-broker-impl/pom.xml
@@ -81,17 +81,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.xerces</groupId>
-      <artifactId>com.springsource.org.apache.xerces</artifactId>
-      <version>2.9.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -970,11 +970,6 @@
       </dependency>
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.xerces</artifactId>
-        <version>2.9.1_3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.jsr305</artifactId>
         <version>2.0.1_1</version>
       </dependency>


### PR DESCRIPTION
Adding a default SAXParserFactoryImpl to the system properties resolves the sluggish SAXParserFactory and SAXParser class load. This speeds up the series listprovider response back up to minmal lag when an Opencast system contains many hundreds of series.

I tested with both "org.apache.xerces.jaxp.SAXParserFactoryImpl" and "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl".  Both migitate lag time. But the com.sun internal impl is faster.

Since the pull proposes using the com.sun internal impl, it also proposes updating the other two defaults to JDK javax.xml bundled Impls and to start weaning Opencast from unneeded external Xerces dependencies.
