### PR TITLE
MH-13476 Filter capture agent roles for ACLs

### DIFF
--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
@@ -121,6 +121,11 @@ public class CaptureAgentAdminRoleProviderImpl implements RoleProvider, CaptureA
       throw new IllegalArgumentException("Query must be set");
     }
 
+    // These roles are not meaningful for use in ACLs
+    if (target == Role.Target.ACL) {
+      return Collections.emptyIterator();
+    }
+
     Stream<Role> skip = getRolesStream()
             .filter(e -> like(e.getName(), query) || like(e.getDescription(), query))
             .skip(offset);


### PR DESCRIPTION
ROLE_CAPTURE_AGENT_* roles are intended to provide access to CA scheduling, and not for event and series ACLs. 

They should therefore not be returned by findRoles() called with a target of ACL. This affects how the Admin UI offers roles for event and series ACLs (well, the event ACL is not doing this properly at present which is a regression, but the series ACL is).
