### PR TITLE
MH-13385: Simplify the configuration of the URL signing components

### DIFF
--- a/docs/guides/admin/docs/configuration/stream-security.md
+++ b/docs/guides/admin/docs/configuration/stream-security.md
@@ -39,7 +39,7 @@ The GenericUrlSigningProvider that comes with Opencast has its own configuration
 All signing providers follow the same configuration structure and support multiple configuration blocks, providing the
 settings for separate distributions (i.e. download or streaming servers, services or paths).
 
-Each configuration block consists of the following items:
+Each signing key configuration consists of the following attributes:
 
 * **Key ID:** Key identifier, e.g. `demoKeyOne`
 * **Key secret:** Key value, e.g. `25DA2BA549CB62EF297977845259A`. The key-length is not predefined, but a key length of
@@ -49,19 +49,11 @@ Each configuration block consists of the following items:
 
 A typical configuration looks like this:
 
-    id.1=demoKeyOne
-    key.1=6EDB5EDDCF994B7432C371D7C274F
-    url.1=http://download.opencast.org/engage
+    key.demoKeyOne.secret=6EDB5EDDCF994B7432C371D7C274F
+    key.demoKeyOne.url=http://download.opencast.org/engage
 
-    id.2=demoKeyTwo
-    key.2=6EDB5EDDCF994B7432C371D7C274F
-    url.2=http://download.opencast.org/custom
-
-The properties defined in the configuration file take a numeric suffix that must start at `1` and increase in single
-increments. In the example above these can be seen as: `.1` and `.2`. As soon as there is a missing number it will stop
-looking for further entries.
-
-Note that id and key form a fixed pair, while the same key can be used in more than one configuration block.
+    key.demoKeyTwo.secret=6EDB5EDDCF994B7432C371D7C274F
+    key.demoKeyTwo.url=http://download.opencast.org/custom
 
 Configuration of URL Signing Timeout Values
 -------------------------------------------
@@ -148,17 +140,11 @@ The configuration is located at:
 
     etc/org.opencastproject.security.urlsigning.verifier.impl.UrlSigningVerifierImpl.cfg
 
-First of all, the key pairs used to sign must be configured in order to allow the filter to verify the signatures. More
-than one key pair can be defined by increasing the counter (1, 2, 3, ...) in steps of 1. If you miss any numbers it will
-stop looking for further configurations.
-
 Example:
 
-    id.1=demoKeyOne
-    key.1=6EDB5EDDCF994B7432C371D7C274F
+    key.demoKeyOne=6EDB5EDDCF994B7432C371D7C274F
 
-    id.2=demoKeyTwo
-    key.2=C843C21ECF59F2B38872A1BCAA774
+    key.demoKeyTwo=C843C21ECF59F2B38872A1BCAA774
 
 The entries in this file need to have the same values for the signing providers configuration.
 
@@ -183,11 +169,11 @@ Example:
 
     strict=true
 
-    url.regex.1=.*files\/collection\/.*
-    url.regex.2=.*files\/mediapackage\/.*
-    url.regex.3=(?\=(.*staticfiles.*))(?=^(?!.*staticfiles.*url|.*docs.*).*$)(.*)
-    url.regex.4=.*archive\/archive\/mediapackage\/.*\/.*\/.*
-    url.regex.5=.*static.*
+    url.regex.collection=.*files\/collection\/.*
+    url.regex.mediapackage=.*files\/mediapackage\/.*
+    url.regex.staticfiles=(?\=(.*staticfiles.*))(?=^(?!.*staticfiles.*url|.*docs.*).*$)(.*)
+    url.regex.archive=.*archive\/archive\/mediapackage\/.*\/.*\/.*
+    url.regex.static=.*static.*
 
 Testing
 -------

--- a/etc/org.opencastproject.security.urlsigning.filter.UrlSigningFilter.cfg
+++ b/etc/org.opencastproject.security.urlsigning.filter.UrlSigningFilter.cfg
@@ -15,20 +15,20 @@ strict=true
 # require a signed url by stream security before a file can be downloaded
 
 # Protects: /files/collection/{collectionId}/{fileName}
-url.regex.1=.*files\/collection\/.*
+url.regex.collection=.*files\/collection\/.*
 
 # Protects: /files/mediapackage/{mediaPackageID}/{mediaPackageElementID}
 # and Protects: /files/mediapackage/{mediaPackageID}/{mediaPackageElementID}/{fileName}
-url.regex.2=.*files\/mediapackage\/.*
+url.regex.mediapackage=.*files\/mediapackage\/.*
 
 # Protects: /staticfiles/{uuid} but not /staticfiles/{uuid}/url
