### PR TITLE
MH-13147: OptimisticLockException in ServiceRegistry dispatchJob

### DIFF
--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -154,7 +154,6 @@ CREATE TABLE oc_job (
   parent BIGINT,
   root BIGINT,
   job_load FLOAT NOT NULL DEFAULT 1.0,
-  blocking_job BIGINT DEFAULT NULL,
   PRIMARY KEY (id),
   CONSTRAINT FK_oc_job_creator_service FOREIGN KEY (creator_service) REFERENCES oc_service_registration (id) ON DELETE CASCADE,
   CONSTRAINT FK_oc_job_processor_service FOREIGN KEY (processor_service) REFERENCES oc_service_registration (id) ON DELETE CASCADE,
@@ -182,13 +181,6 @@ CREATE TABLE oc_job_argument (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE INDEX IX_oc_job_argument_id ON oc_job_argument (id);
-
-CREATE TABLE oc_blocking_job (
-  id BIGINT NOT NULL,
-  blocking_job_list BIGINT,
-  job_index INTEGER,
-  CONSTRAINT FK_oc_blocking_job_id FOREIGN KEY (id) REFERENCES oc_job (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_job_context (
   id BIGINT NOT NULL,

--- a/docs/upgrade/6_to_7/mysql5.sql
+++ b/docs/upgrade/6_to_7/mysql5.sql
@@ -1,1 +1,4 @@
 ALTER TABLE oc_assets_asset ADD CONSTRAINT FK_oc_assets_asset_snapshot_id FOREIGN KEY (snapshot_id) REFERENCES oc_assets_snapshot (id) ON DELETE CASCADE; 
+
+ALTER TABLE oc_job DROP COLUMN blocking_job;
+DROP TABLE oc_blocking_job;

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 
 import javax.persistence.Access;
@@ -197,30 +196,6 @@ public class JpaJob {
   @Column(name = "job_load")
   private Float jobLoad;
 
-  public String getBlockedJobIds() {
-    StringBuffer sb = new StringBuffer();
-    for (Long id : blockedJobIds) {
-      sb.append(id);
-      sb.append(" ");
-    }
-    return sb.toString();
-  }
-
-  public Long getBlockingJobId() {
-    return blockingJobId;
-  }
-
-  /** The list of job IDs that are blocking this job from continuing. */
-  @Column(name = "blocking_job_list")
-  @OrderColumn(name = "job_index")
-  @ElementCollection(fetch = FetchType.EAGER)
-  @CollectionTable(name = "oc_blocking_job", joinColumns = @JoinColumn(name = "id", referencedColumnName = "id"))
-  private List<Long> blockedJobIds = new LinkedList<Long>();
-
-  /** The job that this job is blocking from continuing. */
-  @Column(name = "blocking_job")
-  private Long blockingJobId = null;
-
   @ManyToOne
   @JoinColumn(name = "creator_service")
   private ServiceRegistrationJpaImpl creatorServiceRegistration;
@@ -299,15 +274,13 @@ public class JpaJob {
     newJob.creator = job.getCreator();
     newJob.organization = job.getOrganization();
     newJob.jobLoad = job.getJobLoad();
-    newJob.blockedJobIds = job.getBlockedJobIds();
-    newJob.blockingJobId = job.getBlockingJobId();
     return newJob;
   }
 
   public Job toJob() {
     return new JobImpl(id, creator, organization, version, jobType, operation, arguments, Status.values()[status],
             createdHost, processingHost, dateCreated, dateStarted, dateCompleted, queueTime, runTime, payload,
-            parentJobId, rootJobId, dispatchable, uri, jobLoad, blockedJobIds, blockingJobId);
+            parentJobId, rootJobId, dispatchable, uri, jobLoad);
   }
 
   public static Fn<JpaJob, Job> fnToJob() {
@@ -372,14 +345,6 @@ public class JpaJob {
 
   public void setArguments(List<String> arguments) {
     this.arguments = arguments;
-  }
-
-  public void setBlockedJobIds(List<Long> blockedJobIds) {
-    this.blockedJobIds = blockedJobIds;
-  }
-
-  public void setBlockingJobId(Long blockingJobId) {
-    this.blockingJobId = blockingJobId;
   }
 
   public void setDateCreated(Date dateCreated) {

--- a/modules/common-jpa-impl/src/test/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImplTest.java
+++ b/modules/common-jpa-impl/src/test/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImplTest.java
@@ -128,7 +128,7 @@ public class ServiceRegistrationJpaImplTest {
  @Test
  public void testToString() throws Exception {
    Job newJob = new JobImpl(3L, "test", "test_org", 0L, "simple", "do", null, DISPATCHING, "localhost",
-           "remotehost", null, null, null, 100L, 200L, "result", 3L, 1L, true, null, 1.5F, null, 4L);
+            "remotehost", null, null, null, 100L, 200L, "result", 3L, 1L, true, null, 1.5F);
    JpaJob jpaJob = JpaJob.from(newJob);
    String jobString = "Job {id:3, operation:do, status:DISPATCHING}";
    assertEquals(jpaJob.toString(), jobString);

--- a/modules/common/src/main/java/org/opencastproject/job/api/JaxbJob.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/JaxbJob.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.net.URI;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -111,13 +110,6 @@ public class JaxbJob {
   @XmlElement(name = "jobLoad")
   private Float jobLoad;
 
-  @XmlElement(name = "jobId")
-  @XmlElementWrapper(name = "blockingJobId")
-  private List<Long> blockedJobIds = new LinkedList<Long>();
-
-  @XmlElement(name = "blockingJobId")
-  private Long blockingJobId = null;
-
   /** Default constructor needed by jaxb */
   public JaxbJob() {
   }
@@ -147,15 +139,12 @@ public class JaxbJob {
     this.creator = job.getCreator();
     this.organization = job.getOrganization();
     this.jobLoad = job.getJobLoad();
-    if (job.getBlockedJobIds() != null)
-      this.blockedJobIds = unmodifiableList(job.getBlockedJobIds());
-    this.blockingJobId = job.getBlockingJobId();
   }
 
   public Job toJob() {
     return new JobImpl(id, creator, organization, version, jobType, operation, arguments, status, createdHost,
             processingHost, dateCreated, dateStarted, dateCompleted, queueTime, runTime, payload, parentJobId,
-            rootJobId, dispatchable, uri, jobLoad, blockedJobIds, blockingJobId);
+            rootJobId, dispatchable, uri, jobLoad);
   }
 
   public static Fn<JaxbJob, Job> fnToJob() {
@@ -196,7 +185,7 @@ public class JaxbJob {
             .append(parentJobId, jaxbJob.parentJobId).append(rootJobId, jaxbJob.rootJobId)
             .append(queueTime, jaxbJob.queueTime).append(runTime, jaxbJob.runTime)
             .append(payload, jaxbJob.payload).append(jobLoad, jaxbJob.jobLoad)
-            .append(blockedJobIds, jaxbJob.blockedJobIds).append(blockingJobId, jaxbJob.blockingJobId).isEquals();
+            .isEquals();
   }
 
   @Override
@@ -205,6 +194,6 @@ public class JaxbJob {
             .append(uri).append(operation).append(arguments).append(createdHost).append(processingHost).append(status)
             .append(dateCreated).append(dateStarted).append(dateCompleted).append(parentJobId).append(rootJobId)
             .append(queueTime).append(runTime).append(payload).append(dispatchable).append(jobLoad)
-            .append(blockedJobIds).append(blockingJobId).toHashCode();
+            .toHashCode();
   }
 }

--- a/modules/common/src/main/java/org/opencastproject/job/api/Job.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/Job.java
@@ -271,31 +271,4 @@ public interface Job {
 
   void setJobLoad(Float load);
 
-  /**
-   * Gets the list of job IDs that are blocking this job from continuing
-   * 
-   * @return the list of Job IDs that are blocking this job
-   */
-  List<Long> getBlockedJobIds();
-
-  void setBlockedJobIds(List<Long> list);
-
-  /**
-   * Clears the list of jobs blocking this job from continuing
-   */
-  void removeBlockedJobsIds();
-
-  /**
-   * Gets which job, if any, this job is blocking
-   * 
-   * @return the Job ID this job is blocking, or null
-   */
-  Long getBlockingJobId();
-
-  void setBlockingJobId(Long jobId);
-
-  /**
-   * Clears the reference to the job which this job is blocking, if any
-   */
-  void removeBlockingJobId();
 }

--- a/modules/common/src/main/java/org/opencastproject/job/api/JobImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/JobImpl.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.job.api;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static org.opencastproject.job.api.Job.FailureReason.NONE;
 
@@ -57,8 +56,6 @@ public class JobImpl implements Job {
   private boolean dispatchable = true;
   private URI uri;
   private Float load = 1.0F;
-  private List<Long> blockedJobIds = new ArrayList<>();
-  private Long blockingJobId = null;
 
   public JobImpl() { }
 
@@ -87,10 +84,7 @@ public class JobImpl implements Job {
           Long rootJobId,
           boolean dispatchable,
           URI uri,
-          Float load,
-          List<Long> blockedJobIds,
-          Long blockingJobId
-  ) {
+          Float load) {
     this.id = id;
     this.creator = creator;
     this.organization = organization;
@@ -113,9 +107,6 @@ public class JobImpl implements Job {
     this.dispatchable = dispatchable;
     this.uri = uri;
     this.load = load;
-    if (blockedJobIds != null)
-      this.blockedJobIds.addAll(blockedJobIds);
-    this.blockingJobId = blockingJobId;
   }
 
   @Override
@@ -324,36 +315,6 @@ public class JobImpl implements Job {
   }
 
   @Override
-  public List<Long> getBlockedJobIds() {
-    return unmodifiableList(blockedJobIds);
-  }
-
-  @Override
-  public void setBlockedJobIds(List<Long> list) {
-    this.blockedJobIds = unmodifiableList(list);
-  }
-
-  @Override
-  public void removeBlockedJobsIds() {
-    this.blockedJobIds = emptyList();
-  }
-
-  @Override
-  public Long getBlockingJobId() {
-    return blockingJobId;
-  }
-
-  @Override
-  public void setBlockingJobId(Long jobId) {
-    this.blockingJobId = jobId;
-  }
-
-  @Override
-  public void removeBlockingJobId() {
-    this.blockingJobId = null;
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o)
       return true;
@@ -371,8 +332,7 @@ public class JobImpl implements Job {
             .append(dateStarted, job.dateStarted).append(dateCompleted, job.dateCompleted)
             .append(queueTime, job.queueTime).append(runTime, job.runTime).append(payload, job.payload)
             .append(parentJobId, job.parentJobId).append(rootJobId, job.rootJobId)
-            .append(uri, job.uri).append(load, job.load).append(blockedJobIds, job.blockedJobIds)
-            .append(blockingJobId, job.blockingJobId).isEquals();
+            .append(uri, job.uri).append(load, job.load).isEquals();
   }
 
   @Override
@@ -381,7 +341,7 @@ public class JobImpl implements Job {
             .append(operation).append(arguments).append(status).append(failureReason).append(createdHost)
             .append(processingHost).append(dateCreated).append(dateStarted).append(dateCompleted).append(queueTime)
             .append(runTime).append(payload).append(parentJobId).append(rootJobId).append(dispatchable).append(uri)
-            .append(load).append(blockedJobIds).append(blockingJobId).toHashCode();
+            .append(load).toHashCode();
   }
 
   @Override

--- a/modules/common/src/test/java/org/opencastproject/job/api/JaxbJobTest.java
+++ b/modules/common/src/test/java/org/opencastproject/job/api/JaxbJobTest.java
@@ -44,7 +44,7 @@ public class JaxbJobTest {
 
     final JaxbJob jaxb = new JaxbJob(
             new JobImpl(3L, "test", "test_org", 0L, "simple", "do", arguments, DISPATCHING, "localhost", "remotehost",
-                    now, now, now, 100L, 200L, "result", 1L, 3L, true, uri, 1.5F, blockedJobs, 4L));
+                    now, now, now, 100L, 200L, "result", 1L, 3L, true, uri, 1.5F));
     final Job job = jaxb.toJob();
 
     assertEquals(3L, job.getId());
@@ -68,8 +68,6 @@ public class JaxbJobTest {
     assertTrue(job.isDispatchable());
     assertEquals(uri, job.getUri());
     assertEquals((Float) 1.5F, job.getJobLoad());
-    assertEquals(blockedJobs, job.getBlockedJobIds());
-    assertEquals((Long) 4L, job.getBlockingJobId());
   }
 
 }

--- a/modules/common/src/test/java/org/opencastproject/job/api/JobImplTest.java
+++ b/modules/common/src/test/java/org/opencastproject/job/api/JobImplTest.java
@@ -53,7 +53,7 @@ public class JobImplTest {
   @Before
   public void setUp() throws Exception {
     job = new JobImpl(3L, "test", "test_org", 0L, "simple", "do", arguments, DISPATCHING, "localhost", "remotehost",
-            created, started, completed, 100L, 200L, "result", 3L, 1L, true, uri, 1.5F, blockedJobs, 4L);
+            created, started, completed, 100L, 200L, "result", 3L, 1L, true, uri, 1.5F);
   }
 
   @Test
@@ -172,19 +172,9 @@ public class JobImplTest {
   }
 
   @Test
-  public void testGetBlockedJobIds() throws Exception {
-    assertEquals(blockedJobs, job.getBlockedJobIds());
-  }
-
-  @Test
-  public void testGetBlockingJobId() throws Exception {
-    assertEquals((Long) 4L, job.getBlockingJobId());
-  }
-
-  @Test
   public void testEquals() throws Exception {
     Job equalJob = new JobImpl(3L, "test", "test_org", 0L, "simple", "do", arguments, DISPATCHING, "localhost", "remotehost",
-            created, started, completed, 100L, 200L, "result", 3L, 1L, true, uri, 1.5F, blockedJobs, 4L);
+            created, started, completed, 100L, 200L, "result", 3L, 1L, true, uri, 1.5F);
 
     assertEquals(job, equalJob);
   }
@@ -192,7 +182,7 @@ public class JobImplTest {
   @Test
   public void testToString() throws Exception {
     Job newJob = new JobImpl(3L, "test", "test_org", 0L, "simple", "do", arguments, DISPATCHING, "localhost",
-            "remotehost", created, started, completed, 100L, 200L, "result", 3L, 1L, true, uri, 1.5F, blockedJobs, 4L);
+            "remotehost", created, started, completed, 100L, 200L, "result", 3L, 1L, true, uri, 1.5F);
     String jobString = "Job {id:3, operation:do, status:DISPATCHING}";
     assertEquals(newJob.toString(), jobString);
   }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -1037,10 +1037,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         logger.error("JPA processor service mismatch: " + originalJob.getProcessorServiceRegistration().getId() + " vs " + fromDb.getProcessorServiceRegistration().getId());
       if (!originalJob.getDateStarted().equals(fromDb.getDateStarted()))
         logger.error("JPA date started mismatch: " + originalJob.getDateStarted() + " vs " + fromDb.getDateStarted());
-      if (!originalJob.getBlockedJobIds().equals(fromDb.getBlockedJobIds()))
-        logger.error("JPA blocked job ids mismatch: " + originalJob.getBlockedJobIds() + " vs " + fromDb.getBlockedJobIds());
-      if (!originalJob.getBlockingJobId().equals(fromDb.getBlockingJobId()))
-        logger.error("JPA blocking job id mismatch: " + originalJob.getBlockingJobId() + " vs " + fromDb.getBlockingJobId());
       if (!originalJob.getChildJobsString().equals(fromDb.getChildJobsString()))
         logger.error("JPA child job id mismatch: " + originalJob.getChildJobsString() + " vs " + fromDb.getChildJobsString());
     } catch (Exception e) {
@@ -1106,8 +1102,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     fromDb.setVersion(job.getVersion());
     fromDb.setOperation(job.getOperation());
     fromDb.setArguments(job.getArguments());
-    fromDb.setBlockedJobIds(job.getBlockedJobIds());
-    fromDb.setBlockingJobId(job.getBlockingJobId());
 
     if (job.getDateCreated() == null) {
       jpaJob.setDateCreated(now);


### PR DESCRIPTION
It turns out that the blocking/blocked job info stored in the database was not used. It is enough to keep that info in memory, even when Opencast is restarted. Removing the need to update it in the database prevents the optimistic error.
The problem is difficult to reproduce so it's hard to test the fix, but we have been successfully using this fix in production (our version is "5.x + tiered asset manager") for a few months.  