### PR TITLE
MH-13506, Automatically Launch Logs for `dist-develop`

### DIFF
--- a/assemblies/dist-develop/resources/shell.init.script.append
+++ b/assemblies/dist-develop/resources/shell.init.script.append
@@ -1,0 +1,3 @@
+
+sleep 1
+log:tail

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -143,6 +143,9 @@
                   <concat destfile="target/assembly/etc/system.properties" append="true">
                     <filelist dir="../resources" files="system.properties.append"/>
                   </concat>
+                  <concat destfile="target/assembly/etc/shell.init.script" append="true">
+                    <filelist dir="resources" files="shell.init.script.append"/>
+                  </concat>
                   <!-- Adding extra OSGi system packages to configuration -->
                   <replace file="target/assembly/etc/config.properties" token="org.osgi.framework.system.packages= \" value="org.osgi.framework.system.packages= com.sun.image.codec.jpeg, com.sun.jndi.ldap, \"/>
                   <!-- Disabled write permissions on karaf configuration by deactivating config saves -->


### PR DESCRIPTION
This patch automatically launches the `log:tail` command in the
development distribution.