### PR TITLE
MH-13355 Increase the default timeout for TrustedHttpClientImpl 

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedHttpClientImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedHttpClientImpl.java
@@ -114,7 +114,7 @@ public class TrustedHttpClientImpl implements TrustedHttpClient, HttpConnectionM
   public static final int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
 
   /** The default time between packets that causes a connection to fail */
-  public static final int DEFAULT_SOCKET_TIMEOUT = DEFAULT_CONNECTION_TIMEOUT;
+  public static final int DEFAULT_SOCKET_TIMEOUT = 300 * 1000;
 
   /** The default number of times to attempt a request after it has failed due to a nonce expiring. */
   public static final int DEFAULT_NONCE_TIMEOUT_RETRIES = 12;


### PR DESCRIPTION
Inter-server operations like ingest -> admin to start a new workflow on an ingested mediapackage use a POST to start a workflow.

Under some conditions, this can take longer than 60s, in which case the calling node (ingest server) thinks the request has failed, whereas it actually executes fine.

This increases the default timeout for HttpTrustedClient from 1 minute to 5 minutes so it doesn't fail prematurely, which will make Opencast a little more robust and avoid services being flagged as WARN or ERROR unnecessarily.
