### PR TITLE
MH-13343 Load track into workspace with unique ID

### DIFF
--- a/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/ComplexCmdsEncoderEngineTest.java
+++ b/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/ComplexCmdsEncoderEngineTest.java
@@ -20,6 +20,7 @@
  */
 package org.opencastproject.composer.impl;
 
+import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.capture;
 import static org.junit.Assert.assertTrue;
 
@@ -175,6 +176,24 @@ public class ComplexCmdsEncoderEngineTest {
 
     workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.get((URI) EasyMock.anyObject())).andAnswer(new IAnswer<File>() {
+      @Override
+      public File answer() throws Throwable {
+        URI uri = (URI) EasyMock.getCurrentArguments()[0];
+        String name = uri.getPath();
+        logger.info("workspace Returns " + name);
+        if (name.contains("mux"))
+          return sourceMuxed;
+        else if (name.contains("audiovideo"))
+          return sourceAudioVideo;
+        else if (name.contains("audio"))
+          return sourceAudioOnly;
+        else if (name.contains("video"))
+          return sourceVideoOnly;
+        return sourceAudioVideo; // default
+      }
+    }).anyTimes();
+
+    EasyMock.expect(workspace.get((URI) EasyMock.anyObject(), anyBoolean())).andAnswer(new IAnswer<File>() {
       @Override
       public File answer() throws Throwable {
         URI uri = (URI) EasyMock.getCurrentArguments()[0];

--- a/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/ComposerServiceTest.java
+++ b/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/ComposerServiceTest.java
@@ -84,6 +84,7 @@ import java.util.List;
 public class ComposerServiceTest {
   /** The sources file to test with */
   private File sourceVideoOnly = null;
+  private File[] sourceVideosUnique = new File[10];
   private File sourceAudioOnly = null;
   private File sourceImage = null;
 
@@ -167,6 +168,14 @@ public class ComposerServiceTest {
 
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.get(EasyMock.anyObject())).andReturn(sourceVideoOnly).anyTimes();
+    EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.eq(false))).andReturn(sourceVideoOnly).anyTimes();
+
+    EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.eq(true))).andAnswer(() -> {
+      File f1 = getFile("/video.mp4");
+      File uniqueSourceVideo = File.createTempFile(FilenameUtils.getBaseName(f1.getName()), ".mp4", testDir);
+      FileUtils.copyFile(f1, uniqueSourceVideo);
+      return uniqueSourceVideo;
+    }).anyTimes();
 
     profileScanner = new EncodingProfileScanner();
     File encodingProfile = getFile("/encodingprofiles.properties");
@@ -240,7 +249,7 @@ public class ComposerServiceTest {
 
     // Need different media files
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.get(EasyMock.anyObject())).andReturn(sourceVideoOnly).anyTimes();
+    EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.anyBoolean())).andReturn(sourceVideoOnly).anyTimes();
     EasyMock.expect(workspace.putInCollection(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject()))
             .andReturn(sourceVideoOnly.toURI()).anyTimes();
     composerService.setWorkspace(workspace);
@@ -256,7 +265,7 @@ public class ComposerServiceTest {
 
     // Need different media files
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.get(EasyMock.anyObject())).andReturn(sourceVideoOnly).anyTimes();
+    EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.anyBoolean())).andReturn(sourceVideoOnly).anyTimes();
     EasyMock.expect(workspace.putInCollection(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject()))
             .andReturn(sourceVideoOnly.toURI()).anyTimes();
     composerService.setWorkspace(workspace);
@@ -273,7 +282,7 @@ public class ComposerServiceTest {
 
     // Need different media files
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.get(EasyMock.anyObject())).andReturn(sourceVideoOnly).anyTimes();
+    EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.anyBoolean())).andReturn(sourceVideoOnly).anyTimes();
     EasyMock.expect(workspace.putInCollection(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject()))
             .andReturn(sourceVideoOnly.toURI()).anyTimes();
     composerService.setWorkspace(workspace);
@@ -290,8 +299,8 @@ public class ComposerServiceTest {
 
     // Need different media files
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.get(EasyMock.anyObject())).andReturn(sourceVideoOnly).once();
-    EasyMock.expect(workspace.get(EasyMock.anyObject())).andReturn(sourceAudioOnly).once();
+    EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.anyBoolean())).andReturn(sourceVideoOnly).once();
+    EasyMock.expect(workspace.get(EasyMock.anyObject(), EasyMock.anyBoolean())).andReturn(sourceAudioOnly).once();
     EasyMock.expect(workspace.putInCollection(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject()))
             .andReturn(sourceVideoOnly.toURI()).anyTimes();
     composerService.setWorkspace(workspace);


### PR DESCRIPTION
When extracting multiple thumbnails during one workflow operation in the composer service, load the track into the workspace with a unique id so the different jobs don't step on each other's toes.

_This work was sponsored by SWITCH._