### PR TITLE
MH-13370, Don't configure unnecessary default credentials

### DIFF
--- a/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
+++ b/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
@@ -10,23 +10,23 @@
 
 org.opencastproject.series.overwrite=true
 
-#The approximate load placed on the system by ingesting a file
-#Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node
-#These jobs involve heavy I/O, so we want them to be expensive, but not cripplingly so
+# The approximate load placed on the system by ingesting a file
+# Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node
+# These jobs involve heavy I/O, so we want them to be expensive, but not cripplingly so
 # Default: 0.2
 #job.load.ingest.file=0.2
 
-#The approximate load placed on the system by ingesting a zip file
-#Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node
-#These jobs involve heavy I/O, so we want them to be expensive
+# The approximate load placed on the system by ingesting a zip file
+# Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node
+# These jobs involve heavy I/O, so we want them to be expensive
 # Default: 0.2
-# job.load.ingest.zip=0.2
+#job.load.ingest.zip=0.2
 
-#The Ingest Service is capable of downloading tracks/attachemnts itself from urls.
-#The Credentials can be set for an external source (example: https://develop.opencast.org)
-#The source is written as a regular expression.
-#Example for two sources: (.*)//develop.opencast.org/(.*)|(.*)//stable.opencast.org/(.*)
-
-download.source = https://localhost/(*.)
-download.user = opencast_system_account
-download.password = CHANGE_ME
+# The Ingest Service is capable of downloading tracks/attachments itself from URLs.
+# The Credentials can be set for an external source (example: https://develop.opencast.org)
+# The source is written as a regular expression.
+# Example for two sources: (.*)//develop.opencast.org/(.*)|(.*)//stable.opencast.org/(.*)
+# Default: <empty>
+#download.source = http://localhost/.*
+#download.user = opencast_system_account
+#download.password = CHANGE_ME


### PR DESCRIPTION
The default configuration for the ingest service contains unnecessary
credentials which are used if the configured regular expresseion (which
has a typo) matches. This could (given the type get's fixed) cause
trouble with ingests from that system.

This just goes with the empty default configuration instead.