### PR TITLE
MH-13381, Use Organization Identifier in Workflows

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
@@ -160,7 +160,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
           if (!instance.isActive())
             continue;
 
-          Organization org = organizationDirectoryService.getOrganization(instance.getOrganization());
+          Organization org = organizationDirectoryService.getOrganization(instance.getOrganizationId());
           securityService.setOrganization(org);
 
           MediaPackage mp = instance.getMediaPackage();

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
@@ -160,7 +160,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
           if (!instance.isActive())
             continue;
 
-          Organization org = instance.getOrganization();
+          Organization org = organizationDirectoryService.getOrganization(instance.getOrganization());
           securityService.setOrganization(org);
 
           MediaPackage mp = instance.getMediaPackage();
@@ -227,11 +227,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
         q = q.withStartPage(offset);
         result = workflowService.getWorkflowInstancesForAdministrativeRead(q);
       }
-    } catch (WorkflowException e) {
-      logger.warn(e.getMessage());
-    } catch (UnauthorizedException e) {
-      logger.warn(e.getMessage());
-    } catch (IOException e) {
+    } catch (WorkflowException | NotFoundException | IOException | UnauthorizedException e) {
       logger.warn(e.getMessage());
     } finally {
       securityService.setOrganization(prevOrg);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -387,7 +387,7 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
         logger.info("Publishing media package {} to search index", mediaPackageForSearch);
 
         URL engageBaseUrl;
-        Organization organization = organizationDirectoryService.getOrganization(workflowInstance.getOrganization());
+        Organization organization = organizationDirectoryService.getOrganization(workflowInstance.getOrganizationId());
         engageUrlString = StringUtils.trimToNull(organization.getProperties().get(ENGAGE_URL_PROPERTY));
         if (engageUrlString != null) {
           engageBaseUrl = new URL(engageUrlString);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -49,6 +49,7 @@ import org.opencastproject.search.api.SearchQuery;
 import org.opencastproject.search.api.SearchResult;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
@@ -130,6 +131,8 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
   /** To get the tenant path to the player URL **/
   private SecurityService securityService;
 
+  private OrganizationDirectoryService organizationDirectoryService = null;
+
   /** Whether to distribute to streaming server */
   private boolean distributeStreaming = false;
 
@@ -162,6 +165,10 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    */
   protected void setSearchService(SearchService searchService) {
     this.searchService = searchService;
+  }
+
+  public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
+    this.organizationDirectoryService = organizationDirectoryService;
   }
 
   /** The configuration options for this handler */
@@ -379,9 +386,9 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
 
         logger.info("Publishing media package {} to search index", mediaPackageForSearch);
 
-        URL engageBaseUrl = null;
-        engageUrlString = StringUtils.trimToNull(workflowInstance.getOrganization().getProperties()
-                .get(ENGAGE_URL_PROPERTY));
+        URL engageBaseUrl;
+        Organization organization = organizationDirectoryService.getOrganization(workflowInstance.getOrganization());
+        engageUrlString = StringUtils.trimToNull(organization.getProperties().get(ENGAGE_URL_PROPERTY));
         if (engageUrlString != null) {
           engageBaseUrl = new URL(engageUrlString);
         } else {

--- a/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-engage.xml
+++ b/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-engage.xml
@@ -21,4 +21,7 @@
              policy="static" bind="setServiceRegistry"/>
   <reference cardinality="1..1" interface="org.opencastproject.security.api.SecurityService"
              name="SecurityService" policy="static" bind="setSecurityService"/>
+  <reference name="organizationDirectoryService"
+             interface="org.opencastproject.security.api.OrganizationDirectoryService"
+             bind="setOrganizationDirectoryService"/>
 </scr:component>

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -94,7 +94,7 @@ public interface WorkflowInstance extends Configurable {
    *
    * @return the organization
    */
-  String getOrganization();
+  String getOrganizationId();
 
   /**
    * Returns a copy of the {@link WorkflowOperationInstance}s that make up this workflow. In order to modify the

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -22,7 +22,6 @@
 package org.opencastproject.workflow.api;
 
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.User;
 
 import java.util.List;
@@ -95,7 +94,7 @@ public interface WorkflowInstance extends Configurable {
    *
    * @return the organization
    */
-  Organization getOrganization();
+  String getOrganization();
 
   /**
    * Returns a copy of the {@link WorkflowOperationInstance}s that make up this workflow. In order to modify the

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstanceImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstanceImpl.java
@@ -37,6 +37,9 @@ import org.opencastproject.workflow.api.WorkflowOperationInstance.OperationState
 
 import com.entwinemedia.fn.Fn;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -61,6 +64,8 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 @XmlRootElement(name = "workflow", namespace = "http://workflow.opencastproject.org")
 @XmlAccessorType(XmlAccessType.NONE)
 public class WorkflowInstanceImpl implements WorkflowInstance {
+
+  private final Logger logger = LoggerFactory.getLogger(WorkflowInstance.class);
 
   @XmlAttribute()
   private long id;
@@ -87,6 +92,9 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
   @XmlJavaTypeAdapter(OrganizationAdapter.class)
   @XmlElement(name = "organization", namespace = "http://org.opencastproject.security")
   private JaxbOrganization organization;
+
+  @XmlElement(name = "organizationid", namespace = "http://org.opencastproject.security")
+  private String organizationId;
 
   @XmlElement(name = "mediapackage", namespace = "http://mediapackage.opencastproject.org")
   private MediaPackage mediaPackage;
@@ -134,7 +142,7 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
     this.parentId = parentWorkflowId;
     this.creator = creator;
     if (organization != null)
-      this.organization = JaxbOrganization.fromOrganization(organization);
+      this.organizationId = organization.getId();
     this.state = WorkflowState.INSTANTIATED;
     this.mediaPackage = mediaPackage;
     this.operations = new ArrayList<WorkflowOperationInstance>();
@@ -202,8 +210,15 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
    * @see org.opencastproject.workflow.api.WorkflowInstance#getOrganization()
    */
   @Override
-  public Organization getOrganization() {
-    return organization;
+  public String getOrganization() {
+    if (organizationId != null) {
+      return organizationId;
+    }
+    // get id from old jobs which stored the whole organization
+    if (organization != null) {
+      return organization.getId();
+    }
+    return null;
   }
 
   /**
@@ -217,14 +232,11 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
   /**
    * Sets the workflow's organization.
    *
-   * @param organization
-   *          the organization
+   * @param organizationId
+   *          the organization identifier
    */
-  public void setOrganization(Organization organization) {
-    if (organization == null)
-      this.organization = null;
-    else
-      this.organization = JaxbOrganization.fromOrganization(organization);
+  public void setOrganization(final String organizationId) {
+    this.organizationId = organizationId;
   }
 
   /**
@@ -597,8 +609,9 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
    * Allows JAXB handling of {@link Organization} interfaces.
    */
   static class OrganizationAdapter extends XmlAdapter<JaxbOrganization, Organization> {
+
     @Override
-    public JaxbOrganization marshal(Organization org) throws Exception {
+    public JaxbOrganization marshal(Organization org) {
       if (org == null)
         return null;
       if (org instanceof JaxbOrganization)
@@ -607,9 +620,10 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
     }
 
     @Override
-    public Organization unmarshal(JaxbOrganization org) throws Exception {
+    public Organization unmarshal(JaxbOrganization org) {
       return org;
     }
+
   }
 
   /**

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstanceImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstanceImpl.java
@@ -93,7 +93,7 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
   @XmlElement(name = "organization", namespace = "http://org.opencastproject.security")
   private JaxbOrganization organization;
 
-  @XmlElement(name = "organizationid", namespace = "http://org.opencastproject.security")
+  @XmlElement(name = "organization-id", namespace = "http://org.opencastproject.security")
   private String organizationId;
 
   @XmlElement(name = "mediapackage", namespace = "http://mediapackage.opencastproject.org")
@@ -207,10 +207,10 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
   /**
    * {@inheritDoc}
    *
-   * @see org.opencastproject.workflow.api.WorkflowInstance#getOrganization()
+   * @see org.opencastproject.workflow.api.WorkflowInstance#getOrganizationId()
    */
   @Override
-  public String getOrganization() {
+  public String getOrganizationId() {
     if (organizationId != null) {
       return organizationId;
     }
@@ -235,7 +235,7 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
    * @param organizationId
    *          the organization identifier
    */
-  public void setOrganization(final String organizationId) {
+  public void setOrganizationId(final String organizationId) {
     this.organizationId = organizationId;
   }
 

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2389,9 +2389,9 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
         }
         Organization organization = null;
         try {
-          organization = organizationDirectoryService.getOrganization(instance.getOrganization());
+          organization = organizationDirectoryService.getOrganization(instance.getOrganizationId());
         } catch (NotFoundException e) {
-          logger.error("Found workflow with non-existing organization {}", instance.getOrganization());
+          logger.error("Found workflow with non-existing organization {}", instance.getOrganizationId());
           continue;
         }
 

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2364,7 +2364,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   }
 
   @Override
-  public void repopulate(final String indexName) throws Exception {
+  public void repopulate(final String indexName) throws ServiceRegistryException {
     List<String> workflows =  serviceRegistry.getJobPayloads(Operation.START_WORKFLOW.toString());
 
     final String destinationId = WorkflowItem.WORKFLOW_QUEUE_PREFIX + indexName.substring(0, 1).toUpperCase()
@@ -2387,7 +2387,13 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           logger.warn("Skipping restoring of workflow. Error parsing: {}", workflow, e);
           continue;
         }
-        Organization organization = instance.getOrganization();
+        Organization organization = null;
+        try {
+          organization = organizationDirectoryService.getOrganization(instance.getOrganization());
+        } catch (NotFoundException e) {
+          logger.error("Found workflow with non-existing organization {}", instance.getOrganization());
+          continue;
+        }
 
         // get metadata for index update
         final String dcXml = getEpisodeDublinCoreXml(instance.getMediaPackage());

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
@@ -303,7 +303,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
         WorkflowInstance instance = null;
         try {
           instance = WorkflowParser.parseWorkflowInstance(payload);
-          Organization organization = orgDirectory.getOrganization(instance.getOrganization());
+          Organization organization = orgDirectory.getOrganization(instance.getOrganizationId());
           securityService.setOrganization(organization);
           securityService.setUser(SecurityUtil.createSystemUser(systemUserName, organization));
           index(instance);
@@ -494,7 +494,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
 
     User workflowCreator = instance.getCreator();
     doc.addField(WORKFLOW_CREATOR_KEY, workflowCreator.getUsername());
-    doc.addField(ORG_KEY, instance.getOrganization());
+    doc.addField(ORG_KEY, instance.getOrganizationId());
 
     // Media package used to get the active acl
     MediaPackage aclMp = mp;

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
@@ -303,11 +303,11 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
         WorkflowInstance instance = null;
         try {
           instance = WorkflowParser.parseWorkflowInstance(payload);
-          Organization organization = instance.getOrganization();
+          Organization organization = orgDirectory.getOrganization(instance.getOrganization());
           securityService.setOrganization(organization);
           securityService.setUser(SecurityUtil.createSystemUser(systemUserName, organization));
           index(instance);
-        } catch (WorkflowParsingException | WorkflowDatabaseException e) {
+        } catch (WorkflowParsingException | WorkflowDatabaseException | NotFoundException e) {
           logger.warn("Skipping restoring of workflow {}", payload, e);
         }
         if (current % 100 == 0) {
@@ -494,7 +494,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
 
     User workflowCreator = instance.getCreator();
     doc.addField(WORKFLOW_CREATOR_KEY, workflowCreator.getUsername());
-    doc.addField(ORG_KEY, instance.getOrganization().getId());
+    doc.addField(ORG_KEY, instance.getOrganization());
 
     // Media package used to get the active acl
     MediaPackage aclMp = mp;

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndexTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndexTest.java
@@ -79,7 +79,7 @@ public class WorkflowServiceSolrIndexTest {
     WorkflowInstanceImpl workflow = new WorkflowInstanceImpl();
     workflow.setId(123);
     workflow.setCreator(securityService.getUser());
-    workflow.setOrganization(securityService.getOrganization());
+    workflow.setOrganization(securityService.getOrganization().getId());
     workflow.setState(WorkflowState.INSTANTIATED);
     workflow.setMediaPackage(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());
     String jobPayload = WorkflowParser.toXml(workflow);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndexTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndexTest.java
@@ -79,7 +79,7 @@ public class WorkflowServiceSolrIndexTest {
     WorkflowInstanceImpl workflow = new WorkflowInstanceImpl();
     workflow.setId(123);
     workflow.setCreator(securityService.getUser());
-    workflow.setOrganization(securityService.getOrganization().getId());
+    workflow.setOrganizationId(securityService.getOrganization().getId());
     workflow.setState(WorkflowState.INSTANTIATED);
     workflow.setMediaPackage(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());
     String jobPayload = WorkflowParser.toXml(workflow);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandler.java
@@ -22,7 +22,6 @@ package org.opencastproject.workflow.handler.workflow;
 
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.presets.api.PresetProvider;
-import org.opencastproject.security.api.Organization;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -66,7 +65,7 @@ public class DefaultsWorkflowOperationHandler extends AbstractWorkflowOperationH
    *          The key name for the preset to check for.
    * @return The preset if available, null if not.
    */
-  private String getPreset(final Organization organization, final String seriesID, final String key) {
+  private String getPreset(final String organizationId, final String seriesID, final String key) {
     // Check to see if the default value was set as a preset at the series or organization level
     try {
       if (presetProvider != null) {
@@ -74,7 +73,7 @@ public class DefaultsWorkflowOperationHandler extends AbstractWorkflowOperationH
       }
     } catch (NotFoundException e) {
       logger.debug("No preset for key {} from organization {} and series {}. Using the default value if available.",
-                   key, organization, seriesID);
+                   key, organizationId, seriesID);
     }
     return null;
   }
@@ -88,16 +87,16 @@ public class DefaultsWorkflowOperationHandler extends AbstractWorkflowOperationH
     logger.debug("Applying default values to {}", workflowInstance.getId());
     WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
     Long id = workflowInstance.getId();
-    Organization organization = workflowInstance.getOrganization();
+    String organizationId = workflowInstance.getOrganization();
     String seriesID = workflowInstance.getMediaPackage().getSeries();
     // Iterate over all configuration keys
     Map<String, String> properties = new HashMap<>();
-    logger.debug("Getting properties for " + id + " " + organization + " " + seriesID);
+    logger.debug("Getting properties for {} {} {}", id, organizationId, seriesID);
     for (String key : operation.getConfigurationKeys()) {
       String value = workflowInstance.getConfiguration(key);
       if (StringUtils.isBlank(value)) {
         // Check to see if the default value was set as a preset at the series or organization level
-        String preset = getPreset(organization, seriesID, key);
+        String preset = getPreset(organizationId, seriesID, key);
         if (StringUtils.isNotBlank(preset)) {
           properties.put(key, preset);
           logger.debug("Configuration key '{}' of workflow {} is set to preset value '{}'", key, id, preset);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandler.java
@@ -87,7 +87,7 @@ public class DefaultsWorkflowOperationHandler extends AbstractWorkflowOperationH
     logger.debug("Applying default values to {}", workflowInstance.getId());
     WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
     Long id = workflowInstance.getId();
-    String organizationId = workflowInstance.getOrganization();
+    String organizationId = workflowInstance.getOrganizationId();
     String seriesID = workflowInstance.getMediaPackage().getSeries();
     // Iterate over all configuration keys
     Map<String, String> properties = new HashMap<>();

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandlerTest.java
@@ -279,7 +279,7 @@ public class DefaultsWorkflowOperationHandlerTest {
     WorkflowInstance workflowInstance = EasyMock.createMock(WorkflowInstance.class);
     EasyMock.expect(workflowInstance.getId()).andReturn(1L).anyTimes();
     EasyMock.expect(workflowInstance.getCurrentOperation()).andReturn(operation).anyTimes();
-    EasyMock.expect(workflowInstance.getOrganization()).andReturn("org1").anyTimes();
+    EasyMock.expect(workflowInstance.getOrganizationId()).andReturn("org1").anyTimes();
     EasyMock.expect(workflowInstance.getMediaPackage()).andReturn(mediaPackage).anyTimes();
     if (provideEventValue) {
       EasyMock.expect(workflowInstance.getConfiguration(OPT_KEY)).andReturn(EVENT_PRESET_VALUE);

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandlerTest.java
@@ -127,15 +127,12 @@ public class DefaultsWorkflowOperationHandlerTest {
 
   @Test
   public void usesEventLevelPreset() throws WorkflowOperationException {
-    Organization organization = EasyMock.createMock(Organization.class);
-    EasyMock.replay(organization);
-
     String seriesID = "series-ID";
 
     Map<String, String> workflowConfiguration = new HashMap<String, String>();
     workflowConfiguration.put(OPT_KEY, WORKFLOW_PRESET_VALUE);
 
-    WorkflowInstance workflowInstance = setupInstance(organization, seriesID, workflowConfiguration, true);
+    WorkflowInstance workflowInstance = setupInstance(seriesID, workflowConfiguration, true);
 
     DefaultsWorkflowOperationHandler handler = new DefaultsWorkflowOperationHandler();
     handler.setPresetProvider(presetProvider);
@@ -158,7 +155,7 @@ public class DefaultsWorkflowOperationHandlerTest {
     Map<String, String> workflowConfiguration = new HashMap<String, String>();
     workflowConfiguration.put(OPT_KEY, WORKFLOW_PRESET_VALUE);
 
-    WorkflowInstance workflowInstance = setupInstance(organization, seriesID, workflowConfiguration, false);
+    WorkflowInstance workflowInstance = setupInstance(seriesID, workflowConfiguration, false);
 
     DefaultsWorkflowOperationHandler handler = new DefaultsWorkflowOperationHandler();
     handler.setPresetProvider(presetProvider);
@@ -181,7 +178,7 @@ public class DefaultsWorkflowOperationHandlerTest {
     Map<String, String> workflowConfiguration = new HashMap<String, String>();
     workflowConfiguration.put(OPT_KEY, WORKFLOW_PRESET_VALUE);
 
-    WorkflowInstance workflowInstance = setupInstance(organization, seriesID, workflowConfiguration, false);
+    WorkflowInstance workflowInstance = setupInstance(seriesID, workflowConfiguration, false);
 
     DefaultsWorkflowOperationHandler handler = new DefaultsWorkflowOperationHandler();
     handler.setPresetProvider(presetProvider);
@@ -204,7 +201,7 @@ public class DefaultsWorkflowOperationHandlerTest {
     Map<String, String> workflowConfiguration = new HashMap<String, String>();
     workflowConfiguration.put(OPT_KEY, WORKFLOW_PRESET_VALUE);
 
-    WorkflowInstance workflowInstance = setupInstance(organization, seriesID, workflowConfiguration, false);
+    WorkflowInstance workflowInstance = setupInstance(seriesID, workflowConfiguration, false);
 
     DefaultsWorkflowOperationHandler handler = new DefaultsWorkflowOperationHandler();
     handler.setPresetProvider(presetProvider);
@@ -227,7 +224,7 @@ public class DefaultsWorkflowOperationHandlerTest {
     Map<String, String> workflowConfiguration = new HashMap<String, String>();
     workflowConfiguration.put(OPT_KEY, WORKFLOW_PRESET_VALUE);
 
-    WorkflowInstance workflowInstance = setupInstance(organization, seriesID, workflowConfiguration, false);
+    WorkflowInstance workflowInstance = setupInstance(seriesID, workflowConfiguration, false);
 
     DefaultsWorkflowOperationHandler handler = new DefaultsWorkflowOperationHandler();
     handler.setPresetProvider(presetProvider);
@@ -250,7 +247,7 @@ public class DefaultsWorkflowOperationHandlerTest {
     Map<String, String> workflowConfiguration = new HashMap<String, String>();
     workflowConfiguration.put(OPT_KEY, WORKFLOW_PRESET_VALUE);
 
-    WorkflowInstance workflowInstance = setupInstance(organization, seriesID, workflowConfiguration, false);
+    WorkflowInstance workflowInstance = setupInstance(seriesID, workflowConfiguration, false);
 
     DefaultsWorkflowOperationHandler handler = new DefaultsWorkflowOperationHandler();
     handler.setPresetProvider(presetProvider);
@@ -261,8 +258,6 @@ public class DefaultsWorkflowOperationHandlerTest {
   /**
    * Setup a workflow instance to test the preset values.
    * 
-   * @param organization
-   *          The {@link Organization} to use to get presets.
    * @param seriesID
    *          The series id to get the presets.
    * @param workflowConfiguration
@@ -271,8 +266,7 @@ public class DefaultsWorkflowOperationHandlerTest {
    *          Whether to provide an event level value for the key
    * @return A {@link WorkflowInstance} ready to run a test of {@link DefaultsWorkflowOperationHandler}
    */
-  private WorkflowInstance setupInstance(Organization organization, String seriesID,
-          Map<String, String> workflowConfiguration, boolean provideEventValue) {
+  private WorkflowInstance setupInstance(String seriesID, Map<String, String> workflowConfiguration, boolean provideEventValue) {
     WorkflowOperationInstance operation = EasyMock.createMock(WorkflowOperationInstance.class);
     EasyMock.expect(operation.getConfigurationKeys()).andReturn(workflowConfiguration.keySet());
     EasyMock.expect(operation.getConfiguration(OPT_KEY)).andReturn(WORKFLOW_PRESET_VALUE);
@@ -285,7 +279,7 @@ public class DefaultsWorkflowOperationHandlerTest {
     WorkflowInstance workflowInstance = EasyMock.createMock(WorkflowInstance.class);
     EasyMock.expect(workflowInstance.getId()).andReturn(1L).anyTimes();
     EasyMock.expect(workflowInstance.getCurrentOperation()).andReturn(operation).anyTimes();
-    EasyMock.expect(workflowInstance.getOrganization()).andReturn(organization).anyTimes();
+    EasyMock.expect(workflowInstance.getOrganization()).andReturn("org1").anyTimes();
     EasyMock.expect(workflowInstance.getMediaPackage()).andReturn(mediaPackage).anyTimes();
     if (provideEventValue) {
       EasyMock.expect(workflowInstance.getConfiguration(OPT_KEY)).andReturn(EVENT_PRESET_VALUE);


### PR DESCRIPTION
The maximum size of the serialized workflow instances stored in the
database is huge, causing an unnecessary performance overhead for the
frequent serialization and deserialization to/from XML. One cause for
this is the large organization data stored multiple times in the XML.

This patch drops the use of the serialized organization which is not
frequently being used anyway and replaces it by referencing the
organization via its unique identifier.

The old organization is still kept as an optional field, ensuring
backward compatibility to old serialized workflows. This means that no
migration is required.

There are more references to organizations in the XML caused by the user
data stored in the XML, but they will be dealt with separately.