### PR TITLE
MH-13354, Asset Manager Property Performance

### DIFF
--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestTasksEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestTasksEndpoint.java
@@ -144,7 +144,7 @@ public class TestTasksEndpoint extends TasksEndpoint {
 
   AssetManager mkAssetManager(final Workspace workspace) throws Exception {
     final PersistenceEnv penv = PersistenceEnvs.mk(mkEntityManagerFactory("org.opencastproject.assetmanager.impl"));
-    final Database db = new Database(penv);
+    final Database db = new Database(null, penv);
     return new AbstractAssetManager() {
       @Override
       public HttpAssetProvider getHttpAssetProvider() {

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
@@ -96,6 +96,24 @@ public interface AssetManager {
    */
   boolean setProperty(Property property);
 
+  /**
+   * Delete all properties for a given media package identifier
+   *
+   * @param mediaPackageId
+   *          Media package identifier
+   */
+  void deleteProperties(String mediaPackageId);
+
+  /**
+   * Delete all properties for a given media package identifier and namespace.
+   *
+   * @param mediaPackageId
+   *          Media package identifier
+   * @param namespace
+   *          A namespace prefix to use for deletion
+   */
+  void deleteProperties(String mediaPackageId, String namespace);
+
   /** Create a new query builder. */
   AQueryBuilder createQuery();
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
@@ -146,6 +146,16 @@ public abstract class AbstractAssetManager implements AssetManager {
     return getDb().saveProperty(property);
   }
 
+  @Override
+  public void deleteProperties(final String mediaPackageId) {
+    getDb().deleteProperties(mediaPackageId);
+  }
+
+  @Override
+  public void deleteProperties(final String mediaPackageId, final String namespace) {
+    getDb().deleteProperties(mediaPackageId, namespace);
+  }
+
   @Override public AQueryBuilder createQuery() {
     return new AQueryBuilderImpl(this);
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
@@ -64,6 +64,16 @@ public class AssetManagerDecorator<A extends TieredStorageAssetManager> implemen
     return delegate.setProperty(property);
   }
 
+  @Override
+  public void deleteProperties(final String mediaPackageId) {
+    delegate.deleteProperties(mediaPackageId);
+  }
+
+  @Override
+  public void deleteProperties(final String mediaPackageId, final String namespace) {
+    delegate.deleteProperties(mediaPackageId, namespace);
+  }
+
   @Override public AQueryBuilder createQuery() {
     return delegate.createQuery();
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerWithSecurity.java
@@ -77,6 +77,7 @@ public class AssetManagerWithSecurity extends AssetManagerDecorator<TieredStorag
   }
 
   @Override public Snapshot takeSnapshot(String owner, MediaPackage mp) {
+
     final String mediaPackageId = mp.getIdentifier().toString();
     final AQueryBuilder q = q();
     final AResult r = q.select(q.snapshot())
@@ -208,13 +209,18 @@ public class AssetManagerWithSecurity extends AssetManagerDecorator<TieredStorag
     GLOBAL, ORGANIZATION, NONE
   }
 
+  /**
+   * Update the ACL properties. Note that this method assumes proper proper authorization.
+   *
+   * @param snapshot
+   *          Snapshot to reference the media package identifier
+   * @param acl
+   *          ACL to set
+   */
   private void storeAclAsProperties(Snapshot snapshot, AccessControlList acl) {
     final String mediaPackageId =  snapshot.getMediaPackage().getIdentifier().toString();
     // Drop old ACL rules
-    final AQueryBuilder queryBuilder = createQuery();
-    queryBuilder.delete(snapshot.getOwner(), queryBuilder.propertiesOf(SECURITY_NAMESPACE))
-            .where(queryBuilder.mediaPackageId(mediaPackageId))
-            .run();
+    super.deleteProperties(mediaPackageId, SECURITY_NAMESPACE);
     // Set new ACL rules
     for (final AccessControlEntry ace : acl.getEntries()) {
       super.setProperty(Property.mk(

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
@@ -39,7 +39,6 @@ import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.util.NotFoundException;
-import org.opencastproject.util.persistencefn.PersistenceEnvs;
 import org.opencastproject.workspace.api.Workspace;
 
 import com.entwinemedia.fn.data.Opt;
@@ -86,7 +85,7 @@ public class OsgiAssetManager implements AssetManager, TieredStorageAssetManager
   /** OSGi callback. */
   public synchronized void activate(ComponentContext cc) {
     logger.info("Activating AssetManager");
-    final Database db = new Database(PersistenceEnvs.mk(emf));
+    final Database db = new Database(emf);
     final String systemUserName = SecurityUtil.getSystemUserName(cc);
     // create the core asset manager
     final AbstractAssetManagerWithTieredStorage core = new AbstractAssetManagerWithTieredStorage() {
@@ -198,6 +197,16 @@ public class OsgiAssetManager implements AssetManager, TieredStorageAssetManager
   @Override
   public boolean setProperty(Property property) {
     return delegate.setProperty(property);
+  }
+
+  @Override
+  public void deleteProperties(final String mediaPackageId) {
+    delegate.deleteProperties(mediaPackageId);
+  }
+
+  @Override
+  public void deleteProperties(final String mediaPackageId, final String namespace) {
+    delegate.deleteProperties(mediaPackageId, namespace);
   }
 
   @Override

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
@@ -30,6 +30,7 @@ import org.opencastproject.assetmanager.impl.persistence.AssetDtos.Full;
 import org.opencastproject.assetmanager.impl.persistence.AssetDtos.Medium;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.util.persistencefn.PersistenceEnv;
+import org.opencastproject.util.persistencefn.PersistenceEnvs;
 import org.opencastproject.util.persistencefn.PersistenceUtil;
 import org.opencastproject.util.persistencefn.PersistenceUtil.DatabaseVendor;
 import org.opencastproject.util.persistencefn.Queries;
@@ -46,6 +47,7 @@ import com.mysema.query.jpa.impl.JPAQueryFactory;
 import com.mysema.query.jpa.impl.JPAUpdateClause;
 import com.mysema.query.types.expr.BooleanExpression;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +57,7 @@ import java.util.Date;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.inject.Provider;
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 /**
  * Data access object.
@@ -66,9 +69,16 @@ public class Database implements EntityPaths {
   public static final JPQLTemplates TEMPLATES = EclipseLinkTemplates.DEFAULT;
 
   private final PersistenceEnv penv;
+  private final EntityManagerFactory entityManagerFactory;
 
-  public Database(PersistenceEnv penv) {
-    this.penv = penv;
+  public Database(EntityManagerFactory emf, PersistenceEnv persistenceEnv) {
+    penv = persistenceEnv;
+    entityManagerFactory = emf;
+  }
+
+  public Database(EntityManagerFactory emf) {
+    penv = PersistenceEnvs.mk(emf);
+    entityManagerFactory = emf;
   }
 
   /**
@@ -313,6 +323,32 @@ public class Database implements EntityPaths {
         return Opt.nul(result).map(Full.fromTuple);
       }
     });
+  }
+
+  /**
+   * Delete all properties for a given media package identifier
+   *
+   * @param mediaPackageId
+   *          Media package identifier
+   */
+  public void deleteProperties(final String mediaPackageId) {
+    PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId);
+  }
+
+  /**
+   * Delete all properties for a given media package identifier and namespace.
+   *
+   * @param mediaPackageId
+   *          Media package identifier
+   * @param namespace
+   *          A namespace prefix to use for deletion
+   */
+  public void deleteProperties(final String mediaPackageId, final String namespace) {
+    if (StringUtils.isBlank(namespace)) {
+      PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId);
+    } else {
+      PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId, namespace);
+    }
   }
 
   public Opt<AssetDtos.Full> findAssetByChecksumAndStore(final String checksum, final String storeId) {

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/PropertyDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/PropertyDto.java
@@ -29,20 +29,33 @@ import org.opencastproject.assetmanager.impl.RuntimeTypes;
 import com.entwinemedia.fn.Fn;
 import com.entwinemedia.fn.Fx;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.TypedQuery;
 
 @Entity(name = "Property")
 @Table(name = "oc_assets_properties")
-
+@NamedQueries({
+    @NamedQuery(name = "Property.delete", query = "delete from Property p where p.mediaPackageId = :mediaPackageId"),
+    @NamedQuery(name = "Property.deleteByNamespace", query = "delete from Property p "
+            + "where p.mediaPackageId = :mediaPackageId and p.namespace = :namespace")})
 public class PropertyDto {
+  private static final Logger logger = LoggerFactory.getLogger(PropertyDto.class);
+
   /** Surrogate key. */
   @Id
   @GeneratedValue
@@ -141,5 +154,26 @@ public class PropertyDto {
                 dto.longValue = RuntimeTypes.convert(a).value();
               }
             }.toFn());
+  }
+
+  public static void delete(EntityManager em, final String mediaPackageId) {
+    delete(em, mediaPackageId, null);
+  }
+
+  public static void delete(EntityManager em, final String mediaPackageId, final String namespace) {
+    TypedQuery<PropertyDto> query;
+    if (namespace == null) {
+      query = em.createNamedQuery("Property.delete", PropertyDto.class)
+              .setParameter("mediaPackageId", mediaPackageId);
+    } else {
+      query = em.createNamedQuery("Property.deleteByNamespace", PropertyDto.class)
+              .setParameter("mediaPackageId", mediaPackageId)
+              .setParameter("namespace", namespace);
+    }
+    logger.debug("Executing query {}", query);
+    EntityTransaction tx = em.getTransaction();
+    tx.begin();
+    query.executeUpdate();
+    tx.commit();
   }
 }

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AbstractTieredStorageAssetManagerTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AbstractTieredStorageAssetManagerTest.java
@@ -53,6 +53,9 @@ import java.util.Random;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.TypedQuery;
 
 public class AbstractTieredStorageAssetManagerTest<A extends TieredStorageAssetManager> extends AssetManagerTestBase<A> {
   public static final String LOCAL_STORE_ID = "local-test";
@@ -77,7 +80,18 @@ public class AbstractTieredStorageAssetManagerTest<A extends TieredStorageAssetM
         return null;
       }
     });
-    final Database db = new Database(penv);
+
+    final EntityManagerFactory emf = EasyMock.createMock(EntityManagerFactory.class);
+    final EntityManager em = EasyMock.createMock(EntityManager.class);
+    final TypedQuery query = EasyMock.createMock(TypedQuery.class);
+    final EntityTransaction tx = EasyMock.createNiceMock(EntityTransaction.class);
+    EasyMock.expect(emf.createEntityManager()).andReturn(em).anyTimes();
+    EasyMock.expect(em.createNamedQuery(EasyMock.anyString(), EasyMock.anyObject())).andReturn(query).anyTimes();
+    EasyMock.expect(em.getTransaction()).andReturn(tx).anyTimes();
+    EasyMock.expect(query.setParameter(EasyMock.anyString(), EasyMock.anyString())).andReturn(query).anyTimes();
+    EasyMock.expect(query.executeUpdate()).andReturn(0).anyTimes();
+    EasyMock.replay(emf, em, query, tx);
+    final Database db = new Database(emf, penv);
     //
     final Workspace workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.get(EasyMock.anyObject(URI.class)))

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerTestBase.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerTestBase.java
@@ -280,7 +280,7 @@ public abstract class AssetManagerTestBase<A extends AssetManager> {
         return null;
       }
     });
-    final Database db = new Database(penv);
+    final Database db = new Database(null, penv);
     //
     final Workspace workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.get(EasyMock.anyObject(URI.class)))

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -2496,7 +2496,7 @@ public class SchedulerServiceImplTest {
 
   AssetManager mkAssetManager() throws Exception {
     final PersistenceEnv penv = PersistenceEnvs.mk(mkEntityManagerFactory("org.opencastproject.assetmanager.impl"));
-    final Database db = new Database(penv);
+    final Database db = new Database(null, penv);
     return new AbstractAssetManager() {
 
       @Override


### PR DESCRIPTION
All asset manager delete queries suffer from very poor performance in
large systems since they always probing for orphaned properties of any
media packages and will always create a joined table of all snapshots
and all properties in the process, even if it is completely unnecessary
like in the case of updating the ACL properties.

This patch fixes the problem by introducing a way to directly delete
specific properties in a single, well performing database query.