### PR TITLE
MH-13363 Publish to OAI-PMH an allready published mediapackage …

### DIFF
--- a/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
+++ b/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
@@ -195,7 +195,7 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
     if (searchResult.size() > 0) {
       try {
         Publication p = retract(job, mediaPackage, repository);
-        if (mediaPackage.contains(p))
+        if (p != null && mediaPackage.contains(p))
           mediaPackage.remove(p);
       } catch (NotFoundException e) {
         logger.debug("No OAI-PMH publication found for media package {}.", mpId, e);


### PR DESCRIPTION
…shouldn't end with an exception

During the first publication to OAI-PMH, the publication media package element isn't part of the media package itself. The retract call will then return null. Calling `MediaPackage#contains(publication)` with a null argument will end up with an `IllegalArgumentException`. 

Test the retracted publication element for null value (as it is a possible return value) will fix this issue.