### PR TITLE
adds an WOH, which can add catalogs to the MediaPackage of an workflow instance

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/add-catalog-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/add-catalog-woh.md
@@ -1,0 +1,54 @@
+AddCatalogWorkflowOperationHandler
+==================================
+
+Description
+-----------
+
+This operation adds a catalog to the media package of the running workflow.
+The catalog to add is specified by path. Additionally the name, flavor and tags of the catalog can be configured.
+If a catalog of the same flavor already exits in the media package,
+the parameter `catalog-type-collision-behavior` specifies how this case is handled.
+
+
+Parameter Table
+---------------
+
+| Configuration Key                 | Example                                        | Description                                         |
+|-----------------------------------|------------------------------------------------|-----------------------------------------------------|
+| `catalog-path`                    | `${karaf.etc}/catalogs/default_dublincore.xml` | Path to the catalog                                 |
+| `catalog-flavor`                  | `dublincore/episode`                           | Flavor of the catalog                               |
+| `catalog-name`                    | `dublincore.xml`                               | Name of the catalog                                 |
+| `catalog-tags`                    | `archive,dublincore`                           | List of tags, separated by commas                   |
+| `catalog-type-collision-behavior` | `keep`                                         | How a collision is handled (more information below) |
+
+All parameters are mandatory except `catalog-tags`.
+
+
+### catalog-type-collision-behavior
+
+If the flavor of the new catalog and the flavor of an already existing catalog match,
+the `catalog-type-collision-behavior` specifies how this situation is handled.
+There are multiple supported options:
+- `keep`: The new catalog is added despite the collision. This results in two catalogs of the same type coexisting.
+- `skip`: The addition of the new catalog is skipped, the new catalog is not added.
+- `fail`: The workflow operation fails with an error, depending on the your configurations the complete workflow is aborted.
+
+
+Operation Example
+-----------------
+
+```xml
+<operation
+  id="add-catalog"
+  fail-on-error="true"
+  exception-handler-workflow="partial-error"
+  description="Add catalog to media package">
+  <configurations>
+    <configuration key="catalog-path">${karaf.etc}/catalogs/default_dublincore.xml</configuration>
+    <configuration key="catalog-flavor">dublincore/episode</configuration>
+    <configuration key="catalog-name">dublincore.xml</configuration>
+    <configuration key="catalog-tags">archive,dublincore</configuration>
+    <configuration key="catalog-type-collision-behavior">keep</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -23,6 +23,7 @@ The following table contains the workflow operations that are available in an ou
 
 |Operation Handler   |Description                                                    |Details|
 |--------------------|---------------------------------------------------------------|------------------------------------|
+|add-catalog         |Add a catalog to the media package                             |[Documentation](add-catalog-woh.md)|
 |analyze-audio       |Analyze first audio stream                                     |[Documentation](analyzeaudio-woh.md)|
 |analyze-tracks      |Analyze tracks in media package                                |[Documentation](analyze-tracks-woh.md)|
 |animate             |Create animated video sequence                                 |[Documentation](animate-woh.md)|

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
 - Workflow Operation Handler:
    - Overview: 'workflowoperationhandlers/index.md'
    - Retry Strategies: 'workflowoperationhandlers/retry-strategies.md'
+   - Add Catalog: 'workflowoperationhandlers/add-catalog-woh.md'
    - Analyze Tracks: 'workflowoperationhandlers/analyze-tracks-woh.md'
    - Analyze Audio: 'workflowoperationhandlers/analyzeaudio-woh.md'
    - Animate: 'workflowoperationhandlers/animate-woh.md'

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -140,6 +140,7 @@
               org.opencastproject.workflow.handler.workflow;version=${project.version}
             </Export-Package>
             <Service-Component>
+              OSGI-INF/operations/add-catalog.xml,
               OSGI-INF/operations/analyze-tracks.xml,
               OSGI-INF/operations/cleanup.xml,
               OSGI-INF/operations/clone.xml,

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
@@ -66,7 +66,7 @@ public class AddCatalogWorkflowOperationHandler extends AbstractWorkflowOperatio
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory
-    .getLogger(ProbeResolutionWorkflowOperationHandler.class);
+    .getLogger(AddCatalogWorkflowOperationHandler.class);
 
   /** config key for the catalog name */
   private static final String CFG_KEY_CATALOG_NAME   = "catalog-name";
@@ -215,17 +215,13 @@ public class AddCatalogWorkflowOperationHandler extends AbstractWorkflowOperatio
    */
   private CatalogTypeCollisionBehavior parseCollisionBehavior(String rawBehavior)
       throws WorkflowOperationException {
-    switch (rawBehavior) {
-      case "skip":
-        return CatalogTypeCollisionBehavior.SKIP;
-      case "keep":
-        return CatalogTypeCollisionBehavior.KEEP;
-      case "fail":
-        return CatalogTypeCollisionBehavior.FAIL;
-      default:
-        throw new WorkflowOperationException("Workflowoperation configured incorrectly, the configuration '"
-                                             + CFG_KEY_CATALOG_TYPE_COLLISION_BEHAVIOR
-                                             + "' only accepts 'skip', 'keep', 'fail'");
+    try {
+      return CatalogTypeCollisionBehavior.valueOf(rawBehavior.toUpperCase());
+    }
+    catch (IllegalArgumentException e) {
+      throw new WorkflowOperationException("Workflowoperation configured incorrectly, the configuration '"
+                                           + CFG_KEY_CATALOG_TYPE_COLLISION_BEHAVIOR
+                                           + "' only accepts 'skip', 'keep', 'fail'");
     }
   }
 }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
@@ -180,7 +180,7 @@ public class AddCatalogWorkflowOperationHandler extends AbstractWorkflowOperatio
       throws WorkflowOperationException {
     String value = inst.getCurrentOperation().getConfiguration(cfgKey);
 
-    if (!isOptional && value == null) {
+    if (!isOptional && (value == null || value.isEmpty())) {
       throw new WorkflowOperationException("'" + cfgKey + "' not set");
     }
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
@@ -1,0 +1,231 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.Catalog;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.util.MimeType;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * This WorkflowOperationHandler adds an configurable catalog to the MediaPackage.
+ * It supports the following workflow configuration keys:
+ *   catalog-path the path of the catalog to add;
+ *   catalog-flavor the flavor of the catalog, used to identify catalogs of the same type;
+ *   catalog-name name of the catalog in the workspace;
+ *   catalog-tags list of comma seperated catalog tags;
+ *   catalog-type-collision-behavior the action to perform, if an catalog of the same flavor already exists,
+ *     three options are supported: 'skip' the adding of the catalog, 'fail' the workflow operation or 'keep'
+ *     the new catalog, resulting in two or more catalogs of the same type coexisting
+ */
+public class AddCatalogWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+
+  /** enum used to specify the behavior on detecting a catalog type collision */
+  private enum CatalogTypeCollisionBehavior {
+    SKIP, KEEP, FAIL
+  }
+
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory
+    .getLogger(ProbeResolutionWorkflowOperationHandler.class);
+
+  /** config key for the catalog name */
+  private static final String CFG_KEY_CATALOG_NAME   = "catalog-name";
+  /** config key for the catalog flavor */
+  private static final String CFG_KEY_CATALOG_FLAVOR = "catalog-flavor";
+  /** config key, which locates the catalog on the filesystem */
+  private static final String CFG_KEY_CATALOG_PATH   = "catalog-path";
+  /** config key for the catalog tags */
+  private static final String CFG_KEY_CATALOG_TAGS   = "catalog-tags";
+  /** config key, which defines the behavior if a catalog of the same flavor already exists */
+  private static final String CFG_KEY_CATALOG_TYPE_COLLISION_BEHAVIOR = "catalog-type-collision-behavior";
+
+  /** The mimetype of the added catalogs */
+  private static final MimeType CATALOG_MIME_TYPE = MimeType.mimeType("text", "xml");
+
+  /** The workspace, where the catalog files are put. */
+  private Workspace workspace;
+
+  /**
+   * Sets the workspace to use.
+   *
+   * @param workspace
+   *          the workspace
+   */
+  public void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
+  }
+
+  @Override
+  public WorkflowOperationResult start(WorkflowInstance wInst, JobContext context)
+      throws WorkflowOperationException {
+    // get Workflow configuration
+    String catalogName = getCfgValueFromOp(wInst, CFG_KEY_CATALOG_NAME, false);
+    String catalogPath = getCfgValueFromOp(wInst, CFG_KEY_CATALOG_PATH, false);
+    String catalogTags = getCfgValueFromOp(wInst, CFG_KEY_CATALOG_TAGS, true);
+    MediaPackageElementFlavor    catalogFlavor = parseFlavor(
+                           getCfgValueFromOp(wInst, CFG_KEY_CATALOG_FLAVOR, false));
+    CatalogTypeCollisionBehavior collBehavior  = parseCollisionBehavior(
+                           getCfgValueFromOp(wInst, CFG_KEY_CATALOG_TYPE_COLLISION_BEHAVIOR, false));
+
+    MediaPackage mp = wInst.getMediaPackage();
+
+    // if CatalogType is already part of the MediaPackage handle special cases
+    if (doesCatalogFlavorExist(catalogFlavor, mp.getCatalogs())) {
+      if (collBehavior == CatalogTypeCollisionBehavior.FAIL) {
+        throw new WorkflowOperationException("Catalog Type already exists and 'fail' was specified");
+      }
+      else if (collBehavior == CatalogTypeCollisionBehavior.SKIP) {
+        // don't add the Catalog
+        return createResult(mp, Action.CONTINUE);
+      }
+    }
+
+    // 'upload Catalog' to workspace
+    File   catalogFile = new File(catalogPath);
+    String catalogId   = UUID.randomUUID().toString();
+    URI    catalogURI  = null;
+    try (InputStream catalogInputStream = FileUtils.openInputStream(catalogFile)) {
+      catalogURI = workspace.put(mp.getIdentifier().toString(), catalogId,
+              catalogName, catalogInputStream);
+    }
+    catch (IOException e) {
+      throw new WorkflowOperationException(e);
+    }
+
+    // add Catalog to MediaPackage (and set Properties)
+    MediaPackageElement mpe = mp.add(catalogURI, MediaPackageElement.Type.Catalog, catalogFlavor);
+    mpe.setIdentifier(catalogId);
+    mpe.setMimeType(CATALOG_MIME_TYPE);
+    if (catalogTags != null) {
+      for (String tag : catalogTags.split(",")) {
+        mpe.addTag(tag);
+      }
+    }
+
+    return createResult(mp, Action.CONTINUE);
+  }
+
+  /**
+   * Checks whether the catalogFlavor exists in the array of catalogs
+   *
+   * @param catalogFlavor
+   * @param catalogs
+   * @return true, if the catalogFlavor exists in the array of catalogs, else false
+   */
+  private boolean doesCatalogFlavorExist(MediaPackageElementFlavor catalogFlavor, Catalog[] catalogs) {
+    List<Catalog> ctls = Arrays.asList(catalogs);
+
+    boolean doesFlavorExist = ctls.stream()
+      .anyMatch(cat -> catalogFlavor.matches(cat.getFlavor()));
+
+    return doesFlavorExist;
+  }
+
+  /**
+   * Gets a configuration value for a specific key from the current operation.
+   * isOptional can be used to specify whether null values are allowed to be returned
+   * or whether an WorkflowOperationException should be thrown.
+   *
+   * @param inst
+   *          used to get the value of the configuration
+   * @param cfgKey
+   *          specifies the value to get
+   * @param isOptional
+   *          is the configuration value allowed to be not set
+   * @return the value of the configuration key or null if isOptional is set and the configuration value is not set
+   * @throws WorkflowOperationException
+   *           if isOptional is false and the configuration value is not set
+   */
+  private String getCfgValueFromOp(WorkflowInstance inst, String cfgKey, boolean isOptional)
+      throws WorkflowOperationException {
+    String value = inst.getCurrentOperation().getConfiguration(cfgKey);
+
+    if (!isOptional && value == null) {
+      throw new WorkflowOperationException("'" + cfgKey + "' not set");
+    }
+
+    return value;
+  }
+
+  /**
+   * Parses the rawFlavor String to an MediaPackageElementFlavor
+   * or throws an WorkflowOperationException if the parsing failed
+   *
+   * @param rawFlavor
+   * @return
+   * @throws WorkflowOperationException
+   */
+  private MediaPackageElementFlavor parseFlavor(String rawFlavor)
+      throws WorkflowOperationException {
+    try {
+      return MediaPackageElementFlavor.parseFlavor(rawFlavor);
+    }
+    catch (IllegalArgumentException e) {
+      throw new WorkflowOperationException("Flavor needs to be an correct Flavor MimeType");
+    }
+  }
+
+  /**
+   * Parses the rawBehavior String into an CatalogTypeCollisionBehavior.
+   * Throws an WorkflowOperationException if the String couldn't be parsed.
+   *
+   * @param rawBehavior
+   * @return
+   * @throws WorkflowOperationException
+   */
+  private CatalogTypeCollisionBehavior parseCollisionBehavior(String rawBehavior)
+      throws WorkflowOperationException {
+    switch (rawBehavior) {
+      case "skip":
+        return CatalogTypeCollisionBehavior.SKIP;
+      case "keep":
+        return CatalogTypeCollisionBehavior.KEEP;
+      case "fail":
+        return CatalogTypeCollisionBehavior.FAIL;
+      default:
+        throw new WorkflowOperationException("Workflowoperation configured incorrectly, the configuration '"
+                                             + CFG_KEY_CATALOG_TYPE_COLLISION_BEHAVIOR
+                                             + "' only accepts 'skip', 'keep', 'fail'");
+    }
+  }
+}

--- a/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/add-catalog.xml
+++ b/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/add-catalog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.workflow.handler.workflow.AddCatalogWorkflowOperationHandler"
+               immediate="true">
+  <implementation class="org.opencastproject.workflow.handler.workflow.AddCatalogWorkflowOperationHandler"/>
+  <property name="service.description" value="Add Catalog Operation Handler"/>
+  <property name="workflow.operation" value="add-catalog"/>
+  <service>
+    <provide interface="org.opencastproject.workflow.api.WorkflowOperationHandler"/>
+  </service>
+  <reference cardinality="1..1" interface="org.opencastproject.workspace.api.Workspace" name="Workspace"
+             policy="static" bind="setWorkspace"/>
+</scr:component>

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandlerTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import org.junit.Before;
+
+public class AddCatalogWorkflowOperationHandlerTest {
+
+  private AddCatalogWorkflowOperationHandler operationHandler;
+
+  @Before
+  public void setUp() {
+    operationHandler = new AddCatalogWorkflowOperationHandler();
+  }
+
+}

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandlerTest.java
@@ -139,6 +139,17 @@ public class AddCatalogWorkflowOperationHandlerTest {
   }
 
   @Test
+  public void testNoFlavorFail() throws WorkflowOperationException {
+    // setup
+    operation.setConfiguration("catalog-flavor", "");
+    operation.setConfiguration("catalog-type-collision-behavior", "keep");
+
+    // execution
+    expectedException.expect(WorkflowOperationException.class);
+    operationHandler.start(instance, null);
+  }
+
+  @Test
   public void testKeep() throws WorkflowOperationException {
     // setup
     operation.setConfiguration("catalog-flavor", "flavor/test");

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandlerTest.java
@@ -21,15 +21,168 @@
 
 package org.opencastproject.workflow.handler.workflow;
 
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.workflow.api.WorkflowInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationInstance.OperationState;
+import org.opencastproject.workflow.api.WorkflowOperationInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.FileUtils;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AddCatalogWorkflowOperationHandlerTest {
 
   private AddCatalogWorkflowOperationHandler operationHandler;
+  private WorkflowInstanceImpl instance;
+  private WorkflowOperationInstanceImpl operation;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
     operationHandler = new AddCatalogWorkflowOperationHandler();
+
+    instance = new WorkflowInstanceImpl();
+
+    List<WorkflowOperationInstance> ops = new ArrayList<WorkflowOperationInstance>();
+    operation = new WorkflowOperationInstanceImpl("test", OperationState.RUNNING);
+    ops.add(operation);
+    instance.setOperations(ops);
+    String catalogName = "test-catalog";
+    operation.setConfiguration("catalog-name", catalogName);
+    operation.setConfiguration("catalog-path", getClass().getResource("/dublincore.xml").getPath());
+
+    MediaPackage mp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
+    instance.setMediaPackage(mp);
+
+    Workspace workspace = EasyMock.createMock(Workspace.class);
+    final Capture<InputStream> inStream = EasyMock.newCapture();
+    EasyMock.expect(workspace.put(EasyMock.anyString(), EasyMock.anyString(), EasyMock.eq(catalogName),
+                                  EasyMock.capture(inStream))).andAnswer(() -> {
+                                      final File file = temporaryFolder.newFile();
+                                      FileUtils.copyInputStreamToFile(inStream.getValue(), file);
+                                      return file.toURI();
+                                    }).anyTimes();
+    EasyMock.replay(workspace);
+
+    operationHandler.setWorkspace(workspace);
   }
 
+  @Test
+  public void testBasic() throws WorkflowOperationException {
+    // setup
+    operation.setConfiguration("catalog-flavor", "flavor/test");
+    operation.setConfiguration("catalog-type-collision-behavior", "keep");
+
+    operation.setConfiguration("catalog-tags", "tag1,tag2");
+
+    // execution
+    WorkflowOperationResult result = operationHandler.start(instance, null);
+
+    // checks
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    MediaPackage mp = result.getMediaPackage();
+
+    Assert.assertEquals(mp.getCatalogs().length, 1);
+
+    Assert.assertEquals(mp.getCatalogs()[0].getTags().length, 2);
+    Assert.assertEquals(mp.getCatalogs()[0].getTags()[0], "tag1");
+    Assert.assertEquals(mp.getCatalogs()[0].getTags()[1], "tag2");
+
+    Assert.assertEquals(mp.getCatalogs()[0].getFlavor(),
+                        MediaPackageElementFlavor.parseFlavor("flavor/test"));
+  }
+
+  @Test
+  public void testNoTags() throws WorkflowOperationException {
+    // setup
+    operation.setConfiguration("catalog-flavor", "flavor/test");
+    operation.setConfiguration("catalog-type-collision-behavior", "keep");
+
+    // execution
+    WorkflowOperationResult result = operationHandler.start(instance, null);
+
+    // checks
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    MediaPackage mp = result.getMediaPackage();
+
+    Assert.assertEquals(mp.getCatalogs().length, 1);
+
+    Assert.assertEquals(mp.getCatalogs()[0].getTags().length, 0);
+
+    Assert.assertEquals(mp.getCatalogs()[0].getFlavor(),
+                        MediaPackageElementFlavor.parseFlavor("flavor/test"));
+  }
+
+  @Test
+  public void testKeep() throws WorkflowOperationException {
+    // setup
+    operation.setConfiguration("catalog-flavor", "flavor/test");
+    operation.setConfiguration("catalog-type-collision-behavior", "keep");
+
+    // execution
+    operationHandler.start(instance, null);
+    WorkflowOperationResult result = operationHandler.start(instance, null);
+
+    // checks
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    MediaPackage mp = result.getMediaPackage();
+
+    Assert.assertEquals(mp.getCatalogs().length, 2);
+  }
+
+  @Test
+  public void testSkip() throws WorkflowOperationException {
+    // setup
+    operation.setConfiguration("catalog-flavor", "flavor/test");
+    operation.setConfiguration("catalog-type-collision-behavior", "skip");
+
+    // execution
+    operationHandler.start(instance, null);
+    WorkflowOperationResult result = operationHandler.start(instance, null);
+
+    // checks
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    MediaPackage mp = result.getMediaPackage();
+
+    Assert.assertEquals(mp.getCatalogs().length, 1);
+  }
+
+  @Test
+  public void testFail() throws WorkflowOperationException {
+    // setup
+    operation.setConfiguration("catalog-flavor", "flavor/test");
+    operation.setConfiguration("catalog-type-collision-behavior", "fail");
+
+    // execution
+    operationHandler.start(instance, null);
+    expectedException.expect(WorkflowOperationException.class);
+    operationHandler.start(instance, null);
+  }
 }


### PR DESCRIPTION
This WorkflowOperationHandler can add a catalog to the MediaPackage.
It supports the following workflow configuration keys:
- `catalog-path`: The path to the catalog, which will be added.
- `catalog-flavor`: The flavor of the catalog, also used to identify catalogs of the same type.
- `catalog-name`: Name of the catalog in the workspace.
- `catalog-tags`: List of comma seperated catalog tags.
- `catalog-type-collision-behavior` the action to perform, if an catalog of the same flavor already exists. Three options are supported: `skip` the adding of the catalog, `fail` the workflow operation or `keep` the new catalog, resulting in two or more catalogs of the same type coexisting.