### PR TITLE
MH-13209, Add CAS Feature to Opencast's Core

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -146,6 +146,8 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-working-file-repository-service-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-workspace-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-workspace-impl/${project.version}</bundle>
+
+    <feature start-level="80">opencast-security-cas</feature>
   </feature>
 
   <feature name="opencast-allinone" version="${project.version}">
@@ -742,7 +744,7 @@
     <bundle start-level="85">mvn:org.opencastproject/opencast-migration/${project.version}</bundle>
   </feature>
 
-  <feature name="opencast-security-cas" version="${project.version}">  
+  <feature name="opencast-security-cas" version="${project.version}">
     <bundle start-level="82">mvn:commons-collections/commons-collections/3.2.1</bundle>
     <bundle start-level="82">mvn:org.apache.velocity/velocity/1.7</bundle>
     <bundle start-level="82">mvn:org.apache.santuario/xmlsec/2.1.2</bundle>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -116,9 +116,6 @@
             </libraries>
             <archiveZip>false</archiveZip>
             <archiveTarGz>false</archiveTarGz>
-            <installedFeatures>
-              <feature>opencast-security-cas</feature>
-            </installedFeatures>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This is an alternative to pull request #795.

The discussion on pull request #795 is about wanting to put all optional
features/modules into the Opencast core. Pull request #543 was declined
for exactly the reason that we wouldn't want to do that. If we decide to
do this way after all, we should also accept the old pull request.

This patch reverts pull request #544 and applies the previously declined
pull request #543 instead. The pull request adds all of the CAS modules
to Opencast's core feature, always starting those modules with Opencast,
regardless of users needing the feature or not.

This change has the advantage of making the feature slightly easier to
configure as well as better tested since problems with those features
will affect all installations.