### PR TITLE
Make button `Edit on Github` link works on documentation page

### DIFF
--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Opencast - Administration Guide
-repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/admin/docs
+repo_url: https://github.com/opencast/opencast
+edit_uri: edit/r/6.x/docs/guides/admin/docs
 
 # Default theme used is readthedocs
 theme: readthedocs

--- a/docs/guides/developer/mkdocs.yml
+++ b/docs/guides/developer/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Opencast - Developer Guide
-repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/developer/docs
+repo_url: https://github.com/opencast/opencast
+edit_uri: edit/r/6.x/docs/guides/developer/docs
 
 # Default theme used is readthedocs
 theme: readthedocs

--- a/docs/guides/user/mkdocs.yml
+++ b/docs/guides/user/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Opencast - Users Guide
-repo_url: https://github.com/opencast/opencast/tree/develop/docs/guides/user/docs
+repo_url: https://github.com/opencast/opencast
+edit_uri: edit/r/6.x/docs/guides/user/docs
 
 # Default theme used is readthedocs
 theme: readthedocs


### PR DESCRIPTION
The documentation page has a link `Edit on Github`, but the link does not work because is linking to an incorrect page.

This PR fix that. This allow people reading the documentation to fix errors easily.