### PR TITLE
Document encoding-profiles parameter in ComposeWorkflowHandler

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/compose-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/compose-woh.md
@@ -5,27 +5,45 @@ The ComposeWorkflowHandler is used to encode media files to different formats us
 
 ## Parameter Table
 
-|configuration keys|example             |description                                                                    |
-|------------------|--------------------|-------------------------------------------------------------------------------|
-|source-flavor     | presenter/work     | Which media should be encoded                                                 |
-|target-flavor     | presenter/delivery | Specifies the flavor of the new media                                         |
-|source-tags       | sometag            | Tags of media to encode                                                       |
-|target-tags       | sometag            | Specifies the tags of the new media                                           |
-|encoding-profile  | webm-hd            | Specifies the encoding profile to use                                         |
-|tags-and-flavors  | true               | When false (default), the operation selects input elements that have EITHER any of the source tags OR the source flavor. When true, the operation selects input elements that have BOTH the source-flavor AND any of the source tags |
+|configuration keys|example                   |description                                                                    |
+|------------------|--------------------------|-------------------------------------------------------------------------------|
+|source-flavor     | presenter/work           | Which media should be encoded                                                 |
+|target-flavor     | presenter/delivery       | Specifies the flavor of the new media                                         |
+|source-tags       | sometag                  | Tags of media to encode                                                       |
+|target-tags       | sometag                  | Specifies the tags of the new media                                           |
+|encoding-profile  | mp4-hd.http              | Specifies the encoding profile to use                                         |
+|encoding-profiles | mp4-low.http,mp4-hd.http | Specifies a coma separated encoding profiles to use                           |
+|tags-and-flavors  | true                     | When false (default), the operation selects input elements that have EITHER any of the source tags OR the source flavor. When true, the operation selects input elements that have BOTH the source-flavor AND any of the source tags |
 
 
-## Operation Example
+## Operation Examples
+
+Encoding presenter (camera) video to MP4 medium quality:
 
     <operation
         id="compose"
         fail-on-error="true"
-        exception-handler-workflow="error"
-        description="Encoding presenter (camera) video to Flash download">
+        exception-handler-workflow="partial-error"
+        description="Encoding presenter (camera) video to MP4 medium quality">
         <configurations>
             <configuration key="source-flavor">presenter/trimmed</configuration>
             <configuration key="target-flavor">presenter/delivery</configuration>
-            <configuration key="target-tags">engage</configuration>
-            <configuration key="encoding-profile">flash.http</configuration>
+            <configuration key="target-tags">engage-download</configuration>
+            <configuration key="encoding-profile">mp4-medium.http</configuration>
+        </configurations>
+    </operation>
+
+Encoding 480p, 720p and 1080p video to MP4 adaptative streaming:
+
+    <operation
+        id="compose"
+        fail-on-error="true"
+        exception-handler-workflow="partial-error"
+        description="Encoding 480p, 720p and 1080p video to MP4 streaming">
+        <configurations>
+            <configuration key="source-flavor">*/work</configuration>
+            <configuration key="target-flavor">*/delivery</configuration>
+            <configuration key="target-tags">engage-download,engage-streaming</configuration>
+            <configuration key="encoding-profiles">adaptive-480p.http,adaptive-720p.http,adaptive-1080p.http</configuration>
         </configurations>
     </operation>

--- a/docs/guides/admin/docs/workflowoperationhandlers/compose-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/compose-woh.md
@@ -12,7 +12,7 @@ The ComposeWorkflowHandler is used to encode media files to different formats us
 |source-tags       | sometag                  | Tags of media to encode                                                       |
 |target-tags       | sometag                  | Specifies the tags of the new media                                           |
 |encoding-profile  | mp4-hd.http              | Specifies the encoding profile to use                                         |
-|encoding-profiles | mp4-low.http,mp4-hd.http | Specifies a coma separated encoding profiles to use                           |
+|encoding-profiles | mp4-low.http,mp4-hd.http | Specifies a comma-separated encoding profiles to use                           |
 |tags-and-flavors  | true                     | When false (default), the operation selects input elements that have EITHER any of the source tags OR the source flavor. When true, the operation selects input elements that have BOTH the source-flavor AND any of the source tags |
 
 
@@ -33,7 +33,7 @@ Encoding presenter (camera) video to MP4 medium quality:
         </configurations>
     </operation>
 
-Encoding 480p, 720p and 1080p video to MP4 adaptative streaming:
+Encoding 480p, 720p and 1080p video to MP4 adaptive streaming:
 
     <operation
         id="compose"


### PR DESCRIPTION
The `compose` operation has a `encoding-profiles` parameter that is not documented.
This PR adds the parameter to the parameters table and an example.