### PR TITLE
extend the ingest-download-woh

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/ingestdownload-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/ingestdownload-woh.md
@@ -8,14 +8,19 @@ working file repository URI.
 
 In case of having external element URI's showing to a different Opencast working file repository, it's also possible to
 delete them after downloading it by activating the "delete-external" option.
+Additionally the "source-flavors" and "source-tags" option can be used to specifiy exactly, which external URI's should
+be downloaded.
 
 This operation is originally implemented to get rid of remaining files on ingest working file repositories.
 
 ## Parameter Table
 
-|configuration keys|example|description|default value|
-|------------------|-------|-----------|-------------|
-|delete-external|"true"|Whether to try to delete external working file repository URIs.|FALSE|
+| configuration keys | example              | description                                                                         | default value   |
+|--------------------|----------------------|-------------------------------------------------------------------------------------|-----------------|
+| delete-external    | "true"               | Whether to try to delete external working file repository URIs.                     | FALSE           |
+| source-flavors     | "dublincore/episode" | List of flavors (seperated by comma), elements matching a flavor will be downloaded | "\*/\*"         |
+| source-tags        | "archive"            | List of tags (seperated by comma), elements matching a tag will be downloaded       | "" (empty list) |
+| tags-and-flavors   | "true"               | Whether both, a tag and a flavor, must match or if one is sufficient                | FALSE           |
 
 ## Operation Example
 
@@ -25,5 +30,8 @@ This operation is originally implemented to get rid of remaining files on ingest
       description="Downloads external artifacts to the working file repository">
       <configurations>
         <configuration key="delete-external">true</configuration>
+        <configuration key="source-flavors">dublincore/episode</configuration>
+        <configuration key="source-tags">archive</configuration>
+        <configuration key="tags-and-flavors">true</configuration>
       </configurations>
     </operation>


### PR DESCRIPTION
This extends the ingest-download-woh with the possibility to select elements by flavor and tag.
Three new configuration options are added:

- `source-flavors`: List of flavors, elements matching a flavor will be downloaded
- `source-tags`: List of tags, elements matching a tag will be downloaded
- `tags-and-flavors`: Whether both, a tag and a flavor, must match or if one is sufficient