### PR TITLE
MH-13424, Elasticsearch 5.6.15

### DIFF
--- a/docs/guides/admin/docs/modules/searchindex/elasticsearch.md
+++ b/docs/guides/admin/docs/modules/searchindex/elasticsearch.md
@@ -24,18 +24,16 @@ Elasticsearch configuration file called `elasticsearch.yml`:
 
 ```yml
 cluster.name: opencast
-node.name: opencast-elasticsearch-single-node
-index.max_result_window: 2147483647
 network.host: 0.0.0.0
+discovery.type: single-node
 ```
 
 …and run
 
 ```sh
 % docker run -p 9200:9200 -p 9300:9300 \
-    -e "discovery.type=single-node" \
     -v "$(pwd)/elasticsearch.yml":/usr/share/elasticsearch/config/elasticsearch.yml \
-    elasticsearch:2.4.6
+    elasticsearch:5.6.15
 ```
 
 This will already give you a running cluster with the cluster name `opencast`. Note that the cluster name is important

--- a/etc/elasticsearch.yml
+++ b/etc/elasticsearch.yml
@@ -34,6 +34,3 @@ network.host: 127.0.0.1
 
 # Disable HTTP completely:
 #http.enabled: false
-
-# Disable the Elasticsearch Shutdown API:
-action.disable_shutdown: true

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
@@ -64,16 +64,18 @@ import org.opencastproject.util.data.Option;
 import com.entwinemedia.fn.Fn;
 
 import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitField;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms.Bucket;
-import org.elasticsearch.search.aggregations.bucket.terms.TermsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -366,9 +368,9 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
     logger.debug("Removing element with id '{}' from searching index '{}'", uid, getIndexName());
 
     DeleteRequestBuilder deleteRequest = getSearchClient().prepareDelete(getIndexName(), documentType, uid);
-    deleteRequest.setRefresh(true);
+    deleteRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
     DeleteResponse delete = deleteRequest.execute().actionGet();
