### PR TITLE
MH-13436: Improve error message for out of bounds image extraction

### DIFF
--- a/modules/composer-ffmpeg/src/main/resources/incident-l10n/org.opencastproject.composer.properties
+++ b/modules/composer-ffmpeg/src/main/resources/incident-l10n/org.opencastproject.composer.properties
@@ -93,7 +93,7 @@
 #  track-duration The source track duration
 #  time The extraction time
 17.title = Image extraction failed - time outside duration
-17.description = An image could not be extracted from the track '\#{track-url}' with id '\#{track-id}' because the extraction time '\#{time}' is outside of the track's duration '\#{track-duration}'.
+17.description = An image could not be extracted from the track '\#{track-url}' with id '\#{track-id}' because the extraction time (\#{time} second(s)) is outside of the track's duration (\#{track-duration} second(s)).
 # params:
 #  track-id The source track id
 #  track-url The source track url


### PR DESCRIPTION
The error message for when you try to extract an image from a time
past the end of the video is confusing because of the lack of explicit units
and also inconsistency of the units implied.

Example:

```
org.opencastproject.composer.api.EncoderException: Can not extract an image at time 1.0 f
rom a track with duration 520
```