### PR TITLE
MH-13411, Fix UI Config Service Dependencies

### DIFF
--- a/modules/user-interface-configuration/pom.xml
+++ b/modules/user-interface-configuration/pom.xml
@@ -34,9 +34,21 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
This patch adds some missing dependencies to the UI config service and
adds the module to the automatic dependency check.