### PR TITLE
MH-13313, Properly Use ACL Merge-Mode Configuration

### DIFF
--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -82,16 +82,17 @@ public class XACMLAuthorizationService implements AuthorizationService, ManagedS
   private static final String CONFIG_MERGE_MODE = "merge.mode";
 
   /** Definition of how merging of series and episode ACLs work */
-  private MergeMode mergeMode = MergeMode.OVERRIDE;
+  private static MergeMode mergeMode = MergeMode.OVERRIDE;
 
   enum MergeMode {
     OVERRIDE, ROLES, ACTIONS
   }
 
   @Override
-  public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+  public synchronized void updated(Dictionary<String, ?> properties) throws ConfigurationException {
     if (properties == null) {
       mergeMode = MergeMode.OVERRIDE;
+      logger.debug("Merge mode set to {}", mergeMode);
       return;
     }
     final String mode = StringUtils.defaultIfBlank((String) properties.get(CONFIG_MERGE_MODE),
@@ -102,6 +103,7 @@ public class XACMLAuthorizationService implements AuthorizationService, ManagedS
       logger.warn("Invalid value set for ACL merge mode, defaulting to {}", MergeMode.OVERRIDE);
       mergeMode = MergeMode.OVERRIDE;
     }
+    logger.debug("Merge mode set to {}", mergeMode);
   }
 
   @Override

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -45,8 +45,8 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
+import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +55,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Dictionary;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.xml.bind.JAXBException;
@@ -88,8 +89,17 @@ public class XACMLAuthorizationService implements AuthorizationService, ManagedS
     OVERRIDE, ROLES, ACTIONS
   }
 
+  public void activate(ComponentContext cc) {
+    updated(cc.getProperties());
+  }
+
+  public void modified(Map<String, Object> config) {
+    // this prevents the service from restarting on configuration updated.
+    // updated() will handle the configuration update.
+  }
+
   @Override
-  public synchronized void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+  public synchronized void updated(Dictionary<String, ?> properties) {
     if (properties == null) {
       mergeMode = MergeMode.OVERRIDE;
       logger.debug("Merge mode set to {}", mergeMode);

--- a/modules/authorization-xacml/src/main/resources/OSGI-INF/authorization-service.xml
+++ b/modules/authorization-xacml/src/main/resources/OSGI-INF/authorization-service.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
-               name="org.opencastproject.authorization.xacml.XACMLAuthorizationService">
+               name="org.opencastproject.authorization.xacml.XACMLAuthorizationService"
+               modified="modified">
   <implementation class="org.opencastproject.authorization.xacml.XACMLAuthorizationService"/>
   <property name="service.description"
             value="Provides translation between access control entries and xacml documents"/>


### PR DESCRIPTION
The useage of non-static, internal variables for storing the
authorization managers configuration may lead to the default
configuration being used in production due to the way, the
configuration admin service is calling the `updated()` method.

*Work sponsored by SWITCH*