### PR TITLE
MH-13423 Possible NPE if debugging is enabled

### DIFF
--- a/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaAdaptiveStreamingDistributionService.java
+++ b/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaAdaptiveStreamingDistributionService.java
@@ -1193,7 +1193,7 @@ public class WowzaAdaptiveStreamingDistributionService extends AbstractDistribut
       switch (op) {
         case Distribute:
           MediaPackageElement[] distributedElements = distributeElements(channelId, mediapackage, elementIds);
-          if (logger.isDebugEnabled()) {
+          if (logger.isDebugEnabled() && distributedElements != null) {
             for (MediaPackageElement element : distributedElements)
               if (element != null)
                 logger.debug("Distributed element {} with URL {}", element.getIdentifier(), element.getURI());
@@ -1211,7 +1211,7 @@ public class WowzaAdaptiveStreamingDistributionService extends AbstractDistribut
           if (distributionDirectory != null) {
             if (streamingUri != null || adaptiveStreamingUri != null) {
               retractedElements = retractElements(channelId, mediapackage, elementIds);
-              if (logger.isDebugEnabled()) {
+              if (logger.isDebugEnabled() && retractedElements != null) {
                 for (MediaPackageElement element : retractedElements)
                   if (element != null)
                     logger.debug("Retracted element {} with URL {}", element.getIdentifier(), element.getURI());


### PR DESCRIPTION
If debugging is enabled and the media package contains no elements to distribute, an NPE is thrown.

