### PR TITLE
MH-12533, Re-introduce ability to avoid data loss during ingest

### DIFF
--- a/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
+++ b/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
@@ -1,28 +1,37 @@
 #This is the config file for the IngestServiceImpl
 
-# This is an option to update Series metadata during ingest
-# The default is true. This will updated an existing series with catalog found in the ingest
-# false means the exiting series catalog will not be updated using new series metadata found in the ingest
-# In both cases, the series catalog will be created if it does not already exist in Opencast
-# In both cases, the catalog for the episode will be created in Opencast
-
-# TODO: consider moving this key to the system.properties if used by other services, such as mediapackage update
-
-org.opencastproject.series.overwrite=false
-
-# Control if catalogs sent by capture agents for scheduled events are skipped. Not skipping them means that they will
+# Control if all catalogs sent by capture agents for scheduled events are skipped. Not skipping them means that they will
 # potentially overwrite existing metadata catalogs in Opencast.
 #
-# Default: true
+# Default: false
 #
-#skip.catalogs.for.existing.events=true
+#skip.catalogs.for.existing.events=false
 
-# Control if attachments sent by capture agents for scheduled events are skipped. Not skipping them means that they will
+# Control if all attachments sent by capture agents for scheduled events are skipped. Not skipping them means that they will
 # potentially overwrite existing attachments in Opencast.
 #
+# Default: false
+#
+#skip.attachments.for.existing.events=false
+
+# Control if some attachments and catalogs sent by capture agents for scheduled are added only if they do not overwrite
+# existing attachments and catalogs of the same flavor in Opencast. Not restricting to only new catalogs and attachments means
+# that ingested ones with flavors that match existing catalogs and attachments in Opencast will be overwritten.
+#
+# Note: if the skip catalogs and skip attachments parameters, above, are set to true, new catalogs and attachments are also skipped.
+#
 # Default: true
 #
-#skip.attachments.for.existing.events=true
+#add.only.new.catalogs.attachments.for.existing.events=true
+
+# *Deprecated*
+# Control to allow an Opencast series to be modified if an event is ingested. Enabling this feature is not recommended.
+# Enabling series overwrite during event ingest will potentially start an event update chain reaction affecting all events associated
+# to that series in Opencast. Every time an event is ingested.
+#
+# Default is false
+# *Deprecated*
+#org.opencastproject.series.overwrite=false
 
 # The approximate load placed on the system by ingesting a file
 # Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -156,9 +156,6 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
 
   public static final String JOB_TYPE = "org.opencastproject.ingest";
 
-  /** Managed Property key to overwrite existing series */
-  public static final String PROPKEY_OVERWRITE_SERIES = "org.opencastproject.series.overwrite";
-
   /** Methods that ingest zips create jobs with this operation type */
   public static final String INGEST_ZIP = "zip";
 
@@ -202,13 +199,31 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
   public static final String DOWNLOAD_PASSWORD = "org.opencastproject.download.password";
 
   /** By default, do not allow event ingest to modify existing series metadata */
-  static final boolean DEFAULT_ALLOW_SERIES_MODIFICATIONS = false;
+  public static final boolean DEFAULT_ALLOW_SERIES_MODIFICATIONS = false;
+
+  /** The default is to preserve existing Opencast flavors during ingest. */
+  public static final boolean DEFAULT_ALLOW_ONLY_NEW_FLAVORS = true;
+
+  /** The default is not to automatically skip attachments and catalogs from capture agent */
+  public static final boolean DEFAULT_SKIP = false;
+
+  /** Managed Property key to allow Opencast series modification during ingest
+   * Deprecated, the param potentially causes an update chain reaction for all
+   * events associated to that series, for each ingest */
+  @Deprecated
+  public static final String MODIFY_OPENCAST_SERIES_KEY = "org.opencastproject.series.overwrite";
+
+  /** Managed Property key to allow new flavors of ingested attachments and catalogs
+   * to be added to the existing Opencast mediapackage. But, not catalogs and attachments
+   * that would overwrite existing ones in Opencast.
+   */
+  public static final String ADD_ONLY_NEW_FLAVORS_KEY = "add.only.new.catalogs.attachments.for.existing.events";
 
   /** Control if catalogs sent by capture agents for scheduled events are skipped. */
