### PR TITLE
MH-13300 Display multi-value fields correctly on summary pages

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
@@ -84,33 +84,24 @@ angular.module('adminNg.services')
     };
 
     this.extractPresentableValue = function (field) {
-      var actualValue = field.value;
       var presentableValue = '';
-
-      if (actualValue !== undefined && actualValue !== '' && actualValue !== null) {
-        if (field.collection) {
-          if (angular.isArray(actualValue)) {
-            angular.forEach(actualValue, function (item, index) {
-              presentableValue += item;
-              if ((index + 1) < actualValue.length) {
-                presentableValue += ', ';
-              }
-            });
-            field.presentableValue = presentableValue;
+      if (field.value !== undefined && field.value !== '' && field.value !== null) {
+        if (angular.isArray(field.value)) {
+          presentableValue = field.value.join(', ');
+        } else if (field.collection) {
+          // We need to lookup the presentable value in the collection
+          if (field.collection.hasOwnProperty(field.value)) {
+            presentableValue = field.collection[field.value];
           } else {
-            if (field.collection.hasOwnProperty(actualValue)) {
-              presentableValue = field.collection[actualValue];
-            } else {
-              // this should work in older browsers, albeit looking clumsy
-              var matchingKey = Object.keys(field.collection)
-                .filter(function(key) {return field.collection[key] === actualValue;})[0];
-              presentableValue = field.type === 'ordered_text'
-                ? JSON.parse(matchingKey)['label']
-                : matchingKey;
-            }
+            // This should work in older browsers, albeit looking clumsy
+            var matchingKey = Object.keys(field.collection)
+              .filter(function(key) {return field.collection[key] === field.value;})[0];
+            presentableValue = field.type === 'ordered_text'
+              ? JSON.parse(matchingKey)['label']
+              : matchingKey;
           }
         } else {
-          presentableValue = actualValue;
+          presentableValue = field.value;
         }
       }
       return presentableValue;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
@@ -79,33 +79,24 @@ angular.module('adminNg.services')
     };
 
     this.extractPresentableValue = function (field) {
-      var actualValue = field.value;
       var presentableValue = '';
-
-      if (actualValue !== undefined && actualValue !== '' && actualValue !== null) {
-        if (field.collection) {
-          if (angular.isArray(actualValue)) {
-            angular.forEach(actualValue, function (item, index) {
-              presentableValue += item;
-              if ((index + 1) < actualValue.length) {
-                presentableValue += ', ';
-              }
-            });
-            field.presentableValue = presentableValue;
+      if (field.value !== undefined && field.value !== '' && field.value !== null) {
+        if (angular.isArray(field.value)) {
+          presentableValue = field.value.join(', ');
+        } else if (field.collection) {
+          // We need to lookup the presentable value in the collection
+          if (field.collection.hasOwnProperty(field.value)) {
+            presentableValue = field.collection[field.value];
           } else {
-            if (field.collection.hasOwnProperty(actualValue)) {
-              presentableValue = field.collection[actualValue];
-            } else {
-              // this should work in older browsers, albeit looking clumsy
-              var matchingKey = Object.keys(field.collection)
-                .filter(function(key) {return field.collection[key] === actualValue;})[0];
-              presentableValue = field.type === 'ordered_text'
-                ? JSON.parse(matchingKey)['label']
-                : matchingKey;
-            }
+            // This should work in older browsers, albeit looking clumsy
+            var matchingKey = Object.keys(field.collection)
+              .filter(function(key) {return field.collection[key] === field.value;})[0];
+            presentableValue = field.type === 'ordered_text'
+              ? JSON.parse(matchingKey)['label']
+              : matchingKey;
           }
         } else {
-          presentableValue = actualValue;
+          presentableValue = field.value;
         }
       }
       return presentableValue;


### PR DESCRIPTION
The case that the actual value of a metadata field is an array but the metadata field has no collection assigned was not handled correctly.

Steps to reproduce: 
1. Remove list providers from metadata configuration for event and/or series metadata for all multi-value fields (type mixed_text or iterable_text) 
2. Have a look at the summary pages of the Add Event and/or Add Series wizard 
  
 Actual Results: 
The values are not displayed in human readable formats:

![screen shot 2019-01-09 at 16 14 45](https://user-images.githubusercontent.com/1590263/50911944-39f7b980-1431-11e9-9f6a-a63d5e30f4c1.png)
  
 Expected Results: 
 The values should be displayed in human readable formats. 