### PR TITLE
MH-13414 extended metadata multivalue fields are not handled properly

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/series/ConfigurableSeriesDCCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/series/ConfigurableSeriesDCCatalogUIAdapter.java
@@ -52,10 +52,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Dictionary;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * A series catalog UI adapter that is managed by a configuration.
@@ -239,7 +242,7 @@ public class ConfigurableSeriesDCCatalogUIAdapter implements SeriesCatalogUIAdap
         logger.warn("Skipping field {} because it is not defined in the properties file.", field);
       }
       try {
-        dublinCoreMetadata.addField(dublinCoreProperties.get(field), "", listProvidersService);
+        dublinCoreMetadata.addField(dublinCoreProperties.get(field), Collections.emptyList(), listProvidersService);
       } catch (Exception e) {
         logger.error("Skipping metadata field '{}' because of error", field, e);
       }
@@ -257,10 +260,13 @@ public class ConfigurableSeriesDCCatalogUIAdapter implements SeriesCatalogUIAdap
         }
         if (namespace.equalsIgnoreCase(propertyKey.getNamespaceURI())
                 && metadataField.getInputID().equalsIgnoreCase(propertyKey.getLocalName())) {
-          for (DublinCoreValue dublinCoreValue : dc.get(propertyKey)) {
+          List<DublinCoreValue> values = dc.get(propertyKey);
+          if (!values.isEmpty()) {
             emptyFields.remove(metdataFieldKey);
             try {
-              dublinCoreMetadata.addField(metadataField, dublinCoreValue.getValue(), listProvidersService);
+              dublinCoreMetadata.addField(metadataField, values.stream()
+                      .map(DublinCoreValue::getValue)
+                      .collect(Collectors.toList()), listProvidersService);
             } catch (IllegalArgumentException e) {
               logger.error("Skipping metadata field '{}' because of error: {}", metadataField.getInputID(),
                       ExceptionUtils.getStackTrace(e));


### PR DESCRIPTION
This Patch corrects the behaviour of multivalue extended metadata fields.
If non multivalue fields contain multiple values, the last value is used to not change the behaviour.