### PR TITLE
MH-13365 inbox ingest into series and inbox retry

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -211,8 +211,8 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-incident-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-index-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
-    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-ffmpeg/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-workflowoperation/${project.version}</bundle>
@@ -324,7 +324,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-incident-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-index-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-remote/${project.version}</bundle>
@@ -449,7 +449,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-incident-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-index-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-remote/${project.version}</bundle>
@@ -526,7 +526,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-smil-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-smil-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-runtime-info-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-series-service-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-workflow-service-remote/${project.version}</bundle>
@@ -619,7 +619,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-incident-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-index-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-ffmpeg/${project.version}</bundle>

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -211,8 +211,8 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-incident-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-index-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
+    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-ffmpeg/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-workflowoperation/${project.version}</bundle>
@@ -324,7 +324,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-incident-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-index-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-remote/${project.version}</bundle>
@@ -449,7 +449,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-incident-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-index-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-remote/${project.version}</bundle>
@@ -526,7 +526,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-smil-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-smil-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-runtime-info-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-series-service-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-workflow-service-remote/${project.version}</bundle>
@@ -619,7 +619,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-incident-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-index-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
+    <bundle start-level="83">mvn:org.opencastproject/opencast-ingest-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-ingest-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-ffmpeg/${project.version}</bundle>

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -245,10 +245,6 @@ org.opencastproject.workspace.cleanup.max.age=2592000
 # Default: 0
 #org.opencastproject.ingest.max.concurrent=0
 
-# The maximum number of concurrent files to ingest from the inbox directory
-# Default: 1
-#org.opencastproject.inbox.threads=1
-
 ######### Third-party Binaries #########
 
 # Path to the ffmpeg binary. Its name is sufficient if the binary is in the

--- a/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
+++ b/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
@@ -3,7 +3,7 @@ user.name=admin
 user.organization=mh_default_org
 
 # Specify the workflow definition (by its identifier) to run for media, ingested from the inbox
-workflow.definition=fast
+workflow.definition=schedule-and-upload
 
 # Specify flavor to use for ingested media files. This configuration has no effect on zipped mediapackages since they
 # contain the flavor information in their manifest xml file.

--- a/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
+++ b/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
@@ -3,7 +3,7 @@ user.name=admin
 user.organization=mh_default_org
 
 # Specify the workflow definition (by its identifier) to run for media, ingested from the inbox
-workflow.definition=schedule-and-upload
+workflow.definition=fast
 
 # Specify flavor to use for ingested media files. This configuration has no effect on zipped mediapackages since they
 # contain the flavor information in their manifest xml file.
@@ -18,5 +18,18 @@ workflow.config.straightToPublishing=false
 # Path to the Inbox directory
 inbox.path=${karaf.data}/inbox
 
-# Inbox polling interval in ms.
-inbox.poll=5000
+# Inbox polling interval in milliseconds
+# Default: 5000
+#inbox.poll=5000
+
+# The maximum number of concurrent files to ingest from the inbox directory
+# Default: 1
+#inbox.threads=1
+
+# The maximum number of retries when ingesting from inbox
+# Default: 3
+#inbox.tries=3
+
+# The time between each retry in seconds
+# Default: 300
+#inbox.tries.between.sec=300

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/InboxScannerService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/InboxScannerService.java
@@ -36,6 +36,7 @@ import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.security.util.SecurityContext;
+import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.data.Effect;
 import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Option;
