### PR TITLE
MH-13404, Improve Workspace Logging

### DIFF
--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -400,10 +400,10 @@ public final class WorkspaceImpl implements Workspace {
         logger.debug("{} is not ready, try again later.", url);
         return left(response.getHeaders("token")[0].getValue());
       case HttpServletResponse.SC_OK:
-        logger.info("Downloading {} to {}", url, dst.getAbsolutePath());
+        logger.debug("Downloading {} to {}", url, dst.getAbsolutePath());
         return right(some(downloadTo(response, dst)));
       default:
-        logger.warn(format("Received unexpected response status %s while trying to download from %s", status, url));
+        logger.warn("Received unexpected response status {} while trying to download from {}", status, url);
         FileUtils.deleteQuietly(dst);
         return right(none(File.class));
     }


### PR DESCRIPTION
The workspace is spamming the logs with lines about what files it is
downloading which is not a very helpful or important information unless
the download fails. This drown other, important messages right now.

This patch reduces the log level to debug.