### PR TITLE
MH-13372, Clean up orphaned asset manager properties

### DIFF
--- a/docs/upgrade/6_to_7/mysql5.sql
+++ b/docs/upgrade/6_to_7/mysql5.sql
@@ -28,3 +28,9 @@ DELETE FROM oc_assets_properties WHERE namespace = 'org.opencastproject.schedule
 
 ALTER TABLE oc_job DROP COLUMN blocking_job;
 DROP TABLE oc_blocking_job;
+
+-- Clean up orphaned asset manager properties
+delete p from oc_assets_properties p where not exists (
+  select * from oc_assets_snapshot s
+    where p.mediapackage_id = s.mediapackage_id
+);


### PR DESCRIPTION
Pull request #695 drops the automatic removal of orphaned asset manager
properties due to its extremely bad performance compared to just keeping
these relatively small data.

While these orphaned data have barely any impact, this pull request adds
clean-up SQL code to the upgrade script. After all, we are modifying the
database anyway and running a slow query here is not a problem.