### PR TITLE
MH-13277 fix concurrent Map updates in scheduler

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -147,7 +147,6 @@ import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -155,6 +154,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -516,7 +516,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     notNull(optOutStatus, "optOutStatus");
     notNull(schedulingSource, "schedulingSource");
 
-    Map<String, Period> scheduledEvents = new LinkedHashMap<>();
+    Map<String, Period> scheduledEvents = new ConcurrentHashMap<>();
 
     try {
       LinkedList<Id> ids = new LinkedList<>();


### PR DESCRIPTION
While adding multiple scheduled events, the results of adding an event were put into a `LinkedHashMap`. This was fine, up until we added `parallelStream` into the equation. Using a `ConcurrentHashMap` should
mitigate this issue (which I, unfortunately, couldn’t event reproduce on my machine).

I also did a cursory check if other data structures are similarly modified in this process, but the rest seems fine to me.