@@ -108,6 +109,7 @@ public class InboxScannerService implements ArtifactInstaller, ManagedService {
   private SecurityService securityService;
   private UserDirectoryService userDir;
   private OrganizationDirectoryService orgDir;
+  private SeriesService seriesService;
 
   private ComponentContext cc;
 
@@ -169,7 +171,7 @@ public class InboxScannerService implements ArtifactInstaller, ManagedService {
       fileInstallCfg = some(configureFileInstall(cc.getBundleContext(), inbox, interval));
       // create new scanner
       ingestor = some(new Ingestor(ingestService, workingFileRepository, secCtx.get(), workflowDefinition,
-            workflowConfig, mediaFlavor, inbox, maxthreads));
+            workflowConfig, mediaFlavor, inbox, maxthreads, seriesService));
       logger.info("Now watching inbox {}", inbox.getAbsolutePath());
     } else {
       logger.warn("Cannot create security context for user {}, organization {}. "
@@ -196,7 +198,8 @@ public class InboxScannerService implements ArtifactInstaller, ManagedService {
       throw new Error("Cannot obtain a reference to the ConfigurationAdmin service");
     }
     final Dictionary<String, String> fileInstallConfig = dict(tuple("felix.fileinstall.dir", inbox.getAbsolutePath()),
-            tuple("felix.fileinstall.poll", Integer.toString(interval)));
+            tuple("felix.fileinstall.poll", Integer.toString(interval)),
+            tuple("felix.fileinstall.subdir.mode", "recurse"));
 
     // update file install config with the new directory
     try {
@@ -311,5 +314,9 @@ public class InboxScannerService implements ArtifactInstaller, ManagedService {
     } catch (NumberFormatException e) {
       throw new ConfigurationException(key, "not an integer");
     }
+  }
+
+  public void setSeriesService(SeriesService seriesService) {
+    this.seriesService = seriesService;
   }
 }

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/InboxScannerService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/InboxScannerService.java
@@ -324,31 +324,12 @@ public class InboxScannerService implements ArtifactInstaller, ManagedService {
     return config;
   }
 
