### PR TITLE
WIP MH-13310: Fix event deletion

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
@@ -86,6 +86,18 @@ public interface AssetManager {
    */
   void setAvailability(Version version, String mpId, Availability availability);
 
+  /**
+   * Remove an event completely from the asset manager.
+   * @param id the media package ID of the event to remove
+   * @return the number of items deleted
+   */
+  long removeEvent(String id, DeleteSnapshotHandler nopDeleteSnapshotHandler);
+
+  /** Call {@link #removeEvent(String, DeleteSnapshotHandler)} with a callback that does nothing. */
+  default long removeEvent(String id) {
+    return removeEvent(id, DeleteSnapshotHandler.NOP_DELETE_SNAPSHOT_HANDLER);
+  }
+
   // Properties
 
   /**

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/DeleteSnapshotHandler.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/DeleteSnapshotHandler.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.assetmanager.api;
+
+import org.opencastproject.assetmanager.api.query.ADeleteQuery;
+
+/**
+ * Call {@link ADeleteQuery#run(DeleteSnapshotHandler)} with a deletion handler to get notified about deletions.
+ */
+public interface DeleteSnapshotHandler {
+
+  // TODO This should take a `Version`
+  void notifyDeleteSnapshot(String mpId, long version);
+
+  void notifyDeleteEpisode(String mpId);
+
+  DeleteSnapshotHandler NOP_DELETE_SNAPSHOT_HANDLER = new DeleteSnapshotHandler() {
+    @Override public void notifyDeleteSnapshot(String mpId, long version) {
+    }
+
+    @Override public void notifyDeleteEpisode(String mpId) {
+    }
+  };
+
+  static DeleteSnapshotHandler compose(DeleteSnapshotHandler first, DeleteSnapshotHandler second) {
+    return new DeleteSnapshotHandler() {
+      @Override
+      public void notifyDeleteSnapshot(String mpId, long version) {
+        first.notifyDeleteSnapshot(mpId, version);
+        second.notifyDeleteSnapshot(mpId, version);
+      }
+
+      @Override
+      public void notifyDeleteEpisode(String mpId) {
+        first.notifyDeleteEpisode(mpId);
+        second.notifyDeleteEpisode(mpId);
+      }
+    };
+  }
+}

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/ADeleteQuery.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/ADeleteQuery.java
@@ -20,6 +20,8 @@
  */
 package org.opencastproject.assetmanager.api.query;
 
+import org.opencastproject.assetmanager.api.DeleteSnapshotHandler;
+
 public interface ADeleteQuery {
   ADeleteQuery where(Predicate predicate);
 
@@ -38,7 +40,13 @@ public interface ADeleteQuery {
   /**
    * Delete the selected items.
    *
+   * @param deleteSnapshotHandler callback to learn about deleted snapshots and episodes
    * @return the number of affected items
    */
-  long run();
+  long run(DeleteSnapshotHandler deleteSnapshotHandler);
+
+  /** Call {@link #run()} with a deletion handler that does nothing. */
+  default long run() {
+    return run(DeleteSnapshotHandler.NOP_DELETE_SNAPSHOT_HANDLER);
+  };
 }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/ADeleteQueryDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/ADeleteQueryDecorator.java
@@ -20,6 +20,7 @@
  */
 package org.opencastproject.assetmanager.impl;
 
+import org.opencastproject.assetmanager.api.DeleteSnapshotHandler;
 import org.opencastproject.assetmanager.api.query.ADeleteQuery;
 import org.opencastproject.assetmanager.api.query.Predicate;
 
@@ -43,8 +44,8 @@ public class ADeleteQueryDecorator implements ADeleteQuery {
     return mkDecorator(delegate.willRemoveWholeMediaPackage(willRemoveWholeMediaPackage));
   }
 
-  @Override public long run() {
-    return delegate.run();
+  @Override public long run(DeleteSnapshotHandler deleteSnapshotHandler) {
+    return delegate.run(deleteSnapshotHandler);
   }
 
   protected ADeleteQueryDecorator mkDecorator(ADeleteQuery delegate) {

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
@@ -33,6 +33,7 @@ import org.opencastproject.assetmanager.api.AssetId;
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.AssetManagerException;
 import org.opencastproject.assetmanager.api.Availability;
+import org.opencastproject.assetmanager.api.DeleteSnapshotHandler;
 import org.opencastproject.assetmanager.api.Property;
 import org.opencastproject.assetmanager.api.Snapshot;
 import org.opencastproject.assetmanager.api.Version;
@@ -140,6 +141,19 @@ public abstract class AbstractAssetManager implements AssetManager {
 
   @Override public void setAvailability(Version version, String mpId, Availability availability) {
     getDb().setAvailability(RuntimeTypes.convert(version), mpId, availability);
+  }
+
+  @Override public long removeEvent(String id, DeleteSnapshotHandler deletionHandler) {
+    AQueryBuilder q = createQuery();
+    long deletedItems = q.delete(DEFAULT_OWNER, q.propertiesOf())
+            .where(q.mediaPackageId(id))
+            .willRemoveWholeMediaPackage(true)
+            .run(deletionHandler);
+    deletedItems += q.delete(DEFAULT_OWNER, q.snapshot())
+            .where(q.mediaPackageId(id))
+            .willRemoveWholeMediaPackage(true)
+            .run(deletionHandler);
+    return deletedItems;
   }
 
   @Override public boolean setProperty(Property property) {

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
@@ -22,6 +22,7 @@ package org.opencastproject.assetmanager.impl;
 
 import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.Availability;
+import org.opencastproject.assetmanager.api.DeleteSnapshotHandler;
 import org.opencastproject.assetmanager.api.Property;
 import org.opencastproject.assetmanager.api.Snapshot;
 import org.opencastproject.assetmanager.api.Version;
@@ -58,6 +59,10 @@ public class AssetManagerDecorator<A extends TieredStorageAssetManager> implemen
 
   @Override public void setAvailability(Version version, String mpId, Availability availability) {
     delegate.setAvailability(version, mpId, availability);
+  }
+
+  @Override public long removeEvent(String id, DeleteSnapshotHandler deleteSnapshotHandler) {
+    return delegate.removeEvent(id, deleteSnapshotHandler);
   }
 
   @Override public boolean setProperty(Property property) {

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithMessaging.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithMessaging.java
@@ -228,6 +228,17 @@ public class AssetManagerWithMessaging extends AssetManagerDecorator<TieredStora
             AssetManagerItem.deleteEpisode(mpId, new Date()));
   }
 
+  @Override
+  public long removeEvent(String id, DeleteSnapshotHandler deleteSnapshotHandler) {
+    return super.removeEvent(id, DeleteSnapshotHandler.compose(deleteSnapshotHandler, this));
+  }
+
+  /** Optimized version without {@link DeleteSnapshotHandler#NOP_DELETE_SNAPSHOT_HANDLER} */
+  @Override
+  public long removeEvent(String id) {
+    return super.removeEvent(id, this);
+  }
+
   /**
    * Create a {@link TakeSnapshot} message.
    * <p>

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
@@ -27,6 +27,7 @@ import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_RO
 
 import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.Availability;
+import org.opencastproject.assetmanager.api.DeleteSnapshotHandler;
 import org.opencastproject.assetmanager.api.Property;
 import org.opencastproject.assetmanager.api.PropertyId;
 import org.opencastproject.assetmanager.api.Snapshot;
@@ -100,6 +101,15 @@ public class AssetManagerWithSecurity extends AssetManagerDecorator<TieredStorag
       super.setAvailability(version, mpId, availability);
     } else {
       chuck(new UnauthorizedException("Not allowed to set availability of episode " + mpId));
+    }
+  }
+
+  @Override public long removeEvent(String id, DeleteSnapshotHandler deleteSnapshotHandler) {
+    if (isAuthorized(id, WRITE_ACTION)) {
+      return super.removeEvent(id, deleteSnapshotHandler);
+    } else {
+      // TODO Is this right?
+      return chuck(new UnauthorizedException("Not allowed to delete episode " + id));
     }
   }
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
@@ -23,6 +23,7 @@ package org.opencastproject.assetmanager.impl;
 import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.Availability;
+import org.opencastproject.assetmanager.api.DeleteSnapshotHandler;
 import org.opencastproject.assetmanager.api.Property;
 import org.opencastproject.assetmanager.api.Snapshot;
 import org.opencastproject.assetmanager.api.Version;
@@ -193,6 +194,11 @@ public class OsgiAssetManager implements AssetManager, TieredStorageAssetManager
   @Override
   public void setAvailability(Version version, String mpId, Availability availability) {
     delegate.setAvailability(version, mpId, availability);
+  }
+
+  @Override
+  public long removeEvent(String id, DeleteSnapshotHandler deleteSnapshotHandler) {
+    return delegate.removeEvent(id, deleteSnapshotHandler);
   }
 
   @Override

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
@@ -47,6 +47,7 @@ import com.entwinemedia.fn.Fn;
 import com.entwinemedia.fn.Stream;
 import com.entwinemedia.fn.data.Opt;
 import com.mysema.query.jpa.impl.JPAQueryFactory;
+import com.mysema.query.support.Expressions;
 import com.mysema.query.types.expr.BooleanExpression;
 
 import java.util.Date;
@@ -322,14 +323,12 @@ public final class AQueryBuilderImpl implements AQueryBuilder, EntityPaths {
     return new AbstractPredicate() {
       /* SELECT */
       @Override public SelectQueryContribution contributeSelect(JPAQueryFactory f) {
-        // could not find a boolean expression being constantly true, so use this as a workaround
-        return SelectQueryContribution.mk().where(Q_SNAPSHOT.eq(Q_SNAPSHOT));
+        return SelectQueryContribution.mk().where(Expressions.booleanTemplate("true = true"));
       }
 
       /* DELETE */
       @Override public DeleteQueryContribution contributeDelete(String owner) {
-        // could not find a boolean expression being constantly true, so use this as a workaround
-        return DeleteQueryContribution.mk().where(Q_SNAPSHOT.eq(Q_SNAPSHOT));
+        return DeleteQueryContribution.mk().where(Expressions.booleanTemplate("true = true"));
       }
     };
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -22,7 +22,6 @@
 package org.opencastproject.index.service.impl;
 
 import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
-import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
 import static org.opencastproject.assetmanager.api.fn.Enrichments.enrich;
 import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_IDENTIFIER;
 
@@ -30,7 +29,6 @@ import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.AssetManagerException;
 import org.opencastproject.assetmanager.api.query.AQueryBuilder;
 import org.opencastproject.assetmanager.api.query.AResult;
-import org.opencastproject.assetmanager.api.query.Predicate;
 import org.opencastproject.assetmanager.util.WorkflowPropertiesUtil;
 import org.opencastproject.assetmanager.util.Workflows;
 import org.opencastproject.authorization.xacml.manager.api.AclService;
@@ -1532,10 +1530,7 @@ public class IndexServiceImpl implements IndexService {
     boolean notFoundArchive = false;
     boolean removedArchive = true;
     try {
-      final AQueryBuilder q = assetManager.createQuery();
-      final Predicate p = q.organizationId().eq(securityService.getOrganization().getId()).and(q.mediaPackageId(id));
-      q.delete(DEFAULT_OWNER, q.propertiesOf()).where(q.mediaPackageId(id)).willRemoveWholeMediaPackage(true).run();
-      q.delete(DEFAULT_OWNER, q.snapshot()).where(p).willRemoveWholeMediaPackage(true).run();
+      assetManager.removeEvent(id);
     } catch (AssetManagerException e) {
       if (e.getCause() instanceof UnauthorizedException) {
         unauthorizedArchive = true;


### PR DESCRIPTION
Ever since #523, events can't be deleted anymore, neither in the admin UI, nor using the external API. The problem only indirectly relates to that PR, though; it just surfaced it. The `AQueryBuilderImpl#always` implementation is to blame, introducing random variables into queries that might not declare them.

This improves the implementation. See also the commit message for more details.

Issue:  [MH-13310](https://opencast.jira.com/browse/MH-13310)