### PR TITLE
MH-13312 Do not show outdated conflict information

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -87,7 +87,22 @@ angular.module('adminNg.services')
       };
       this.loadCaptureAgents();
 
+      this.clearConflicts = function () {
+        self.conflicts.splice(0);
+        self.hasConflicts = false;
+      }
+
+      this.removeAllNotifications = function () {
+        self.notification = undefined;
+        self.alreadyEndedNotification = undefined;
+        self.endBeforeStartNotification = undefined;
+        Notifications.removeAll(NOTIFICATION_CONTEXT);
+      };
+
       this.reset = function (opts) {
+
+        self.removeAllNotifications();
+        self.clearConflicts();
 
         self.createStartDate();
         self.weekdays = _.clone(WEEKDAYS);
@@ -303,10 +318,6 @@ angular.module('adminNg.services')
           //                Notifications.remove(self.notification, NOTIFICATION_CONTEXT);
 
           var onSuccess = function () {
-            if (self.notification) {
-              Notifications.remove(self.notification, NOTIFICATION_CONTEXT);
-              self.notification = undefined;
-            }
             release();
           };
           var onError = function (response) {
@@ -325,11 +336,19 @@ angular.module('adminNg.services')
 
           var settings = self.ud[getType()];
           ConflictCheckResource.check(settings, onSuccess, onError);
+        } else {
+          self.clearConflicts();
+          self.removeAllNotifications();
         }
       };
 
       this.checkValidity = function () {
         var data = self.ud[getType()];
+
+        if (self.notification && !self.hasConflicts) {
+          Notifications.remove(self.notification, NOTIFICATION_CONTEXT);
+          self.notification = undefined;
+        }
 
         if (self.alreadyEndedNotification) {
           Notifications.remove(self.alreadyEndedNotification, NOTIFICATION_CONTEXT);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/source.js
@@ -90,7 +90,7 @@ angular.module('adminNg.services')
       this.clearConflicts = function () {
         self.conflicts.splice(0);
         self.hasConflicts = false;
-      }
+      };
 
       this.removeAllNotifications = function () {
         self.notification = undefined;


### PR DESCRIPTION
There are a number of issues related to the information regarding scheduling conflicts in the Add Event Wizard: 

1. When closing the Add Event Wizard on the tab "Source" while a scheduling conflict is displayed, those conflicts are displayed again when the Add Event Wizard is opened again even the user has not yet chosen date, time & location 

2. When the user deselects the week day while a scheduling conflict is displayed, the conflict is still displayed even there is no conflict as the user has not yet chosen data, time and location 

3. When the user has chosen data, time and location but the end date is before the start date, two notifications are displayed: a) end before start (correct) and b) conflicting events (incorrect as there are no conflicting events) 


Steps to reproduce: 
1. Create some scheduled events 
2. Start to create some more scheduled events that cause a conflict. When the list of conflicting events is displayed, close the add event wizard by left-clicking the 'x' at the top-left corner of the modal window 
3. Open "Add event wizard" and navigate to tab "Source" 
  
 Actual Results: 
 The tab source shows the list of the conflicting events from step 2 which is not correct 
  
 Expected Results: 
 The Add Event Wizard should not display outdated lists of conflicting events. 

Note that this requires #655. Without #655, the Add Event Wizard will not show scheduling conflict notifications when opened again.