### PR TITLE
url query string incorrect

### DIFF
--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -100,8 +100,8 @@ custom parameters to be defined separately in each place where an LTI tool is us
 custom parameters to be defined globally.
 
 * To show the Opencast Media Module, use `tool=engage/ui/`
-* To show all videos for a single series, use `tool=ltitools/series/index.html;series=SERIESID`
-* To show a single video, use `tool=engage/theodul/ui/core.html;id=MEDIAPACKAGEID`
+* To show all videos for a single series, use `tool=ltitools/series/index.html?series=SERIESID`
+* To show a single video, use `tool=engage/theodul/ui/core.html?id=MEDIAPACKAGEID`
 * To show a short debugging page before proceeding to the tool page, add the parameter `test=true`
 
 For more information about how to set custom LTI parameters, please check the documentation of your LMS.

--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -101,7 +101,7 @@ custom parameters to be defined globally.
 
 * To show the Opencast Media Module, use `tool=engage/ui/`
 * To show all videos for a single series, use `tool=ltitools/series/index.html?series=SERIESID`
-* To show a single video, use `tool=engage/theodul/ui/core.html?id=MEDIAPACKAGEID`
+* To show a single video, use `tool=/play/MEDIAPACKAGEID`
 * To show a short debugging page before proceeding to the tool page, add the parameter `test=true`
 
 For more information about how to set custom LTI parameters, please check the documentation of your LMS.


### PR DESCRIPTION
The url query string should use ? instead of ; to work in an lti context.