### PR TITLE
MH-13361, Fix Scheduler Item Serialization

### DIFF
--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/scheduler/SchedulerItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/scheduler/SchedulerItem.java
@@ -66,7 +66,7 @@ public class SchedulerItem implements MessageItem, Serializable {
   private final long reviewDate;
   private final String recordingState;
   private final long start;
-  private final Long lastHeardFrom;
+  private final String lastHeardFrom;
   private final Type type;
 
   public enum Type {
@@ -428,7 +428,7 @@ public class SchedulerItem implements MessageItem, Serializable {
     this.reviewDate = -1;
     this.recordingState = state;
     this.start = -1;
-    this.lastHeardFrom = lastHeardFrom;
+    this.lastHeardFrom = gson.toJson(lastHeardFrom);
     this.type = Type.UpdateRecordingStatus;
   }
 
@@ -531,7 +531,7 @@ public class SchedulerItem implements MessageItem, Serializable {
   }
 
   public Long getLastHeardFrom() {
-    return lastHeardFrom;
+    return gson.fromJson(lastHeardFrom, Long.class);
   }
 
   public Boolean getOptOut() {


### PR DESCRIPTION
Opencast cannot serialize Long whcih are used in a few scheduler
messages given the right (or wrong) circumstances.  We need to use
native data types (long) or Stings instead.

This patch fixes the sending of some scheduler related messages via
ActiveMQ.