### PR TITLE
MH-13439, Dynamic Player Redirect

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -90,7 +90,7 @@ Update Player Links
 > This step is optional
 
 Opencast 7 comes with the capability of dynamically switching the configured player without requiring the republication
-of all published material by providing the dynamic target `https://example.opencast.org/watch/<id>`. This new target
+of all published material by providing the dynamic target `https://example.opencast.org/play/<id>`. This new target
 will be used for all new engage publications.
 
 But old publications still reference the players directly in the admin interface and the external API. This does not
@@ -101,34 +101,34 @@ Alternatively, you can rewrite the old links all at once without re-publication 
 
 1. Find the archive directory and run the following command (replacing `<playerlink>`):
 
-        sed -i 's_<playerlink>_/watch/_g' .../archive/*/*/*/manifest.xml
+        sed -i 's_<playerlink>_/play/_g' .../archive/*/*/*/manifest.xml
 
     For Theodul, Paella and the Engage player the specific commands would be:
 
-        sed -i 's_/engage/theodul/ui/core.html?id=_/watch/_g' .../archive/*/*/*/manifest.xml
-        sed -i 's_/paella/ui/watch.html?id=_/watch/_g' .../archive/*/*/*/manifest.xml
-        sed -i 's_/engage/ui/watch.html?id=_/watch/_g' .../archive/*/*/*/manifest.xml
+        sed -i 's_/engage/theodul/ui/core.html?id=_/play/_g' .../archive/*/*/*/manifest.xml
+        sed -i 's_/paella/ui/watch.html?id=_/play/_g' .../archive/*/*/*/manifest.xml
+        sed -i 's_/engage/ui/watch.html?id=_/play/_g' .../archive/*/*/*/manifest.xml
 
 2. Run the following SQL commands on your opencast database (replacing `<playerlink>`):
 
         UPDATE oc_assets_snapshot
           SET mediapackage_xml =
-          REPLACE(mediapackage_xml, '<playerlink>', '/watch/')
+          REPLACE(mediapackage_xml, '<playerlink>', '/play/')
           WHERE INSTR(mediapackage_xml, '<playerlink>') > 0;
 
     For Theodul, Paella and the Engage player the specific commands would be:
 
         UPDATE oc_assets_snapshot
           SET mediapackage_xml =
-          REPLACE(mediapackage_xml, '/engage/theodul/ui/core.html?id=', '/watch/')
+          REPLACE(mediapackage_xml, '/engage/theodul/ui/core.html?id=', '/play/')
           WHERE INSTR(mediapackage_xml, '/engage/theodul/ui/core.html?id=') > 0;
         UPDATE oc_assets_snapshot
           SET mediapackage_xml =
-          REPLACE(mediapackage_xml, '/paella/ui/watch.html?id=', '/watch/')
+          REPLACE(mediapackage_xml, '/paella/ui/watch.html?id=', '/play/')
           WHERE INSTR(mediapackage_xml, '/paella/ui/watch.html?id=') > 0;
         UPDATE oc_assets_snapshot
           SET mediapackage_xml =
-          REPLACE(mediapackage_xml, '/engage/ui/watch.html?id=', '/watch/')
+          REPLACE(mediapackage_xml, '/engage/ui/watch.html?id=', '/play/')
           WHERE INSTR(mediapackage_xml, '/engage/ui/watch.html?id=') > 0;
 
 Please ensure to execute these steps before rebuilding the index.

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -224,9 +224,12 @@ prop.adminui.user.external_role_display=false
 
 # Path to the default video player used by the engage interfaces and the LTI tools. Parameters for selecting the
 # specific videos will be appended automatically.  Common values include:
-# - theodul player: /engage/theodul/ui/core.html
-# - paella  player: /paella/ui/watch.html
-prop.player=/engage/theodul/ui/core.html
+#
+# - theodul player: /engage/theodul/ui/core.html?id={{id}}
+# - paella  player: /paella/ui/watch.html?id={{id}}
+#
+# Default: /engage/theodul/ui/core.html?id={{id}}
+#prop.player=/engage/theodul/ui/core.html?id={{id}}
 
 # The default flavor of the master video (the video on the "left side" in the video display)
 prop.player.mastervideotype=presenter/delivery

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -114,7 +114,7 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
   private static final String MERGE_FORCE_FLAVORS_DEFAULT = "dublincore/*,security/*";
 
   /** Path the REST endpoint which will re-direct users to the currently configured video player **/
