### PR TITLE
MH-13521, Switch to openJDK 8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true
 
 language: java
 
-jdk: oraclejdk8
+jdk: openjdk8
 
 # Cache maven artifacts, pip downloads and the node modules for markdownlint
 cache:


### PR DESCRIPTION
There seems to be some hick-ups with oraclejdk8 and we recommending
openJDK anyway.