-url.regex.3=(?\=(.*staticfiles.*))(?=^(?!.*staticfiles.*url|.*docs.*).*$)(.*)
+url.regex.staticfiles=(?\=(.*staticfiles.*))(?=^(?!.*staticfiles.*url|.*docs.*).*$)(.*)
 
 # Protects: /archive/archive/mediapackage/{mediaPackageID}/{mediaPackageElementID}/{version}
-url.regex.4=.*archive\/archive\/mediapackage\/.*\/.*\/.*
+url.regex.archive=.*archive\/archive\/mediapackage\/.*\/.*\/.*
 
 # Protects files hosted by the built in jetty server for engage
-url.regex.5=.*static\/engage-player.*
+url.regex.engage=.*static\/engage-player.*
 
 # Protects files hosted by the built in jetty server for previews / editing
-url.regex.6=.*static\/internal.*
+url.regex.internal=.*static\/internal.*

--- a/etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg
+++ b/etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg
@@ -5,22 +5,13 @@
 # This provider supports multiple configuration blocks, providing the settings for separate distributions (i.e. download
 # or streaming servers, services or paths).
 
-# Each configuration block consists of the following items:
+# A URL signing key has the following attributes:
+
     # Key ID: Key Identifier, e.g. ‘demoKeyOne’
     # Key secret: Key value, e.g. ‘25DA2BA549CB62EF297977845259A’. The key-length is not predefined, but a key length of
         # at least 128 bit is recommended. Any larger value will not increase security of the underlying algorithm.
     # URL prefix: The URL Signing Provider will only sign URLs that start with this value. This allows to support
         # multiple distributions and different key pairs.
-    # Organization: Optional tenant identifier of organization allowed to sign using this key. Can be set to "*"
-        # (default) to indicate that any organization is allowed to use this key for URL signing.
-
-# The properties defined in the configuration file take a numeric suffix that must start at “1" and increase in single
-# increments. In the example below these can be seen as: “.1” and “.2”. As soon as there is a missing number it will
-# stop looking for further entries so be careful not to remove configurations with numbers lower than others. For
-# example if there are configurations using number suffixes from 1 to 5, then commenting out the number 2 configurations
-# will prevent the 3, 4, 5 configurations from being used.
-
-# Note that id and key form a fixed pair, while the same key can be used in more than one configuration block.
 
 # Important: For all URL prefixes, no URL prefix may be a prefix of any other URL prefix
 
@@ -29,12 +20,10 @@
 
 # A typical configuration looks like this:
 
-# id.1=demoKeyOne
-# key.1=6EDB5EDDCF994B7432C371D7C274F
-# url.1=http://download.opencast.org/engage
-# organization.1=mh_default_org
+# key.demoKeyOne.secret=6EDB5EDDCF994B7432C371D7C274F
+# key.demoKeyOne.url=http://download.opencast.org/engage
+# key.demoKeyOne.organization=mh_default_org
 
-# id.2=demoKeyOne
-# key.2=6EDB5EDDCF994B7432C371D7C274F
-# url.2=http://download.opencast.org/custom
-# organization.2=mh_default_org
+# key.demoKeyTwo.secret=6EDB5EDDCF994B7432C371D7C274F
+# key.demoKeyTwo.url=http://download.opencast.org/custom
+# key.demoKeyTwo.organization=mh_default_org

--- a/etc/org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg
+++ b/etc/org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg
@@ -7,30 +7,21 @@
 # This provider supports multiple configuration blocks, providing the settings for separate distributions (i.e. download
 # or streaming servers, services or paths).
 
-# Each configuration block consists of the following items:
+# A URL signing key has the following attributes:
+
     # Key ID: Key Identifier, e.g. ‘demoKeyOne’
     # Key secret: Key value, e.g. ‘25DA2BA549CB62EF297977845259A’. The key-length is not predefined, but a key length of
         # at least 128 bit is recommended. Any larger value will not increase security of the underlying algorithm.
     # URL prefix: The URL Signing Provider will only sign URLs that start with this value. This allows to support
         # multiple distributions and different key pairs.
 
-# The properties defined in the configuration file take a numeric suffix that must start at “1" and increase in single
-# increments. In the example below these can be seen as: “.1” and “.2”. As soon as there is a missing number it will
-# stop looking for further entries so be careful not to remove configurations with numbers lower than others. For
-# example if there are configurations using number suffixes from 1 to 5, then commenting out the number 2 configurations
-# will prevent the 3, 4, 5 configurations from being used.
-
-# Note that id and key form a fixed pair, while the same key can be used in more than one configuration block.
-
 # For further information please see:
 # http://docs.opencast.org/latest/admin/configuration/stream-security/
 
 # A typical configuration looks like this:
 
-# id.1=demoKeyOne
-# key.1=6EDB5EDDCF994B7432C371D7C274F
-# url.1=rtmp
+# key.demoKeyOne.secret=6EDB5EDDCF994B7432C371D7C274F
+# key.demoKeyOne.url=rtmp
 