-  static final String PLAYER_PATH = "/watch/";
+  static final String PLAYER_PATH = "/play/";
 
   /** The streaming distribution service */
   private DistributionService streamingDistributionService = null;

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -113,8 +113,8 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
 
   private static final String MERGE_FORCE_FLAVORS_DEFAULT = "dublincore/*,security/*";
 
-  /** The default path to the player **/
-  protected static final String DEFAULT_PLAYER_PATH = "/engage/ui/watch.html";
+  /** Path the REST endpoint which will re-direct users to the currently configured video player **/
+  static final String PLAYER_PATH = "/watch/";
 
   /** The streaming distribution service */
   private DistributionService streamingDistributionService = null;
@@ -456,18 +456,8 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param mp
    * @return the assembled player URI for this mediapackage
    */
-  protected URI createEngageUri(URI engageUri, MediaPackage mp) {
-    String playerPath = null;
-    String configedPlayerPath = null;
-    // Use the current user's organizational information for the player path
-    Organization currentOrg = securityService.getOrganization();
-    if (currentOrg != null) {
-      configedPlayerPath = StringUtils
-              .trimToNull(currentOrg.getProperties().get(ConfigurablePublishWorkflowOperationHandler.PLAYER_PROPERTY));
-    }
-    // If not configuration, use a default path
-    playerPath = configedPlayerPath != null ? configedPlayerPath : DEFAULT_PLAYER_PATH;
-    return URIUtils.resolve(engageUri, playerPath + "?id=" + mp.getIdentifier().compact());
+  URI createEngageUri(URI engageUri, MediaPackage mp) {
+    return URIUtils.resolve(engageUri, PLAYER_PATH + mp.getIdentifier().compact());
   }
 
   /**

--- a/modules/distribution-workflowoperation/src/test/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandlerTest.java
+++ b/modules/distribution-workflowoperation/src/test/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandlerTest.java
@@ -41,7 +41,6 @@ import java.util.Map;
 
 public class PublishEngageWorkflowOperationHandlerTest {
   private Organization org;
-  private String examplePlayer = "/engage/theodul/ui/watch.html";
 
   @Test
   public void testPlayerUrl() throws WorkflowOperationException, URISyntaxException {
@@ -60,7 +59,7 @@ public class PublishEngageWorkflowOperationHandlerTest {
     PublishEngageWorkflowOperationHandler publishEngagePublish = new PublishEngageWorkflowOperationHandler();
     publishEngagePublish.setSecurityService(securityService);
     URI result = publishEngagePublish.createEngageUri(engageURI, mp);
-    assertEquals(engageURI.toString() + examplePlayer + "?id=" + mpId, result.toString());
+    assertEquals(engageURI.toString() + "/watch/" + mpId, result.toString());
   }
 
   @Test
@@ -80,17 +79,14 @@ public class PublishEngageWorkflowOperationHandlerTest {
     PublishEngageWorkflowOperationHandler publishEngagePublish = new PublishEngageWorkflowOperationHandler();
     publishEngagePublish.setSecurityService(securityService);
     URI result = publishEngagePublish.createEngageUri(engageURI, mp);
-    assertEquals(engageURI.toString() + PublishEngageWorkflowOperationHandler.DEFAULT_PLAYER_PATH + "?id=" + mpId,
+    assertEquals(engageURI.toString() + PublishEngageWorkflowOperationHandler.PLAYER_PATH + mpId,
             result.toString());
 
   }
 
   // Util to set org properties with player path
-  public Organization getOrgWithPlayerPath() {
-    Map<String, String> properties = new HashMap<String, String>();
-    properties.put(ConfigurablePublishWorkflowOperationHandler.PLAYER_PROPERTY, examplePlayer);
+  private Organization getOrgWithPlayerPath() {
     org = EasyMock.createNiceMock(Organization.class);
-    EasyMock.expect(org.getProperties()).andStubReturn(properties);
     EasyMock.replay(org);
     return org;
   }

--- a/modules/distribution-workflowoperation/src/test/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandlerTest.java
+++ b/modules/distribution-workflowoperation/src/test/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandlerTest.java
@@ -59,7 +59,7 @@ public class PublishEngageWorkflowOperationHandlerTest {
     PublishEngageWorkflowOperationHandler publishEngagePublish = new PublishEngageWorkflowOperationHandler();
     publishEngagePublish.setSecurityService(securityService);
     URI result = publishEngagePublish.createEngageUri(engageURI, mp);
-    assertEquals(engageURI.toString() + "/watch/" + mpId, result.toString());
+    assertEquals(engageURI.toString() + "/play/" + mpId, result.toString());
   }
 
   @Test

--- a/modules/engage-ui/pom.xml
+++ b/modules/engage-ui/pom.xml
@@ -16,32 +16,25 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -54,6 +47,15 @@
             <Http-Alias>/engage/ui</Http-Alias>
             <Http-Classpath>/ui</Http-Classpath>
             <Http-Welcome>index.html</Http-Welcome>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>org.opencastproject.engage.ui</Export-Package>
+            <Service-Component>
+              OSGI-INF/player-redirect.xml
+            </Service-Component>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
+++ b/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.engage.ui;
+
+import static javax.servlet.http.HttpServletResponse.SC_TEMPORARY_REDIRECT;
+import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
+
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.util.doc.rest.RestParameter;
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
+import org.opencastproject.util.doc.rest.RestService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+/**
+ * This REST endpoint redirects users to the currently configured default player, allowing the default to be changed
+ * without re-publishing all events.
+ */
+@Path("/")
+@RestService(
+  name = "PlayerRedirect",
+  title = "Configurable Player Endpoint",
+  abstractText = "This service redirects to configured players.",
+  notes = {})
+public class PlayerRedirect {
+
+  private static final Logger logger = LoggerFactory.getLogger(PlayerRedirect.class);
+
+  private static final String PLAYER_DEFAULT = "/engage/theodul/ui/core.html?id={{id}}";
+
+  private SecurityService securityService;
+
+  protected void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
+  }
+
+  @GET
+  @Path("/{id:.+}")
+  @RestQuery(name = "redirect", description = "Player redirect",
+          pathParameters = {
+            @RestParameter(name = "id", description = "The event identifier", isRequired = true, type = STRING)
+          }, reponses = {
+            @RestResponse(description = "Returns the paella configuration", responseCode = SC_TEMPORARY_REDIRECT)
+          }, returnDescription = "")
+  public Response redirect(@PathParam("id") String id) {
+    final Organization org = securityService.getOrganization();
+    final String playerPath = Objects.toString(org.getProperties().get("player"), PLAYER_DEFAULT)
+            .replace("{{id}}", id);
+    logger.debug("redirecting to player: {}", playerPath);
+    return Response
+            .status(Response.Status.TEMPORARY_REDIRECT)
+            .header("location", playerPath)
+            .build();
+  }
+}

