### PR TITLE
MH-13503: Job Dispatch Fairness

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -113,6 +113,14 @@ within Opencast's `org.springframework.security.oauth:spring-security-oauth` dep
 `CVE-2019-3778`.
 
 
+Additional Notes about 6.5
+--------------------------
+
+Opencast 6.5 contains a change to the job dispatching logic, which will change how your cluster dispatches jobs to its
+workers.  This change means that workers with a higher maximum load will absorb more work before workers with lower
+maximum loads will accept heavy workloads.  This change does not require any configuration changes, however you may
+notice large changes in processing load distribution depending on your cluster configuration.
+
 Release Schedule
 ----------------
 

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
@@ -61,7 +61,7 @@ import javax.persistence.UniqueConstraint;
                 + "avg(job.runTime) as meanRun FROM Job job "
                 + "where job.dateCreated >= :minDateCreated and job.dateCreated <= :maxDateCreated "
                 + "group by job.processorServiceRegistration.id, job.status"),
-        @NamedQuery(name = "ServiceRegistration.hostloads", query = "SELECT job.processorServiceRegistration.hostRegistration.baseUrl as host, job.status, sum(job.jobLoad) "
+        @NamedQuery(name = "ServiceRegistration.hostloads", query = "SELECT job.processorServiceRegistration.hostRegistration.baseUrl as host, job.status, sum(job.jobLoad), job.processorServiceRegistration.hostRegistration.maxLoad "
                 + "FROM Job job "
                 + "WHERE job.processorServiceRegistration.online=true and job.processorServiceRegistration.active=true and job.processorServiceRegistration.hostRegistration.maintenanceMode=false "
                 + "AND job.status in :statuses "

--- a/modules/common/src/main/java/org/opencastproject/job/api/AbstractJobProducer.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/AbstractJobProducer.java
@@ -175,30 +175,30 @@ public abstract class AbstractJobProducer implements JobProducer {
     float currentLoad = getServiceRegistry().getOwnLoad();
     logger.debug("{} Current load on this host: {}, job's load: {}, job's status: {}, max load: {}",
             Thread.currentThread().getId(), currentLoad, job.getJobLoad(), job.getStatus().name(),
-            maxload.getLoadFactor());
+            maxload.getMaxLoad());
     // Add the current job load to compare below
     currentLoad += job.getJobLoad();
 
     /* Note that this first clause looks at the *job's*, the other two look at the *node's* load
      * We're assuming that if this case is true, then we're also the most powerful node in the system for this service,
      * per the current job dispatching code in ServiceRegistryJpaImpl */
-    if (job.getJobLoad() > maxload.getLoadFactor() && acceptJobLoadsExeedingMaxLoad) {
+    if (job.getJobLoad() > maxload.getMaxLoad() && acceptJobLoadsExeedingMaxLoad) {
       logger.warn(
               "{} Accepting job {} of type {} with load {} even though load of {} is above this node's limit of {}.",
               Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
-              df.format(currentLoad), df.format(maxload.getLoadFactor()));
+              df.format(currentLoad), df.format(maxload.getMaxLoad()));
       logger.warn("This is a configuration issue that you should resolve in a production system!");
       return true;
-    } else if (currentLoad > maxload.getLoadFactor()) {
+    } else if (currentLoad > maxload.getMaxLoad()) {
       logger.debug(
               "{} Declining job {} of type {} with load {} because load of {} would exceed this node's limit of {}.",
               Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
-              df.format(currentLoad), df.format(maxload.getLoadFactor()));
+              df.format(currentLoad), df.format(maxload.getMaxLoad()));
       return false;
     } else  {
       logger.debug("{} Accepting job {} of type {} with load {} because load of {} is within this node's limit of {}.",
               Thread.currentThread().getId(), job.getId(), job.getJobType(), df.format(job.getJobLoad()),
-              df.format(currentLoad), df.format(maxload.getLoadFactor()));
+              df.format(currentLoad), df.format(maxload.getMaxLoad()));
       return true;
     }
   }

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
@@ -1003,7 +1003,7 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
   @Override
   public SystemLoad getMaxLoads() throws ServiceRegistryException {
     SystemLoad systemLoad = new SystemLoad();
-    systemLoad.addNodeLoad(new NodeLoad(LOCALHOST, Runtime.getRuntime().availableProcessors()));
+    systemLoad.addNodeLoad(new NodeLoad(LOCALHOST, 0.0f, Runtime.getRuntime().availableProcessors()));
     return systemLoad;
   }
 
