### PR TITLE
MH-13454, Drop Unused Configuration Option Maps

### DIFF
--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerDeleteWorkflowOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerDeleteWorkflowOperationHandler.java
@@ -38,9 +38,6 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.SortedMap;
-import java.util.TreeMap;
-
 /**
  * Workflow operation for deleting an episode from the asset manager.
  *
@@ -54,18 +51,6 @@ public class AssetManagerDeleteWorkflowOperationHandler extends AbstractWorkflow
 
   /** Configuration if last snapshot should not be deleted */
   private static final String OPT_LAST_SNAPSHOT = "keep-last-snapshot";
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-  }
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /** OSGi DI */
   public void setAssetManager(AssetManager assetManager) {

--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerSnapshotWorkflowOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerSnapshotWorkflowOperationHandler.java
@@ -21,8 +21,6 @@
 package org.opencastproject.workflow.handler.assetmanager;
 
 import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
-import static org.opencastproject.util.data.Collections.smap;
-import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.job.api.JobContext;
@@ -48,7 +46,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
 
 /**
  * Workflow operation for taking a snapshot of a media package.
@@ -60,16 +57,6 @@ public class AssetManagerSnapshotWorkflowOperationHandler extends AbstractWorkfl
 
   /** The asset manager. */
   private AssetManager assetManager;
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS = smap(
-          tuple("source-tags", "Add any media package elements with one of these (comma separated) tags"),
-          tuple("source-flavors", "Add any media package elements with one of these (comma separated) flavors"));
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /** OSGi DI */
   public void setAssetManager(AssetManager assetManager) {

--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerStorageMoveOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerStorageMoveOperationHandler.java
@@ -21,9 +21,6 @@
 
 package org.opencastproject.workflow.handler.assetmanager;
 
-import static org.opencastproject.util.data.Collections.smap;
-import static org.opencastproject.util.data.Tuple.tuple;
-
 import org.opencastproject.assetmanager.api.Version;
 import org.opencastproject.assetmanager.impl.TieredStorageAssetManagerJobProducer;
 import org.opencastproject.assetmanager.impl.VersionImpl;
@@ -40,24 +37,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.SortedMap;
-
 public class AssetManagerStorageMoveOperationHandler extends AbstractWorkflowOperationHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(AssetManagerStorageMoveOperationHandler.class);
 
   /** The asset manager. */
   private TieredStorageAssetManagerJobProducer tsamjp;
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS = smap(
-          tuple("target-storage", "The target storage type"),
-          tuple("target-version", "The specific version to move"));
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /** OSGi DI */
   public void setJobProducer(TieredStorageAssetManagerJobProducer tsamjp) {

--- a/modules/comments-workflowoperation/src/main/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandler.java
+++ b/modules/comments-workflowoperation/src/main/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandler.java
@@ -43,8 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * A workflow operation handler for creating, resolving and deleting comments automatically during the workflow process.
@@ -61,26 +59,9 @@ public class CommentWorkflowOperationHandler extends AbstractWorkflowOperationHa
   private EventCommentService eventCommentService;
   private SecurityService securityService;
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
   public enum Operation {
     create, resolve, delete
   };
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(REASON,
-            "The optional comment reason's i18n id. You can find the id in etc/listproviders/event.comment.reasons.properties");
-    CONFIG_OPTIONS.put(DESCRIPTION, "The description text to add to the comment.");
-    CONFIG_OPTIONS.put(ACTION, "Options are " + StringUtils.join(Operation.values(), ",")
-            + ". Creates a new comment, marks a comment as resolved or deletes a comment that matches the same description and reason. By default creates.");
-  }
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * {@inheritDoc}

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ComposeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ComposeWorkflowOperationHandler.java
@@ -53,8 +53,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The workflow definition for handling "compose" operations
@@ -63,23 +61,6 @@ public class ComposeWorkflowOperationHandler extends AbstractWorkflowOperationHa
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ComposeWorkflowOperationHandler.class);
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-flavors", "The \"flavor\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("source-tags", "The \"tag\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("encoding-profiles", "The encoding profile(s) to use");
-    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the encoded file");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the encoded file");
-    CONFIG_OPTIONS.put("audio-only", "Set to 'true' to process tracks containing only audio streams");
-    CONFIG_OPTIONS.put("video-only", "Set to 'true' to process tracks containing only video streams");
-    // Only process the first file that matches tags/flavors
-    CONFIG_OPTIONS.put("process-first-match-only",
-            "Set to 'true' indicates only one track will be processed if more are selected");
-  }
 
   /** The composer service */
   private ComposerService composerService = null;
@@ -106,16 +87,6 @@ public class ComposeWorkflowOperationHandler extends AbstractWorkflowOperationHa
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
@@ -75,8 +75,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -114,41 +112,9 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(CompositeWorkflowOperationHandler.class);
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
   /** The legal options for SOURCE_AUDIO_NAME */
   private static final Pattern sourceAudioOption = Pattern.compile(
           ComposerService.LOWER + "|" + ComposerService.UPPER + "|" + ComposerService.BOTH, Pattern.CASE_INSENSITIVE);
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_AUDIO_NAME, "Only \"upper\", \"lower\" or \"both\" track to be used as source audio");
-    CONFIG_OPTIONS.put(SOURCE_TAGS_UPPER, "The \"tag\" of the upper track to use as a source input");
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_UPPER, "The \"flavor\" of the upper track to use as a source input");
-    CONFIG_OPTIONS.put(SOURCE_TAGS_LOWER, "The \"tag\" of the lower track to use as a source input");
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_LOWER, "The \"flavor\" of the lower track to use as a source input");
-    CONFIG_OPTIONS.put(SOURCE_TAGS_WATERMARK, "The \"tag\" of the attachement image to use as a source input");
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_WATERMARK, "The \"flavor\" of the attachement image to use as a source input");
-    CONFIG_OPTIONS.put(SOURCE_URL_WATERMARK, "The \"URL\" of the fallback image to use as a source input");
-
-    CONFIG_OPTIONS.put(ENCODING_PROFILE, "The encoding profile to use");
-
-    CONFIG_OPTIONS.put(TARGET_TAGS, "The tags to apply to the compound video track");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR, "The flavor to apply to the compound video track");
-
-    CONFIG_OPTIONS
-            .put(LAYOUT_MULTIPLE,
-                    "The layout name to use or a semi-colon separated JSON layout definition (lower, upper, optional watermark) if there are multiple videos");
-    CONFIG_OPTIONS
-            .put(LAYOUT_SINGLE,
-                    "The layout name to use or a semi-colon separated JSON layout definition (video, optional watermark) if there is a single video source");
-    CONFIG_OPTIONS.put(LAYOUT_PREFIX,
-            "Define semi-colon separated JSON layouts (lower, upper, optional watermark) to provide by name");
-
-    CONFIG_OPTIONS.put(OUTPUT_RESOLUTION, "The resulting resolution of the compound video e.g. 1900x1080");
-    CONFIG_OPTIONS.put(OUTPUT_BACKGROUND, "The resulting background color of the compound video e.g. black");
-  }
 
   /** The composer service */
   private ComposerService composerService = null;
@@ -175,16 +141,6 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
@@ -60,8 +60,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The workflow definition for handling "concat" operations
@@ -95,31 +93,6 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ConcatWorkflowOperationHandler.class);
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_TAGS_PREFIX,
-            "The prefix of the iterative \"tags\" used to specify the order of the source input tracks");
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_PREFIX,
-            "The prefix of the iterative \"flavors\" used to specify the order of the source input tracks");
-
-    CONFIG_OPTIONS.put(TARGET_TAGS, "The tags to apply to the compound video track");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR, "The flavor to apply to the compound video track");
-    CONFIG_OPTIONS
-            .put(OUTPUT_RESOLUTION,
-                    "The resulting resolution of the concat video e.g. 1900x1080 or the part name to take as the output resolution");
-    CONFIG_OPTIONS.put(ENCODING_PROFILE, "The encoding profile to use");
-    CONFIG_OPTIONS.put(OUTPUT_FRAMERATE,
-            "The frame rate of the resulting video in frames per second, e.g. 25, 23.976 "
-            + "or part name to take the value from, e.g. part-1.");
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_NUMBERED_FILES,
-          "The tagged input files are an LEXIGRAPHICALLY ordered set of iterative videos, whose names are a prefix followed immediately by a number to specify the order of the source input tracks. This cannot be used with other source flavors/tags");
-    CONFIG_OPTIONS.put(SAME_CODEC,
-      "true if source files all have the identical codec/framerate/dimension, etc - do not scale and transcode before concatenation");
-  }
-
   /** The composer service */
   private ComposerService composerService = null;
 
