### PR TITLE
MH-13467: opencast-security-cas feature can not be started

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -742,7 +742,8 @@
     <bundle start-level="85">mvn:org.opencastproject/opencast-migration/${project.version}</bundle>
   </feature>
 
-  <feature name="opencast-security-cas" version="${project.version}">
+  <feature name="opencast-security-cas" version="${project.version}">  
+    <bundle start-level="82">mvn:commons-collections/commons-collections/3.2.1</bundle>
     <bundle start-level="82">mvn:org.apache.velocity/velocity/1.7</bundle>
     <bundle start-level="82">mvn:org.apache.santuario/xmlsec/2.1.2</bundle>
     <bundle start-level="82">mvn:org.bouncycastle/bcprov-jdk15on/1.51</bundle>


### PR DESCRIPTION
There is a dependency problem. 
The`opencast-security-cas` feature need the bundle `mvn:commons-collections/commons-collections/3.2.1`