### PR TITLE
MH-13420 ngRepeat does not allow duplicates

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
@@ -1,6 +1,6 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
   &nbsp;<ul ng-show="!editMode">
-    <li ng-repeat="value in params.value">
+    <li ng-repeat="value in params.value track by $index">
       <span ng-if="value">{{ getText(value).value | translate }}</span>
     </li>
   </ul>
@@ -13,14 +13,14 @@
            list="{{ data.list.id }}-data-list" ng-keyup="keyUp($event)" name="{{ params.name }}" ng-model="data.value"
            placeholder="{{ 'EDITABLE.MULTI.PLACEHOLDER' | translate}}">
     <datalist id="{{ data.list.id }}-data-list">
-      <option ng-repeat="(item, label) in collection"
+      <option ng-repeat="(item, label) in collection track by $index"
               value="{{ item }}">
       {{ label | translate | limitTo : 70 }}
       </option>
     </datalist>
   </div>
   <span ng-show="editMode" class="ng-multi-value"
-                           ng-repeat="value in params.value">
+                           ng-repeat="value in params.value track by $index">
     {{ getText(value).value | translate | limitTo : 70 }}
     <a ng-mousedown="removeValue($index)">
       <i class="fa fa-times"></i>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiValue.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiValue.html
@@ -1,6 +1,6 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
   &nbsp;<ul ng-show="!editMode">
-    <li ng-repeat="value in params.value">
+    <li ng-repeat="value in params.value track by $index">
       <span ng-if="value">{{ value | translate }}</span>
     </li>
   </ul>
@@ -18,7 +18,7 @@
                        placeholder="{{ 'EDITABLE.MULTI.PLACEHOLDER' | translate}}">
   </div>
   <span ng-show="editMode" class="ng-multi-value"
-                           ng-repeat="value in params.value">
+                           ng-repeat="value in params.value track by $index">
     {{ value | translate | limitTo : 70}}
     <a ng-mousedown="removeValue($index)">
       <i class="fa fa-times"></i>


### PR DESCRIPTION
This patch allows duplicate values to be displayed in multivalue fields if they are present in the data source.