### PR TITLE
MH-12047 MH-13380 MH-13490 MH-13489 Add missing indexes

### DIFF
--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -367,7 +367,8 @@ CREATE TABLE oc_assets_snapshot (
   INDEX IX_oc_assets_snapshot_archival_date (archival_date),
   INDEX IX_oc_assets_snapshot_mediapackage_id (mediapackage_id),
   INDEX IX_oc_assets_snapshot_organization_id (organization_id),
-  INDEX IX_oc_assets_snapshot_owner (owner)
+  INDEX IX_oc_assets_snapshot_owner (owner),
+  INDEX IX_oc_assets_snapshot_series (series_id, version)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_assets_asset (

--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -381,7 +381,8 @@ CREATE TABLE oc_assets_asset (
   --
   CONSTRAINT FK_oc_assets_asset_snapshot_id FOREIGN KEY (snapshot_id) REFERENCES oc_assets_snapshot (id) ON DELETE CASCADE,
   INDEX IX_oc_assets_asset_checksum (checksum),
-  INDEX IX_oc_assets_asset_mediapackage_element_id (mediapackage_element_id)
+  INDEX IX_oc_assets_asset_mediapackage_element_id (mediapackage_element_id),
+  INDEX IX_oc_assets_asset_snapshot_id (snapshot_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_assets_properties (

--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -524,7 +524,8 @@ CREATE TABLE oc_event_comment (
   reason VARCHAR(255) DEFAULT NULL,
   modification_date DATETIME NOT NULL,
   resolved_status TINYINT(1) NOT NULL DEFAULT '0',
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  KEY IX_oc_event_comment_event (event, organization)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE oc_event_comment_reply (

--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -262,6 +262,7 @@ CREATE TABLE oc_search (
   mediapackage_xml MEDIUMTEXT,
   modification_date DATETIME,
   PRIMARY KEY (id),
+  KEY `IX_oc_search_series` (`series_id`),
   CONSTRAINT FK_oc_search_organization FOREIGN KEY (organization) REFERENCES oc_organization (id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/docs/upgrade/6_to_7/mysql5.sql
+++ b/docs/upgrade/6_to_7/mysql5.sql
@@ -52,3 +52,6 @@ CREATE INDEX IX_oc_assets_asset_snapshot_id ON oc_assets_asset (snapshot_id);
 
 -- MH-13490 Add event index for efficiency
 CREATE INDEX IX_oc_event_comment_event ON oc_event_comment (event, organization);
+
+-- MH-13489 Add index on series_id for efficiency
+CREATE INDEX IX_oc_assets_snapshot_series ON oc_assets_snapshot (series_id, version);

--- a/docs/upgrade/6_to_7/mysql5.sql
+++ b/docs/upgrade/6_to_7/mysql5.sql
@@ -46,3 +46,6 @@ delete p from oc_assets_properties p where not exists (
 
 -- MH-12047 Add series index for efficiency
 CREATE INDEX IX_oc_search_series ON oc_search (series_id);
+
+-- MH-13380 Add snapshot_id index for efficiency
+CREATE INDEX IX_oc_assets_asset_snapshot_id ON oc_assets_asset (snapshot_id);

--- a/docs/upgrade/6_to_7/mysql5.sql
+++ b/docs/upgrade/6_to_7/mysql5.sql
@@ -49,3 +49,6 @@ CREATE INDEX IX_oc_search_series ON oc_search (series_id);
 
 -- MH-13380 Add snapshot_id index for efficiency
 CREATE INDEX IX_oc_assets_asset_snapshot_id ON oc_assets_asset (snapshot_id);
+
+-- MH-13490 Add event index for efficiency
+CREATE INDEX IX_oc_event_comment_event ON oc_event_comment (event, organization);

--- a/docs/upgrade/6_to_7/mysql5.sql
+++ b/docs/upgrade/6_to_7/mysql5.sql
@@ -43,3 +43,6 @@ delete p from oc_assets_properties p where not exists (
   select * from oc_assets_snapshot s
     where p.mediapackage_id = s.mediapackage_id
 );
+
+-- MH-12047 Add series index for efficiency
+CREATE INDEX IX_oc_search_series ON oc_search (series_id);


### PR DESCRIPTION
Adds some indexes that are necessary to prevent related queries from doing a full table scan or querying a large number rows.

These are also of benefit to sites running 6.x or earlier.
