### PR TITLE
MH-13482 Prevent incorrect local job load total

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -355,8 +355,8 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
               .getOrElse(DEFAULT_ACCEPT_JOB_LOADS_EXCEEDING);
     }
 
-    localSystemLoad = getHostLoads(emf.createEntityManager()).get(hostName).getLoadFactor();
-    logger.info("Current system load: {}", format("%.1f", localSystemLoad));
+    localSystemLoad = 0;
+    logger.info("Activated");
   }
 
   @Override

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -947,6 +947,11 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
               job.getId(), job.getJobType(), job.getStatus());
     }
     logger.debug("Current host load: {}, job load cache size: {}", format("%.1f", localSystemLoad), jobCache.size());
+
+    if (jobCache.isEmpty() && (localSystemLoad != 0)) {
+      logger.warn("No jobs in the job load cache, but load is {}: resetting job load to 0", format("%.1f", localSystemLoad));
+      localSystemLoad = 0;
+    }
   }
 
   private synchronized void removeFromLoadCache(Long jobId) {

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -948,8 +948,9 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     }
     logger.debug("Current host load: {}, job load cache size: {}", format("%.1f", localSystemLoad), jobCache.size());
 
-    if (jobCache.isEmpty() && (localSystemLoad != 0)) {
-      logger.warn("No jobs in the job load cache, but load is {}: resetting job load to 0", format("%.1f", localSystemLoad));
+    if (jobCache.isEmpty() && Math.abs(localSystemLoad) > 0.01f) {
+      logger.warn("No jobs in the job load cache, but load is {}: setting job load to 0",
+              format("%.2f", localSystemLoad));
       localSystemLoad = 0;
     }
   }


### PR DESCRIPTION
A worker node that has been restarted after an unclean shutdown can have an incorrect local job load value.

On startup (activation of the serviceregistry) set the job load to 0.

If the job load cache has no entries (which should correspond to no running jobs) and the job load is non-zero, reset it to 0 if it's non-zero and log a warning (because this situation should not arise).
