### PR TITLE
MH-13466, Prevent Capture Agents From Modifying Metadata

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -36,6 +36,10 @@ Configuration changes
 - `KARAF_NOROOT` is now set to `true` by default, preventing Opencast to be started as root user unless the
   configuration is changed.
 - The default configuration for the Paella player has been moved to `etc/ui-config/mh_default_org/paella/config.json`
+- By default, metadata catalogs and attachments sent by capture agents are discarded since this data is usually
+  controlled by Opencast and the routing through capture agents which existed for historical reasons was just an
+  additional source for errors. If you rely on the old behavior, it can be configured in
+  `etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg`.
 
 API changes
 -----------

--- a/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
+++ b/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
@@ -10,6 +10,20 @@
 
 org.opencastproject.series.overwrite=false
 
+# Control if catalogs sent by capture agents for scheduled events are skipped. Not skipping them means that they will
+# potentially overwrite existing metadata catalogs in Opencast.
+#
+# Default: true
+#
+#skip.catalogs.for.existing.events=true
+
+# Control if attachments sent by capture agents for scheduled events are skipped. Not skipping them means that they will
+# potentially overwrite existing attachments in Opencast.
+#
+# Default: true
+#
+#skip.attachments.for.existing.events=true
+
 # The approximate load placed on the system by ingesting a file
 # Since these jobs are *not* dispatched there is no current way to limit the simultaneous number of ingests, but these jobs will block further jobs from running on an already busy admin node
 # These jobs involve heavy I/O, so we want them to be expensive, but not cripplingly so

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -1393,25 +1393,29 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     // Merge media package fields
     if (mp.getDate() == null)
       mp.setDate(scheduledMp.getDate());
-    if (isBlank(mp.getLicense()))
+
+    if (skipCatalogs || isBlank(mp.getLicense()))
       mp.setLicense(scheduledMp.getLicense());
-    if (isBlank(mp.getSeries()))
+    if (skipCatalogs || isBlank(mp.getSeries()))
       mp.setSeries(scheduledMp.getSeries());
-    if (isBlank(mp.getSeriesTitle()))
+    if (skipCatalogs || isBlank(mp.getSeriesTitle()))
       mp.setSeriesTitle(scheduledMp.getSeriesTitle());
-    if (isBlank(mp.getTitle()))
+    if (skipCatalogs || isBlank(mp.getTitle()))
       mp.setTitle(scheduledMp.getTitle());
-    if (mp.getSubjects().length == 0) {
+    if (skipCatalogs || mp.getSubjects().length == 0) {
+      Arrays.stream(mp.getSubjects()).forEach(mp::removeSubject);
       for (String subject : scheduledMp.getSubjects()) {
         mp.addSubject(subject);
       }
     }
-    if (mp.getContributors().length == 0) {
+    if (skipCatalogs || mp.getContributors().length == 0) {
+      Arrays.stream(mp.getContributors()).forEach(mp::removeContributor);
       for (String contributor : scheduledMp.getContributors()) {
         mp.addContributor(contributor);
       }
     }
-    if (mp.getCreators().length == 0) {
+    if (skipCatalogs || mp.getCreators().length == 0) {
+      Arrays.stream(mp.getCreators()).forEach(mp::removeCreator);
       for (String creator : scheduledMp.getCreators()) {
         mp.addCreator(creator);
       }


### PR DESCRIPTION
Capture agents usually do not need to handle metadata at all but for
historical reasons, all capture agent data take precedence over
Opencast's data. This has shown to be troublesome as agents have broken
data for several reasons in the past.

This patch introduces two options causing the ingest service to discard
metadata catalogs and/or attachments sent by capture agents for
scheduled events, using the metadata available in Opencast instead.

The default is to discard the capture agent metadata.