@@ -145,16 +118,6 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
@@ -53,8 +53,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The workflow definition for handling "compose" operations
@@ -63,18 +61,6 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(EncodeWorkflowOperationHandler.class);
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-flavors", "The \"flavor\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("source-tags", "The \"tag\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("encoding-profiles", "The encoding profile(s) to use");
-    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the encoded file");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the encoded file");
-  }
 
   /** The composer service */
   private ComposerService composerService = null;
@@ -101,16 +87,6 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandler.java
@@ -22,9 +22,7 @@
 package org.opencastproject.workflow.handler.composer;
 
 import static org.opencastproject.util.data.Collections.nil;
-import static org.opencastproject.util.data.Collections.smap;
 import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.composer.api.ComposerService;
 import org.opencastproject.composer.api.EncoderException;
@@ -58,7 +56,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.SortedMap;
 
 /**
  * The workflow definition creating a video from a still image.
@@ -73,12 +70,6 @@ public class ImageToVideoWorkflowOperationHandler extends AbstractWorkflowOperat
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ImageToVideoWorkflowOperationHandler.class);
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS = smap(
-          tuple(OPT_SOURCE_TAGS, "The image attachment must be tagged with one of the given tags"),
-          tuple(OPT_SOURCE_FLAVOR, "The image attachment must be of the given flavor"),
-          tuple(OPT_DURATION, "The duration of the resulting video in seconds"));
 
   /** The composer service */
   private ComposerService composerService = null;
@@ -105,16 +96,6 @@ public class ImageToVideoWorkflowOperationHandler extends AbstractWorkflowOperat
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   @Override

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -34,7 +34,6 @@ import static com.entwinemedia.fn.parser.Parsers.token;
 import static com.entwinemedia.fn.parser.Parsers.yield;
 import static java.lang.String.format;
 import static org.opencastproject.util.EqualsUtil.eq;
-import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.composer.api.ComposerService;
 import org.opencastproject.composer.api.EncodingProfile;
@@ -85,7 +84,6 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.util.IllegalFormatException;
 import java.util.List;
-import java.util.SortedMap;
 import java.util.UUID;
 
 /**
@@ -108,22 +106,6 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
   public static final String OPT_END_MARGIN = "end-margin";
 
   private static final long END_MARGIN_DEFAULT = 100;
-
-  /** The configuration options for this handler */
-  @SuppressWarnings("unchecked")
-  private static final SortedMap<String, String> CONFIG_OPTIONS = Collections.smap(
-          tuple(OPT_SOURCE_FLAVOR, "The \"flavor\" of the track to use as a video source input"),
-          tuple(OPT_SOURCE_FLAVORS, "The \"flavors\" of the track to use as a video source input"),
-          tuple(OPT_SOURCE_TAGS,
-                "The required tags that must exist on the track for the track to be used as a video source"),
-          tuple(OPT_PROFILES, "The encoding profile to use"),
-          tuple(OPT_POSITIONS, "The number of seconds into the video file to extract the image"),
-          tuple(OPT_TARGET_FLAVOR, "The flavor to apply to the extracted image"),
-          tuple(OPT_TARGET_TAGS, "The tags to apply to the extracted image"),
-          tuple(OPT_TARGET_BASE_NAME_FORMAT_SECOND, "TODO"), // todo description
-          tuple(OPT_TARGET_BASE_NAME_FORMAT_PERCENT, "The target base name pattern for seconds 'thumbnail' or 'extracted'."), //todo description
-          tuple(OPT_END_MARGIN, "A margin in milliseconds at the end of the video. Each position is "
-                  + "limited to not exceed this bound. Defaults to " + END_MARGIN_DEFAULT + "ms."));
 
   /** The composer service */
   private ComposerService composerService = null;
@@ -150,11 +132,6 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   @Override

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -87,8 +87,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 
 /**
@@ -133,29 +131,6 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
   private static final String SILENT_AUDIO_PROFILE = "import.silent";
   private static final String IMAGE_MOVIE_PROFILE = "image-movie.work";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_PRESENTER_FLAVOR, "The source flavor of the partial presenter tracks");
-    CONFIG_OPTIONS.put(SOURCE_PRESENTATION_FLAVOR, "The source flavor of the partial presentation tracks");
-    CONFIG_OPTIONS.put(SOURCE_SMIL_FLAVOR, "The source flavor of the partial smil catalog");
-
-    CONFIG_OPTIONS.put(TARGET_PRESENTER_FLAVOR,
-            "The target flavor to apply to the standard media presenter video track");
-    CONFIG_OPTIONS.put(TARGET_PRESENTATION_FLAVOR,
-            "The target flavor to apply to the standard media presentation video track");
-    CONFIG_OPTIONS.put(CONCAT_ENCODING_PROFILE, "The concat encoding profile to use");
-    CONFIG_OPTIONS.put(CONCAT_OUTPUT_FRAMERATE, "Output framerate for concat operation");
-    CONFIG_OPTIONS.put(FORCE_ENCODING_PROFILE, "The force encoding profile to use");
-    CONFIG_OPTIONS.put(TRIM_ENCODING_PROFILE, "The trim encoding profile to use");
-    CONFIG_OPTIONS.put(FORCE_ENCODING, "Whether to force the tracks to be encoded");
-    CONFIG_OPTIONS.put(REQUIRED_EXTENSIONS,
-            "Automatically re-encode a track if its extension doesn't match one in this comma separated list");
-    CONFIG_OPTIONS.put(ENFORCE_DIVISIBLE_BY_TWO, "Whether to enforce the track's dimension to be divisible by two");
-  }
-
   /** The composer service */
   private ComposerService composerService = null;
 
@@ -181,16 +156,6 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
@@ -46,8 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The <tt>prepare media</tt> operation will make sure that media where audio and video track come in separate files
@@ -77,19 +75,6 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
   /** Name of audio muxing configuration key */
   public static final String OPT_AUDIO_MUXING_SOURCE_FLAVORS = "audio-muxing-source-flavors";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-flavor", "The \"flavor\" of the track to use as a video source input");
-    CONFIG_OPTIONS.put("encoding-profile", "The encoding profile to use (default is 'mux-av.http')");
-    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the encoded file");
-    CONFIG_OPTIONS.put(OPT_REWRITE, "Indicating whether the container for audio and video tracks should be rewritten");
-    CONFIG_OPTIONS.put(OPT_AUDIO_MUXING_SOURCE_FLAVORS, "If the video track has no audio, try to find an audio track in this sequence of flavors");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the encoded file");
-  }
-
   /** The composer service */
   private ComposerService composerService = null;
 
@@ -115,16 +100,6 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandler.java
@@ -69,8 +69,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The workflow definition for handling "compose" operations
@@ -79,22 +77,6 @@ public class ProcessSmilWorkflowOperationHandler extends AbstractWorkflowOperati
   static final String SEPARATOR = ";";
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ProcessSmilWorkflowOperationHandler.class);
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("smil-flavor", "The flavor of the smil file");
-    CONFIG_OPTIONS.put("source-flavors", "The \"flavor\" of the track to use as a source input, use \"" + SEPARATOR
-            + "\" to separate sections when using multiple target flavors");
-    CONFIG_OPTIONS.put("encoding-profiles", "The encoding profile(s) to use, use \"" + SEPARATOR
-            + "\" to separate sections mapped to each source-flavor section in the same order");
-    CONFIG_OPTIONS.put("target-flavors", "The flavors to apply to the encoded file, use \"" + SEPARATOR
-            + "\" to separate sections mapped to each source-flavor section in the same order");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the encoded file");
-    CONFIG_OPTIONS.put("tag-with-profile",
-            "Set to 'true' to tag target tracks with corresponding encoding profile Id, false by default");
-  }
 
   /** The composer service */
   private ComposerService composerService = null;
@@ -212,16 +194,6 @@ public class ProcessSmilWorkflowOperationHandler extends AbstractWorkflowOperati
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
@@ -70,8 +70,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -82,21 +80,6 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(SegmentPreviewsWorkflowOperationHandler.class);
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-    CONFIG_OPTIONS.put("source-flavor", "The \"flavor\" of the track to use as a video source input");
-    CONFIG_OPTIONS.put("source-tags",
-            "The required tags that must exist on the track for the track to be used as a video source");
-    CONFIG_OPTIONS.put("encoding-profile", "The encoding profile to use for generating the image");
-    CONFIG_OPTIONS.put("reference-flavor", "The \"flavor\" of the track to used as the reference");
-    CONFIG_OPTIONS.put("reference-tags", "The \"tags\" of the track to used as the reference");
-    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the extracted images");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the extracted images");
-  }
-
   /** The composer service */
   private ComposerService composerService = null;
 
