### PR TITLE
MH-12643, Allow workspace to read from asset manager

### DIFF
--- a/modules/asset-manager-util/pom.xml
+++ b/modules/asset-manager-util/pom.xml
@@ -62,64 +62,24 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <!--
-      - test
-      -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <!--
-      - Parameterized tests for JUnit
-      - https://github.com/Pragmatists/JUnitParams
-      -->
-    <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
-      <version>1.0.4</version>
-    </dependency>
-    <!-- logging -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <scope>test</scope>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
     </dependency>
   </dependencies>
   <build>
     <plugins>
-      <!--
-        - http://pitest.org/quickstart/maven/
-        - run with mvn org.pitest:pitest-maven:mutationCoverage
-        -->
       <plugin>
-        <groupId>org.pitest</groupId>
-        <artifactId>pitest-maven</artifactId>
-        <version>1.1.5</version>
-        <configuration>
-          <targetClasses>
-            <param>org.opencastproject.assetmanager.util*</param>
-          </targetClasses>
-          <targetTests>
-            <param>org.opencastproject.assetmanager.util*Test</param>
-          </targetTests>
-        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/AssetPathUtils.java
+++ b/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/AssetPathUtils.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.assetmanager.util;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Paths;
+
+/**
+ *
+ */
+public final class AssetPathUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(AssetPathUtils.class);
+
+  /** Key defining the asset manager root directory */
+  private static final String CONFIG_ASSET_MANAGER_ROOT = "org.opencastproject.episode.rootdir";
+
+  /** Key defining the main storage directory */
+  private static final String CONFIG_STORAGE_DIR = "org.opencastproject.storage.dir";
+
+  private AssetPathUtils() {
+  }
+
+  /**
+   * Get the local mount point of the asset manager if it exists.
+   *
+   * @param componentContext
+   *        The OSGI component context
+   * @return Path to the local asset manager directory if it exists
+   */
+  public static String getAssetManagerPath(final ComponentContext componentContext) {
+    if (componentContext == null || componentContext.getBundleContext() == null) {
+      return null;
+    }
+    final BundleContext bundleContext = componentContext.getBundleContext();
+
+    String assetManagerDir = StringUtils.trimToNull(bundleContext.getProperty(CONFIG_ASSET_MANAGER_ROOT));
+    if (assetManagerDir == null) {
+      assetManagerDir = StringUtils.trimToNull(bundleContext.getProperty(CONFIG_STORAGE_DIR));
+      if (assetManagerDir != null) {
+        assetManagerDir = new File(assetManagerDir, "archive").getAbsolutePath();
+      }
+    }
+
+    // Is the asset manager available locally?
+    if (assetManagerDir != null && new File(assetManagerDir).isDirectory()) {
+      logger.debug("Found local asset manager directory at {}", assetManagerDir);
+      return assetManagerDir;
+    }
+
+    return null;
+  }
+
+  /**
+   * Splits up an asset manager URI and returns a local path instead.
+   *
+   * @param localPath
+   *          Path to the local asset manager directory
+   * @param organizationId
+   *          Organization identifier
+   * @param uri
+   *          URI to the asset
+   * @return Local file
+   */
+  public static File getLocalFile(final String localPath, final String organizationId, final URI uri) {
+    if (localPath == null
+            || organizationId == null
+            || !uri.getScheme().startsWith("http")
+            || !uri.getPath().startsWith("/assets/assets/")) {
+      return null;
+    }
+
+    final String[] assetPath = uri.getPath().split("/");
+    // /assets/assets/{mediaPackageID}/{mediaPackageElementID}/{version}/{filenameIgnore}
+    if (assetPath.length != 7) {
+      return null;
+    }
+
+    final String mediaPackageID = assetPath[3];
+    final String mediaPackageElementID = assetPath[4];
+    final String version = assetPath[5];
+    final String filename = mediaPackageElementID + '.' + FilenameUtils.getExtension(assetPath[6]);
+    final File file = Paths.get(localPath, organizationId, mediaPackageID, version, filename).toFile();
+    if (file.isFile()) {
+      logger.debug("Converted {} to local file at {}", uri, file);
+      return file;
+    }
+    logger.debug("Local file for {} not available. {} does not exist.", uri, file);
+    return null;
+  }
+
+}

