### PR TITLE
MH-13410, Fix Broken Build Number

### DIFF
--- a/modules/user-interface-configuration/pom.xml
+++ b/modules/user-interface-configuration/pom.xml
@@ -44,6 +44,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,


### PR DESCRIPTION
The UI configuration service did not provide a build hash, causing
Opencast's version to be displayed as inconsistent.

---

Build number from the bottom of the admin interface of https://develop.opencast.org:

> Opencast 7.0.0.SNAPSHOT - inconsistent