### PR TITLE
MH-13337 Admin UI workflow status translation keys added

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -898,7 +898,9 @@
               "PAUSED": "Paused",
               "SUCCEEDED": "Succeeded",
               "FAILED": "Failed",
+              "FAILING": "Failing",
               "SKIPPED": "Skipped",
+              "STOPPED": "Stopped",
               "RETRY": "Retry"
             }
           },


### PR DESCRIPTION
Added missing translation keys. See screenshot in the ticket.