-  private static final String SKIP_CATALOGS_KEY = "skip.catalogs.for.existing.events";
+  public static final String SKIP_CATALOGS_KEY = "skip.catalogs.for.existing.events";
 
   /** Control if attachments sent by capture agents for scheduled events are skipped. */
-  private static final String SKIP_ATTACHMENTS_KEY = "skip.attachments.for.existing.events";
+  public static final String SKIP_ATTACHMENTS_KEY = "skip.attachments.for.existing.events";
 
   /** The approximate load placed on the system by ingesting a file */
   private float ingestFileJobLoad = DEFAULT_INGEST_FILE_JOB_LOAD;
@@ -274,11 +289,13 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
   private Cache<String, Long> partialTrackStartTimes = CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.DAYS)
           .build();
 
-  /** Option, if an event ingest may modify metadata from existing series */
-  private boolean allowSeriesModifications = DEFAULT_ALLOW_SERIES_MODIFICATIONS;
+  /** Option to overwrite matching flavors (e.g. series and episode metadata) on ingest,
+   *  tracks are always taken on ingest */
+  protected boolean isAddOnlyNew = DEFAULT_ALLOW_ONLY_NEW_FLAVORS;
+  protected boolean isAllowModifySeries = DEFAULT_ALLOW_SERIES_MODIFICATIONS;
 
-  private boolean skipCatalogs = true;
-  private boolean skipAttachments = true;
+  private boolean skipCatalogs = DEFAULT_SKIP;
+  private boolean skipAttachments = DEFAULT_SKIP;
 
   /**
    * Creates a new ingest service instance.
@@ -319,6 +336,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
    */
   @Override
   public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+
     if (properties == null) {
       logger.info("No configuration available, using defaults");
       return;
@@ -328,8 +346,10 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     downloadUser = StringUtils.trimToEmpty(((String) properties.get(DOWNLOAD_USER)));
     downloadSource = StringUtils.trimToEmpty(((String) properties.get(DOWNLOAD_SOURCE)));
 
-    skipAttachments = BooleanUtils.toBoolean(Objects.toString(properties.get(SKIP_ATTACHMENTS_KEY), "true"));
-    skipCatalogs = BooleanUtils.toBoolean(Objects.toString(properties.get(SKIP_CATALOGS_KEY), "true"));
+    skipAttachments = BooleanUtils.toBoolean(Objects.toString(properties.get(SKIP_ATTACHMENTS_KEY),
+            BooleanUtils.toStringTrueFalse(DEFAULT_SKIP)));
+    skipCatalogs = BooleanUtils.toBoolean(Objects.toString(properties.get(SKIP_CATALOGS_KEY),
+            BooleanUtils.toStringTrueFalse(DEFAULT_SKIP)));
     logger.debug("Skip attachments sent by agents for scheduled events: {}", skipAttachments);
     logger.debug("Skip metadata catalogs sent by agents for scheduled events: {}", skipCatalogs);
 
@@ -337,15 +357,13 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
             serviceRegistry);
     ingestZipJobLoad = LoadUtil.getConfiguredLoadValue(properties, ZIP_JOB_LOAD_KEY, DEFAULT_INGEST_ZIP_JOB_LOAD,
             serviceRegistry);
