### PR TITLE
MH-13301 Don't require event.publisher since it is a readonly field

### DIFF
--- a/docs/guides/admin/docs/configuration/metadata.md
+++ b/docs/guides/admin/docs/configuration/metadata.md
@@ -161,7 +161,7 @@ First option is the default one and the configuration is as follows:
     property.publisher.label=EVENTS.EVENTS.DETAILS.METADATA.PUBLISHER
     property.publisher.type=text
     property.publisher.readOnly=true
-    property.publisher.required=true
+    property.publisher.required=false
     property.publisher.order=16
 
 To configure the second option:

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -161,5 +161,5 @@ property.publisher.inputID=publisher
 property.publisher.label=EVENTS.EVENTS.DETAILS.METADATA.PUBLISHER
 property.publisher.type=text
 property.publisher.readOnly=true
-property.publisher.required=true
+property.publisher.required=false
 property.publisher.order=16


### PR DESCRIPTION
The metadata field "publisher" of events is configured to be both required and read-only. This is a contraction as this would require the field to be set (think of the External API) but it can't be set since it is read-only.

The goal of this task is to don't require this field. This also makes Opencast 5.x External API clients likely work again with Opencast 6.x (although the External API version 1.0.0 and 1.1.0 still have changed because the field "publisher" is visible on some endpoints)