### PR TITLE
MH-13496 Highlight main table rows on hover

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/configuration/partials/index.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/configuration/partials/index.html
@@ -23,5 +23,5 @@
     </h4>
 
   </div>
-  <div class="table-container top-addon" admin-ng-table="" table="table"></div>
+  <div class="table-container top-addon" admin-ng-table="" table="table" highlight="true"></div>
 </div>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/index.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/index.html
@@ -50,5 +50,5 @@
     </h4>
 
   </div>
-  <div class="table-container top-addon" admin-ng-table="" table="table"></div>
+  <div class="table-container top-addon" admin-ng-table="" table="table" highlight="true"></div>
 </div>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/index.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/index.html
@@ -24,5 +24,5 @@
     </h4>
 
   </div>
-  <div class="table-container top-addon" admin-ng-table="" table="table"></div>
+  <div class="table-container top-addon" admin-ng-table="" table="table" highlight="true"></div>
 </div>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/systems/partials/index.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/systems/partials/index.html
@@ -27,5 +27,5 @@
     </h4>
 
   </div>
-  <div class="table-container top-addon" admin-ng-table="" table="table"></div>
+  <div class="table-container top-addon" admin-ng-table="" table="table" highlight="true"></div>
 </div>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/partials/index.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/partials/index.html
@@ -30,5 +30,5 @@
     </h4>
 
   </div>
-  <div class="table-container top-addon" admin-ng-table="" table="table"></div>
+  <div class="table-container top-addon" admin-ng-table="" table="table" highlight="true"></div>
 </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/tableDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/tableDirective.js
@@ -62,7 +62,8 @@ angular.module('adminNg.directives')
     templateUrl: 'shared/partials/table.html',
     replace: false,
     scope: {
-      table: '='
+      table: '=',
+      highlight: '<'
     },
     link: function (scope, element) {
       scope.table.fetch(true);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/table.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/table.html
@@ -5,7 +5,7 @@
 </div>
 <div id="length-div" style="position: absolute; visibility: hidden; height: auto; width: auto; white-space: nowrap;">
 </div>
-<table class="main-tbl">
+<table ng-class="{'main-tbl highlight-hover': highlight, 'main-tbl': !highlight }">
   <thead>
     <tr>
       <th ng-if="table.multiSelect" class="small">

--- a/modules/admin-ui/src/main/webapp/styles/base/_variables.scss
+++ b/modules/admin-ui/src/main/webapp/styles/base/_variables.scss
@@ -94,6 +94,8 @@ $primary-color-green-dark-1: darken($primary-color-green, 9%);      // #2d9d68
 $primary-color-green-dark-2: darken($primary-color-green, 15%);     // #268558
 $primary-color-green-dark-3: darken($primary-color-green, 20%);     // #20724b
 
+$table-highlight: lighten($light-prim-color, 28%);
+
 // Border
 // ----------------------------------------
 
@@ -152,7 +154,7 @@ $border-box-sizing: false;
 
 // Helpers
 $side-margin:                   20px;
-$z-0:                             0;  
+$z-0:                             0;
 $z-10:                          100;
 $z-20:                          200;
 $z-30:                          300;

--- a/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/_tables.scss
@@ -45,6 +45,11 @@
         }
     }
 
+
+    &.highlight-hover tr:hover {
+        background-color: $table-highlight;
+    }
+
     th {
         &.sortable {
             cursor: pointer;


### PR DESCRIPTION
This patch adds an optional "highlight" flags to the table directive. When this flag is set to true, table rows are highlighted when hovered.

The following image illustrates the feature (unfortunately my screenshot tool hides my mouse pointer):

![highlight](https://user-images.githubusercontent.com/1727976/57019153-ee5a5d00-6c25-11e9-93f6-c22c247f169b.png)

This work is sponsored by SWITCH.