### PR TITLE
MH-13512 Improve URL signing performance

### DIFF
--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/AbstractUrlSigningProvider.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/AbstractUrlSigningProvider.java
@@ -20,6 +20,7 @@
  */
 package org.opencastproject.security.urlsigning.provider.impl;
 
+import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.urlsigning.exception.UrlSigningException;
 import org.opencastproject.security.urlsigning.provider.UrlSigningProvider;
@@ -47,18 +48,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.TreeMap;
 
 public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, ManagedService {
-  /** The prefix for key entry configuration keys */
-  public static final String KEY_ENTRY_PREFIX = "key";
-  /** The postfix in the configuration file to define the encryption key. */
+  /** The prefix for key configuration keys */
+  public static final String KEY_PROPERTY_PREFIX = "key";
+  /** The attribute name in the configuration file to define the encryption key. */
   public static final String SECRET = "secret";
-  /** The postfix in the configuration file to define the matching url. */
+  /** The attribute name in the configuration file to define the matching url. */
   public static final String URL = "url";
-  /** The postfix in the configuration file to define the organization owning the key. */
+  /** The attribute name in the configuration file to define the organization owning the key. */
   public static final String ORGANIZATION = "organization";
 
   /** Value indicating that the key can be used by any organization */
@@ -78,16 +78,24 @@ public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, 
   public abstract Logger getLogger();
 
   /**
-   * A class to contain the necessary key entries for url signing.
+   * A class representing a URL signing key.
    */
-  private static class KeyEntry {
-    private String key = null;
-    private String url = null;
-    private String organization = ANY_ORGANIZATION;
+  private static class Key {
+    private String id = null;
+    private String secret = null;
+    private String organizationId = ANY_ORGANIZATION;
+
+    Key(String id) {
+      this.id = id;
+    }
+
+    boolean supports(String organizationId) {
+      return this.organizationId.equals(ANY_ORGANIZATION) || this.organizationId.equals(organizationId);
+    }
   }
 
-  /** The map to contain the list of keys, their ids and the urls they match. */
-  private Map<String, KeyEntry> keys = new HashMap<>();
+  /** A mapping of URL prefixes to keys used to lookup keys for a given URL. */
+  private TreeMap<String, Key> urls = new TreeMap<>();
 
   /**
    * @param securityService
@@ -101,24 +109,34 @@ public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, 
    * @return The current set of url beginnings this signing provider is looking for.
    */
   public Set<String> getUris() {
-    return keys.values().stream()
-            .map(keyEntry -> keyEntry.url)
-            .collect(Collectors.collectingAndThen(
-                    Collectors.toSet(),
-                    Collections::unmodifiableSet));
+    return Collections.unmodifiableSet(urls.keySet());
   }
 
   /**
-   * If available get a {@link KeyEntry} if there is a matching Url matcher.
+   * Get{@link Key} for a given URL.
+   * This method supports multi-tenancy in means of only returning keys that can be used by the current
+   * organization. In case the current organization cannot be determined, no key will be returned. 
    *
    * @param baseUrl
-   *          The url to check against the possible matchers.
-   * @return The {@link KeyEntry} if it is available.
+   *          The URL that needs to be signed.
+   * @return The {@link Key} if it is available.
    */
-  private Optional<Map.Entry<String, KeyEntry>> getKeyEntry(String baseUrl) {
-    return keys.entrySet().stream()
-            .filter(entry -> baseUrl.startsWith(entry.getValue().url))
-            .findAny();
+  private Key getKey(String baseUrl) {
+    /* Optimization: Use TreeMap.floorEntry that can retrieve the greatest URL equal to or greater than 'baseUrl'
+       in O(log(n)). As we are trying to find an URL that is a prefix of 'baseUrl', candidate.getKey() either is
+       that URL (needs to be checked!) or there is no such URL. */
+    Map.Entry<String, Key> candidate = urls.floorEntry(baseUrl);
+    if (candidate != null && baseUrl.startsWith(candidate.getKey())) {
+      Key key = candidate.getValue();
+
+      // Don't accept URLs without an organization context
+      // (for example from the ServiceRegistry JobProducerHeartbeat)
+      Organization organization = securityService.getOrganization();
+      if (organization != null && key.supports(organization.getId())) {
+        return key;
+      }
+    }
+    return null;
   }
 
   @Override
@@ -130,62 +148,66 @@ public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, 
     }
 
     // Collect configuration in a new map so we don't partially override the old one in case of error
-    Map<String, KeyEntry> keys = new HashMap<>();
+    TreeMap<String, Key> urls = new TreeMap<>();
+
+    // Temporary list of key entries to simplify building up the keys
+    Map<String, Key> keys = new HashMap<>();
 
     Enumeration<String> propertyKeys = properties.keys();
     while (propertyKeys.hasMoreElements()) {
       String propertyKey = propertyKeys.nextElement();
 
-      String keyEntryProperty = StringUtils.removeStart(propertyKey, KEY_ENTRY_PREFIX + ".");
-      if (keyEntryProperty == propertyKey) continue;
+      if (propertyKey.startsWith(KEY_PROPERTY_PREFIX + ".")) {
 
-      String[] parts = Arrays.stream(keyEntryProperty.split("\\."))
-              .map(String::trim)
-              .toArray(String[]::new);
-      if (parts.length != 2) {
-        throw new ConfigurationException(propertyKey, "wrong property key format");
-      }
+        // We expected the parts [KEY_PROPERTY_PREFIX, id, attribute]
+        String[] parts = Arrays.stream(propertyKey.split("\\.")).map(String::trim).toArray(String[]::new);
+        if (parts.length != 3) {
+          throw new ConfigurationException(propertyKey, "Wrong property key format");
+        }
 
-      String id = parts[0];
-      KeyEntry currentKeyEntry = keys.computeIfAbsent(id, __ -> new KeyEntry());
+        String propertyValue = StringUtils.trimToNull(Objects.toString(properties.get(propertyKey), null));
+        if (propertyValue == null) {
+          throw new ConfigurationException(propertyKey, "Can't be null or empty");
+        }
 
-      String attribute = parts[1];
-      String propertyValue = StringUtils.trimToNull(Objects.toString(properties.get(propertyKey), null));
-      if (propertyValue == null) {
-        throw new ConfigurationException(propertyKey, "can't be null or empty");
-      }
-      switch (attribute) {
-        case ORGANIZATION:
-          currentKeyEntry.organization = propertyValue;
-          break;
-        case URL:
-          if (keys.values().stream()
-                  .map(keyEntry -> keyEntry.url)
-                  .filter(Objects::nonNull)
-                  .anyMatch(url -> propertyValue.startsWith(url) || (url != null && url.startsWith(propertyValue)))) {
-            throw new ConfigurationException(propertyKey,
-                    "there is already a key configuration for a URL with the prefix " + propertyValue);
-          }
-          currentKeyEntry.url = propertyValue;
-          break;
-        case SECRET:
-          currentKeyEntry.key = propertyValue;
-          break;
-        default:
-          throw new ConfigurationException(propertyKey, "unknown attribute " + attribute + " for key " + id);
+        String id = parts[1];
+        Key currentKey = keys.computeIfAbsent(id, __ -> new Key(id));
+
+        String attribute = parts[2];
+        switch (attribute) {
+          case ORGANIZATION:
+            currentKey.organizationId = propertyValue;
+            break;
+          case URL:
+            if (urls.keySet().stream().anyMatch(v -> propertyValue.startsWith(v) || (v.startsWith(propertyValue)))) {
+              throw new ConfigurationException(propertyKey,
+                      "There is already a key configuration for a URL with the prefix " + propertyValue);
+            }
+            /* We explicitely support multiple URLs that map to the same key */
+            urls.put(propertyValue, currentKey);
+            break;
+          case SECRET:
+            currentKey.secret = propertyValue;
+            break;
+          default:
+            throw new ConfigurationException(propertyKey, "Unknown attribute " + attribute + " for key " + id);
+        }
       }
     }
 
-    keys = keys.entrySet().stream()
-            .filter(entry -> entry.getValue().key != null && entry.getValue().url != null)
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    /* Validate key entries */
+    for (Key key : keys.values()) {
+      if (key.secret == null) {
+        throw new ConfigurationException(key.id, "No secret set");
+      }
+    }
 
     // Has the rewriter been fully configured
-    if (keys.size() == 0) {
+    if (urls.size() == 0) {
       getLogger().info("{} configured to not sign any urls.", toString());
     }
 
-    this.keys = keys;
+    this.urls = urls;
   }
 
   @Override
@@ -196,39 +218,26 @@ public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, 
       getLogger().debug("Unable to support url {} because", baseUrl, e);
       return false;
     }
-
-    // Don't accept URLs without an organization context
-    // (for example from the ServiceRegistry JobProducerHeartbeat)
-    if (securityService.getOrganization() == null)
-      return false;
-
-    String orgId = securityService.getOrganization().getId();
-
-    Optional<Map.Entry<String, KeyEntry>> keyEntry = getKeyEntry(baseUrl);
-    return keyEntry
-            .map(entry -> entry.getValue().organization)
-            .map(organization -> organization.equals(ANY_ORGANIZATION) || organization.equals(orgId))
-            .orElse(false);
+    return getKey(baseUrl) != null;
   }
 
   @Override
   public String sign(Policy policy) throws UrlSigningException {
-    if (!accepts(policy.getBaseUrl())) {
+    Key key = getKey(policy.getBaseUrl());
+    if (key == null) {
       throw UrlSigningException.urlNotSupported();
     }
 
     policy.setResourceStrategy(getResourceStrategy());
 
     try {
-      // Get the key that matches this URI since there must be one that matches as the base url has been accepted.
-      Map.Entry<String, KeyEntry> keyEntry = getKeyEntry(policy.getBaseUrl()).get();
       URI uri = new URI(policy.getBaseUrl());
       List<NameValuePair> queryStringParameters = new ArrayList<>();
       if (uri.getQuery() != null) {
         queryStringParameters = URLEncodedUtils.parse(new URI(policy.getBaseUrl()).getQuery(), StandardCharsets.UTF_8);
       }
       queryStringParameters.addAll(URLEncodedUtils.parse(
-              ResourceRequestUtil.policyToResourceRequestQueryString(policy, keyEntry.getKey(), keyEntry.getValue().key),
+              ResourceRequestUtil.policyToResourceRequestQueryString(policy, key.id, key.secret),
               StandardCharsets.UTF_8));
       return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(),
               URLEncodedUtils.format(queryStringParameters, StandardCharsets.UTF_8), null).toString();

--- a/modules/urlsigning-service-impl/src/test/java/org/opencastproject/security/urlsigning/provider/impl/GenericUrlSigningProviderTest.java
+++ b/modules/urlsigning-service-impl/src/test/java/org/opencastproject/security/urlsigning/provider/impl/GenericUrlSigningProviderTest.java
@@ -48,24 +48,26 @@ public class GenericUrlSigningProviderTest {
   private static final String RTMP_MATCHER = "rtmp";
   private static final String RESOURCE_URL = "/path/to/resource.mp4";
   private static final String NON_MATCHING_URI = "http://hello.com";
-  private static final String NON_MATCHING_KEY = "abcdef0123456789";
+  private static final String NON_MATCHING_SECRET = "abcdef0123456789";
 
   private static final String KEY_ID = "theId";
   private static final String KEY_ID_2 = "theSecondId";
   private static final String MATCHING_URI = "http://www.opencast.org";
-  private static final String KEY = "0123456789abcdef";
+  private static final String MATCHING_URI_2 = "http://docs.opencast.org";
+  private static final String SECRET = "0123456789abcdef";
   private static final String RESOURCE_PATH = MATCHING_URI + RESOURCE_URL;
+  private static final String RESOURCE_PATH_2 = MATCHING_URI_2 + RESOURCE_URL;
 
   private static final String ORGANIZATION_A_ID = "organization-a";
   private static final String ORGANIZATION_A_MATCHING_URI = "http://organization-a.opencast.org";
   private static final String ORGANIZATION_A_KEY_ID = "key-id-organization-a";
-  private static final String ORGANIZATION_A_KEY = "key-organization-a";
+  private static final String ORGANIZATION_A_SECRET = "secret-organization-a";
   private static final String ORGANIZATION_A_RESOURCE_PATH = ORGANIZATION_A_MATCHING_URI + RESOURCE_URL;
 
   private static final String ORGANIZATION_B_ID = "organization-b";
   private static final String ORGANIZATION_B_MATCHING_URI = "http://organization-b.opencast.org";
   private static final String ORGANIZATION_B_KEY_ID = "key-id-organizatino-b";
-  private static final String ORGANIZATION_B_KEY = "key-organization-b";
+  private static final String ORGANIZATION_B_SECRET = "secret-organization-b";
   private static final String ORGANIZATION_B_RESOURCE_PATH = ORGANIZATION_B_MATCHING_URI + RESOURCE_URL;
 
   private static GenericUrlSigningProvider signer;
@@ -116,36 +118,42 @@ public class GenericUrlSigningProviderTest {
     assertFalse(signer.accepts(RESOURCE_PATH));
     assertEquals(0, signer.getUris().size());
 
-    // Incomplete entries
+    // Incomplete entries (no secret configured)
     properties = new Hashtable<>();
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
-    signer.updated(properties);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
+    boolean exceptionThrown = false;
+    try {
+      signer.updated(properties);
+    } catch (ConfigurationException e) {
+      exceptionThrown = true;
+    }
+    assertTrue(exceptionThrown);
     assertFalse(signer.accepts(RESOURCE_PATH));
     assertEquals(0, signer.getUris().size());
 
-    // Non-Matching key
+    // Non-Matching secret
     properties = new Hashtable<>();
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), NON_MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), NON_MATCHING_KEY);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), NON_MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), NON_MATCHING_SECRET);
     signer.updated(properties);
     assertFalse(signer.accepts(RESOURCE_PATH));
     assertEquals(1, signer.getUris().size());
 
