### PR TITLE
MH-13315 Don't destroy Notifications service on destruction of the Notifications directive

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/notificationsDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/notificationsDirective.js
@@ -42,23 +42,16 @@ angular.module('adminNg.directives')
 
       scope.notifications = Notifications.get(scope.context);
 
-      scope.deregisterAdd = Notifications.$on('added', function (event, context) {
+      Notifications.$on('added', function (event, context) {
         updateNotifications(context);
       });
 
-      scope.deregisterChanged = Notifications.$on('changed', function (event, context) {
+      Notifications.$on('changed', function (event, context) {
         updateNotifications(context);
       });
 
-      scope.deregisterDelete = Notifications.$on('deleted', function (event, context) {
+      Notifications.$on('deleted', function (event, context) {
         updateNotifications(context);
-      });
-
-      scope.$on('$destroy', function () {
-        scope.deregisterAdd();
-        scope.deregisterChanged();
-        scope.deregisterDelete();
-        Notifications.$destroy();
       });
     }
   };


### PR DESCRIPTION
Steps to reproduce: 
1. Apply https://opencast.jira.com/browse/MH-13312 
2. Start adding a new scheduled events that generates scheduling conflicts and quit the Add Event Wizard by left-clicking the 'x' 
3. Start adding a new scheduled event that generates a conflict 
  
 Actual Results: 
 The conflict notification is not displayed anymore (the table listing the conflicts is displayed) 
  
 Expected Results: 
 The conflict should be displayed 

Besides the deRegister* methods don't actually deregister anything, do not call the destroy method of the Notifications service as this causes problems when re-using scopes that use the Notification service.

