### PR TITLE
MH-13376, Fix OSGI Bindings

### DIFF
--- a/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-acl.xml
+++ b/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-acl.xml
@@ -30,7 +30,7 @@
 
   <reference name="search-index"
              cardinality="1..1"
-             interface="org.opencastproject.external.impl.index.ExternalIndex"
+             interface="org.opencastproject.external.index.ExternalIndex"
              policy="static"
              bind="setSearchIndex"/>
 

--- a/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-assetmanager.xml
+++ b/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-assetmanager.xml
@@ -31,7 +31,7 @@
              interface="org.opencastproject.index.service.message.MessageReceiverLockService"
              cardinality="1..1" policy="static" bind="setMessageReceiverLockService"/>
   <reference name="search-index" cardinality="1..1"
-             interface="org.opencastproject.external.impl.index.ExternalIndex" policy="static"
+             interface="org.opencastproject.external.index.ExternalIndex" policy="static"
              bind="setSearchIndex"/>
 
   <reference name="security-service" interface="org.opencastproject.security.api.SecurityService" cardinality="1..1"

--- a/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-comment.xml
+++ b/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-comment.xml
@@ -16,7 +16,7 @@
   <reference name="message-receiver-lock-service"
              interface="org.opencastproject.index.service.message.MessageReceiverLockService"
              cardinality="1..1" policy="static" bind="setMessageReceiverLockService"/>
-  <reference name="search-index" interface="org.opencastproject.external.impl.index.ExternalIndex"
+  <reference name="search-index" interface="org.opencastproject.external.index.ExternalIndex"
              cardinality="1..1" policy="static" bind="setSearchIndex"/>
   <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
              cardinality="1..1" policy="static" bind="setSecurityService"/>

--- a/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-group.xml
+++ b/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-group.xml
@@ -30,7 +30,7 @@
 
   <reference name="search-index"
              cardinality="1..1"
-             interface="org.opencastproject.external.impl.index.ExternalIndex"
+             interface="org.opencastproject.external.index.ExternalIndex"
              policy="static"
              bind="setSearchIndex"/>
 

--- a/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-scheduler.xml
+++ b/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-scheduler.xml
@@ -16,7 +16,7 @@
   <reference name="message-receiver-lock-service"
              interface="org.opencastproject.index.service.message.MessageReceiverLockService"
              cardinality="1..1" policy="static" bind="setMessageReceiverLockService"/>
-  <reference name="search-index" interface="org.opencastproject.external.impl.index.ExternalIndex"
+  <reference name="search-index" interface="org.opencastproject.external.index.ExternalIndex"
              cardinality="1..1" policy="static" bind="setSearchIndex"/>
   <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
              cardinality="1..1" policy="static" bind="setSecurityService"/>

--- a/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-series.xml
+++ b/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-series.xml
@@ -16,7 +16,7 @@
   <reference name="message-receiver-lock-service"
              interface="org.opencastproject.index.service.message.MessageReceiverLockService"
              cardinality="1..1" policy="static" bind="setMessageReceiverLockService"/>
-  <reference name="search-index" interface="org.opencastproject.external.impl.index.ExternalIndex"
+  <reference name="search-index" interface="org.opencastproject.external.index.ExternalIndex"
              cardinality="1..1" policy="static" bind="setSearchIndex"/>
   <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
              cardinality="1..1" policy="static" bind="setSecurityService"/>

--- a/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-theme.xml
+++ b/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-theme.xml
@@ -30,7 +30,7 @@
 
   <reference name="search-index"
              cardinality="1..1"
-             interface="org.opencastproject.external.impl.index.ExternalIndex"
+             interface="org.opencastproject.external.index.ExternalIndex"
              policy="static"
              bind="setSearchIndex"/>
 

--- a/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-workflow.xml
+++ b/modules/external-api-index/src/main/resources/OSGI-INF/message-receiver-workflow.xml
@@ -23,7 +23,7 @@
              bind="setMessageReceiverLockService"/>
 
   <reference name="search-index"
-             interface="org.opencastproject.external.impl.index.ExternalIndex"
+             interface="org.opencastproject.external.index.ExternalIndex"
              bind="setSearchIndex"/>
 
   <reference name="security-service"

--- a/modules/index-service/src/main/resources/OSGI-INF/list-providers/contributors.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/list-providers/contributors.xml
@@ -13,14 +13,10 @@
 
   <reference name="userDirectoryService"
              interface="org.opencastproject.security.api.UserDirectoryService"
-             cardinality="1..1"
-             policy="static"
              bind="setUserDirectoryService"/>
 
   <reference name="AdminUISearchIndex"
-             interface="AdminUISearchIndex"
-             cardinality="1..1"
-             policy="static"
+             interface="org.opencastproject.adminui.index.AdminUISearchIndex"
              bind="setIndex"/>
 
 </scr:component>

--- a/modules/index-service/src/main/resources/OSGI-INF/list-providers/events.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/list-providers/events.xml
@@ -12,8 +12,6 @@
   </service>
 
   <reference name="AdminUISearchIndex"
-             interface="AdminUISearchIndex"
-             cardinality="1..1"
-             policy="static"
+             interface="org.opencastproject.adminui.index.AdminUISearchIndex"
              bind="setIndex"/>
 </scr:component>

--- a/modules/index-service/src/main/resources/OSGI-INF/list-providers/themes.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/list-providers/themes.xml
@@ -12,15 +12,11 @@
   </service>
 
   <reference name="AdminUISearchIndex"
-             interface="AdminUISearchIndex"
-             cardinality="1..1"
-             policy="static"
+             interface="org.opencastproject.adminui.index.AdminUISearchIndex"
              bind="setIndex"/>
 
   <reference name="SecurityService"
              interface="org.opencastproject.security.api.SecurityService"
-             cardinality="1..1"
-             policy="static"
              bind="setSecurityService"/>
 
 </scr:component>


### PR DESCRIPTION
When splitting off the admin and external api index, I accidentally
used an invalid identifier for the OSGI binding configuration, causing
the binding to fail.