### PR TITLE
MH-13495 Ignore old requests instead of cancelling

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
@@ -271,10 +271,6 @@ angular.module('adminNg.services')
          */
       this.fetch = function (reset) {
 
-        if(me.lastRequest && !me.lastRequest.$resolved) {
-          me.lastRequest.$cancelRequest();
-        }
-
         if (angular.isUndefined(me.apiService)) {
           return;
         }
@@ -321,8 +317,14 @@ angular.module('adminNg.services')
 
         (function(resource){
 
-          me.lastRequest = me.apiService.query(query);
-          me.lastRequest.$promise.then(function (data) {
+          var startTime = new Date();
+          me.apiService.query(query).$promise.then(function (data) {
+
+            if (me.lastStartTime && me.lastStartTime > startTime) {
+              return; // a more recent request got a response earlier, so we ignore this one
+            }
+            me.lastStartTime = startTime;
+
             if(resource != me.resource) {
               return;
             }


### PR DESCRIPTION
Instead of cancelling old requests, which leads to a 'server unavailable' notification, we ignore the response of a request if a more recent request finished earlier.

_This work was sponsored by SWITCH._