### PR TITLE
MH-13330 The video editor does not always close after the user presses "Publish"

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
@@ -175,9 +175,11 @@ angular.module('adminNg.controllers')
       $scope.activeTransaction = true;
       $scope.video.thumbnail.loading = $scope.video.thumbnail && $scope.video.thumbnail.type &&
               ($scope.video.thumbnail.type === 'DEFAULT');
+      // Remember $scope.video.workflow as $scope.video.$save will potentially overwrite this value
+      var closeVideoEditor = $scope.video.workflow;
       $scope.video.$save({ id: $scope.id, tool: $scope.tab }, function (response) {
         $scope.activeTransaction = false;
-        if ($scope.video.workflow) {
+        if (closeVideoEditor) {
           Notifications.add('success', 'VIDEO_CUT_PROCESSING');
           $location.url('/events/' + $scope.resource);
         } else {


### PR DESCRIPTION

Steps to reproduce: 
1. Open the video editor 
2. Remove the first 10 seconds of video 
3. Press on "Publish" 
  
 Actual Results: 
 The video editor should close after the user presses on publish 
  
 Expected Results: 
 The video editor does not close after the user presses on publish 
  
 Workaround (if any): 
 Ignore 

Analysis: 
The logic that determines whether the video editor should close after the request returns uses the variable $scope.video.workflow. 
In case the default thumbnail changes because of the cutting, this variable is overwritten by the save request. 
The solution is to use a separate variable to store the state of $scope.video.workflow before performing the save reques