### PR TITLE
MH-13357 Enable being able to disable 2 confusing Admin UI metadata: "duration" & "created"

### DIFF
--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -85,7 +85,7 @@ property.description.readOnly=false
 property.description.required=false
 property.description.order=2
 
-# A Duration property (Display is optional)
+# A Duration property
 property.duration.inputID=temporal
 property.duration.outputID=duration
 property.duration.label=EVENTS.EVENTS.DETAILS.METADATA.DURATION
@@ -94,7 +94,7 @@ property.duration.readOnly=false
 property.duration.required=false
 property.duration.order=11
 
-# A Start Date property (Display is required)
+# A Start Date property
 property.startDate.inputID=temporal
 property.startDate.outputID=startDate
 property.startDate.label=EVENTS.EVENTS.DETAILS.METADATA.START_DATE
@@ -120,7 +120,7 @@ property.source.readOnly=false
 property.source.required=false
 property.source.order=13
 
-# Created (Display is optional)
+# Created
 property.created.inputID=created
 property.created.label=EVENTS.EVENTS.DETAILS.METADATA.CREATED
 property.created.type=date

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -85,7 +85,7 @@ property.description.readOnly=false
 property.description.required=false
 property.description.order=2
 
-# A Duration property
+# A Duration property (Display is optional)
 property.duration.inputID=temporal
 property.duration.outputID=duration
 property.duration.label=EVENTS.EVENTS.DETAILS.METADATA.DURATION
@@ -94,7 +94,7 @@ property.duration.readOnly=false
 property.duration.required=false
 property.duration.order=11
 
-# A Start Date property
+# A Start Date property (Display is required)
 property.startDate.inputID=temporal
 property.startDate.outputID=startDate
 property.startDate.label=EVENTS.EVENTS.DETAILS.METADATA.START_DATE
@@ -120,7 +120,7 @@ property.source.readOnly=false
 property.source.required=false
 property.source.order=13
 
-# Created
+# Created (Display is optional)
 property.created.inputID=created
 property.created.label=EVENTS.EVENTS.DETAILS.METADATA.CREATED
 property.created.type=date

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
@@ -78,8 +78,10 @@ public final class DublinCoreMetadataUtil {
         if (field.getType() == MetadataField.Type.START_DATE) {
           setStartDate(dc, field, ename);
         } else if (field.getType() == MetadataField.Type.DURATION) {
+          // WARN: the duration change assumes the catalog's start date is already up to date.
           setDuration(dc, field, ename);
         } else if (field.getType() == Type.DATE) {
+          // Skip over metadata field tagged with key "created".
           // DC created should only be modified by changing the start date, see MH-12250
           if (! DublinCore.PROPERTY_CREATED.equals(ename))
             setDate(dc, field, ename);
@@ -268,7 +270,7 @@ public final class DublinCoreMetadataUtil {
     if (duration < 1L) {
       duration = getDuration(period);
     }
-    // Get the current start date
+    // Get the current start date (WARN: this assumes any start time updates have already been performed)
     DateTime startDateTime = getCurrentStartDateTime(period);
     // Get the current end date based on new date and duration.
     DateTime endDate = new DateTime(startDateTime.toDate().getTime() + duration);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/events/CommonEventCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/events/CommonEventCatalogUIAdapter.java
@@ -92,6 +92,7 @@ public class CommonEventCatalogUIAdapter extends ConfigurableEventDCCatalogUIAda
       }
     }
 
+    // Mediapackage start date is set by event metadata start date. The "created" metadata field is not used.
     MetadataField<?> startDate = abstractMetadata.getOutputFields().get("startDate");
     if (startDate != null && startDate.getValue().isSome() && startDate.isUpdated()
             && isNotBlank(startDate.getValue().get().toString())) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -856,8 +856,13 @@ public class IndexServiceImpl implements IndexService {
       eventMetadata.addField(newStartDate);
     }
 
+    // This field is null when it is not used in the Admin UI event details metadata tab.
+    // If used, set it to the the start Date or a new date.
+    // Note, even though this field borrows the DublinCore.PROPERTY_CREATED key,
+    // the startDate is used to update the DublinCore catalog PROPERTY_CREATED field,
+    // event, and mediapackage start fields.
     MetadataField<?> created = eventMetadata.getOutputFields().get(DublinCore.PROPERTY_CREATED.getLocalName());
-    if (created == null || !created.isUpdated() || created.getValue().isNone()) {
+    if (created != null && (!created.isUpdated() || created.getValue().isNone())) {
       eventMetadata.removeField(created);
       MetadataField<String> newCreated = MetadataUtils.copyMetadataField(created);
       if (currentStartDate != null) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
@@ -159,7 +159,8 @@ public final class EventUtils {
       }
     }
 
-    if (event.getDuration() != null) {
+    // The duration event details metadata is an optional display field
+    if (metadata.getOutputFields().containsKey("duration")  && event.getDuration() != null) {
       MetadataField<?> duration = metadata.getOutputFields().get("duration");
       metadata.removeField(duration);
       MetadataField<String> newDuration = MetadataUtils.copyMetadataField(duration);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventUtils.java
@@ -159,7 +159,6 @@ public final class EventUtils {
       }
     }
 
-    // The duration event details metadata is an optional display field
     if (metadata.getOutputFields().containsKey("duration")  && event.getDuration() != null) {
       MetadataField<?> duration = metadata.getOutputFields().get("duration");
       metadata.removeField(duration);


### PR DESCRIPTION
These 2 fields throw NullPointer currently, when omitted from  org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg.
But, there is no technical reason why they need to be required in the Event Details Metadata display.

Making them optional allows sites to reduce confusion they can cause to users.  Display of "duration" display cause confusion with actual published and uploaded media duration times and does not correspond to a changed schedule time. The "created' display causes confusion with schedule, event, media package start time, and published event start time.