### PR TITLE
MH-13299 Make multi-select fields consistent again

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableMultiSelectDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableMultiSelectDirective.js
@@ -71,8 +71,9 @@ angular.module('adminNg.directives')
         });
       };
 
-      scope.onBlur = function (event) {
+      scope.onBlur = function () {
         if (!scope.removedValue) {
+          scope.addCurrentValue();
           scope.leaveEditMode();
         } else {
           $timeout(function () {
@@ -83,21 +84,26 @@ angular.module('adminNg.directives')
       };
 
       scope.leaveEditMode = function () {
+        scope.data.value = '';
         scope.editMode = false;
       };
 
       scope.keyUp = function (event) {
         if (event.keyCode === 13) {
           // ENTER
-          if (angular.isDefined(scope.data.value)) {
-            scope.addValue(scope.params.value, scope.data.value);
-          }
+          scope.addCurrentValue();
           scope.data.value = '';
         } else if (event.keyCode === 27) {
           // ESC
           scope.leaveEditMode();
         }
         event.stopPropagation();
+      };
+
+      scope.addCurrentValue = function () {
+        if (angular.isDefined(scope.data.value)) {
+          scope.addValue(scope.params.value, scope.data.value);
+        }
       };
 
       scope.addValue = function (model, value) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
@@ -9,7 +9,7 @@
   <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
 
   <div class="editable-select" ng-if="editMode">
-    <input type="text" ng-blur="onBlur($event)" ng-required="params.required" tabindex="{{ params.tabindex }}"
+    <input type="text" ng-blur="onBlur()" ng-required="params.required" tabindex="{{ params.tabindex }}"
                                                                                list="{{ data.list.id }}-data-list" ng-keyup="keyUp($event)" name="{{ params.name }}" ng-model="data.value">
     <datalist id="{{ data.list.id }}-data-list">
       <option ng-repeat="(item, label) in collection"

--- a/modules/admin-ui/src/test/resources/test/unit/shared/directives/editableMultiSelectDirectiveSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/directives/editableMultiSelectDirectiveSpec.js
@@ -91,7 +91,7 @@ describe('adminNg.directives.adminNgEditableMultiSelect', function () {
     describe('#leaveEditMode', function () {
 
         it('leaves edit mode', function () {
-            var scope = element.find('ul').scope();  // the div & input elements doesn't exist when editMode = false
+            var scope = element.find('ul').scope();  // the div & input elements don't exist when editMode = false
             scope.editMode = true;
             scope.data.value = 'edited';
 
@@ -99,9 +99,29 @@ describe('adminNg.directives.adminNgEditableMultiSelect', function () {
 
             expect(element.scope().params.value).not.toContain('edited')
             expect(scope.editMode).toBe(false);
-            expect(scope.data.value).toEqual('edited');
+            expect(scope.data.value).toEqual('');
         });
     });
+
+    describe('#onBlur', function () {
+
+        var scope;
+
+        beforeEach(function () {
+            scope = element.find('ul').scope();  // the div & input elements don't exist when editMode = false
+            scope.editMode = true;
+            scope.mixed = true;
+            scope.data.value = 'edited';
+        });
+
+        it('saves and leaves edit mode', function () {
+            scope.onBlur();
+
+            expect(scope.editMode).toBe(false);
+            expect(scope.data.value).toEqual('');
+            expect(scope.params.value).toContain('edited')
+        });
+    })
 
     describe('#addValue', function () {
 
@@ -120,7 +140,6 @@ describe('adminNg.directives.adminNgEditableMultiSelect', function () {
             event.stopPropagation = jasmine.createSpy();
             scope = element.find('ul').scope()
             scope.editMode = true;
-
         });
 
         it('does nothing by default', function () {
@@ -141,6 +160,10 @@ describe('adminNg.directives.adminNgEditableMultiSelect', function () {
 
             it('leaves edit mode', function () {
                 expect(scope.editMode).toBe(false);
+            });
+
+            it('clears value', function () {
+              expect(scope.data.value).toBe('');
             });
         });
 


### PR DESCRIPTION
Make the multi-select metadata fields again consistent with the other fields by restoring the old behavior regarding TAB and blur (saving the value instead of merely hiding it) and discarding the current value completely on ESC.

This was broken by PR #585.