### PR TITLE
MH-13383 don't smooth the waveform in the editor

### DIFF
--- a/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
@@ -195,6 +195,12 @@ $segment-deleted-selected: saturate(darken($segment-deleted, 25%), 5%);
                 // needed for zoom offset
                 position: relative;
 
+                // don't smooth the waveform
+                -ms-interpolation-mode: nearest-neighbor;
+                image-rendering: -webkit-optimize-contrast;
+                image-rendering: -moz-crisp-edges;
+                image-rendering: pixelated;
+
                 .segment-container {
                     float: left;
                     height: $segment-height;


### PR DESCRIPTION
This patch disable the smoothing of the waveform image in the editor.

Before (with smoothing waveform image):
![editor-waveform-before](https://user-images.githubusercontent.com/26736/53039223-fc01a280-347e-11e9-8f0e-b9d91fd7e34d.png)

After this patch (without smoothing waveform image):
![editor-waveform-after](https://user-images.githubusercontent.com/26736/53039235-0623a100-347f-11e9-8e1d-3ab8b70cca6d.png)
