### PR TITLE
MH-13462, Prevent Being Started By Root

### DIFF
--- a/assemblies/dist-allinone/src/main/resources/bin/setenv
+++ b/assemblies/dist-allinone/src/main/resources/bin/setenv
@@ -37,3 +37,4 @@
 export EXTRA_JAVA_OPTS="-Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
 export JAVA_MAX_MEM=1G
 export JAVA_PERM_MEM=256M
+export KARAF_NOROOT=true

--- a/assemblies/dist-develop/src/main/resources/bin/setenv
+++ b/assemblies/dist-develop/src/main/resources/bin/setenv
@@ -37,3 +37,4 @@
 export EXTRA_JAVA_OPTS="-Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
 export JAVA_MAX_MEM=1G
 export JAVA_PERM_MEM=256M
+export KARAF_NOROOT=true

--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -35,3 +35,4 @@
 # export KARAF_REDIRECT    # Enable/set the std/err redirection when using bin/start
 
 export EXTRA_JAVA_OPTS="-Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
+export KARAF_NOROOT=true

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -36,7 +36,8 @@ A non-comprehensive list of improvements:
 Configuration changes
 ---------------------
 
-- …
+- `KARAF_NOROOT` is now set to `true` by default, preventing Opencast to be started as root user unless the
+  configuration is changed.
 
 API changes
 -----------


### PR DESCRIPTION
This patch changes the configuration to prevent Opencast from being
started by a root user unless the configuration is changed.

We have seen several times in the past that someone launched Opencast
manually as root user on e.g. a RPM or deb install, causing a number of
artifacts to be written with root privileges so that for later usage,
access rights for all these files needed to be modified again.