### PR TITLE
MH-13324, Simplify Data Loader

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -284,12 +284,10 @@ org.opencastproject.workspace.cleanup.max.age=2592000
 
 ######### Test Data #########
 
-# Whether opencast should import test-data by the given csv file path.
-# Default: false
-#org.opencastproject.dataloader.testdata=false
-
-# The path to the CSV file to import the data from it
-org.opencastproject.dataloader.csv=${karaf.etc}/dataimport
+# Path to a CSV file to import test data from.
+# If this is not set, no data is imported.
+# Default: <unset>
+#org.opencastproject.dataloader.csv=${karaf.etc}/dataimport.csv
 
 
 ######### Static Files #########

--- a/modules/dataloader/src/main/java/org/opencastproject/dataloader/EventsLoader.java
+++ b/modules/dataloader/src/main/java/org/opencastproject/dataloader/EventsLoader.java
@@ -138,17 +138,18 @@ public class EventsLoader {
    * Callback on component activation.
    */
   protected void activate(ComponentContext cc) throws Exception {
-    boolean loadTestData = BooleanUtils
-            .toBoolean(cc.getBundleContext().getProperty("org.opencastproject.dataloader.testdata"));
 
     String csvPath = StringUtils.trimToNull(cc.getBundleContext().getProperty("org.opencastproject.dataloader.csv"));
+    if (StringUtils.isBlank(csvPath)) {
+      return; // no file is set
+    }
 
     systemUserName = cc.getBundleContext().getProperty(SecurityUtil.PROPERTY_KEY_SYS_USER);
 
     File csv = new File(csvPath);
 
     // Load the demo users, if necessary
-    if (loadTestData && csv.exists() && serviceRegistry.count(null, null) == 0) {
+    if (csv.exists() && serviceRegistry.count(null, null) == 0) {
       // Load events by CSV file
       new Loader(csv).start();
     }


### PR DESCRIPTION
Instead of having a second variable to activate the data loader and
having Opencast throw an exception if no path is set, this patch will
make the data loader deactivate itself automatically if no path is set
which now is the default.