### PR TITLE
MH-13307, Update Release Manager Documentation

### DIFF
--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -33,9 +33,8 @@ schedule by six months).
 
 ### Release Notes
 
-It's usually a good idea to create or clean the release notes page. This allows for a place to put the release schedule
-and makes it easy to encourage people to put short descriptions of features there while these features are reviewed.
-This makes it easier to later create the final release notes.
+It's usually a good idea to create or clean the release notes page early in the release phase. This allows for a place
+to put the release schedule, short descriptions of features or noteworthy configuration changes early on.
 
 ### The  Release Schedule
 
@@ -83,7 +82,7 @@ Example on how to create the Opencast 7 release branch:
 6. If everything looks fine, commit the changes and push it to the community repository:
 
         git add $(git status | grep 'modified:.*pom.xml' | awk '{print $2;}')
-        git commit -s
+        git commit -s -m 'Bumping pom.xml Version Numbers'
         git push <remote> develop
 
 
@@ -241,7 +240,7 @@ The following steps outline the necessary steps for cutting the final release:
         cd docs/guides/admin/docs/
         vim releasenotes.md
         vim changelog.md
-        git commit -S releasenotes.md changelog.md
+        git commit -S releasenotes.md changelog.md -m 'Updated Release Notes'
         git push <remote> r/6.x
 
 3. Switch to a new branch to create the release (name does not really matter):

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -122,7 +122,7 @@ source.
 ### Status of Translations
 
 When the release branch is cut, the release manager should check if there are languages to be in- or excluded for the
-upcoming release as specified [by the criteria in the localization documentation](localization.md).  If any modification
+upcoming release as specified [by the criteria in the localization documentation](localization.md). If any modification
 criteria are met, an announcement should be published on the Opencast users list that specifies:
 
 - Translations that will be included in the upcoming release
@@ -144,16 +144,14 @@ languages meet the criteria to be included in Opencast
 - <LANGUAGE2> (<PERCENTAGE2>)
 - ....
 
-Sincerely,
-Your Opencast <VERSION> Release Managers
 
-[1] Opencast project on Crowdin
+[1] Opencast on Crowdin
     https://crowdin.com/project/opencast-community
-[2] Inclusion and Exclusion of Translations
+[2] Inclusion and exclusion of translations
     https://docs.opencast.org/develop/developer/...
 ```
 
-Example announcement for endangered languages. Please create a post for each endangered language:
+Example announcement for endangered languages:
 
 ```no-highlight
 To: users@opencast.org
@@ -177,6 +175,57 @@ Your Opencast <VERSION> Release Managers
 
 [1] Inclusion and Exclusion of Translations
     https://docs.opencast.org/
+```
+
+A specific translation week may be announced using an email
+like this:
+
+```no-highlight
+To: users@opencast.org
+Subject: Opencast <version>: Translation Week
+
+Hi everyone,
+starting on <date> the Opencast <version> translation week
+will take place, during which we particular focus on
+improving Opencast's translations.
+
+
+Can I help?
+-----------
+
+Everybody that speaks a different language or dialect and
+feels confident enough to participate can participate.
+
+
+How can I help?
+---------------
+
+We use Crowdin [1] to manage translations. Please sign up
+and request to help with a particular language.
+
+
+What is the current status?
+---------------------------
+
+Fully translated:
+
+- …
+
+Mostly translated (>80% translated):
+
+- …
+
+Endangered translations (≤80% translated):
+
+- …
+
+Note that we can add any additional languages you are
+willing to translate.
+
+If you have any additional questions, please do not hesitate
+to ask.
+
+[1] https://crowdin.com/project/opencast-community
 ```
 
 

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -3,7 +3,7 @@ Release Manager Guide
 
 The single most important duty of release managers is to keep an eye on their release, notify the community about
 possible problems in a timely manner and encourage community members to help out if needed. While working on Opencast's
-code is often done as well during the release process, for a release manager this is secondary to the communication and
+code is often done as well during the release process, for release managers this is secondary to the communication and
 management role and with few exceptions no requirement for this position.
 
 The community has a number of expectations for release managers, and their handling of the problems which may arise
@@ -13,19 +13,19 @@ during the release cycle. The core of these expectations are:
 - The release should be on time
 - The release should not have any critical technical, usability or security issues
 
-This means that a release manager may need to force decisions around the release, help negotiate the acceptance or
+This means that release managers may need to force decisions around the release, help negotiate the acceptance or
 rejection of contributions and provide regular updates about the release on list and during the technical and adopter
-meetings. It is important to note that, while the release manager drives the release process, the committer body is in
+meetings. It is important to note that, while release managers drive the release process, the committer body is in
 charge of both the work and the decision making, meaning that votes and successful proposals from this body take
-precedence over a release manager's decision.
+precedence over release manager decisions.
 
 
 Responsibilities
 ----------------
 
 While a general rule is certainly just to look out for the release, work together with the community to make the release
-work properly and be pragmatic about the process, there are a few tasks which really can only be done by the release
-manager.
+work properly and be pragmatic about the process, there are a few tasks which really can only be done by release
+managers.
 
 For all of these tasks, it's generally a good idea to look at previous releases and at their solutions for the tasks.
 Often, completing the task is simply a matter of repeating or updating previous work (e.g. advance the previous release
@@ -33,7 +33,7 @@ schedule by six months).
 
 ### Release Notes
 
-It's usually a good idea to create or clean the release notes page early in the release phase. This allows for a place
+It's usually a good idea to create or clean the release notes page early in the release cycle. This allows for a place
 to put the release schedule, short descriptions of features or noteworthy configuration changes early on.
 
 ### The  Release Schedule
@@ -45,7 +45,7 @@ list and publish it on the release notes page.
 ### Release Branch
 
 According to the set release schedule, at one point a release branch should be cut, effectively marking a feature freeze
-for a given release.  This branch is split of `develop` and should be named `r/N.x` (e.g. `r/6.x` for the Opencast 6
+for a given release.  This branch is split off `develop` and should be named `r/N.x` (e.g. `r/6.x` for the Opencast 6
 release branch).
 
 Example on how to create the Opencast 7 release branch:
@@ -121,12 +121,9 @@ source.
 
 ### Status of Translations
 
-When the release branch is cut, the release manager should check if there are languages to be in- or excluded for the
-upcoming release as specified [by the criteria in the localization documentation](localization.md). If any modification
-criteria are met, an announcement should be published on the Opencast users list that specifies:
-
-- Translations that will be included in the upcoming release
-- Endangered translations
+After the release branch is cut, the release managers should check if there are languages to be in- or excluded for the
+upcoming release as specified by the [criteria in the localization documentation](localization.md) and notify the
+community about the status of Opencast's translations if necessary.
 
 Example announcement for included languages:
 
@@ -148,7 +145,7 @@ languages meet the criteria to be included in Opencast
 [1] Opencast on Crowdin
     https://crowdin.com/project/opencast-community
 [2] Inclusion and exclusion of translations
-    https://docs.opencast.org/develop/developer/...
+    https://docs.opencast.org/develop/developer/localization/#inclusion-and-exclusion-of-translations
 ```
 
 Example announcement for endangered languages:
