### PR TITLE
MH-13429 Make sure series LTI tool respects provided series custom param

### DIFF
--- a/modules/lti/src/main/resources/tools/series/series.js
+++ b/modules/lti/src/main/resources/tools/series/series.js
@@ -27,9 +27,9 @@ var player,
     currentpage;
 
 function getSeries() {
-  var prefix = '?series=';
-  if (location.search.startsWith(prefix)) {
-    return location.search.substring(prefix.length).split('&')[0];
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.has('series')) {
+    return urlParams.get('series');
   }
   return '';
 }


### PR DESCRIPTION
Series LTI tool only looks at the first item in the query string so if that is not the series than the provided series will not be used in the search query.