### PR TITLE
MH-13369, Delete Capture Agents

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/captureAgentsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/captureAgentsResource.js
@@ -41,7 +41,7 @@ angular.module('adminNg.resources')
           row.inputs = r.inputs;
           row.roomId = r.roomId;
           row.type = 'LOCATION';
-          row.removable = ('offline' == r.Status) || ('unknown' == r.Status);
+          row.removable = 'AGENTS.STATUS.OFFLINE' === r.Status || 'AGENTS.STATUS.UNKNOWN' === r.Status;
           return row;
         };
 


### PR DESCRIPTION
Pull request #384 broke the mechanism to show the icon for deleting
capture agents which are offline from within the admin interface since
the JavaScript code does no longer see the actual status but the
translation key used to represent this status.