@@ -105,16 +88,6 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
 
   /** The local workspace */
   private Workspace workspace = null;
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * Callback for the OSGi declarative services configuration.

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -51,8 +51,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -75,9 +73,6 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
   /** The local workspace */
   private Workspace workspace = null;
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
   private enum AudioMuxing {
     NONE, FORCE, DUPLICATE;
 
@@ -96,24 +91,6 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
   private static final String CONFIG_FORCE_TARGET = "force-target";
 
   private static final String FORCE_TARGET_DEFAULT = "presenter";
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-    CONFIG_OPTIONS.put("source-flavor", "The \"flavor\" of the track to use as a video source input");
-    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the encoded file");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the encoded file");
-    CONFIG_OPTIONS.put(CONFIG_FORCE_TARGET,
-            String.format("Target flavor type for the \"%s\" option \"%s\" (default %s)", CONFIG_AUDIO_MUXING,
-                    AudioMuxing.FORCE, FORCE_TARGET_DEFAULT));
-    CONFIG_OPTIONS.put(CONFIG_AUDIO_MUXING,
-            String.format("Either \"%s\", \"%s\" or \"%s\" to specially mux audio streams", AudioMuxing.NONE,
-                    AudioMuxing.DUPLICATE, AudioMuxing.FORCE));
-  }
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * Callback for the OSGi declarative services configuration.

--- a/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerBase.java
+++ b/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerBase.java
@@ -63,8 +63,6 @@ import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 
 /**
@@ -82,23 +80,8 @@ public abstract class CoverImageWorkflowOperationHandlerBase extends AbstractWor
   private static final String TARGET_FLAVOR = "target-flavor";
   private static final String TARGET_TAGS = "target-tags";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(CoverImageWorkflowOperationHandlerBase.class);
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(XSL_FILE_URL, "URL to the XSL stylesheet");
-    CONFIG_OPTIONS.put(XML_METADATA, "XML metadata");
-    CONFIG_OPTIONS.put(WIDTH, "Width of the resulting cover image");
-    CONFIG_OPTIONS.put(HEIGHT, "Height of the resulting cover image");
-    CONFIG_OPTIONS.put(POSTERIMAGE_FLAVOR, "Poster image flavor");
-    CONFIG_OPTIONS.put(POSTERIMAGE_URL, "URL to a poster image");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR, "Target flavor");
-    CONFIG_OPTIONS.put(TARGET_TAGS, "Target tags");
-  }
 
   /** Returns a cover image service */
   protected abstract CoverImageService getCoverImageService();

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -81,8 +81,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -180,33 +178,6 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
           TrackImpl.StreamingProtocol.HDS,
           TrackImpl.StreamingProtocol.SMOOTH));
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(DOWNLOAD_SOURCE_FLAVORS,
-            "Distribute any mediapackage elements with one of these (comma separated) flavors to download");
-    CONFIG_OPTIONS.put(STREAMING_TARGET_SUBFLAVOR,
-            "Target subflavor for elements that have been distributed for downloads");
-    CONFIG_OPTIONS.put(DOWNLOAD_SOURCE_TAGS,
-            "Distribute any mediapackage elements with one of these (comma separated) tags to download.");
-    CONFIG_OPTIONS.put(DOWNLOAD_TARGET_TAGS,
-            "Add all of these comma separated tags to elements that have been distributed for download.");
-    CONFIG_OPTIONS.put(STREAMING_SOURCE_FLAVORS,
-            "Distribute any mediapackage elements with one of these (comma separated) flavors to streaming");
-    CONFIG_OPTIONS.put(STREAMING_TARGET_SUBFLAVOR,
-            "Target subflavor for elements that have been distributed for streaming");
-    CONFIG_OPTIONS.put(STREAMING_SOURCE_TAGS,
-            "Distribute any mediapackage elements with one of these (comma separated) tags to streaming.");
-    CONFIG_OPTIONS.put(STREAMING_TARGET_TAGS,
-            "Add all of these comma separated tags to elements that have been distributed for streaming.");
-    CONFIG_OPTIONS.put(CHECK_AVAILABILITY,
-            "( true | false ) defaults to true. Check if the distributed download artifact is available at its URL");
-    CONFIG_OPTIONS.put(STRATEGY,
-            "Strategy if there is an existing Publication");
-  }
-
   @Override
   protected void activate(ComponentContext cc) {
     super.activate(cc);
@@ -215,16 +186,6 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
     // Get configuration
     serverUrl = UrlSupport.url(bundleContext.getProperty(SERVER_URL_PROPERTY));
     distributeStreaming = StringUtils.isNotBlank(bundleContext.getProperty(STREAMING_URL_PROPERTY));
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishOaiPmhWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishOaiPmhWorkflowOperationHandler.java
@@ -58,8 +58,6 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 
 /**
@@ -96,38 +94,6 @@ public class PublishOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
    */
   public void setPublicationService(OaiPmhPublicationService publicationService) {
     this.publicationService = publicationService;
-  }
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-    CONFIG_OPTIONS.put(DOWNLOAD_FLAVORS,
-            "Distribute any mediapackage elements with one of these (comma separated) flavors to download");
-    CONFIG_OPTIONS.put(DOWNLOAD_TAGS,
-            "Distribute any mediapackage elements with one of these (comma separated) tags to download.");
-    CONFIG_OPTIONS.put(STREAMING_FLAVORS,
-            "Distribute any mediapackage elements with one of these (comma separated) flavors to streaming");
-    CONFIG_OPTIONS.put(STREAMING_TAGS,
-            "Distribute any mediapackage elements with one of these (comma separated) tags to streaming.");
-    CONFIG_OPTIONS.put(CHECK_AVAILABILITY,
-            "( true | false ) defaults to true. Check if the distributed download artifact is available at its URL");
-    CONFIG_OPTIONS.put(REPOSITORY, "The OAI-PMH repository");
-    CONFIG_OPTIONS.put(EXTERNAL_CHANNEL_NAME, "The external element's channel name");
-    CONFIG_OPTIONS.put(EXTERNAL_TEMPLATE,
-            "The external element's URL template (https://www.externalURL.com/watch.html?series={series}&id={event})");
-    CONFIG_OPTIONS.put(EXTERNAL_MIME_TYPE, "The external element's mime type");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /** OSGi component activation. */

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishYouTubeWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishYouTubeWorkflowOperationHandler.java
@@ -45,8 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The workflow definition for handling "publish" operations
@@ -67,25 +65,6 @@ public class PublishYouTubeWorkflowOperationHandler extends AbstractWorkflowOper
    */
   public void setPublicationService(YouTubePublicationService publicationService) {
     this.publicationService = publicationService;
-  }
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-tags", "Publish the mediapackage element with these matching (comma separated) tags.");
-    CONFIG_OPTIONS.put("source-flavors", "Publish the mediapackage element with one of these matching flavors");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RepublishOaiPmhWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RepublishOaiPmhWorkflowOperationHandler.java
@@ -24,8 +24,6 @@ import static com.entwinemedia.fn.fns.Strings.trimToNone;
 import static java.lang.String.format;
 import static org.opencastproject.util.JobUtil.waitForJobs;
 import static org.opencastproject.util.data.Collections.set;
-import static org.opencastproject.util.data.Collections.smap;
-import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobContext;
@@ -46,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedMap;
 
 /** Workflow operation for handling "republish" operations to OAI-PMH repositories. */
 public final class RepublishOaiPmhWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
@@ -59,17 +56,6 @@ public final class RepublishOaiPmhWorkflowOperationHandler extends AbstractWorkf
   private static final String OPT_SOURCE_FLAVORS = "source-flavors";
   private static final String OPT_SOURCE_TAGS = "source-tags";
   private static final String OPT_REPOSITORY = "repository";
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS = smap(
-          tuple(OPT_SOURCE_FLAVORS, "Republish any media package elements with one of these flavors"),
-          tuple(OPT_SOURCE_TAGS, "Republish only media package elements that are tagged with one of these tags"),
-          tuple(OPT_REPOSITORY, "The OAI-PMH repository to update"));
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   @Override
   public WorkflowOperationResult start(WorkflowInstance wi, JobContext context) throws WorkflowOperationException {

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
@@ -49,8 +49,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Workflow operation for retracting a media package from the engage player.
@@ -62,9 +60,6 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
 
   /** Configuration property id */
   private static final String STREAMING_URL_PROPERTY = "org.opencastproject.streaming.url";
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS = new TreeMap<String, String>();
 
   /** The streaming distribution service */
   private DistributionService streamingDistributionService = null;
@@ -107,16 +102,6 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    */
   protected void setSearchService(SearchService searchService) {
     this.searchService = searchService;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractOaiPmhWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractOaiPmhWorkflowOperationHandler.java
@@ -37,9 +37,6 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.SortedMap;
-import java.util.TreeMap;
-
 /**
  * Workflow operation for retracting a media package from OAI-PMH publication repository.
  */
@@ -51,25 +48,8 @@ public class RetractOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
   /** Workflow configuration option keys */
   private static final String REPOSITORY = "repository";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS = new TreeMap<String, String>();
-
-  static {
-    CONFIG_OPTIONS.put(REPOSITORY, "The OAI-PMH repository");
-  }
-
   /** The OAI-PMH publication service */
   private OaiPmhPublicationService publicationService = null;
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * OSGi declarative service configuration callback.

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractYouTubeWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractYouTubeWorkflowOperationHandler.java
@@ -38,9 +38,6 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.SortedMap;
-import java.util.TreeMap;
-
 /**
  * Workflow operation for retracting a media package from youtube publication channel.
  */
@@ -48,21 +45,8 @@ public class RetractYouTubeWorkflowOperationHandler extends AbstractWorkflowOper
 
   private static final Logger logger = LoggerFactory.getLogger(RetractYouTubeWorkflowOperationHandler.class);
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS = new TreeMap<String, String>();
-
   /** The youtube publication service */
   private YouTubePublicationService publicationService = null;
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * OSGi declarative service configuration callback.

--- a/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteManyWorkflowOperationHandler.java
+++ b/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteManyWorkflowOperationHandler.java
@@ -53,8 +53,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Runs an operation multiple times with each MediaPackageElement matching the characteristics
@@ -102,25 +100,6 @@ public class ExecuteManyWorkflowOperationHandler extends AbstractWorkflowOperati
 
   /** The workspace service */
   protected Workspace workspace;
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-    CONFIG_OPTIONS.put(EXEC_PROPERTY, "The full path the executable to run");
-    CONFIG_OPTIONS.put(PARAMS_PROPERTY, "Space separated list of command line parameters to pass to the executable");
-    CONFIG_OPTIONS.put(LOAD_PROPERTY, "A floating point estimate of the load imposed on the node by this job");
-    CONFIG_OPTIONS.put(OUTPUT_FILENAME_PROPERTY, "The name of the elements created by this operation");
-    CONFIG_OPTIONS.put(EXPECTED_TYPE_PROPERTY,
-            "The type of the element returned by this operation. Accepted values are: manifest, timeline, track, catalog, attachment, other");
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_PROPERTY,
-            "The \"flavor\" that the mediapackage elements must have in order to be used as an input argument");
-    CONFIG_OPTIONS.put(SOURCE_TAGS_PROPERTY,
-            "The required tags that must exist on the mediapackage element for the element to be used as an input argument");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR_PROPERTY, "The flavor that the resulting mediapackage elements will be assigned");
-    CONFIG_OPTIONS.put(TARGET_TAGS_PROPERTY, "The tags that the resulting mediapackage elements will be assigned");
-  }
 
   /**
    * {@inheritDoc}
@@ -308,16 +287,6 @@ public class ExecuteManyWorkflowOperationHandler extends AbstractWorkflowOperati
   @Override
   public void destroy(WorkflowInstance workflowInstance, JobContext context) throws WorkflowOperationException {
     // Do nothing (nothing to clean up, the command line program should do this itself)
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandler.java
+++ b/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandler.java
@@ -55,8 +55,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Runs an operation once with using elements within a certain MediaPackage as parameters
@@ -104,22 +102,6 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
 
   /** The workspace service */
   protected Workspace workspace;
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(EXEC_PROPERTY, "The full path the executable to run");
-    CONFIG_OPTIONS.put(PARAMS_PROPERTY, "Space separated list of command line parameters to pass to the executable')");
-    CONFIG_OPTIONS.put(LOAD_PROPERTY, "A floating point estimate of the load imposed on the node by this job");
-    CONFIG_OPTIONS.put(OUTPUT_FILENAME_PROPERTY, "The name of the elements created by this operation");
-    CONFIG_OPTIONS.put(EXPECTED_TYPE_PROPERTY,
-            "The type of the element returned by this operation. Accepted values are: manifest, timeline, track, catalog, attachment, other");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR_PROPERTY, "The flavor that the resulting mediapackage elements will be assigned");
-    CONFIG_OPTIONS.put(TARGET_TAGS_PROPERTY, "The tags that the resulting mediapackage elements will be assigned");
-    CONFIG_OPTIONS.put(SET_WF_PROPS_PROPERTY, "If true, command output will be used to set workflow properties");
-  }
 
   /**
    * {@inheritDoc}
@@ -286,17 +268,6 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
   @Override
   public void destroy(WorkflowInstance workflowInstance, JobContext context) throws WorkflowOperationException {
     // Do nothing (nothing to clean up, the command line program should do this itself)
-  }
-
-
-  /**
-   * {@inheritDoc}
-   * 
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/incident-workflowoperation/src/main/java/org/opencastproject/workflow/handler/incident/IncidentCreatorWorkflowOperationHandler.java
+++ b/modules/incident-workflowoperation/src/main/java/org/opencastproject/workflow/handler/incident/IncidentCreatorWorkflowOperationHandler.java
@@ -43,8 +43,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 public class IncidentCreatorWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
@@ -55,22 +53,7 @@ public class IncidentCreatorWorkflowOperationHandler extends AbstractWorkflowOpe
   private static final String OPT_DETAILS = "details";
   private static final String OPT_PARAMS = "params";
 
-  private static final SortedMap<String, String> CONFIG_OPTS;
-
-  static {
-    CONFIG_OPTS = new TreeMap<>();
-    CONFIG_OPTS.put(OPT_CODE, "The code number of the incident to produce.");
-    CONFIG_OPTS.put(OPT_SEVERITY, "The severity");
-    CONFIG_OPTS.put(OPT_DETAILS, "Some details: title=content;title=content;...");
-    CONFIG_OPTS.put(OPT_PARAMS, "Some params: key=value;key=value;...");
-  }
-
   private NopService nopService;
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTS;
-  }
 
   @Override
   public WorkflowOperationResult start(WorkflowInstance wi, JobContext ctx) throws WorkflowOperationException {

--- a/modules/ingest-workflowoperation/src/main/java/org/opencastproject/workflow/handler/ingest/IngestDownloadWorkflowOperationHandler.java
+++ b/modules/ingest-workflowoperation/src/main/java/org/opencastproject/workflow/handler/ingest/IngestDownloadWorkflowOperationHandler.java
@@ -53,8 +53,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Downloads all external URI's to the working file repository and optionally deletes external working file repository
@@ -68,9 +66,6 @@ public class IngestDownloadWorkflowOperationHandler extends AbstractWorkflowOper
   /** Deleting external working file repository URI's after download config key */
   public static final String DELETE_EXTERNAL = "delete-external";
 
