### PR TITLE
MH-13321, Fix Series Item Serialization

### DIFF
--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/series/SeriesItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/series/SeriesItem.java
@@ -51,7 +51,7 @@ public final class SeriesItem implements MessageItem, Serializable {
   private final String optOut;
   private final String element;
   private final String elementType;
-  private final Boolean overrideEpisodeAcl;
+  private final String overrideEpisodeAcl;
 
   public enum Type {
     UpdateCatalog, UpdateElement, UpdateAcl, UpdateOptOut, UpdateProperty, Delete
@@ -194,7 +194,7 @@ public final class SeriesItem implements MessageItem, Serializable {
     this.optOut = optOut == null ? null : Boolean.toString(optOut);
     this.elementType = elementType;
     this.element = element;
-    this.overrideEpisodeAcl = overrideEpisodeAcl;
+    this.overrideEpisodeAcl = overrideEpisodeAcl == null ? null : overrideEpisodeAcl.toString();
   }
 
   @Override
@@ -252,6 +252,6 @@ public final class SeriesItem implements MessageItem, Serializable {
   }
 
   public Boolean getOverrideEpisodeAcl() {
-    return overrideEpisodeAcl;
+    return overrideEpisodeAcl == null ? null : Boolean.parseBoolean(overrideEpisodeAcl);
   }
 }


### PR DESCRIPTION
Opencast cannot serialize Boolean objects newly introduced in series
messages for ActiveMQ. We need to use native data types (boolean) or
Stings instead.

This patch fixes the sending of series related messages via ActiveMQ

*Work sponsored by SWITCH*