### PR TITLE
MH-13471, Shibboleth SSO plugin to add roles for users on OC according to their EDUPERSONAFFILIATION. eg: "ROLE_AAI_USER_AFFILIATION_student" for "student"

### DIFF
--- a/etc/org.opencastproject.security.aai.ConfigurableLoginHandler.cfg
+++ b/etc/org.opencastproject.security.aai.ConfigurableLoginHandler.cfg
@@ -27,6 +27,9 @@
 #header.home_organization = homeOrganization
 
 # Optional header to extract the affiliation
+# Note: Only if "header.affiliation" is uncommented and set to the correct Shibboleth header value, then
+# the corresponding roles will be added for each user with "role.affiliation.prefix" value prefix.
+# Default: none
 #header.affiliation = EDUPERSONAFFILIATION
 
 # Roles assigned to Shibboleth authenticated users

--- a/etc/org.opencastproject.security.aai.ConfigurableLoginHandler.cfg
+++ b/etc/org.opencastproject.security.aai.ConfigurableLoginHandler.cfg
@@ -26,6 +26,9 @@
 # Optional header to extract the home organization from
 #header.home_organization = homeOrganization
 
+# Optional header to extract the affiliation
+#header.affiliation = EDUPERSONAFFILIATION
+
 # Roles assigned to Shibboleth authenticated users
 
 # Based on information from the HTTP request headers, the configurable AAI login handler
@@ -50,4 +53,8 @@
 # Federation membership role name
 # Default: ROLE_AAI_USER
 #role.federation = ROLE_AAI_USER
+
+# Role prefix for affiliation
+# Default: ROLE_AAI_USER_AFFILIATION_
+#role.affiliation.prefix = ROLE_AAI_USER_AFFILIATION_
 

--- a/etc/org.opencastproject.security.aai.ConfigurableLoginHandler.cfg
+++ b/etc/org.opencastproject.security.aai.ConfigurableLoginHandler.cfg
@@ -32,11 +32,12 @@
 # Roles assigned to Shibboleth authenticated users
 
 # Based on information from the HTTP request headers, the configurable AAI login handler
-# assigns three basic roles to authenticated users:
+# assigns these basic roles to authenticated users:
 #
 # 1. The user role unique for each user
 # 2. The organization membership role indicating the home organization a user belongs to
 # 3. The federation membership role indicating a Shibboleth authenticated user
+# 4. The affiliation role based on the Shibboleth affiliation
 
 # User role prefix
 # Default: ROLE_AAI_USER_

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -273,7 +273,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
       logger.warn("Optional header '{}' is not configured ", CFG_HEADER_HOME_ORGANIZATION_KEY);
     }
 	
-	String cfgAffiliation = StringUtils.trimToNull((String) properties.get(CFG_HEADER_AFFILIATION_KEY));
+    String cfgAffiliation = StringUtils.trimToNull((String) properties.get(CFG_HEADER_AFFILIATION_KEY));
     if (cfgAffiliation != null) {
       headerAffiliation = cfgAffiliation;
       logger.info("Header '{}' set to '{}'", CFG_HEADER_AFFILIATION_KEY, headerAffiliation);
@@ -328,7 +328,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
               CFG_ROLE_ORGANIZATION_SUFFIX_KEY, roleOrganizationSuffix);
     }
 	