-  /** The configuration properties */
-  protected SortedMap<String, String> configurationOptions = null;
-
   /**
    * The workspace to use in retrieving and storing files.
    */
@@ -81,9 +76,6 @@ public class IngestDownloadWorkflowOperationHandler extends AbstractWorkflowOper
 
   /** The default no-arg constructor builds the configuration options set */
   public IngestDownloadWorkflowOperationHandler() {
-    configurationOptions = new TreeMap<String, String>();
-    configurationOptions.put(DELETE_EXTERNAL,
-            "Whether to try to delete external working file repository URIs. Default is false.");
   }
 
   /**
@@ -243,15 +235,5 @@ public class IngestDownloadWorkflowOperationHandler extends AbstractWorkflowOper
     }
 
     return createResult(mediaPackage, Action.CONTINUE);
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return configurationOptions;
   }
 }

--- a/modules/inspection-workflowoperation/src/main/java/org/opencastproject/workflow/handler/inspection/InspectWorkflowOperationHandler.java
+++ b/modules/inspection-workflowoperation/src/main/java/org/opencastproject/workflow/handler/inspection/InspectWorkflowOperationHandler.java
@@ -63,8 +63,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Workflow operation used to inspect all tracks of a media package.
@@ -73,9 +71,6 @@ public class InspectWorkflowOperationHandler extends AbstractWorkflowOperationHa
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(InspectWorkflowOperationHandler.class);
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
 
   /** Option for rewriting existing metadata */
   private static final String OPT_OVERWRITE = "overwrite";
@@ -88,14 +83,6 @@ public class InspectWorkflowOperationHandler extends AbstractWorkflowOperationHa
       Default: false */
   private static final String OPT_ACCURATE_FRAME_COUNT = "accurate-frame-count";
 
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(OPT_OVERWRITE, "Whether to rewrite existing metadata");
-    CONFIG_OPTIONS.put(OPT_ACCEPT_NO_MEDIA, "Whether mediapackages with no media tracks should be accepted");
-    CONFIG_OPTIONS.put(OPT_ACCURATE_FRAME_COUNT,
-            "Whether the media inspection service should determine the exact frame count");
-  }
-
   /** The inspection service */
   private MediaInspectionService inspectionService = null;
 