-    // try to get overwrite series option from config, use default if not configured
-    try {
-      allowSeriesModifications = Boolean.parseBoolean(((String) properties.get(PROPKEY_OVERWRITE_SERIES)).trim());
-    } catch (Exception e) {
-      allowSeriesModifications = DEFAULT_ALLOW_SERIES_MODIFICATIONS;
-      logger.warn("Unable to update configuration. {}", e.getMessage());
-    }
-    logger.info("Configuration updated. It is {} that existing series will be overwritten during ingest.",
-            allowSeriesModifications);
+
+    isAllowModifySeries = BooleanUtils.toBoolean(Objects.toString(properties.get(MODIFY_OPENCAST_SERIES_KEY),
+              BooleanUtils.toStringTrueFalse(DEFAULT_ALLOW_SERIES_MODIFICATIONS)));
+    isAddOnlyNew = BooleanUtils.toBoolean(Objects.toString(properties.get(ADD_ONLY_NEW_FLAVORS_KEY),
+            BooleanUtils.toStringTrueFalse(DEFAULT_ALLOW_ONLY_NEW_FLAVORS)));
+    logger.info("Only allow new flavored catalogs and attachments on ingest:'{}'", isAddOnlyNew);
+    logger.info("Allowing series modification:'{}'", isAllowModifySeries);
   }
 
   /**
@@ -886,6 +904,8 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
    *          the URI to the dublin core document containing series metadata.
    * @return
    *         true, if the series is created or overwritten, false if the existing series remains intact.
+   * @throws IOException if the series catalog was not found
+   * @throws IngestException if any other exception was encountered
    */
   protected boolean updateSeries(URI uri) throws IOException, IngestException {
     HttpResponse response = null;
@@ -903,7 +923,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
         try {
           try {
             seriesService.getSeries(id);
-            if (allowSeriesModifications) {
+            if (isAllowModifySeries) {
               // Update existing series
               seriesService.updateSeries(dc);
               isUpdated = true;
@@ -1359,7 +1379,17 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     }
   }
 
-  private void mergeMediaPackageElements(final MediaPackage mp, final MediaPackage scheduledMp) {
+  /**
+   * Merge different elements from capture agent ingesting mp and Asset manager. Overwrite or replace same flavored
+   * elements depending on the Ingest Service overwrite configuration. Ignore publications (i.e. live publication
+   * channel from Asset Manager) Always keep tracks from the capture agent.
+   *
+   * @param mp
+   *          the medipackage being ingested from the Capture Agent
+   * @param scheduledMp
+   *          the mediapckage that was schedule and managed by the Asset Manager
+   */
+  private void mergeMediaPackageElements(MediaPackage mp, MediaPackage scheduledMp) {
     // drop catalogs sent by the capture agent in favor of Opencast's own metadata
     if (skipCatalogs) {
       for (MediaPackageElement element : mp.getCatalogs()) {
@@ -1376,45 +1406,80 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     }
 
     for (MediaPackageElement element : scheduledMp.getElements()) {
-      // Asset manager media package may have a publication element (for live) if retract live has not run yet
-      if (element.getFlavor() != null
-              && !MediaPackageElement.Type.Publication.equals(element.getElementType())
-              && mp.getElementsByFlavor(element.getFlavor()).length > 0) {
-        logger.info("Ignore scheduled element '{}', there is already an ingested element with flavor '{}'", element,
-                element.getFlavor());
+      if (MediaPackageElement.Type.Publication.equals(element.getElementType())) {
+        // The Asset managed media package may have a publication element for a live event, if retract live has not run yet.
+        // Publications do not have flavors and are never part of the mediapackage from the capture agent.
+        // Therefore, ignore publication element because it is removed when the recorded media is published and causes complications (on short media) if added.
+        logger.debug("Ignoring {}, not adding to ingested mediapackage {}", MediaPackageElement.Type.Publication, mp);
         continue;
+      } else if (mp.getElementsByFlavor(element.getFlavor()).length > 0) {
+        // The default is to overwrite matching flavored elements in the Asset managed mediapackage (e.g. catalogs)
+        // If isOverwrite is true, changes made from the CA overwrite (update/revert) changes made from the Admin UI.
+        // If isOverwrite is false, changes made from the CA do not overwrite (update/revert) changes made from the Admin UI.
+        // regardless of overwrite, always keep new ingested tracks.
+        if (!isAddOnlyNew || MediaPackageElement.Type.Track.equals(element.getElementType())) {
+          // Allow updates made from the Capture Agent to overwrite existing metadata in Opencast
+          logger.info(
+                  "Omitting Opencast (Asset Managed) element '{}', replacing with ingested element of same flavor '{}'",
+                  element,
+                  element.getFlavor());
+          continue;
+        }
+        // Remove flavored element from ingested mp and replaced it with maching element from Asset Managed mediapackage.
+        // This protects updates made from the admin UI during an event capture from being reverted by artifacts from the ingested CA.
+        for (MediaPackageElement el : mp.getElementsByFlavor(element.getFlavor())) {
+          logger.info("Omitting ingested element '{}' {}, keeping existing (Asset Managed) element of same flavor '{}'", el, el.getURI(),
+                  element.getFlavor());
+          mp.remove(el);
+        }
       }
-      logger.info("Adding new scheduled element '{}' to ingested mediapackage", element);
+      logger.info("Adding element {} from scheduled (Asset Managed) event '{}' into ingested mediapackage", element, mp);
       mp.add(element);
     }
   }
 
+  /**
+   *
+   * The previous OC behaviour is for metadata in the ingested mediapackage to be updated by the
+   * Asset Managed metadata *only* when the field is blank on the ingested mediapackage.
+   * However, that field may have been intentionally emptied by
+   * removing its value from the Capture Agent UI (e.g. Galicaster)
+   *
+   * If isOverwrite is true, metadata values in the ingest mediapackage overwrite Asset Managed metadata.
+   * If isOverwrite is false, Asset Managed metadata is preserved.
+   *
+   * @param mp,
+   *          the inbound ingested mp
+   * @param scheduledMp,
+   *          the existing scheduled mp
+   */
   private void mergeMediaPackageMetadata(MediaPackage mp, MediaPackage scheduledMp) {
-    // Merge media package fields
-    if (mp.getDate() == null)
+    // Merge media package fields depending on overwrite setting
+    boolean noOverwrite = (isAddOnlyNew && !skipCatalogs) || skipCatalogs;
+    if ((mp.getDate() == null) || noOverwrite)
       mp.setDate(scheduledMp.getDate());
-
-    if (skipCatalogs || isBlank(mp.getLicense()))
+    if (isBlank(mp.getLicense()) || noOverwrite)
       mp.setLicense(scheduledMp.getLicense());
-    if (skipCatalogs || isBlank(mp.getSeries()))
+    if (isBlank(mp.getSeries()) || noOverwrite)
       mp.setSeries(scheduledMp.getSeries());
-    if (skipCatalogs || isBlank(mp.getSeriesTitle()))
+    if (isBlank(mp.getSeriesTitle()) || noOverwrite)
       mp.setSeriesTitle(scheduledMp.getSeriesTitle());
-    if (skipCatalogs || isBlank(mp.getTitle()))
+    if (isBlank(mp.getTitle()) || noOverwrite)
       mp.setTitle(scheduledMp.getTitle());
-    if (skipCatalogs || mp.getSubjects().length == 0) {
+
+    if (mp.getSubjects().length <= 0 || noOverwrite) {
       Arrays.stream(mp.getSubjects()).forEach(mp::removeSubject);
       for (String subject : scheduledMp.getSubjects()) {
         mp.addSubject(subject);
       }
     }
-    if (skipCatalogs || mp.getContributors().length == 0) {
+    if (noOverwrite || mp.getContributors().length == 0) {
       Arrays.stream(mp.getContributors()).forEach(mp::removeContributor);
       for (String contributor : scheduledMp.getContributors()) {
         mp.addContributor(contributor);
       }
     }
-    if (skipCatalogs || mp.getCreators().length == 0) {
+    if (noOverwrite || mp.getCreators().length == 0) {
       Arrays.stream(mp.getCreators()).forEach(mp::removeCreator);
       for (String creator : scheduledMp.getCreators()) {
         mp.addCreator(creator);
@@ -1533,9 +1598,9 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
   /**
    * Creates a StandAloneTrustedHttpClientImpl
    *
-   * @param user
-   * @param password
-   * @return
+   * @param user the username
+   * @param password the password
+   * @return the trusted client
    */
   protected TrustedHttpClient createStandaloneHttpClient(String user, String password) {
     return new StandAloneTrustedHttpClientImpl(this.downloadUser, this.downloadPassword, none(), none(), none());
@@ -1837,7 +1902,12 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     }
   }
 
-  /** Create a media inspection job for a mediapackage element. */
+  /**
+   * Create a media inspection job for a mediapackage element.
+   *
+   * @param svc the media inspection service
+   * @return a function
+   */
   public static Function<MediaPackageElement, Job> newEnrichJob(final MediaInspectionService svc) {
     return new Function.X<MediaPackageElement, Job>() {
       @Override
@@ -1849,6 +1919,9 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
 
   /**
    * Interpret the payload of a completed Job as a MediaPackageElement. Wait for the job to complete if necessary.
+   *
+   * @param reg the service registry
+   * @return a function
    */
   public static Function<Job, Track> payloadAsTrack(final ServiceRegistry reg) {
     return new Function.X<Job, Track>() {

--- a/modules/ingest-service-impl/src/test/resources/source-manifest-partial.xml
+++ b/modules/ingest-service-impl/src/test/resources/source-manifest-partial.xml
@@ -84,9 +84,19 @@
       <url>metadata/mpeg-7.xml</url>
       <checksum type="md5">2b8a52878c536e64e20e309b5d7c1070</checksum>
     </catalog>
+    <catalog id="catalog-4" type="foo/bar">
+      <mimetype>text/xml</mimetype>
+      <url>metadata/dublincore.xml</url>
+      <checksum type="md5">2b8a52878c536e64e20e309b5d7c1070</checksum>
+    </catalog>
   </metadata>
   <attachments>
     <attachment id="cover" type="cover/source">
+      <mimetype>image/png</mimetype>
+      <url>attachments/cover.png</url>
+      <checksum type="md5">6d535f61a1b31a3edeb01be0951a2b4e</checksum>
+    </attachment>
+      <attachment id="new-flavor-attachment" type="foo/bar">
       <mimetype>image/png</mimetype>
       <url>attachments/cover.png</url>
       <checksum type="md5">6d535f61a1b31a3edeb01be0951a2b4e</checksum>

--- a/modules/ingest-service-impl/src/test/resources/source-manifest.xml
+++ b/modules/ingest-service-impl/src/test/resources/source-manifest.xml
@@ -35,4 +35,15 @@
       <checksum type="md5">6d535f61a1b31a3edeb01be0951a2b4e</checksum>
     </attachment>    
   </attachments>
+  <!-- test with live pub in asset manager -->
+  <publications>
+    <publication id="1004b8ad-a794-4a6c-93e2-073b80a2eb7f" channel="engage-live">
+      <mimetype>text/html</mimetype>
+        <tags/>
+        <url>http://opencast.acme.edu/engage/player/watch.html?id=537fec50-690a-4dee-a4ce-528ae90c1f9c</url>
+        <media/>
+        <attachments/>
+        <metadata/>
+      </publication>
+   </publications>
 </mediapackage>


### PR DESCRIPTION
This pull re-introduces the ability for sites preserve metadata edits to scheduled events made from the Opencast Admin UI when using a capture agent that ingests with potentially stale material, such as series and event catalogs.

Tracks from the ingest always given priority from the CA. But, attachments and catalogs from the CA have a lower precedence than existing ones in the Opencast system.

This config should go into the docs, somewhere, to describe the various configs, but I'm having a hard time finding a spot. I might make an Ingest Service page.