@@ -174,7 +171,7 @@ Sincerely,
 Your Opencast <VERSION> Release Managers
 
 [1] Inclusion and Exclusion of Translations
-    https://docs.opencast.org/
+    https://docs.opencast.org/develop/developer/localization/#inclusion-and-exclusion-of-translations
 ```
 
 A specific translation week may be announced using an email
@@ -238,9 +235,9 @@ developer list or wherever appropriate.
 
 ### Merging Release Branches
 
-To not have to merge bug fixes into several branches and create several pull requests, release branch should be merged
-down on a regular basis. Assuming, for example, that `r/6.x` is the latest release branch, merges should happen like
-this:
+To not have to merge bug fixes into several branches and create several pull requests, the release branch should be
+merged down on a regular basis. Assuming, for example, that `r/6.x` is the latest release branch, merges should happen
+like this:
 
     r/5.x → r/6.x → develop
 
@@ -271,17 +268,20 @@ For example, to merge the latest release branch into `develop`, follow these ste
 ### Updating Translations
 
 Updating the [localization translations](localization.md) is automated for existing translation files. If new files need
-to be added, it is something that should happen early during the release process.
+to be added, it is something that should happen early during the release process. If files need to be removed, this
+needs to be done manually.
 
 
 ### Releasing
 
 The following steps outline the necessary steps for cutting the final release:
 
-1. Switch to and update your release branch:
+1. Switch to and update your release branch and ensure the latest state of the previous release branch is merged:
 
         git checkout r/6.x
-        git pull <remote>/r/6.x
+        git fetch <remote>
+        git merge <remote>/r/6.x
+        git merge <remote>/r/5.x
 
 2. Add the release notes, and update the changelog. The `create-changelog` [helper script
    ](https://github.com/opencast/helper-scripts/tree/master/create-changelog) is a convenient tool for this.
@@ -358,7 +358,7 @@ For that, this email template may be used:
 
 ```no-highlight
 To: dev@opencast.org
-Subject: Opencast <NEXT_RELEASE> release manager wanted
+Subject: Opencast <NEXT_RELEASE> release managers wanted
 
 Hi everyone,
 the Opencast community is looking for release managers for
@@ -367,9 +367,9 @@ release around <DATE>).
 
 Note that the release manager's job contains very little
 technical work. Instead, they mostly focus on motivation and
-coordination of the community during the release phase.  The
-role of the release manager is described in more detail in
-the Opencast development documentation:
+coordination of the community during the release phase. The
+role of release managers is described in more detail in the
+Opencast development documentation:
 
   https://docs.opencast.org/develop/developer/release-manager/
 

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -1,20 +1,20 @@
 Release Manager Guide
 =====================
 
-The single most important duty of release managers is to keep an eye on their release, timely notify the community about
-possible problems and encourage community members to help out if needed. While working on Opencast's code is often done
-as well during the release process, for a release manager this is secondary to the communication and management role and
-with few exceptions no requirement for this position.
+The single most important duty of release managers is to keep an eye on their release, notify the community about
+possible problems in a timely manner and encourage community members to help out if needed. While working on Opencast's
+code is often done as well during the release process, for a release manager this is secondary to the communication and
+management role and with few exceptions no requirement for this position.
 
-Expectations of the community towards releases from which problems can arise and which should be handles be release
-managers are for example that:
+The community has a number of expectations for release managers, and their handling of the problems which may arise
+during the release cycle. The core of these expectations are:
 
 - The development process should be followed or amended if required
 - The release should be on time
 - The release should not have any critical technical, usability or security issues
 
 This means that a release manager may need to force decisions around the release, help negotiate the acceptance or
-rejection of contributions and provide regular updates about the release on list, during the technical and the adopter
+rejection of contributions and provide regular updates about the release on list and during the technical and adopter
 meetings. It is important to note that, while the release manager drives the release process, the committer body is in
 charge of both the work and the decision making, meaning that votes and successful proposals from this body take
 precedence over a release manager's decision.
@@ -24,12 +24,12 @@ Responsibilities
 ----------------
 
 While a general rule is certainly just to look out for the release, work together with the community to make the release