@@ -107,16 +94,6 @@ public class InspectWorkflowOperationHandler extends AbstractWorkflowOperationHa
 
   public void setDublincoreService(DublinCoreCatalogService dcService) {
     this.dcService = dcService;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -78,13 +78,6 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
   @Override
   protected void activate(ComponentContext cc) {
     super.activate(cc);
-    addConfigurationOption(TO_PROPERTY, "The mail address(es) to send to");
-    addConfigurationOption(CC_PROPERTY, "The mail address(es) to send to as \"carbon copy\"");
-    addConfigurationOption(BCC_PROPERTY, "The mail address(es) to send to as \"blind carbon copy\"");
-    addConfigurationOption(SUBJECT_PROPERTY, "The subject line");
-    addConfigurationOption(BODY_PROPERTY, "The email body text (or email template)");
-    addConfigurationOption(BODY_TEMPLATE_FILE_PROPERTY, "The file name of the Freemarker template for the email body");
-    addConfigurationOption(IS_HTML, "Is the body text (or email template) in HTML");
   }
 
   /**

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/HttpNotificationWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/HttpNotificationWorkflowOperationHandler.java
@@ -54,8 +54,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Workflow operation handler that will send HTTP POST or PUT requests to a specified address.
@@ -94,19 +92,6 @@ public class HttpNotificationWorkflowOperationHandler extends AbstractWorkflowOp
 
   /** Name of the workflow instance id HTTP parameter */
   public static final String HTTP_PARAM_WORKFLOW = "workflowInstanceId";
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-    CONFIG_OPTIONS.put(OPT_URL_PATH, "Notification request target");
-    CONFIG_OPTIONS.put(OPT_NOTIFICATION_SUBJECT, "Notification title");
-    CONFIG_OPTIONS.put(OPT_NOTIFICATION_MESSAGE, "Notification");
-    CONFIG_OPTIONS.put(OPT_METHOD, "HTTP Method");
-    CONFIG_OPTIONS.put(OPT_MAX_RETRY, "Maximum attempts for the notification request");
-    CONFIG_OPTIONS.put(OPT_TIMEOUT, "Request timeout");
-  }
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(HttpNotificationWorkflowOperationHandler.class);

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/MediaPackagePostOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/MediaPackagePostOperationHandler.java
@@ -51,8 +51,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Workflow Operation for POSTing a MediaPackage via HTTP
@@ -68,16 +66,6 @@ public class MediaPackagePostOperationHandler extends AbstractWorkflowOperationH
   public void setSearchService(SearchService searchService) {
     this.searchService = searchService;
   }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-    public SortedMap<String, String> getConfigurationOptions() {
-      return Configuration.OPTIONS;
-    }
 
   /**
    * {@inheritDoc}
@@ -182,7 +170,7 @@ public class MediaPackagePostOperationHandler extends AbstractWorkflowOperationH
 
     public enum Format {
       XML, JSON
-    };
+    }
 
     // Key for the WorkflowOperation Configuration
     public static final String PROPERTY_URL = "url";
@@ -193,27 +181,6 @@ public class MediaPackagePostOperationHandler extends AbstractWorkflowOperationH
     public static final String PROPERTY_AUTHPASSWD = "auth.password";
     public static final String PROPERTY_DEBUG = "debug";
     public static final String PROPERTY_MEDIAPACKAGE_TYPE = "mediapackage.type";
-    public static final TreeMap<String, String> OPTIONS;
-
-    static {
-      OPTIONS = new TreeMap<String, String>();
-      OPTIONS.put(Configuration.PROPERTY_URL,
-          "The URL to which the MediaPackage will be submitted");
-      OPTIONS.put(Configuration.PROPERTY_FORMAT,
-          "The output format for the MediaPackage (default: XML)");
-      OPTIONS.put(Configuration.PROPERTY_ENCODING,
-          "Message Encoding (default: UTF-8)");
-      OPTIONS.put(Configuration.PROPERTY_AUTH,
-          "The authentication method to use (no/http-digest)");
-      OPTIONS.put(Configuration.PROPERTY_AUTHUSER,
-          "The username to use for authentication");
-      OPTIONS.put(Configuration.PROPERTY_AUTHPASSWD,
-          "The password to use for authentication");
-      OPTIONS.put(Configuration.PROPERTY_DEBUG,
-          "If this options is set the message body returned by target host is dumped to log (default: no)");
-      OPTIONS.put(Configuration.PROPERTY_MEDIAPACKAGE_TYPE,
-          "Type of Mediapackage to send (workflow, search; default: search)");
-    }
 
     // Configuration values
     private URI url;

--- a/modules/sox-workflowoperation/src/main/java/org/opencastproject/workflow/handler/sox/AnalyzeAudioWorkflowOperationHandler.java
+++ b/modules/sox-workflowoperation/src/main/java/org/opencastproject/workflow/handler/sox/AnalyzeAudioWorkflowOperationHandler.java
@@ -56,8 +56,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The workflow definition for handling "sox" operations
@@ -69,17 +67,6 @@ public class AnalyzeAudioWorkflowOperationHandler extends AbstractWorkflowOperat
 
   /** Name of the 'encode to SoX audio only work copy' encoding profile */
   public static final String SOX_AONLY_PROFILE = "sox-audio-only.work";
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-flavors", "The \"flavors\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("source-flavor", "The \"flavor\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("source-tags", "The \"tag\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("force-transcode", "Whether to force transcoding the audio stream");
-  }
 
   /** The SoX service */
   private SoxService soxService = null;
@@ -118,16 +105,6 @@ public class AnalyzeAudioWorkflowOperationHandler extends AbstractWorkflowOperat
    */
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/sox-workflowoperation/src/main/java/org/opencastproject/workflow/handler/sox/NormalizeAudioWorkflowOperationHandler.java
+++ b/modules/sox-workflowoperation/src/main/java/org/opencastproject/workflow/handler/sox/NormalizeAudioWorkflowOperationHandler.java
@@ -58,8 +58,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The workflow definition for handling "sox" operations
@@ -74,20 +72,6 @@ public class NormalizeAudioWorkflowOperationHandler extends AbstractWorkflowOper
 
   /** Name of the muxing encoding profile */
   public static final String SOX_AREPLACE_PROFILE = "sox-audio-replace.work";
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-flavors", "The \"flavors\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("source-flavor", "The \"flavor\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("source-tags", "The \"tag\" of the track to use as a source input");
-    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the normalized file");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the normalized file");
-    CONFIG_OPTIONS.put("target-decibel", "The target RMS Level Decibel");
-    CONFIG_OPTIONS.put("force-transcode", "Whether to force transcoding the audio stream");
-  }
 
   /** The SoX service */
   private SoxService soxService = null;
@@ -127,16 +111,6 @@ public class NormalizeAudioWorkflowOperationHandler extends AbstractWorkflowOper
    */
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/textanalyzer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/textanalyzer/TextAnalysisWorkflowOperationHandler.java
+++ b/modules/textanalyzer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/textanalyzer/TextAnalysisWorkflowOperationHandler.java
@@ -107,18 +107,8 @@ public class TextAnalysisWorkflowOperationHandler extends AbstractWorkflowOperat
   /** Name of the constant used to retreive the stability threshold */
   public static final String OPT_STABILITY_THRESHOLD = "stabilitythreshold";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
   /** The stability threshold */
   private int stabilityThreshold = DEFAULT_STABILITY_THRESHOLD;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-flavor", "The flavor of the input tracks");
-    CONFIG_OPTIONS.put("source-tags", "The required tags that must exist on the segments catalog");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the resulting mpeg-7 catalog");
-  }
 
   /** The local workspace */
   private Workspace workspace = null;
@@ -131,16 +121,6 @@ public class TextAnalysisWorkflowOperationHandler extends AbstractWorkflowOperat
 
   /** The composer service */
   protected ComposerService composer = null;
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * Callback for the OSGi declarative services configuration that will set the text analysis service.

