### PR TITLE
MH-13364, Fix hidden OSGI wiring errors

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -111,7 +111,6 @@
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.2/2.8.0;type:=endorsed;export:=true</library>
               <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.2_3;type:=endorsed;export:=true</library>
               <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan-serializer/2.7.2_1;type:=endorsed;export:=true</library>
-              <library>mvn:javax.annotation/javax.annotation-api/1.2;type:=endorsed;export:=true</library>
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activator/2.8.0;type:=default;export:=true</library>
               <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.locator/2.8.0;type:=default;export:=true</library>
             </libraries>

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -207,6 +207,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              !javax.annotation,
               org.eclipse.persistence.descriptors.changetracking,
               org.eclipse.persistence.internal.descriptors,
               org.eclipse.persistence.internal.identitymaps,

--- a/modules/message-broker-api/pom.xml
+++ b/modules/message-broker-api/pom.xml
@@ -68,6 +68,10 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              !javax.annotation,
+              *
+            </Import-Package>
             <Private-Package>
             </Private-Package>
             <Export-Package>

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -160,6 +160,7 @@
               com.google.api.*
             </_exportcontents>
             <Import-Package>
+              !javax.annotation,
               !oracle.xml.parser.*,
               !org.jaxen.*,
               !sun.security.util,


### PR DESCRIPTION
While OSGI could eventually resolve all dependencies, some conflicts
caused resolution to be extremely slow. Looking at Karaf's debug logs
would actually reveal the problems:

```
2019-01-27T01:32:36,132 | DEBUG | (Slf4jResolverLog:45) - Candidate permutation failed due to a conflict between imports; will try another if possible. (Uses constraint violation. Unable to resolve resource opencast-message-broker-api [opencast-message-broker-api/7.0.0.SNAPSHOT] because it is exposed to package 'javax.annotation' from resources javax.annotation-api [javax.annotation-api/1.3.0] and org.apache.felix.framework [org.apache.felix.framework [0](R 0)] via two dependency chains.

Chain 1:
  opencast-message-broker-api [opencast-message-broker-api/7.0.0.SNAPSHOT]
    import: (&(osgi.wiring.package=javax.annotation)(version>=1.3.0)(!(version>=2.0.0)))
     |
    export: osgi.wiring.package: javax.annotation
  javax.annotation-api [javax.annotation-api/1.3.0]

Chain 2:
  opencast-message-broker-api [opencast-message-broker-api/7.0.0.SNAPSHOT]
    import: (&(osgi.wiring.package=com.entwinemedia.fn)(version>=1.4.0)(!(version>=2.0.0)))
     |
    export: osgi.wiring.package=com.entwinemedia.fn; uses:=javax.annotation
  functional [functional/1.4.2]
    import: (osgi.wiring.package=javax.annotation)
     |
    export: osgi.wiring.package: javax.annotation
  org.apache.felix.framework [org.apache.felix.framework [0](R 0)])
2019-01-27T01:32:36,224 | DEBUG | (Slf4jResolverLog:45) - Candidate permutation failed due to a conflict between imports; will try another if possible. (Uses constraint violation. Unable to resolve resource opencast-message-broker-api [opencast-message-broker-api/7.0.0.SNAPSHOT] because it is exposed to package 'javax.annotation' from resources javax.annotation-api [javax.annotation-api/1.3.0] and org.apache.felix.framework [org.apache.felix.framework [0](R 0)] via two dependency chains.

Chain 1:
  opencast-message-broker-api [opencast-message-broker-api/7.0.0.SNAPSHOT]
    import: (&(osgi.wiring.package=javax.annotation)(version>=1.3.0)(!(version>=2.0.0)))
     |
    export: osgi.wiring.package: javax.annotation
  javax.annotation-api [javax.annotation-api/1.3.0]
…
```
Full log (~25M): https://data.lkiesow.de/opencast/opencast-debug-osgi-wiring-errors.log

This patch fixes the problem, giving Opencast a huge boost when it comes
to boot performance.