### PR TITLE
MH-13392: Added allowConflict parameter to methods and implemented

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -42,9 +42,6 @@ Configuration changes
 API changes
 -----------
 
-Due to [MH-13392](https://opencast.jira.com/browse/MH-13392):
-- Modified PUT /api/events/{id}/scheduling: Added optional field 'allowConflict'
-
 Due to [MH-13397](https://opencast.jira.com/browse/MH-13397):
 
 - Modified GET /recordings/{id}/technical.json: Removed field `optOut`

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -42,6 +42,9 @@ Configuration changes
 API changes
 -----------
 
+Due to [MH-13392](https://opencast.jira.com/browse/MH-13392):
+- Modified PUT /api/events/{id}/scheduling: Added optional field 'allowConflict'
+
 Due to [MH-13397](https://opencast.jira.com/browse/MH-13397):
 
 - Modified GET /recordings/{id}/technical.json: Removed field `optOut`

--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -886,9 +886,10 @@ Available since API version 1.1.0.
 
 Update the scheduling information of the event with id `{event_id}`.
 
-Form Parameters             |Type            | Description
-:---------------------------|:---------------|:----------------------------
-`scheduling`                | `string`       | The scheduling information.
+Form Parameters             |Type            | Description                              | Default | Version   
+:---------------------------|:---------------|:-----------------------------------------|:--------|:------- 
+`scheduling`                | `string`       | The scheduling information.              | <span class="required">Required</span>| 1.1.0    
+`allowConflict`             | `boolean`      | Allow conflicts when updating scheduling.| false   | 1.2.0
 
 __Sample__
 
@@ -919,3 +920,9 @@ In case of a conflict:
   }
 ]
 ```
+
+`allowConflict` was introduced in version 1.2.0, it allows the schedule to be updated without checking for conflicts. To allow conflicts (`true`) the call **MUST** be made with a user that has an _Administrative Role_.
+
+If not handled properly this will likely cause two or more events to be scheduled on a particular capture agent at the same time, which will then cause a capture failure for all but one of the events.
+
+The person making this call and allowing conflicts to exist, will bear the responsibility of resolving the conflicts that might result.

--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -921,9 +921,8 @@ In case of a conflict:
 ]
 ```
 
-`allowConflict` was introduced in version 1.2.0, it allows the schedule to be
-updated without checking for conflicts. To allow conflicts (`true`) the call
-**MUST** be made with a user that has an _Administrative Role_.
+`allowConflict` allows the schedule to be updated without checking for conflicts.
+To allow conflicts (`true`) the call **MUST** be made with a user that has an _Administrative Role_.
 
 If not handled properly this will likely cause two or more events to be
 scheduled on a particular capture agent at the same time, which will then

--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -886,9 +886,9 @@ Available since API version 1.1.0.
 
 Update the scheduling information of the event with id `{event_id}`.
 
-Form Parameters             |Type            | Description                              | Default | Version   
-:---------------------------|:---------------|:-----------------------------------------|:--------|:------- 
-`scheduling`                | `string`       | The scheduling information.              | <span class="required">Required</span>| 1.1.0    
+Form Parameters             |Type            | Description                              | Default | Version
+:---------------------------|:---------------|:-----------------------------------------|:--------|:-------
+`scheduling`                | `string`       | The scheduling information.              | <span class="required">Required</span>| 1.1.0
 `allowConflict`             | `boolean`      | Allow conflicts when updating scheduling.| false   | 1.2.0
 
 __Sample__
@@ -921,8 +921,13 @@ In case of a conflict:
 ]
 ```
 
-`allowConflict` was introduced in version 1.2.0, it allows the schedule to be updated without checking for conflicts. To allow conflicts (`true`) the call **MUST** be made with a user that has an _Administrative Role_.
+`allowConflict` was introduced in version 1.2.0, it allows the schedule to be
+updated without checking for conflicts. To allow conflicts (`true`) the call
+**MUST** be made with a user that has an _Administrative Role_.
 
-If not handled properly this will likely cause two or more events to be scheduled on a particular capture agent at the same time, which will then cause a capture failure for all but one of the events.
+If not handled properly this will likely cause two or more events to be
+scheduled on a particular capture agent at the same time, which will then
+cause a capture failure for all but one of the events.
 
-The person making this call and allowing conflicts to exist, will bear the responsibility of resolving the conflicts that might result.
+The person making this call and allowing conflicts to exist, will bear the
+responsibility of resolving the conflicts that might result.

--- a/docs/guides/developer/docs/css/style-guide.css
+++ b/docs/guides/developer/docs/css/style-guide.css
@@ -505,3 +505,9 @@ dl.images img {
     float: left;
     margin-right: 15px;
 }
+
+.required {
+    color: #E45253;
+    font-size: 90%;
+    font-weight: bold;
+}

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1706,7 +1706,7 @@ public class EventsEndpoint implements ManagedService {
   @RestQuery(name = "updateeventscheduling", description = "Update an event's scheduling information.", returnDescription = "", pathParameters = {
       @RestParameter(name = "eventId", description = "The event id", isRequired = true, type = Type.STRING) }, restParameters = {
       @RestParameter(name = "scheduling", isRequired = true, description = "Scheduling Information", type = Type.STRING),
-      @RestParameter(name = "allowConflict", description = "Allow the conflict when updating scheduling.", defaultValue = "false", isRequired = false, type = Type.BOOLEAN) }, reponses = {
+      @RestParameter(name = "allowConflict", description = "Allow conflicts when updating scheduling", defaultValue = "false", isRequired = false, type = Type.BOOLEAN) }, reponses = {
       @RestResponse(description = "The  scheduling information for the specified event is updated.", responseCode = HttpServletResponse.SC_NO_CONTENT),
       @RestResponse(description = "The specified event has no scheduling information to update.", responseCode = HttpServletResponse.SC_NOT_ACCEPTABLE),
       @RestResponse(description = "The scheduling information could not be updated due to a conflict.", responseCode = HttpServletResponse.SC_CONFLICT),
@@ -1717,6 +1717,9 @@ public class EventsEndpoint implements ManagedService {
     final ApiVersion requestedVersion = ApiMediaType.parse(acceptHeader).getVersion();
     final Opt<Event> event = indexService.getEvent(id, externalIndex);
 
+    if (!requestedVersion.isSmallerThan(ApiVersion.VERSION_1_2_0)) {
+        allowConflict = false;
+    }
     if (event.isNone()) {
       return ApiResponses.notFound(String.format("Unable to find event with id '%s'", id));
     }
@@ -1731,7 +1734,6 @@ public class EventsEndpoint implements ManagedService {
     Optional<Response> clientError = updateSchedulingInformation(parsedJson, id, requestedVersion, allowConflict);
     return clientError.orElse(Response.noContent().build());
   }
-
 
   private Optional<Response> updateSchedulingInformation(
       JSONObject parsedScheduling,

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -149,6 +149,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -32,7 +32,6 @@ import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_2_0;
 import static org.opencastproject.util.DateTimeSupport.toUTC;
 import static org.opencastproject.util.RestUtil.getEndpointUrl;
-import static org.opencastproject.util.doc.rest.RestParameter.Type.BOOLEAN;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
 
 import org.opencastproject.external.common.ApiMediaType;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -943,7 +943,7 @@ public class SeriesEndpoint {
   @RestQuery(name = "updateseriesacl", description = "Updates a series' access policy.", returnDescription = "", pathParameters = {
           @RestParameter(name = "seriesId", description = "The series id", isRequired = true, type = STRING) }, restParameters = {
                   @RestParameter(name = "acl", isRequired = true, description = "Access policy", type = STRING),
-                  @RestParameter(name = "override", isRequired = false, defaultValue = "false", description = "If true the series ACL will take precedence over any existing episode ACL", type = STRING)}, reponses = {
+                  @RestParameter(name = "override", isRequired = false, description = "If true the series ACL will take precedence over any existing episode ACL", type = STRING)}, reponses = {
                           @RestResponse(description = "The access control list for the specified series is updated.", responseCode = HttpServletResponse.SC_OK),
                           @RestResponse(description = "The specified series does not exist.", responseCode = HttpServletResponse.SC_NOT_FOUND) })
   public Response updateSeriesAcl(@HeaderParam("Accept") String acceptHeader, @PathParam("seriesId") String seriesID,

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -944,7 +944,7 @@ public class SeriesEndpoint {
   @RestQuery(name = "updateseriesacl", description = "Updates a series' access policy.", returnDescription = "", pathParameters = {
           @RestParameter(name = "seriesId", description = "The series id", isRequired = true, type = STRING) }, restParameters = {
                   @RestParameter(name = "acl", isRequired = true, description = "Access policy", type = STRING),
-                  @RestParameter(name = "override", isRequired = false, description = "If true the series ACL will take precedence over any existing episode ACL", type = BOOLEAN)}, reponses = {
+                  @RestParameter(name = "override", isRequired = false, defaultValue = "false", description = "If true the series ACL will take precedence over any existing episode ACL", type = STRING)}, reponses = {
                           @RestResponse(description = "The access control list for the specified series is updated.", responseCode = HttpServletResponse.SC_OK),
                           @RestResponse(description = "The specified series does not exist.", responseCode = HttpServletResponse.SC_NOT_FOUND) })
   public Response updateSeriesAcl(@HeaderParam("Accept") String acceptHeader, @PathParam("seriesId") String seriesID,

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestEventsEndpoint.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestEventsEndpoint.java
@@ -246,7 +246,8 @@ public class TestEventsEndpoint extends EventsEndpoint {
         eq(Opt.none()),
         eq(Opt.none()),
         eq(Opt.none()),
-        capture(capturedAgentConfig)
+        capture(capturedAgentConfig),
+        eq(false)
     );
     EasyMock.expectLastCall();
 

--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
@@ -136,7 +136,7 @@ public interface SchedulerService {
           throws UnauthorizedException, SchedulerConflictException, SchedulerException;
 
   /**
-   * Updates event with specified ID.
+   * Updates event with specified ID and check for conflicts.
    *
    * Default capture agent properties are created from DublinCore. Following values are generated:
    * <ul>
@@ -173,6 +173,50 @@ public interface SchedulerService {
   void updateEvent(String mediaPackageId, Opt<Date> startDateTime, Opt<Date> endDateTime, Opt<String> captureAgentId,
           Opt<Set<String>> userIds, Opt<MediaPackage> mediaPackage, Opt<Map<String, String>> wfProperties,
           Opt<Map<String, String>> caMetadata)
+                  throws NotFoundException, UnauthorizedException, SchedulerConflictException, SchedulerException;
+
+  /**
+   * Updates event with specified ID and possiblyDictionary checking for conflicts.
+   *
+   * Default capture agent properties are created from DublinCore. Following values are generated:
+   * <ul>
+   * <li>event.title (mapped from dc:title)</li>
+   * <li>event.series (mapped from mediaPackage#getSeries())</li>
+   * <li>event.location (mapped from captureAgentId)</li>
+   * </ul>
+   *
+   * @param mediaPackageId
+   *          the event identifier
+   * @param startDateTime
+   *          the optional event start time
+   * @param endDateTime
+   *          the optional event end time
+   * @param captureAgentId
+   *          the optional capture agent id
+   * @param userIds
+   *          the optional list of user identifiers of speakers/lecturers
+   * @param mediaPackage
+   *          the optional mediapackage to update
+   * @param wfProperties
+   *          the optional workflow configuration to update
+   * @param caMetadata
+   *          the optional capture configuration to update
+   * @param optOut
+   *          the optional opt out status to update
+   * @param allowConflict
+   *          the flag to ignore conflict checks
+   * @throws NotFoundException
+   *           if event with specified ID cannot be found
+   * @throws UnauthorizedException
+   *           if the current user is not authorized to perform this action
+   * @throws SchedulerConflictException
+   *           if there are conflicting events
+   * @throws SchedulerException
+   *           if exception occurred
+   */
+  void updateEvent(String mediaPackageId, Opt<Date> startDateTime, Opt<Date> endDateTime, Opt<String> captureAgentId,
+          Opt<Set<String>> userIds, Opt<MediaPackage> mediaPackage, Opt<Map<String, String>> wfProperties,
+          Opt<Map<String, String>> caMetadata, Opt<Opt<Boolean>> optOut, boolean allowConflict)
                   throws NotFoundException, UnauthorizedException, SchedulerConflictException, SchedulerException;
 
   /**

--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
@@ -201,8 +201,6 @@ public interface SchedulerService {
    *          the optional workflow configuration to update
    * @param caMetadata
    *          the optional capture configuration to update
-   * @param optOut
-   *          the optional opt out status to update
    * @param allowConflict
    *          the flag to ignore conflict checks
    * @throws NotFoundException
@@ -216,7 +214,7 @@ public interface SchedulerService {
    */
   void updateEvent(String mediaPackageId, Opt<Date> startDateTime, Opt<Date> endDateTime, Opt<String> captureAgentId,
           Opt<Set<String>> userIds, Opt<MediaPackage> mediaPackage, Opt<Map<String, String>> wfProperties,
-          Opt<Map<String, String>> caMetadata, Opt<Opt<Boolean>> optOut, boolean allowConflict)
+          Opt<Map<String, String>> caMetadata, boolean allowConflict)
                   throws NotFoundException, UnauthorizedException, SchedulerConflictException, SchedulerException;
 
   /**

--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
@@ -176,7 +176,7 @@ public interface SchedulerService {
                   throws NotFoundException, UnauthorizedException, SchedulerConflictException, SchedulerException;
 
   /**
-   * Updates event with specified ID and possiblyDictionary checking for conflicts.
+   * Updates event with specified ID and possibly checking for conflicts.
    *
    * Default capture agent properties are created from DublinCore. Following values are generated:
    * <ul>

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -699,7 +699,8 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       Opt<String> seriesId = Opt.nul(record.getSnapshot().get().getMediaPackage().getSeries());
 
       // Check for conflicting events
-      if ((!isNewOptOut && readyForRecording || !isNewOptOut && propertyChanged && !oldOptOut)
+      // Check scheduling conficts in case a property relevant for conflicts has changed
+      if ((captureAgentId.isSome() || startDateTime.isSome() || endDateTime.isSome())
             && (!isAdmin() || (isAdmin() && !allowConflict))) {
         List<MediaPackage> conflictingEvents = $(findConflictingEvents(captureAgentId.getOr(agentId),
                 startDateTime.getOr(start), endDateTime.getOr(end))).filter(new Fn<MediaPackage, Boolean>() {

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -29,6 +29,7 @@ import static org.opencastproject.scheduler.impl.SchedulerUtil.eventOrganization
 import static org.opencastproject.scheduler.impl.SchedulerUtil.isNotEpisodeDublinCore;
 import static org.opencastproject.scheduler.impl.SchedulerUtil.recordToMp;
 import static org.opencastproject.scheduler.impl.SchedulerUtil.uiAdapterToFlavor;
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.EqualsUtil.ne;
 import static org.opencastproject.util.Log.getHumanReadableTimeString;
 import static org.opencastproject.util.RequireUtil.notEmpty;
@@ -640,13 +641,22 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
           Opt<Map<String, String>> caMetadata)
                   throws NotFoundException, UnauthorizedException, SchedulerException {
     updateEventInternal(mpId, startDateTime, endDateTime, captureAgentId, userIds, mediaPackage,
-            wfProperties, caMetadata);
+            wfProperties, caMetadata, false);
+  }
+
+  @Override
+  public void updateEvent(final String mpId, Opt<Date> startDateTime, Opt<Date> endDateTime, Opt<String> captureAgentId,
+          Opt<Set<String>> userIds, Opt<MediaPackage> mediaPackage, Opt<Map<String, String>> wfProperties,
+          Opt<Map<String, String>> caMetadata, boolean allowConflict)
+                throws NotFoundException, UnauthorizedException, SchedulerException {
+    updateEventInternal(mpId, startDateTime, endDateTime, captureAgentId, userIds, mediaPackage,
+            wfProperties, caMetadata, allowConflict);
   }
 
   private void updateEventInternal(final String mpId, Opt<Date> startDateTime,
           Opt<Date> endDateTime, Opt<String> captureAgentId, Opt<Set<String>> userIds, Opt<MediaPackage> mediaPackage,
-          Opt<Map<String, String>> wfProperties, Opt<Map<String, String>> caMetadata
-  ) throws NotFoundException, SchedulerException {
+          Opt<Map<String, String>> wfProperties, Opt<Map<String, String>> caMetadata, boolean allowConflict)
+                throws NotFoundException, SchedulerException {
     notEmpty(mpId, "mpId");
     notNull(startDateTime, "startDateTime");
     notNull(endDateTime, "endDateTime");
@@ -688,8 +698,9 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       String agentId = extendedEventDto.getCaptureAgentId();
       Opt<String> seriesId = Opt.nul(record.getSnapshot().get().getMediaPackage().getSeries());
 
-      // Check scheduling conficts in case a property relevant for conflicts has changed
-      if (captureAgentId.isSome() || startDateTime.isSome() || endDateTime.isSome()) {
+      // Check for conflicting events
+      if ((!isNewOptOut && readyForRecording || !isNewOptOut && propertyChanged && !oldOptOut)
+            && (!isAdmin() || (isAdmin() && !allowConflict))) {
         List<MediaPackage> conflictingEvents = $(findConflictingEvents(captureAgentId.getOr(agentId),
                 startDateTime.getOr(start), endDateTime.getOr(end))).filter(new Fn<MediaPackage, Boolean>() {
                     @Override
@@ -789,6 +800,17 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     } catch (Exception e) {
       throw new SchedulerException(e);
     }
+  }
+
+  private boolean isAdmin() {
+    if (securityService.getUser().hasRole(GLOBAL_ADMIN_ROLE)) {
+      return true;
+    }
+    else if (securityService.getUser().hasRole(securityService.getOrganization().getAdminRole())) {
+      return true;
+    }
+
+    return false;
   }
 
   private Opt<AccessControlList> loadEpisodeAclFromAsset(Snapshot snapshot) {

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -701,7 +701,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       // Check for conflicting events
       // Check scheduling conficts in case a property relevant for conflicts has changed
       if ((captureAgentId.isSome() || startDateTime.isSome() || endDateTime.isSome())
-            && (!isAdmin() || (isAdmin() && !allowConflict))) {
+            && (!allowConflict || !isAdmin())) {
         List<MediaPackage> conflictingEvents = $(findConflictingEvents(captureAgentId.getOr(agentId),
                 startDateTime.getOr(start), endDateTime.getOr(end))).filter(new Fn<MediaPackage, Boolean>() {
                     @Override

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -804,14 +804,8 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   }
 
   private boolean isAdmin() {
-    if (securityService.getUser().hasRole(GLOBAL_ADMIN_ROLE)) {
-      return true;
-    }
-    else if (securityService.getUser().hasRole(securityService.getOrganization().getAdminRole())) {
-      return true;
-    }
-
-    return false;
+    return (securityService.getUser().hasRole(GLOBAL_ADMIN_ROLE)
+            || securityService.getUser().hasRole(securityService.getOrganization().getAdminRole()));
   }
 
   private Opt<AccessControlList> loadEpisodeAclFromAsset(Snapshot snapshot) {

--- a/modules/scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
+++ b/modules/scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
@@ -211,6 +211,17 @@ public class SchedulerServiceRemoteImpl extends RemoteBase implements SchedulerS
           Opt<Set<String>> userIds, Opt<MediaPackage> mediaPackage, Opt<Map<String, String>> wfProperties,
           Opt<Map<String, String>> caMetadata)
                   throws NotFoundException, UnauthorizedException, SchedulerConflictException, SchedulerException {
+
+    updateEvent(eventId, startDateTime, endDateTime, captureAgentId, userIds,
+                mediaPackage, wfProperties, caMetadata, false);
+  }
+
+  @Override
+  public void updateEvent(String eventId, Opt<Date> startDateTime, Opt<Date> endDateTime, Opt<String> captureAgentId,
+          Opt<Set<String>> userIds, Opt<MediaPackage> mediaPackage, Opt<Map<String, String>> wfProperties,
+          Opt<Map<String, String>> caMetadata, boolean allowConflict)
+                  throws NotFoundException, UnauthorizedException, SchedulerConflictException, SchedulerException {
+
     logger.debug("Start updating event {}.", eventId);
     HttpPut put = new HttpPut("/" + eventId);
 
@@ -229,6 +240,7 @@ public class SchedulerServiceRemoteImpl extends RemoteBase implements SchedulerS
       params.add(new BasicNameValuePair("wfproperties", toPropertyString(wfProperties.get())));
     if (caMetadata.isSome())
       params.add(new BasicNameValuePair("agentparameters", toPropertyString(caMetadata.get())));
+    params.add(new BasicNameValuePair("allowConflict", BooleanUtils.toString(allowConflict, "true", "false", "false")));
     put.setEntity(new UrlEncodedFormEntity(params, UTF_8));
 
     HttpResponse response = getResponse(put, SC_OK, SC_NOT_FOUND, SC_UNAUTHORIZED, SC_FORBIDDEN, SC_CONFLICT);

--- a/modules/scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
+++ b/modules/scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
@@ -55,6 +55,7 @@ import com.entwinemedia.fn.data.Opt;
 import net.fortuna.ical4j.model.Period;
 import net.fortuna.ical4j.model.property.RRule;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;


### PR DESCRIPTION
Add a rest parameter to the EventsEndpoint > @PUT > @Path("{eventId}/scheduling") endpoint; 
called _allowConflict_ to send to _SchedulerServiceImpl_ to allow conflicts and not perform the conflict check when updating an event, only if the call was made by an admin user and the flag is checked.

If not handled properly this will likely cause two or more events to be scheduled on a particular capture agent at the same time, which will then cause a capture failure for all but one of the events.

Now the reason that this exists is that it will be possible to move around events from capture agents and have them overlap (conflict) for a short period of time until all the shuffling of events to different locations have been completed. 

ONLY IF THE FLAG IS SET AND THE CALL IS MADE WITH ADMIN PRIVILEGES.

So it will be up to the person writing the script to add logic in terms of conflict checking afterwards, but by setting the flag and using an admin user to make the call; that's what they signed up for.

If this is not implemented then a method for moving events to temporary locations will have to be implemented, and shuffling all the correct locations back might cause huge processing overheads. This is equivalent to a Towers of Hanoi problem (the https://en.wikipedia.org/wiki/Tower_of_Hanoi) but with potentially many more events/locations/discs to move around.

https://opencast.jira.com/browse/MH-13392