### PR TITLE
Documentation: Publish Engage Workflow OH

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-engage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-engage-woh.md
@@ -10,21 +10,21 @@ download, …)
 Parameter Table
 ---------------
 
-|configuration keys         |description                                                                   |
-|---------------------------|------------------------------------------------------------------------------|
-|check-availability         |Check if the media if reachable                                               |
-|download-source-flavors    |Specifies which media should be published for download                        |
-|download-source-tags       |Specifies which media should be published for download                        |
-|download-target-subflavors |Subflavor to use for distributed material                                     |
-|download-target-tags       |Modify tags of published media                                                |
-|strategy                   |If there is no key, published media would be retracted before publishing      |
-|                           |`<configuration key="strategy">merge</configuration>`                         |
-|                           |merges new publication with existing publication                              |
-|streaming-source-flavors   |Specifies which media should be published to the streaming server             |
-|streaming-source-tags      |Specifies which media should be published to the streaming server             |
-|streaming-target-tags      |Modify tags of published media                                                |
-|streaming-target-subflavors|Subflavor to use for distributed material                                     |
-|merge-force-flavors        |Flavors of elements for which an update is enforced when mergeing catalogs.   |
+|configuration keys         |description                                                                                  |
+|---------------------------|---------------------------------------------------------------------------------------------|
+|check-availability         |Check if the media if reachable                                                              |
+|download-source-flavors    |Distribute any mediapackage elements with one of these (comma separated) flavors to download |
+|download-source-tags       |Distribute any mediapackage elements with one of these (comma separated) tags to download    |
+|download-target-subflavors |Subflavor to use for distributed material                                                    |
+|download-target-tags       |Add tags (comma separated) to published media                                                |
+|strategy                   |If there is no key, published media would be retracted before publishing                     |
+|                           |`<configuration key="strategy">merge</configuration>`                                        |
+|                           |merges new publication with existing publication                                             |
+|streaming-source-flavors   |Specifies which media should be published to the streaming server                            |
+|streaming-source-tags      |Specifies which media should be published to the streaming server                            |
+|streaming-target-tags      |Add tags (comma separated) to published media                                                |
+|streaming-target-subflavors|Subflavor to use for distributed material                                                    |
+|merge-force-flavors        |Flavors of elements for which an update is enforced when mergeing catalogs.                  |
 |                           |Defaults to `dublincore/*,security/*`.
 
 Operation Example

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -184,7 +184,7 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
     CONFIG_OPTIONS.put(STREAMING_SOURCE_TAGS,
             "Distribute any mediapackage elements with one of these (comma separated) tags to streaming.");
     CONFIG_OPTIONS.put(STREAMING_TARGET_TAGS,
-            "Add all of these comma separated tags to elements that have been distributed for download.");
+            "Add all of these comma separated tags to elements that have been distributed for streaming.");
     CONFIG_OPTIONS.put(CHECK_AVAILABILITY,
             "( true | false ) defaults to true. Check if the distributed download artifact is available at its URL");
     CONFIG_OPTIONS.put(STRATEGY,


### PR DESCRIPTION
The *-target-tags are always added and the syntax from the tag WOH
allowing removal of tags does not work on the Publish Engage WOH.

Also clarify and fix some other documentation related to this WOH.