### PR TITLE
MH-13387 Get ACLs of finished workflows from AssetManager

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
@@ -50,6 +50,14 @@ public interface AssetManager {
   String DEFAULT_OWNER = "default";
 
   /**
+   * Get the media package from the lates snapshot.
+   *
+   * @param mediaPackageId
+   * @return mediapackage
+   */
+  Opt<MediaPackage> getMediaPackage(String mediaPackageId);
+
+  /**
    * Take a versioned snapshot of a media package.
    * <p>
    * Snapshot are tagged with string identifying the owner. Only the owner

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/Property.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/Property.java
@@ -31,7 +31,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * Properties can be defined and associated to a media package's version history.
  */
 @ParametersAreNonnullByDefault
-public final class Property {
+public class Property {
   private final PropertyId id;
   private final Value value;
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
@@ -106,7 +106,20 @@ public abstract class AbstractAssetManager implements AssetManager {
 
   /* ------------------------------------------------------------------------------------------------------------------ */
 
-  @Override public Snapshot takeSnapshot(final String owner, final MediaPackage mp) {
+  @Override
+  public Opt<MediaPackage> getMediaPackage(String mediaPackageId) {
+    final AQueryBuilder q = createQuery();
+    final AResult r = q.select(q.snapshot()).where(q.mediaPackageId(mediaPackageId).and(q.version().isLatest()))
+            .run();
+
+    if (r.getSize() == 0) {
+      return Opt.none();
+    }
+    return Opt.some(r.getRecords().head2().getSnapshot().get().getMediaPackage());
+  }
+
+  @Override
+  public Snapshot takeSnapshot(final String owner, final MediaPackage mp) {
     if (owner == null)
       return takeSnapshot(mp);
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
@@ -56,6 +56,10 @@ public class AssetManagerDecorator<A extends TieredStorageAssetManager> implemen
     return delegate.getAsset(version, mpId, mpeId);
   }
 
+  @Override public Opt<MediaPackage> getMediaPackage(String mediaPackageId) {
+    return delegate.getMediaPackage(mediaPackageId);
+  }
+
   @Override public void setAvailability(Version version, String mpId, Availability availability) {
     delegate.setAvailability(version, mpId, availability);
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
@@ -190,6 +190,11 @@ public class OsgiAssetManager implements AssetManager, TieredStorageAssetManager
   }
 
   @Override
+  public Opt<MediaPackage> getMediaPackage(String mediaPackageId) {
+    return delegate.getMediaPackage(mediaPackageId);
+  }
+
+  @Override
   public void setAvailability(Version version, String mpId, Availability availability) {
     delegate.setAvailability(version, mpId, availability);
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
@@ -48,6 +48,7 @@ import org.opencastproject.assetmanager.api.query.AQueryBuilder;
 import org.opencastproject.assetmanager.api.query.AResult;
 import org.opencastproject.assetmanager.api.query.ASelectQuery;
 import org.opencastproject.assetmanager.impl.TieredStorageAssetManager;
+import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageImpl;
 import org.opencastproject.rest.AbstractJobProducerEndpoint;
 import org.opencastproject.security.api.UnauthorizedException;
@@ -59,6 +60,7 @@ import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
+import com.entwinemedia.fn.data.Opt;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
@@ -223,17 +225,15 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
           @RestResponse(responseCode = SC_INTERNAL_SERVER_ERROR, description = "There has been an internal error.")
       })
   public Response getMediaPackage(@PathParam("mediaPackageID") final String mediaPackageId) {
+
     try {
-      final AQueryBuilder q = getAssetManager().createQuery();
-      final AResult r = q.select(q.snapshot())
-              .where(q.mediaPackageId(mediaPackageId).and(q.version().isLatest()))
-              .run();
-      if (r.getSize() == 1) {
-        return ok(r.getRecords().head2().getSnapshot().get().getMediaPackage());
-      } else if (r.getSize() == 0) {
+      Opt<MediaPackage> mp = getAssetManager().getMediaPackage(mediaPackageId);
+
+      if (mp.isSome()) {
+        return ok(mp);
+      } else {
         return notFound();
       }
-      return serverError();
     } catch (Exception e) {
       return handleException(e);
     }

--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
@@ -201,6 +201,12 @@ public class TestRestService extends AbstractAclServiceRestEndpoint {
     EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(select).anyTimes();
 
     AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
+    try {
+    EasyMock.expect(assetManager.getMediaPackage(EasyMock.anyString())).andReturn(Opt.some(new MediaPackageBuilderImpl()
+            .createNew())).anyTimes();
+    } catch (MediaPackageException e) {
+      throw new RuntimeException(e);
+    }
     EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
     EasyMock.replay(assetManager, version, query, predicate, select, result, record, snapshot);
     return assetManager;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1589,12 +1589,10 @@ public class IndexServiceImpl implements IndexService {
         }
         return currentWorkflowInstance.get().getMediaPackage();
       case ARCHIVE:
-        final AQueryBuilder q = assetManager.createQuery();
-        final AResult r = q.select(q.snapshot())
-                .where(q.mediaPackageId(event.getIdentifier()).and(q.version().isLatest())).run();
-        if (r.getSize() > 0) {
+        Opt<MediaPackage> mpOpt = assetManager.getMediaPackage(event.getIdentifier());
+        if (mpOpt.isSome()) {
           logger.debug("Found event in archive with id {}", event.getIdentifier());
-          return enrich(r).getSnapshots().head2().getMediaPackage();
+          return mpOpt.get();
         }
         logger.error("No event with id {} found from archive!", event.getIdentifier());
         throw new IndexServiceException("No archived event found with id " + event.getIdentifier());

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -607,14 +607,11 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           Long parentWorkflowId, Map<String, String> originalProperties) throws WorkflowDatabaseException,
           WorkflowParsingException, NotFoundException {
     final String mediaPackageId = sourceMediaPackage.getIdentifier().compact();
+    Map<String, String> properties = null;
 
-    final Map<String, String> properties;
-    // Currently, the only place where the asset manager isn't involved is in the tests. But it might change.
-    if (assetManager != null) {
+    if (originalProperties != null) {
       WorkflowPropertiesUtil.storeProperties(assetManager, sourceMediaPackage, originalProperties);
       properties = WorkflowPropertiesUtil.getLatestWorkflowProperties(assetManager, mediaPackageId);
-    } else {
-      properties = originalProperties;
     }
 
     // We have to synchronize per media package to avoid starting multiple simultaneous workflows for one media package.

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -104,6 +104,7 @@ import org.opencastproject.workflow.api.WorkflowStatistics;
 import org.opencastproject.workflow.impl.jmx.WorkflowsStatistics;
 import org.opencastproject.workspace.api.Workspace;
 
+import com.entwinemedia.fn.data.Opt;
 import com.google.common.util.concurrent.Striped;
 
 import org.apache.commons.io.IOUtils;
@@ -1056,6 +1057,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     }
   }
 
+
   /**
    * {@inheritDoc}
    *
@@ -1293,6 +1295,15 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     String currentOrgId = currentOrg.getId();
 
     MediaPackage mediapackage = workflow.getMediaPackage();
+
+    WorkflowState state = workflow.getState();
+    if (state != INSTANTIATED && state != RUNNING && workflow.getState() != FAILING) {
+      Opt<MediaPackage> assetMediapackage = assetManager.getMediaPackage(mediapackage.getIdentifier().toString());
+      if (assetMediapackage.isSome()) {
+        mediapackage = assetMediapackage.get();
+      }
+    }
+
     User workflowCreator = workflow.getCreator();
     String workflowOrgId = workflowCreator.getOrganization().getId();
 

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.workflow.impl;
 
+import static org.easymock.EasyMock.createNiceMock;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
@@ -181,6 +182,33 @@ public class CountWorkflowsTest {
 
     serviceRegistry = new ServiceRegistryInMemoryImpl(service, securityService, userDirectoryService,
             organizationDirectoryService, EasyMock.createNiceMock(IncidentService.class));
+
+    {
+      final AssetManager assetManager = createNiceMock(AssetManager.class);
+      final AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+      final Target t = EasyMock.createNiceMock(Target.class);
+      final Predicate p = EasyMock.createNiceMock(Predicate.class);
+      EasyMock.expect(p.and(EasyMock.anyObject(Predicate.class))).andReturn(p).anyTimes();
+      EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+      EasyMock.expect(query.propertiesOf(EasyMock.anyString())).andReturn(t).anyTimes();
+      final VersionField v = EasyMock.createNiceMock(VersionField.class);
+      EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+      EasyMock.expect(query.version()).andReturn(v).anyTimes();
+      EasyMock.expect(assetManager.getMediaPackage(EasyMock.anyString())).andReturn(Opt.none()).anyTimes();
+      EasyMock.expect(query.mediaPackageId(EasyMock.anyString())).andReturn(p).anyTimes();
+      final ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+      EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+      final AResult r = EasyMock.createNiceMock(AResult.class);
+      EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+      final Stream<ARecord> recStream = Stream.mk();
+      EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+      EasyMock.expect(query.select(EasyMock.anyObject(Target.class), EasyMock.anyObject(Target.class))).
+              andReturn(selectQuery).anyTimes();
+      EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+      EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+      EasyMock.replay(query, t, r, selectQuery, assetManager, p, v);
+      service.setAssetManager(assetManager);
+    }
 
     AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
     Version version = EasyMock.createNiceMock(Version.class);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.workflow.impl;
 
+import static org.easymock.EasyMock.createNiceMock;
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
 import org.opencastproject.assetmanager.api.AssetManager;
@@ -175,6 +176,32 @@ public class PauseFinalOperationTest {
     workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.getCollectionContents((String) EasyMock.anyObject())).andReturn(new URI[0]);
     EasyMock.replay(workspace);
+
+    {
+      final AssetManager assetManager = createNiceMock(AssetManager.class);
+      final AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+      final Target t = EasyMock.createNiceMock(Target.class);
+      final Predicate p = EasyMock.createNiceMock(Predicate.class);
+      EasyMock.expect(p.and(EasyMock.anyObject(Predicate.class))).andReturn(p).anyTimes();
+      EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+      EasyMock.expect(query.propertiesOf(EasyMock.anyString())).andReturn(t).anyTimes();
+      final VersionField v = EasyMock.createNiceMock(VersionField.class);
+      EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+      EasyMock.expect(query.version()).andReturn(v).anyTimes();
+      EasyMock.expect(assetManager.getMediaPackage(EasyMock.anyString())).andReturn(Opt.none()).anyTimes();
+      EasyMock.expect(query.mediaPackageId(EasyMock.anyString())).andReturn(p).anyTimes();
+      final ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+      EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+      final AResult r = EasyMock.createNiceMock(AResult.class);
+      EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+      final Stream<ARecord> recStream = Stream.mk();
+      EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+      EasyMock.expect(query.select(EasyMock.anyObject(Target.class), EasyMock.anyObject(Target.class))).
+              andReturn(selectQuery).anyTimes();
+      EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+      EasyMock.replay(query, t, r, selectQuery, assetManager, p, v);
+      service.setAssetManager(assetManager);
+    }
 
     AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
     Version version = EasyMock.createNiceMock(Version.class);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
@@ -21,8 +21,17 @@
 
 package org.opencastproject.workflow.impl;
 
+import static org.easymock.EasyMock.createNiceMock;
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.mediapackage.DefaultMediaPackageSerializerImpl;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilder;
@@ -47,6 +56,9 @@ import org.opencastproject.workflow.api.WorkflowParser;
 import org.opencastproject.workflow.api.WorkflowStateListener;
 import org.opencastproject.workflow.impl.WorkflowServiceImpl.HandlerRegistration;
 import org.opencastproject.workspace.api.Workspace;
+
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -123,6 +135,30 @@ public class PauseWorkflowTest {
 
     scanner = new WorkflowDefinitionScanner();
     service.addWorkflowDefinitionScanner(scanner);
+
+    final AssetManager assetManager = createNiceMock(AssetManager.class);
+    final AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+    final Target t = EasyMock.createNiceMock(Target.class);
+    final Predicate p = EasyMock.createNiceMock(Predicate.class);
+    EasyMock.expect(p.and(EasyMock.anyObject(Predicate.class))).andReturn(p).anyTimes();
+    EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+    EasyMock.expect(query.propertiesOf(EasyMock.anyString())).andReturn(t).anyTimes();
+    final VersionField v = EasyMock.createNiceMock(VersionField.class);
+    EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+    EasyMock.expect(query.version()).andReturn(v).anyTimes();
+    EasyMock.expect(assetManager.getMediaPackage(EasyMock.anyString())).andReturn(Opt.none()).anyTimes();
+    EasyMock.expect(query.mediaPackageId(EasyMock.anyString())).andReturn(p).anyTimes();
+    final ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+    EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+    final AResult r = EasyMock.createNiceMock(AResult.class);
+    EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+    final Stream<ARecord> recStream = Stream.mk();
+    EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+    EasyMock.expect(query.select(EasyMock.anyObject(Target.class), EasyMock.anyObject(Target.class)))
+            .andReturn(selectQuery).anyTimes();
+    EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+    EasyMock.replay(query, t, r, selectQuery, assetManager, p, v);
+    service.setAssetManager(assetManager);
 
     // security service
     DefaultOrganization organization = new DefaultOrganization();

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplAuthzTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplAuthzTest.java
@@ -21,10 +21,19 @@
 
 package org.opencastproject.workflow.impl;
 
+import static org.easymock.EasyMock.createNiceMock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
 import org.opencastproject.message.broker.api.MessageSender;
@@ -52,6 +61,9 @@ import org.opencastproject.workflow.api.WorkflowDefinitionImpl;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowOperationDefinitionImpl;
 import org.opencastproject.workspace.api.Workspace;
+
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.FileUtils;
 import org.easymock.EasyMock;
@@ -152,6 +164,33 @@ public class WorkflowServiceImplAuthzTest {
 
     scanner = new WorkflowDefinitionScanner();
     service.addWorkflowDefinitionScanner(scanner);
+
+    {
+      final AssetManager assetManager = createNiceMock(AssetManager.class);
+      final AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+      final Target t = EasyMock.createNiceMock(Target.class);
+      final Predicate p = EasyMock.createNiceMock(Predicate.class);
+      EasyMock.expect(p.and(EasyMock.anyObject(Predicate.class))).andReturn(p).anyTimes();
+      EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+      EasyMock.expect(query.propertiesOf(EasyMock.anyString())).andReturn(t).anyTimes();
+      final VersionField v = EasyMock.createNiceMock(VersionField.class);
+      EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+      EasyMock.expect(query.version()).andReturn(v).anyTimes();
+      EasyMock.expect(assetManager.getMediaPackage(EasyMock.anyString())).andReturn(Opt.none()).anyTimes();
+      EasyMock.expect(query.mediaPackageId(EasyMock.anyString())).andReturn(p).anyTimes();
+      final ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+      EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+      final AResult r = EasyMock.createNiceMock(AResult.class);
+      EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+      final Stream<ARecord> recStream = Stream.mk();
+      EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+      EasyMock.expect(query.select(EasyMock.anyObject(Target.class), EasyMock.anyObject(Target.class))).
+              andReturn(selectQuery).anyTimes();
+      EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+      EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+      EasyMock.replay(query, t, r, selectQuery, assetManager, p, v);
+      service.setAssetManager(assetManager);
+    }
 
     // Organization Service
     List<Organization> organizationList = new ArrayList<Organization>();

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -210,6 +210,7 @@ public class WorkflowServiceImplTest {
       final VersionField v = EasyMock.createNiceMock(VersionField.class);
       EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
       EasyMock.expect(query.version()).andReturn(v).anyTimes();
+      EasyMock.expect(assetManager.getMediaPackage(EasyMock.anyString())).andReturn(Opt.none()).anyTimes();
       EasyMock.expect(query.mediaPackageId(EasyMock.anyString())).andReturn(p).anyTimes();
       final ASelectQuery selectQuery = EasyMock.createMock(ASelectQuery.class);
       EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
@@ -217,7 +218,8 @@ public class WorkflowServiceImplTest {
       EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
       final Stream<ARecord> recStream = Stream.mk();
       EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
-      EasyMock.expect(query.select(EasyMock.anyObject(Target.class), EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+      EasyMock.expect(query.select(EasyMock.anyObject(Target.class), EasyMock.anyObject(Target.class))).
+              andReturn(selectQuery).anyTimes();
       EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
       EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
       EasyMock.replay(query, t, r, selectQuery, assetManager, p, v);
@@ -252,7 +254,8 @@ public class WorkflowServiceImplTest {
 
     serviceRegistry = new ServiceRegistryInMemoryImpl(service, securityService, userDirectoryService,
             organizationDirectoryService, incidentService);
-    serviceRegistry.registerHost(REMOTE_HOST, REMOTE_HOST, Runtime.getRuntime().totalMemory(), Runtime.getRuntime().availableProcessors(), Runtime.getRuntime().availableProcessors());
+    serviceRegistry.registerHost(REMOTE_HOST, REMOTE_HOST, Runtime.getRuntime().totalMemory(), Runtime.getRuntime().
+            availableProcessors(), Runtime.getRuntime().availableProcessors());
     serviceRegistry.registerService(REMOTE_SERVICE, REMOTE_HOST, "/path", true);
     service.setWorkspace(workspace);
 

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowStatisticsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowStatisticsTest.java
@@ -21,9 +21,18 @@
 
 package org.opencastproject.workflow.impl;
 
+import static org.easymock.EasyMock.createNiceMock;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.workflow.impl.SecurityServiceStub.DEFAULT_ORG_ADMIN;
 
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.query.Predicate;
+import org.opencastproject.assetmanager.api.query.Target;
+import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.mediapackage.DefaultMediaPackageSerializerImpl;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilder;
@@ -57,6 +66,9 @@ import org.opencastproject.workflow.api.WorkflowStatistics.WorkflowDefinitionRep
 import org.opencastproject.workflow.api.WorkflowStatistics.WorkflowDefinitionReport.OperationReport;
 import org.opencastproject.workflow.impl.WorkflowServiceImpl.HandlerRegistration;
 import org.opencastproject.workspace.api.Workspace;
+
+import com.entwinemedia.fn.Stream;
+import com.entwinemedia.fn.data.Opt;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -142,6 +154,31 @@ public class WorkflowStatisticsTest {
 
     scanner = new WorkflowDefinitionScanner();
     service.addWorkflowDefinitionScanner(scanner);
+
+    final AssetManager assetManager = createNiceMock(AssetManager.class);
+    final AQueryBuilder query = EasyMock.createNiceMock(AQueryBuilder.class);
+    final Target t = EasyMock.createNiceMock(Target.class);
+    final Predicate p = EasyMock.createNiceMock(Predicate.class);
+    EasyMock.expect(p.and(EasyMock.anyObject(Predicate.class))).andReturn(p).anyTimes();
+    EasyMock.expect(query.snapshot()).andReturn(t).anyTimes();
+    EasyMock.expect(query.propertiesOf(EasyMock.anyString())).andReturn(t).anyTimes();
+    final VersionField v = EasyMock.createNiceMock(VersionField.class);
+    EasyMock.expect(v.isLatest()).andReturn(p).anyTimes();
+    EasyMock.expect(query.version()).andReturn(v).anyTimes();
+    EasyMock.expect(assetManager.getMediaPackage(EasyMock.anyString())).andReturn(Opt.none()).anyTimes();
+    EasyMock.expect(query.mediaPackageId(EasyMock.anyString())).andReturn(p).anyTimes();
+    final ASelectQuery selectQuery = EasyMock.createNiceMock(ASelectQuery.class);
+    EasyMock.expect(selectQuery.where(EasyMock.anyObject(Predicate.class))).andReturn(selectQuery).anyTimes();
+    final AResult r = EasyMock.createNiceMock(AResult.class);
+    EasyMock.expect(selectQuery.run()).andReturn(r).anyTimes();
+    final Stream<ARecord> recStream = Stream.mk();
+    EasyMock.expect(r.getRecords()).andReturn(recStream).anyTimes();
+    EasyMock.expect(query.select(EasyMock.anyObject(Target.class), EasyMock.anyObject(Target.class))).
+            andReturn(selectQuery).anyTimes();
+    EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(selectQuery).anyTimes();
+    EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
+    EasyMock.replay(query, t, r, selectQuery, assetManager, p, v);
+    service.setAssetManager(assetManager);
 
     // security service
     securityService = EasyMock.createNiceMock(SecurityService.class);


### PR DESCRIPTION
Deleting an event as a Non-Admin can fail if there are finished workflows to remove that were started by another user, since in that case the ACL will be looked for in the WFR, where it might no longer be. This PR gets the ACL for workflows that are no longer running from the AssetManager.

This also contains PR #776.

_This work was sponsored by SWITCH._