### PR TITLE
SUREFIRE-1588: Resolving compilation issue on Debian and related distros

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This is not really an Opencast bug, but rather caused by a bad backport of a patch by the Debian maintainers.  Unfortunately, Debian Stretch appears to be stuck with the broken version of the JDK, and it's not obvious to someone attempting to build Opencast that the issue comes from upstream.

Upgrading maven-sure-plugin past 3.0.0-M1 (M3 is the most current) resolves the issue, and would need to be done for newer JDKs anyway.