-# id.2=demoKeyOne
-# key.2=6EDB5EDDCF994B7432C371D7C274F
-# url.2=http://wowza.opencast.org/custom
+# key.demoKeyTwo.secret=6EDB5EDDCF994B7432C371D7C274F
+# key.demoKeyTwo.url=http://wowza.opencast.org/custom

--- a/etc/org.opencastproject.security.urlsigning.verifier.impl.UrlSigningVerifierImpl.cfg
+++ b/etc/org.opencastproject.security.urlsigning.verifier.impl.UrlSigningVerifierImpl.cfg
@@ -1,25 +1,15 @@
 # The UrlSigningVerifierImpl is a verification component that works with the UrlSigningFilter to protect Opencast
-# internal resources. This service defines the key pairs used to sign and must be configured in order to allow the
-# filter to verify the signatures. More than one key pair can be defined by increasing the counter (1, 2, 3, ...) in
-# steps of 1. If you miss any numbers it will stop looking for further configurations.
-
-# There is the id that will identify which key to decode the signature with on the resource provider side. e.g.
-# id.1=demoKeyOne
-
-# There is the encryption key that is the 128 bit key used to sign the url. e.g.6EDB5EDDCF994B7432C371D7C274F
-# key.1=6EDB5EDDCF994B7432C371D7C274F
-
-# Note: These should be the same id / key pairs defined in the *UrlSigningProvider.cfg files where the urls will
-# match Opencast servers (not other verification components such as the Apache HTTPd or Wowza verification components).
-# The suffix numbers in this file don't have to match up with those other configuration files.
+# internal resources. This service defines the keys used to sign and must be configured in order to allow the
+# filter to verify the signatures.
 
 # Example:
 
-#id.1=demoKeyOne
-#key.1=6EDB5EDDCF994B7432C371D7C274F
+#key.demoKeyOne=6EDB5EDDCF994B7432C371D7C274F
 
-#id.2=demoKeyTwo
-#key.2=C843C21ECF59F2B38872A1BCAA774
+#key.demoKeyTwo=C843C21ECF59F2B38872A1BCAA774
+
+# Note: These IDs and keys should be the same id / key pairs defined in the *UrlSigningProvider.cfg files where the urls will
+# match Opencast servers (not other verification components such as the Apache HTTPd or Wowza verification components).
 
 # The other step to protect internal Opencast resources is to configure the filter defining the endpoints to be
 # protected. The configuration file is located at:

--- a/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilter.java
+++ b/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilter.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -189,7 +190,7 @@ public class UrlSigningFilter implements Filter, ManagedService {
   }
 
   @Override
