### PR TITLE
MH-13377 Fix scheduler rrule TimeZone issue

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -155,7 +155,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -971,9 +970,7 @@ public class IndexServiceImpl implements IndexService {
         }
         return mediaPackage.getIdentifier().compact();
       case SCHEDULE_MULTIPLE:
-        List<Period> periods = schedulerService.calculatePeriods(rRule, start.toDate(), end.toDate(), duration, tz);
-        Map<String, Period> scheduled = new LinkedHashMap<>();
-         scheduled = schedulerService.addMultipleEvents(rRule, start.toDate(), end.toDate(), duration, tz, captureAgentId,
+        final Map<String, Period> scheduled = schedulerService.addMultipleEvents(rRule, start.toDate(), end.toDate(), duration, tz, captureAgentId,
                 presenterUsernames, eventHttpServletRequest.getMediaPackage().get(), configuration, (Map) caProperties, Opt.none(), Opt.none(), SchedulerService.ORIGIN);
         return StringUtils.join(scheduled.keySet(), ",");
       default:

--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
@@ -488,24 +488,6 @@ public interface SchedulerService {
           throws NotFoundException, UnauthorizedException, SchedulerException;
 
   /**
-   * Returns a list of {@link Period}s which would be scheduled between a start and end date with a given recurrence
-   * rule. Note that this method does not actually schedule anything, merely calculates where things *would* be scheduled.
-   *
-   * @param rrule
-   *          The {@link RRule} defining the recurrence rules
-   * @param start
-   *          The start date and time
-   * @param end
-   *          The end date and time
-   * @param duration
-   *          The duration for each event
-   * @param tz
-   *          The timezone to schedule in
-   * @return The list of Periods which would be scheduled
-   */
-  List<Period> calculatePeriods(RRule rrule, Date start, Date end, long duration, TimeZone tz);
-
-  /**
    * Query
    */
 

--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/Util.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/Util.java
@@ -35,6 +35,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.LinkedList;
@@ -47,6 +49,28 @@ public final class Util {
   private static final TimeZoneRegistry registry = TimeZoneRegistryFactory.getInstance().createRegistry();
 
   private Util() {
+  }
+
+
+  /**
+   * Adjust the given UTC rrule to the given timezone.
+   *
+   * @param rRule The rrule to adjust.
+   * @param start The start date in UTC
+   *
+   * @param tz The target timezone.
+   */
+  public static void adjustRrule(final RRule rRule, final Date start, final TimeZone tz) {
+    final Recur recur = rRule.getRecur();
+    if (recur.getHourList().size() != 1 || recur.getMinuteList().size() != 1) {
+      throw new IllegalArgumentException("RRules with multiple hours/minutes are not supported by Opencast. " + recur.toString());
+    }
+    final ZonedDateTime adjustedDate = ZonedDateTime.ofInstant(start.toInstant(), ZoneOffset.UTC)
+            .withHour(recur.getHourList().get(0))
+            .withMinute(recur.getMinuteList().get(0))
+            .withZoneSameInstant(tz.toZoneId());
+    recur.getHourList().set(0, adjustedDate.getHour());
+    recur.getMinuteList().set(0, adjustedDate.getMinute());
   }
 
   /**

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -183,6 +183,8 @@ import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1892,8 +1894,9 @@ public class SchedulerServiceImplTest {
       assertEquals(1, events.size());
     }
     {
+      ZonedDateTime startZdt = ZonedDateTime.ofInstant(start.toInstant(), ZoneOffset.UTC);
       List<MediaPackage> events = schedSvc.findConflictingEvents("Device A",
-              new RRule("FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA"), start, new Date(start.getTime() + hours(48)),
+              new RRule("FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA;BYHOUR=" + startZdt.getHour() + ";BYMINUTE=" + startZdt.getMinute()), start, new Date(start.getTime() + hours(48)),
               new Long(seconds(36)), TimeZone.getTimeZone("America/Chicago"));
       assertEquals(2, events.size());
     }

--- a/modules/scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
+++ b/modules/scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
@@ -43,7 +43,6 @@ import org.opencastproject.scheduler.api.SchedulerService;
 import org.opencastproject.scheduler.api.SchedulerTransactionLockException;
 import org.opencastproject.scheduler.api.TechnicalMetadata;
 import org.opencastproject.scheduler.api.TechnicalMetadataImpl;
-import org.opencastproject.scheduler.api.Util;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.UnauthorizedException;
@@ -851,11 +850,6 @@ public class SchedulerServiceRemoteImpl extends RemoteBase implements SchedulerS
       closeConnection(response);
     }
     throw new SchedulerException("Unable to get event review status from remote scheduler service");
-  }
-
-  @Override
-  public List<Period> calculatePeriods(RRule rrule, Date start, Date end, long duration, TimeZone tz) {
-    return Util.calculatePeriods(start, end, duration, rrule, tz);
   }
 
   @Override


### PR DESCRIPTION
When scheduling mutliple events, the admin UI sends an RRULE with UTC
hours and minutes plus start and end date  to the server.
The server than retrieves the timezone from the capture agent and
adjusts start and end date accordingly, which is fine. However, what was
missing was converting the hour and minute in the RRULE.