### PR TITLE
MH-13499 Improve navigation in video editor when zoom is active

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
@@ -24,8 +24,20 @@
 /* eslint-disable no-redeclare */
 
 angular.module('adminNg.directives')
-.directive('adminNgTimeline', ['AuthService', 'PlayerAdapter', '$document', 'VideoService', '$timeout',
-  function (AuthService, PlayerAdapter, $document, VideoService, $timeout) {
+.directive('adminNgTimeline', [
+  'AuthService',
+  'PlayerAdapter',
+  '$document',
+  'VideoService',
+  '$timeout',
+  '$interval',
+  function (
+    AuthService,
+    PlayerAdapter,
+    $document,
+    VideoService,
+    $timeout,
+    $interval) {
 
     return {
       templateUrl: 'shared/partials/timeline.html',
@@ -37,9 +49,17 @@ angular.module('adminNg.directives')
       link: function (scope, element) {
         var replaySegment = {};
 
+        scope.previousPosition = -1;
         scope.position = 0;
         scope.positionStyle = 0;
+        scope.hoverPosition = 0;
+        scope.hoverPositionStyle = 0;
+        scope.timelineCursorPositionStyle = 0;
         scope.widthPerSegment = 0;
+        scope.cursorDisplay = 'inline';
+        scope.hoverCursorDisplay = 'none';
+        scope.cursorTouchedZoomWindow = false;
+        scope.dragTimer = null;
 
         scope.ZoomSelectOptions = [
           { name: 'All', time: 0 }
@@ -52,8 +72,6 @@ angular.module('adminNg.directives')
         scope.zoomLevel = 0;
         scope.zoomValue = 0;
         scope.zoomSelected = scope.ZoomSelectOptions[0];
-        scope.zoomOffset = 0;
-        scope.zoomFieldOffset = 0;
 
         scope.from = 0;
         scope.to = 0;
@@ -71,8 +89,44 @@ angular.module('adminNg.directives')
 
         scope.wrapperClass = ''; // list of border classes for the segment wrapper.
 
-        scope.player.adapter.addListener(PlayerAdapter.EVENTS.DURATION_CHANGE, function () {
+        scope.mouseEnterPlayTrack = function(event) {
+          scope.hoverCursorDisplay = 'inline';
+        };
 
+        scope.mouseLeavePlayTrack = function(event) {
+          scope.hoverCursorDisplay = 'none';
+        };
+
+        scope.videoTooShortToZoom = function() {
+          return scope.video.duration <= 10000;
+        };
+
+        scope.normalizeTrackPosition = function (pos) {
+          var track = element.find('.timeline-track');
+          if (track !== undefined && track.width() !== 0) {
+            var onePxInPercent = 100.0 / track.width();
+          } else {
+            var onePxInPercent = 0.0;
+          }
+          var result = onePxInPercent + (pos - scope.from) / scope.zoomValue * (100 - 2 * onePxInPercent);
+          return result + '%';
+        };
+
+        scope.moveMouseOnPlayTrack = function(event) {
+          var mx = $document.mx;
+
+          var el = $(event.target);
+          if (el.attr('id') === 'cursor-track') {
+            var position = (mx - el.offset().left) / el.width() * scope.zoomValue + scope.from;
+            scope.hoverCursorDisplay = 'inline';
+            scope.hoverPositionStyle = scope.normalizeTrackPosition(position);
+            scope.hoverPosition = position;
+          } else {
+            scope.hoverCursorDisplay = 'none';
+          }
+        };
+
+        scope.player.adapter.addListener(PlayerAdapter.EVENTS.DURATION_CHANGE, function () {
           // reset then remove the items that are longer than the video duration
           scope.ZoomSelectOptions = [
             { name: 'All', time: 0 }
@@ -90,14 +144,89 @@ angular.module('adminNg.directives')
           }
 
           scope.zoomValue = scope.getZoomValue();
-          scope.zoomOffset = scope.getZoomOffset();
-          scope.zoomFieldOffset = scope.getZoomFieldOffset();
+          scope.from = scope.getZoomFieldOffset();
+          scope.to = scope.from + scope.zoomValue;
           scope.setWrapperClasses();
+          scope.updateShuttle();
         });
 
-        scope.player.adapter.addListener(PlayerAdapter.EVENTS.TIMEUPDATE, function () {
+        scope.updatePlayHead = function() {
+          if ((scope.position < scope.from || scope.position > scope.to) && scope.dragTimer === null) {
+            scope.cursorDisplay = 'none';
+          } else {
+            scope.cursorDisplay = 'inline';
+          }
+          scope.timelineCursorPositionStyle = (scope.position / scope.video.duration * 100) + '%';
+          scope.positionStyle = scope.normalizeTrackPosition(scope.position);
+        };
+
+        scope.player.adapter.addListener(PlayerAdapter.EVENTS.PLAY, function () {
+          scope.cursorTouchedZoomWindow = scope.position >= scope.from && scope.position <= scope.to;
+        });
+        scope.player.adapter.addListener(PlayerAdapter.EVENTS.PAUSE, function () {
+          scope.cursorTouchedZoomWindow = false;
+        });
+
+        scope.inZoomWindow = function(pos) {
+          return pos >= scope.from && pos <= scope.to;
+        };
+
+        scope.overflowsRight = function(pos) {
+          return pos > scope.to && pos < scope.video.duration;
+        };
+
+        scope.overflowsLeft = function(pos) {
+          // Using the keyboard, we can also decrease our play position and have to adapt the zoom boundaries
+          // accordingly. Note that there can be minute differences between position and from due to
+          // numerical inaccuracies when dragging the timeline, thus the 0.5.
+          return pos - scope.from < -0.5;
+        };
+
+        $interval(function () {
           scope.position = scope.player.adapter.getCurrentTime() * 1000;
-          scope.positionStyle = (scope.position * 100 / scope.video.duration) + '%';
+          if (scope.position > scope.video.duration) {
+            scope.position = scope.video.duration;
+            scope.player.adapter.setCurrentTime(scope.position / 1000);
+            scope.player.adapter.pause();
+          }
+          if (scope.position === scope.previousPosition) {
+            return;
+          }
+          if (scope.player.adapter.getStatus() === PlayerAdapter.STATUS.PLAYING) {
+            if (scope.inZoomWindow(scope.position)) {
+              scope.cursorTouchedZoomWindow = true;
+            }
+            if (scope.cursorTouchedZoomWindow) {
+              if (scope.overflowsRight(scope.position)) {
+                // Are we out of space for a full piece of zoomed-in video?
+                if (scope.video.duration - scope.to < scope.zoomValue) {
+                  scope.from = scope.video.duration - scope.zoomValue;
+                } else {
+                  scope.from = scope.to;
+                }
+                scope.to = scope.from + scope.zoomValue;
+              }
+            }
+          } else {
+            var previouslyInBoundary = scope.previousPosition >= scope.from && scope.previousPosition <= scope.to;
+            // Not currently playing, past the right boundary: probably because of a seek to the right
+            if (scope.overflowsRight(scope.position) && previouslyInBoundary) {
+              // Are we out of space for a full piece of zoomed-in video?
+              if (scope.video.duration - scope.to < scope.zoomValue) {
+                scope.from = scope.video.duration - scope.zoomValue;
+              } else {
+                scope.from = scope.to;
+              }
+              scope.to = scope.from + scope.zoomValue;
+            } else if (scope.overflowsLeft(scope.position) && previouslyInBoundary) {
+              // Same thing for the left overflow
+              scope.from = Math.max(0, scope.from - scope.zoomValue);
+              scope.to = scope.from + scope.zoomValue;
+            }
+          }
+          scope.previousPosition = scope.position;
+          scope.updatePlayHead();
+          scope.updateShuttle();
 
           var segment = VideoService.getCurrentSegment(scope.player, scope.video);
 
@@ -123,7 +252,7 @@ angular.module('adminNg.directives')
           {
             scope.player.adapter.setCurrentTime(segment.end / 1000);
           }
-        });
+        }, 40);
 
         /**
          * Formats time stamps to HH:MM:SS.sss
@@ -203,12 +332,10 @@ angular.module('adminNg.directives')
             scope.video.duration = parseInt(scope.video.duration, 10);
           }
 
-          var zoom = 1,
-              absoluteSize = segment.end - segment.start,
-              relativeSize = absoluteSize / scope.video.duration,
-              scaledSize = relativeSize * zoom;
+          var absoluteSize = segment.end - segment.start,
+              relativeSize = absoluteSize / scope.video.duration;
 
-          return (scaledSize * 100) + (!dropPercent ? '%' : 0);
+          return (relativeSize * 100) + (!dropPercent ? '%' : 0);
         };
 
         /**
@@ -231,20 +358,40 @@ angular.module('adminNg.directives')
                     scope.video.duration;
         };
 
-        /**
-         * Returns the offset for the currently visible portion.
-         *
-         * Based on the following linear equation.
-         *
-         *          duration
-         * y(pos) = -------- * pos - pos
-         *           zoom
-         *
-         * @return {Number} Relative offset
-         */
-        scope.getZoomOffset = function () {
-          return scope.position * scope.video.duration / scope.zoomValue -
-                    scope.position;
+        scope.changeZoomInternal = function() {
+          var addition = scope.zoomValue / 2;
+          //if (scope.position >= scope.from && scope.position <= scope.to) {
+          if (scope.from === 0) {
+            var relativePosition = 0;
+          } else if (scope.to == scope.video.duration) {
+            var relativePosition = scope.video.duration;
+          } else {
+            var relativePosition = (scope.from + scope.to) / 2;
+          }
+          // Were we to move the zoom boundaries to the right/left, by
+          // how far do we run out of the video?
+          var overheadRight = relativePosition + addition - scope.video.duration;
+          var overheadLeft = addition - relativePosition;
+          // Check for overheads and distribute the overhead space to
+          // the other side of the zoom boundary, if possible.
+          if (overheadRight > 0) {
+            // Overhead on the right, so move the boundary more to the left
+            scope.to = scope.video.duration;
+            scope.from = Math.max(0, relativePosition - addition - overheadRight);
+          } else if (overheadLeft > 0) {
+            // Overhead on the left, so move the right boundary a bit
+            // farther away.
+            scope.from = 0;
+            scope.to = Math.min(scope.video.duration, relativePosition + addition + overheadLeft);
+          } else {
+            // No overhead, simply center the zoom boundaries around
+            // the current playing position.
+            scope.from = relativePosition - addition;
+            scope.to = relativePosition + addition;
+          }
+          scope.updatePlayHead();
+          scope.updateShuttle();
+          scope.setWrapperClasses();
         };
 
         /**
@@ -256,9 +403,7 @@ angular.module('adminNg.directives')
 
           // Cache the zoom value and position
           scope.zoomValue = scope.getZoomValue();
-          scope.zoomOffset = scope.getZoomOffset();
-          scope.zoomFieldOffset = scope.getZoomFieldOffset();
-          scope.setWrapperClasses();
+          scope.changeZoomInternal();
 
           if (scope.zoomValue >= 0) {
             scope.zoomSelected = '';
@@ -285,9 +430,7 @@ angular.module('adminNg.directives')
 
             // Cache the zoom value and position
             scope.zoomValue = scope.getZoomValue();
-            scope.zoomOffset = scope.getZoomOffset();
-            scope.zoomFieldOffset = scope.getZoomFieldOffset();
-            scope.setWrapperClasses();
+            scope.changeZoomInternal();
 
             var dropdown = element.find('.zoom-control #zoomSelect');
 
@@ -309,16 +452,14 @@ angular.module('adminNg.directives')
 
           angular.forEach(scope.video.segments, function (segment) {
 
-            if ((segment.start <= scope.zoomFieldOffset) && (segment.end >= scope.zoomFieldOffset)) {
+            if (segment.start <= scope.from && segment.end >= scope.from) {
               classes[0] = 'left-' + (
                 segment.deleted
                   ? ( segment.selected ? 'deleted-selected' : 'deleted')
                   : ( segment.selected ? 'selected' : 'normal'));
             }
 
-            if ((segment.start <= (scope.zoomFieldOffset + scope.zoomValue))
-              && (segment.end >= (scope.zoomFieldOffset + scope.zoomValue)))
-            {
+            if (segment.start <= scope.to && segment.end >= scope.to) {
               classes[1] = 'right-' + (
                 segment.deleted
                   ? ( segment.selected ? 'deleted-selected' : 'deleted')
@@ -342,7 +483,7 @@ angular.module('adminNg.directives')
           }
 
           var width = (scope.video.duration * 100 / scope.zoomValue),
-              left = (scope.zoomOffset * -100 / scope.video.duration);
+              left = scope.from / scope.zoomValue * -100;
 
           // if less than possible length then set to possible length
           if (scope.video.duration <= scope.zoomValue) {
@@ -461,14 +602,9 @@ angular.module('adminNg.directives')
 
           // Cache the zoom value and position
           scope.zoomValue = scope.getZoomValue();
-          scope.zoomOffset = scope.getZoomOffset();
-          scope.zoomFieldOffset = scope.getZoomFieldOffset();
-
-          scope.from = scope.zoomFieldOffset;
-          scope.to = scope.zoomFieldOffset + scope.zoomValue;
 
           var width = (scope.zoomValue * 100 / scope.video.duration),
-              left = (scope.zoomFieldOffset * 100 / scope.video.duration);
+              left = (scope.from * 100 / scope.video.duration);
 
           // if less than possible length then set to possible length
           if (scope.video.duration <= scope.zoomValue) {
@@ -614,6 +750,10 @@ angular.module('adminNg.directives')
          * 3. Segment start handle
          */
         $document.mouseup(function () {
+          if (scope.dragTimer !== null) {
+            $interval.cancel(scope.dragTimer);
+            scope.dragTimer = null;
+          }
 
           // Timeline mouse events
           if (scope.canMoveTimeline) {
@@ -670,7 +810,7 @@ angular.module('adminNg.directives')
             var pxPosition = scope.movingSegment.parent().offset().left
               + parseInt(scope.movingSegment.css('left'),10)
               - topTrack.offset().left + 3;
-            var position = Math.floor((pxPosition / track.width() * scope.video.duration) + scope.zoomFieldOffset);
+            var position = Math.floor((pxPosition / track.width() * scope.video.duration) + scope.from);
 
             if (position < 0) position = 0;
             if (position >= scope.video.duration) position = scope.video.duration;
@@ -761,7 +901,7 @@ angular.module('adminNg.directives')
 
             if (el.attr('id') === 'cursor-track') {
 
-              var position = (event.clientX - el.offset().left) / el.width() * scope.zoomValue + scope.zoomFieldOffset;
+              var position = scope.hoverPosition;
 
               // Limit position to the length of the video
               if (position > scope.video.duration) {
@@ -773,6 +913,9 @@ angular.module('adminNg.directives')
               }
 
               scope.player.adapter.setCurrentTime(position / 1000);
+              scope.position = position;
+              scope.updatePlayHead();
+
               scope.setWrapperClasses();
 
               // show small cut button below timeline handle
@@ -790,6 +933,44 @@ angular.module('adminNg.directives')
           }
         };
 
+        scope.moveOutsideBounds = function() {
+          var track = element.find('.timeline-track');
+          var differenceToLeft = $document.mx - track.offset().left;
+          var differenceToRight = $document.mx - (track.offset().left + track.width());
+          if (differenceToLeft < 0) {
+            var differenceToBorder = differenceToLeft;
+            var sign = -1;
+          } else if (differenceToRight > 0) {
+            var differenceToBorder = differenceToRight;
+            var sign = 1;
+          } else {
+            return;
+          }
+          var zoomScrollPercentage = 0.001 + Math.min(1.0, Math.max(0, Math.abs(differenceToBorder) / 10.0)) * 0.01;
+          var increment = sign * scope.zoomValue * zoomScrollPercentage;
+          if (scope.from + increment < 0) {
+            scope.from = 0;
+            scope.to = scope.zoomValue;
+            scope.position = 0;
+          } else if (scope.to + increment > scope.video.duration) {
+            scope.from = scope.video.duration - scope.zoomValue;
+            scope.to = scope.video.duration;
+            scope.position = scope.video.duration;
+          } else {
+            scope.from += increment;
+            scope.to += increment;
+            if (differenceToBorder < 0) {
+              scope.position = scope.from;
+            } else {
+              scope.position = scope.to;
+            }
+          }
+          scope.player.adapter.setCurrentTime(scope.position / 1000);
+          scope.updatePlayHead();
+          scope.updateShuttle();
+          scope.setWrapperClasses();
+        };
+
         /**
          * Sets the timeline handle cursor position depending on the mouse coordinates.
          *
@@ -802,22 +983,40 @@ angular.module('adminNg.directives')
           var track = element.find('.timeline-track'),
               handle = element.find('#cursor .handle'),
               position_absolute = $document.mx - handle.data('dx') + handle.width() / 2 - track.offset().left,
-              position = position_absolute / track.width() * scope.video.duration;
+              position = scope.from + position_absolute / track.width() * scope.zoomValue;
 
-          // Limit position to the length of the video
-          if (position > scope.video.duration) {
-            position = scope.video.duration;
+          if ($document.mx < track.offset().left || $document.mx > track.offset().left + track.width()) {
+            if (scope.dragTimer === null) {
+              scope.dragTimer = $interval(function() {
+                scope.moveOutsideBounds();
+              }, 50);
+            }
+          } else {
+            if (scope.dragTimer !== null) {
+              $interval.cancel(scope.dragTimer);
+              scope.dragTimer = null;
+            }
+            // Limit position to the length of the video
+            var zoomScrollPercentage = 0.001;
+            if (position > scope.to) {
+              scope.to = Math.min(scope.to + scope.zoomValue * zoomScrollPercentage, scope.video.duration);
+              scope.from = scope.to - scope.zoomValue;
+              position = scope.to;
+            } else if (position < scope.from) {
+              scope.from = Math.max(scope.from - scope.zoomValue * zoomScrollPercentage, 0);
+              scope.to = scope.from + scope.zoomValue;
+              position = scope.from;
+            }
+
+            scope.position = position;
+            scope.player.adapter.setCurrentTime(scope.position / 1000);
+            scope.$apply(function () {
+              scope.updatePlayHead();
+              scope.updateShuttle();
+            });
+
+            scope.setWrapperClasses();
           }
-          if (position < 0) {
-            position = 0;
-          }
-
-          scope.position = position;
-          scope.$apply(function () {
-            scope.positionStyle = (scope.position * 100 / scope.video.duration) + '%';
-          });
-
-          scope.setWrapperClasses();
         };
 
         /**
@@ -909,27 +1108,31 @@ angular.module('adminNg.directives')
           event.preventDefault();
           if (!scope.canMoveTimeline) { return; }
 
-          var track = element.find('.field-of-vision'),
-              shuttle = element.find('.field-of-vision .field'),
-              nx = $document.mx - shuttle.data('dx');
+          var shuttle = element.find('.field-of-vision .field'),
+              nx = $document.mx - shuttle.data('dx'),
+              newPosition = shuttle.data('ox') + nx;
 
-          if (nx <= 0) nx = 0;
-          if (nx >= shuttle.data('end')) nx = shuttle.data('end');
+          if (newPosition <= 0) newPosition = 0;
+          if (newPosition >= shuttle.data('end')) newPosition = shuttle.data('end');
 
-          var percentage = nx / shuttle.data('track_width') * 100;
+          var percentage = newPosition / shuttle.data('track_width') * 100;
 
           shuttle.css('left', percentage + '%');
-          scope.zoomFieldOffset = (scope.video.duration * percentage) / 100;
-          scope.position = (scope.zoomFieldOffset * scope.video.duration) / (scope.video.duration - scope.zoomValue);
+          scope.from = (scope.video.duration * percentage) / 100;
+          scope.to = scope.from + scope.zoomValue;
+          scope.updatePlayHead();
 
           if (isNaN(scope.position) || (scope.position < 0)) scope.position = 0;
           if (scope.position > scope.video.duration) scope.position = scope.video.duration;
 
-          scope.from = scope.zoomFieldOffset;
-          scope.to = scope.zoomFieldOffset + scope.zoomValue;
+          scope.updateShuttle();
+          scope.setWrapperClasses();
+        };
+
+        scope.updateShuttle = function() {
+          var shuttle = element.find('.field-of-vision .field');
           shuttle.find(':first-child').html( scope.formatMilliseconds(scope.from) );
           shuttle.find(':last-child').html( scope.formatMilliseconds(scope.to) );
-          scope.setWrapperClasses();
         };
 
         /**
@@ -947,7 +1150,8 @@ angular.module('adminNg.directives')
           var track = element.find('.field-of-vision'),
               shuttle = element.find('.field-of-vision .field');
 
-          shuttle.data('dx', $document.mx - shuttle.offset().left);
+          shuttle.data('dx', $document.mx);
+          shuttle.data('ox', shuttle.offset().left - shuttle.parent().offset().left);
           shuttle.data('dy', $document.my - shuttle.offset().top);
           shuttle.data('track_width', track.width());
           shuttle.data('shuttle_width', shuttle.width());
@@ -1024,7 +1228,7 @@ angular.module('adminNg.directives')
           if (!segment.selected) {
             scope.player.adapter.setCurrentTime(segment.start / 1000);
             scope.position = segment.start;
-            scope.positionStyle = (scope.position * 100 / scope.video.duration) + '%';
+            scope.updatePlayHead();
             scope.selectSegment(segment);
           }
         };

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/timeline.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/timeline.html
@@ -5,7 +5,7 @@
       <label translate>VIDEO_TOOL.TIMELINE</label>
       <div class="zoom-control">
         <label translate>VIDEO_TOOL.ZOOMLEVEL</label>
-        <input type="range" class="zoom-level" ng-model="zoomLevel" ng-change="changeZoomLevel($event)">
+        <input type="range" class="zoom-level" ng-model="zoomLevel" ng-change="changeZoomLevel($event)" ng-disabled="videoTooShortToZoom()">
 
         <select chosen class="workflow" id="zoomSelect"
                                         data-width="'85px'"
@@ -13,12 +13,15 @@
                                         data-translated="{{ 'VIDEO_TOOL.ZOOM' | translate }}"
                                         ng-model="zoomSelected"
                                         ng-change="changeZoomSelected($event)"
+                                        ng-disabled="videoTooShortToZoom()"
                                         ng-options="y.name for (x, y) in ZoomSelectOptions track by y.name">
           <option value=""></option>
         </select>
       </div>
     </div>
     <div class="field-of-vision">
+      <div id="timeline-cursor" ng-style="{ left: timelineCursorPositionStyle }">
+      </div>
       <div class="field" ng-class="getZoomClass()" ng-mousedown="dragTimeline($event)" ng-style="getZoomStyle()">
         <div class="boundary from">{{ formatMilliseconds(from) }}</div>
         <div class="boundary to">{{ formatMilliseconds(to) }}</div>
@@ -52,6 +55,8 @@
         </div>
 
         <div class="{{wrapperClass}}">
+          <div id="hover-cursor" ng-style="{ left: hoverPositionStyle, display: hoverCursorDisplay }">
+          </div>
           <div class="segments" ng-style="getSegmentStyle(track)">
             <div ng-class="{'segment-container': true, displayWaveform: getSegmentWidth(segment, true) < 0.5}"
                  ng-repeat="segment in video.segments | orderBy:'start'"
@@ -78,8 +83,8 @@
           </div>
         </div>
       </div>
-      <div id="cursor-track" ng-click="clickPlayTrack($event)">
-        <div id="cursor" ng-mousedown="dragPlayhead($event)" ng-style="{ left: positionStyle }">
+      <div id="cursor-track" ng-click="clickPlayTrack($event)" ng-mousemove="moveMouseOnPlayTrack($event)" ng-mouseenter="mouseEnterPlayTrack($event)" ng-mouseleave="mouseLeavePlayTrack($event)">
+        <div id="cursor" ng-mousedown="dragPlayhead($event)" ng-style="{ left: positionStyle, display: cursorDisplay }">
           <div class="handle"></div>
           <div class="arrow_box">
             <a title="{{'VIDEO_TOOL.ACTIONS.SPLIT' | translate}}"

--- a/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/video/_video-editor.scss
@@ -447,6 +447,14 @@ $segment-deleted-selected: saturate(darken($segment-deleted, 25%), 5%);
              border-radius: 4px;
         }
 
+        #hover-cursor {
+            width: 1px;
+            background-color: #777;
+            height: 60px;
+            position: absolute;
+            z-index: $z-80;
+        }
+
         #cursor, #cursor_fake {
             width: 1px;
             height: calc(100% - 23px);
@@ -578,6 +586,14 @@ $segment-deleted-selected: saturate(darken($segment-deleted, 25%), 5%);
             position: relative;
             width: 100%;
             z-index: 100;
+
+            #timeline-cursor {
+                width: 1px;
+                background-color: #777;
+                height: 30px;
+                position: absolute;
+                z-index: $z-80;
+            }
 
             &::before {
               content: "";


### PR DESCRIPTION
This PR changes the way the video editor timeline behaves when the user zooms in, and also adds some new visual elements.

Previously, what the waveform and the timeline “shuttle” (as it's apparently called) did was solely dependent on the current playing position. Both continuously recentered around it. Furthermore, as is described in the corresponding JIRA issue, clicking on the timeline didn’t cause the play head to jump to that position, which was particularly counterintuitive.

With this PR, the waveform and the timeline shuttle _only_ moves or changes if…

- …you drag the shuttle while zoomed in (this PR also fixes a bug where the shuttle would jump a few pixels when it’s clicked and moved).
- …the video is playing and the play head moves out of the currently zoomed in window of the waveform; then, the next piece of zoomed-in waveform is displayed and the shuttle is updated as well.
- …you change the video position by dragging the play head or entering it explicitly in the input field.
- …you change the zoom level.

This way, clicking on the timeline actually moves the play head to that position, and the behavior is more consistent with other video editor solutions – as I’m told at least. :)

The following things were changed in addition to that:

- Dragging the play head far to the left or right, you can now continuously scroll through the timeline.
- There are two new "cursors", one on the topmost timeline, indicating the playing position even when the play head isn't visible, and one on the bottom timeline, only appearing when the mouse is over the cursor track. The latter helps pick out exact positions to cut segments in, for example.
- Instead of relying on the browser to update the play head (via the corresponding listener), we now use a timer to regularly update the position. This looks much smoother, especially on high zoom levels.

The PR also resolves an issue where the timeline shuttle doesn’t update its offsets (the texts on the left and right of it) as it moves.

This PR also resolves an issue where clicking on the play track while horizontal scrolling was in effect lead to the wrong playing position to be selected (zoomed in or not).

This PR also disables the zoom controls for videos smaller than 10 Seconds (for which zoom isn't properly supported anyway).

Also, note that the indentation for the injection list was changed to include a newline after each comma. This new style helps resolve devious merge conflicts and conforms to what eslint wants, so I hope it's okay (I talked quickly on IRC about this).

This work was sponsored by SWITCH.
