### PR TITLE
MH-13508 Remove method canLogin from interface User

### DIFF
--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/util/TestUser.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/util/TestUser.java
@@ -44,7 +44,6 @@ public class TestUser implements User {
   private final String email;
   private final String provider;
   private final boolean manageable;
-  private final boolean canLogin;
   private final Organization organization;
   private final Set<Role> roles;
 
@@ -55,7 +54,6 @@ public class TestUser implements User {
       String email,
       String provider,
       boolean manageable,
-      boolean canLogin,
       Organization organization,
       Set<Role> roles) {
     this.username = username;
@@ -64,26 +62,25 @@ public class TestUser implements User {
     this.email = email;
     this.provider = provider;
     this.manageable = manageable;
-    this.canLogin = canLogin;
     this.organization = organization;
     this.roles = roles;
   }
 
   public static User mk(String userName, Organization organization,
                         Set<Role> roles) {
-    return new TestUser(userName, "password", "name", "email", "provider", true, true, organization, roles);
+    return new TestUser(userName, "password", "name", "email", "provider", true, organization, roles);
   }
 
   public static User mk(Organization organization, Set<Role> roles) {
-    return new TestUser("user", "password", "name", "email", "provider", true, true, organization, roles);
+    return new TestUser("user", "password", "name", "email", "provider", true, organization, roles);
   }
 
   public static User mk(Organization organization) {
-    return new TestUser("user", "password", "name", "email", "provider", true, true, organization, Collections.<Role>emptySet());
+    return new TestUser("user", "password", "name", "email", "provider", true, organization, Collections.<Role>emptySet());
   }
 
   public static User mk(Organization organization, Role... roles) {
-    return new TestUser("user", "password", "name", "email", "provider", true, true, organization, $(roles).toSet());
+    return new TestUser("user", "password", "name", "email", "provider", true, organization, $(roles).toSet());
   }
 
   /**
@@ -92,7 +89,7 @@ public class TestUser implements User {
    */
   public static User mk(final Organization organization, String... roles) {
     return new TestUser(
-        "user", "password", "name", "email", "provider", true, true, organization,
+        "user", "password", "name", "email", "provider", true, organization,
         $(roles).map(new Fn<String, Role>() {
           @Override public Role apply(String role) {
             return TestRole.mk(role, organization);
@@ -124,10 +121,6 @@ public class TestUser implements User {
     return manageable;
   }
 
-  @Override public boolean canLogin() {
-    return canLogin;
-  }
-
   @Override public Organization getOrganization() {
     return organization;
   }
@@ -147,7 +140,7 @@ public class TestUser implements User {
   };
 
   @Override public int hashCode() {
-    return hash(username, password, name, email, provider, manageable, canLogin, organization, roles);
+    return hash(username, password, name, email, provider, manageable, organization, roles);
   }
 
   @Override public boolean equals(Object that) {
@@ -156,8 +149,8 @@ public class TestUser implements User {
 
   private boolean eqFields(TestUser that) {
     return eq(username, that.username) && eq(password, that.password) && eq(name, that.name) && eq(email, that.email)
-        && eq(provider, that.provider) && eq(manageable, that.manageable) && eq(canLogin, that.canLogin)
-        && eq(organization, that.organization) && eq(roles, that.roles);
+        && eq(provider, that.provider) && eq(manageable, that.manageable) && eq(organization, that.organization)
+        && eq(roles, that.roles);
   }
 
   @Override public String toString() {

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUser.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUser.java
@@ -211,14 +211,6 @@ public class JpaUser implements User {
   }
 
   /**
-   * @see org.opencastproject.security.api.User#canLogin()
-   */
-  @Override
-  public boolean canLogin() {
-    return true;
-  }
-
-  /**
    * @see org.opencastproject.security.api.User#getUsername()
    */
   @Override

--- a/modules/common/src/main/java/org/opencastproject/security/api/JaxbUser.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/JaxbUser.java
@@ -77,9 +77,6 @@ public final class JaxbUser implements User {
   @XmlTransient
   protected String password;
 
-  @XmlTransient
-  protected boolean canLogin = false;
-
   /** The user's home organization identifier */
   @XmlElement(name = "organization")
   protected JaxbOrganization organization;
@@ -139,29 +136,6 @@ public final class JaxbUser implements User {
    *          the password
    * @param provider
    *          the provider
-   * @param canLogin
-   *          <code>true</code> if able to login
-   * @param organization
-   *          the organization
-   * @param roles
-   *          the set of roles for this user
-   * @throws IllegalArgumentException
-   *           if <code>userName</code> or <code>organization</code> is <code>null</code>
-   */
-  public JaxbUser(String userName, String password, String provider, boolean canLogin, JaxbOrganization organization,
-          JaxbRole... roles) throws IllegalArgumentException {
-    this(userName, password, null, null, provider, canLogin, organization, new HashSet<JaxbRole>(Arrays.asList(roles)));
-  }
-
-  /**
-   * Constructs a user which is a member of the given organization that has the specified roles.
-   *
-   * @param userName
-   *          the username
-   * @param password
-   *          the password
-   * @param provider
-   *          the provider
    * @param organization
    *          the organization
    * @param roles
@@ -171,32 +145,7 @@ public final class JaxbUser implements User {
    */
   public JaxbUser(String userName, String password, String provider, JaxbOrganization organization, Set<JaxbRole> roles)
           throws IllegalArgumentException {
-    this(userName, password, null, null, provider, true, organization, roles);
-  }
-
-  /**
-   * Constructs a user which is a member of the given organization that has the specified roles.
-   *
-   * @param userName
-   *          the username
-   * @param password
-   *          the password
-   * @param name
-   *          the name
-   * @param email
-   *          the email
-   * @param provider
-   *          the provider
-   * @param organization
-   *          the organization
-   * @param roles
-   *          the set of roles for this user
-   * @throws IllegalArgumentException
-   *           if <code>userName</code> or <code>organization</code> is <code>null</code>
-   */
-  public JaxbUser(String userName, String password, String name, String email, String provider,
-          JaxbOrganization organization, Set<JaxbRole> roles) throws IllegalArgumentException {
-    this(userName, password, name, email, provider, true, organization, roles);
+    this(userName, password, null, null, provider, organization, roles);
   }
 
   /**
@@ -231,8 +180,6 @@ public final class JaxbUser implements User {
    *          the email
    * @param provider
    *          the provider
-   * @param canLogin
-   *          <code>true</code> if able to login
    * @param organization
    *          the organization
    * @param roles
@@ -240,7 +187,7 @@ public final class JaxbUser implements User {
    * @throws IllegalArgumentException
    *           if <code>userName</code> or <code>organization</code> is <code>null</code>
    */
-  public JaxbUser(String userName, String password, String name, String email, String provider, boolean canLogin,
+  public JaxbUser(String userName, String password, String name, String email, String provider,
           JaxbOrganization organization, Set<JaxbRole> roles) throws IllegalArgumentException {
     if (StringUtils.isBlank(userName))
       throw new IllegalArgumentException("Username must be set");
@@ -250,7 +197,6 @@ public final class JaxbUser implements User {
     this.password = password;
     this.name = name;
     this.email = email;
-    this.canLogin = canLogin;
     this.provider = provider;
     this.organization = organization;
     if (roles == null) {
@@ -295,7 +241,7 @@ public final class JaxbUser implements User {
     }
 
     JaxbUser jaxbUser = new JaxbUser(user.getUsername(), user.getPassword(), user.getName(), user.getEmail(),
-            user.getProvider(), user.canLogin(), JaxbOrganization.fromOrganization(user.getOrganization()), roles);
+            user.getProvider(), JaxbOrganization.fromOrganization(user.getOrganization()), roles);
     jaxbUser.setManageable(user.isManageable());
     return jaxbUser;
   }
@@ -314,14 +260,6 @@ public final class JaxbUser implements User {
   @Override
   public String getPassword() {
     return password;
-  }
-
-  /**
-   * @see org.opencastproject.security.api.User#canLogin()
-   */
-  @Override
-  public boolean canLogin() {
-    return canLogin;
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/security/api/User.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/User.java
@@ -71,13 +71,6 @@ public interface User {
   boolean isManageable();
 
   /**
-   * Returns <code>true</code> if this user object can be used to log into Opencast.
-   *
-   * @return <code>true</code> if this user can login
-   */
-  boolean canLogin();
-
-  /**
    * Returns the user's organization identifier.
    *
    * @return the organization

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
@@ -234,7 +234,7 @@ public class RemoteUserAndOrganizationFilter implements Filter {
 
         // Set roles to requested user
         requestedUser = new JaxbUser(requestedUser.getUsername(), requestedUser.getPassword(), requestedUser.getName(),
-                requestedUser.getEmail(), requestedUser.getProvider(), requestedUser.canLogin(),
+                requestedUser.getEmail(), requestedUser.getProvider(),
                 JaxbOrganization.fromOrganization(requestedUser.getOrganization()),
                 Stream.$(requestedRoles).map(toJaxbRole._2(requestedOrganization)).toSet());
         logger.trace("Request roles '{}' are amended to user '{}'", rolesHeader, requestedUser.getUsername());

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderInstance.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderInstance.java
@@ -520,7 +520,7 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
       }
 
       return new JaxbUser(moodleUser.getUsername(), null, moodleUser.getFullname(), moodleUser.getEmail(),
-              this.getName(), true, jaxbOrganization, roles);
+              this.getName(), jaxbOrganization, roles);
     } catch (Exception e) {
       logger.warn("Exception loading Moodle user {} at {}: {}", username, client.getURL(), e.getMessage());
     } finally {

--- a/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderInstance.java
+++ b/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderInstance.java
@@ -310,8 +310,7 @@ public class SakaiUserProviderInstance implements UserProvider, RoleProvider, Ca
 
       logger.debug("Returning JaxbRoles: " + roles);
 
-      // JaxbUser(String userName, String password, String name, String email, String provider, boolean canLogin, JaxbOrganization organization, Set<JaxbRole> roles)
-      User user = new JaxbUser(userName, null, displayName, email, PROVIDER_NAME, true, jaxbOrganization, roles);
+      User user = new JaxbUser(userName, null, displayName, email, PROVIDER_NAME, jaxbOrganization, roles);
 
       cache.put(userName, user);
       logger.debug("Returning user {}", userName);

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
@@ -228,7 +228,7 @@ public class InMemoryUserAndRoleProvider implements UserProvider, RoleProvider, 
       for (String roleName : SecurityConstants.GLOBAL_SYSTEM_ROLES) {
         roleList.add(new JaxbRole(roleName, jaxbOrganization));
       }
-      User digestUser = new JaxbUser(digestUsername, digestUserPass, DIGEST_USER_NAME, null, getName(), true,
+      User digestUser = new JaxbUser(digestUsername, digestUserPass, DIGEST_USER_NAME, null, getName(),
               jaxbOrganization, roleList);
       users.add(digestUser);
       logger.info("Added system digest user '{}' for organization '{}'", digestUsername, organization.getId());
@@ -251,7 +251,7 @@ public class InMemoryUserAndRoleProvider implements UserProvider, RoleProvider, 
 
       // Create the capture agent user
       logger.info("Creating the capture agent digest user '{}'", username);
-      User caUser = new JaxbUser(username, password, CAPTURE_AGENT_USER_NAME, null, getName(), true,
+      User caUser = new JaxbUser(username, password, CAPTURE_AGENT_USER_NAME, null, getName(),
               jaxbOrganization, caRoleList);
       users.add(caUser);
     }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -365,7 +365,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
 
     // Create and return the final user
     JaxbUser mergedUser = new JaxbUser(user.getUsername(), user.getPassword(), user.getName(), user.getEmail(),
-            user.getProvider(), user.canLogin(), JaxbOrganization.fromOrganization(user.getOrganization()), roles);
+            user.getProvider(), JaxbOrganization.fromOrganization(user.getOrganization()), roles);
     mergedUser.setManageable(user.isManageable());
     return mergedUser;
   }
@@ -402,7 +402,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
     // need a non null password to instantiate org.springframework.security.core.userdetails.User
     // but CAS authenticated users have no password
     String password = user.getPassword() == null ? DEFAULT_PASSWORD : user.getPassword();
-    return new org.springframework.security.core.userdetails.User(user.getUsername(), password, user.canLogin(), true,
+    return new org.springframework.security.core.userdetails.User(user.getUsername(), password, true, true,
             true, true, authorities);
 
   }

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImplTest.java
@@ -74,7 +74,7 @@ public class UserAndRoleDirectoryServiceImplTest {
 
     JaxbUser user1 = new JaxbUser(userName, "matterhorn", org, role1, role2);
     user1.setManageable(true);
-    User user2 = new JaxbUser(userName, "secret", "test", true, org, role2, role3);
+    User user2 = new JaxbUser(userName, "secret", "test", org, role2, role3);
     User user3 = new JaxbUser("userSample", "test", org, role2, role3);
 
     List<User> users = new ArrayList<User>();


### PR DESCRIPTION
The interface User offers a method canLogin which is not really used in means of it is used to set the isEnabled of https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/userdetails/User.html but it always sets it to true.

The goal of this maintenance task is to remove that code from our codebase since it is not really actually used.

In case we need this in the future, we might also decide to make the field persistent in the database and call it "active" or something like that.