-  /**
-   * Get a mandatory integer from a dictionary.
-   *
-   * @throws ConfigurationException
-   *           key does not exist or is not an integer
-   */
-  public static Integer getCfgAsInt(Dictionary d, String key) throws ConfigurationException {
-    try {
-      return Integer.parseInt(getCfg(d, key));
-    } catch (NumberFormatException e) {
-      throw new ConfigurationException(key, "not an integer");
-    }
-  }
-
   public static int getCfgAsIntOrDefault(Dictionary d, String key, int defaultValue) throws ConfigurationException {
     String valStr = getCfgOrDefault(d, key, null);
     if (StringUtils.isEmpty(valStr))
       return defaultValue;
-    try {
+    else
       return Integer.parseInt(valStr);
-    } catch (Exception e) {
-      logger.warn("The inbox configuration {} value {} is not an integer. Use default value of {}", key, valStr,
-              defaultValue);
-    }
-    return defaultValue;
   }
 
   public void setSeriesService(SeriesService seriesService) {

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
@@ -30,15 +30,16 @@ import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCores;
-import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.util.SecurityContext;
-import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesService;
-import org.opencastproject.util.NotFoundException;
+import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workingfilerepository.api.WorkingFileRepository;
+
+import com.google.common.util.concurrent.RateLimiter;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,13 +50,20 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /** Used by the {@link InboxScannerService} to do the actual ingest. */
-public class Ingestor {
+public class Ingestor implements Runnable {
 
-  /** The logger */
+  /**
+   * The logger
+   */
   private static final Logger logger = LoggerFactory.getLogger(Ingestor.class);
 
   public static final String WFR_COLLECTION = "inbox";
@@ -72,34 +80,163 @@ public class Ingestor {
 
   private final File inbox;
 
-  /** Thread pool to run the ingest worker. */
   private final SeriesService seriesService;
+
+  private final int maxTries;
+
+  private final int secondsBetweenTries;
+
+  private RateLimiter throttle = RateLimiter.create(1.0);
+
+  /**
+   * Thread pool to run the ingest worker.
+   */
   private final ExecutorService executorService;
+
+  /**
+   * Completion service to manage internal completion queue of ingest jobs including retries
+   */
+  private final CompletionService<RetriableIngestJob> completionService;
+
+
+  private class RetriableIngestJob implements Callable<RetriableIngestJob> {
+    private final File artifact;
+    private int retryCount;
+    private boolean failed;
+    private RateLimiter throttle;
+
+    RetriableIngestJob(final File artifact, int secondsBetweenTries) {
+      this.artifact = artifact;
+      this.retryCount = 0;
+      this.failed = false;
+      throttle = RateLimiter.create(1.0 / secondsBetweenTries);
+    }
+
+    public boolean hasFailed() {
+      return this.failed;
+    }
+
+    public int getRetryCount() {
+      return this.retryCount;
+    }
+
+    public File getArtifact() {
+      return this.artifact;
+    }
+
+    @Override
+    public RetriableIngestJob call() {
+      return secCtx.runInContext(() -> {
+          if (hasFailed()) {
+            logger.warn("This is retry number {} for file {}. We will wait for {} seconds before trying again",
+                    retryCount, artifact.getName(), secondsBetweenTries);
+            throttle.acquire();
+          }
+          try (InputStream in = new FileInputStream(artifact)) {
+            failed = false;
+            ++retryCount;
+            if ("zip".equalsIgnoreCase(FilenameUtils.getExtension(artifact.getName()))) {
+              logger.info("Start ingest inbox file {} as a zipped mediapackage", artifact.getName());
+              WorkflowInstance workflowInstance = ingestService.addZippedMediaPackage(in, workflowDefinition, workflowConfig);
+              logger.info("Ingested {} as a zipped mediapackage from inbox as {}. Started workflow {}.",
+                      artifact.getName(), workflowInstance.getMediaPackage().getIdentifier().compact(),
+                      workflowInstance.getId());
+            } else {
+              /* Create MediaPackage and add Track */
+              MediaPackage mp = ingestService.createMediaPackage();
+              logger.info("Start ingest track from file {} to mediapackage {}",
+                      artifact.getName(), mp.getIdentifier().compact());
+
+              /* Check if we have a subdir and if its name matches an existing series */
+              File dir = artifact.getParentFile();
+              String seriesID = "";
+              if (FileUtils.directoryContains(inbox, dir)) {
+                /* cut away inbox path and trailing slash from artifact path */
+                seriesID = dir.getName();
+                if (seriesService.getSeries(seriesID) != null) {
+                  logger.info("Ingest from inbox into series with id {}", seriesID);
+                } else {
+                  seriesID = null;
+                }
+              }
+
+              /* Add title */
+              DublinCoreCatalog dcc = DublinCores.mkOpencastEpisode().getCatalog();
+              dcc.add(DublinCore.PROPERTY_TITLE, artifact.getName());
+              if (StringUtils.isNotBlank(seriesID))
+                dcc.add(DublinCore.PROPERTY_IS_PART_OF, seriesID);
+              logger.debug("episode dublincore for the inbox file {}: {}", artifact.getName(), dcc.toXml());
+              try (ByteArrayOutputStream dcout = new ByteArrayOutputStream()) {
+                dcc.toXml(dcout, true);
+                try (InputStream dcin = new ByteArrayInputStream(dcout.toByteArray())) {
+                  mp = ingestService.addCatalog(dcin, "dublincore.xml", MediaPackageElements.EPISODE, mp);
+                  logger.info("Added DC catalog to media package for ingest from inbox");
+                }
+              }
+              /* Ingest media*/
+              mp = ingestService.addTrack(in, artifact.getName(), mediaFlavor, mp);
+              logger.info("Ingested track from file {} to mediapackage {}",
+                      artifact.getName(), mp.getIdentifier().compact());
+              /* Ingest mediapackage */
+              WorkflowInstance workflowInstance = ingestService.ingest(mp, workflowDefinition, workflowConfig);
+              logger.info("Ingested {} from inbox, workflow {} started", artifact.getName(), workflowInstance.getId());
+            }
+          } catch (Exception e) {
+            logger.error("Error ingesting inbox file {}", artifact.getName(), e);
+            failed = true;
+            return RetriableIngestJob.this;
+          }
+          try {
+            FileUtils.forceDelete(artifact);
+          } catch (IOException e) {
+            logger.error("Unable to delete file {}", artifact.getAbsolutePath(), e);
+          }
+          return RetriableIngestJob.this;
+      });
+    }
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      try {
+        final Future<RetriableIngestJob> f = completionService.take();
+        final RetriableIngestJob task = f.get();
+        if (task.hasFailed()) {
+          if (task.getRetryCount() < maxTries) {
+            throttle.acquire();
+            logger.warn("Retrying inbox ingest of {}", task.getArtifact().getAbsolutePath());
+            completionService.submit(task);
+          } else {
+            logger.error("Inbox ingest failed after {} tries for {}", maxTries, task.getArtifact().getAbsolutePath());
+          }
+        }
+      } catch (InterruptedException e) {
+        logger.debug("Ingestor check interrupted", e);
+        return;
+      } catch (ExecutionException e) {
+        logger.error("Ingestor check interrupted", e);
+      }
+    }
+  }
 
   /**
    * Create new ingestor.
    *
-   * @param ingestService
-   *          media packages are passed to the ingest service
-   * @param workingFileRepository
-   *          inbox files are put in the working file repository collection {@link #WFR_COLLECTION}.
-   * @param secCtx
-   *          security context needed for ingesting with the IngestService or for putting files into the working file
-   *          repository
-   * @param workflowDefinition
-   *          workflow to apply to ingested media packages
-   * @param workflowConfig
-   *          the workflow definition configuration
-   * @param mediaFlavor
-   *          media flavor to use by default
-   * @param inbox
-   *          inbox directory to watch
-   * @param maxThreads
-   *          maximum worker threads doing the actual ingest
+   * @param ingestService         media packages are passed to the ingest service
+   * @param workingFileRepository inbox files are put in the working file repository collection {@link #WFR_COLLECTION}.
+   * @param secCtx                security context needed for ingesting with the IngestService or for putting files into the working file
+   *                              repository
+   * @param workflowDefinition    workflow to apply to ingested media packages
+   * @param workflowConfig        the workflow definition configuration
+   * @param mediaFlavor           media flavor to use by default
+   * @param inbox                 inbox directory to watch
+   * @param maxThreads            maximum worker threads doing the actual ingest
+   * @param maxTries              maximum tries for a ingest job
    */
   public Ingestor(IngestService ingestService, WorkingFileRepository workingFileRepository, SecurityContext secCtx,
           String workflowDefinition, Map<String, String> workflowConfig, String mediaFlavor, File inbox, int maxThreads,
-          SeriesService seriesService) {
+          SeriesService seriesService, int maxTries, int secondsBetweenTries) {
     this.ingestService = ingestService;
     this.secCtx = secCtx;
     this.workflowDefinition = workflowDefinition;
@@ -107,70 +244,18 @@ public class Ingestor {
     this.mediaFlavor = MediaPackageElementFlavor.parseFlavor(mediaFlavor);
     this.inbox = inbox;
     this.executorService = Executors.newFixedThreadPool(maxThreads);
+    this.completionService = new ExecutorCompletionService<>(executorService);
     this.seriesService = seriesService;
+    this.maxTries = maxTries;
+    this.secondsBetweenTries = secondsBetweenTries;
   }
 
-  /** Asynchronous ingest of an artifact. */
+  /**
+   * Asynchronous ingest of an artifact.
+   */
   public void ingest(final File artifact) {
-    logger.info("Try ingest of file `{}`", artifact.getName());
-    executorService.execute(getIngestRunnable(artifact));
-  }
-
-  private Runnable getIngestRunnable(final File artifact) {
-    return () -> secCtx.runInContext(() -> {
-      String seriesID = "";
-      try (InputStream in = new FileInputStream(artifact)) {
-        if ("zip".equalsIgnoreCase(FilenameUtils.getExtension(artifact.getName()))) {
-          ingestService.addZippedMediaPackage(in, workflowDefinition, workflowConfig);
-          logger.info("Ingested {} as a mediapackage from inbox", artifact.getName());
-        } else {
-          /* Create MediaPackage and add Track */
-          MediaPackage mp = ingestService.createMediaPackage();
-          ingestService.addTrack(in, artifact.getName(), mediaFlavor, mp);
-          logger.info("Added track to mediapackage for ingest from inbox");
-
-          /* Check if we have a subdir and if its name matches an existing series */
-          File dir = artifact.getParentFile();
-          if (dir.getCanonicalPath().length() > inbox.getCanonicalPath().length()) {
-            /* cut away inbox path and trailing slash from artifact path */
-            seriesID = dir.getCanonicalPath().substring(inbox.getCanonicalPath().length() + 1);
-            if (seriesService.getSeries(seriesID) != null) {
-              logger.info("Ingest from inbox into series with id {}", seriesID);
-            }
-          }
-
-          /* Add title */
-          DublinCoreCatalog dcc = DublinCores.mkOpencastEpisode().getCatalog();
-          dcc.add(DublinCore.PROPERTY_TITLE, artifact.getName());
-          dcc.add(DublinCore.PROPERTY_IS_PART_OF, seriesID);
-          ByteArrayOutputStream dcout = new ByteArrayOutputStream();
-          dcc.toXml(dcout, true);
-          InputStream dcin = new ByteArrayInputStream(dcout.toByteArray());
-          ingestService.addCatalog(dcin, "dublincore.xml", MediaPackageElements.EPISODE, mp);
-          logger.info("Added DC catalog to mediapackage for ingest from inbox");
-
-          /* Ingest media */
-          ingestService.ingest(mp, workflowDefinition, workflowConfig);
-          logger.info("Ingested {} from inbox", artifact.getName());
-        }
-        in.close();
-      } catch (UnauthorizedException e) {
-        logger.warn("Not authorized to check if series with id {} exists", seriesID, e);
-      } catch (NotFoundException e) {
-        logger.warn("Could not find series with id {}", seriesID, e);
-      } catch (SeriesException e) {
-        logger.warn("Error while getting series with id {}", seriesID, e);
-      } catch (IOException e) {
-        logger.error("Error accessing inbox file '{}'", artifact.getName(), e);
-      } catch (Exception e) {
-        logger.error("Error ingesting inbox file '{}'", artifact.getName(), e);
-      }
-      try {
-        FileUtils.forceDelete(artifact);
-      } catch (IOException e) {
-        logger.error("Unable to delete file {}", artifact.getAbsolutePath(), e);
-      }
-    });
+    logger.info("Try ingest of file {}", artifact.getName());
+    completionService.submit(new RetriableIngestJob(artifact, secondsBetweenTries));
   }
 
   /**
@@ -178,15 +263,32 @@ public class Ingestor {
    * false if not (e.g. it lies outside of inbox or its name starts with a ".")
    */
   public boolean canHandle(final File artifact) {
-    logger.debug("CanHandle {}, {}", myInfo(), artifact.getAbsolutePath());
+    logger.trace("canHandle() {}, {}", myInfo(), artifact.getAbsolutePath());
     File dir = artifact.getParentFile();
     try {
       /* Stop if dir is empty, stop if artifact is dotfile, stop if artifact lives outside of inbox path */
       return dir != null && !artifact.getName().startsWith(".")
-              && dir.getCanonicalPath().startsWith(inbox.getCanonicalPath());
+              && FileUtils.directoryContains(inbox, artifact)
+              && artifact.canRead() && artifact.length() > 0;
     } catch (IOException e) {
       logger.warn("Unable to determine canonical path of {}", artifact.getAbsolutePath(), e);
       return false;
+    }
+  }
+
+  public void cleanup(final File artifact) {
+    try {
+      File parentDir = artifact.getParentFile();
+      if (FileUtils.directoryContains(inbox, parentDir)) {
+        String[] filesList = parentDir.list();
+        if (filesList == null || filesList.length == 0) {
+          logger.info("Delete empty inbox for series {}",
+                  StringUtils.substring(parentDir.getCanonicalPath(), inbox.getCanonicalPath().length() + 1));
+          FileUtils.deleteDirectory(parentDir);
+        }
+      }
+    } catch (Exception e) {
+      logger.error("Unable to cleanup inbox for the artifact {}", artifact, e);
     }
   }
 

--- a/modules/ingest-service-impl/src/main/resources/OSGI-INF/inbox-scanner-service.xml
+++ b/modules/ingest-service-impl/src/main/resources/OSGI-INF/inbox-scanner-service.xml
@@ -28,4 +28,6 @@
              cardinality="1..1" policy="static" bind="setUserDirectoryService"/>
   <reference name="orgDirectory" interface="org.opencastproject.security.api.OrganizationDirectoryService"
              cardinality="1..1" policy="static" bind="setOrganizationDirectoryService"/>
+  <reference name="service-impl" interface="org.opencastproject.series.api.SeriesService"
+             cardinality="1..1" policy="static" bind="setSeriesService" />
 </scr:component>


### PR DESCRIPTION
This patch adds the ability to ingest videos via the inbox directly into a existing series. Furthermore a retry strategy was implemented to make the inbox somewhat more robust to failure.

@reviewer: I suggest to squash all commits of this PR as there is a lot of back and forth with some changes