### PR TITLE
MH-13336, Upgrade c3p0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1174,7 +1174,7 @@
       <dependency>
         <groupId>com.mchange</groupId>
         <artifactId>c3p0</artifactId>
-        <version>0.9.5.2</version>
+        <version>0.9.5.3</version>
       </dependency>
       <dependency>
         <groupId>com.entwinemedia.common</groupId>


### PR DESCRIPTION
This patch fixes CVE-2018-20433

> https://nvd.nist.gov/vuln/detail/CVE-2018-20433