-work properly and be pragmatic about the process, there are a few tasks a release manager has to ensure that they are
-being done.
+work properly and be pragmatic about the process, there are a few tasks which really can only be done by the release
+manager.
 
 For all of these tasks, it's generally a good idea to look at previous releases and at their solutions for the tasks.
 Often, completing the task is simply a matter of repeating or updating previous work (e.g. advance the previous release
-schedule by six month).
+schedule by six months).
 
 ### Release Notes
 
@@ -161,7 +161,7 @@ is in danger of being removed in Opencast <VERSION> if its
 status stays the same.
 
 To save the <LANGUAGE> translation from removal, it needs to
-be translated at least 90% until <DATE>.
+be translated at least 90% before <DATE>.
 
 Sincerely,
 Your Opencast <VERSION> Release Managers
@@ -200,7 +200,7 @@ For example, to merge the latest release branch into `develop`, follow these ste
         git checkout develop
         git merge <remote>/develop   # this should be a fast-forward merge
 
-3. Merge the release branch. Not that if large merge conflicts arise, you may ask for help from the people creating the
+3. Merge the release branch. Note that if large merge conflicts arise, you may ask for help from the people creating the
    problematic patches:
 
         git merge <remote>/r/6.x
@@ -213,7 +213,7 @@ For example, to merge the latest release branch into `develop`, follow these ste
 ### Updating Translations
 
 Updating the [localization translations](localization.md) is automated for existing translation files. If new files need
-to be added, it is is something that should happen early during the release process.
+to be added, it is something that should happen early during the release process.
 
 
 ### Releasing
@@ -222,7 +222,7 @@ The following steps outline the necessary steps for cutting the final release:
 
 1. Switch to and update your release branch:
 
