### PR TITLE
MH-13367 External API series acl returns null pointer with missing acl

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -722,12 +722,11 @@ public class SeriesEndpoint {
       // The ACL is stored as JSON string in the index. Parse it and extract the part we want to have in the API.
       JSONObject acl = (JSONObject) parser.parse(series.getAccessPolicy());
 
-      if (((JSONObject) acl.get("acl")).containsKey("ace")) {
-        return ApiResponses.Json.ok(requestedVersion, ((JSONArray) ((JSONObject) acl.get("acl")).get("ace")).toJSONString());
-      } else if (!((JSONObject) acl.get("acl")).containsKey("ace")) {
+      if (!((JSONObject) acl.get("acl")).containsKey("ace")) {
         return ApiResponses.notFound("Cannot find acl for series with id '%s'.", id);
+      } else {
+        return ApiResponses.Json.ok(requestedVersion, ((JSONArray) ((JSONObject) acl.get("acl")).get("ace")).toJSONString());
       }
-      return ApiResponses.Json.ok(requestedVersion, ((JSONArray) ((JSONObject) acl.get("acl")).get("ace")).toJSONString());
     }
 
     return ApiResponses.notFound("Cannot find an series with id '%s'.", id);

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -721,6 +721,12 @@ public class SeriesEndpoint {
     for (final Series series : indexService.getSeries(id, externalIndex)) {
       // The ACL is stored as JSON string in the index. Parse it and extract the part we want to have in the API.
       JSONObject acl = (JSONObject) parser.parse(series.getAccessPolicy());
+
+      if (((JSONObject) acl.get("acl")).containsKey("ace")) {
+        return ApiResponses.Json.ok(requestedVersion, ((JSONArray) ((JSONObject) acl.get("acl")).get("ace")).toJSONString());
+      } else if (!((JSONObject) acl.get("acl")).containsKey("ace")) {
+        return ApiResponses.notFound("Cannot find acl for series with id '%s'.", id);
+      }
       return ApiResponses.Json.ok(requestedVersion, ((JSONArray) ((JSONObject) acl.get("acl")).get("ace")).toJSONString());
     }
 


### PR DESCRIPTION
External API series acl returns Server Error null pointer with missing acl.
This patch returns http not found.

This is a problem when a series is created. And directly after this accessed before
creation is completed.
