### PR TITLE
Revert "MH-13243, Asset Manager ACL Cache Updates"

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
@@ -210,17 +210,10 @@ public class AssetManagerWithSecurity extends AssetManagerDecorator {
   }
 
   private void storeAclAsProperties(Snapshot snapshot, AccessControlList acl) {
-    final String mediaPackageId =  snapshot.getMediaPackage().getIdentifier().toString();
-    // Drop old ACL rules
-    final AQueryBuilder queryBuilder = createQuery();
-    queryBuilder.delete(snapshot.getOwner(), queryBuilder.propertiesOf(SECURITY_NAMESPACE))
-            .where(queryBuilder.mediaPackageId(mediaPackageId))
-            .run();
-    // Set new ACL rules
     for (final AccessControlEntry ace : acl.getEntries()) {
       super.setProperty(Property.mk(
           PropertyId.mk(
-              mediaPackageId,
+              snapshot.getMediaPackage().getIdentifier().toString(),
               SECURITY_NAMESPACE,
               mkPropertyName(ace)),
           Value.mk(ace.isAllow())));


### PR DESCRIPTION
This reverts commit 271df274c22423e73dd43f89f6ee3206b61230d6 because is causes massive performance problems in systems that have large number of objects in the tables oc_assets_asset and oc_assets_properties.

The problem addressed by MH-13243 should be fixed at some point of time, but as we don't have this on our radar in the near future (and it does not seem like anybody else does), it's probably best to revert it for now.

@wsmirnow & @ts23 (5.x) and @mtneug & @lkiesow (6.x): This is a highly critical release blocker that essentially totally breaks Opencast if the tables mentioned above are large enough.