--- a/modules/themes-workflowoperation/src/main/java/org/opencastproject/workflow/handler/themes/ThemeWorkflowOperationHandler.java
+++ b/modules/themes-workflowoperation/src/main/java/org/opencastproject/workflow/handler/themes/ThemeWorkflowOperationHandler.java
@@ -67,8 +67,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 
 /**
@@ -107,37 +105,8 @@ public class ThemeWorkflowOperationHandler extends AbstractWorkflowOperationHand
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ThemeWorkflowOperationHandler.class);
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
   private static final MediaPackageElementBuilderFactory elementBuilderFactory = MediaPackageElementBuilderFactory
           .newInstance();
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(BUMPER_FLAVOR, "The flavor to apply to the added bumper element");
-    CONFIG_OPTIONS.put(BUMPER_TAGS, "The tags to apply to the added bumper element");
-    CONFIG_OPTIONS.put(TRAILER_FLAVOR, "The flavor to apply to the added trailer element");
-    CONFIG_OPTIONS.put(TRAILER_TAGS, "The tags to apply to the added trailer element");
-    CONFIG_OPTIONS.put(TITLE_SLIDE_FLAVOR, "The flavor to apply to the added title slide element");
-    CONFIG_OPTIONS.put(TITLE_SLIDE_TAGS, "The tags to apply to the added title slide element");
-    CONFIG_OPTIONS.put(LICENSE_SLIDE_FLAVOR, "The flavor to apply to the added license slide element");
-    CONFIG_OPTIONS.put(LICENSE_SLIDE_TAGS, "The tags to apply to the added license slide element");
-    CONFIG_OPTIONS.put(WATERMARK_FLAVOR, "The flavor to apply to the added watermark element");
-    CONFIG_OPTIONS.put(WATERMARK_TAGS, "The tags to apply to the added watermark element");
-    CONFIG_OPTIONS.put(WATERMARK_LAYOUT, "The layout to adjust by the watermark position");
-    CONFIG_OPTIONS.put(WATERMARK_LAYOUT_VARIABLE, "The workflow variable where the adjusted layout is stored");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /** The series service */
   private SeriesService seriesService;

--- a/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
+++ b/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
@@ -53,8 +53,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Workflow operation for the timeline previews service.
@@ -82,21 +80,6 @@ public class TimelinePreviewsWorkflowOperationHandler extends AbstractWorkflowOp
   /** Default value for image size. */
   private static final int DEFAULT_IMAGE_SIZE = 10;
 
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_PROPERTY, "The source media file flavor.");
-    CONFIG_OPTIONS.put(SOURCE_TAGS_PROPERTY, "Comma-separated tags of the source media files. "
-            + "Any media that match " + SOURCE_FLAVOR_PROPERTY + " or " + SOURCE_TAGS_PROPERTY
-            + " will be processed.");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR_PROPERTY, "The target timeline previews image flavor.");
-    CONFIG_OPTIONS.put(TARGET_TAGS_PROPERTY, "The timeline previews image (comma separated) target tags.");
-    CONFIG_OPTIONS.put(IMAGE_SIZE_PROPERTY, "The number of timeline previews in the image.");
-  }
-
   /** The timeline previews service. */
   private TimelinePreviewsService timelinePreviewsService = null;
 
@@ -107,17 +90,6 @@ public class TimelinePreviewsWorkflowOperationHandler extends AbstractWorkflowOp
   public void activate(ComponentContext cc) {
     super.activate(cc);
     logger.info("Registering timeline previews workflow operation handler");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see
-   * org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
@@ -41,9 +41,6 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.SortedMap;
-import java.util.TreeMap;
-
 public class AttachTranscriptionOperationHandler extends AbstractWorkflowOperationHandler {
 
   /** The logging facility */
@@ -60,30 +57,9 @@ public class AttachTranscriptionOperationHandler extends AbstractWorkflowOperati
   private Workspace workspace;
   private CaptionService captionService;
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(TRANSCRIPTION_JOB_ID, "The job id that identifies the file to be attached");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR, "The target \"flavor\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_TAG, "The target \"tag\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_CAPTION_FORMAT, "The target caption format of the transcription file (dfxp, etc)");
-  }
-
   @Override
   protected void activate(ComponentContext cc) {
     super.activate(cc);
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
@@ -43,8 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 public class StartTranscriptionOperationHandler extends AbstractWorkflowOperationHandler {
 
@@ -59,30 +57,9 @@ public class StartTranscriptionOperationHandler extends AbstractWorkflowOperatio
   /** The transcription service */
   private TranscriptionService service = null;
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR, "The \"flavor\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(SOURCE_TAG, "The \"tag\" of the track to use as audio input");
-    CONFIG_OPTIONS
-            .put(SKIP_IF_FLAVOR_EXISTS, "If this \"flavor\" is already in the media package, skip this operation");
-  }
-
   @Override
   protected void activate(ComponentContext cc) {
     super.activate(cc);
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
@@ -52,8 +52,6 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * workflowoperationhandler for silencedetection executes the silencedetection and adds a SMIL document to the
@@ -82,19 +80,6 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
   /** Name of the configuration option that provides the smil file name */
   private static final String TARGET_FILE_NAME = "smil.smil";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVORS_PROPERTY, "The flavors for source files (tracks containing audio stream).");
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_PROPERTY, "The flavor for source files (tracks containing audio stream).");
-    CONFIG_OPTIONS.put(SMIL_FLAVOR_SUBTYPE_PROPERTY, "The flavor subtype for target smil files.");
-    CONFIG_OPTIONS.put(SMIL_TARGET_FLAVOR_PROPERTY, "The flavor for target smil files.");
-    CONFIG_OPTIONS.put(REFERENCE_TRACKS_FLAVOR_PROPERTY,
-            "The track flavors for referencing in smil as source files. If not set, fallback to "
-                    + SOURCE_FLAVORS_PROPERTY);
-  }
   /** The silence detection service. */
   private SilenceDetectionService detetionService;
 
@@ -103,16 +88,6 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
 
   /** The workspace. */
   private Workspace workspace;
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   @Override
   public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
@@ -72,8 +72,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import javax.xml.bind.JAXBException;
 
@@ -118,28 +116,6 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
   private static final String SKIP_NOT_TRIMMED_PROPERTY = "skip-if-not-trimmed";
 
   /**
-   * The configuration options for this handler
-   */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVORS_PROPERTY, "The flavor for working files (tracks to edit).");
-    CONFIG_OPTIONS.put(PREVIEW_FLAVORS_PROPERTY, "The flavor for preview files (tracks to show in edit UI).");
-    CONFIG_OPTIONS.put(SKIPPED_FLAVORS_PROPERTY, "The flavor for working files if videoeditor operation is disabled."
-            + " This is an optional option." + " Default value is given by \"" + SOURCE_FLAVORS_PROPERTY + "\".");
-    CONFIG_OPTIONS.put(SMIL_FLAVORS_PROPERTY, "The flavor for input SMIL files.");
-    CONFIG_OPTIONS.put(TARGET_SMIL_FLAVOR_PROPERTY, "The flavor for target SMIL file.");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR_SUBTYPE_PROPERTY, "The flavor subtype for target media files.");
-    CONFIG_OPTIONS.put(INTERACTIVE_PROPERTY, "Whether the operation is interactive or not.");
-    CONFIG_OPTIONS.put(SKIP_PROCESSING_PROPERTY,
-            "Do not processing the files, keep the raw smil produced by the videoeditor operation if it is enabled."
-                    + " This is an optional option." + " Default value is \"FALSE\".");
-    CONFIG_OPTIONS.put(SKIP_NOT_TRIMMED_PROPERTY,
-            "If 'true', do not process the input track(s) if no trimming points are defined.");
-  }
-
-  /**
    * The SMIL service to modify SMIL files.
    */
   private SmilService smilService;
@@ -158,16 +134,6 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
     setHoldActionTitle("Review / VideoEdit");
     registerHoldStateUserInterface(HOLD_UI_PATH);
     logger.info("Registering videoEditor hold state ui from classpath {}", HOLD_UI_PATH);
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/videosegmenter-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videosegmenter/VideoSegmenterWorkflowOperationHandler.java
+++ b/modules/videosegmenter-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videosegmenter/VideoSegmenterWorkflowOperationHandler.java
@@ -47,8 +47,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * The workflow definition will run suitable recordings by the video segmentation.
@@ -64,31 +62,11 @@ public class VideoSegmenterWorkflowOperationHandler extends AbstractWorkflowOper
   /** Name of the configuration key that specifies the flavor of the track to analyze */
   private static final String PROP_TARGET_TAGS = "target-tags";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(PROP_ANALYSIS_TRACK_FLAVOR,
-            "The flavor of the track to analyze. If multiple tracks match this flavor, the first will be used.");
-    CONFIG_OPTIONS.put(PROP_TARGET_TAGS, "The tags to apply to the resulting mpeg-7 segments catalog");
-  }
-
   /** The composer service */
   private VideoSegmenterService videosegmenter = null;
 
   /** The local workspace */
   private Workspace workspace = null;
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * {@inheritDoc}

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
@@ -47,8 +47,6 @@ import org.osgi.service.component.ComponentContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Abstract base implementation for an operation handler, which implements a simple start operation that returns a
@@ -61,9 +59,6 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
 
   /** The description of what this handler actually does */
   protected String description = null;
-
-  /** The configuration options for this operation handler */
-  protected SortedMap<String, String> options = new TreeMap<String, String>();
 
   /** Optional service registry */
   protected ServiceRegistry serviceRegistry = null;
