### PR TITLE
NOJIRA: Fix adaptive streaming configuration guide

### DIFF
--- a/docs/guides/admin/docs/modules/adaptivestreaming-wowza.md
+++ b/docs/guides/admin/docs/modules/adaptivestreaming-wowza.md
@@ -61,8 +61,8 @@ below.
 ## Configuration
 
 
-1. Edit the file etc/org.opencastproject.streaming.wowza.StreamingDistributionService.cfg with your preferred
-configuration. The contents should be self-explanatory.
+1. Edit the file `etc/org.opencastproject.distribution.streaming.wowza.WowzaAdaptiveStreamingDistributionService.cfg`
+with your preferred configuration. The contents should be self-explanatory.
 
 2. Edit `$KARAF/etc/custom.properties` and adjust these values to match those of your scenario:
 


### PR DESCRIPTION
`etc/org.opencastproject.streaming.wowza.StreamingDistributionService.cfg ` does not exist, AFAIK.

`etc/org.opencastproject.distribution.streaming.wowza.WowzaAdaptiveStreamingDistributionService.cfg` does, though.

P.S.: Is the NOJIRA "label" accepted for cases like these? If I were a commiter, I could just merge a change like this, too, right? :wink: