### PR TITLE
MH-13386 Event status calculation wrong assumption fixed

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
@@ -36,6 +36,8 @@ import org.codehaus.jettison.mapped.Configuration;
 import org.codehaus.jettison.mapped.MappedNamespaceConvention;
 import org.codehaus.jettison.mapped.MappedXMLStreamReader;
 import org.codehaus.jettison.mapped.MappedXMLStreamWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -77,12 +79,13 @@ import javax.xml.transform.stream.StreamSource;
 @XmlAccessorType(XmlAccessType.NONE)
 public class Event implements IndexObject {
 
-  /**
-   * The scheduling status of the event
-   */
+  /** The logger */
+  private static final Logger logger = LoggerFactory.getLogger(Event.class);
+
+  /** The scheduling status of the event */
   public enum SchedulingStatus {
     BLACKLISTED, OPTED_OUT, READY_FOR_RECORDING
-  };
+  }
 
   /** The document type */
   public static final String DOCUMENT_TYPE = "event";
@@ -1144,6 +1147,12 @@ public class Event implements IndexObject {
   }
 
   private void updateEventStatus() {
+    if (getWorkflowId() != null && StringUtils.isBlank(getWorkflowState())
+            || getWorkflowId() == null && StringUtils.isNotBlank(getWorkflowState())) {
+      logger.warn("The workflow id {} and workflow state {} are not in sync on event {} organization {}",
+              getWorkflowId(), getWorkflowState(), getIdentifier(), getOrganization());
+    }
+
     if (getWorkflowId() != null && StringUtils.isNotBlank(getWorkflowState())) {
       eventStatus = workflowStatusMapping.get(getWorkflowState());
       return;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
@@ -1144,12 +1144,12 @@ public class Event implements IndexObject {
   }
 
   private void updateEventStatus() {
-    if (getWorkflowId() != null) {
+    if (getWorkflowId() != null && StringUtils.isNotBlank(getWorkflowState())) {
       eventStatus = workflowStatusMapping.get(getWorkflowState());
       return;
     }
 
-    if (getRecordingStatus() != null) {
+    if (StringUtils.isNotBlank(getRecordingStatus())) {
       eventStatus = recordingStatusMapping.get(getRecordingStatus());
       return;
     }


### PR DESCRIPTION
We may not assume, that the workflow state is set if an workflow id exists. As it should not happen… but it does ;-) What is the result of the next line of the condition with null as workflow state? This patch fix it.