### PR TITLE
add docs.opencast.org anchors for somewhat deep linking

### DIFF
--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -194,5 +194,9 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.js"></script>
+    <script type=application/javascript>
+        anchors.add();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
This patch allows for links to the projects docs page jumping to the relevant part of the website. example: https://docs.opencast.org/#communication-help