-    // Matching Key
+    // Matching secret
     properties = new Hashtable<>();
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), KEY);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), SECRET);
     signer.updated(properties);
     assertTrue(signer.accepts(RESOURCE_PATH));
     assertEquals(1, signer.getUris().size());
 
-    // Matching Key and Unrelated Key
+    // Matching secret and Unrelated Key
     properties = new Hashtable<>();
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), KEY);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), SECRET);
 
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID_2, GenericUrlSigningProvider.URL), NON_MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID_2, GenericUrlSigningProvider.SECRET), NON_MATCHING_KEY);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID_2, GenericUrlSigningProvider.URL), NON_MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID_2, GenericUrlSigningProvider.SECRET), NON_MATCHING_SECRET);
 
     signer.updated(properties);
     assertTrue(signer.accepts(RESOURCE_PATH));
@@ -153,9 +161,9 @@ public class GenericUrlSigningProviderTest {
 
     // Organization set to "any" organization works
     properties = new Hashtable<>();
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), KEY);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.ORGANIZATION),
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), SECRET);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.ORGANIZATION),
             GenericUrlSigningProvider.ANY_ORGANIZATION);
 
     signer.updated(properties);
@@ -165,11 +173,11 @@ public class GenericUrlSigningProviderTest {
 
   @Test
   public void testSign() throws UrlSigningException, ConfigurationException {
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), KEY);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), SECRET);
 
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID_2, GenericUrlSigningProvider.URL), RTMP_MATCHER);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID_2, GenericUrlSigningProvider.SECRET), KEY);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID_2, GenericUrlSigningProvider.URL), RTMP_MATCHER);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID_2, GenericUrlSigningProvider.SECRET), SECRET);
 
     signer.updated(properties);
 
