### PR TITLE
MH-13511 Adding events in parallel does not work correctly

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/newEventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/newEventController.js
@@ -145,15 +145,14 @@ angular.module('adminNg.controllers')
 
         Notifications.add('success', 'EVENTS_CREATED');
         Notifications.remove(messageId);
-        resetStates();
         window.onbeforeunload = null;
       }, function () {
         Notifications.add('error', 'EVENTS_NOT_CREATED');
         Notifications.remove(messageId);
-        resetStates();
         window.onbeforeunload = null;
       });
 
+      resetStates();
       Modal.$scope.close();
       // add message that never disappears
       messageId = Notifications.add('success', 'EVENTS_UPLOAD_STARTED', 'global', -1);


### PR DESCRIPTION
Steps to reproduce: 
1. Go to http://stable.opencast.org 
2. Throttle connection speed in your browser to Fast 3G 
3. Add a new event (upload a file) 
4. While the event added in step 3 is still uploading, start adding another event (add a title for that event in the Add Event Wizard) 
5. Wait until the upload of the Event of step 3 is completed 
  
 Actual Results: 
 The Add Event Wizard is resetted, i.e. the metadata that you have entered is lost 
  
 Expected Results: 
 The completion of an ongoing upload should not affect the creation of a new one. 
  
 Workaround (if any): 
 Don't add (scheduled) events in parallel 

Analysis: 

We need to reset the state of the wizard right after leaving the submit method. If we wait for the potentially long running requests to complete, the user might meanwhile have opened the wizard again and resetting the state causes loss of the data the user has entered. 
