### PR TITLE
MH-13344 Enable AssetManager to reply NOT_MODIFIED

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/Asset.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/Asset.java
@@ -20,6 +20,7 @@
  */
 package org.opencastproject.assetmanager.api;
 
+import org.opencastproject.util.Checksum;
 import org.opencastproject.util.MimeType;
 
 import com.entwinemedia.fn.data.Opt;
@@ -53,4 +54,7 @@ public interface Asset {
 
   /** Get the store ID of the asset store where this snapshot currently lives */
   String getStorageId();
+
+  /** Get the checksum */
+  Checksum getChecksum();
 }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
@@ -75,6 +75,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 
 /**
@@ -154,13 +155,22 @@ public abstract class AbstractAssetManager implements AssetManager {
     // try to fetch the asset
     for (final AssetDtos.Medium asset : getDb().getAsset(RuntimeTypes.convert(version), mpId, mpeId)) {
       for (final InputStream assetStream : getLocalAssetStore().get(StoragePath.mk(asset.getOrganizationId(), mpId, version, mpeId))) {
+
+        Checksum checksum = null;
+        try {
+          checksum = Checksum.fromString(asset.getAssetDto().getChecksum());
+        } catch (NoSuchAlgorithmException e) {
+          logger.warn("Invalid checksum for asset {} of media package {}", e, mpeId, mpId);
+        }
+
         final Asset a = new AssetImpl(
                 AssetId.mk(version, mpId, mpeId),
                 assetStream,
                 asset.getAssetDto().getMimeType(),
                 asset.getAssetDto().getSize(),
                 asset.getStorageId(),
-                asset.getAvailability());
+                asset.getAvailability(),
+                checksum);
         return Opt.some(a);
       }
     }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManagerWithTieredStorage.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManagerWithTieredStorage.java
@@ -39,6 +39,7 @@ import org.opencastproject.assetmanager.impl.storage.DeletionSelector;
 import org.opencastproject.assetmanager.impl.storage.Source;
 import org.opencastproject.assetmanager.impl.storage.StoragePath;
 import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.util.Checksum;
 import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.RequireUtil;
@@ -56,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
@@ -326,13 +328,22 @@ public abstract class AbstractAssetManagerWithTieredStorage extends AbstractAsse
       for (final String storageId : getSnapshotStorageLocation(version, mpId)) {
         for (final AssetStore store : getAssetStore(storageId)) {
           for (final InputStream assetStream : store.get(StoragePath.mk(asset.getOrganizationId(), mpId, version, mpeId))) {
+
+            Checksum checksum = null;
+            try {
+              checksum = Checksum.fromString(asset.getAssetDto().getChecksum());
+            } catch (NoSuchAlgorithmException e) {
+              logger.warn("Invalid checksum for asset {} of media package {}", e, mpeId, mpId);
+            }
+
             final Asset a = new AssetImpl(
                     AssetId.mk(version, mpId, mpeId),
                     assetStream,
                     asset.getAssetDto().getMimeType(),
                     asset.getAssetDto().getSize(),
                     asset.getStorageId(),
-                    asset.getAvailability());
+                    asset.getAvailability(),
+                    checksum);
             return Opt.some(a);
           }
         }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetImpl.java
@@ -23,6 +23,7 @@ package org.opencastproject.assetmanager.impl;
 import org.opencastproject.assetmanager.api.Asset;
 import org.opencastproject.assetmanager.api.AssetId;
 import org.opencastproject.assetmanager.api.Availability;
+import org.opencastproject.util.Checksum;
 import org.opencastproject.util.MimeType;
 
 import com.entwinemedia.fn.data.Opt;
@@ -36,6 +37,7 @@ public class AssetImpl implements Asset {
   private final long size;
   private final Availability availability;
   private final String storageId;
+  private final Checksum checksum;
 
   public AssetImpl(
           AssetId id,
@@ -43,13 +45,15 @@ public class AssetImpl implements Asset {
           Opt<MimeType> mimeType,
           long size,
           String storeId,
-          Availability availability) {
+          Availability availability,
+          Checksum checksum) {
     this.id = id;
     this.in = in;
     this.mimeType = mimeType;
     this.size = size;
     this.availability = availability;
     this.storageId = storeId;
+    this.checksum = checksum;
   }
 
   @Override public AssetId getId() {
@@ -73,4 +77,9 @@ public class AssetImpl implements Asset {
   }
 
   @Override public String getStorageId() { return storageId; }
+
+  @Override
+  public Checksum getChecksum() {
+    return checksum;
+  }
 }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/AssetDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/AssetDto.java
@@ -93,6 +93,10 @@ public class AssetDto {
     return mediaPackageElementId;
   }
 
+  public String getChecksum() {
+    return checksum;
+  }
+
   public Opt<MimeType> getMimeType() {
     return Conversions.toMimeType(mimeType);
   }

--- a/modules/common/src/main/java/org/opencastproject/util/Checksum.java
+++ b/modules/common/src/main/java/org/opencastproject/util/Checksum.java
@@ -139,6 +139,28 @@ public final class Checksum implements Serializable {
   }
 
   /**
+   * Creates a checksum from a string in the form "value (type)".
+   *
+   * @param checksum
+   *         the checksum in string form
+   * @return the checksum
+   * @throws NoSuchAlgorithmException
+   *           if the checksum of the specified type cannot be created
+   */
+  public static Checksum fromString(String checksum) throws NoSuchAlgorithmException {
+    String[] checksumParts = checksum.split(" ");
+
+    if (checksumParts.length != 2) {
+      throw new IllegalArgumentException("Invalid string for checksum!");
+    }
+
+    String value = checksumParts[0];
+    String type = checksumParts[1].replace("(","").replace(")", "");
+
+    return create(type, value);
+  }
+
+  /**
    * Creates a checksum of type <code>type</code> and value <code>value</code>.
    *
    * @param type


### PR DESCRIPTION
This enables the Asset Manager to reply NOT_MODIFIED in case the Workspace already has the file with a matching md5 hash, similarly to how the Working File Repository does it.