### PR TITLE
MH-13474  Change the default composer job load from 0.8 to 1.5

### DIFF
--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfileImpl.java
@@ -85,7 +85,7 @@ public class EncodingProfileImpl implements EncodingProfile {
   protected HashMap<String,String> suffixes = new HashMap<String, String>();
 
   @XmlElement(name = "jobLoad")
-  protected Float jobLoad = 0.8f;
+  protected Float jobLoad = 1.5f;
 
   /**
    * Private, since the profile should be created using the static factory method.


### PR DESCRIPTION
Based on production experience, the default composer job load of 0.8 is too low.