--- a/modules/engage-ui/src/main/resources/OSGI-INF/player-redirect.xml
+++ b/modules/engage-ui/src/main/resources/OSGI-INF/player-redirect.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.engage.ui.PlayerRedirect" immediate="true">
+  <implementation class="org.opencastproject.engage.ui.PlayerRedirect"/>
+  <property name="service.description" value="Configurable Player Endpoint"/>
+
+  <property name="opencast.service.type" value="org.opencastproject.engage.ui.player.redirect"/>
+  <property name="opencast.service.path" value="/watch"/>
+
+  <service>
+    <provide interface="org.opencastproject.engage.ui.PlayerRedirect"/>
+  </service>
+  <reference name="security-service" interface="org.opencastproject.security.api.SecurityService"
+             bind="setSecurityService"/>
+</scr:component>

--- a/modules/engage-ui/src/main/resources/OSGI-INF/player-redirect.xml
+++ b/modules/engage-ui/src/main/resources/OSGI-INF/player-redirect.xml
@@ -5,7 +5,7 @@
   <property name="service.description" value="Configurable Player Endpoint"/>
 
   <property name="opencast.service.type" value="org.opencastproject.engage.ui.player.redirect"/>
-  <property name="opencast.service.path" value="/watch"/>
+  <property name="opencast.service.path" value="/play"/>
 
   <service>
     <provide interface="org.opencastproject.engage.ui.PlayerRedirect"/>

