### PR TITLE
MH-13221 Add placeholder to multi-select fields

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2187,7 +2187,7 @@
     }
   },
   "EDITABLE": {
-    "MULTI_SELECT": {
+    "MULTI": {
       "PLACEHOLDER": "To insert multiple values press Enter in between"
     }
   }

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2185,5 +2185,10 @@
       "UNKNOWN": "Unknown",
       "UPLOADING": "Uploading"
     }
+  },
+  "EDITABLE": {
+    "MULTI_SELECT": {
+      "PLACEHOLDER": "To insert multiple values press Enter in between"
+    }
   }
 }

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
@@ -10,7 +10,7 @@
 
   <div class="editable-select" ng-if="editMode">
     <input type="text" ng-blur="onBlur()" ng-required="params.required" tabindex="{{ params.tabindex }}"
-           list="{{ data.list.id }}-data-list" ng-keyup="keyUp($event)" name="{{ params.name }}" ng-model="data.value">
+           placeholder="{{ 'EDITABLE.MULTI_SELECT.PLACEHOLDER' | translate}}">
     <datalist id="{{ data.list.id }}-data-list">
       <option ng-repeat="(item, label) in collection"
               value="{{ item }}">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
@@ -10,7 +10,8 @@
 
   <div class="editable-select" ng-if="editMode">
     <input type="text" ng-blur="onBlur()" ng-required="params.required" tabindex="{{ params.tabindex }}"
-           placeholder="{{ 'EDITABLE.MULTI_SELECT.PLACEHOLDER' | translate}}">
+           list="{{ data.list.id }}-data-list" ng-keyup="keyUp($event)" name="{{ params.name }}" ng-model="data.value"
+           placeholder="{{ 'EDITABLE.MULTI.PLACEHOLDER' | translate}}">
     <datalist id="{{ data.list.id }}-data-list">
       <option ng-repeat="(item, label) in collection"
               value="{{ item }}">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiValue.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiValue.html
@@ -14,7 +14,8 @@
                        name="{{ params.name }}"
                        tabindex="{{ params.tabindex }}"
                        ng-blur="onBlur()"
-                       ng-keyup="keyUp($event)">
+                       ng-keyup="keyUp($event)"
+                       placeholder="{{ 'EDITABLE.MULTI.PLACEHOLDER' | translate}}">
   </div>
   <span ng-show="editMode" class="ng-multi-value"
                            ng-repeat="value in params.value">


### PR DESCRIPTION
Add placeholder to multi-select metadata fields explaining how to enter multiple values without leaving edit mode.

~~**Attention:** This depends on PR #639, please don't merge until that one was merged and has reached develop, since it doesn't make much sense without it.~~