### PR TITLE
MH-13342 Don't try to create events with empty metadata

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadata.js
@@ -51,7 +51,7 @@ angular.module('adminNg.services')
           // preserve default value, if set
           if (field.hasOwnProperty('value') && field.value) {
             field.presentableValue = me.extractPresentableValue(field);
-            me.ud[mainMetadataName].fields[field.id] = field;
+            me.ud[mainMetadataName].fields[i] = field;
           }
           // just hooking the tab index up here, as this is already running through all elements
           field.tabindex = i + 1;
@@ -108,19 +108,15 @@ angular.module('adminNg.services')
     };
 
     this.save = function (scope) {
-      //FIXME: This should be nicer, rather propagate the id and values
-      //instead of looking for them in the parent scope.
-      var params = scope.$parent.params,
-          fieldId = params.id,
-          value = params.value;
+      //FIXME: This should be nicer, rather propagate the id and values instead of looking for them in the parent scope.
+      var field = scope.$parent.params;
+      field.presentableValue = me.extractPresentableValue(field);
 
-      params.presentableValue = me.extractPresentableValue(params);
-
-      me.ud[mainMetadataName].fields[fieldId] = params;
-
-      if (angular.isDefined(me.requiredMetadata[fieldId])) {
-        me.updateRequiredMetadata(fieldId, value);
+      if (angular.isDefined(me.requiredMetadata[field.id])) {
+        me.updateRequiredMetadata(field.id, field.value);
       }
+
+      me.ud[mainMetadataName].fields[field.tabindex - 1] = field;
     };
 
     this.reset = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadataExtended.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadataExtended.js
@@ -58,6 +58,8 @@ angular.module('adminNg.services')
       // we go for the extended metadata here
       if (fields.length > 0) {
         for (i = 0; i < fields.length; i++) {
+          // just hooking the tab index up here, as this is already running through all elements
+          fields[i].tabindex = i + 1;
           if (fields[i].required) {
             me.updateRequiredMetadata(fields[i].id, fields[i].value);
             if (fields[i].type === 'boolean') {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadataExtended.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/metadataExtended.js
@@ -94,28 +94,25 @@ angular.module('adminNg.services')
     };
 
     this.save = function (scope) {
-      //FIXME: This should be nicer, rather propagate the id and values
-      //instead of looking for them in the parent scope.
-      var params = scope.$parent.params,
-          target = scope.$parent.target,
-          fieldId = params.id,
-          value = params.value;
+      //FIXME: This should be nicer, rather propagate the id and values instead of looking for them in the parent scope.
+      var field = scope.$parent.params,
+          target = scope.$parent.target;
 
-      if (params.collection) {
-        if (angular.isArray(value)) {
-          params.presentableValue = value;
+      if (field.collection) {
+        if (angular.isArray(field.value)) {
+          field.presentableValue = field.value;
         } else {
-          params.presentableValue = params.collection[value];
+          field.presentableValue = field.collection[field.value];
         }
       } else {
-        params.presentableValue = value;
+        field.presentableValue = field.value;
       }
 
-      me.ud[target].fields[fieldId] = params;
-
-      if (angular.isDefined(me.requiredMetadata[fieldId])) {
-        me.updateRequiredMetadata(fieldId, value);
+      if (angular.isDefined(me.requiredMetadata[field.id])) {
+        me.updateRequiredMetadata(field.id, field.value);
       }
+
+      me.ud[target].fields[field.tabindex - 1] = field;
     };
 
     this.reset = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadata.js
@@ -48,7 +48,7 @@ angular.module('adminNg.services')
           // preserve default value, if set
           if (field.hasOwnProperty('value') && field.value) {
             field.presentableValue = me.extractPresentableValue(field);
-            me.ud[mainMetadataName].fields[field.id] = field;
+            me.ud[mainMetadataName].fields[i] = field;
           }
           // just hooking the tab index up here, as this is already running through all elements
           field.tabindex = i + 1;
@@ -103,19 +103,15 @@ angular.module('adminNg.services')
     };
 
     this.save = function (scope) {
-      //FIXME: This should be nicer, rather propagate the id and values
-      //instead of looking for them in the parent scope.
-      var params = scope.$parent.params,
-          fieldId = params.id,
-          value = params.value;
+      //FIXME: This should be nicer, rather propagate the id and values instead of looking for them in the parent scope.
+      var field = scope.$parent.params;
+      field.presentableValue = me.extractPresentableValue(field);
 
-      params.presentableValue = me.extractPresentableValue(params);
-
-      me.ud[mainMetadataName].fields[fieldId] = params;
-
-      if (angular.isDefined(me.requiredMetadata[fieldId])) {
-        me.updateRequiredMetadata(fieldId, value);
+      if (angular.isDefined(me.requiredMetadata[field.id])) {
+        me.updateRequiredMetadata(field.id, field.value);
       }
+
+      me.ud[mainMetadataName].fields[field.tabindex - 1] = field;
     };
 
     this.reset = function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadataExtended.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadataExtended.js
@@ -54,6 +54,8 @@ angular.module('adminNg.services')
       // we go for the extended metadata here
       if (fields.length > 0) {
         for (i = 0; i < fields.length; i++) {
+          // just hooking the tab index up here, as this is already running through all elements
+          fields[i].tabindex = i + 1;
           if (fields[i].required) {
             me.updateRequiredMetadata(fields[i].id, fields[i].value);
             if (fields[i].type === 'boolean') {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadataExtended.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-series/metadataExtended.js
@@ -86,28 +86,25 @@ angular.module('adminNg.services')
     };
 
     this.save = function (scope) {
-      //FIXME: This should be nicer, rather propagate the id and values
-      //instead of looking for them in the parent scope.
-      var params = scope.$parent.params,
-          target = scope.$parent.target,
-          fieldId = params.id,
-          value = params.value;
+      //FIXME: This should be nicer, rather propagate the id and values instead of looking for them in the parent scope.
+      var field = scope.$parent.params,
+          target = scope.$parent.target;
 
-      if (params.collection) {
-        if (angular.isArray(value)) {
-          params.presentableValue = value;
+      if (field.collection) {
+        if (angular.isArray(field.value)) {
+          field.presentableValue = field.value;
         } else {
-          params.presentableValue = params.collection[value];
+          field.presentableValue = field.collection[field.value];
         }
       } else {
-        params.presentableValue = value;
+        field.presentableValue = field.value;
       }
 
-      me.ud[target].fields[fieldId] = params;
-
-      if (angular.isDefined(me.requiredMetadata[fieldId])) {
-        me.updateRequiredMetadata(fieldId, value);
+      if (angular.isDefined(me.requiredMetadata[field.id])) {
+        me.updateRequiredMetadata(field.id, field.value);
       }
+
+      me.ud[target].fields[field.tabindex - 1] = field;
     };
 
     this.getFiledCatalogs = function () {

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-event/metadataSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-event/metadataSpec.js
@@ -35,10 +35,11 @@ describe('Metadata Step in New Event Wizard', function () {
         expect(NewEventMetadata.metadata['dublincore/episode'].fields.length).toEqual(9);
     });
 
-    setParams = function (ctrl, id, value) {
+    setParams = function (ctrl, id, value, tabindex) {
         $scope.$parent.params = {
             id: id,
-            value: value
+            value: value,
+            tabindex: tabindex
         };
         ctrl.save($scope);
     };
@@ -46,14 +47,14 @@ describe('Metadata Step in New Event Wizard', function () {
     describe('#save', function () {
 
         it('saves new values', function () {
-            setParams(NewEventMetadata, 'testid', 'testvalue');
+            setParams(NewEventMetadata, 'testid', 'testvalue', 1);
             NewEventMetadata.save($scope);
-            expect(NewEventMetadata.ud['dublincore/episode'].fields.testid.value).toEqual('testvalue');
+            expect(NewEventMetadata.ud['dublincore/episode'].fields[0].value).toEqual('testvalue');
         });
 
         describe('with collection', function () {
             beforeEach(function () {
-                $scope.$parent.params = { collection: [], id: 'testid' };
+                $scope.$parent.params = { collection: [], id: 'testid', tabindex: 2 };
             });
 
             describe('with an array of values', function () {
@@ -63,7 +64,7 @@ describe('Metadata Step in New Event Wizard', function () {
 
                 it('assign the entire values array', function () {
                     NewEventMetadata.save($scope);
-                    expect(NewEventMetadata.ud['dublincore/episode'].fields.testid.value).toEqual(['a', 'b']);
+                    expect(NewEventMetadata.ud['dublincore/episode'].fields[1].value).toEqual(['a', 'b']);
                 });
             });
 
@@ -74,7 +75,7 @@ describe('Metadata Step in New Event Wizard', function () {
 
                 it('assign the entire values array', function () {
                     NewEventMetadata.save($scope);
-                    expect(NewEventMetadata.ud['dublincore/episode'].fields.testid.value).toEqual('a');
+                    expect(NewEventMetadata.ud['dublincore/episode'].fields[1].value).toEqual('a');
                 });
             });
         });
@@ -87,18 +88,18 @@ describe('Metadata Step in New Event Wizard', function () {
         });
 
         it('invalidates if a required field is deleted', function () {
-            setParams(NewEventMetadata, 'title', 'testTitle');
-            setParams(NewEventMetadata, 'presenters', '[Mark Twain]');
-            setParams(NewEventMetadata, 'subject', 'test subject');
+            setParams(NewEventMetadata, 'title', 'testTitle', 1);
+            setParams(NewEventMetadata, 'presenters', '[Mark Twain]', 2);
+            setParams(NewEventMetadata, 'subject', 'test subject', 3);
             expect(NewEventMetadata.isValid()).toBeTruthy();
-            setParams(NewEventMetadata, 'title', '');
+            setParams(NewEventMetadata, 'title', '', 1);
             expect(NewEventMetadata.isValid()).toBeFalsy();
         });
 
         it('becomes valid when all required fields are set', function () {
-            setParams(NewEventMetadata, 'title', 'testTitle');
-            setParams(NewEventMetadata, 'presenters', '[Mark Twain]');
-            setParams(NewEventMetadata, 'subject', 'test subject');
+            setParams(NewEventMetadata, 'title', 'testTitle', 1);
+            setParams(NewEventMetadata, 'presenters', '[Mark Twain]', 1);
+            setParams(NewEventMetadata, 'subject', 'test subject', 1);
             expect(NewEventMetadata.isValid()).toBeTruthy();
         });
     });

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-series/metadataSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/wizards/new-series/metadataSpec.js
@@ -35,10 +35,11 @@ describe('Metadata Step in New Series Wizard', function () {
         expect(NewSeriesMetadata.metadata['dublincore/series'].fields.length).toEqual(9);
     });
 
-    setParams = function (ctrl, id, value) {
+    setParams = function (ctrl, id, value, tabindex) {
         $scope.$parent.params = {
             id: id,
-            value: value
+            value: value,
+            tabindex: tabindex
         };
         ctrl.save($scope);
     };
@@ -46,14 +47,14 @@ describe('Metadata Step in New Series Wizard', function () {
     describe('#save', function () {
 
         it('saves new values', function () {
-            setParams(NewSeriesMetadata, 'testid', 'testvalue');
+            setParams(NewSeriesMetadata, 'testid', 'testvalue', 1);
             NewSeriesMetadata.save($scope);
-            expect(NewSeriesMetadata.ud['dublincore/series'].fields.testid.value).toEqual('testvalue');
+            expect(NewSeriesMetadata.ud['dublincore/series'].fields[0].value).toEqual('testvalue');
         });
 
         describe('with collection', function () {
             beforeEach(function () {
-                $scope.$parent.params = { collection: [], id: 'testid' };
+                $scope.$parent.params = { collection: [], id: 'testid', tabindex: 2 };
             });
 
             describe('with an array of values', function () {
@@ -63,7 +64,7 @@ describe('Metadata Step in New Series Wizard', function () {
 
                 it('assign the entire values array', function () {
                     NewSeriesMetadata.save($scope);
-                    expect(NewSeriesMetadata.ud['dublincore/series'].fields.testid.value).toEqual(['a', 'b']);
+                    expect(NewSeriesMetadata.ud['dublincore/series'].fields[1].value).toEqual(['a', 'b']);
                 });
             });
 
@@ -74,7 +75,7 @@ describe('Metadata Step in New Series Wizard', function () {
 
                 it('assign the entire values array', function () {
                     NewSeriesMetadata.save($scope);
-                    expect(NewSeriesMetadata.ud['dublincore/series'].fields.testid.value).toEqual('a');
+                    expect(NewSeriesMetadata.ud['dublincore/series'].fields[1].value).toEqual('a');
                 });
             });
         });


### PR DESCRIPTION
This is an attempt to fix a bug where an event cannot be created because the metadata sent to the backend are empty, resulting in a server error complaining about an empty title. So far this could only be reproduced in Firefox when trying to create an event for the first time, and it doesn't happen consistently.

This PR rewrites the save method that currently effectively doesn't save anything (the metadata fields that are attached to the userdata under their field id are duplicates and are discarded in the backend on event creation) and only works because of the metadata fields in the userdata being the exact same objects used as models for the input fields. When this isn't true (and it seems it sometimes isn't) no values are saved. This PR saves the metadata fields explicitly and directly into the userdata array to work around this problem.

_This work is sponsored by SWITCH._