### PR TITLE
MH-13329 Removing a capture agent resets the password of all Opencast users

### DIFF
--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
@@ -146,7 +146,7 @@ public class CaptureAgentAdminRoleProviderImpl implements RoleProvider, CaptureA
               .map(role -> (JpaRole)role)
               .collect(Collectors.toSet());
       try {
-        this.userAndRoleProvider.updateUser(new JpaUser(user.getUsername(), user.getPassword(),
+        this.userAndRoleProvider.updateUser(new JpaUser(user.getUsername(), "",
             (JpaOrganization) user.getOrganization(), user.getName(), user.getEmail(), user.getProvider(),
             user.isManageable(), newRoles));
       } catch (final NotFoundException | UnauthorizedException e) {


### PR DESCRIPTION
The method getPassword() returns the encoded user password. If we set this as new password, it will be encoded again resulting in the user password being changed. If we set an empty string, the old encoded password will be re-used.

Steps to reproduce: 
1. Login as admin:opencast 
2. Create another user test:test 
3. Login as test 
4. Login as admin:opencast again 
5. Create a capture agent "test" 
6. Delete the capture agent "test" 
7. Login as test:test 
  
 Actual Results: 
 You cannot login as test:test because the password "test" is not valid anymore. 
  
 Expected Results: 
 Deleting a capture agent should not reset the passwords of users. 
  
 Workaround (if any): 
Do not delete capture agents ;-) 