### PR TITLE
MH-13381, Use Username In Workflows

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/JobEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/JobEndpoint.java
@@ -39,6 +39,7 @@ import org.opencastproject.matterhorn.search.SearchQuery;
 import org.opencastproject.matterhorn.search.SortCriterion;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.serviceregistry.api.IncidentL10n;
 import org.opencastproject.serviceregistry.api.IncidentService;
 import org.opencastproject.serviceregistry.api.IncidentServiceException;
@@ -123,6 +124,7 @@ public class JobEndpoint {
   private WorkflowService workflowService;
   private ServiceRegistry serviceRegistry;
   private IncidentService incidentService;
+  private UserDirectoryService userDirectoryService;
 
   /** OSGi callback for the workflow service. */
   public void setWorkflowService(WorkflowService workflowService) {
@@ -137,6 +139,10 @@ public class JobEndpoint {
   /** OSGi callback for the incident service. */
   public void setIncidentService(IncidentService incidentService) {
     this.incidentService = incidentService;
+  }
+
+  public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
+    this.userDirectoryService = userDirectoryService;
   }
 
   protected void activate(BundleContext bundleContext) {
@@ -411,11 +417,7 @@ public class JobEndpoint {
                 instanceId, e), e.getCause());
       }
 
-      String creatorName = null;
-      User creator = instance.getCreator();
-      if (creator != null) {
-        creatorName = creator.getName();
-      }
+      final String creatorName = instance.getCreatorName();
 
       jsonList.add(obj(f("id", v(instanceId)), f("title", v(instance.getTitle(), Jsons.BLANK)),
               f("status", v(WORKFLOW_STATUS_TRANSLATION_PREFIX + instance.getState().toString())),
@@ -423,9 +425,8 @@ public class JobEndpoint {
               f("submitter", v(creatorName, Jsons.BLANK))));
     }
 
-    JObject json = obj(f("results", arr(jsonList)), f("count", v(workflowInstances.getTotalCount())),
+    return obj(f("results", arr(jsonList)), f("count", v(workflowInstances.getTotalCount())),
             f("offset", v(query.getStartPage())), f("limit", v(jsonList.size())), f("total", v(totalWithoutFilters)));
-    return json;
   }
 
   /**
@@ -439,7 +440,7 @@ public class JobEndpoint {
   public JObject getTasksAsJSON(long id) throws JobEndpointException, NotFoundException {
     WorkflowInstance instance = getWorkflowById(id);
     // Gather user information
-    User user = instance.getCreator();
+    User user = userDirectoryService.loadUser(instance.getCreatorName());
     List<Field> userInformation = new ArrayList<>();
     if (user != null) {
       userInformation.add(f("username", v(user.getUsername())));

--- a/modules/admin-ui/src/main/resources/OSGI-INF/job_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/job_endpoint.xml
@@ -10,10 +10,16 @@
     <provide interface="org.opencastproject.adminui.endpoint.JobEndpoint"/>
   </service>
 
-  <reference name="workflowService" interface="org.opencastproject.workflow.api.WorkflowService"
-             cardinality="1..1" policy="static" bind="setWorkflowService"/>
-  <reference name="serviceRegistry" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
-             cardinality="1..1" policy="static" bind="setServiceRegistry"/>
-  <reference name="incidentService" interface="org.opencastproject.serviceregistry.api.IncidentService"
-             cardinality="1..1" policy="static" bind="setIncidentService"/>
+  <reference name="workflowService"
+             interface="org.opencastproject.workflow.api.WorkflowService"
+             bind="setWorkflowService"/>
+  <reference name="serviceRegistry"
+             interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
+             bind="setServiceRegistry"/>
+  <reference name="incidentService"
+             interface="org.opencastproject.serviceregistry.api.IncidentService"
+             bind="setIncidentService"/>
+  <reference name="UserDirectory"
+             interface="org.opencastproject.security.api.UserDirectoryService"
+             bind="setUserDirectoryService"/>
 </scr:component>

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -96,6 +96,7 @@ import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.series.impl.SeriesServiceDatabaseException;
 import org.opencastproject.series.impl.SeriesServiceImpl;
@@ -451,10 +452,15 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
             .anyTimes();
     EasyMock.replay(incidentService);
 
+    UserDirectoryService userDirectoryService = EasyMock.createMock(UserDirectoryService.class);
+    EasyMock.expect(userDirectoryService.loadUser(EasyMock.anyString())).andReturn(userWithPermissions).anyTimes();
+    EasyMock.replay(userDirectoryService);
+
     JobEndpoint endpoint = new JobEndpoint();
     endpoint.setServiceRegistry(serviceRegistry);
     endpoint.setWorkflowService(workflowService);
     endpoint.setIncidentService(incidentService);
+    endpoint.setUserDirectoryService(userDirectoryService);
     endpoint.activate(null);
     env.setJobService(endpoint);
 

--- a/modules/admin-ui/src/test/resources/eventWorkflow.json
+++ b/modules/admin-ui/src/test/resources/eventWorkflow.json
@@ -1,6 +1,11 @@
 {
   "wiid": 1,
   "title": "Full",
+  "creator": {
+    "name": "WithPermissions",
+    "email": "with@permissions.com",
+    "username": "sample"
+  },
   "executionTime": 3600000,
   "submittedAt": "2014-06-05T15:00:00Z",
   "wdid": "full",

--- a/modules/comments-workflowoperation/src/main/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandler.java
+++ b/modules/comments-workflowoperation/src/main/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandler.java
@@ -26,6 +26,8 @@ import org.opencastproject.event.comment.EventCommentException;
 import org.opencastproject.event.comment.EventCommentService;
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
@@ -58,6 +60,7 @@ public class CommentWorkflowOperationHandler extends AbstractWorkflowOperationHa
   /* service references */
   private EventCommentService eventCommentService;
   private SecurityService securityService;
+  private UserDirectoryService userDirectoryService;
 
   public enum Operation {
     create, resolve, delete
@@ -138,8 +141,9 @@ public class CommentWorkflowOperationHandler extends AbstractWorkflowOperationHa
     Opt<EventComment> optComment = findComment(workflowInstance.getMediaPackage().getIdentifier().toString(), reason,
             description);
     if (optComment.isNone()) {
-      EventComment comment = EventComment.create(Option.<Long> none(), workflowInstance.getMediaPackage().getIdentifier().toString(),
-              securityService.getOrganization().getId(), description, workflowInstance.getCreator(), reason, false);
+      final User user = userDirectoryService.loadUser(workflowInstance.getCreatorName());
+      EventComment comment = EventComment.create(Option.none(), workflowInstance.getMediaPackage().getIdentifier().toString(),
+              securityService.getOrganization().getId(), description, user, reason, false);
       eventCommentService.updateComment(comment);
     } else {
       logger.debug("Not creating comment with '{}' text and '{}' reason as it already exists for this event.",
@@ -257,4 +261,7 @@ public class CommentWorkflowOperationHandler extends AbstractWorkflowOperationHa
     this.securityService = service;
   }
 
+  public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
+    this.userDirectoryService = userDirectoryService;
+  }
 }

--- a/modules/comments-workflowoperation/src/main/resources/OSGI-INF/operations/comments.xml
+++ b/modules/comments-workflowoperation/src/main/resources/OSGI-INF/operations/comments.xml
@@ -8,12 +8,17 @@
     <provide interface="org.opencastproject.workflow.api.WorkflowOperationHandler"/>
   </service>
 
-  <reference name="event-comment-service" interface="org.opencastproject.event.comment.EventCommentService"
-             cardinality="1..1" policy="static" bind="setEventCommentService"/>
-  <reference cardinality="1..1" interface="org.opencastproject.security.api.SecurityService"
-             name="SecurityService" policy="static" bind="setSecurityService"/>
-  <reference name="ServiceRegistry" cardinality="1..1"
+  <reference name="event-comment-service"
+             interface="org.opencastproject.event.comment.EventCommentService"
+             bind="setEventCommentService"/>
+  <reference interface="org.opencastproject.security.api.SecurityService"
+             name="SecurityService"
+             bind="setSecurityService"/>
+  <reference name="ServiceRegistry"
              interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
-             policy="static" bind="setServiceRegistry"/>
+             bind="setServiceRegistry"/>
+  <reference name="UserDirectory"
+             interface="org.opencastproject.security.api.UserDirectoryService"
+             bind="setUserDirectoryService"/>
 
 </scr:component>

--- a/modules/comments-workflowoperation/src/test/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandlerTest.java
+++ b/modules/comments-workflowoperation/src/test/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandlerTest.java
@@ -35,6 +35,7 @@ import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -96,14 +97,18 @@ public class CommentWorkflowOperationHandlerTest {
     // Setup user
     User creator = EasyMock.createMock(User.class);
 
+    // setup user directory
+    UserDirectoryService userDirectoryService = EasyMock.createMock(UserDirectoryService.class);
+    EasyMock.expect(userDirectoryService.loadUser(EasyMock.anyString())).andReturn(creator).anyTimes();
+
     // Setup WorkflowInstance
     WorkflowInstance workflowInstance = EasyMock.createMock(WorkflowInstance.class);
     EasyMock.expect(workflowInstance.getId()).andReturn(workflowId).anyTimes();
     EasyMock.expect(workflowInstance.getCurrentOperation()).andReturn(workflowOperationInstance).anyTimes();
     EasyMock.expect(workflowInstance.getMediaPackage()).andReturn(mediaPackage).anyTimes();
-    EasyMock.expect(workflowInstance.getCreator()).andReturn(creator).anyTimes();
+    EasyMock.expect(workflowInstance.getCreatorName()).andReturn("user").anyTimes();
 
-    EasyMock.replay(creator, mediaPackage, workflowInstance, workflowOperationInstance);
+    EasyMock.replay(creator, userDirectoryService, mediaPackage, workflowInstance, workflowOperationInstance);
 
     // Test create
     EventCommentService eventCommentService = EasyMock.createMock(EventCommentService.class);
@@ -119,6 +124,7 @@ public class CommentWorkflowOperationHandlerTest {
     CommentWorkflowOperationHandler commentWorkflowOperationHandler = new CommentWorkflowOperationHandler();
     commentWorkflowOperationHandler.setEventCommentService(eventCommentService);
     commentWorkflowOperationHandler.setSecurityService(secSrv);
+    commentWorkflowOperationHandler.setUserDirectoryService(userDirectoryService);
     commentWorkflowOperationHandler.start(workflowInstance, null);
     assertTrue(comment.hasCaptured());
     assertEquals(creator, comment.getValue().getAuthor());
@@ -153,6 +159,7 @@ public class CommentWorkflowOperationHandlerTest {
     commentWorkflowOperationHandler = new CommentWorkflowOperationHandler();
     commentWorkflowOperationHandler.setEventCommentService(eventCommentService);
     commentWorkflowOperationHandler.setSecurityService(secSrv);
+    commentWorkflowOperationHandler.setUserDirectoryService(userDirectoryService);
     commentWorkflowOperationHandler.start(workflowInstance, null);
 
     // Test delete with no result, no delete
@@ -233,14 +240,18 @@ public class CommentWorkflowOperationHandlerTest {
     // Setup user
     User creator = EasyMock.createMock(User.class);
 
+    // setup user directory
+    UserDirectoryService userDirectoryService = EasyMock.createMock(UserDirectoryService.class);
+    EasyMock.expect(userDirectoryService.loadUser(EasyMock.anyString())).andReturn(creator).anyTimes();
+
     // Setup WorkflowInstance
     WorkflowInstance workflowInstance = EasyMock.createMock(WorkflowInstance.class);
     EasyMock.expect(workflowInstance.getId()).andReturn(workflowId).anyTimes();
     EasyMock.expect(workflowInstance.getCurrentOperation()).andReturn(workflowOperationInstance).anyTimes();
     EasyMock.expect(workflowInstance.getMediaPackage()).andReturn(mediaPackage).anyTimes();
-    EasyMock.expect(workflowInstance.getCreator()).andReturn(creator).anyTimes();
+    EasyMock.expect(workflowInstance.getCreatorName()).andReturn("user").anyTimes();
 
-    EasyMock.replay(creator, mediaPackage, workflowInstance, workflowOperationInstance);
+    EasyMock.replay(creator, userDirectoryService, mediaPackage, workflowInstance, workflowOperationInstance);
 
     // Test no previous comments
     EventCommentService eventCommentService = EasyMock.createMock(EventCommentService.class);
@@ -252,6 +263,7 @@ public class CommentWorkflowOperationHandlerTest {
     CommentWorkflowOperationHandler commentWorkflowOperationHandler = new CommentWorkflowOperationHandler();
     commentWorkflowOperationHandler.setEventCommentService(eventCommentService);
     commentWorkflowOperationHandler.setSecurityService(secSrv);
+    commentWorkflowOperationHandler.setUserDirectoryService(userDirectoryService);
     commentWorkflowOperationHandler.start(workflowInstance, null);
     assertTrue(comment.hasCaptured());
     assertEquals(creator, comment.getValue().getAuthor());
@@ -267,6 +279,7 @@ public class CommentWorkflowOperationHandlerTest {
     commentWorkflowOperationHandler = new CommentWorkflowOperationHandler();
     commentWorkflowOperationHandler.setEventCommentService(eventCommentService);
     commentWorkflowOperationHandler.setSecurityService(secSrv);
+    commentWorkflowOperationHandler.setUserDirectoryService(userDirectoryService);
     commentWorkflowOperationHandler.start(workflowInstance, null);
     assertTrue(comment.hasCaptured());
     assertEquals(creator, comment.getValue().getAuthor());
@@ -282,8 +295,7 @@ public class CommentWorkflowOperationHandlerTest {
     commentWorkflowOperationHandler = new CommentWorkflowOperationHandler();
     commentWorkflowOperationHandler.setEventCommentService(eventCommentService);
     commentWorkflowOperationHandler.setSecurityService(secSrv);
-    commentWorkflowOperationHandler.setSecurityService(secSrv);
-
+    commentWorkflowOperationHandler.setUserDirectoryService(userDirectoryService);
     commentWorkflowOperationHandler.start(workflowInstance, null);
     assertTrue(comment.hasCaptured());
     assertEquals(creator, comment.getValue().getAuthor());
@@ -324,12 +336,16 @@ public class CommentWorkflowOperationHandlerTest {
     // Setup user
     User creator = EasyMock.createMock(User.class);
 
+    // setup user directory
+    UserDirectoryService userDirectoryService = EasyMock.createMock(UserDirectoryService.class);
+    EasyMock.expect(userDirectoryService.loadUser(EasyMock.anyString())).andReturn(creator).anyTimes();
+
     // Setup WorkflowInstance
     WorkflowInstance workflowInstance = EasyMock.createMock(WorkflowInstance.class);
     EasyMock.expect(workflowInstance.getId()).andReturn(workflowId).anyTimes();
     EasyMock.expect(workflowInstance.getCurrentOperation()).andReturn(workflowOperationInstance).anyTimes();
     EasyMock.expect(workflowInstance.getMediaPackage()).andReturn(mediaPackage).anyTimes();
-    EasyMock.expect(workflowInstance.getCreator()).andReturn(creator).anyTimes();
+    EasyMock.expect(workflowInstance.getCreatorName()).andReturn("user").anyTimes();
 
     // Test no previous comments
     EventCommentService eventCommentService = EasyMock.createMock(EventCommentService.class);
@@ -337,10 +353,12 @@ public class CommentWorkflowOperationHandlerTest {
     Capture<EventComment> comment = EasyMock.newCapture();
     EasyMock.expect(eventCommentService.updateComment(EasyMock.capture(comment)))
             .andReturn(EventComment.create(Option.option(15L), mediaPackageId, org.getId(), description, creator));
-    EasyMock.replay(creator, eventCommentService, mediaPackage, workflowInstance, workflowOperationInstance);
+    EasyMock.replay(creator, userDirectoryService, eventCommentService, mediaPackage, workflowInstance,
+            workflowOperationInstance);
     CommentWorkflowOperationHandler commentWorkflowOperationHandler = new CommentWorkflowOperationHandler();
     commentWorkflowOperationHandler.setEventCommentService(eventCommentService);
     commentWorkflowOperationHandler.setSecurityService(secSrv);
+    commentWorkflowOperationHandler.setUserDirectoryService(userDirectoryService);
     commentWorkflowOperationHandler.start(workflowInstance, null);
     assertTrue(comment.hasCaptured());
     assertEquals(creator, comment.getValue().getAuthor());
@@ -355,6 +373,7 @@ public class CommentWorkflowOperationHandlerTest {
     EasyMock.replay(eventCommentService);
     commentWorkflowOperationHandler = new CommentWorkflowOperationHandler();
     commentWorkflowOperationHandler.setEventCommentService(eventCommentService);
+    commentWorkflowOperationHandler.setUserDirectoryService(userDirectoryService);
     commentWorkflowOperationHandler.start(workflowInstance, null);
     assertTrue(comment.hasCaptured());
     assertEquals(creator, comment.getValue().getAuthor());
@@ -376,6 +395,7 @@ public class CommentWorkflowOperationHandlerTest {
     commentWorkflowOperationHandler = new CommentWorkflowOperationHandler();
     commentWorkflowOperationHandler.setEventCommentService(eventCommentService);
     commentWorkflowOperationHandler.setSecurityService(secSrv);
+    commentWorkflowOperationHandler.setUserDirectoryService(userDirectoryService);
     commentWorkflowOperationHandler.start(workflowInstance, null);
     assertTrue(comment.hasCaptured());
     assertEquals(creator, comment.getValue().getAuthor());

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
@@ -539,7 +539,7 @@ public class WorkflowsEndpoint {
     fields.add(f("description", v(wi.getDescription(), BLANK)));
     fields.add(f("workflow_definition_identifier", v(wi.getTemplate(), BLANK)));
     fields.add(f("event_identifier", v(wi.getMediaPackage().getIdentifier().toString())));
-    fields.add(f("creator", v(wi.getCreator().getName())));
+    fields.add(f("creator", v(wi.getCreatorName())));
     fields.add(f("state", enumToJSON(wi.getState())));
     if (withOperations) {
       fields.add(f("operations", arr(wi.getOperations()

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestWorkflowsEndpoint.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestWorkflowsEndpoint.java
@@ -35,7 +35,6 @@ import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.security.api.UnauthorizedException;
-import org.opencastproject.security.impl.jpa.JpaUser;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.RetryStrategy;
 import org.opencastproject.workflow.api.WorkflowDefinition;
@@ -119,7 +118,7 @@ public class TestWorkflowsEndpoint extends WorkflowsEndpoint {
     expect(runningWorkflow.getDescription()).andReturn("A running workflow");
     expect(runningWorkflow.getTemplate()).andReturn("fast");
     expect(runningWorkflow.getMediaPackage()).andReturn(mp);
-    expect(runningWorkflow.getCreator()).andReturn(new JpaUser("User1", null, null, "User Name", null, null, true));
+    expect(runningWorkflow.getCreatorName()).andReturn("User1");
     expect(runningWorkflow.getState()).andReturn(WorkflowInstance.WorkflowState.RUNNING);
     expect(runningWorkflow.getOperations()).andReturn(Lists.newArrayList(woi1));
     expect(runningWorkflow.getConfigurationKeys()).andReturn(Sets.newHashSet("efgh"));
@@ -132,7 +131,7 @@ public class TestWorkflowsEndpoint extends WorkflowsEndpoint {
     expect(stoppedWorkflow.getDescription()).andReturn("A stopped workflow");
     expect(stoppedWorkflow.getTemplate()).andReturn("fast");
     expect(stoppedWorkflow.getMediaPackage()).andReturn(mp);
-    expect(stoppedWorkflow.getCreator()).andReturn(new JpaUser("User2", null, null, "User Name2", null, null, true));
+    expect(stoppedWorkflow.getCreatorName()).andReturn("User2");
     expect(stoppedWorkflow.getState()).andReturn(WorkflowInstance.WorkflowState.STOPPED);
     expect(stoppedWorkflow.getOperations()).andReturn(Lists.newArrayList(woi2));
     expect(stoppedWorkflow.getConfigurationKeys()).andReturn(Sets.newHashSet("ijklm"));
@@ -145,8 +144,7 @@ public class TestWorkflowsEndpoint extends WorkflowsEndpoint {
     expect(startedStoppedWorkflow.getDescription()).andReturn("A stopped workflow");
     expect(startedStoppedWorkflow.getTemplate()).andReturn("fast");
     expect(startedStoppedWorkflow.getMediaPackage()).andReturn(mp);
-    expect(startedStoppedWorkflow.getCreator()).andReturn(
-            new JpaUser("User2", null, null, "User Name2", null, null, true));
+    expect(startedStoppedWorkflow.getCreatorName()).andReturn("User2");
     expect(startedStoppedWorkflow.getState()).andReturn(WorkflowInstance.WorkflowState.PAUSED);
     expect(startedStoppedWorkflow.getOperations()).andReturn(Lists.newArrayList(woi2));
     expect(startedStoppedWorkflow.getConfigurationKeys()).andReturn(Sets.newHashSet("abc"));

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -22,7 +22,6 @@
 package org.opencastproject.workflow.api;
 
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.security.api.User;
 
 import java.util.List;
 
@@ -83,11 +82,11 @@ public interface WorkflowInstance extends Configurable {
   Long getParentId();
 
   /**
-   * Returns the user that created this workflow.
+   * Returns the username of the user that created this workflow.
    *
-   * @return the workflow's creator
+   * @return username of the workflow's creator
    */
-  User getCreator();
+  String getCreatorName();
 
   /**
    * Returns the organization that this workflow belongs to.

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstanceImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstanceImpl.java
@@ -89,6 +89,9 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
   @XmlElement(name = "creator", namespace = "http://org.opencastproject.security")
   private User creator;
 
+  @XmlElement(name = "creator-id", namespace = "http://org.opencastproject.security")
+  private String creatorName;
+
   @XmlJavaTypeAdapter(OrganizationAdapter.class)
   @XmlElement(name = "organization", namespace = "http://org.opencastproject.security")
   private JaxbOrganization organization;
@@ -140,7 +143,7 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
     this.template = def.getId();
     this.description = def.getDescription();
     this.parentId = parentWorkflowId;
-    this.creator = creator;
+    this.creatorName = creator != null ? creator.getUsername() : null;
     if (organization != null)
       this.organizationId = organization.getId();
     this.state = WorkflowState.INSTANTIATED;
@@ -197,11 +200,17 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
   /**
    * {@inheritDoc}
    *
-   * @see org.opencastproject.workflow.api.WorkflowInstance#getCreator()
+   * @see org.opencastproject.workflow.api.WorkflowInstance#getCreatorName()
    */
   @Override
-  public User getCreator() {
-    return creator;
+  public String getCreatorName() {
+    if (creatorName != null) {
+      return creatorName;
+    }
+    if (creator != null) {
+      return creator.getUsername();
+    }
+    return null;
   }
 
   /**
@@ -222,11 +231,11 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
   }
 
   /**
-   * @param creator
-   *          the creator to set
+   * @param username
+   *          username of the creator to set
    */
-  public void setCreator(User creator) {
-    this.creator = creator;
+  public void setCreatorName(final String username) {
+    creatorName = username;
   }
 
   /**

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1245,7 +1245,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
       }
     }
 
-    User workflowCreator = workflow.getCreator();
+    User workflowCreator = userDirectoryService.loadUser(workflow.getCreatorName());
     String workflowOrgId = workflowCreator.getOrganization().getId();
 
     boolean authorized = currentUser.hasRole(GLOBAL_ADMIN_ROLE)

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
@@ -492,8 +492,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
       doc.addField(SUBJECT_KEY, buf.toString());
     }
 
-    User workflowCreator = instance.getCreator();
-    doc.addField(WORKFLOW_CREATOR_KEY, workflowCreator.getUsername());
+    doc.addField(WORKFLOW_CREATOR_KEY, instance.getCreatorName());
     doc.addField(ORG_KEY, instance.getOrganizationId());
 
     // Media package used to get the active acl

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndexTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndexTest.java
@@ -78,7 +78,7 @@ public class WorkflowServiceSolrIndexTest {
     Job job = new JobImpl();
     WorkflowInstanceImpl workflow = new WorkflowInstanceImpl();
     workflow.setId(123);
-    workflow.setCreator(securityService.getUser());
+    workflow.setCreatorName(securityService.getUser().getName());
     workflow.setOrganizationId(securityService.getOrganization().getId());
     workflow.setState(WorkflowState.INSTANTIATED);
     workflow.setMediaPackage(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());


### PR DESCRIPTION
Instead of using a serialized version of a user object which can be
potentially huge, use a username for identifying creators.