### PR TITLE
MH-12139  Admin UI new event media upload progress bar

### DIFF
--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -162,6 +162,7 @@
     <script src="scripts/shared/services/regexService.js"></script>
     <script src="scripts/shared/services/schedulingHelperService.js"></script>
     <script src="scripts/shared/services/eventHelperService.js"></script>
+    <script src="scripts/shared/services/progressBarService.js"></script>
     <script src="scripts/shared/services/hotkeysService.js"></script>
     <script src="scripts/shared/services/restServiceMonitor.js"></script>
     <script src="scripts/shared/resources/resources.js"></script>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/newEventResource.js
@@ -21,7 +21,8 @@
 'use strict';
 
 angular.module('adminNg.resources')
-.factory('NewEventResource', ['$resource', 'JsHelper', function ($resource, JsHelper) {
+.factory('NewEventResource', ['$resource', 'JsHelper', 'ProgressBar', function ($resource, JsHelper, ProgressBar) {
+
   return $resource('/admin-ng/event/new', {}, {
     save: {
       method: 'POST',
@@ -33,9 +34,21 @@ angular.module('adminNg.resources')
       // of the request.
       headers: { 'Content-Type': undefined },
 
+      //Track file upload progress
+      uploadEventHandlers: {
+        progress: function(event) {
+          if (event.loaded && event.loaded < event.total) {
+            ProgressBar.onUploadFileProgress(event);
+          }
+        }
+      },
+
       responseType: 'text',
 
-      transformResponse: [],
+      transformResponse: function () {
+        // Update ProgressBar service
+        ProgressBar.reset();
+      },
 
       transformRequest: function (data) {
 
@@ -175,3 +188,4 @@ angular.module('adminNg.resources')
     }
   });
 }]);
+

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/progressBarService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/progressBarService.js
@@ -1,0 +1,105 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+'use strict';
+
+/**
+ * @ngdoc service
+ * @name adminNg.modal ProgressBar
+ * @description
+ * Provides a service to show an "upload" progress status for users to see the progress
+ *  of big file uploads from the browser.
+ */
+
+angular.module('adminNg.services')
+.factory('ProgressBar', function () {
+
+  // One upload notification message at a time, variables help track the life of the current session upload
+  var progressTextId = 'new-event-upload-progress-text',
+      progressNotificationParentQuery = '[data-message=\'NOTIFICATIONS.EVENTS_UPLOAD_STARTED\']',
+      progressNotificationTemplate = '<p id="' + progressTextId + '"></p>',
+      // The following must be reset on upload complete
+      progressNotificationElement,
+      progressLastRatio = 0,  // Track progress of first upload update and ignore others until current is uploaded
+      progressCurrentTotal = 0; // Track current upload and ignore others until current is uploaded
+
+  /**
+   * Calculate the current upload event progress
+   * @param event
+   */
+  this.onUploadFileProgress = function (event) {
+
+    // init new upload tracking total
+    if (progressCurrentTotal == 0) {
+      progressCurrentTotal = event.total;
+    } else if (event.total != progressCurrentTotal) {
+      // do not track additional uploads until the current one finishes
+      return;
+    }
+
+    // Get current progress ratio from the event
+    var ratioLoaded = event.loaded / event.total;
+    var ratioLoadedPercentText =  (ratioLoaded * 100).toFixed(2) + '%';
+
+    if (progressLastRatio < ratioLoaded) {
+      progressLastRatio = ratioLoaded;
+    } else {
+      // do not track newer uploads, of the same file size, until the current one finishes
+      return;
+    }
+
+    if (! progressNotificationElement) {
+      // Locate the upload notification element
+      // Ignore this update when the upload notification element is not found
+      var parentEl = angular.element.find(progressNotificationParentQuery);
+      if (parentEl.length > 0) {
+        // create a progress text element and update it
+        parentEl[0].append(angular.element(progressNotificationTemplate)[0]);
+        progressNotificationElement = document.getElementById(progressTextId);
+        progressNotificationElement.innerText = ratioLoadedPercentText;
+      }
+    } else {
+      // upate the existing progress text element
+      progressNotificationElement.innerText = ratioLoadedPercentText;
+    }
+  };
+
+  /**
+   * Reset upload vars
+   */
+  this.reset = function () {
+    progressLastRatio = progressCurrentTotal = 0;
+    progressNotificationElement = undefined;
+  };
+
+  /**
+   *  Helper for unit tests
+   */
+  this.getProgress = function () {
+    return progressLastRatio;
+  };
+
+  return {
+    reset: this.reset,
+    onUploadFileProgress: this.onUploadFileProgress,
+    getProgress: this.getProgress
+  };
+});

--- a/modules/admin-ui/src/main/webapp/styles/main.scss
+++ b/modules/admin-ui/src/main/webapp/styles/main.scss
@@ -454,6 +454,16 @@ input.disabled, select.disabled {
   }
 }
 
+
+/*
+ * ---------------------------------------------
+ * MH-12139 notification upload ratio override
+ * ---------------------------------------------
+ */
+.alert p {
+  display: inline-flex;
+}
+
 // pagination of tables
 .main-view {
   #tbl-view-controls-container {
@@ -558,3 +568,4 @@ tr.info {
 .playback-controls-wrapper {
   width: 280px;
 }
+

--- a/modules/admin-ui/src/test/resources/test/unit/shared/services/progressBarServiceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/services/progressBarServiceSpec.js
@@ -1,0 +1,65 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+'use strict';
+
+describe('adminNg.services.ProgressBar', function () {
+  var $httpBackend, ProgressBar;
+
+  beforeEach(module('ngResource'));
+  beforeEach(module('adminNg.services'));
+  beforeEach(module('adminNg.resources'));
+  beforeEach(module('pascalprecht.translate'));
+
+  beforeEach(inject(function (_$httpBackend_, _ProgressBar_) {
+    $httpBackend = _$httpBackend_;
+    ProgressBar = _ProgressBar_;
+  }));
+
+  it('has the two public methods', function () {
+    expect(ProgressBar.onUploadFileProgress).toBeDefined();
+    expect(ProgressBar.reset).toBeDefined();
+  });
+
+  describe('#onUploadFileProgress', function () {
+    it('updates the progress status ratio', function () {
+      expect(ProgressBar.getProgress()).toBe(0);
+      ProgressBar.onUploadFileProgress({
+        'loaded': 2, "total": 4
+      });
+      // precision 1, for example: 0.5226440368941985 to be close to 0.5
+      expect(ProgressBar.getProgress()).toBeCloseTo(0.5, 1);
+    });
+  });
+
+  describe('#reset', function () {
+    it('resets progress variables', function () {
+      expect(ProgressBar.getProgress()).toBe(0);
+      ProgressBar.onUploadFileProgress({
+        'loaded': 2, "total": 4
+      });
+      expect(ProgressBar.getProgress()).toBeGreaterThan(0);
+      expect(ProgressBar.getProgress()).toBeLessThan(1);
+      ProgressBar.reset();
+      expect(ProgressBar.getProgress()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
This pull causes a new event media upload to show a prominent yellow progress bar containing the percentage of upload across the top of the Admin UI, below the main banner.

The motivation is to let the user know what is going on the background when a large file upload is started and an indication of when it will be complete. Showing this information helps to stop the user from accidentally closing the browser, or starting another upload, or anything that will jeopardize the current large file upload.

This pull adds a new resource, chieffancypants angular-loading-bar tool. There is already a chieffancypants hot key tool with the same license. The angular-loading-bar is included in the same way the first tool was included (a checked in bower_component).

This pull also changes the behavior of the event success/fail notification, in that it does not automatically remove the notification after a few seconds, and it gives the notification a global context so the user can see it if the user has moved onto other tabs while the event was still being processed.