-    if (!delete.isFound()) {
+    if (delete.getResult() == DocWriteResponse.Result.NOT_FOUND) {
       logger.trace("Document {} to delete was not found on index '{}'", uid, getIndexName());
       return false;
     }
@@ -613,7 +615,7 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
    */
   public List<String> getTermsForField(String field, Option<String[]> types) {
     final String facetName = "terms";
-    TermsBuilder aggBuilder = AggregationBuilders.terms(facetName).field(field);
+    AggregationBuilder aggBuilder = AggregationBuilders.terms(facetName).field(field);
     SearchRequestBuilder search = getSearchClient().prepareSearch(getIndexName()).addAggregation(aggBuilder);
 
     if (types.isSome())

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventQueryBuilder.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventQueryBuilder.java
@@ -306,7 +306,7 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
     // Text
     if (query.getTerms() != null) {
       for (SearchTerms<String> terms : query.getTerms()) {
-        StringBuffer queryText = new StringBuffer();
+        StringBuilder queryText = new StringBuilder();
         for (String term : terms.getTerms()) {
           if (queryText.length() > 0)
             queryText.append(" ");
@@ -318,7 +318,7 @@ public class EventQueryBuilder extends AbstractElasticsearchQueryBuilder<EventSe
           this.text = queryText.toString();
         if (Quantifier.All.equals(terms.getQuantifier())) {
           if (groups == null)
-            groups = new ArrayList<ValueGroup>();
+            groups = new ArrayList<>();
           if (query.isFuzzySearch()) {
             logger.warn("All quantifier not supported in conjunction with wildcard text");
           }

--- a/modules/search/pom.xml
+++ b/modules/search/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <lucene.version>5.5.4</lucene.version>
+    <lucene.version>6.6.1</lucene.version>
   </properties>
   <dependencies>
     <dependency>
@@ -39,9 +39,44 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>2.4.6</version>
+      <version>5.6.15</version>
     </dependency>
-    <!-- elasticsearch dependencies -->
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>transport</artifactId>
+      <version>5.6.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.plugin</groupId>
+      <artifactId>transport-netty3-client</artifactId>
+      <version>5.6.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.plugin</groupId>
+      <artifactId>transport-netty4-client</artifactId>
+      <version>5.6.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.plugin</groupId>
+      <artifactId>reindex-client</artifactId>
+      <version>5.6.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.plugin</groupId>
+      <artifactId>percolator-client</artifactId>
+      <version>5.6.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.plugin</groupId>
+      <artifactId>lang-mustache-client</artifactId>
+      <version>5.6.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.plugin</groupId>
+      <artifactId>parent-join-client</artifactId>
+      <version>5.6.15</version>
+    </dependency>
+    <!-- Elasticsearch dependencies -->
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
@@ -50,6 +85,12 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
+      <version>${lucene.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-backward-codecs</artifactId>
       <version>${lucene.version}</version>
       <scope>runtime</scope>
     </dependency>
@@ -125,6 +166,18 @@
     </dependency>
     <dependency>
       <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-spatial-extras</artifactId>
+      <version>${lucene.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-spatial3d</artifactId>
+      <version>${lucene.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-suggest</artifactId>
       <version>${lucene.version}</version>
       <scope>runtime</scope>
@@ -182,12 +235,12 @@
     <dependency>
       <groupId>com.tdunning</groupId>
       <artifactId>t-digest</artifactId>
-      <version>3.0</version>
+      <version>3.2</version>
     </dependency>
     <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
-      <version>2.1.6</version>
+      <version>2.1.9</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -196,8 +249,8 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-      <version>3.10.6.Final</version>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.33.Final</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
@@ -232,6 +285,19 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jzlib</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+
+    <!-- logging -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.11.1</version>
+    </dependency>
+
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -260,34 +326,61 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              !com.barchart.udt*,
+              !org.jctools*,
+              !org.zeromq*,
+              !com.conversantmedia*,
+              !com.fasterxml.jackson.dataformat.xml*,
+              !com.lmax.disruptor*,
+              !org.apache.kafka*,
+              !com.fasterxml.aalto*,
               !com.github.mustachejava*,
-              !com.google.protobuf,
+              !com.google.common.geometry,
+              !com.google.protobuf*,
+              !com.jcraft.jzlib,
+              !gnu.io*,
               !groovy.lang,
+              !io.netty.internal.tcnative,
+              !org.eclipse.jetty.alpn,
               !org.antlr.*,
               !org.apache.log4j.*,
-              !org.apache.lucene.*,
+              !org.conscrypt*,
               !org.tartarus.snowball*,
+              !org.apache.http.impl.nio.client,
               !org.apache.tomcat.*,
               !org.bouncycastle.*,
               !org.codehaus.groovy.*,
               !org.eclipse.jetty.npn.*,
+              !org.elasticsearch.join,
+              !org.elasticsearch.percolator,
+              !org.elasticsearch.script*,
               !org.hyperic.sigar,
               !org.jboss.logging,
               !org.jboss.marshalling,
+              !org.locationtech*,
+              !lzma.sdk*,
+              !net.jpountz.*,
+              !joptsimple*,
               !sun.security.*,
               *
             </Import-Package>
+            <Private-Package>
+              org.jboss.netty.*
+            </Private-Package>
             <Export-Package>
+              org.apache.logging.log4j*,
               org.opencastproject.matterhorn.search.impl;version=${project.version}
             </Export-Package>
             <Embed-Dependency>
               HdrHistogram,
+              log4j-core,
               asm,
               asm-commons,
               asm-tree,
               commons-cli,
               compress-lzf,
               elasticsearch,
+              transport,
               hppc,
               jackson-dataformat-smile,
               jackson-dataformat-yaml,
@@ -296,7 +389,10 @@
               joda-convert,
               jsr166e,
               jts,
+              jzlib,
+              lang-mustache-client,
               lucene-analyzers-common,
+              lucene-backward-codecs,
               lucene-codecs,
               lucene-core,
               lucene-expressions,
@@ -309,10 +405,18 @@
               lucene-queryparser,
               lucene-sandbox,
               lucene-spatial,
+              lucene-spatial-extras,
+              lucene-spatial3d,
               lucene-suggest,
-              netty,
+              netty-all,
+              parent-join-client,
+              percolator-client,
+              reindex-client,
               snakeyaml,
               spatial4j,
+              transport,
+              transport-netty3-client,
+              transport-netty4-client,
               t-digest
             </Embed-Dependency>
             <_exportcontents>

--- a/modules/search/pom.xml
+++ b/modules/search/pom.xml
@@ -14,6 +14,7 @@
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
     <lucene.version>6.6.1</lucene.version>
+    <elasticsearch.version>5.6.15</elasticsearch.version>
   </properties>
   <dependencies>
     <dependency>
@@ -39,42 +40,42 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>5.6.15</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>transport</artifactId>
-      <version>5.6.15</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.plugin</groupId>
       <artifactId>transport-netty3-client</artifactId>
-      <version>5.6.15</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.plugin</groupId>
       <artifactId>transport-netty4-client</artifactId>
-      <version>5.6.15</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.plugin</groupId>
       <artifactId>reindex-client</artifactId>
-      <version>5.6.15</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.plugin</groupId>
       <artifactId>percolator-client</artifactId>
-      <version>5.6.15</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.plugin</groupId>
       <artifactId>lang-mustache-client</artifactId>
-      <version>5.6.15</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch.plugin</groupId>
       <artifactId>parent-join-client</artifactId>
-      <version>5.6.15</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
     <!-- Elasticsearch dependencies -->
     <dependency>

--- a/modules/search/src/main/resources/elasticsearch/event-mapping.json
+++ b/modules/search/src/main/resources/elasticsearch/event-mapping.json
@@ -1,7 +1,6 @@
 {
     "event" : {
         "_source" : { "enabled" : true },
-        "_timestamp" : { "enabled" : true },
         "dynamic": "true",
         "properties" : {
 

--- a/modules/search/src/main/resources/elasticsearch/group-mapping.json
+++ b/modules/search/src/main/resources/elasticsearch/group-mapping.json
@@ -1,7 +1,6 @@
 {
     "group" : {
         "_source" : { "enabled" : true },
-        "_timestamp" : { "enabled" : true },
         "dynamic": "true",
         "properties" : {
 

--- a/modules/search/src/main/resources/elasticsearch/series-mapping.json
+++ b/modules/search/src/main/resources/elasticsearch/series-mapping.json
@@ -1,7 +1,6 @@
 {
     "series" : {
         "_source" : { "enabled" : true },
-        "_timestamp" : { "enabled" : true },
         "dynamic": "true",
         "properties" : {
 

--- a/modules/search/src/main/resources/elasticsearch/theme-mapping.json
+++ b/modules/search/src/main/resources/elasticsearch/theme-mapping.json
@@ -1,7 +1,6 @@
 {
     "theme" : {
         "_source" : { "enabled" : true },
-        "_timestamp" : { "enabled" : true },
         "dynamic": "true",
         "properties" : {
 


### PR DESCRIPTION
This patch updates Opencast's Elasticsearch compatibility and the
internal Elasticsearch node to version 5.6.15, finally btinging us to a
recent (Feb 19, 2019), still supported version.