### PR TITLE
MH-13402 WOH select-tracks does not work with audio-only input

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
@@ -12,6 +12,9 @@ video stream of the presenter track and the audio stream of the presentation tra
 The workflow operation will use workflow properties set by the Opencast video editor to determine which streams should be
 selected for further processing and add them to the media package based on `target-flavor` and `target-tags`.
 
+**IMPORTANT:** The input tracks need to be inspected using the workflow operation [inspect](inspect-woh.md) before running this
+operation.
+
 
 Parameter Table
 ---------------
@@ -25,6 +28,23 @@ audio-muxing      | force     | Move single-audio media packages to a specific t
 force-target      | presenter     | Target track for the `force` setting for `audio-muxing`
 
 \* mandatory configuration key
+
+
+Workflow Properties
+-------------------
+
+The names of the workflow properties that control which streams are included in the output tracks are
+
+    "hide_" + source-flavor.type + "_audio"
+    "hide_" + source-flavor.type + "_video"
+
+Example:
+
+For the source flavor `presenter/work`, use the boolean workflow properties `hide_presenter_audio` and
+`hide_presenter_video` to control which streams should be included in the output tracks.
+
+Those properties are set by the Opencast video editor and can also be set using a custom workflow configuration panel.
+
 
 Audio Muxing
 -----------------
@@ -62,6 +82,19 @@ The parameter value `duplicate` only applies to media packages that have exactly
 hidden video streams. For these media packages, the WOH will mux the audio stream it found to all video streams in
 the media package. For media packages without an audio stream or with more than one audio stream, the behavior is
 the same as if the parameter were omitted.
+
+Encoding Profiles
+-----------------
+
+This workflow operation handler depends on the presence of the following encoding profiles:
+
+Name            | Description
+----------------|------------
+video-only.work | Removes all audio streams from a media track
+audio-only.work | Removes all video streams from a media track
+mux-av.work     | Mux a video stream and an audio stream into a media track
+
+Note that those encoding profiles are included in the default configuration of Opencast.
 
 Operation Example
 -----------------

--- a/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
@@ -12,8 +12,8 @@ video stream of the presenter track and the audio stream of the presentation tra
 The workflow operation will use workflow properties set by the Opencast video editor to determine which streams should be
 selected for further processing and add them to the media package based on `target-flavor` and `target-tags`.
 
-**IMPORTANT:** The input tracks need to be inspected using the workflow operation [inspect](inspect-woh.md) before running this
-operation.
+**IMPORTANT:** The input tracks need to be inspected using the workflow operation [inspect](inspect-woh.md) before
+running this operation.
 
 
 Parameter Table


### PR DESCRIPTION
Steps to reproduce: 
1. Create a simple test workflow only containing WOH inspect followed by WOH select-tracks 
2. Upload an audio-only file 
  
 Actual Results: 
WOH select-tracks will fails because it insist of at least one video stream as input 
  
 Expected Results: 
WOH select-tracks should also work with audio-only input so that Adopter can configure Opencast to work with audio-only 
  
 Workaround (if any): 
Use WOH analyse-tracks to get information about available video streams, then execute WOH select-streams conditionally (if at least one video stream is available) or WOH tag (if no video stream is available). 

Exception: 
```
2019-02-28 13:47:56,757 | ERROR | (WorkflowOperationWorker:180) - Workflow operation 'operation:'select-tracks', position:0, state:'FAILED'' failed 
java.lang.IllegalStateException: couldn't find a stream with non-hidden video 
at org.opencastproject.workflow.handler.composer.SelectStreamsWorkflowOperationHandler.lambda$muxSingleVideoTrack$6(SelectStreamsWorkflowOperationHandler.java:358) ~[?:?] 
at java.util.Optional.orElseThrow(Optional.java:290) ~[?:?] 
at org.opencastproject.workflow.handler.composer.SelectStreamsWorkflowOperationHandler.muxSingleVideoTrack(SelectStreamsWorkflowOperationHandler.java:358) ~[?:?] 
at org.opencastproject.workflow.handler.composer.SelectStreamsWorkflowOperationHandler.doStart(SelectStreamsWorkflowOperationHandler.java:324) ~[?:?] 
at org.opencastproject.workflow.handler.composer.SelectStreamsWorkflowOperationHandler.start(SelectStreamsWorkflowOperationHandler.java:227) ~[?:?] 
at org.opencastproject.workflow.impl.WorkflowOperationWorker.start(WorkflowOperationWorker.java:233) ~[198:opencast-workflow-service-impl:7.0.0.SNAPSHOT] 
at org.opencastproject.workflow.impl.WorkflowOperationWorker.execute(WorkflowOperationWorker.java:155) [198:opencast-workflow-service-impl:7.0.0.SNAPSHOT] 
at org.opencastproject.workflow.impl.WorkflowServiceImpl.runWorkflowOperation(WorkflowServiceImpl.java:857) [198:opencast-workflow-service-impl:7.0.0.SNAPSHOT] 
at org.opencastproject.workflow.impl.WorkflowServiceImpl.process(WorkflowServiceImpl.java:1890) [198:opencast-workflow-service-impl:7.0.0.SNAPSHOT] 
at org.opencastproject.workflow.impl.WorkflowServiceImpl$JobRunner.call(WorkflowServiceImpl.java:2318) [198:opencast-workflow-service-impl:7.0.0.SNAPSHOT] 
at org.opencastproject.workflow.impl.WorkflowServiceImpl$JobRunner.call(WorkflowServiceImpl.java:2284) [198:opencast-workflow-service-impl:7.0.0.SNAPSHOT] 
at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?] 
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?] 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?] 
```