### PR TITLE
Revert #523: Special handling of asset manager event removal

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/ADeleteQuery.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/ADeleteQuery.java
@@ -29,13 +29,6 @@ public interface ADeleteQuery {
   ADeleteQuery name(String queryName);
 
   /**
-   * When this is called with true, the AssetManager will assume that the whole media package will be removed. This is
-   * faster, but then it is your responsibility to remove all properties associated with the media package since no
-   * orphan removal will take place.
-   */
-  ADeleteQuery willRemoveWholeMediaPackage(boolean willRemoveWholeMediaPackage);
-
-  /**
    * Delete the selected items.
    *
    * @return the number of affected items

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/ADeleteQueryDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/ADeleteQueryDecorator.java
@@ -38,11 +38,6 @@ public class ADeleteQueryDecorator implements ADeleteQuery {
     return mkDecorator(delegate.name(queryName));
   }
 
-  @Override
-  public ADeleteQuery willRemoveWholeMediaPackage(boolean willRemoveWholeMediaPackage) {
-    return mkDecorator(delegate.willRemoveWholeMediaPackage(willRemoveWholeMediaPackage));
-  }
-
   @Override public long run() {
     return delegate.run();
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/DeleteQueryContribution.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/DeleteQueryContribution.java
@@ -51,8 +51,6 @@ public final class DeleteQueryContribution {
 
   final String name;
 
-  final boolean willRemoveWholeMediaPackage;
-
   private static final Fn<EntityPath<?>, BooleanExpression> NO_WHERE = new Fn<EntityPath<?>, BooleanExpression>() {
     @Override public BooleanExpression apply(EntityPath<?> entityPathBase) {
       return null;
@@ -69,20 +67,6 @@ public final class DeleteQueryContribution {
     this.where = where;
     this.targetPredicate = targetPredicate;
     this.name = name;
-    this.willRemoveWholeMediaPackage = false;
-  }
-
-  private DeleteQueryContribution(
-      Stream<EntityPath<?>> from,
-      Fn<EntityPath<?>, BooleanExpression> where,
-      Opt<BooleanExpression> targetPredicate,
-      String name,
-      boolean willRemoveWholeMediaPackage) {
-    this.from = from;
-    this.where = where;
-    this.targetPredicate = targetPredicate;
-    this.name = name;
-    this.willRemoveWholeMediaPackage = willRemoveWholeMediaPackage;
   }
 
   /**
@@ -126,11 +110,6 @@ public final class DeleteQueryContribution {
       }
     };
     return new DeleteQueryContribution(from, w, targetPredicate, name);
-  }
-
-
-  DeleteQueryContribution willRemoveWholeMediaPackage(final boolean willRemoveWholeMediaPackage) {
-    return new DeleteQueryContribution(from, where, targetPredicate, name, willRemoveWholeMediaPackage);
   }
 
   DeleteQueryContribution name(String name) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1532,8 +1532,9 @@ public class IndexServiceImpl implements IndexService {
     try {
       final AQueryBuilder q = assetManager.createQuery();
       final Predicate p = q.organizationId().eq(securityService.getOrganization().getId()).and(q.mediaPackageId(id));
-      q.delete(DEFAULT_OWNER, q.propertiesOf()).where(q.mediaPackageId(id)).willRemoveWholeMediaPackage(true).run();
-      q.delete(DEFAULT_OWNER, q.snapshot()).where(p).willRemoveWholeMediaPackage(true).run();
+      final AResult r = q.select(q.nothing()).where(p).run();
+      if (r.getSize() > 0)
+        q.delete(DEFAULT_OWNER, q.snapshot()).where(p).run();
     } catch (AssetManagerException e) {
       if (e.getCause() instanceof UnauthorizedException) {
         unauthorizedArchive = true;

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -904,10 +904,9 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
       // Delete scheduler snapshot
       long deletedSnapshots = query.delete(SNAPSHOT_OWNER, query.snapshot())
-              .where(withOrganization(query).and(query.mediaPackageId(mediaPackageId)).and(withOwner(query)))
-              .name("delete episode")
-              .willRemoveWholeMediaPackage(true)
-              .run();
+              .where(withOrganization(query).and(query.mediaPackageId(mediaPackageId)))
+              .name("delete episode").run();
+
       if (deletedProperties + deletedSnapshots == 0)
         throw new NotFoundException();
 


### PR DESCRIPTION
This patch reverts pull request #523 which introduced a special query option to indicate that a query will remove a whole media package which would disable a set of checks and cleanup operations.

Since pull request #696 (alone with the other asset manager performance fixes) removed the whole expensive handling which was circumvented, this now only removes some left-over complexity which had no gain any longer.

Note that the performance patches are not yet merged into `develop` (which really means that `r/6.x` is not merged) which is intentional since they cause merge conflicts with pull request #523 meaning that the merge should be way cleaner after this is merged.