-	String cfgRoleAffiliationPrefix = StringUtils.trimToNull((String) properties.get(
+    String cfgRoleAffiliationPrefix = StringUtils.trimToNull((String) properties.get(
             CFG_ROLE_AFFILIATION_PREFIX_KEY));
     if (cfgRoleAffiliationPrefix != null) {
       roleAffiliationPrefix = cfgRoleAffiliationPrefix;
@@ -465,11 +465,11 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
     if (StringUtils.equals(id, bootstrapUserId)) {
       roles.add(new JpaRole(GLOBAL_ADMIN_ROLE, organization));
     }
-	if (headerAffiliation != null) {
+    if (headerAffiliation != null) {
       String affiliation = request.getHeader(headerAffiliation);
-	  List<String> affiliations = Arrays.asList(affiliation.split(";"));
-	  for (String eachAffiliation : affiliations) {
-		roles.add(new JpaRole(roleAffiliationPrefix + eachAffiliation, organization));
+      List<String> affiliations = Arrays.asList(affiliation.split(";"));
+      for (String eachAffiliation : affiliations) {
+        roles.add(new JpaRole(roleAffiliationPrefix + eachAffiliation, organization));
       }
     }
 	

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -468,8 +468,8 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 	if (headerAffiliation != null) {
       String affiliation = request.getHeader(headerAffiliation);
 	  List<String> affiliations = Arrays.asList(affiliation.split(";"));
-	  for (String var : affiliations) {
-		roles.add(new JpaRole(roleAffiliationPrefix + var, organization));
+	  for (String affiliation : affiliations) {
+		roles.add(new JpaRole(roleAffiliationPrefix + affiliation, organization));
       }
     }
 	

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -52,6 +52,7 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.regex.Pattern;
 

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -468,8 +468,8 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 	if (headerAffiliation != null) {
       String affiliation = request.getHeader(headerAffiliation);
 	  List<String> affiliations = Arrays.asList(affiliation.split(";"));
-	  for (String affiliation : affiliations) {
-		roles.add(new JpaRole(roleAffiliationPrefix + affiliation, organization));
+	  for (String eachAffiliation : affiliations) {
+		roles.add(new JpaRole(roleAffiliationPrefix + eachAffiliation, organization));
       }
     }
 	

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -467,9 +467,11 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
     }
     if (headerAffiliation != null) {
       String affiliation = request.getHeader(headerAffiliation);
-      List<String> affiliations = Arrays.asList(affiliation.split(";"));
-      for (String eachAffiliation : affiliations) {
-        roles.add(new JpaRole(roleAffiliationPrefix + eachAffiliation, organization));
+      if (affiliation != null) {
+        List<String> affiliations = Arrays.asList(affiliation.split(";"));
+        for (String eachAffiliation : affiliations) {
+          roles.add(new JpaRole(roleAffiliationPrefix + eachAffiliation, organization));
+        }
       }
     }
 	

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -92,6 +92,10 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 
   /** Name of the optional configuration property specifying a list of home organizations */
   private static final String CFG_HEADER_HOME_ORGANIZATION_KEY = "header.home_organization";
+  
+  /** Name of the optional configuration property specifying the name of the HTTP request header where affiliations
+      can be extracted */
+  private static final String CFG_HEADER_AFFILIATION_KEY = "header.affiliation";
 
   /** Shibboleth roles configuration */
 
@@ -125,6 +129,15 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 
   /** Default value of the configuration property CFG_ROLE_FEDERATION_KEY */
   private static final String CFG_ROLE_FEDERATION_DEFAULT = "ROLE_AAI_USER";
+  
+  /**
+   * Name of the configuration property that specifies the prefix of the affiliation role for Shibboleth
+   * authenticated users. The role will be of the form ROLE_AFFILIATION_PREFIX + SHIBBOLETH_EDUPERSONAFFILIATION
+   */
+  private static final String CFG_ROLE_AFFILIATION_PREFIX_KEY = "role.affiliation.prefix";
+
+  /** Default value of configuration property CFG_ROLE_USER_PREFIX_KEY */
+  private static final String CFG_ROLE_AFFILIATION_PREFIX_DEFAULT = "ROLE_AAI_USER_AFFILIATION_";
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ConfigurableLoginHandler.class);
@@ -152,6 +165,9 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 
   /** Header to extract the home organization */
   private String headerHomeOrganization = null;
+  
+  /** Header to extract the affiliation */
+  private String headerAffiliation = null;
 
   /** Role assigned to all Shibboleth authenticated users */
   private String roleFederationMember = CFG_ROLE_FEDERATION_DEFAULT;
@@ -164,6 +180,9 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 
   /** Suffix of the home organization membership role */
   private String roleOrganizationSuffix = CFG_ROLE_ORGANIZATION_SUFFIX_DEFAULT;
+  
+  /** Prefix of the affiliation role */
+  private String roleAffiliationPrefix = CFG_ROLE_AFFILIATION_PREFIX_DEFAULT;
 
   /*
    * It is the bundle kernel what will need to instantiate the ConfigurableLoginHandler
@@ -252,6 +271,14 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
     } else {
       logger.warn("Optional header '{}' is not configured ", CFG_HEADER_HOME_ORGANIZATION_KEY);
     }
+	
+	String cfgAffiliation = StringUtils.trimToNull((String) properties.get(CFG_HEADER_AFFILIATION_KEY));
+    if (cfgAffiliation != null) {
+      headerAffiliation = cfgAffiliation;
+      logger.info("Header '{}' set to '{}'", CFG_HEADER_AFFILIATION_KEY, headerAffiliation);
+    } else {
+      logger.warn("Optional header '{}' is not configured ", CFG_HEADER_AFFILIATION_KEY);
+    }
 
     /* Shibboleth roles configuration */
 
@@ -298,6 +325,18 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
       roleOrganizationSuffix = CFG_ROLE_ORGANIZATION_SUFFIX_DEFAULT;
       logger.info("AAI organization membership role suffix '{}' is not configured, using default '{}'",
               CFG_ROLE_ORGANIZATION_SUFFIX_KEY, roleOrganizationSuffix);
+    }
+	
+	String cfgRoleAffiliationPrefix = StringUtils.trimToNull((String) properties.get(
+            CFG_ROLE_AFFILIATION_PREFIX_KEY));
+    if (cfgRoleAffiliationPrefix != null) {
+      roleAffiliationPrefix = cfgRoleAffiliationPrefix;
+      logger.info("AAI affiliation role prefix '{}' set to '{}'", CFG_ROLE_AFFILIATION_PREFIX_KEY,
+              cfgRoleAffiliationPrefix);
+    } else {
+      roleAffiliationPrefix = CFG_ROLE_AFFILIATION_PREFIX_DEFAULT;
+      logger.info("AAI affiliation role prefix '{}' is not configured, using default '{}'",
+              CFG_ROLE_AFFILIATION_PREFIX_KEY, roleAffiliationPrefix);
     }
   }
 
@@ -425,6 +464,14 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
     if (StringUtils.equals(id, bootstrapUserId)) {
       roles.add(new JpaRole(GLOBAL_ADMIN_ROLE, organization));
     }
+	if (headerAffiliation != null) {
+      String affiliation = request.getHeader(headerAffiliation);
+	  List<String> affiliations = Arrays.asList(affiliation.split(";"));
+	  for (String var : affiliations) {
+		roles.add(new JpaRole(roleAffiliationPrefix + var, organization));
+      }
+    }
+	
     return roles;
   }
 

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
@@ -52,7 +53,6 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Arrays;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -93,7 +93,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 
   /** Name of the optional configuration property specifying a list of home organizations */
   private static final String CFG_HEADER_HOME_ORGANIZATION_KEY = "header.home_organization";
-  
+
   /** Name of the optional configuration property specifying the name of the HTTP request header where affiliations
       can be extracted */
   private static final String CFG_HEADER_AFFILIATION_KEY = "header.affiliation";
@@ -130,7 +130,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 
   /** Default value of the configuration property CFG_ROLE_FEDERATION_KEY */
   private static final String CFG_ROLE_FEDERATION_DEFAULT = "ROLE_AAI_USER";
-  
+
   /**
    * Name of the configuration property that specifies the prefix of the affiliation role for Shibboleth
    * authenticated users. The role will be of the form ROLE_AFFILIATION_PREFIX + SHIBBOLETH_EDUPERSONAFFILIATION
@@ -166,7 +166,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 
   /** Header to extract the home organization */
   private String headerHomeOrganization = null;
-  
+
   /** Header to extract the affiliation */
   private String headerAffiliation = null;
 
@@ -181,7 +181,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
 
   /** Suffix of the home organization membership role */
   private String roleOrganizationSuffix = CFG_ROLE_ORGANIZATION_SUFFIX_DEFAULT;
-  
+
   /** Prefix of the affiliation role */
   private String roleAffiliationPrefix = CFG_ROLE_AFFILIATION_PREFIX_DEFAULT;
 
@@ -272,7 +272,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
     } else {
       logger.warn("Optional header '{}' is not configured ", CFG_HEADER_HOME_ORGANIZATION_KEY);
     }
-	
+
     String cfgAffiliation = StringUtils.trimToNull((String) properties.get(CFG_HEADER_AFFILIATION_KEY));
     if (cfgAffiliation != null) {
       headerAffiliation = cfgAffiliation;
@@ -327,7 +327,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
       logger.info("AAI organization membership role suffix '{}' is not configured, using default '{}'",
               CFG_ROLE_ORGANIZATION_SUFFIX_KEY, roleOrganizationSuffix);
     }
-	
+
     String cfgRoleAffiliationPrefix = StringUtils.trimToNull((String) properties.get(
             CFG_ROLE_AFFILIATION_PREFIX_KEY));
     if (cfgRoleAffiliationPrefix != null) {
@@ -474,7 +474,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
         }
       }
     }
-	
+
     return roles;
   }
 


### PR DESCRIPTION


Shibboleth SSO plugin to add roles for users on OC according to their EDUPERSONAFFILIATION.

Example 1: if Alice as EDUPERSONAFFILIATION has "student;" value then "ROLE_AAI_USER_AFFILIATION_student" will be added to OC for Alice.

Example 2: if Bob as EDUPERSONAFFILIATION has "student;member;staff;alum" value then
"ROLE_AAI_USER_AFFILIATION_student"
"ROLE_AAI_USER_AFFILIATION_member"
"ROLE_AAI_USER_AFFILIATION_staff"
"ROLE_AAI_USER_AFFILIATION_alum" roles will be added to OC for Bob.

Developed for the following initial ticket: https://opencast.jira.com/browse/MH-13223
