### PR TITLE
MH-13322, Avoid . in Elasticsearch Field Names

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -253,10 +253,6 @@ public final class EventIndexUtils {
               event.getTechnicalPresenters().toArray(new String[event.getTechnicalPresenters().size()]), true);
     }
 
-    if (event.getAgentConfiguration() != null) {
-      metadata.addField(EventIndexSchema.AGENT_CONFIGURATION, event.getAgentConfiguration(), false);
-    }
-
     return metadata;
   }
 

--- a/modules/search/src/main/java/org/opencastproject/matterhorn/search/impl/SearchMetadataCollection.java
+++ b/modules/search/src/main/java/org/opencastproject/matterhorn/search/impl/SearchMetadataCollection.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public class SearchMetadataCollection implements Collection<SearchMetadata<?>> {
 
   /** The metadata */
-  protected Map<String, SearchMetadata<?>> metadata = new HashMap<String, SearchMetadata<?>>();
+  protected Map<String, SearchMetadata<?>> metadata = new HashMap<>();
 
   /** Returns the document identifier */
   protected String identifier = null;
@@ -117,6 +117,8 @@ public class SearchMetadataCollection implements Collection<SearchMetadata<?>> {
   public void addField(String fieldName, Object fieldValue, boolean addToText) {
     if (fieldName == null)
       throw new IllegalArgumentException("Field name cannot be null");
+    if (fieldName.contains("."))
+      throw new IllegalArgumentException("Field name may not contain '.'");
     if (fieldValue == null)
       return;
 
@@ -158,9 +160,7 @@ public class SearchMetadataCollection implements Collection<SearchMetadata<?>> {
    * @return the metadata items
    */
   public List<SearchMetadata<?>> getMetadata() {
-    List<SearchMetadata<?>> result = new ArrayList<SearchMetadata<?>>();
-    result.addAll(metadata.values());
-    return result;
+    return new ArrayList<>(metadata.values());
   }
 
   /**


### PR DESCRIPTION
Elasticsearch ≥ 2 does not allow '.' to be used in any field names.
Right now, this can happen with the stored capture agent properties in
the events index. Luckily we do not seem to use those data at all right
now.

This patch removes setting those data and introduces an additional check
for those fields.