### PR TITLE
MH-13501 Match against user pattern for loadUser() lookups

### DIFF
--- a/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderInstance.java
+++ b/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderInstance.java
@@ -215,6 +215,17 @@ public class SakaiUserProviderInstance implements UserProvider, RoleProvider, Ca
   @Override
   public User loadUser(String userName) {
     logger.debug("loaduser(" + userName + ")");
+
+    try {
+      if ((userPattern != null) && !userName.matches(userPattern)) {
+        logger.debug("load user {} failed regexp {}", userName, userPattern);
+        return null;
+      }
+    } catch (PatternSyntaxException e) {
+      logger.warn("Invalid regular expression for user pattern {} - disabling checks", userPattern);
+      userPattern = null;
+    }
+
     requests.incrementAndGet();
     try {
       Object user = cache.getUnchecked(userName);


### PR DESCRIPTION
When entering presenter information, Opencast tries to resolve the
presenter name as a user. This avoids trying to look up full names
(including spaces) as user eids from Sakai.