@@ -112,38 +107,6 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
    */
   @Override
   public void destroy(WorkflowInstance workflowInstance, JobContext context) throws WorkflowOperationException {
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return options;
-  }
-
-  /**
-   * Adds a configuration option to the list of possible configuration options.
-   *
-   * @param name
-   *          the option name
-   * @param description
-   *          the option description
-   */
-  public void addConfigurationOption(String name, String description) {
-    options.put(name, description);
-  }
-
-  /**
-   * Removes the configuration option from the list of possible configuration options.
-   *
-   * @param name
-   *          the option name
-   */
-  public void removeConfigurationOption(String name) {
-    options.remove(name);
   }
 
   /**

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationHandler.java
@@ -23,8 +23,6 @@ package org.opencastproject.workflow.api;
 
 import org.opencastproject.job.api.JobContext;
 
-import java.util.SortedMap;
-
 /**
  * Handler for workflow operations.
  */
@@ -43,13 +41,6 @@ public interface WorkflowOperationHandler {
    * @return The handler's description
    */
   String getDescription();
-
-  /**
-   * Returns the configuration keys that this handler accepts, along with a description of their purpose.
-   *
-   * @return The configuration keys and their meaning
-   */
-  SortedMap<String, String> getConfigurationOptions();
 
   /**
    * Runs the workflow operation on this {@link WorkflowInstance}. If the execution fails for some reason, this must

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
@@ -91,7 +91,6 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 
@@ -704,11 +703,6 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
       JSONObject jsonHandler = new JSONObject();
       jsonHandler.put("id", handler.getId());
       jsonHandler.put("description", handler.getDescription());
-      JSONObject jsonConfigOptions = new JSONObject();
-      for (Entry<String, String> configEntry : handler.getConfigurationOptions().entrySet()) {
-        jsonConfigOptions.put(configEntry.getKey(), configEntry.getValue());
-      }
-      jsonHandler.put("options", jsonConfigOptions);
       jsonArray.add(jsonHandler);
     }
     return Response.ok(jsonArray.toJSONString()).header("Content-Type", MediaType.APPLICATION_JSON).build();

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
@@ -58,7 +58,6 @@ import org.opencastproject.workflow.api.ResumableWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
-import org.opencastproject.workflow.api.WorkflowOperationException;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workflow.api.WorkflowParser;
@@ -84,8 +83,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import junit.framework.Assert;
 
@@ -287,14 +284,8 @@ public class CountWorkflowsTest {
    */
   class ContinuingWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
     @Override
-    public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
-            throws WorkflowOperationException {
+    public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context) {
       return createResult(Action.CONTINUE);
-    }
-
-    @Override
-    public SortedMap<String, String> getConfigurationOptions() {
-      return new TreeMap<String, String>();
     }
 
     @Override

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
@@ -55,7 +55,6 @@ import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
-import org.opencastproject.workflow.api.WorkflowOperationException;
 import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workflow.api.WorkflowParser;
@@ -83,8 +82,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import junit.framework.Assert;
 
@@ -316,14 +313,8 @@ public class HoldStateTest {
 
   class ContinuingWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
     @Override
-    public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
-            throws WorkflowOperationException {
+    public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context) {
       return createResult(Action.CONTINUE);
-    }
-
-    @Override
-    public SortedMap<String, String> getConfigurationOptions() {
-      return new TreeMap<String, String>();
     }
 
     @Override

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
@@ -87,8 +87,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 import junit.framework.Assert;
 
@@ -325,11 +323,6 @@ public class WorkflowOperationSkippingTest {
 
     SucceedingWorkflowOperationHandler(MediaPackage mp) {
       this.mp = mp;
-    }
-
-    @Override
-    public SortedMap<String, String> getConfigurationOptions() {
-      return new TreeMap<String, String>();
     }
 
     @Override

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -113,8 +113,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 public class WorkflowServiceImplTest {
 
@@ -1037,10 +1035,6 @@ public class WorkflowServiceImplTest {
   }
 
   class SucceedingWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
-    @Override
-    public SortedMap<String, String> getConfigurationOptions() {
-      return new TreeMap<String, String>();
-    }
 
     @Override
     public String getId() {
@@ -1060,11 +1054,6 @@ public class WorkflowServiceImplTest {
   }
 
   class FailingWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
-    @Override
-    public SortedMap<String, String> getConfigurationOptions() {
-      return new TreeMap<String, String>();
-    }
-
     @Override
     public String getId() {
       return this.getClass().getName();

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandler.java
@@ -54,8 +54,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Removes all files in the working file repository for mediapackage elements that don't match one of the
@@ -75,9 +73,6 @@ public class CleanupWorkflowOperationHandler extends AbstractWorkflowOperationHa
   /** Time to wait in seconds before removing files */
   public static final String DELAY = "delay";
 
-  /** The configuration properties */
-  protected SortedMap<String, String> configurationOptions = null;
-
   /**
    * The workspace to use in retrieving and storing files.
    */
@@ -85,18 +80,6 @@ public class CleanupWorkflowOperationHandler extends AbstractWorkflowOperationHa
 
   /** The http client to use when connecting to remote servers */
   protected TrustedHttpClient client = null;
-
-  /** The default no-arg constructor builds the configuration options set */
-  public CleanupWorkflowOperationHandler() {
-    configurationOptions = new TreeMap<String, String>();
-    configurationOptions.put(PRESERVE_FLAVOR_PROPERTY,
-            "The configuration key that specifies the flavors to preserve.  If not specified, this operation will not"
-                    + "remove any files.");
-    configurationOptions.put(DELETE_EXTERNAL,
-            "Whether to try to delete external working file repository URIs. Default is false.");
-    configurationOptions.put(DELAY,
-            "Time to wait in seconds before removing files. Default is 1s.");
-  }
 
   /**
    * Sets the workspace to use.
@@ -310,15 +293,5 @@ public class CleanupWorkflowOperationHandler extends AbstractWorkflowOperationHa
     } finally {
       client.close(response);
     }
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return configurationOptions;
   }
 }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
@@ -44,8 +44,6 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Take look in specified catalog for specified term, if the value matches the specified value add the target-tags
@@ -53,9 +51,6 @@ import java.util.TreeMap;
 public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBase {
 
   private static final Logger logger = LoggerFactory.getLogger(ConfigureByDublinCoreTermWOH.class);
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
 
   /** Name of the configuration option that provides the catalog to examine */
   public static final String DCCATALOG_PROPERTY = "dccatalog";
@@ -74,27 +69,6 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
 
   /** The local workspace */
   private Workspace workspace = null;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-
-    CONFIG_OPTIONS.put(DCCATALOG_PROPERTY, "The flavor of the catalog to examine, will throw error if not present");
-    CONFIG_OPTIONS.put(DCTERM_PROPERTY, "The Dublin Core term/element to examine");
-    CONFIG_OPTIONS.put(DEFAULT_VALUE_PROPERTY,
-            "The Dublin Core term/element's value if not found, if this is not given then match will fail");
-    CONFIG_OPTIONS.put(MATCH_VALUE_PROPERTY,
-            "The match the Dublin Core term/element against this value, if true then apply target-tags");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * Callback for declarative services configuration that will introduce us to the local workspace service.

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CopyWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CopyWorkflowOperationHandler.java
@@ -49,8 +49,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Workflow operation handler for copying video data through NFS
@@ -68,17 +66,6 @@ public class CopyWorkflowOperationHandler extends AbstractWorkflowOperationHandl
 
   /** Configuration key for the name of the target file */
   public static final String OPT_TARGET_FILENAME = "target-filename";
-
-  /** The configuration options for this handler */
-  public static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(OPT_SOURCE_TAGS, "The \"tag\" of the track to use as a source input");
-    CONFIG_OPTIONS.put(OPT_SOURCE_FLAVORS, "The \"flavor\" of the track to use as a source input");
-    CONFIG_OPTIONS.put(OPT_TARGET_DIRECTORY, "The directory where the file must be delivered");
-    CONFIG_OPTIONS.put(OPT_TARGET_FILENAME, "The optional name of the target file");
-  }
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(CopyWorkflowOperationHandler.class);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
@@ -55,8 +55,6 @@ import java.io.StringWriter;
 import java.net.URI;
 import java.util.Properties;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 
 /**
@@ -71,17 +69,6 @@ public class ExportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
 
   public static final String DEFAULT_TARGET_FLAVOR = MediaPackageElements.PROCESSING_PROPERTIES.toString();
   public static final String EXPORTED_PROPERTIES_FILENAME = "processing-properties.xml";
-
-  /** The configuration options for this handler */
-  public static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(KEYS_PROPERTY,
-            "The workflow property keys that need to be persisted. If the option is not specified, all defined properties should be persisted.");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR_PROPERTY, "The flavor to apply to the exported workflow properties");
-    CONFIG_OPTIONS.put(TARGET_TAGS_PROPERTY, "The tags to apply to the exported workflow properties");
-  }
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ExportWorkflowPropertiesWOH.class);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
@@ -52,8 +52,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Workflow operation handler for importing workflow properties.
@@ -61,7 +59,6 @@ import java.util.TreeMap;
 public class ImportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandler {
 
   /* Configuration options */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
   public static final String SOURCE_FLAVOR_PROPERTY = "source-flavor";
   public static final String KEYS_PROPERTY = "keys";
 
@@ -70,22 +67,9 @@ public class ImportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
   /* Service references */
   private Workspace workspace;
 
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR_PROPERTY,
-            "Flavor of the attachment that contains the serialized workflow instance properties");
-    CONFIG_OPTIONS.put(KEYS_PROPERTY,
-            "The workflow property keys to retrieve (comma separated list). If the option has not been specified, all keys will be retrieved");
-  }
-
   /** OSGi DI */
   void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
-  }
-
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   @Override

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/IncludeWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/IncludeWorkflowOperationHandler.java
@@ -63,8 +63,6 @@ public final class IncludeWorkflowOperationHandler extends AbstractWorkflowOpera
   @Override
   public void activate(ComponentContext componentContext) {
     super.activate(componentContext);
-    // Register the supported configuration options
-    addConfigurationOption(WORKFLOW_CFG, "Workflow definition identifier");
   }
 
   /**

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
@@ -20,8 +20,6 @@
  */
 package org.opencastproject.workflow.handler.workflow;
 