@@ -199,8 +207,8 @@ public class GenericUrlSigningProviderTest {
 
   @Test
   public void testSignUrlWithPort() throws Exception {
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), RTMP_MATCHER);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), KEY);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), RTMP_MATCHER);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), SECRET);
 
     signer.updated(properties);
 
@@ -212,16 +220,16 @@ public class GenericUrlSigningProviderTest {
   @Test
   public void testMultitenantSign() throws UrlSigningException, ConfigurationException {
 
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), KEY);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL), MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), SECRET);
 
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, ORGANIZATION_A_KEY_ID, GenericUrlSigningProvider.URL), ORGANIZATION_A_MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, ORGANIZATION_A_KEY_ID, GenericUrlSigningProvider.SECRET), ORGANIZATION_A_KEY);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, ORGANIZATION_A_KEY_ID, GenericUrlSigningProvider.ORGANIZATION), ORGANIZATION_A_ID);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, ORGANIZATION_A_KEY_ID, GenericUrlSigningProvider.URL), ORGANIZATION_A_MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, ORGANIZATION_A_KEY_ID, GenericUrlSigningProvider.SECRET), ORGANIZATION_A_SECRET);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, ORGANIZATION_A_KEY_ID, GenericUrlSigningProvider.ORGANIZATION), ORGANIZATION_A_ID);
 
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, ORGANIZATION_B_KEY_ID, GenericUrlSigningProvider.URL), ORGANIZATION_B_MATCHING_URI);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, ORGANIZATION_B_KEY_ID, GenericUrlSigningProvider.SECRET), ORGANIZATION_B_KEY);
-    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_ENTRY_PREFIX, ORGANIZATION_B_KEY_ID, GenericUrlSigningProvider.ORGANIZATION), ORGANIZATION_B_ID);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, ORGANIZATION_B_KEY_ID, GenericUrlSigningProvider.URL), ORGANIZATION_B_MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, ORGANIZATION_B_KEY_ID, GenericUrlSigningProvider.SECRET), ORGANIZATION_B_SECRET);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, ORGANIZATION_B_KEY_ID, GenericUrlSigningProvider.ORGANIZATION), ORGANIZATION_B_ID);
 
     signerA.updated(properties);
     signerB.updated(properties);
