### PR TITLE
MH-13366: Add `REFERENCES` permission to standard Opencast `GRANT` statement

### DIFF
--- a/docs/guides/admin/docs/configuration/database.md
+++ b/docs/guides/admin/docs/configuration/database.md
@@ -68,7 +68,7 @@ create a database called `opencast` by executing:
 
 Then create a user `opencast` with a password and grant it all necessary rights:
 
-    GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX,TRIGGER,CREATE TEMPORARY TABLES ON opencast.*
+    GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX,TRIGGER,CREATE TEMPORARY TABLES,REFERENCES ON opencast.*
       TO 'opencast'@'localhost' IDENTIFIED BY 'opencast_password';
 
 You can choose another name for the user and database and should use a different password.


### PR DESCRIPTION
You apparently need `REFERENCES` permissions in MySQL (as opposed to MariaDB), to create foreign key constraints. In MariaDB, this permission is simply ignored.