-        git checkot r/6.x
+        git checkout r/6.x
         git pull <remote>/r/6.x
 
 2. Add the release notes, and update the changelog. The `create-changelog` [helper script

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -68,19 +68,19 @@ Example on how to create the Opencast 7 release branch:
         git checkout -b r/7.x
         git push <remote> r/7.x
 
-5. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
+4. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
 
         git checkout develop
         for i in `find . -name pom.xml`; do \
-          sed -i 's/<version>6-SNAPSHOT</<version>7-SNAPSHOT</' $i; done
+          sed -i 's/<version>7-SNAPSHOT</<version>8-SNAPSHOT</' $i; done
 
-6. Have a look at the changes. Make sure no library version we use has the version `6-SNAPSHOT` and was accidentally
+5. Have a look at the changes. Make sure no library version we use has the version `6-SNAPSHOT` and was accidentally
    changed. Also make sure that nothing else was modified:
 
         git diff
         git status | grep modified: | grep -v pom.xml   # this should have no output
 
-8. If everything looks fine, commit the changes and push it to the community repository:
+6. If everything looks fine, commit the changes and push it to the community repository:
 
         git add $(git status | grep 'modified:.*pom.xml' | awk '{print $2;}')
         git commit -s
@@ -95,18 +95,28 @@ To: dev@opencast.org
 Subject: Release Branch for Opencast <version> Cut
 
 Hi everyone,
-the <version> release branch (r/<version>) has been cut.
-Pull requests for bug fixes may still be made against
-this branch but, as usual, features should go into
-develop instead.
+the Opencast <version> release branch (r/<version>) has been
+cut.  Pull requests for bug fixes may still be made against
+this branch but, as usual, features should go into develop
+instead.
 
 Remember the release schedule for this release:
 
   <release_schedule>
 
 As always, we hope to have a lot of people testing this
-version, especially during the public QA phase.  Please
+version, especially during the public QA phase. Please
 report any bugs or issues you encounter.
+
+For testing, you may use https://stable.opencast.org if you
+do not want to set up a test server yourself. The server is
+reset on a daily basis and will follow the new release
+branch with its next rebuild.
+
+Additionally, look out for announcements regarding container
+and package builds for testing on list if you want to run
+your own system but do not want to build Opencast from
+source.
 ```
 
 
@@ -228,9 +238,10 @@ The following steps outline the necessary steps for cutting the final release:
 2. Add the release notes, and update the changelog. The `create-changelog` [helper script
    ](https://github.com/opencast/helper-scripts/tree/master/create-changelog) is a convenient tool for this.
 
-        vim docs/guides/admin/docs/releasenotes.md
-        vim docs/guides/admin/docs/changelog.md
-        git commit -S docs/guides/admin/docs/releasenotes.md docs/guides/admin/docs/changelog.md
+        cd docs/guides/admin/docs/
+        vim releasenotes.md
+        vim changelog.md
+        git commit -S releasenotes.md changelog.md
         git push <remote> r/6.x
 
 3. Switch to a new branch to create the release (name does not really matter):
@@ -247,7 +258,7 @@ The following steps outline the necessary steps for cutting the final release:
    changed. Also make sure that nothing else was modified:
 
         git diff
-        git status | grep modified: | grep -v pom.xml   # this should have no output
+        git status | grep modified: | grep -v pom.xml   # this should yield no output
 
 6. Commit the changes and create a release tag:
 
@@ -255,11 +266,11 @@ The following steps outline the necessary steps for cutting the final release:
         git commit -S -m 'Opencast 6.0'
         git tag -s 6.0
 
-9. Push the tag to the community repository (you can remove the branch afterwards):
+7. Push the tag to the community repository (you can remove the branch afterwards):
 
         git push <remote> 6.0:6.0
 
-10. Create a new release on Github using the [graphical user interface](https://github.com/opencast/opencast/releases)
+8. Create a new release on GitHub using the [graphical user interface](https://github.com/opencast/opencast/releases)
     to upload the distribution tarballs.
 
 Finally, send a release notice to Opencast's announcement list. Note that posting to this list is restricted to those
@@ -270,7 +281,7 @@ list, please ask to be given permission. For the message, you may use the follow
 To: announcements@opencast.org
 Subject: Opencast <VERSION> Released
 
-Hi all,
+Hi everyone,
 it is my pleasure to announce that Opencast <VERSION> has
 been released:
 

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -1,474 +1,366 @@
 Release Manager Guide
 =====================
 
-Role
-----
+The single most important duty of release managers is to keep an eye on their release, timely notify the community about
+possible problems and encourage community members to help out if needed. While working on Opencast's code is often done
+as well during the release process, for a release manager this is secondary to the communication and management role and
+with few exceptions no requirement for this position.
 
-The release manager is ultimately responsible for making sure that the development process is being followed during his
-or her release.
+Expectations of the community towards releases from which problems can arise and which should be handles be release
+managers are for example that:
 
-The release manager has the following duties:
+- The development process should be followed or amended if required
+- The release should be on time
+- The release should not have any critical technical, usability or security issues
 
-* To ensure that the release measures up to the quality expected by the community.
-* To ensure that the development process is followed and amended if required.
-* To ensure that the release is timely and does not languish in process.
-* To encourage committers to be involved in testing and fixing of bugs.
+This means that a release manager may need to force decisions around the release, help negotiate the acceptance or
+rejection of contributions and provide regular updates about the release on list, during the technical and the adopter
+meetings. It is important to note that, while the release manager drives the release process, the committer body is in
+charge of both the work and the decision making, meaning that votes and successful proposals from this body take
+precedence over a release manager's decision.
 
-It is in the release manager's responsibility to force decisions around the release, help negotiate the acceptance or
-rejection of contributions and to provide regular updates about the release on list and during the weekly technical and
-monthly adopter meetings. It is important to note that, while the release manager drives the release process, the
-committer body is in charge of both the work and the decision making, meaning that votes and successful proposals from
-this body take precedence over a release managers decision.
 
-The release manager does not have to be a committer. In case the release manager is not, a committer must agree to be
-the proxy release manager for communication on the confidential committers list.
+Responsibilities
+----------------
 
-A release manager can abandon the release at any time, giving up their duties and privileges of being the release
-manager. The committer list must then either vote within 72 hours on a new release manager, or consider the release
-abandoned (the major, minor, and maintenance numbers remain unchanged).
+While a general rule is certainly just to look out for the release, work together with the community to make the release
+work properly and be pragmatic about the process, there are a few tasks a release manager has to ensure that they are
+being done.
 
-Duties
-------
+For all of these tasks, it's generally a good idea to look at previous releases and at their solutions for the tasks.
+Often, completing the task is simply a matter of repeating or updating previous work (e.g. advance the previous release
+schedule by six month).
 
-### Setting Release Schedule
+### Release Notes
+
+It's usually a good idea to create or clean the release notes page. This allows for a place to put the release schedule
+and makes it easy to encourage people to put short descriptions of features there while these features are reviewed.
+This makes it easier to later create the final release notes.
+
+### The  Release Schedule
 
 Releases should happen twice a year, usually within a time span of 9.5 months between the cut of the previous release
-branch and the final release. The release manager should create a release schedule as soon as possible.
-For more details about the release schedule, have a look at the [Development Process](development-process.md)
+branch and the final release. The release managers should create a release schedule as soon as possible, announce it on
+list and publish it on the release notes page.
 
-### Creation of Release Branch
+### Release Branch
 
 According to the set release schedule, at one point a release branch should be cut, effectively marking a feature freeze
-for a given release.
+for a given release.  This branch is split of `develop` and should be named `r/N.x` (e.g. `r/6.x` for the Opencast 6
+release branch).
 
-Once a release process has started, a branch should be created with the proposed version number of that release. This
-branch is created off of `develop` and should be named `r/N.x` (e.g. `r/3.x` for the Opencast 3.0 release branch).
-In the following command, we assume that the release branch for 3.0 is to be created. For other versions, please adjust
-the version number accordingly.
+Example on how to create the Opencast 7 release branch:
 
-Create the Branch:
 
-1. Grab the merge ticket for `develop`. You are going to make changes there and it becomes ugly if someone else changes
-   something at the same time.
-
-2. Check out `develop` and make sure it has the latest state (replace `<remote>` with your remote name for the community
+1. Check out `develop` and make sure it has the latest state (replace `<remote>` with your remote name for the community
    repository):
 
         git checkout develop
         git pull <remote> develop
 
-3. Create and push release branch:
+2. Make sure you did not modify any files. If you did, stash those changes:
 
-        git checkout -b r/3.x
-        git push <remote> r/3.x
+        git status   # check for modified files
+        git stash    # stash them if necessary
 
-4. Make sure you did not modify any files. If you did, stash those changes.
+3. Create and push the new release branch:
 
-5. That is it for the release branch. Now lets make sure we update the versions in `develop` in preparation for the next
-   release:
+        git checkout -b r/7.x
+        git push <remote> r/7.x
+
+5. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
 
         git checkout develop
         for i in `find . -name pom.xml`; do \
-          sed -i 's/<version>3.0-SNAPSHOT</<version>4.0-SNAPSHOT</' $i; done
+          sed -i 's/<version>6-SNAPSHOT</<version>7-SNAPSHOT</' $i; done
 
-6. Have a look at the changes. Make sure no library version we use has the version `3.0-SNAPSHOT` and was accidentally
+6. Have a look at the changes. Make sure no library version we use has the version `6-SNAPSHOT` and was accidentally
    changed. Also make sure that nothing else was modified:
 
         git diff
+        git status | grep modified: | grep -v pom.xml   # this should have no output
 
-7. Check again for unwanted changes.
+8. If everything looks fine, commit the changes and push it to the community repository:
 
-8. If everything looks fine, commit everything and push it to the community repository:
-
-        git commit -as
+        git add $(git status | grep 'modified:.*pom.xml' | awk '{print $2;}')
+        git commit -s
         git push <remote> develop
 
-9. Finally change the `fixVersion` and `summary` on the merge ticket for 3.0 and create a new one for develop.
+
+At this point, the developer community should then be notified by writing an email like the following to the developers
+list:
+
+```no-highlight
+To: dev@opencast.org
+Subject: Release Branch for Opencast <version> Cut
+
+Hi everyone,
+the <version> release branch (r/<version>) has been cut.
+Pull requests for bug fixes may still be made against
+this branch but, as usual, features should go into
+develop instead.
+
+Remember the release schedule for this release:
+
+  <release_schedule>
+
+As always, we hope to have a lot of people testing this
+version, especially during the public QA phase.  Please
+report any bugs or issues you encounter.
+```
 
 
-At this point, the developer community should then be notified. Consider using the following as a template email:
+### Status of Translations
 
-    To: dev@opencast.org
-    Subject: Release Branch for Opencast <VERSION> Cut
+When the release branch is cut, the release manager should check if there are languages to be in- or excluded for the
+upcoming release as specified [by the criteria in the localization documentation](localization.md).  If any modification
+criteria are met, an announcement should be published on the Opencast users list that specifies:
 
-    Hi everyone,
-    it is my pleasure to announce that the <VERSION> release branch has now been
-    cut, available as r/<VERSION>. Pull requests for bug fixes are to be made
-    against this branch.
+- Translations that will be included in the upcoming release
+- Endangered translations
 
-    Remember that the release schedule for this release:
+Example announcement for included languages:
 
-      <RELEASE_SCHEDULE>
+```no-highlight
+To: users@opencast.org
+Subject: Opencast <VERSION>: Translation Status
 
-    As always, we hope to have a lot of people testing this version, especially
-    during the public QA phase.  Please report any bugs or issues you encounter.
+Hi everyone,
+while checking the translation statuses of the languages
+available on Crowdin[1], we have found that the following
+languages meet the criteria to be included in Opencast
+<VERSION>:
 
+- <LANGUAGE1> (<PERCENTAGE1>)
+- <LANGUAGE2> (<PERCENTAGE2>)
+- ....
 
-### Check Status of Language Translations
+Sincerely,
+Your Opencast <VERSION> Release Managers
 
-On the date when the release branch is cut, the release manager is responsible to check whether there are language
-translations that need to be included or excluded for the upcoming release.
-Have a look at [Inclusion and Exclusion of Languages](localization.md) for the criteria.
+[1] Opencast project on Crowdin
+    https://crowdin.com/project/opencast-community
+[2] Inclusion and Exclusion of Translations
+    https://docs.opencast.org/develop/developer/...
+```
 
-1. Check whether translations not yet included in Opencast meet the inclusion criteria (candidates for includsion)
-2. Check whether translations in Opencast meet the exclusion criteria (endangered translations)
-3. Publish an announcement on the Opencast Users list that specifies:
-    a. Translations that will be included in the upcoming release
-    b. Endangered translations
+Example announcement for endangered languages. Please create a post for each endangered language:
 
-Please create a single post on the Opencast Users list:
+```no-highlight
+To: users@opencast.org
+Subject: Opencast <VERSION>: <LANGUAGE> Translation Endangered
 
-    To: users@opencast.org
-    Subject: Opencast <VERSION>: Language translation status
+Hi everyone,
+while checking the <LANGUAGE> translation status of
+Opencast, we have found that it is only <PERCENTAGE>
+translated.
 
-    Hi everyone,
+This is not enough to justify its inclusion in the upcoming
+Opencast release[1], meaning that the <LANGUAGE> translation
+is in danger of being removed in Opencast <VERSION> if its
+status stays the same.
 
-    While checking the translation statuses of the languages available on Crowdin (see [1]), we have found
-    that the following language translations meet the criteria to be included in Opencast <VERSION>:
+To save the <LANGUAGE> translation from removal, it needs to
+be translated at least 90% until <DATE>.
 
-    - <LANGUAGE1> (<PERCENTAGE1>)
-    - <LANGUAGE2> (<PERCENTAGE2>)
-    - ....
+Sincerely,
+Your Opencast <VERSION> Release Managers
 
-    Sincerly,
-    Your Opencast <VERSION> Release Manager
-
-    [1] Opencast project on Crowdin, https://crowdin.com/project/opencast-community
-    [2] Inclusion and Exclusion of Translations, https://docs.opencast.org/develop/developer/...
-
-In case endangered languages have been identified, this needs to be communicated immediately to the Opencast community.
-Please create a post for each endangered translation on the Opencast Users list:
-
-    To: users@opencast.org
-    Subject: Opencast <VERSION>: <LANGUAGE> translation is endangered! [HELP NEEDED!]
-
-    Hi everyone,
-
-    While checking the translation status of the <LANGUAGE> translation, we have found that it is
-    only <PERCENTAGE> translated.
-
-    This is not enough to justify its inclusion in the upcoming Opencast release (see [1]).
-
-    We hereby declare the <LANGUAGE> translation endangered! This means that it will not be included in
-    Opencast <VERSION> unless it is saved by the community.
-
-    To save the <LANGUAGE> translation from removal from the Opencast release, <LANGUAGE> needs to be
-    translated at least 90% until <DATE>.
-
-    Sincerly,
-    Your Opencast <VERSION> Release Managers
-
-    [1] Inclusion and Exclusion of Translations, https://docs.opencast.org/
-
-
-### Creating the Merge Ticket
-
-The [Opencast pull request filter](http://pullrequests.opencast.org) links the versions currently in development. The
-merge ticket identifier needs to be added to that filter. To do this, create a ticket with a title in the format of
-`Merge the result of the current peer review to <VERSION>`. The ticket will be automatically detected by the pull
-request filter and will appear shortly.
-
-
-### Creating the Release Version
-
-The release manager is responsible for creating, or triggering the creation of, the appropriate fix version for the new
-release. You may be able to do this yourself by assigning a new fix version to their newly created merge ticket. If you
-are unable to do that, please contact one of the JIRA administrators so we can create it for you!
-
-
-### Release Documentation
-
-The [Opencast release documentation](http://docs.opencast.org) will be built automatically from available release tags.
-However, new branches need to be included.  As release manager, please talk to
-the [administrator](https://docs.opencast.org/develop/developer/infrastructure/#administrators) of that
-tool to ensure the ticket is added.
+[1] Inclusion and Exclusion of Translations
+    https://docs.opencast.org/
+```
 
 
 ### Moderation of Peer Reviews
 
-Apart from creating branches and tags, one of the most important things for release managers to do is to ensure that
-pull requests for the release are going forward. This does not mean that the release manager has to do the reviews, but
-he should talk to developers, remind them about outstanding reviews and help to resolve possible issues.
+Release managers should regularly check open pull requests for possible problems (no reviewers, discussions in need of
+moderation, issues that should be raised to community awareness, …) and bring these up in the technical meeting, on the
+developer list or wherever appropriate.
 
 
-### Merging Release Branch Into Develop
+### Merging Release Branches
 
-To not have to merge bug fixes into several branches and create several pull requests, the release manager should merge
-the release branch back into `develop` on a regular basis. It is encouraged to do that frequently, to not let the
-branches diverge too much and to avoid possible merge conflicts.
+To not have to merge bug fixes into several branches and create several pull requests, release branch should be merged
+down on a regular basis. Assuming, for example, that `r/6.x` is the latest release branch, merges should happen like
+this:
 
-To merge the release branch into `develop`. As example, we do that for 3.0. Please adjust the version accordingly:
+    r/5.x → r/6.x → develop
 
-1. Grab the merge ticket for `develop`. You are not doing any changes to the release branch, so you will not need that
-   merge ticket. If someone else holds the merge ticket for a feature pull request, talk to that person that you will
-   temporarily steal the ticket.
+While any committer may do this at any time, it is good practice for release managers to do this for their release
+branches on a regular basis.
 
-2. Update release branch:
+For example, to merge the latest release branch into `develop`, follow these steps:
 
-        git checkout r/3.x
-        git pull <remote> r/3.x
+1. Update your local repository
 
-3. Update `develop`:
+        git fetch <remote>
+
+2. Update `develop`:
 
         git checkout develop
-        git pull <remote> develop
+        git merge <remote>/develop   # this should be a fast-forward merge
 
-4. Merge the release branch. Not that if large merge conflicts arise, you may ask for help from the people creating the
+3. Merge the release branch. Not that if large merge conflicts arise, you may ask for help from the people creating the
    problematic patches:
 
-        git merge r/3.x
+        git merge <remote>/r/6.x
 
-5. Push updated branch into the community repository:
+4. Push the updated branch into the community repository:
 
         git push <remote> develop
-
-6. Leave a comment in the merge ticket and assign it back to the next pull request in line on `develop`.
 
 
 ### Updating Translations
 
-Updating the [localization translations](localization.md) is easy, and should be done at minimum as part of every
-release candidate.
-
-
-### Beta Versions and Release Candidates
-
-For testing purposes, the release manager should regularly create beta versions. Especially before the public QA phase,
-a beta version should exist. Additionally, he should create a release candidate for testing before proposing that a
-release be cut.
-
-Create a version/tag. Again, version 3.0 is used as example. Please adjust the version accordingly:
-
-1. Switch to release branch you want to create the beta from:
-
-        git checkout r/3.x
-
-2. Switch to a new branch to create the release (name does not really matter):
-
-        git checkout -b r/3.0-beta1
-
-3. Update the [localization translations](localization.md).
-
-4. Make version changes for release. You can use `sed` to make things easier. Please make sure, the changes are correct:
-
-        for i in `find . -name pom.xml`; do \
-          sed -i 's/<version>3.0-SNAPSHOT</<version>3.0-beta1</' $i; done
-
-5. Commit changes and create release tag:
-
-        git commit -asS -m 'Opencast 3.0-beta1'
-        git tag -s 3.0-beta1
-
-6. Switch back to release branch and push tags:
-
-        git checkout r/3.x
-        git push <remote> 3.0-beta1:3.0-beta1
-
-7. You can remove the new branch afterwards:
-
-        git branch -D r/3.0-beta1
-
-For a release candidate, instead of `A.B-betaX` the tag should be named `A.B-rcX`.
-
-At this point the developer community should then be notified. Consider using the following email template:
-
-    To: dev@opencast.org
-    Subject: <VERSION> Available for testing!
-
-    Hi everyone,
-    I am pleased to announce that Opencast <VERSION> is now available for
-    testing. Please download the source from GitHub [1] or use git to check
-    out the tag.
-
-    Issue Count:
-
-      Blockers   <BLOCKER_COUNT>
-      Critical   <CRITICAL_ISSUE_COUNT>
-      Major      <MAJOR_ISSUE_COUNT>
-      Minor      <MINOR_ISSUE_COUNT>
-
-    Please test this release as thoroughly as
-    possible.
-
-    [1] https://github.com/opencast/opencast/releases
-
-If the version is a release candidate, you probably want to highlight that there are no *Blockers* left at the moment
-and *#propose* this to become the final release.
+Updating the [localization translations](localization.md) is automated for existing translation files. If new files need
+to be added, it is is something that should happen early during the release process.
 
 
 ### Releasing
 
-Once the proposal for a release candidate to become the final release has passed, the release manager should create the
-final release. In the following example, again, version 3.0 is used. Please adjust the version accordingly. We also
-assume the final release should be based on `3.0-rc2`.
+The following steps outline the necessary steps for cutting the final release:
 
-1. Check which commit the release candidate was based on:
+1. Switch to and update your release branch:
 
-        git merge-base 3.0-rc2 r/3.x
-          060dfc3e2328518ae402846577fc6e7ce3b650d7
+        git checkot r/6.x
+        git pull <remote>/r/6.x
 
-2. Switch to commit you want to create the release from:
+2. Add the release notes, and update the changelog. The `create-changelog` [helper script
+   ](https://github.com/opencast/helper-scripts/tree/master/create-changelog) is a convenient tool for this.
 
-        git checkout 060dfc3e2328518ae402846577fc6e7ce3b650d7
+        vim docs/guides/admin/docs/releasenotes.md
+        vim docs/guides/admin/docs/changelog.md
+        git commit -S docs/guides/admin/docs/releasenotes.md docs/guides/admin/docs/changelog.md
+        git push <remote> r/6.x
 
 3. Switch to a new branch to create the release (name does not really matter):
 
-        git checkout -b r/3.0
+        git checkout -b tmp-6.0
 
-4. Add release notes, and update the changelog using the `create-changelog`
-   [helper script](https://github.com/opencast/helper-scripts/tree/master/create-changelog) to
-   easily format the list, the commit:
-
-        vim docs/guides/admin/docs/releasenotes.md docs/guides/admin/docs/changelog.md
-        git commit docs/guides/admin/docs/releasenotes.md docs/guides/admin/docs/changelog.md -sS
-
-5. Update the [localization translations](localization.md).
-
-6. Merge release notes into release branch:
-
-        git checkout r/3.x
-        git merge r/3.0
-        git checkout r/3.0
-
-7. Make version changes for release. You can use `sed` to make things easier. Please make sure, the changes are correct:
+4. Make the version changes for the release. You can use `sed` to make things easier but please make sure that the
+   changes are correct:
 
         for i in `find . -name pom.xml`; do \
-          sed -i 's/<version>3.0-SNAPSHOT</<version>3.0</' $i; done
+          sed -i 's/<version>6-SNAPSHOT</<version>6.0</' $i; done
 
-8. Commit changes and create release tag:
+5. Have a look at the changes. Make sure no library version we use had the version `6-SNAPSHOT` and was accidentally
+   changed. Also make sure that nothing else was modified:
 
-        git commit -asS -m 'Opencast 3.0'
-        git tag -s 3.0
+        git diff
+        git status | grep modified: | grep -v pom.xml   # this should have no output
 
-9. Switch back to release branch, push release notes and tags:
+6. Commit the changes and create a release tag:
 
-        git checkout r/3.x
-        git push <remote> 3.0:3.0
-        git push <remote> r/3.x
+        git add $(git status | grep 'modified:.*pom.xml' | awk '{print $2;}')
+        git commit -S -m 'Opencast 6.0'
+        git tag -s 6.0
 
-10. You can remove the new branch afterwards:
+9. Push the tag to the community repository (you can remove the branch afterwards):
 
-        git branch -D r/3.0
+        git push <remote> 6.0:6.0
 
-11. Release the branch in JIRA, and create the next one. Talk to your JIRA administrators to have this done.
-
-12. Push the built artifacts to Maven. Bug the QA Coordinator to do this so that he remembers to set this up from the CI
-    servers.
-
-13. Push the built artifacts back to GitHub. Create a new release using the
-    [graphical user interface](https://github.com/opencast/opencast/releases) to upload the distribution tarballs
-    manually.
-
-14. Update [the website](https://github.com/opencast/opencast.github.io) with a pull request, or directly if you have
-    the appropriate permissions.
+10. Create a new release on Github using the [graphical user interface](https://github.com/opencast/opencast/releases)
+    to upload the distribution tarballs.
 
 Finally, send a release notice to Opencast's announcement list. Note that posting to this list is restricted to those
 who need access to avoid general discussions on that list. In case you do not already have permissions to post on this
 list, please ask to be given permission. For the message, you may use the following template:
 
-    To: announcements@opencast.org
-    Subject: Opencast <VERSION> Released
-    Hi all,
-    it is my pleasure to announce that Opencast <VERSION> has been released and
-    can be downloaded from GitHub [1] or checked out via git.
+```no-highlight
+To: announcements@opencast.org
+Subject: Opencast <VERSION> Released
 
-    The documentation for this release can be found at [http://docs.opencast.org].
+Hi all,
+it is my pleasure to announce that Opencast <VERSION> has
+been released:
 
-    RPM and Debian packages will be available soon. Watch for announcements on
-    the users list.
+  https://github.com/opencast/opencast/releases
 
-    To all committers and involved contributors, thank you for all your work.
-    This could not have happened without you and I am glad we were able to work
-    together and get this release out.
+The documentation for this release can be found at:
 
-    [1] https://github.com/opencast/opencast/releases
+  https://docs.opencast.org/r/<VERSION>/admin/
+
+RPM and Debian packages as well as Docker images will be
+available soon. Watch for announcements on the users list.
+
+To all committers and involved contributors, thank you for
+all your work. This could not have happened without you and
+I am glad we were able to work together and get this release
+out.
+```
 
 
 ### Appointment of Next Release Manager
 
-#### Identification of a volunteer
-
 After the release branch is cut, all work on `develop` is effectively the preparation for the next release. At this
-point, the release manager sends an inquiry to the users, developers and community list to identify a volunteer for the
-job of release manager for the next release.
+point, the release managers should send an inquiry to the development list to identify volunteers for the next release.
 
 For that, this email template may be used:
 
-    To: dev@opencast.org
-    Subject: Opencast <NEXT_RELEASE_VERSION> release manager wanted
+```no-highlight
+To: dev@opencast.org
+Subject: Opencast <NEXT_RELEASE> release manager wanted
 
-    Hi everyone,
-    as release manager of Opencast <VERSION> release, it is my duty to announce
-    that the Opencast community is looking for a release manager of the upcoming
-    <NEXT_RELEASE_VERSION> release between now and <INTENDED RELEASE DATE>
-    (release date).
+Hi everyone,
+the Opencast community is looking for release managers for
+the upcoming <NEXT_RELEASE> (Feature freeze around <DATE>,
+release around <DATE>).
 
-    Note that the release manager's duties do not contain a lot of technical
-    work. Instead, they focus on motivation, coordination, and ensuring that the
-    development process [1] is being followed. The role of the release manager
-    is described in more detail in the Opencast development documentation wiki
-    [2].
+Note that the release manager's job contains very little
+technical work. Instead, they mostly focus on motivation and
+coordination of the community during the release phase.  The
+role of the release manager is described in more detail in
+the Opencast development documentation:
 
-    The job does not have to be done by one person alone and it has proven good
-    practice to have two people fill this job as co-release managers to help
-    keep up the process during vacation, sickness and in case of local
-    emergencies.
+  https://docs.opencast.org/develop/developer/release-manager/
 
-    I am looking forward to your applications on list, please voice your
-    interest no later than <TWO WEEKS FROM NOW>.
+In the past, it has proven good practice to have two people
+fill this job as co-release managers to help keep up the
+process during vacation, sickness and in case of local
+emergencies.
 
-    [1] http://docs.opencast.org/develop/developer/development/
-    [2] http://docs.opencast.org/develop/developer/release-manager/
-
-
-#### Initiate the Vote
+I am looking forward to your applications on list, please
+voice your interest until <DATE>.
+```
 
 In the case where someone steps up and offers to fill in the role of a release manager for the upcoming release, a vote
-is held on the committers list to determine whether the candidate is deemed suitable for the position. Should there be
-more than one candidate wanting to become the release manager for the next release, the candidate with the largest
-number of votes and no “-1” gets elected.
+is held on the committers list to determine whether the candidates are deemed suitable for the position.
 
 This email template may be used to initiate the vote:
 
-    To: committers@opencast.org
-    Subject: [#proposal] Vote on Release Managers of Opencast <NEXT_RELEASE_VERSION>
+```no-highlight
+To: committers@opencast.org
+Subject: [#vote] Vote on Release Managers of Opencast <NEXT_RELEASE>
 
-    Hi everyone,
-    after roughly two weeks of looking for candidates for the position of the
-    release manager of the upcoming Opencast <NEXT_RELEASE_VERSION> release, I
-    am happy to announce that the following Opencast members have volunteered
-    for the position and have expressed the intention of sharing the position as
-    release managers:
+Hi everyone,
+I am happy to announce that the following community members
+have volunteered themselves for the position of the Opencast
+<NEXT_RELEASE> release manager and have expressed the
+intention of sharing the position:
 
-      <Name, Institition>
-      <Name, Institution>
+  <NAME, INSTITITION>
+  <NAME, INSTITUTION>
 
-    As the release manager of Opencast <BRANCH_VERSION_FINAL> and in accordance
-    with the development process [1], I hereby open the vote on accepting the
-    applications of <Name(s)>. The vote will be open for the coming 72h.
+I hereby open the vote on accepting them for this position.
+The vote will be open for the coming 72h.
+```
 
-    [1] http://docs.opencast.org/develop/developer/development/
-
-#### Announcing Election Results
-
-Votes, once complete, are announced on the developer list by the current QA, or the last release manager.
+Once the voting is complete, the result should be announced on the development list:
 
 As an example:
 
-    To: dev@opencast.org
-    Subject: Release Managers of Opencast <NEXT_RELEASE_VERSION>
+```no-highlight
+To: dev@opencast.org
+Subject: Release Managers of Opencast <NEXT_RELEASE>
 
-    Hi everyone,
+Hi everyone,
+it is my pleasure to announce that the following people have
+been elected to be the release managers for the upcoming
+Opencast <NEXT_RELEASE> release:
 
-    It is my pleasure to announce that the following person/people have been
-    elected to position of Release Manager for the upcoming Opencast <NEXT_RELEASE_VERSION>
-    release:
+  <NAME, INSTITUTION>
+  <NAME, INSTITUTION>
 
-      <Name, Institution>
-      <Name, Institution>
-
-    We wish to thank them for volunteering, and hope the release goes smoothly!
-
-
-Once the vote has been held, the current release manager announces the elected release manager on list, and the newly
-elected release manager is expected to start work on the release shortly after.
+We wish to thank them for volunteering, and hope the release
+goes smoothly!
+```


### PR DESCRIPTION
The release manager documentation was heavily outdated. This new version
tries to reflect the current responsibilities of release managers
instead, giving new candidates an idea about the work involved in this
role.