### PR TITLE
MH-13309: return empty list when finding findUsersByUserName when the name param is empty.

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
@@ -401,6 +401,9 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
    * @return the user references list
    */
   private List<JpaUserReference> findUsersByUserName(String orgId, Collection<String> names, EntityManagerFactory emf) {
+    if (names.isEmpty()) {
+      return Collections.<JpaUserReference>emptyList();
+    }
     EntityManager em = null;
     try {
       em = emf.createEntityManager();

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserDirectoryPersistenceUtil.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserDirectoryPersistenceUtil.java
@@ -29,6 +29,7 @@ import org.opencastproject.security.impl.jpa.JpaUser;
 import org.opencastproject.util.NotFoundException;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -298,6 +299,9 @@ public final class UserDirectoryPersistenceUtil {
    * @return the list of users that was found
    */
   public static List<JpaUser> findUsersByUserName(Collection<String> userNames, String organizationId, EntityManagerFactory emf) {
+    if (userNames.isEmpty()) {
+      return Collections.<JpaUser>emptyList();
+    }
     EntityManager em = null;
     try {
       em = emf.createEntityManager();


### PR DESCRIPTION
When modifying a group in the Admin UI it might occur that the group does not have a list of users associated with it and when calling the function _findUsersByUserName_ for the appropriate table it throws an error like:

Call: SELECT id, email, last_login, login_mechanism, name, username, organization FROM oc_user_ref WHERE ((organization = ?) AND (username IN ()))

This pull request fixes that oversight and the groups load without further issue. 