--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -12,9 +12,8 @@ function($, bootbox, _, alertify) {
 
         // URL's and Endpoints
         var restEndpoint = "/search/";
-        var playerEndpoint = "";
+        var playerEndpoint = "/watch/";
         var infoMeURL = "/info/me.json";
-        var defaultPlayerURL = "/engage/ui/watch.html";
         var springSecurityLoginURL = "/j_spring_security_check";
         var springSecurityLogoutURL = "/j_spring_security_logout";
 
@@ -52,7 +51,6 @@ function($, bootbox, _, alertify) {
         var msg_live_in_progress = "Live (in progress)";
         var msg_live_not_in_progress = "Live (not in progress)";
         var infoMeURL = "/info/me.json";
-        var defaultPlayerURL = "/engage/ui/watch.html";
         var springSecurityLoginURL = "/j_spring_security_check";
         var springSecurityLogoutURL = "/j_spring_security_logout";
         var springLoggedInStrCheck = "j_spring_security_check";
@@ -485,12 +483,6 @@ function($, bootbox, _, alertify) {
                         if (data.org && data.org.properties) {
                             var logo = data.org.properties.logo_mediamodule ? data.org.properties.logo_mediamodule : "";
                             $($headerLogo).attr("src", logo);
-
-                            var player = data.org.properties.player ? data.org.properties.player : defaultPlayerURL;
-                            if (player.charAt(0) != "/")
-                                player = "/" + player;
-
-                            playerEndpoint = player;
                         } else {
                             log("Error: No info data received.");
                             setAnonymousUser();
@@ -691,11 +683,11 @@ function($, bootbox, _, alertify) {
                     $($main_container).append(tile);
 
                     if (canLaunch) {
-                        $("#" + _.escape(data["id"])).attr("href", playerEndpoint + "?id=" + _.escape(data["id"]));
+                        $("#" + _.escape(data["id"])).attr("href", _.escape(playerEndpoint + data["id"]));
 
                         $("#" + _.escape(data["id"])).on("keypress", function(ev) {
                             if (ev.which == 13 || ev.which == 32) {
-                                $(location).attr("href", playerEndpoint + "?id=" + _.escape(data["id"]));
+                                $(location).attr("href", _.escape(playerEndpoint + data["id"]));
                             }
                         });
                     }

--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -12,7 +12,7 @@ function($, bootbox, _, alertify) {
 
         // URL's and Endpoints
         var restEndpoint = "/search/";
-        var playerEndpoint = "/watch/";
+        var playerEndpoint = "/play/";
         var infoMeURL = "/info/me.json";
         var springSecurityLoginURL = "/j_spring_security_check";
         var springSecurityLogoutURL = "/j_spring_security_logout";

--- a/modules/engage-ui/src/main/resources/ui/js/redirect.js
+++ b/modules/engage-ui/src/main/resources/ui/js/redirect.js
@@ -1,32 +1,38 @@
-var defaultPlayerURL = "/engage/theodul/ui/core.html";
-var infoMeURL = "/info/me.json";
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+const player = '/watch/';
 
 function error() {
-  $('body').show();
+  $('#error').show();
+  $('#redirect').hide();
 }
 
-function redirect(player) {
-  var params = window.location.search.split(/\?/);
+$(document).ready(function() {
+  const urlParams = new URLSearchParams(window.location.search);
 
-  if (params.length > 1) {
-    window.location.replace(player + "?" + params[1]);
-  } else {
+  if (!urlParams.has('id')) {
     error();
   }
-}
 
-$.ajax({
-  url: infoMeURL,
-  dataType: "json",
-  success: function(data) {
-    if (data && data.org && data.org.properties) {
-      var player = data.org.properties.player || defaultPlayerURL;
-      if (!player.startsWith('/')) {
-        player = "/" + player;
-      }
-      var server = data.org.properties['org.opencastproject.engage.ui.url'] || '';
-      redirect(server + player);
-    } 
-  },
-  error: error
-})
+  const target = player + urlParams.get('id');
+  $('#link').attr('href', target).text(target);
+});

--- a/modules/engage-ui/src/main/resources/ui/js/redirect.js
+++ b/modules/engage-ui/src/main/resources/ui/js/redirect.js
@@ -19,7 +19,7 @@
  *
  */
 
-const player = '/watch/';
+const player = '/play/';
 
 function error() {
   $('#error').show();

--- a/modules/engage-ui/src/main/resources/ui/watch.html
+++ b/modules/engage-ui/src/main/resources/ui/watch.html
@@ -7,7 +7,16 @@
         <meta name="author" content="Opencast">
         <title>Forwarding to Opencast Player</title>
     </head>
-    <body style="display: none;">
-        Forwarding to selected player failed.
+    <body>
+        <div id=error style="display: none;">
+            Forwarding to selected player failed.
+        </div>
+        <div id=redirect>
+            This page is deprecated and may be removed at any time in the future.
+            If you landed on this page, please notify the institution responsible for this site
+            or, if possible, update the source link.
+            <p>
+            The media you are looking for can probably be found at: <a id=link> </a>
+        </div>
     </body>
 </html>

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -103,9 +103,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   /** The engage base url property **/
   static final String ENGAGE_URL_PROPERTY = "org.opencastproject.engage.ui.url";
   /** The default path to the player **/
-  static final String DEFAULT_PLAYER_PATH = "/engage/ui/watch.html";
-  /** The configuration property value for the player location. */
-  static final String PLAYER_PROPERTY = "player";
+  static final String PLAYER_PATH = "/watch/";
 
   /** Default values for configuration options */
   private static final String DEFAULT_STREAM_MIME_TYPE = "video/mp4";
@@ -679,10 +677,8 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   void addLivePublicationChannel(Organization currentOrg, MediaPackage mp) throws LiveScheduleException {
     logger.debug("Adding live channel publication element to media package {}", mp);
     String engageUrlString = null;
-    String playerPath = null;
     if (currentOrg != null) {
       engageUrlString = StringUtils.trimToNull(currentOrg.getProperties().get(ENGAGE_URL_PROPERTY));
-      playerPath = StringUtils.trimToNull(currentOrg.getProperties().get(PLAYER_PROPERTY));
     }
     if (engageUrlString == null) {
       engageUrlString = serverUrl;
@@ -690,12 +686,10 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
               "Using 'server.url' as a fallback for the non-existing organization level key '{}' for the publication url",
               ENGAGE_URL_PROPERTY);
     }
-    if (playerPath == null)
-      playerPath = DEFAULT_PLAYER_PATH;
 
     try {
       // Create new distribution element
-      URI engageUri = URIUtils.resolve(new URI(engageUrlString), playerPath + "?id=" + mp.getIdentifier().compact());
+      URI engageUri = URIUtils.resolve(new URI(engageUrlString), PLAYER_PATH + mp.getIdentifier().compact());
       Publication publicationElement = PublicationImpl.publication(UUID.randomUUID().toString(), CHANNEL_ID, engageUri,
               MimeTypes.parseMimeType("text/html"));
       mp.add(publicationElement);

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -103,7 +103,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   /** The engage base url property **/
   static final String ENGAGE_URL_PROPERTY = "org.opencastproject.engage.ui.url";
   /** The default path to the player **/
-  static final String PLAYER_PATH = "/watch/";
+  static final String PLAYER_PATH = "/play/";
 
   /** Default values for configuration options */
   private static final String DEFAULT_STREAM_MIME_TYPE = "video/mp4";

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -107,7 +107,6 @@ public class LiveScheduleServiceImplTest {
   private static final long DURATION = 60000L;
   private static final String ORG_ID = "org";
   private static final String ENGAGE_URL = "htttp://engage.server";
-  private static final String PATH_TO_PLAYER = "/path-to-playengageer/view.html";
 
   /** The service to test */
   private LiveScheduleServiceImpl service;
@@ -151,8 +150,7 @@ public class LiveScheduleServiceImplTest {
     organizationService = EasyMock.createNiceMock(OrganizationDirectoryService.class);
 
     Organization defOrg = new DefaultOrganization();
-    Map<String, String> orgProps = new HashMap<String, String>();
-    orgProps.put(LiveScheduleServiceImpl.PLAYER_PROPERTY, PATH_TO_PLAYER);
+    Map<String, String> orgProps = new HashMap<>();
     orgProps.put(LiveScheduleServiceImpl.ENGAGE_URL_PROPERTY, ENGAGE_URL);
     org = new JaxbOrganization(ORG_ID, "Test Organization", defOrg.getServers(), defOrg.getAdminRole(),
             defOrg.getAnonymousRole(), orgProps);
@@ -596,7 +594,7 @@ public class LiveScheduleServiceImplTest {
     Assert.assertEquals(1, publications.length);
     Assert.assertEquals(LiveScheduleService.CHANNEL_ID, publications[0].getChannel());
     Assert.assertEquals("text/html", publications[0].getMimeType().toString());
-    Assert.assertEquals(ENGAGE_URL + PATH_TO_PLAYER + "?id=" + MP_ID, publications[0].getURI().toString());
+    Assert.assertEquals(ENGAGE_URL + "/watch/" + MP_ID, publications[0].getURI().toString());
   }
 
   @Test

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -594,7 +594,7 @@ public class LiveScheduleServiceImplTest {
     Assert.assertEquals(1, publications.length);
     Assert.assertEquals(LiveScheduleService.CHANNEL_ID, publications[0].getChannel());
     Assert.assertEquals("text/html", publications[0].getMimeType().toString());
-    Assert.assertEquals(ENGAGE_URL + "/watch/" + MP_ID, publications[0].getURI().toString());
+    Assert.assertEquals(ENGAGE_URL + "/play/" + MP_ID, publications[0].getURI().toString());
   }
 
   @Test

--- a/modules/lti/src/main/resources/tools/series/series.js
+++ b/modules/lti/src/main/resources/tools/series/series.js
@@ -23,7 +23,7 @@
 
 'use strict';
 
-var player,
+var player = '/watch/',
     currentpage,
     defaultLang = i18ndata['en-US'],
     lang = defaultLang;
@@ -67,18 +67,6 @@ function getSeries() {
   return '';
 }
 
-function loadDefaultPlayer() {
-  var infoUrl = '/info/me.json';
-
-  // load spinner
-  $('main').html($('#template-loading').html());
-
-  // get organization configuration
-  return $.getJSON(infoUrl, function( data ) {
-    player = data.org.properties.player;
-  });
-}
-
 function loadPage(page) {
 
   var limit = 15,
@@ -111,7 +99,7 @@ function loadPage(page) {
           i18ncreator = Mustache.render(i18n('CREATOR'), {creator: episode.dcCreator}),
           template = $('#template-episode').html(),
           tpldata = {
-            player: player + '?id=' + episode.id,
+            player: player + episode.id,
             title: episode.dcTitle,
             i18ncreator: i18ncreator,
             created: tryLocalDate(episode.dcCreated)};
@@ -162,6 +150,5 @@ function loadPage(page) {
 
 $(document).ready(function() {
   lang = matchLanguage(navigator.language);
-  loadDefaultPlayer()
-    .then(loadPage(1));
+  loadPage(1);
 });

--- a/modules/lti/src/main/resources/tools/series/series.js
+++ b/modules/lti/src/main/resources/tools/series/series.js
@@ -23,8 +23,9 @@
 
 'use strict';
 
-var player = '/watch/',
-    currentpage,
+const player = '/play/';
+
+var currentpage,
     defaultLang = i18ndata['en-US'],
     lang = defaultLang;
 


### PR DESCRIPTION
This patch adds a `/watch/<id>` endpoint as a universal place for
Opencast players, regardless of which specific player is configured to
be used right now. The endpoint will redirect users to the correct place
using an HTTP redirect.

Furthermore, this patch integrates the new endpoint into all relevant
Opencast components like the publication channels and the engage tools.

Note that this behavior is similar to the JavaScript redirect included
in `/engage/ui/watch.html` in commit aac56d7 which was later partially
broken by commit 23dbfa9 causing the direct player links to be written
into the media packages publication elements directly.

But unlike the old mechanism, the new endpoint does not require the web
browser to render the page before issuing the redirect or even load any
additional resources.

To sum up what this patch does:

- Add a new player redirection endpoint

- Use this endpoint wherever a player link is required to unify the
  behavior

- Update the player settings in the organization configuration file

- Deprecate the old `/engage/ui/watch.html`

- Provide instructions to migrate all old links if desired