### PR TITLE
MH-13296 Disable buttons of start task wizard while the tasks are being submitted

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
@@ -1,6 +1,6 @@
 <section ng-form="scheduleTaskForm" ng-show="open" ng-keyup="keyUp($event)" tabindex="1" class="modal wizard modal-animation ng-hide" ng-controller="ScheduleTaskCtrl">
     <header>
-        <a class="fa fa-times close-modal" ng-click="close()"></a>
+        <a class="fa fa-times close-modal" ng-click="close()" ng-class="{disabled: submitButton}"></a>
         <h2 translate="BULK_ACTIONS.SCHEDULE_TASK.CAPTION"><!-- Template --></h2>
     </header>
     <wizard edit-mode="false" name="scheduleTaskWz" on-finish="submit()" template="shared/partials/wizardNav.html">
@@ -114,7 +114,7 @@
         </wz-step>
 
         <!-- Third step: Summary -->
-        <wz-step wz-title="{{ 'BULK_ACTIONS.SCHEDULE_TASK.SUMMARY.CAPTION' | translate }}" novalidate canexit="true">
+        <wz-step wz-title="{{ 'BULK_ACTIONS.SCHEDULE_TASK.SUMMARY.CAPTION' | translate }}" novalidate canexit="submitButton">
             <div class="modal-content active">
                 <div class="modal-body">
                     <div class="full-col">
@@ -152,7 +152,7 @@
                    ng-class="{active: scheduleTaskForm.$valid, inactive: scheduleTaskForm.$invalid, disabled: submitButton}">
                     {{ 'WIZARD.CREATE' | translate }}
                 </a>
-                <a wz-previous translate="WIZARD.BACK" class="cancel">
+                <a wz-previous translate="WIZARD.BACK" class="cancel" ng-class="{disabled: submitButton}">
                 </a>
             </footer>
         </wz-step>


### PR DESCRIPTION
When the user presses the submit button on the last tab of the start task wizard, it takes a while until the tasks are actually submitted.
During this time, the submit button is disabled (which is correct).

The following buttons should, however, also be disabled:

- back button
- close modal button (X on top right on the window)
- bread crumb navigation