### PR TITLE
MH-13384: Remove duplicate `joda-time` dependency declaration

### DIFF
--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -194,10 +194,6 @@
       <groupId>org.mnode.ical4j</groupId>
       <artifactId>ical4j</artifactId>
     </dependency>
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-    </dependency>
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Maven is complaining about a duplicate dependency again:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.opencastproject:opencast-index-service:bundle:7-SNAPSHOT 
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: joda-time:joda-time:jar -> duplicate declaration of version (?) @ org.opencastproject:opencast-index-service:[unknown-version], /home/cyrus/src/opencast/modules/index-service/pom.xml, line 197, column 17 
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build. 
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects. 
[WARNING] 
```