@@ -1015,7 +1015,7 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
   @Override
   public NodeLoad getMaxLoadOnNode(String host) throws ServiceRegistryException {
     if (hosts.containsKey(host)) {
-      return new NodeLoad(host, hosts.get(host).getMaxLoad());
+      return new NodeLoad(host, 0.0f, hosts.get(host).getMaxLoad());
     }
     throw new ServiceRegistryException("Unable to find host " + host + " in service registry");
   }
@@ -1072,7 +1072,7 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
             }
           }
         }
-        node.setLoadFactor(node.getLoadFactor() + loadSum);
+        node.setCurrentLoad(loadSum);
       }
       systemLoad.addNodeLoad(node);
     }
@@ -1099,7 +1099,7 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
 
   @Override
   public float getOwnLoad() {
-    return getCurrentHostLoads().get(getRegistryHostname()).getLoadFactor();
+    return getCurrentHostLoads().get(getRegistryHostname()).getCurrentLoad();
   }
 
   @Override

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/SystemLoad.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/SystemLoad.java
@@ -85,8 +85,7 @@ public class SystemLoad {
     if (!nodeLoads.containsKey(host)) {
       throw new NotFoundException("Host " + host + " not in this load object");
     }
-    NodeLoad current = nodeLoads.get(host);
-    current.setLoadFactor(current.getLoadFactor() + modifier);
+    nodeLoads.get(host).modifyLoad(modifier);
   }
 
   /**
@@ -134,9 +133,10 @@ public class SystemLoad {
     public NodeLoad() {
     }
 
-    public NodeLoad(String host, float load) {
+    public NodeLoad(String host, float currentload, float maxload) {
       this.host = host;
-      this.loadFactor = load;
+      this.currentLoad = currentload;
+      this.maxLoad = maxload;
     }
 
     /** This node's base URL */
