### PR TITLE
MH-13444, Insecure Series Creation

### DIFF
--- a/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
+++ b/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
@@ -8,7 +8,7 @@
 
 # TODO: consider moving this key to the system.properties if used by other services, such as mediapackage update
 
-org.opencastproject.series.overwrite=true
+org.opencastproject.series.overwrite=false
 
 #The approximate load placed on the system by ingesting a file
 #Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -56,8 +56,6 @@ import org.opencastproject.metadata.dublincore.DublinCoreValue;
 import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
 import org.opencastproject.scheduler.api.SchedulerException;
 import org.opencastproject.scheduler.api.SchedulerService;
-import org.opencastproject.security.api.AccessControlEntry;
-import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.SecurityService;
@@ -249,7 +247,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
           .build();
 
   /** The default is to overwrite series catalog on ingest */
-  protected boolean defaultIsOverWriteSeries = true;
+  protected boolean defaultIsOverWriteSeries = false;
 
   /** Option to overwrite series on ingest */
   protected boolean isOverwriteSeries = defaultIsOverWriteSeries;
@@ -880,9 +878,6 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
             logger.info("Creating new series {} with default ACL", id);
             seriesService.updateSeries(dc);
             isUpdated = true;
-            String anonymousRole = securityService.getOrganization().getAnonymousRole();
-            AccessControlList acl = new AccessControlList(new AccessControlEntry(anonymousRole, "read", true));
-            seriesService.updateAccessControl(id, acl);
           }
 
         } catch (Exception e) {

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -191,6 +191,9 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
   /** The key to look for in the service configuration file to override the {@link DEFAULT_INGEST_ZIP_JOB_LOAD} */
   public static final String ZIP_JOB_LOAD_KEY = "job.load.ingest.zip";
 
+  /** The default is to leave series catalogs untouched on ingest */
+  static final boolean DEFAULT_IS_OVERWRITE_SERIES = false;
+
   /** The approximate load placed on the system by ingesting a file */
   private float ingestFileJobLoad = DEFAULT_INGEST_FILE_JOB_LOAD;
 
@@ -246,11 +249,8 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
   private Cache<String, Long> partialTrackStartTimes = CacheBuilder.newBuilder().expireAfterWrite(1, TimeUnit.DAYS)
           .build();
 
-  /** The default is to overwrite series catalog on ingest */
-  protected boolean defaultIsOverWriteSeries = false;
-
   /** Option to overwrite series on ingest */
-  protected boolean isOverwriteSeries = defaultIsOverWriteSeries;
+  protected boolean isOverwriteSeries = DEFAULT_IS_OVERWRITE_SERIES;
 
   /**
    * Creates a new ingest service instance.
@@ -304,7 +304,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     try {
       isOverwriteSeries = Boolean.parseBoolean(((String) properties.get(PROPKEY_OVERWRITE_SERIES)).trim());
     } catch (Exception e) {
-      isOverwriteSeries = defaultIsOverWriteSeries;
+      isOverwriteSeries = DEFAULT_IS_OVERWRITE_SERIES;
       logger.warn("Unable to update configuration. {}", e.getMessage());
     }
     logger.info("Configuration updated. It is {} that existing series will be overwritten during ingest.",

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
@@ -561,7 +561,7 @@ public class IngestServiceImplTest {
   private void testSeriesUpdateNewAndExisting(Dictionary<String, String> properties) throws Exception {
 
     // default expectation for series overwrite is True
-    boolean isExpectSeriesOverwrite = true;
+    boolean isExpectSeriesOverwrite = false;
 
     if (properties != null) {
       service.updated(properties);
@@ -596,7 +596,7 @@ public class IngestServiceImplTest {
     service.setSeriesService(seriesService);
 
     // This is true or false depending on the isOverwrite value
-    Assert.assertEquals("Desire to update series is " + String.valueOf(isExpectSeriesOverwrite) + ".",
+    Assert.assertEquals("Desire to update series is " + isExpectSeriesOverwrite + ".",
             isExpectSeriesOverwrite, service.updateSeries(urlCatalog2));
 
     // Test with mock not found exception

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
@@ -560,8 +560,8 @@ public class IngestServiceImplTest {
    */
   private void testSeriesUpdateNewAndExisting(Dictionary<String, String> properties) throws Exception {
 
-    // default expectation for series overwrite is True
-    boolean isExpectSeriesOverwrite = false;
+    // default expectation for series overwrite
+    boolean isExpectSeriesOverwrite = IngestServiceImpl.DEFAULT_IS_OVERWRITE_SERIES;
 
     if (properties != null) {
       service.updated(properties);

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
@@ -561,13 +561,13 @@ public class IngestServiceImplTest {
   private void testSeriesUpdateNewAndExisting(Dictionary<String, String> properties) throws Exception {
 
     // default expectation for series overwrite
-    boolean isExpectSeriesOverwrite = IngestServiceImpl.DEFAULT_IS_OVERWRITE_SERIES;
+    boolean allowSeriesModifications = IngestServiceImpl.DEFAULT_ALLOW_SERIES_MODIFICATIONS;
 
     if (properties != null) {
       service.updated(properties);
       try {
         boolean testForValue = Boolean.parseBoolean(properties.get(IngestServiceImpl.PROPKEY_OVERWRITE_SERIES).trim());
-        isExpectSeriesOverwrite = testForValue;
+        allowSeriesModifications = testForValue;
       } catch (Exception e) {
         // If key or value not found or not boolean, use the default overwrite expectation
       }
@@ -596,8 +596,8 @@ public class IngestServiceImplTest {
     service.setSeriesService(seriesService);
 
     // This is true or false depending on the isOverwrite value
-    Assert.assertEquals("Desire to update series is " + isExpectSeriesOverwrite + ".",
-            isExpectSeriesOverwrite, service.updateSeries(urlCatalog2));
+    Assert.assertEquals("Desire to update series is " + allowSeriesModifications + ".",
+            allowSeriesModifications, service.updateSeries(urlCatalog2));
 
     // Test with mock not found exception
     EasyMock.reset(seriesService);


### PR DESCRIPTION
This patch prevents users from being able to overwrite series metadata
by default when ingesting event data. Users can still enable this, if
they need this functionality.

In addition to this, Opencast will not any longer add anonymous access
to series if they are created as part of the event ingest.

*Note that the behavior of both features is questionable and we may want
to remove this entirely in the future.*