### PR TITLE
MH-13327 Disable save button on pending request

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
@@ -169,14 +169,14 @@ angular.module('adminNg.controllers')
     $scope.player = {};
     $scope.video  = ToolsResource.get({ id: $scope.id, tool: 'editor' });
 
-    $scope.activeTransaction = false;
+    $scope.activeRequest = false;
 
     $scope.submit = function () {
-      $scope.activeTransaction = true;
+      $scope.activeRequest = true;
       $scope.video.thumbnail.loading = $scope.video.thumbnail && $scope.video.thumbnail.type &&
               ($scope.video.thumbnail.type === 'DEFAULT');
       $scope.video.$save({ id: $scope.id, tool: $scope.tab }, function (response) {
-        $scope.activeTransaction = false;
+        $scope.activeRequest = false;
         if ($scope.video.workflow) {
           Notifications.add('success', 'VIDEO_CUT_PROCESSING');
           $location.url('/events/' + $scope.resource);
@@ -197,7 +197,7 @@ angular.module('adminNg.controllers')
           trackErrorMessageId = null;
         }
       }, function () {
-        $scope.activeTransaction = false;
+        $scope.activeRequest = false;
         $scope.video.thumbnail.loading = false;
         trackErrorMessageId = Notifications.add('error', 'VIDEO_CUT_NOT_SAVED', LOCAL_CONTEXT);
       });

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
@@ -33,7 +33,7 @@
                                                              ng-options="workflow.id as workflow.name for workflow in video.workflows | orderBy: 'displayOrder':true" />
 
               <a ng-click="submit()"
-                 ng-class="{disabled: activeTransaction}"
+                 ng-class="{disabled: activeTransaction || sanityCheckFlags() || activeRequest}"
                  class="save-and-close-button"
                  translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
                 <!-- Save and Continue -->
@@ -409,7 +409,7 @@
                                                                  ng-options="workflow.id as workflow.name for workflow in video.workflows | orderBy: 'displayOrder':true" />
 
                   <a ng-click="submit()"
-                     ng-class="{disabled: activeTransaction || sanityCheckFlags()}"
+                     ng-class="{disabled: activeTransaction || sanityCheckFlags() || activeRequest}"
                      class="save-and-close-button"
                      translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
                     <!-- Save and Continue -->


### PR DESCRIPTION
Disable the save button in the video editor after clicking until the request is finished to avoid users clicking it multiple times.

_This work is sponsored by SWITCH._