-  public void updated(Dictionary properties) throws ConfigurationException {
+  public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
     logger.info("Updating UrlSigningFilter");
 
     Option<String> enableFilterConfig = OsgiUtil.getOptCfg(properties, ENABLE_FILTER_CONFIG_KEY);
@@ -230,24 +231,22 @@ public class UrlSigningFilter implements Filter, ManagedService {
       return;
     }
 
-    String urlRegularExpression = null;
-    int i = 1;
-    while (true) {
-      // Create the configuration prefixes
-      urlRegularExpression = new StringBuilder(URL_REGEX_PREFIX).append(".").append(i).toString();
-      // Read the url regular expression
-      String urlRegularExpressionValue = StringUtils.trimToNull((String) properties.get(urlRegularExpression));
-      logger.debug("Looking for configuration of {} and found '{}'", urlRegularExpression, urlRegularExpressionValue);
+    Enumeration<String> propertyKeys = properties.keys();
+    while (propertyKeys.hasMoreElements()) {
+      String propertyKey = propertyKeys.nextElement();
+      if (!propertyKey.startsWith(URL_REGEX_PREFIX)) continue;
+
+      String urlRegularExpression = StringUtils.trimToNull((String) properties.get(propertyKey));
+      logger.debug("Looking for configuration of {} and found '{}'", propertyKey, urlRegularExpression);
       // Has the url signing provider been fully configured
-      if (urlRegularExpressionValue == null) {
+      if (urlRegularExpression == null) {
         logger.debug(
                 "Unable to configure url regular expression with id '{}' because it is missing. Stopping to look for new keys.",
-                urlRegularExpression);
+                propertyKey);
         break;
       }
 
-      urlRegularExpressions.add(urlRegularExpressionValue);
-      i++;
+      urlRegularExpressions.add(urlRegularExpression);
     }
 
     if (urlRegularExpressions.size() == 0) {

--- a/modules/urlsigning-verifier-service-impl/src/test/java/org/opencastproject/security/urlsigning/verifier/impl/UrlSigningVerifierImplTest.java
+++ b/modules/urlsigning-verifier-service-impl/src/test/java/org/opencastproject/security/urlsigning/verifier/impl/UrlSigningVerifierImplTest.java
@@ -30,7 +30,8 @@ import org.opencastproject.urlsigning.utils.ResourceRequestUtil;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-import java.util.Properties;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 public class UrlSigningVerifierImplTest {
   private static final String CLIENT_IP = "10.0.0.1";
@@ -51,40 +52,34 @@ public class UrlSigningVerifierImplTest {
 
     // Test no matching key
     urlSigningVerifierImpl = new UrlSigningVerifierImpl();
-    Properties keys = new Properties();
-    keys.put(UrlSigningVerifierImpl.ID_PREFIX + ".1", "otherKey");
-    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + ".1", "ThisIsTheOtherKey");
+    Dictionary<String, String> keys = new Hashtable<>();
+    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + "otherKey", "ThisIsTheOtherKey");
     urlSigningVerifierImpl.updated(keys);
     result = urlSigningVerifierImpl.verify(queryString, CLIENT_IP, URL, true);
     assertEquals(Status.Forbidden, result.getStatus());
 
     // Test only matching keys
     urlSigningVerifierImpl = new UrlSigningVerifierImpl();
-    keys = new Properties();
-    keys.put(UrlSigningVerifierImpl.ID_PREFIX + ".1", keyId);
-    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + ".1", key);
+    keys = new Hashtable<>();
+    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + keyId, key);
     urlSigningVerifierImpl.updated(keys);
     result = urlSigningVerifierImpl.verify(queryString, CLIENT_IP, URL, true);
     assertEquals(Status.Ok, result.getStatus());
 
     // Test matching and non-matching keys
     urlSigningVerifierImpl = new UrlSigningVerifierImpl();
-    keys = new Properties();
-    keys.put(UrlSigningVerifierImpl.ID_PREFIX + ".1", "otherKey");
-    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + ".1", "ThisIsTheOtherKey");
-    keys.put(UrlSigningVerifierImpl.ID_PREFIX + ".2", keyId);
-    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + ".2", key);
+    keys = new Hashtable<>();
+    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + "otherKey", "ThisIsTheOtherKey");
+    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + keyId, key);
     urlSigningVerifierImpl.updated(keys);
     result = urlSigningVerifierImpl.verify(queryString, CLIENT_IP, URL, true);
     assertEquals(Status.Ok, result.getStatus());
 
     // Test correct key id and wrong key
     urlSigningVerifierImpl = new UrlSigningVerifierImpl();
-    keys = new Properties();
-    keys.put(UrlSigningVerifierImpl.ID_PREFIX + ".1", "otherKey");
-    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + ".1", "ThisIsTheOtherKey");
-    keys.put(UrlSigningVerifierImpl.ID_PREFIX + ".2", keyId);
-    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + ".2", "The Wrong Key");
+    keys = new Hashtable<>();
+    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + "otherKey", "ThisIsTheOtherKey");
+    keys.put(UrlSigningVerifierImpl.KEY_PREFIX + keyId, "The Wrong Key");
     urlSigningVerifierImpl.updated(keys);
     result = urlSigningVerifierImpl.verify(queryString, CLIENT_IP, URL, true);
     assertEquals(Status.Forbidden, result.getStatus());

--- a/modules/urlsigning-verifier-service-impl/src/test/resources/UrlSigningFilter.properties
+++ b/modules/urlsigning-verifier-service-impl/src/test/resources/UrlSigningFilter.properties
@@ -3,14 +3,14 @@
 # stream security before a file can be downloaded if keys are installed.
 
 # Protects: /files/collection/{collectionId}/{fileName}
-url.regex.1=.*files\/collection\/.*
+url.regex.foo=.*files\/collection\/.*
 
 # Protects: /files/mediapackage/{mediaPackageID}/{mediaPackageElementID}
 # and Protects: /files/mediapackage/{mediaPackageID}/{mediaPackageElementID}/{fileName}
-url.regex.2=.*files\/mediapackage\/.*
+url.regex.bar=.*files\/mediapackage\/.*
 
 # Protects: /staticfiles/{uuid} but not /staticfiles/{uuid}/url
-url.regex.3=(?\=(.*staticfiles.*))(?=^(?!.*staticfiles.*url).*$)(.*)
+url.regex.baz=(?\=(.*staticfiles.*))(?=^(?!.*staticfiles.*url).*$)(.*)
 
 # Protects: /archive/archive/mediapackage/{mediaPackageID}/{mediaPackageElementID}/{version}
-url.regex.4=.*archive\/archive\/mediapackage\/.*\/.*\/.*
+url.regex.qux=.*archive\/archive\/mediapackage\/.*\/.*\/.*


### PR DESCRIPTION
Instead of having to consecutively number certain configuration
properties, these changes allow you to specify them in a more free
form manner. This makes generating the corresponding files
automatically much simpler and also makes the manual editing process
less error prone.