### PR TITLE
MH-13415: Timelinepreviews process first one only  

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/timelinepreviews-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/timelinepreviews-woh.md
@@ -19,6 +19,7 @@ Parameter Table
 |target-flavor|\*/timeline+preview|Specifies the flavor the new files will get. This should use the \*-operator if it was used in the source-flavor too. This flavor has to contain the words "timeline" and "preview" for the file to be found by the player.|EMPTY|
 |target-tags|engage-download|Specifies the tags the new files will get.|EMPTY|
 |image-count|100|Specifies the number of generated timeline preview images. In the example 100 timeline preview images will be generated and stored in a 10x10 grid in the output image|100|
+|process-first-match-only|true|Only use the first resource that matches the source-flavor and/or target-tag|false|
 
 Operation Example
 -----------------
@@ -32,6 +33,8 @@ Operation Example
     <configuration key="target-flavor">*/timeline+preview</configuration>
     <configuration key="target-tags">engage-download</configuration>
     <configuration key="image-count">100</configuration>
+    <!-- If there is more than one file that match the source-tags, use only the first one -->
+    <configuration key="process-first-match-only">true</configuration>
   </configurations>
 </operation>
 ```

--- a/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
+++ b/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
@@ -84,23 +84,6 @@ public class TimelinePreviewsWorkflowOperationHandler extends AbstractWorkflowOp
   /** Default value for image size. */
   private static final int DEFAULT_IMAGE_SIZE = 10;
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_PROPERTY, "The source media file flavor.");
-    CONFIG_OPTIONS.put(SOURCE_TAGS_PROPERTY, "Comma-separated tags of the source media files. "
-            + "Any media that match " + SOURCE_FLAVOR_PROPERTY + " or " + SOURCE_TAGS_PROPERTY
-            + " will be processed.");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR_PROPERTY, "The target timeline previews image flavor.");
-    CONFIG_OPTIONS.put(TARGET_TAGS_PROPERTY, "The timeline previews image (comma separated) target tags.");
-    CONFIG_OPTIONS.put(IMAGE_SIZE_PROPERTY, "The number of timeline previews in the image.");
-    // Only process the first file that matches tags/flavors
-    CONFIG_OPTIONS.put("process-first-match-only",
-            "Set to 'true' indicates only one track will be processed if more are selected");
-  }
-
   /** The timeline previews service. */
   private TimelinePreviewsService timelinePreviewsService = null;
 
@@ -186,13 +169,14 @@ public class TimelinePreviewsWorkflowOperationHandler extends AbstractWorkflowOp
 
         Job timelinepreviewsJob = timelinePreviewsService.createTimelinePreviewImages(sourceTrack, imageSize);
         timelinepreviewsJobs.add(timelinepreviewsJob);
+
+        if (processOnlyOne)
+            break;
+
       } catch (MediaPackageException | TimelinePreviewsException ex) {
         logger.error("Creating timeline previews job for track '{}' in media package '{}' failed with error {}",
                 sourceTrack.getIdentifier(), mediaPackage.getIdentifier().compact(), ex.getMessage());
       }
-
-      if (processOnlyOne)
-        break;
     }
 
     logger.info("Wait for timeline previews jobs for media package {}", mediaPackage.getIdentifier().compact());


### PR DESCRIPTION
Documentation states:
In the engage player only the preview images of one video are shown (the first that is found), so to make sure the correct preview images are shown, better generate them only for one video.

## Example:
### Flavors:
presenter/trimmed
presentation/trimmed
presentation2/trimmed

### Before:
#### Running:
<configuration key="source-flavor">*/trimmed</configuration>

#### Output (3 flavors):
presenter/timeline+preview
presentation/timeline+preview
presentation2/timeline+preview

### After change:
#### Running:
<configuration key="source-flavor">*/trimmed</configuration>
<configuration key="process-first-match-only">true</configuration>

#### Output (1 Flavor > which one depends on input flavors):
presenter/timeline+preview

or
presentation/timeline+preview

or
presentation2/timeline+preview
