### PR TITLE
MH-13445, Update Checkstyle

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/JsonpFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/JsonpFilter.java
@@ -367,7 +367,7 @@ public class JsonpFilter implements Filter {
      *
      * @return the buffer as a byte array
      */
-    public synchronized byte toByteArray()[] {
+    public synchronized byte[] toByteArray() {
       return Arrays.copyOf(buf, count);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.14</version>
+            <version>8.18</version>
           </dependency>
         </dependencies>
         <configuration>


### PR DESCRIPTION
This fixes CVE-2019-9658:

Checkstyle prior to 8.18 loads external DTDs by default, which can
potentially lead to denial of service attacks or the leaking of
confidential information.