### PR TITLE
MH-13455, Opencast Plug-in Features

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -133,8 +133,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-static-file-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-ldap/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-moodle/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-sakai/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-user-interface-configuration/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-urlsigning-common/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-urlsigning-service-api/${project.version}</bundle>
@@ -753,5 +751,14 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-cas/${project.version}</bundle>
   </feature>
 
+  <feature name="opencast-moodle" version="${project.version}">
+    <feature start-level="80">opencast-core</feature>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-moodle/${project.version}</bundle>
+  </feature>
+
+  <feature name="opencast-sakai" version="${project.version}">
+    <feature start-level="80">opencast-core</feature>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-sakai/${project.version}</bundle>
+  </feature>
 
 </features>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -118,6 +118,8 @@
             <archiveTarGz>false</archiveTarGz>
             <installedFeatures>
               <feature>opencast-security-cas</feature>
+              <feature>opencast-moodle</feature>
+              <feature>opencast-sakai</feature>
             </installedFeatures>
           </configuration>
         </plugin>

--- a/docs/guides/admin/docs/configuration/security.user.moodle.md
+++ b/docs/guides/admin/docs/configuration/security.user.moodle.md
@@ -36,12 +36,12 @@ After the installation, a new user with the capabilities
 Then generate a new web service token and add that user to the "Opencast web
 service" service.
 
-### Step 0
+### Step 1
 
 Edit `etc/org.apache.karaf.features.cfg` and make sure the `opencast-moodle` feature is listed in the `featuresBoot`
 option.
 
-### Step 1
+### Step 2
 
 To enable the Moodle User Provider, copy and rename the bundled configuration
 template from
@@ -57,7 +57,7 @@ org.opencastproject.userdirectory.moodle.url=http://localhost/webservice/rest/se
 org.opencastproject.userdirectory.moodle.token=mytoken1234abcdef
 ```
 
-### Step 2
+### Step 3
 
 Verify that the Moodle User Provider starts up with the correct Moodle URL by looking
 for a log entry like this:
@@ -78,7 +78,7 @@ by adding an entry to `OPENCAST/etc/org.ops4j.pax.logging.cfg`:
 log4j.logger.org.opencastproject.userdirectory.moodle=DEBUG
 ```
 
-### Step 3
+### Step 4
 
 You can grant additional roles to all Moodle users in Opencast by creating a
 group with the name 'Moodle'. You can then add additional roles to this group,

--- a/docs/guides/admin/docs/configuration/security.user.moodle.md
+++ b/docs/guides/admin/docs/configuration/security.user.moodle.md
@@ -36,6 +36,11 @@ After the installation, a new user with the capabilities
 Then generate a new web service token and add that user to the "Opencast web
 service" service.
 
+### Step 0
+
+Edit `etc/org.apache.karaf.features.cfg` and make sure the `opencast-moodle` feature is listed in the `featuresBoot`
+option.
+
 ### Step 1
 
 To enable the Moodle User Provider, copy and rename the bundled configuration

--- a/docs/guides/admin/docs/configuration/security.user.sakai.md
+++ b/docs/guides/admin/docs/configuration/security.user.sakai.md
@@ -21,6 +21,11 @@ Series ACL to grant access to the Series to members of the `mysiteid` site in Sa
 The Sakai User Provider requires Sakai 11.0 or later, and an admin-equivalent
 account on the Sakai instance.
 
+### Step 0
+
+Edit `etc/org.apache.karaf.features.cfg` and make sure the `opencast-sakai` feature is listed in the `featuresBoot`
+option.
+
 ### Step 1
 
 To enable the Sakai User Provider, copy and rename the bundled configuration template from

--- a/docs/guides/admin/docs/configuration/security.user.sakai.md
+++ b/docs/guides/admin/docs/configuration/security.user.sakai.md
@@ -21,12 +21,12 @@ Series ACL to grant access to the Series to members of the `mysiteid` site in Sa
 The Sakai User Provider requires Sakai 11.0 or later, and an admin-equivalent
 account on the Sakai instance.
 
-### Step 0
+### Step 1
 
 Edit `etc/org.apache.karaf.features.cfg` and make sure the `opencast-sakai` feature is listed in the `featuresBoot`
 option.
 
-### Step 1
+### Step 2
 
 To enable the Sakai User Provider, copy and rename the bundled configuration template from
 `OPENCAST/etc/org.opencastproject.userdirectory.sakai-default.cfg.template` to
@@ -41,7 +41,7 @@ sakai.user=opencast
 sakai.password=CHANGE_ME
 ```
 
-### Step 2
+### Step 3
 
 Verify that the Sakai User Provider starts up with the correct Sakai URL by looking
 for a log entry like this:
@@ -61,11 +61,10 @@ adding an entry to `OPENCAST/etc/org.ops4j.pax.logging.cfg`:
 log4j.logger.org.opencastproject.userdirectory.sakai=DEBUG
 ```
 
-### Step 3
+### Step 4
 
 You can grant additional roles to all Sakai users in Opencast by creating a group
 with the title 'Sakai'. You can then add additional roles to this group, which will
 be inherited by all Sakai users.
 
 You can also use the group role name ROLE_GROUP_SAKAI in Event or Series ACLs.
-

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -20,6 +20,10 @@ New Features
 - Add Internationalization support for series LTI tools
 - Display responsible person for workflows
 - Allow the Ingest Service to make authenticated requests to other servers
+- Some modules are now plugins. These are not started by default to reduce the amount of code running unnecessarily.
+  They can easily be enabled in `etc/org.apache.karaf.features.cfg`. Modified modules are:
+    - Moodle user directory
+    - Sakai user directory
 
 Improvements
 ------------

--- a/etc/org.opencastproject.userdirectory.moodle-default.cfg.template
+++ b/etc/org.opencastproject.userdirectory.moodle-default.cfg.template
@@ -1,5 +1,8 @@
 # Moodle UserDirectoryProvider configuration
 
+# This is an an optional service which is not enabled by default. To enable it,
+# edit etc/org.apache.karaf.features.cfg and add opencast-moodle to the featuresBoot option.
+
 # The organization for this provider
 org.opencastproject.userdirectory.moodle.org=mh_default_org
 

--- a/etc/org.opencastproject.userdirectory.sakai-default.cfg.template
+++ b/etc/org.opencastproject.userdirectory.sakai-default.cfg.template
@@ -1,5 +1,8 @@
 # Sakai UserDirectoryProvider configuration
 
+# This is an an optional service which is not enabled by default. To enable it,
+# edit etc/org.apache.karaf.features.cfg and add opencast-sakai to the featuresBoot option.
+
 # The organization for this provider
 org.opencastproject.userdirectory.sakai.org=mh_default_org
 


### PR DESCRIPTION
This patch extracts some core features into separate Karaf features.
These features are installed by default, but not started by default.
This means that they can be easily enabled but will not launch
regardless of users needing those features or not.

The idea behind this is to extract modules used by just a few users to
minimize the code which is running by default, needing less resources,
booting up faster and also minimizing the risk for security
vulnerabilities.

This patch extracts the Moodle and Sakai user provider as an example.
More modules may follow.

Long-term, it may make sense to still boot all features in the
development distribution to ensure they are not easily broken without
someone noticing. That will be easier once KARAF-6207 is fixed:

- https://github.com/apache/karaf/pull/791