--- a/modules/workspace-impl/pom.xml
+++ b/modules/workspace-impl/pom.xml
@@ -31,6 +31,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-asset-manager-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -36,7 +36,9 @@ import static org.opencastproject.util.data.Option.some;
 import static org.opencastproject.util.data.Prelude.sleep;
 import static org.opencastproject.util.data.Tuple.tuple;
 
+import org.opencastproject.assetmanager.util.AssetPathUtils;
 import org.opencastproject.mediapackage.identifier.Id;
+import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.util.FileSupport;
 import org.opencastproject.util.HttpUtil;
@@ -77,6 +79,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -129,6 +133,8 @@ public final class WorkspaceImpl implements Workspace {
 
   private TrustedHttpClient trustedHttpClient;
 
+  private SecurityService securityService = null;
+
   /** The working file repository */
   private WorkingFileRepository wfr = null;
 
@@ -138,6 +144,9 @@ public final class WorkspaceImpl implements Workspace {
   private CopyOnWriteArraySet<String> staticCollections = new CopyOnWriteArraySet<String>();
 
   private boolean waitForResourceFlag = false;
+
+  /** the asset manager directory if locally available */
+  private String assetManagerPath = null;
 
   /** The workspce cleaner */
   private WorkspaceCleaner workspaceCleaner = null;
@@ -214,7 +223,7 @@ public final class WorkspaceImpl implements Workspace {
       }
 
       // Create a unique target file
-      File targetFile = null;
+      File targetFile;
       try {
         targetFile = File.createTempFile(".linktest.", ".tmp", new File(wsRoot));
         targetFile.delete();
@@ -286,6 +295,8 @@ public final class WorkspaceImpl implements Workspace {
     staticCollections.add("videosegments");
     staticCollections.add("waveform");
 
+    // Check if we can read from the asset manager locally to avoid downloading files via HTTP
+    assetManagerPath = AssetPathUtils.getAssetManagerPath(cc);
   }
 
   /** Callback from OSGi on service deactivation. */
@@ -335,6 +346,15 @@ public final class WorkspaceImpl implements Workspace {
         }
       }
     }
+
+    // Check if we can get the files directly from the asset manager
+    final File asset = AssetPathUtils.getLocalFile(assetManagerPath, securityService.getOrganization().getId(), uri);
+    if (asset != null) {
+      logger.debug("Copy local file {} from asset manager to workspace", asset);
+      Files.copy(asset.toPath(), inWs.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return new File(inWs.getAbsolutePath());
+    }
+
     // do HTTP transfer
     return locked(inWs, downloadIfNecessary(uri));
   }
@@ -342,6 +362,7 @@ public final class WorkspaceImpl implements Workspace {
   @Override
   public InputStream read(final URI uri) throws NotFoundException, IOException {
 
+    // Check if we can get the file from the working file repository directly
     if (pathMappable != null) {
       if (uri.toString().startsWith(pathMappable.getUrlPrefix())) {
         final String localPath = uri.toString().substring(pathMappable.getUrlPrefix().length());
@@ -354,6 +375,12 @@ public final class WorkspaceImpl implements Workspace {
         }
         logger.warn("The working file repository URI and paths don't match. Looking up {} at {} failed", uri, wfrCopy);
       }
+    }
+
+    // Check if we can get the files directly from the asset manager
+    final File asset = AssetPathUtils.getLocalFile(assetManagerPath, securityService.getOrganization().getId(), uri);
+    if (asset != null) {
+      return new FileInputStream(asset);
     }
 
     // fall back to get() which should download the file into local workspace if necessary
@@ -858,6 +885,10 @@ public final class WorkspaceImpl implements Workspace {
 
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     this.trustedHttpClient = trustedHttpClient;
+  }
+
+  public void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
   }
 
   private static final long TIMEOUT = 2L * 60L * 1000L;

--- a/modules/workspace-impl/src/main/resources/OSGI-INF/workspace.xml
+++ b/modules/workspace-impl/src/main/resources/OSGI-INF/workspace.xml
@@ -8,7 +8,9 @@
     <provide interface="org.opencastproject.workspace.api.Workspace"/>
   </service>
   <reference name="REPO" interface="org.opencastproject.workingfilerepository.api.WorkingFileRepository"
-             cardinality="1..1" policy="static" bind="setRepository"/>
+             bind="setRepository" />
   <reference name="trustedHttpClient" interface="org.opencastproject.security.api.TrustedHttpClient"
-             cardinality="1..1" policy="static" bind="setTrustedHttpClient"/>
+             bind="setTrustedHttpClient" />
+  <reference name="securityService" interface="org.opencastproject.security.api.SecurityService"
+             bind="setSecurityService" />
 </scr:component>

--- a/modules/workspace-impl/src/test/java/org/opencastproject/workspace/impl/WorkspaceImplTest.java
+++ b/modules/workspace-impl/src/test/java/org/opencastproject/workspace/impl/WorkspaceImplTest.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.workspace.impl;
 
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.TrustedHttpClient.RequestRunner;
 import org.opencastproject.security.util.StandAloneTrustedHttpClientImpl;
@@ -89,6 +91,13 @@ public class WorkspaceImplTest {
     File source = new File(
             "target/test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/../test-classes/opencast_header.gif");
     URL urlToSource = source.toURI().toURL();
+
+    Organization organization = EasyMock.createMock(Organization.class);
+    EasyMock.expect(organization.getId()).andReturn("org1").anyTimes();
+    SecurityService securityService = EasyMock.createMock(SecurityService.class);
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization).anyTimes();
+    EasyMock.replay(securityService, organization);
+    workspace.setSecurityService(securityService);
 
     final TrustedHttpClient httpClient = EasyMock.createNiceMock(TrustedHttpClient.class);
     HttpEntity entity = EasyMock.createNiceMock(HttpEntity.class);
@@ -239,6 +248,13 @@ public class WorkspaceImplTest {
     EasyMock.expect(repo.getBaseUri()).andReturn(new URI("http://localhost:8080/files")).anyTimes();
     EasyMock.replay(repo);
     workspace.setRepository(repo);
+
+    Organization organization = EasyMock.createMock(Organization.class);
+    EasyMock.expect(organization.getId()).andReturn("org1").anyTimes();
+    SecurityService securityService = EasyMock.createMock(SecurityService.class);
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization).anyTimes();
+    EasyMock.replay(securityService, organization);
+    workspace.setSecurityService(securityService);
 
     RequestRunner<Either<String, Option<File>>> requestRunner = f -> {
       Either<String, Option<File>> right = Either.right(Option.some(expectedFile));


### PR DESCRIPTION
The workspace will get all files from the asset manager via HTTP, even
if the files are accessible as local files. While this will ensure the
data's integrity as no one is able to accidentally write to files in the
asset manager, this protection is unnecessary for a read-only access.

Additional to the slow HTTP download, the current mechanism also
generates a lot more network trafic since all archived files are first
transferred from the storage server to the admin node (which basically
acts as proxy) and then transferred to the workspace (potentially on
another server).

This means that, for example, if a worker requests a media file, it is
transferred twice over the network interface of the admin node,
transforming it into a bottleneck for performance.

This patch now tests if the asset manager storage is accessible via
filesystem and if it is, will try to read files from there directly. If
it fails to access the file, it will still fall back to the old method
downloading the files.

This means that if e.g. the asset manager is not mounted on a worker,
everything will still work the same way it does right now.

Note that this patch makes the workspace access assets directly via the
file system and it is not necessary to have the asset manager running on
the same node (only the asset manager utils which are on all nodes
anyway). This means, that this will work on worker or presentation nodes
without modifications to what is running there.

Also note that the protection against modification of arcgived data
still holds since no general access is granted to the asset manager's
storage system.

---

This patch is an updated version of pull request #38 which was declined
back then for the reason of the workspace getting asset manager specific
code. This is what has changed since then:

- Those who were complaining back then (and many more) are now *actively
  using the old patch in production* ;-)
- Most asset manager specific code (e.g. resolving the asset manager
  URLs) has been moved into the asset manager utils which are readily
  available on all node types.
- Additional to directly reading files for `workspace::read` requests,
  files for `workspace::get` are copied löcally if possible to avoid
  tunneling all traffic through the admin node.