### PR TITLE
MH-13310, Simplify `AQueryBuilderImpl#always`

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
@@ -47,6 +47,7 @@ import com.entwinemedia.fn.Fn;
 import com.entwinemedia.fn.Stream;
 import com.entwinemedia.fn.data.Opt;
 import com.mysema.query.jpa.impl.JPAQueryFactory;
+import com.mysema.query.support.Expressions;
 import com.mysema.query.types.expr.BooleanExpression;
 
 import java.util.Date;
@@ -322,14 +323,12 @@ public final class AQueryBuilderImpl implements AQueryBuilder, EntityPaths {
     return new AbstractPredicate() {
       /* SELECT */
       @Override public SelectQueryContribution contributeSelect(JPAQueryFactory f) {
-        // could not find a boolean expression being constantly true, so use this as a workaround
-        return SelectQueryContribution.mk().where(Q_SNAPSHOT.eq(Q_SNAPSHOT));
+        return SelectQueryContribution.mk().where(Expressions.booleanTemplate("true = true"));
       }
 
       /* DELETE */
       @Override public DeleteQueryContribution contributeDelete(String owner) {
-        // could not find a boolean expression being constantly true, so use this as a workaround
-        return DeleteQueryContribution.mk().where(Q_SNAPSHOT.eq(Q_SNAPSHOT));
+        return DeleteQueryContribution.mk().where(Expressions.booleanTemplate("true = true"));
       }
     };
   }


### PR DESCRIPTION
The previous implementation basically created a predicate of the form
`q == q`, where `q` is some query variable (here `Q_SNAPSHOT`),
to create a predicate that is always true.
This works but introduces `q` as a variable in the `WHERE` clause
of every query that uses this combinator, which in turn requires
a matching declaration in the `FROM` clause, even though a query
in might not even need `q`.

The new implementation is still a bit roundabout. I would have
preferred the empty condition to just look like `true` when rendered
to SQL, but that is not valid JPQL. `true = true` works, though.

@JulianKniephoff, please forgive me, I bluntly stole your commit from the closed pull request #650 since I think that this one does make sense in any case.