### PR TITLE
MH-13360, MH-13316: Watson transcripts improvements 

### DIFF
--- a/docs/guides/admin/docs/modules/watsontranscripts.md
+++ b/docs/guides/admin/docs/modules/watsontranscripts.md
@@ -25,35 +25,30 @@ Workflow 2 runs:
 * Media package is republished with captions/transcripts
 
 IBM Watson Speech-to-Text service documentation, including which languages are currently supported, can be found
- [here](https://www.ibm.com/watson/developercloud/doc/speech-to-text/index.html).
+ [here](https://cloud.ibm.com/docs/services/speech-to-text/index.html#about).
 
 Configuration
 -------------
 
 ### Step 1: Get IBM Watson credentials
 
-* [Create a 30-day trial acoount in IBM Bluemix](https://console.bluemix.net)
+* [Create a 30-day trial acoount in IBM Cloud](https://console.bluemix.net)
 * [Get service credentials](https://console.bluemix.net/docs/services/watson/getting-started-iam.html#iam)
 
 As of 10/30/2018, the service has migrated to token-based Identity and Access Management (IAM) authentication so user
-and password are not generated anymore. Details can be found
-[here](https://cloud.ibm.com/docs/services/speech-to-text/release-notes.html#October2018b).
-
-As a temporary workaround, when configuring the transcription service, enter the constant "apikey" as the user name.
-
-Example:
-
-```
-ibm.watson.user=apikey
-ibm.watson.password=API_KEY_GOTTEN_ABOVE
-```
+and password are not generated anymore. Previously created instances can still use user name and password.
+Details can be found [here](https://cloud.ibm.com/docs/services/speech-to-text/release-notes.html#October2018b).
 
 ### Step 2: Configure IBMWatsonTranscriptionService
 
 Edit  _etc/org.opencastproject.transcription.ibmwatson.IBMWatsonTranscriptionService.cfg_:
 
 * Set _enabled_=true
-* Use service credentials obtained above to set _ibm.watson.user_ and _ibm.watson.psw_
+* Use service credentials obtained above to set _ibm_watson_api_key_ (_ibm.watson.user_ and _ibm.watson.psw_
+are
+still supported to be used with instances created previously)
+* Enter the IBM Watson Speech-to-Text url in _ibm.watson.service.url_, if not using the default
+(https://stream.watsonplatform.net/speech-to-text/api)
 * Enter the appropriate language model in _ibm.watson.model_, if not using the default (_en-US_BroadbandModel_)
 * In _workflow_, enter the workflow definition id of the workflow to be used to attach the generated
 transcripts/captions
@@ -61,47 +56,75 @@ transcripts/captions
 etc/custom.properties (org.opencastproject.admin.email) will be used. Configure the SmtpService.
 If no email address specified in either _notification.email_ or _org.opencastproject.admin.email_,
 email notifications will be disabled.
+* If re-submitting requests is desired in case of failures, configure _max-attempts_ and _retry.workflow_.
+If _max.attempts_ > 1 and the service receives an error callback, it will start the workflow specified in
+_retry_workflow_ to create a new job. When _max.attempts_ is reached for a track, the service will stop retrying.
 
 ```
 # Change enabled to true to enable this service.
-enabled=true
+enabled=false
 
-# User obtained when registering with the IBM Watson Speech-to_text service
-ibm.watson.user=<SERVICE_USER>
+# IBM Watson Speech-to-Text service url
+# Default: https://stream.watsonplatform.net/speech-to-text/api
+# ibm.watson.service.url=https://stream.watsonplatform.net/speech-to-text/api
+
+# APi key obtained when registering with the IBM Watson Speech-to_text service.
+# If empty, user and password below will be used.
+ibm.watson.api.key=<API_KEY>
+
+# User obtained when registering with the IBM Watson Speech-to_text service.
+# Mandatory if ibm.watson.api.key not entered.
+#ibm.watson.user=<SERVICE_USER>
 
 # Password obtained when registering with the IBM Watson Speech-to_text service
-ibm.watson.password=<SERVICE_PSW>
+# Mandatory if ibm.watson.api.key not entered.
+#ibm.watson.password=<SERVICE_PSW>
 
 # Language model to be used. See the IBM Watson Speech-to-Text service documentation
-# for available models. If empty, the default will be used ("en-US_BroadbandModel").
-#ibm.watson.model=
+# for available models.
+# Default: en-US_BroadbandModel
+#ibm.watson.model=en-US_BroadbandModel
 
 # Workflow to be executed when results are ready to be attached to media package.
-#workflow=attach-watson-transcription
+# Default: attach-watson-transcripts
+#workflow=attach-watson-transcripts
 
 # Interval the workflow dispatcher runs to start workflows to attach transcripts to the media package
-# after the transcription job is completed.
-# (in seconds) Default is 1 minute.
+# after the transcription job is completed. In seconds.
+# Default: 60
 #workflow.dispatch.interval=60
 
 # How long it should wait to check jobs after their start date + track duration has passed.
-# The default is 10 minutes. This is only used if we didn't get a callback from the
-# ibm watson speech-to-text service.
-# (in seconds)
+# This is only used if we didn't get a callback from the ibm watson speech-to-text service.
+# In seconds.
+# Default: 600
 #completion.check.buffer=600
 
 # How long to wait after a transcription is supposed to finish before marking the job as
-# canceled in the database. Default is 2 hours.
-# (in seconds)
+# canceled in the database. In seconds. Default is 2 hours.
+# Default: 7200
 #max.processing.time=7200
 
 # How long to keep result files in the working file repository in days.
-# The default is 7 days.
+# Default: 7
 #cleanup.results.days=7
 
 # Email to send notifications of errors. If not entered, the value from
 # org.opencastproject.admin.email in custom.properties will be used.
 #notification.email=
+
+# Start transcription job load
+# Default: 0.1
+#job.load.start.transcription=0.1
+
+# Number of max attempts. If max attempts > 1 and the service returned an error after the recognitions job was
+# accepted or the job did not return any results, the transcription is re-submitted. Default is to not retry.
+# Default: 1
+#max.attempts=
+
+# If max.attempts > 1, name of workflow to use for retries.
+#retry.workflow=
+
 ```
 
 ### Step 3: Add encoding profile for extracting audio
@@ -154,6 +177,9 @@ the second workflow can retrieve it from the Asset Manager to attach the caption
 
 Create a workflow that will add the generated caption/transcript to the media package and republish it.
 A sample one can be found in etc/workflows/attach-watson-transcripts.xml
+
+If re-submitting requests is desired in case of failures, create a workflow that will start a transcription job.
+A sample one can be found in etc/workflows/retry-watson-transcripts.xml
 
 Workflow Operations
 -------------------

--- a/etc/org.opencastproject.transcription.ibmwatson.IBMWatsonTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.ibmwatson.IBMWatsonTranscriptionService.cfg
@@ -1,37 +1,49 @@
 # Change enabled to true to enable this service.
 enabled=false
 
-# User obtained when registering with the IBM Watson Speech-to_text service
-ibm.watson.user=<SERVICE_USER>
+# IBM Watson Speech-to-Text service url
+# Default: https://stream.watsonplatform.net/speech-to-text/api
+# ibm.watson.service.url=https://stream.watsonplatform.net/speech-to-text/api
+
+# APi key obtained when registering with the IBM Watson Speech-to_text service.
+# If empty, user and password below will be used.
+ibm.watson.api.key=<API_KEY>
+
+# User obtained when registering with the IBM Watson Speech-to_text service.
+# Mandatory if ibm.watson.api.key not entered.
+#ibm.watson.user=<SERVICE_USER>
 
 # Password obtained when registering with the IBM Watson Speech-to_text service
-ibm.watson.password=<SERVICE_PSW>
+# Mandatory if ibm.watson.api.key not entered.
+#ibm.watson.password=<SERVICE_PSW>
 
 # Language model to be used. See the IBM Watson Speech-to-Text service documentation
-# for available models. If empty, the default will be used ("en-US_BroadbandModel").
-#ibm.watson.model=
+# for available models.
+# Default: en-US_BroadbandModel
+#ibm.watson.model=en-US_BroadbandModel
 
 # Workflow to be executed when results are ready to be attached to media package.
+# Default: attach-watson-transcripts
 #workflow=attach-watson-transcripts
 
 # Interval the workflow dispatcher runs to start workflows to attach transcripts to the media package
-# after the transcription job is completed.
-# (in seconds) Default is 1 minute.
+# after the transcription job is completed. In seconds.
+# Default: 60
 #workflow.dispatch.interval=60
 
 # How long it should wait to check jobs after their start date + track duration has passed.
-# The default is 10 minutes. This is only used if we didn't get a callback from the
-# ibm watson speech-to-text service.
-# (in seconds)
+# This is only used if we didn't get a callback from the ibm watson speech-to-text service.
+# In seconds.
+# Default: 600
 #completion.check.buffer=600
 
 # How long to wait after a transcription is supposed to finish before marking the job as
-# canceled in the database. Default is 2 hours.
-# (in seconds)
+# canceled in the database. In seconds. Default is 2 hours.
+# Default: 7200
 #max.processing.time=7200
 
 # How long to keep result files in the working file repository in days.
-# The default is 7 days.
+# Default: 7
 #cleanup.results.days=7
 
 # Email to send notifications of errors. If not entered, the value from
@@ -41,3 +53,11 @@ ibm.watson.password=<SERVICE_PSW>
 # Start transcription job load
 # Default: 0.1
 #job.load.start.transcription=0.1
+
+# Number of max attempts. If max attempts > 1 and the service returned an error after the recognitions job was
+# accepted or the job did not return any results, the transcription is re-submitted. Default is to not retry.
+# Default: 1
+#max.attempts=
+
+# If max.attempts > 1, name of workflow to use for retries.
+#retry.workflow=

--- a/etc/org.opencastproject.transcription.ibmwatson.IBMWatsonTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.ibmwatson.IBMWatsonTranscriptionService.cfg
@@ -7,7 +7,7 @@ enabled=false
 
 # APi key obtained when registering with the IBM Watson Speech-to_text service.
 # If empty, user and password below will be used.
-ibm.watson.api.key=<API_KEY>
+#ibm.watson.api.key=<API_KEY>
 
 # User obtained when registering with the IBM Watson Speech-to_text service.
 # Mandatory if ibm.watson.api.key not entered.

--- a/etc/workflows/retry-watson-transcripts.xml
+++ b/etc/workflows/retry-watson-transcripts.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition xmlns="http://workflow.opencastproject.org">
+  <id>retry-watson-transcripts</id>
+  <title>Start automated caption/transcription job (watson)</title>
+  <tags />
+  <description>Retry transcription job in error. Called by the transcription service.</description>
+
+  <configuration_panel />
+
+  <operations>
+
+    <!-- Start transcription -->
+
+    <operation
+      id="start-watson-transcription"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error"
+      description="Start IBM Watson transcription job">
+      <configurations>
+        <!--  Skip this operation if flavor already exists. Used for cases when mp already has captions. -->
+        <configuration key="skip-if-flavor-exists">captions/vtt+en</configuration>
+        <!-- Audio to be translated, produced and tagged in a previous workflow -->
+        <configuration key="source-tag">transcript</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Clean the system from work artifacts -->
+
+    <operation
+      id="include"
+      exception-handler-workflow="partial-error"
+      fail-on-error="false"
+      description="Remove temporary processing artifacts">
+      <configurations>
+        <configuration key="workflow-id">partial-cleanup</configuration>
+      </configurations>
+    </operation>
+
+  </operations>
+
+</definition>

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
@@ -54,6 +54,7 @@ import org.opencastproject.util.LoadUtil;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.PathSupport;
+import org.opencastproject.util.UrlSupport;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workflow.api.ConfiguredWorkflow;
 import org.opencastproject.workflow.api.WorkflowDatabaseException;
@@ -171,7 +172,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
   }
 
   private static final String IBM_WATSON_SERVICE_URL = "https://stream.watsonplatform.net/speech-to-text/api";
-  private static final String API_VERSION = "/v1/";
+  private static final String API_VERSION = "v1";
   private static final String REGISTER_CALLBACK = "register_callback";
   private static final String RECOGNITIONS = "recognitions";
   private static final String CALLBACK_PATH = "/transcripts/watson/results";
@@ -194,7 +195,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
 
   /** Service configuration values */
   private boolean enabled = false; // Disabled by default
-  private String watsonServiceUrl = IBM_WATSON_SERVICE_URL + API_VERSION;
+  private String watsonServiceUrl = UrlSupport.concat(IBM_WATSON_SERVICE_URL, "/", API_VERSION, "/");
   private String user; // user name or 'apikey'
   private String psw; // password or api key
   private String model;
@@ -227,7 +228,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
         // Service url (optional)
         Option<String> urlOpt = OsgiUtil.getOptCfg(cc.getProperties(), IBM_WATSON_SERVICE_URL_CONFIG);
         if (urlOpt.isSome()) {
-          watsonServiceUrl = urlOpt.get() + API_VERSION;
+          watsonServiceUrl = UrlSupport.concat(urlOpt.get(), "/", API_VERSION, "/");
         }
 
         // Api key is checked first. If not entered, user and password are mandatory (to

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
@@ -195,7 +195,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
 
   /** Service configuration values */
   private boolean enabled = false; // Disabled by default
-  private String watsonServiceUrl = UrlSupport.concat(IBM_WATSON_SERVICE_URL, "/", API_VERSION, "/");
+  private String watsonServiceUrl = UrlSupport.concat(IBM_WATSON_SERVICE_URL, API_VERSION);
   private String user; // user name or 'apikey'
   private String psw; // password or api key
   private String model;
@@ -228,7 +228,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
         // Service url (optional)
         Option<String> urlOpt = OsgiUtil.getOptCfg(cc.getProperties(), IBM_WATSON_SERVICE_URL_CONFIG);
         if (urlOpt.isSome()) {
-          watsonServiceUrl = UrlSupport.concat(urlOpt.get(), "/", API_VERSION, "/");
+          watsonServiceUrl = UrlSupport.concat(urlOpt.get(), API_VERSION);
         }
 
         // Api key is checked first. If not entered, user and password are mandatory (to
@@ -485,7 +485,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
 
     CloseableHttpClient httpClient = makeHttpClient();
     HttpPost httpPost = new HttpPost(
-            watsonServiceUrl + REGISTER_CALLBACK + String.format("?callback_url=%s", callbackUrl));
+            UrlSupport.concat(watsonServiceUrl, REGISTER_CALLBACK) + String.format("?callback_url=%s", callbackUrl));
     CloseableHttpResponse response = null;
 
     try {
@@ -557,7 +557,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     }
     CloseableHttpResponse response = null;
     try {
-      HttpPost httpPost = new HttpPost(watsonServiceUrl + RECOGNITIONS
+      HttpPost httpPost = new HttpPost(UrlSupport.concat(watsonServiceUrl, RECOGNITIONS)
               + String.format(
                       "?user_token=%s&inactivity_timeout=-1&timestamps=true&smart_formatting=true%s",
                       mpId, additionalParms));
@@ -634,7 +634,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     CloseableHttpResponse response = null;
     String mpId = "unknown";
     try {
-      HttpGet httpGet = new HttpGet(watsonServiceUrl + RECOGNITIONS + "/" + jobId);
+      HttpGet httpGet = new HttpGet(UrlSupport.concat(watsonServiceUrl, RECOGNITIONS, jobId));
       response = httpClient.execute(httpGet);
       int code = response.getStatusLine().getStatusCode();
 

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
@@ -51,10 +51,12 @@ import org.opencastproject.transcription.ibmwatson.persistence.TranscriptionData
 import org.opencastproject.transcription.ibmwatson.persistence.TranscriptionDatabaseException;
 import org.opencastproject.transcription.ibmwatson.persistence.TranscriptionJobControl;
 import org.opencastproject.util.LoadUtil;
+import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.PathSupport;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workflow.api.ConfiguredWorkflow;
+import org.opencastproject.workflow.api.WorkflowDatabaseException;
 import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowService;
@@ -77,6 +79,7 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.osgi.service.component.ComponentContext;
@@ -105,6 +108,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
   private static final String JOB_TYPE = "org.opencastproject.transcription.ibmwatson";
 
   static final String TRANSCRIPT_COLLECTION = "transcripts";
+  static final String APIKEY = "apikey";
   private static final int CONNECTION_TIMEOUT = 60000; // ms, 1 minute
   private static final int SOCKET_TIMEOUT = 60000; // ms, 1 minute
   // Default wf to attach transcription results to mp
@@ -141,6 +145,12 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     String FAILED = "recognitions.failed";
   }
 
+  public interface RecognitionJobStatus {
+    String COMPLETED = "completed";
+    String FAILED = "failed";
+    String PROCESSING = "processing";
+  }
+
   /** Service dependencies */
   private ServiceRegistry serviceRegistry;
   private SecurityService securityService;
@@ -160,27 +170,33 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     StartTranscription
   }
 
-  private static final String IBM_WATSON_SERVICE_URL = "https://stream.watsonplatform.net/speech-to-text/api/v1/";
+  private static final String IBM_WATSON_SERVICE_URL = "https://stream.watsonplatform.net/speech-to-text/api";
+  private static final String API_VERSION = "/v1/";
   private static final String REGISTER_CALLBACK = "register_callback";
   private static final String RECOGNITIONS = "recognitions";
   private static final String CALLBACK_PATH = "/transcripts/watson/results";
 
   /** Service configuration options */
   public static final String ENABLED_CONFIG = "enabled";
+  public static final String IBM_WATSON_SERVICE_URL_CONFIG = "ibm.watson.service.url";
   public static final String IBM_WATSON_USER_CONFIG = "ibm.watson.user";
   public static final String IBM_WATSON_PSW_CONFIG = "ibm.watson.password";
-  public static final String IBM_WATSON_MODEL = "ibm.watson.model";
+  public static final String IBM_WATSON_API_KEY_CONFIG = "ibm.watson.api.key";
+  public static final String IBM_WATSON_MODEL_CONFIG = "ibm.watson.model";
   public static final String WORKFLOW_CONFIG = "workflow";
   public static final String DISPATCH_WORKFLOW_INTERVAL_CONFIG = "workflow.dispatch.interval";
   public static final String COMPLETION_CHECK_BUFFER_CONFIG = "completion.check.buffer";
   public static final String MAX_PROCESSING_TIME_CONFIG = "max.processing.time";
   public static final String NOTIFICATION_EMAIL_CONFIG = "notification.email";
   public static final String CLEANUP_RESULTS_DAYS_CONFIG = "cleanup.results.days";
+  public static final String MAX_ATTEMPTS_CONFIG = "max.attempts";
+  public static final String RETRY_WORKLFOW_CONFIG = "retry.workflow";
 
   /** Service configuration values */
   private boolean enabled = false; // Disabled by default
-  private String user;
-  private String psw;
+  private String watsonServiceUrl = IBM_WATSON_SERVICE_URL + API_VERSION;
+  private String user; // user name or 'apikey'
+  private String psw; // password or api key
   private String model;
   private String workflowDefinitionId = DEFAULT_WF_DEF;
   private long workflowDispatchInterval = DEFAULT_DISPATCH_INTERVAL;
@@ -189,6 +205,8 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
   private String toEmailAddress;
   private int cleanupResultDays = DEFAULT_CLEANUP_RESULTS_DAYS;
   private String language = DEFAULT_LANGUAGE;
+  private int maxAttempts = 1;
+  private String retryWfDefId = null;
 
   private String systemAccount;
   private String serverUrl;
@@ -206,14 +224,29 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
       enabled = OsgiUtil.getOptCfgAsBoolean(cc.getProperties(), ENABLED_CONFIG).get();
 
       if (enabled) {
-        // User name (mandatory)
-        user = OsgiUtil.getComponentContextProperty(cc, IBM_WATSON_USER_CONFIG);
-        // Password (mandatory)
-        psw = OsgiUtil.getComponentContextProperty(cc, IBM_WATSON_PSW_CONFIG);
-        logger.info("Using transcription service at {} with username {}", IBM_WATSON_SERVICE_URL, user);
+        // Service url (optional)
+        Option<String> urlOpt = OsgiUtil.getOptCfg(cc.getProperties(), IBM_WATSON_SERVICE_URL_CONFIG);
+        if (urlOpt.isSome()) {
+          watsonServiceUrl = urlOpt.get() + API_VERSION;
+        }
 
-        // Language model to be used
-        Option<String> modelOpt = OsgiUtil.getOptCfg(cc.getProperties(), IBM_WATSON_MODEL);
+        // Api key is checked first. If not entered, user and password are mandatory (to
+        // support older instances of the STT service)
+        Option<String> keyOpt = OsgiUtil.getOptCfg(cc.getProperties(), IBM_WATSON_API_KEY_CONFIG);
+        if (keyOpt.isSome()) {
+          user = APIKEY;
+          psw = keyOpt.get();
+          logger.info("Using transcription service at {} with api key", watsonServiceUrl);
+        } else {
+          // User name (mandatory if api key is empty)
+          user = OsgiUtil.getComponentContextProperty(cc, IBM_WATSON_USER_CONFIG);
+          // Password (mandatory if api key is empty)
+          psw = OsgiUtil.getComponentContextProperty(cc, IBM_WATSON_PSW_CONFIG);
+          logger.info("Using transcription service at {} with username {}", watsonServiceUrl, user);
+        }
+
+        // Language model to be used (optional)
+        Option<String> modelOpt = OsgiUtil.getOptCfg(cc.getProperties(), IBM_WATSON_MODEL_CONFIG);
         if (modelOpt.isSome()) {
           model = modelOpt.get();
           language = StringUtils.substringBefore(model, "-");
@@ -269,6 +302,21 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
           }
         }
         logger.info("Cleanup result files after {} days", cleanupResultDays);
+
+        // Maximum number of retries if error (optional)
+        Option<String> maxAttemptsOpt = OsgiUtil.getOptCfg(cc.getProperties(), MAX_ATTEMPTS_CONFIG);
+        if (maxAttemptsOpt.isSome()) {
+          try {
+            maxAttempts = Integer.parseInt(maxAttemptsOpt.get());
+            retryWfDefId = OsgiUtil.getComponentContextProperty(cc, RETRY_WORKLFOW_CONFIG);
+          } catch (NumberFormatException e) {
+            // Use default
+            logger.warn("Invalid configuration for {} : {}. Default used instead: no retries", MAX_ATTEMPTS_CONFIG,
+                    maxAttemptsOpt.get());
+          }
+        } else {
+          logger.info("No retries in case of errors");
+        }
 
         serverUrl = OsgiUtil.getContextProperty(cc, OpencastConstants.SERVER_URL_PROPERTY);
         systemAccount = OsgiUtil.getContextProperty(cc, DIGEST_USER_PROPERTY);
@@ -335,6 +383,27 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     try {
       jsonObj = (JSONObject) obj;
       jobId = (String) jsonObj.get("id");
+
+      // Check for errors inside the results object. Sometimes we get a status completed, but
+      // the transcription failed e.g.
+      // curl --header "Content-Type: application/json" --request POST --data
+      // '{"id":"ebeeb546-2e1a-11e9-941d-f349af2d6273",
+      // "results":[{"error":"failed when posting audio to the STT service"}],
+      // "event":"recognitions.completed_with_results",
+      // "user_token":"66c6c9b0-b6a2-4c9a-92c8-55f953ab3d38",
+      // "created":"2019-02-11T05:04:29.283Z"}' http://ADMIN/transcripts/watson/results
+      if (jsonObj.get("results") instanceof JSONArray) {
+        JSONArray resultsArray = (JSONArray) jsonObj.get("results");
+        if (resultsArray != null && resultsArray.size() > 0) {
+          String error = (String) ((JSONObject) resultsArray.get(0)).get("error");
+          if (!StringUtils.isEmpty(error)) {
+            retryOrError(jobId, mpId,
+                String.format("Transcription completed with error for mpId %s, jobId %s: %s", mpId, jobId, error));
+            return;
+          }
+        }
+      }
+
       logger.info("Transcription done for mpId {}, jobId {}", mpId, jobId);
 
       // Update state in database
@@ -350,31 +419,19 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
               mpId, jobId, jsonObj == null ? "null" : jsonObj.toJSONString());
       throw new TranscriptionServiceException("Could not save transcription results file", e);
     } catch (TranscriptionDatabaseException e) {
-      logger.warn("Transcription results file were saved but state in db not updated for mpId {}, jobId {}", mpId,
-              jobId);
+      logger.warn("Error when updating state in database for mpId {}, jobId {}", mpId, jobId);
       throw new TranscriptionServiceException("Could not update transcription job control db", e);
     }
   }
 
   @Override
   public void transcriptionError(String mpId, Object obj) throws TranscriptionServiceException {
-    JSONObject jsonObj = null;
-    String jobId = null;
+    JSONObject jsonObj = (JSONObject) obj;
+    String jobId = (String) jsonObj.get("id");
     try {
-      jsonObj = (JSONObject) obj;
-      jobId = (String) jsonObj.get("id");
-      // Update state in database
-      database.updateJobControl(jobId, TranscriptionJobControl.Status.Error.name());
-      TranscriptionJobControl jobControl = database.findByJob(jobId);
-      logger.warn(String.format("Error callback received for media package %s, job id %s",
-              jobControl.getMediaPackageId(), jobId));
-      // Send notification email
-      sendEmail("Transcription ERROR",
-              String.format("There was a transcription error for for media package %s, job id %s.",
-                      jobControl.getMediaPackageId(), jobId));
+      retryOrError(jobId, mpId, String.format("Transcription error for media package %s, job id %s", mpId, jobId));
     } catch (TranscriptionDatabaseException e) {
-      logger.warn("Transcription error. State in db could not be updated to error for mpId {}, jobId {}", mpId, jobId);
-      throw new TranscriptionServiceException("Could not update transcription job control db", e);
+      throw new TranscriptionServiceException("Error when updating job state.", e);
     }
   }
 
@@ -407,10 +464,10 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
 
   /**
    * Register the callback url with the Speech-to-text service. From:
-   * https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#register_callback
+   * https://cloud.ibm.com/apidocs/speech-to-text#register-a-callback
    *
-   * curl -X POST -u "{username}":"{password}" --data "{}"
-   * "https://stream.watsonplatform.net/speech-to-text/api/v1/register_callback?callback_url=http://{user_callback_path}/results&user_secret=ThisIsMySecret"
+   * curl -X POST -u "apikey:{apikey}"
+   * "https://stream.watsonplatform.net/speech-to-text/api/v1/register_callback?callback_url=http://{user_callback_path}/job_results&user_secret=ThisIsMySecret"
    * Response looks like: { "status": "created", "url": "http://{user_callback_path}/results" }
    */
   void registerCallback() throws TranscriptionServiceException {
@@ -427,7 +484,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
 
     CloseableHttpClient httpClient = makeHttpClient();
     HttpPost httpPost = new HttpPost(
-            IBM_WATSON_SERVICE_URL + REGISTER_CALLBACK + String.format("?callback_url=%s", callbackUrl));
+            watsonServiceUrl + REGISTER_CALLBACK + String.format("?callback_url=%s", callbackUrl));
     CloseableHttpResponse response = null;
 
     try {
@@ -468,10 +525,10 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
   }
 
   /**
-   * From: https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/#register_callback:
+   * From: https://cloud.ibm.com/apidocs/speech-to-text#create-a-job:
    *
-   * curl -X POST -u "{username}":"{password}" --header "Content-Type: audio/flac" --data-binary @audio-file.flac
-   * "https://stream.watsonplatform.net/speech-to-text/api/v1/recognitions?callback_url=http://{user_callback_path}/results&user_token=job25&continuous=true&timestamps=true"
+   * curl -X POST -u "apikey:{apikey}" --header "Content-Type: audio/flac" --data-binary @audio-file.flac
+   * "https://stream.watsonplatform.net/speech-to-text/api/v1/recognitions?callback_url=http://{user_callback_path}/job_results&user_token=job25&timestamps=true"
    *
    * Response: { "id": "4bd734c0-e575-21f3-de03-f932aa0468a0", "status": "waiting", "url":
    * "http://stream.watsonplatform.net/speech-to-text/api/v1/recognitions/4bd734c0-e575-21f3-de03-f932aa0468a0" }
@@ -499,7 +556,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     }
     CloseableHttpResponse response = null;
     try {
-      HttpPost httpPost = new HttpPost(IBM_WATSON_SERVICE_URL + RECOGNITIONS
+      HttpPost httpPost = new HttpPost(watsonServiceUrl + RECOGNITIONS
               + String.format(
                       "?user_token=%s&inactivity_timeout=-1&timestamps=true&smart_formatting=true%s",
                       mpId, additionalParms));
@@ -562,22 +619,21 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
   }
 
   /**
-   * From: https://www.ibm.com/watson/developercloud/speech-to-text/api/v1 Check a job: GET /v1/recognitions/{id}
+   * From: https://cloud.ibm.com/apidocs/speech-to-text#check-a-job:
    *
-   * curl -X GET -u "{username}":"{password}"
-   * "https://stream.watsonplatform.net/speech-to-text/api/v1/recognitions/{id}"
+   * curl -X GET -u "apikey:{apikey}" "https://stream.watsonplatform.net/speech-to-text/api/v1/recognitions/{id}"
    *
    * Response: { "results": [ { "result_index": 0, "results": [ { "final": true, "alternatives": [ { "transcript":
    * "several tornadoes touch down as a line of severe thunderstorms swept through Colorado on Sunday ", "timestamps": [
    * [ "several", 1, 1.52 ], [ "tornadoes", 1.52, 2.15 ], . . . [ "Sunday", 5.74, 6.33 ] ], "confidence": 0.885 } ] } ]
    * } ], "created": "2016-08-17T19:11:04.298Z", "updated": "2016-08-17T19:11:16.003Z", "status": "completed" }
    */
-  boolean getAndSaveJobResults(String jobId) throws TranscriptionServiceException {
+  String getAndSaveJobResults(String jobId) throws TranscriptionServiceException {
     CloseableHttpClient httpClient = makeHttpClient();
     CloseableHttpResponse response = null;
     String mpId = "unknown";
     try {
-      HttpGet httpGet = new HttpGet(IBM_WATSON_SERVICE_URL + RECOGNITIONS + "/" + jobId);
+      HttpGet httpGet = new HttpGet(watsonServiceUrl + RECOGNITIONS + "/" + jobId);
       response = httpClient.execute(httpGet);
       int code = response.getStatusLine().getStatusCode();
 
@@ -600,11 +656,10 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
           logger.info("Recognitions job {} has been found, status {}", jobId, jobStatus);
           EntityUtils.consume(entity);
 
-          if (jobStatus.indexOf("completed") > -1 && jsonObject.get("results") != null) {
+          if (jobStatus.indexOf(RecognitionJobStatus.COMPLETED) > -1 && jsonObject.get("results") != null) {
             transcriptionDone(mpId, jsonObject);
-            return true;
           }
-          return false;
+          return jobStatus;
         case HttpStatus.SC_NOT_FOUND: // 404
           logger.info("Job not found: {}", jobId);
           break;
@@ -684,6 +739,31 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
             .setSocketTimeout(SOCKET_TIMEOUT).setConnectionRequestTimeout(CONNECTION_TIMEOUT).build();
     return HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).setDefaultRequestConfig(reqConfig)
             .build();
+  }
+
+  protected void retryOrError(String jobId, String mpId, String errorMsg) throws TranscriptionDatabaseException {
+    logger.warn(errorMsg);
+
+    // TranscriptionJobControl.Status status
+    TranscriptionJobControl jc = database.findByJob(jobId);
+    String trackId = jc.getTrackId();
+    // Current job is still in progress state
+    int attempts = database
+            .findByMediaPackageTrackAndStatus(mpId, trackId, TranscriptionJobControl.Status.Error.name(),
+                    TranscriptionJobControl.Status.Progress.name(), TranscriptionJobControl.Status.Canceled.name())
+            .size();
+    if (attempts < maxAttempts) {
+      // Update state in database to retry
+      database.updateJobControl(jobId, TranscriptionJobControl.Status.Retry.name());
+      logger.info("Will retry transcription for media package {}, track {}", mpId, trackId);
+    } else {
+      // Update state in database to error
+      database.updateJobControl(jobId, TranscriptionJobControl.Status.Error.name());
+      // Send error notification email
+      logger.error("{} transcription attempts exceeded maximum of {} for media package {}, track {}.", attempts,
+              maxAttempts, mpId, trackId);
+      sendEmail("Transcription ERROR", String.format(errorMsg, mpId, jobId));
+    }
   }
 
   private void sendEmail(String subject, String body) {
@@ -801,18 +881,21 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
             if (j.getDateCreated().getTime() + j.getTrackDuration() + completionCheckBuffer * 1000 < System
                     .currentTimeMillis()) {
               try {
-                if (!getAndSaveJobResults(jobId)) {
-                  // Job still running, not finished, so check if it should have finished more than N seconds ago
+                String jobStatus = getAndSaveJobResults(jobId);
+                if (RecognitionJobStatus.FAILED.equals(jobStatus)) {
+                  retryOrError(jobId, mpId,
+                          String.format("Transcription job failed for mpId %s, jobId %s", mpId, jobId));
+                  continue;
+                } else if (RecognitionJobStatus.PROCESSING.equals(jobStatus)) {
+                  // Job still running so check if it should have finished more than N seconds ago
                   if (j.getDateCreated().getTime() + j.getTrackDuration()
                           + (completionCheckBuffer + maxProcessingSeconds) * 1000 < System.currentTimeMillis()) {
-                    // Processing for too long, mark job as canceled and don't check anymore
-                    database.updateJobControl(jobId, TranscriptionJobControl.Status.Canceled.name());
-                    // Send notification email
-                    sendEmail("Transcription ERROR", String.format(
-                            "Transcription job was in processing state for too long and was marked as canceled (media package %s, job id %s).",
+                    // Processing for too long, mark job as error or retry and don't check anymore
+                    retryOrError(jobId, mpId, String.format(
+                            "Transcription job was in processing state for too long (media package %s, job id %s)",
                             mpId, jobId));
                   }
-                  // else Job still running, not finished
+                  // else job still running, not finished
                   continue;
                 }
               } catch (TranscriptionServiceException e) {
@@ -829,43 +912,16 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
               continue; // Not time to check yet
           }
 
-          // Jobs that get here have state TranscriptionCompleted
+          // Jobs that get here have state TranscriptionCompleted.
           try {
-            DefaultOrganization defaultOrg = new DefaultOrganization();
-            securityService.setOrganization(defaultOrg);
-            securityService.setUser(SecurityUtil.createSystemUser(systemAccount, defaultOrg));
-
-            // Find the episode
-            final AQueryBuilder q = assetManager.createQuery();
-            final AResult r = q.select(q.snapshot()).where(q.mediaPackageId(mpId).and(q.version().isLatest())).run();
-            if (r.getSize() == 0) {
-              // Media package not archived yet? Skip until next time.
-              logger.warn("Media package {} has not been archived yet. Skipped.", mpId);
-              continue;
-            }
-
-            String org = Enrichments.enrich(r).getSnapshots().head2().getOrganizationId();
-            Organization organization = organizationDirectoryService.getOrganization(org);
-            if (organization == null) {
-              logger.warn("Media package {} has an unknown organization {}. Skipped.", mpId, org);
-              continue;
-            }
-            securityService.setOrganization(organization);
-
-            // Build workflow
+            // Apply workflow to attach transcripts
             Map<String, String> params = new HashMap<String, String>();
             params.put("transcriptionJobId", jobId);
-            WorkflowDefinition wfDef = workflowService.getWorkflowDefinitionById(workflowDefinitionId);
-
-            // Apply workflow
-            // wfUtil is only used by unit tests
-            Workflows workflows = wfUtil != null ? wfUtil : new Workflows(assetManager, workspace, workflowService);
-            Set<String> mpIds = new HashSet<String>();
-            mpIds.add(mpId);
-            List<WorkflowInstance> wfList = workflows
-                    .applyWorkflowToLatestVersion(mpIds, ConfiguredWorkflow.workflow(wfDef, params)).toList();
-            String wfId = wfList.size() > 0 ? Long.toString(wfList.get(0).getId()) : "Unknown";
-
+            String wfId = startWorkflow(mpId, workflowDefinitionId, params);
+            if (wfId == null) {
+              logger.warn("Attach transcription workflow could NOT be scheduled for mp {}, watson job {}", mpId, jobId);
+              continue;
+            }
             // Update state in the database
             database.updateJobControl(jobId, TranscriptionJobControl.Status.Closed.name());
             logger.info("Attach transcription workflow {} scheduled for mp {}, watson job {}",
@@ -875,10 +931,83 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
                     mpId, jobId, e.getClass().getName(), e.getMessage());
           }
         }
+
+        if (maxAttempts > 1) {
+          // Find jobs that need to be re-submitted
+          jobs = database.findByStatus(TranscriptionJobControl.Status.Retry.name());
+          HashMap<String, String> params = new HashMap<String, String>();
+          for (TranscriptionJobControl j : jobs) {
+            String mpId = j.getMediaPackageId();
+            String wfId = startWorkflow(mpId, retryWfDefId, params);
+            String jobId = j.getTranscriptionJobId();
+            if (wfId == null) {
+              logger.warn(
+                      "Retry transcription workflow could NOT be scheduled for mp {}, watson job {}. Will try again next time.",
+                      mpId, jobId);
+              // Will try again next time
+              continue;
+            }
+            logger.info("Retry transcription workflow {} scheduled for mp {}.", wfId, mpId);
+            // Retry was submitted, update previously failed job state to error
+            database.updateJobControl(jobId, TranscriptionJobControl.Status.Error.name());
+          }
+        }
       } catch (TranscriptionDatabaseException e) {
-        logger.warn("Could not read transcription job control database: {}", e.getMessage());
+        logger.warn("Could not read/update transcription job control database.", e);
       }
     }
+  }
+
+  private String startWorkflow(String mpId, String wfDefId, Map<String, String> params) {
+    DefaultOrganization defaultOrg = new DefaultOrganization();
+    securityService.setOrganization(defaultOrg);
+    securityService.setUser(SecurityUtil.createSystemUser(systemAccount, defaultOrg));
+
+    // Find the episode
+    final AQueryBuilder q = assetManager.createQuery();
+    final AResult r = q.select(q.snapshot()).where(q.mediaPackageId(mpId).and(q.version().isLatest())).run();
+    if (r.getSize() == 0) {
+      // Media package not archived yet.
+      logger.warn("Media package {} has not been archived yet.", mpId);
+      return null;
+    }
+
+    String org = Enrichments.enrich(r).getSnapshots().head2().getOrganizationId();
+    Organization organization = null;
+    try {
+      organization = organizationDirectoryService.getOrganization(org);
+      if (organization == null) {
+        logger.warn("Media package {} has an unknown organization {}.", mpId, org);
+        return null;
+      }
+    } catch (NotFoundException e) {
+      logger.warn("Organization {} not found for media package {}.", org, mpId);
+      return null;
+    }
+    securityService.setOrganization(organization);
+
+    try {
+      WorkflowDefinition wfDef = workflowService.getWorkflowDefinitionById(wfDefId);
+      Workflows workflows = wfUtil != null ? wfUtil : new Workflows(assetManager, workspace, workflowService);
+      Set<String> mpIds = new HashSet<String>();
+      mpIds.add(mpId);
+      List<WorkflowInstance> wfList = workflows
+              .applyWorkflowToLatestVersion(mpIds, ConfiguredWorkflow.workflow(wfDef, params)).toList();
+      return wfList.size() > 0 ? Long.toString(wfList.get(0).getId()) : null;
+    } catch (NotFoundException | WorkflowDatabaseException e) {
+      logger.warn("Could not get workflow definition: {}", wfDefId);
+    }
+
+    return null;
+  }
+
+  /**
+   * Allow transcription service to be disabled via config Utility to verify service is active
+   *
+   * @return true if service is enabled, false if service should be skipped
+   */
+  public boolean isEnabled() {
+    return enabled;
   }
 
   class ResultsFileCleanup implements Runnable {

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/persistence/TranscriptionDatabase.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/persistence/TranscriptionDatabase.java
@@ -97,4 +97,15 @@ public class TranscriptionDatabase {
     return resultList;
   }
 
+  public List<TranscriptionJobControl> findByMediaPackageTrackAndStatus(String mpId, String trackId, String... status)
+          throws TranscriptionDatabaseException {
+    List<TranscriptionJobControlDto> list = TranscriptionJobControlDto
+            .findByMediaPackageTrackAndStatus(emf.createEntityManager(), mpId, trackId, status);
+    List<TranscriptionJobControl> resultList = new ArrayList<TranscriptionJobControl>();
+    for (TranscriptionJobControlDto dto : list) {
+      resultList.add(dto.toTranscriptionJobControl());
+    }
+    return resultList;
+  }
+
 }

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/persistence/TranscriptionJobControl.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/persistence/TranscriptionJobControl.java
@@ -24,7 +24,7 @@ import java.util.Date;
 
 public final class TranscriptionJobControl {
   public enum Status {
-    Progress, Canceled, Error, TranscriptionComplete, Closed
+    Progress, Canceled, Error, TranscriptionComplete, Closed, Retry
   }
 
   // Media package id

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/persistence/TranscriptionJobControlDto.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/persistence/TranscriptionJobControlDto.java
@@ -45,6 +45,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 @Table(name = "oc_ibm_watson_transcript_job")
 @NamedQueries({
         @NamedQuery(name = "TranscriptionJobControl.findByMediaPackage", query = "SELECT jc FROM TranscriptionJobControl jc WHERE jc.mediaPackageId = :mediaPackageId ORDER BY jc.dateCreated DESC"),
+        @NamedQuery(name = "TranscriptionJobControl.findByMediaPackageTrackAndStatus", query = "SELECT jc FROM TranscriptionJobControl jc WHERE jc.mediaPackageId = :mediaPackageId AND jc.trackId = :trackId AND jc.status IN :status"),
         @NamedQuery(name = "TranscriptionJobControl.findByJob", query = "SELECT jc FROM TranscriptionJobControl jc WHERE jc.transcriptionJobId = :transcriptionJobId"),
         @NamedQuery(name = "TranscriptionJobControl.findByStatus", query = "SELECT jc FROM TranscriptionJobControl jc WHERE jc.status IN :status") })
 public final class TranscriptionJobControlDto {
@@ -161,6 +162,25 @@ public final class TranscriptionJobControlDto {
     Query query = null;
     try {
       query = em.createNamedQuery("TranscriptionJobControl.findByStatus");
+      query.setParameter("status", statusCol);
+      return query.getResultList();
+    } catch (Exception e) {
+      throw new TranscriptionDatabaseException(e);
+    }
+  }
+
+  /** Find all job controls by media package and status. */
+  @SuppressWarnings("unchecked")
+  public static List<TranscriptionJobControlDto> findByMediaPackageTrackAndStatus(EntityManager em,
+          final String mediaPackageId, String trackId, final String... status) throws TranscriptionDatabaseException {
+    Collection<String> statusCol = new HashSet<String>();
+    for (String st : status)
+      statusCol.add(st);
+    Query query = null;
+    try {
+      query = em.createNamedQuery("TranscriptionJobControl.findByMediaPackageTrackAndStatus");
+      query.setParameter("mediaPackageId", mediaPackageId);
+      query.setParameter("trackId", trackId);
       query.setParameter("status", statusCol);
       return query.getResultList();
     } catch (Exception e) {

--- a/modules/transcription-service-ibm-watson-impl/src/test/java/org/opencastproject/transciption/ibmwatson/persistence/TranscriptionDatabaseTest.java
+++ b/modules/transcription-service-ibm-watson-impl/src/test/java/org/opencastproject/transciption/ibmwatson/persistence/TranscriptionDatabaseTest.java
@@ -127,6 +127,18 @@ public class TranscriptionDatabaseTest {
   }
 
   @Test
+  public void testFindByMediaPackageTrackAndStatus() throws Exception {
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID2, STATUS, TRACK_DURATION);
+    database.storeJobControl(MP_ID, TRACK_ID2, JOB_ID3, STATUS2, TRACK_DURATION);
+    database.storeJobControl(MP_ID2, TRACK_ID2, JOB_ID2, STATUS2, TRACK_DURATION);
+    database.storeJobControl(MP_ID3, TRACK_ID3, JOB_ID3, STATUS, TRACK_DURATION);
+
+    List<TranscriptionJobControl> list = database.findByMediaPackageTrackAndStatus(MP_ID, TRACK_ID, STATUS);
+    Assert.assertEquals(2, list.size());
+  }
+
+  @Test
   public void testDeleteJobControl() throws Exception {
     long dt1 = System.currentTimeMillis();
     database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION);

--- a/modules/transcription-service-ibm-watson-impl/src/test/resources/complete_with_error.json
+++ b/modules/transcription-service-ibm-watson-impl/src/test/resources/complete_with_error.json
@@ -1,0 +1,8 @@
+{
+    "id": "jobId1",
+    "results": [{"error": "failed when posting audio to the STT service"}],
+    "event":"recognitions.completed_with_results",
+    "updated": "2019-02-06T05:04:32.673Z",
+    "user_token": "mpId1",
+    "created": "2019-02-06T05:04:29.283Z"
+}

--- a/modules/transcription-service-ibm-watson-impl/src/test/resources/pulled_transcription_error.json
+++ b/modules/transcription-service-ibm-watson-impl/src/test/resources/pulled_transcription_error.json
@@ -1,0 +1,10 @@
+{
+   "created": "2019-02-05T01:28:11.852Z",
+   "details": [{
+      "code": 500,
+      "error": "failed when posting audio to the STT service"
+   }],
+   "id": "4d27ce28-28e5-11e9-b578-8b39836f7d7a",
+   "updated": "2019-02-05T01:28:14.943Z",
+   "status": "failed"
+}


### PR DESCRIPTION
* Support api key (addresses MH-13316).
* Add ability to re-submit the transcript job by running a workflow when failures occur: callback with failed state, pulling job results with failed state, jobs that stay in progress "forever", jobs that complete but have an error instead of results.
Retrying is configurable by setting the maximum attempts. The default is 1, no retries.
* Update documentation.
