### PR TITLE
MH-12533, Re-introduce ability to preserved Admin UI side edits to scheduled events  (5x)

### DIFF
--- a/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
+++ b/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
@@ -6,9 +6,14 @@
 # In both cases, the series catalog will be created if it does not already exist in Opencast
 # In both cases, the catalog for the episode will be created in Opencast
 
-# TODO: consider moving this key to the system.properties if used by other services, such as mediapackage update
+# MH-12533 Option to prevent ingested flavors (except for tracks) to be overritten during ingest.
+# If true (default), ingested elements that match existing flavors take precedence and overwrite the existing.
+#    For example, metadata changes made from a capture agent UI will override metadata changes made from the Admin UI prior to the ingest.
+# If false, tracks and only new element flavors are accepted from the ingested mp. Existing flavors, like episode and series catalogs,
+#    are not overwritten and retain all updates made from the Admin UI.
+#    Changed the default from true to false to allow metadata edits from the Admin UI to take precedence.
 
-org.opencastproject.series.overwrite=true
+org.opencastproject.ingest.overwrite=true
 
 #The approximate load placed on the system by ingesting a file
 #Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node

--- a/modules/ingest-service-impl/src/test/resources/source-manifest.xml
+++ b/modules/ingest-service-impl/src/test/resources/source-manifest.xml
@@ -35,4 +35,15 @@
       <checksum type="md5">6d535f61a1b31a3edeb01be0951a2b4e</checksum>
     </attachment>    
   </attachments>
+  <!-- test with live pub in asset manager -->
+  <publications>
+    <publication id="1004b8ad-a794-4a6c-93e2-073b80a2eb7f" channel="engage-live">
+      <mimetype>text/html</mimetype>
+        <tags/>
+        <url>http://opencast.acme.edu/engage/player/watch.html?id=537fec50-690a-4dee-a4ce-528ae90c1f9c</url>
+        <media/>
+        <attachments/>
+        <metadata/>
+      </publication>
+   </publications>
 </mediapackage>


### PR DESCRIPTION
This provides site the option of editing the metadata of a schedule event in the Admin UI, prior to ingest, and not loosing the edits upon ingest. Currently, the capture agent's catalogs take precedence over Asset Managed catalogs upon ingest. This allows users to make edits to metadata fro the Capture Agent UI. For sites that don't perform edits from the CA UI, but do from the Admin UI, prior to ingest. This option enforces preservation of the admin UI edits for sites that choose to change the default to true (existing behavior) to false.

This pull bundles preservation of all flavors except tracks on the Admin side. 
