### PR TITLE
MH-13359 Adding UTF-8 encoding for all remote services

### DIFF
--- a/modules/animate-remote/src/main/java/org/opencastproject/animate/remote/AnimateServiceRemoteImpl.java
+++ b/modules/animate-remote/src/main/java/org/opencastproject/animate/remote/AnimateServiceRemoteImpl.java
@@ -73,7 +73,7 @@ public class AnimateServiceRemoteImpl extends RemoteBase implements AnimateServi
     HttpResponse response = null;
     try {
       HttpPost post = new HttpPost("/animate");
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
       response = getResponse(post);
       if (response == null) {
         throw new AnimateServiceException("No response from service");

--- a/modules/caption-remote/src/main/java/org/opencastproject/caption/remote/CaptionServiceRemoteImpl.java
+++ b/modules/caption-remote/src/main/java/org/opencastproject/caption/remote/CaptionServiceRemoteImpl.java
@@ -84,7 +84,7 @@ public class CaptionServiceRemoteImpl extends RemoteBase implements CaptionServi
       params.add(new BasicNameValuePair("output", outputFormat));
       if (StringUtils.isNotBlank(language))
         params.add(new BasicNameValuePair("language", language));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new CaptionConverterException(e);
     }
@@ -117,7 +117,7 @@ public class CaptionServiceRemoteImpl extends RemoteBase implements CaptionServi
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("captions", MediaPackageElementParser.getAsXml(input)));
       params.add(new BasicNameValuePair("input", format));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new CaptionConverterException(e);
     }

--- a/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
+++ b/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
@@ -87,7 +87,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       List<BasicNameValuePair> params = new ArrayList<>();
       params.add(new BasicNameValuePair("sourceTrack", MediaPackageElementParser.getAsXml(sourceTrack)));
       params.add(new BasicNameValuePair("profileId", profileId));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException("Unable to assemble a remote composer request for track " + sourceTrack, e);
     }
@@ -118,7 +118,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       List<BasicNameValuePair> params = new ArrayList<>();
       params.add(new BasicNameValuePair("sourceTrack", MediaPackageElementParser.getAsXml(sourceTrack)));
       params.add(new BasicNameValuePair("profileId", profileId));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException("Unable to assemble a remote composer request for track " + sourceTrack, e);
     }
@@ -153,7 +153,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       params.add(new BasicNameValuePair("profileId", profileId));
       params.add(new BasicNameValuePair("start", Long.toString(start)));
       params.add(new BasicNameValuePair("duration", Long.toString(duration)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException("Unable to assemble a remote composer request for track " + sourceTrack, e);
     }
@@ -188,7 +188,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       params.add(new BasicNameValuePair("videoSourceTrack", MediaPackageElementParser.getAsXml(sourceVideoTrack)));
       params.add(new BasicNameValuePair("audioSourceTrack", MediaPackageElementParser.getAsXml(sourceAudioTrack)));
       params.add(new BasicNameValuePair("profileId", profileId));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException("Unable to assemble a remote composer request", e);
     }
@@ -244,7 +244,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       params.add(new BasicNameValuePair("sourceTrack", MediaPackageElementParser.getAsXml(sourceTrack)));
       params.add(new BasicNameValuePair("profileId", profileId));
       params.add(new BasicNameValuePair("time", buildTimeArray(times)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException(e);
     }
@@ -273,7 +273,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       params.add(new BasicNameValuePair("sourceTrack", MediaPackageElementParser.getAsXml(sourceTrack)));
       params.add(new BasicNameValuePair("profileId", profileId));
       params.add(new BasicNameValuePair("time", buildTimeArray(times)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException(e);
     }
@@ -310,7 +310,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       params.add(new BasicNameValuePair("profileId", profileId));
       if (properties != null)
         params.add(new BasicNameValuePair("properties", mapToString(properties)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException(e);
     }
@@ -344,7 +344,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("sourceImage", MediaPackageElementParser.getAsXml(image)));
       params.add(new BasicNameValuePair("profileId", StringUtils.join(profileIds, ',')));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException(e);
     }
@@ -371,7 +371,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("sourceImage", MediaPackageElementParser.getAsXml(image)));
       params.add(new BasicNameValuePair("profileId", profileId));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException(e);
     }