-import static java.lang.String.format;
-
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.EName;
@@ -75,8 +73,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.UUID;
 
 /**
@@ -86,9 +82,6 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(SeriesWorkflowOperationHandler.class);
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
 
   /** Name of the configuration option that provides the optional series identifier */
   public static final String SERIES_PROPERTY = "series";
@@ -168,29 +161,6 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
   /** OSGi callback to remove {@link SeriesCatalogUIAdapter} instance. */
   public void removeCatalogUIAdapter(SeriesCatalogUIAdapter catalogUIAdapter) {
     seriesCatalogUIAdapters.remove(catalogUIAdapter);
-  }
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-    CONFIG_OPTIONS.put(SERIES_PROPERTY, "The optional series identifier");
-    CONFIG_OPTIONS.put(ATTACH_PROPERTY, "The flavors of the series catalogs to attach to the mediapackage.");
-    CONFIG_OPTIONS.put(APPLY_ACL_PROPERTY, "Whether the ACL should be applied or not");
-    CONFIG_OPTIONS.put(COPY_METADATA_PROPERTY,
-            "A blank- or comma-separated list of metadata fields to copy to the episode catalog, "
-                    + "when they are defined in the series' catalog but not in the episode's");
-    CONFIG_OPTIONS.put(DEFAULT_NS_PROPERTY,
-            format("The default Namespace assumed when the metadata fields are not fully qualified. Defaults to '%s'",
-                    DublinCore.TERMS_NS_URI));
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
@@ -47,8 +47,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Take look in specified catalog for specified term, if the value matches the specified value add the target-tags
@@ -58,9 +56,6 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
   private static final Logger logger = LoggerFactory.getLogger(TagByDublinCoreTermWOH.class);
   private static final String PLUS = "+";
   private static final String MINUS = "-";
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
 
   /** Name of the configuration option that provides the source flavors we are looking for */
   public static final String SOURCE_FLAVORS_PROPERTY = "source-flavors";
@@ -91,40 +86,6 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
 
   /** The local workspace */
   private Workspace workspace = null;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVORS_PROPERTY,
-            "Tagging any mediapackage elements with one of these (comma sparated) flavors.");
-    CONFIG_OPTIONS.put(SOURCE_TAGS_PROPERTY,
-            "Tagging any mediapackage elements with one of these (comma separated) tags.");
-
-    CONFIG_OPTIONS.put(DCCATALOG_PROPERTY,
-            "The flavor of the catalog to examine, will throw error if not present");
-    CONFIG_OPTIONS.put(DCTERM_PROPERTY,
-            "The Dublin Core term/element to examine");
-    CONFIG_OPTIONS.put(DEFAULT_VALUE_PROPERTY,
-            "The Dublin Core term/element's value if not found, if this is not given then match will fail");
-    CONFIG_OPTIONS.put(MATCH_VALUE_PROPERTY,
-            "The match the Dublin Core term/element against this value, if true then apply target-tags");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR_PROPERTY, "Apply these flavor to any mediapackage elements");
-    CONFIG_OPTIONS
-            .put(TARGET_TAGS_PROPERTY,
-                    "Apply these (comma separated) tags to any mediapackage elements. If a target-tag starts with a '-', "
-                    + "tag will removed from preexisting tags, if starts with a '+', tag will added to preexisting tags.");
-    CONFIG_OPTIONS.put(COPY_PROPERTY,
-            "Indicates if any mediapackage elements should be copied 'true' or overridden 'false'");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * Callback for declarative services configuration that will introduce us to the local workspace service.

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
@@ -41,8 +41,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Simple implementation that holds for user-entered trim points.
@@ -52,9 +50,6 @@ public class TagWorkflowOperationHandler extends AbstractWorkflowOperationHandle
   private static final Logger logger = LoggerFactory.getLogger(TagWorkflowOperationHandler.class);
   private static final String PLUS = "+";
   private static final String MINUS = "-";
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
 
   /** Name of the configuration option that provides the source flavors we are looking for */
   public static final String SOURCE_FLAVORS_PROPERTY = "source-flavors";
@@ -70,31 +65,6 @@ public class TagWorkflowOperationHandler extends AbstractWorkflowOperationHandle
 
   /** Name of the configuration option that provides the copy boolean we are looking for */
   public static final String COPY_PROPERTY = "copy";
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVORS_PROPERTY,
-            "Tagging any mediapackage elements with one of these (comma sparated) flavors.");
-    CONFIG_OPTIONS.put(SOURCE_TAGS_PROPERTY,
-            "Tagging any mediapackage elements with one of these (comma separated) tags.");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR_PROPERTY, "Apply these flavor to any mediapackage elements");
-    CONFIG_OPTIONS
-            .put(TARGET_TAGS_PROPERTY,
-                    "Apply these (comma separated) tags to any mediapackage elements. If a target-tag starts with a '-', "
-                            + "tag will removed from preexisting tags, if starts with a '+', tag will added to preexisting tags.");
-    CONFIG_OPTIONS.put(COPY_PROPERTY,
-            "Indicates if any mediapackage elements should be copied 'true' or overridden 'false'");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
-  }
 
   /**
    * {@inheritDoc}

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandler.java
@@ -62,8 +62,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Produces a zipped archive of a mediapackage, places it in the archive collection, and removes the rest of the
@@ -107,29 +105,10 @@ public class ZipWorkflowOperationHandler extends AbstractWorkflowOperationHandle
   /** The temporary storage location */
   protected File tempStorageDir = null;
 
-  /** The configuration properties */
-  protected SortedMap<String, String> configurationOptions = null;
-
   /**
    * The workspace to use in retrieving and storing files.
    */
   protected Workspace workspace;
-
-  /** The default no-arg constructor builds the configuration options set */
-  public ZipWorkflowOperationHandler() {
-    configurationOptions = new TreeMap<String, String>();
-    configurationOptions.put(ZIP_COLLECTION_PROPERTY,
-            "The configuration key that specifies the zip archive collection.  Defaults to " + DEFAULT_ZIP_COLLECTION);
-    configurationOptions.put(COMPRESS_PROPERTY,
-            "The configuration key that specifies whether to compress the zip archive.  Defaults to false.");
-    configurationOptions.put(INCLUDE_FLAVORS_PROPERTY,
-            "The configuration key that specifies the element flavors to include in the zipped mediapackage archive");
-    configurationOptions.put(TARGET_FLAVOR_PROPERTY, "The target flavor for the zip archive element, defaulting to '"
-            + DEFAULT_ARCHIVE_FLAVOR + "'");
-    configurationOptions.put(TARGET_FLAVOR_PROPERTY, "The target flavor for the zip archive element, defaulting to '"
-            + DEFAULT_ARCHIVE_FLAVOR + "'");
-    configurationOptions.put(TARGET_TAGS_PROPERTY, "The target tags for the zip archive element");
-  }
 
   /**
    * Sets the workspace to use.
@@ -353,16 +332,6 @@ public class ZipWorkflowOperationHandler extends AbstractWorkflowOperationHandle
 
     // Return the zip
     return zip;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#getConfigurationOptions()
-   */
-  @Override
-  public SortedMap<String, String> getConfigurationOptions() {
-    return configurationOptions;
   }
 
 }


### PR DESCRIPTION
This patch drops the configuration option maps for workflow operations
since they are not used anywhere. Even if someone wanted to use them,
that wouldn't really be an option since half of our operations do not
implement them (e.g. animate operation) and half of the rest have
implementation errors (e.g. http notify).