### PR TITLE
Documentation: Analyze Audio WOH: Unbreak table

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/analyzeaudio-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/analyzeaudio-woh.md
@@ -48,9 +48,7 @@ Example result track:
 |source-flavors    |"presentation/work,presenter/work"|The "flavors" of the track to use as a source input|EMPTY|
 |source-flavor     |"presentation/work"               |The "flavor" of the track to use as a source input|EMPTY|
 |source-tags       |"engage,atom,rss"                 |The "tag" of the track to use as a source input|EMPTY|
-|force-transcode   |"true" or "false"                 |Whether to force transcoding the audio stream
-(This is needed when trying to strip an audio stream from an audio only video container, because SoX can not handle video formats, so it must be encoded to an audio format)|FALSE|
-
+|force-transcode   |"true" or "false"                 |Whether to force transcoding the audio stream (This is needed when trying to strip an audio stream from an audio only video container, because SoX can not handle video formats, so it must be encoded to an audio format)|FALSE|
 
 ## Operation Example
 


### PR DESCRIPTION
Markdown does not allow line breaks in table cells. If we wanted to avoid overly long lines, we either make this an ASCII table, an HTML table or create more rows and fit the overly long description in its column.
To view the current documentation, visit https://docs.opencast.org/develop/admin/workflowoperationhandlers/analyzeaudio-woh/