@@ -562,7 +562,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("sourceTrack", MediaPackageElementParser.getAsXml(sourceTrack)));
       params.add(new BasicNameValuePair("profileId", profileId));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException("Unable to assemble a remote demux request for track " + sourceTrack, e);
     }
@@ -621,7 +621,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("sourceTrack", MediaPackageElementParser.getAsXml(sourceTrack)));
       params.add(new BasicNameValuePair("profileIds", StringUtils.join(profileIds, ","))); // comma separated profiles
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new EncoderException("Unable to assemble a remote demux request for track " + sourceTrack, e);
     }

--- a/modules/execute-remote/src/main/java/org/opencastproject/execute/remote/ExecuteServiceRemoteImpl.java
+++ b/modules/execute-remote/src/main/java/org/opencastproject/execute/remote/ExecuteServiceRemoteImpl.java
@@ -107,7 +107,7 @@ public class ExecuteServiceRemoteImpl extends RemoteBase implements ExecuteServi
       logger.info("Executing command {} using a remote execute service", exec);
 
       post = new HttpPost("/" + ExecuteService.ENDPOINT_NAME);
-      post.setEntity(new UrlEncodedFormEntity(formStringParams));
+      post.setEntity(new UrlEncodedFormEntity(formStringParams, "UTF-8"));
       response = getResponse(post);
 
       if (response != null) {
@@ -161,7 +161,7 @@ public class ExecuteServiceRemoteImpl extends RemoteBase implements ExecuteServi
       logger.info("Executing command {} using a remote execute service", exec);
 
       post = new HttpPost("/" + ExecuteService.ENDPOINT_NAME);
-      post.setEntity(new UrlEncodedFormEntity(formStringParams));
+      post.setEntity(new UrlEncodedFormEntity(formStringParams, "UTF-8"));
       response = getResponse(post);
 
       if (response != null) {

--- a/modules/inspection-service-remote/src/main/java/org/opencastproject/inspection/remote/MediaInspectionServiceRemoteImpl.java
+++ b/modules/inspection-service-remote/src/main/java/org/opencastproject/inspection/remote/MediaInspectionServiceRemoteImpl.java
@@ -127,7 +127,7 @@ public class MediaInspectionServiceRemoteImpl extends RemoteBase implements Medi
     HttpResponse response = null;
     try {
       HttpPost post = new HttpPost("/enrich");
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
       response = getResponse(post);
       if (response != null) {
         Job receipt = JobParser.parseJob(response.getEntity().getContent());

--- a/modules/publication-service-youtube-remote/src/main/java/org/opencastproject/publication/youtube/remote/YouTubePublicationServiceRemoteImpl.java
+++ b/modules/publication-service-youtube-remote/src/main/java/org/opencastproject/publication/youtube/remote/YouTubePublicationServiceRemoteImpl.java
@@ -61,7 +61,7 @@ public class YouTubePublicationServiceRemoteImpl extends RemoteBase implements Y
     HttpPost post = new HttpPost();
     HttpResponse response = null;
     try {
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
       response = getResponse(post);
       if (response != null) {
         logger.info("Publishing {} to youtube", trackId);
@@ -84,7 +84,7 @@ public class YouTubePublicationServiceRemoteImpl extends RemoteBase implements Y
     HttpPost post = new HttpPost("/retract");
     HttpResponse response = null;
     try {
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
       response = getResponse(post);
       if (response != null) {
         logger.info("Retracting {} from youtube", mediaPackage);

--- a/modules/sox-remote/src/main/java/org/opencastproject/sox/remote/SoxServiceRemoteImpl.java
+++ b/modules/sox-remote/src/main/java/org/opencastproject/sox/remote/SoxServiceRemoteImpl.java
@@ -60,7 +60,7 @@ public class SoxServiceRemoteImpl extends RemoteBase implements SoxService {
     try {
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("sourceAudioTrack", MediaPackageElementParser.getAsXml(sourceAudioTrack)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new SoxException(e);
     }
@@ -96,7 +96,7 @@ public class SoxServiceRemoteImpl extends RemoteBase implements SoxService {
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("sourceAudioTrack", MediaPackageElementParser.getAsXml(sourceAudioTrack)));
       params.add(new BasicNameValuePair("targetRmsLevDb", targetRmsLevDb.toString()));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new SoxException(e);
     }

--- a/modules/textanalyzer-remote/src/main/java/org/opencastproject/textanalyzer/remote/TextAnalysisRemoteImpl.java
+++ b/modules/textanalyzer-remote/src/main/java/org/opencastproject/textanalyzer/remote/TextAnalysisRemoteImpl.java
@@ -57,7 +57,7 @@ public class TextAnalysisRemoteImpl extends RemoteBase implements TextAnalyzerSe
     try {
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("image", MediaPackageElementParser.getAsXml(image)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new TextAnalyzerException(e);
     }

--- a/modules/timelinepreviews-remote/src/main/java/org/opencastproject/timelinepreviews/remote/TimelinePreviewsServiceRemote.java
+++ b/modules/timelinepreviews-remote/src/main/java/org/opencastproject/timelinepreviews/remote/TimelinePreviewsServiceRemote.java
@@ -69,7 +69,7 @@ public class TimelinePreviewsServiceRemote extends RemoteBase implements Timelin
       List<BasicNameValuePair> params = new ArrayList<>();
       params.add(new BasicNameValuePair("track", MediaPackageElementParser.getAsXml(sourceTrack)));
       params.add(new BasicNameValuePair("imageCount", Integer.toString(imageCount)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new TimelinePreviewsException(e);
     }

--- a/modules/videosegmenter-remote/src/main/java/org/opencastproject/videosegmenter/remote/VideoSegmenterRemoteImpl.java
+++ b/modules/videosegmenter-remote/src/main/java/org/opencastproject/videosegmenter/remote/VideoSegmenterRemoteImpl.java
@@ -54,7 +54,7 @@ public class VideoSegmenterRemoteImpl extends RemoteBase implements VideoSegment
     try {
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("track", MediaPackageElementParser.getAsXml(track)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new VideoSegmenterException(e);
     }

--- a/modules/waveform-remote/src/main/java/org/opencastproject/waveform/remote/WaveformServiceRemote.java
+++ b/modules/waveform-remote/src/main/java/org/opencastproject/waveform/remote/WaveformServiceRemote.java
@@ -65,7 +65,7 @@ public class WaveformServiceRemote extends RemoteBase implements WaveformService
     try {
       List<BasicNameValuePair> params = new ArrayList<>();
       params.add(new BasicNameValuePair("track", MediaPackageElementParser.getAsXml(sourceTrack)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new WaveformServiceException(e);
     }

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -319,7 +319,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
         params.add(new BasicNameValuePair("parent", parentWorkflowId.toString()));
       if (properties != null)
         params.add(new BasicNameValuePair("properties", mapToString(properties)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (Exception e) {
       throw new IllegalStateException("Unable to assemble a remote workflow request", e);
     }
@@ -422,7 +422,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
     params.add(new BasicNameValuePair("id", Long.toString(workflowInstanceId)));
     try {
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (UnsupportedEncodingException e) {
       throw new IllegalStateException("Unable to assemble a remote workflow service request", e);
     }
@@ -457,7 +457,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
     params.add(new BasicNameValuePair("id", Long.toString(workflowInstanceId)));
     try {
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (UnsupportedEncodingException e) {
       throw new IllegalStateException("Unable to assemble a remote workflow service request", e);
     }
@@ -545,7 +545,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     try {
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("workflow", WorkflowParser.toXml(workflowInstance)));
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (UnsupportedEncodingException e) {
       throw new IllegalStateException("Unable to assemble a remote workflow service request", e);
     } catch (Exception e) {
@@ -624,7 +624,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     try {
       List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
       params.add(new BasicNameValuePair("workflowDefinition", WorkflowParser.toXml(workflow)));
-      put.setEntity(new UrlEncodedFormEntity(params));
+      put.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (UnsupportedEncodingException e) {
       throw new IllegalStateException("Unable to assemble a remote workflow service request", e);
     } catch (Exception e) {
@@ -704,7 +704,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     if (state != null)
       params.add(new BasicNameValuePair("state", state.toString()));
     try {
-      post.setEntity(new UrlEncodedFormEntity(params));
+      post.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
     } catch (UnsupportedEncodingException e) {
       throw new IllegalStateException("Unable to assemble a remote workflow service request", e);
     }


### PR DESCRIPTION
Using umlauts with an ingest node and extron smp results in nullpointer exception.
Not all remote Services use UTF-8 encoding for UrlEncodedFormEntity.

This Patch adds UTF8-encoding  for all remote services.

This work is sponsored by SWITCH.