@@ -236,7 +244,7 @@ public class GenericUrlSigningProviderTest {
     result = signerA.sign(policy);
     logger.info(result);
     assertEquals(
-            "http://organization-a.opencast.org/path/to/resource.mp4?policy=eyJTdGF0ZW1lbnQiOnsiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6MTU4MzAyMzU3NzAwMH0sIlJlc291cmNlIjoiaHR0cDpcL1wvb3JnYW5pemF0aW9uLWEub3BlbmNhc3Qub3JnXC9wYXRoXC90b1wvcmVzb3VyY2UubXA0In19&keyId=key-id-organization-a&signature=ea715d6ff561f49bb6e2cb8cc3e925029e139f14eeda62fc92573f362c694423",
+            "http://organization-a.opencast.org/path/to/resource.mp4?policy=eyJTdGF0ZW1lbnQiOnsiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6MTU4MzAyMzU3NzAwMH0sIlJlc291cmNlIjoiaHR0cDpcL1wvb3JnYW5pemF0aW9uLWEub3BlbmNhc3Qub3JnXC9wYXRoXC90b1wvcmVzb3VyY2UubXA0In19&keyId=key-id-organization-a&signature=7dce4419738aba73b20a3e9aea02dc8921532243e87635465f67cedac8a7b993",
             result);
 
     // Organization A can sign URLs not specific to any organization
@@ -262,7 +270,7 @@ public class GenericUrlSigningProviderTest {
     result = signerB.sign(policy);
     logger.info(result);
     assertEquals(
-            "http://organization-b.opencast.org/path/to/resource.mp4?policy=eyJTdGF0ZW1lbnQiOnsiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6MTU4MzAyMzU3NzAwMH0sIlJlc291cmNlIjoiaHR0cDpcL1wvb3JnYW5pemF0aW9uLWIub3BlbmNhc3Qub3JnXC9wYXRoXC90b1wvcmVzb3VyY2UubXA0In19&keyId=key-id-organizatino-b&signature=a6d803d4766f808bf2eaabdcf2e9114f85513d3d5596b4a01cb8d2488de816e8",
+            "http://organization-b.opencast.org/path/to/resource.mp4?policy=eyJTdGF0ZW1lbnQiOnsiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6MTU4MzAyMzU3NzAwMH0sIlJlc291cmNlIjoiaHR0cDpcL1wvb3JnYW5pemF0aW9uLWIub3BlbmNhc3Qub3JnXC9wYXRoXC90b1wvcmVzb3VyY2UubXA0In19&keyId=key-id-organizatino-b&signature=331c925e17e7bfc85e8be412955e4c37945c552e9a9198166b0b843a290b67ea",
             result);
 
     // Organization B can sign URLs not specific to any organization


### PR DESCRIPTION
The performance of URL signing is critical for External API request that retrieve publications of events where each URI of each published elements needs to be signed.

The current implementation does a brute force comparison of the URL to be signed vs. the URL prefixes that can be signed. This is not only because of the algorithm that is in O(n) but it also seems that the functional implementation requires some high-overhead transformations of data structures.

The goal of this task is to use a O(log(n)) algorithm and avoid expensive transformations of data structures.

The performance of URL signing is critical for External API request that retrieve publications of events where each URI of each published elements needs to be signed.

The current implementation does a brute force comparison of the URL to be signed vs. the URL prefixes that can be signed. This is not only because of the algorithm that is in O\(n) but it also seems that the functional implementation requires some high-overhead transformations of data structures.

The goal of this task is to use a O(log\(n)) algorithm and avoid expensive transformations of data structures.

Benchmark:
GET /api/events/{event_id}?withpublications=true&sign=true for a event with approx. 40 URLs to be signed takes approx. 40ms with the current code and 30ms with this optimization, whereas approx. 20ms are required without URL signing. So the overhead of enabling URL signing is cut in half.


Open questions:
- This code will not work with prefixes that are equal except of lowercase vs. uppercase differences.