### PR TITLE
MH-13497 resume on past table page when leaving video editor

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
@@ -179,6 +179,7 @@ angular.module('adminNg.controllers')
         $scope.activeRequest = false;
         if ($scope.video.workflow) {
           Notifications.add('success', 'VIDEO_CUT_PROCESSING');
+          Storage.put('pagination', $scope.resource, 'resume', true);
           $location.url('/events/' + $scope.resource);
         } else {
           Notifications.add('success', 'VIDEO_CUT_SAVED');


### PR DESCRIPTION
Like described in the Jira Ticket. The video editor resumes at the last table page the user viewed when clicking **close**. With this patch the button **save & close** also adopts this behavior.

This work is sponsored by SWITCH