@@ -145,7 +145,10 @@ public class SystemLoad {
 
     /** This node's current load */
     @XmlAttribute
-    protected float loadFactor;
+    protected float currentLoad;
+
+    @XmlAttribute
+    protected float maxLoad;
 
     /**
      * @return the host
@@ -163,25 +166,43 @@ public class SystemLoad {
     }
 
     /**
-     * @return the loadFactor
+     * @return the load factor, current / maxload
      */
     public float getLoadFactor() {
-      return loadFactor;
+      return currentLoad / maxLoad;
     }
 
     /**
-     * @param loadFactor
-     *          the loadFactor to set
+     * Modifies the load for this node
+     * @param modifier
+     *              the amount to add or subtract from the current load
      */
-    public void setLoadFactor(float loadFactor) {
-      this.loadFactor = loadFactor;
+    public void modifyLoad(float modifier) {
+      this.currentLoad = this.currentLoad + modifier;
     }
+
+    public float getCurrentLoad() {
+      return currentLoad;
+    }
+
+    public void setCurrentLoad(float load) {
+      this.currentLoad = load;
+    }
+
+    public float getMaxLoad() {
+      return maxLoad;
+    }
+
+    public void setMaxLoad(float load) {
+      this.maxLoad = load;
+    }
+
 
     @Override
     public int compareTo(NodeLoad other) {
-      if (other.getLoadFactor() > this.loadFactor) {
+      if (other.getLoadFactor() > this.getLoadFactor()) {
         return 1;
-      } else if (this.loadFactor > other.getLoadFactor()) {
+      } else if (this.getLoadFactor() > other.getLoadFactor()) {
         return -1;
       } else {
         return 0;

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/SystemLoad.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/SystemLoad.java
@@ -123,6 +123,17 @@ public class SystemLoad {
     return false;
   }
 
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Current Loads:\n");
+    for (NodeLoad n : getNodeLoads()) {
+      sb.append(String.format("  %s: %f / %f\n", n.getHost(), n.getCurrentLoad(), n.getMaxLoad()));
+    }
+    return sb.toString();
+  }
+
+
   /** A record of a node in the cluster and its load factor */
   @XmlType(name = "nodetype", namespace = "http://serviceregistry.opencastproject.org")
   @XmlRootElement(name = "nodetype", namespace = "http://serviceregistry.opencastproject.org")

--- a/modules/common/src/test/java/org/opencastproject/job/api/AbstractJobProducerTest.java
+++ b/modules/common/src/test/java/org/opencastproject/job/api/AbstractJobProducerTest.java
@@ -102,7 +102,7 @@ public class AbstractJobProducerTest extends EasyMockSupport {
   @Test
   public void testIsReadyToAccept() throws Exception {
     expect(serviceRegistry.getRegistryHostname()).andReturn("test").anyTimes();
-    expect(serviceRegistry.getMaxLoadOnNode("test")).andReturn(new NodeLoad("test", 4.0f)).anyTimes();
+    expect(serviceRegistry.getMaxLoadOnNode("test")).andReturn(new NodeLoad("test", 0.0f, 4.0f)).anyTimes();
     //Initially zero load + 1.0f
     expect(serviceRegistry.getOwnLoad()).andReturn(1.0f);
     //Initially 4.0 load + 1.0f
@@ -133,7 +133,7 @@ public class AbstractJobProducerTest extends EasyMockSupport {
   @Test
   public void testIsReadyToAcceptOversize() throws Exception {
     expect(serviceRegistry.getRegistryHostname()).andReturn("test").anyTimes();
-    expect(serviceRegistry.getMaxLoadOnNode("test")).andReturn(new NodeLoad("test", 4.0f)).anyTimes();
+    expect(serviceRegistry.getMaxLoadOnNode("test")).andReturn(new NodeLoad("test", 0.0f, 4.0f)).anyTimes();
     //Initially zero load + 1.0f
     expect(serviceRegistry.getOwnLoad()).andReturn(1.0f);
     //Initially 4.0 load + 1.0f

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -354,7 +354,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
               .getOrElse(DEFAULT_ACCEPT_JOB_LOADS_EXCEEDING);
     }
 
-    systemLoad = getHostLoads(emf.createEntityManager()).get(hostName).getLoadFactor();
+    systemLoad = getHostLoads(emf.createEntityManager()).get(hostName).getCurrentLoad();
     logger.info("Current system load: {}", systemLoad);
   }
 
@@ -2227,29 +2227,23 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       String host = String.valueOf(resultArray[0]);
 
       Status status = Status.values()[(int) resultArray[1]];
-      float load = ((Number) resultArray[2]).floatValue();
+      float currentLoad = ((Number) resultArray[2]).floatValue();
+      float maxLoad = ((Number) resultArray[3]).floatValue();
 
       // Only queued, and running jobs are adding to the load, so every other status is discarded
       if (status == null || !JOB_STATUSES_INFLUENCING_LOAD_BALANCING.contains(status)) {
-        load = 0.0f;
+        currentLoad = 0.0f;
       }
 
       // Add the service registration
-      NodeLoad serviceLoad;
-      if (systemLoad.containsHost(host)) {
-        serviceLoad = systemLoad.get(host);
-        serviceLoad.setLoadFactor(serviceLoad.getLoadFactor() + load);
-      } else {
-        serviceLoad = new NodeLoad(host, load);
-      }
-
+      NodeLoad serviceLoad = new NodeLoad(host, currentLoad, maxLoad);
       systemLoad.addNodeLoad(serviceLoad);
     }
 
     // This is important, otherwise services which have no current load are not listed in the output!
     for (HostRegistration h : getHostRegistrations(em)) {
       if (!systemLoad.containsHost(h.getBaseUrl())) {
-        systemLoad.addNodeLoad(new NodeLoad(h.getBaseUrl(), 0.0f));
+        systemLoad.addNodeLoad(new NodeLoad(h.getBaseUrl(), 0.0f, h.getMaxLoad()));
       }
     }
 
@@ -2754,7 +2748,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         logger.warn("Unable to determine max load for host {}", service.getHost());
 
       // Determine the current load for this host
-      Float hostLoad = systemLoad.get(service.getHost()).getLoadFactor();
+      Float hostLoad = systemLoad.get(service.getHost()).getCurrentLoad();
       if (hostLoad == null)
         logger.warn("Unable to determine current load for host {}", service.getHost());
 
@@ -2847,7 +2841,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   public SystemLoad getMaxLoads() throws ServiceRegistryException {
     final SystemLoad loads = new SystemLoad();
     for (HostRegistration host : getHostRegistrations()) {
-      NodeLoad load = new NodeLoad(host.getBaseUrl(), host.getMaxLoad());
+      NodeLoad load = new NodeLoad(host.getBaseUrl(), 0.0f, host.getMaxLoad());
       loads.addNodeLoad(load);
     }
     return loads;
@@ -2866,7 +2860,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       em = emf.createEntityManager();
       query = em.createNamedQuery("HostRegistration.getMaxLoadByHostName");
       query.setParameter("host", host);
-      return new NodeLoad(host, ((Number) query.getSingleResult()).floatValue());
+      return new NodeLoad(host, 0.0f, ((Number) query.getSingleResult()).floatValue());
     } catch (NoResultException e) {
       throw new NotFoundException(e);
     } catch (Exception e) {

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -3379,7 +3379,17 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     public int compare(ServiceRegistration serviceA, ServiceRegistration serviceB) {
       String hostA = serviceA.getHost();
       String hostB = serviceB.getHost();
-      return Float.compare(loadByHost.get(hostA).getLoadFactor(), loadByHost.get(hostB).getLoadFactor());
+      NodeLoad nodeA = loadByHost.get(hostA);
+      NodeLoad nodeB = loadByHost.get(hostB);
+      //If the load factors are about the same, sort based on maximum load
+      if (Math.abs(nodeA.getLoadFactor() - nodeB.getLoadFactor()) <= 0.01) {
+        //NOTE: The sort order below is *reversed* from what you'd expect
+        //When we're comparing the load factors we want the node with the lowest factor to be first
+        //When we're comparing the maximum load value, we want the node with the highest max to be first
+        return Float.compare(nodeB.getMaxLoad(), nodeA.getMaxLoad());
+      }
+      return Float.compare(nodeA.getLoadFactor(), nodeB.getLoadFactor());
+
     }
 
   }

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/JobTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/JobTest.java
@@ -611,10 +611,10 @@ public class JobTest {
 
   @Test
   public void testMaxLoad() throws Exception {
-    assertEquals(1.0f, serviceRegistry.getMaxLoads().get(serviceRegistry.getRegistryHostname()).getLoadFactor(), 0.01f);
-    assertEquals(1.0f, serviceRegistry.getMaxLoads().get(LOCALHOST).getLoadFactor(), 0.01f);
-    assertEquals(1.0f, serviceRegistry.getMaxLoads().get(REMOTEHOST).getLoadFactor(), 0.01f);
-    assertEquals(1.0f, serviceRegistry.getMaxLoadOnNode(serviceRegistry.getRegistryHostname()).getLoadFactor(), 0.01f);
+    assertEquals(1.0f, serviceRegistry.getMaxLoads().get(serviceRegistry.getRegistryHostname()).getMaxLoad(), 0.01f);
+    assertEquals(1.0f, serviceRegistry.getMaxLoads().get(LOCALHOST).getMaxLoad(), 0.01f);
+    assertEquals(1.0f, serviceRegistry.getMaxLoads().get(REMOTEHOST).getMaxLoad(), 0.01f);
+    assertEquals(1.0f, serviceRegistry.getMaxLoadOnNode(serviceRegistry.getRegistryHostname()).getMaxLoad(), 0.01f);
   }
 
   @Test

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -161,7 +161,7 @@ public class ServiceRegistryJpaImplTest {
     serviceRegistryJpaImpl.setUserDirectoryService(userDirectoryService);
 
     final Capture<HttpUriRequest> request = EasyMock.newCapture();
-    final BasicHttpResponse successRespone = new BasicHttpResponse(
+    final BasicHttpResponse successResponse = new BasicHttpResponse(
             new BasicStatusLine(new HttpVersion(1, 1), HttpStatus.SC_NO_CONTENT, "No message"));
     final BasicHttpResponse unavailableResponse = new BasicHttpResponse(
             new BasicStatusLine(new HttpVersion(1, 1), HttpStatus.SC_SERVICE_UNAVAILABLE, "No message"));
@@ -178,7 +178,7 @@ public class ServiceRegistryJpaImplTest {
         if (request.getValue().getURI().toString().contains(TEST_PATH_3))
           return unavailableResponse;
 
-        return successRespone;
+        return successResponse;
       }
     }).anyTimes();
     EasyMock.replay(trustedHttpClient);

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -406,9 +406,13 @@ public class ServiceRegistryJpaImplTest {
     JobBarrier barrier = new JobBarrier(null, serviceRegistryJpaImpl, testJob);
     try {
       barrier.waitForJobs(2000);
+      //We should never successfully complete the job, so if we get here then something is wrong
       Assert.fail();
     } catch (Exception e) {
       testJob = serviceRegistryJpaImpl.getJob(testJob.getId());
+      //Some explanation here: If the load exceeds the global maximum node load (ie, jobLoad > all individual node max
+      // loads), then we dispatch to the biggest, even if it's not going to normally accept the job.  That node may still
+      // reject the job, but that's AbstractJobProducer's job, not the service registry's
       Assert.assertEquals(TEST_HOST_OTHER, testJob.getProcessingHost());
     }
   }


### PR DESCRIPTION
This pull request changes the logic around job dispatch from lowest current load first, to lowest load factor first.  For instance, in a situation with three nodes, with maximum loads of 1, 2, and 4 the dispatching order looks like this:

Node | Max load
-------|-------------
Node 1 | 1
Node 2 | 2
Node 3 | 4

Current number of jobs running | Node 1 Load | Node 1 Factor | Node 2 Load | Node 2 Factor | Node 3 Load | Node 3 Factor | Notes
-|-|-|-|-|-|-|-
0 | 0 | 0.0 | 0 | 0.0 | 0 | 0.0 |
1 | 1 | 1.0 | 0 | 0.0 | 0 | 0.0 | Already suboptimal, Node 1 is maxed out, should have gone to Node 3
2 | 1 | 1.0 | 1 | 0.5 | 0 | 0.0 | This job should have gone to Node 3 as well
3 | 1 | 1.0 | 1 | 0.5 | 1 | 0.25 | Finally!
4 | 1 | 1.0 | **2** | **1.0** | 1 | 0.25 | This is the opposite of what we want, Node 3 is basically idle!
5 | 1 | 1.0 | 2 | 1.0 | 2 | 0.5 |  From here on, the jobs go to Node 3, but only because everyone else is already maxed out!
6 | 1 | 1.0 | 2 | 1.0 | 3 | 0.75 | 
6 | 1 | 1.0 | 2 | 1.0 | 4 | 1.0 | 

The new dispatch looks like this

Current number of jobs running | Node 1 Load | Node 1 Factor | Node 2 Load | Node 2 Factor | Node 3 Load | Node 3 Factor | Notes
-|-|-|-|-|-|-|-
0 | 0 | 0.0 | 0 | 0.0 | 0 | 0.0 |
1 | 0 | 0.0 | 0 | 0.0 | 1 | 0.25 | In the case of a tie, dispatch to the node with the largest maximum load
2 | 0 | 0.0 | 1 | 0.5 | 1 | 0.25 | Dispatching to lowest load factor, breaking the tie by max load
3 | 1 | 1.0 | 1 | 0.5 | 1 | 0.25 | 
4 | 1 | 1.0 | 1 | 0.5 | 2 | 0.5 | Largest node is being hit hardest
5 | 1 | 1.0 | 1 | 0.5 | 3 | 0.75 | Same tie breaking rules
6 | 1 | 1.0 | 2 | 1.0 | 3 | 0.75 |
7 | 1 | 1.0 | 2 | 1.0 | 4 | 1.0 |

Note that the smaller worker only becomes saturated after 6 jobs are running, vs 4 with the original dispatch logic.  This becomes even more obvious as the maximum load scales - the larger a worker is relative to the rest of the cluster, the more jobs it will attract before the system will start dispatching to weaker workers.

Long term it would be nice to scale things such that especially weak workers are used only as a last resort, however this approach seems good enough for now, and clusters with completely crippled workers present are likely to be pretty rare.