### PR TITLE
MH-13463 WOH select-streams does not hide audio track as expected

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -310,10 +310,15 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
           result.add(copyTrack(singleAudioTrack.track));
         }
 
-        // Just copy the rest of the tracks to ensure they got the correct output flavor
+        // Just copy the rest of the tracks and remove audio where necessary
         for (final AugmentedTrack augmentedTrack : augmentedTracks) {
           if (augmentedTrack.track != singleAudioTrack.track && augmentedTrack.track != forceTargetTrack.track) {
-            result.add(copyTrack(augmentedTrack.track));
+            if (augmentedTrack.hasAudio() && augmentedTrack.hide(SubTrack.AUDIO)) {
+              final TrackJobResult hideAudioResult = hideAudio(augmentedTrack.track, mediaPackage);
+              result.add(hideAudioResult);
+            } else {
+              result.add(copyTrack(augmentedTrack.track));
+            }
           }
         }
       } else {


### PR DESCRIPTION
Steps to reproduce:

Input: 2 tracks, both with audio and video
WOH select-streams with...
- "audio-muxing" set to "FORCE" 
- "force-target" set to "presenter"
- "hide_presentation_audio" set to true

Actual Results:
The resulting presentation track still has an audio stream although we asked WOH select-streams to remove it.
 
Expected Results:
The audio stream of the presentation track should have been removed
 
Workaround (if any):
Use other WOHs to conditionally remove the audio track from the presentation track.

