### PR TITLE
MH-13500 Multitenancy support for workflows

### DIFF
--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -55,6 +55,8 @@ Start by naming the workflow and giving it a meaningful description:
 
       <!-- Description -->
       <id>example</id>
+      <!-- Optionally specify an organization -->
+      <organization>mh_default_org</organization>
       <title>Encode Mp4, Distribute and Publish</title>
       <tags>
         <!-- Tell the UI where to show this workflow -->
@@ -77,7 +79,11 @@ Start by naming the workflow and giving it a meaningful description:
     </definition>
 
 * The `id` is used in several Opencast endpoints to identify and select this workflow. Make sure that this identifier
-  is unique among all endpoints in the system.
+  is unique among all endpoints in the system (except in multitenant workflows, see `organization` below).
+* The `organization` specifies the organization this workflow is valid for (thus, it only makes sense in multitenant
+  installations). If there are two workflows with the same id, the one corresponding to the user’s organization is
+  always chosen. This pertains workflow dropdowns (for example, the “Add new event” dropdown) as well as workflows
+  included in other workflows via the `include` workflow operation handler.
 * The `tags` define where the user interfaces may use these workflows. Useful tags are:
     * *upload*: Usable for uploaded media
     * *schedule*: Usable for scheduled events

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinition.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinition.java
@@ -155,6 +155,12 @@ public interface WorkflowDefinition extends Comparable<WorkflowDefinition> {
   void clearTags();
 
   /**
+   * Gets the organization associated with this workflow (or <code>null</code>, if it's global)
+   * @return the organization
+   */
+  String getOrganization();
+
+  /**
    * Appends the operation to the workflow definition.
    *
    * @param operation

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinitionImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinitionImpl.java
@@ -61,6 +61,9 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
   @XmlElement(name = "title")
   private String title;
 
+  @XmlElement(name = "organization")
+  private String organization;
+
   @XmlElementWrapper(name = "tags")
   @XmlElement(name = "tag")
   protected SortedSet<String> tags = new TreeSet<String>();
@@ -347,12 +350,20 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
     this.title = title;
   }
 
+  @Override
+  public String getOrganization() {
+    return organization;
+  }
+
   /**
    * {@inheritDoc}
    *
    * @see java.lang.Object#toString()
    */
   public String toString() {
+    if (organization != null) {
+      return "Workflow definition {" + id + "/" + organization + "}";
+    }
     return "Workflow definition {" + id + "}";
   }
 

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIdentifier.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIdentifier.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.api;
+
+import java.util.Objects;
+
+/**
+ * Represents a workflow's "primary key", for use in maps and sets (immutable)
+ */
+public final class WorkflowIdentifier {
+  private final String id;
+  private final String organization;
+
+  public WorkflowIdentifier(String id, String organization) {
+    this.id = id;
+    this.organization = organization;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getOrganization() {
+    return organization;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    WorkflowIdentifier that = (WorkflowIdentifier) o;
+    return id.equals(that.id) && Objects.equals(organization, that.organization);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, organization);
+  }
+
+  public String toString() {
+    if (organization == null) {
+      return id;
+    }
+    return String.format("%s/%s", organization, id);
+  }
+
+  /**
+   * Return a new identifier without an organization (idempotent)
+   * @return See above
+   */
+  public WorkflowIdentifier withoutOrganization() {
+    return new WorkflowIdentifier(id, null);
+  }
+}

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
@@ -23,12 +23,14 @@ package org.opencastproject.workflow.impl;
 
 import static org.opencastproject.util.ReadinessIndicator.ARTIFACT;
 
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.util.ReadinessIndicator;
 import org.opencastproject.workflow.api.WorkflowDefinition;
+import org.opencastproject.workflow.api.WorkflowIdentifier;
 import org.opencastproject.workflow.api.WorkflowParser;
 import org.opencastproject.workflow.api.WorkflowStateMapping;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.felix.fileinstall.ArtifactInstaller;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -36,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FilenameFilter;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Dictionary;
@@ -45,6 +46,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Loads, unloads, and reloads {@link WorkflowDefinition}s from "*workflow.xml" files in any of fileinstall's watch
@@ -54,25 +56,31 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
   private static final Logger logger = LoggerFactory.getLogger(WorkflowDefinitionScanner.class);
 
   /** An internal collection of workflows that we have installed */
-  protected Map<String, WorkflowDefinition> installedWorkflows = new HashMap<String, WorkflowDefinition>();
+  protected Map<WorkflowIdentifier, WorkflowDefinition> installedWorkflows = new HashMap<>();
 
   /** All workflow state mappings which are configured for the workflow defintions */
   protected Map<String, Set<WorkflowStateMapping>> workflowStateMappings = new HashMap<>();
 
   /** An internal collection of artifact id, bind the workflow definition files and their id */
-  protected Map<File, String> artifactIds = new HashMap<File, String>();
+  protected Map<File, WorkflowIdentifier> artifactIds = new HashMap<>();
 
   /** List of artifact parsed with error */
-  protected List<File> artifactsWithError = new ArrayList<File>();
+  protected List<File> artifactsWithError = new ArrayList<>();
 
   /** OSGi bundle context */
   private BundleContext bundleCtx = null;
 
   /** Tag to define if the the workflows definition have already been loaded */
-  private boolean isWFSinitiliazed = false;
+  private boolean isWFSinitialized = false;
 
   /** The current workflow definition being installed */
   private WorkflowDefinition currentWFD = null;
+
+  private OrganizationDirectoryService organizationDirectoryService;
+
+  public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
+    this.organizationDirectoryService = organizationDirectoryService;
+  }
 
   /**
    * OSGi callback on component activation. private boolean initialized = true;
@@ -91,7 +99,7 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
    *
    * @see org.apache.felix.fileinstall.ArtifactInstaller#install(java.io.File)
    */
-  public void install(File artifact) throws Exception {
+  public void install(File artifact) {
     WorkflowDefinition def = currentWFD;
 
     // If the current workflow definition is null, it means this is a first install and not an update...
@@ -106,28 +114,37 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
       }
     }
 
+    // Is there a workflow with the exact same ID, but a different file name? Then ignore.
+    final WorkflowIdentifier workflowIdentifier = new WorkflowIdentifier(def.getId(), def.getOrganization());
+    for (Map.Entry<File, WorkflowIdentifier> fileWithIdentifier : artifactIds.entrySet()) {
+      if (fileWithIdentifier.getValue().equals(workflowIdentifier) && !fileWithIdentifier.getKey().equals(artifact)) {
+        logger.warn("Workflow with identifier '{}' already registered in file '{}', ignoring", workflowIdentifier,
+                fileWithIdentifier.getKey());
+        return;
+      }
+    }
+
     logger.debug("Installing workflow from file '{}'", artifact.getName());
     artifactsWithError.remove(artifact);
-    artifactIds.put(artifact, def.getId());
-    putWorkflowDefinition(def.getId(), def);
+    artifactIds.put(artifact, workflowIdentifier);
+    putWorkflowDefinition(workflowIdentifier, def);
 
     // Determine the number of available profiles
-    String[] filesInDirectory = artifact.getParentFile().list(new FilenameFilter() {
-      public boolean accept(File arg0, String name) {
-        return name.endsWith(".xml");
-      }
-    });
+    String[] filesInDirectory = artifact.getParentFile().list((arg0, name) -> name.endsWith(".xml"));
+    if (filesInDirectory == null) {
+      throw new RuntimeException("error retrieving files from directory \"" + artifact.getParentFile() + "\"");
+    }
 
-    logger.info("Worfkflow definition '{}' from file '{}' installed", def.getId(), artifact.getName());
+    logger.info("Workflow definition '{}' from file '{}' installed", workflowIdentifier, artifact.getName());
 
     // Once all profiles have been loaded, announce readiness
-    if ((filesInDirectory.length - artifactsWithError.size()) == artifactIds.size() && !isWFSinitiliazed) {
+    if ((filesInDirectory.length - artifactsWithError.size()) == artifactIds.size() && !isWFSinitialized) {
       logger.info("{} Workflow definitions loaded, activating Workflow service", filesInDirectory.length - artifactsWithError.size());
-      Dictionary<String, String> properties = new Hashtable<String, String>();
+      Dictionary<String, String> properties = new Hashtable<>();
       properties.put(ARTIFACT, "workflowdefinition");
       logger.debug("Indicating readiness of workflow definitions");
       bundleCtx.registerService(ReadinessIndicator.class.getName(), new ReadinessIndicator(), properties);
-      isWFSinitiliazed = true;
+      isWFSinitialized = true;
     }
     workflowStateMappings.put(def.getId(), def.getStateMappings());
   }
@@ -137,12 +154,12 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
    *
    * @see org.apache.felix.fileinstall.ArtifactInstaller#uninstall(java.io.File)
    */
-  public void uninstall(File artifact) throws Exception {
+  public void uninstall(File artifact) {
     // Since the artifact is gone, we can't open it to read its ID. So we look in the local map.
-    String id = artifactIds.remove(artifact);
-    if (id != null) {
-      WorkflowDefinition def = removeWorkflowDefinition(id);
-      logger.info("Uninstalling workflow definition '{}' from file '{}'", def.getId(), artifact.getName());
+    WorkflowIdentifier identifier = artifactIds.remove(artifact);
+    if (identifier != null) {
+      removeWorkflowDefinition(identifier);
+      logger.info("Uninstalling workflow definition '{}' from file '{}'", identifier, artifact.getName());
     }
   }
 
@@ -151,7 +168,7 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
    *
    * @see org.apache.felix.fileinstall.ArtifactInstaller#update(java.io.File)
    */
-  public void update(File artifact) throws Exception {
+  public void update(File artifact) {
     currentWFD = parseWorkflowDefinitionFile(artifact);
 
     if (currentWFD != null) {
@@ -159,6 +176,10 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
       install(artifact);
       currentWFD = null;
     }
+  }
+
+  private boolean organizationExists(final String organization) {
+    return organizationDirectoryService.getOrganizations().stream().anyMatch(org -> org.getId().equals(organization));
   }
 
   /**
@@ -169,61 +190,73 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
    * @return the workflow definition if the given contained a valid one, or null if the file can not be parsed.
    */
   public WorkflowDefinition parseWorkflowDefinitionFile(File artifact) {
-    InputStream stream = null;
-    try {
-      stream = new FileInputStream(artifact);
+    try (InputStream stream = new FileInputStream(artifact)) {
       WorkflowDefinition def = WorkflowParser.parseWorkflowDefinition(stream);
       if (def.getOperations().size() == 0)
         logger.warn("Workflow '{}' has no operations", def.getId());
+      if (def.getOrganization() != null && !organizationExists(def.getOrganization())) {
+        throw new RuntimeException("invalid organization '" + def.getOrganization() + "'");
+      }
       return def;
     } catch (Exception e) {
       logger.warn("Unable to parse workflow from file '{}', {}", artifact.getName(), e.getMessage());
       return null;
-    } finally {
-      IOUtils.closeQuietly(stream);
     }
   }
 
   /**
-   * Gets the workflow definitions with the given id.
+   * Return available workflow definitions
    *
-   * @param id
-   * @return the workflow definition if exist or null
+   * This method finds workflows that are either globally defined or have the correct organization set.
+   * @param organization The organization to check for (must not be <code>null</code>)
+   * @return A stream of available organizations
    */
-  public WorkflowDefinition getWorkflowDefinition(String id) {
-    return installedWorkflows.get(id);
+  public Stream<WorkflowDefinition> getAvailableWorkflowDefinitions(final Organization organization) {
+    return installedWorkflows.keySet().stream()
+            .filter(wfi -> wfi.getOrganization() == null || wfi.getOrganization().equals(organization.getId()))
+            .map(WorkflowIdentifier::getId)
+            .distinct()
+            .map(identifier -> getWorkflowDefinition(new WorkflowIdentifier(identifier, organization.getId())));
   }
 
   /**
-   * Get the list of installed workflow definitions.
+   * Return the workflow definition for a given workflow identifier
    *
-   * @return the collection of installed workflow definitions id
+   * This method tries to get the workflow using the exact identifier and falls back to the global workflow (without
+   * the organization) if that fails.
+   *
+   * @param workflowIdentifier The workflow identifier
+   * @return Either <code>null</code> if no workflow is found for this identifier, or the workflow definition.
    */
-  public Map<String, WorkflowDefinition> getWorkflowDefinitions() {
-    return installedWorkflows;
+  public WorkflowDefinition getWorkflowDefinition(WorkflowIdentifier workflowIdentifier) {
+    WorkflowDefinition result = installedWorkflows.get(workflowIdentifier);
+    if (result != null) {
+      return result;
+    }
+    return installedWorkflows.get(new WorkflowIdentifier(workflowIdentifier.getId(), null));
   }
 
   /**
    * Add the given workflow definition to the installed workflow definition id.
    *
-   * @param id
-   *          the id of the workflow definition to add
+   * @param identifier
+   *          the identifier of the workflow definition to add
    * @param wfd
-   *          the workflow definition id
+   *          the workflow definition
    */
-  public void putWorkflowDefinition(String id, WorkflowDefinition wfd) {
-    installedWorkflows.put(id, wfd);
+  public void putWorkflowDefinition(WorkflowIdentifier identifier, WorkflowDefinition wfd) {
+    installedWorkflows.put(identifier, wfd);
   }
 
   /**
    * Remove the workflow definition with the given id from the installed definition list.
    *
-   * @param id
-   *          the workflow definition id
+   * @param identifier
+   *          the workflow definition identifier
    * @return the removed workflow definition
    */
-  public WorkflowDefinition removeWorkflowDefinition(String id) {
-    return installedWorkflows.remove(id);
+  public WorkflowDefinition removeWorkflowDefinition(WorkflowIdentifier identifier) {
+    return installedWorkflows.remove(identifier);
   }
 
   /**
@@ -234,4 +267,5 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
   public boolean canHandle(File artifact) {
     return "workflows".equals(artifact.getParentFile().getName()) && artifact.getName().endsWith(".xml");
   }
+
 }

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -80,6 +80,7 @@ import org.opencastproject.workflow.api.RetryStrategy;
 import org.opencastproject.workflow.api.WorkflowDatabaseException;
 import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowException;
+import org.opencastproject.workflow.api.WorkflowIdentifier;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
@@ -358,12 +359,8 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    */
   @Override
   public List<WorkflowDefinition> listAvailableWorkflowDefinitions() {
-    List<WorkflowDefinition> list = new ArrayList<>();
-    for (Entry<String, WorkflowDefinition> entry : workflowDefinitionScanner.getWorkflowDefinitions().entrySet()) {
-      list.add(entry.getValue());
-    }
-    Collections.sort(list); //sorts by title
-    return list;
+    return workflowDefinitionScanner.getAvailableWorkflowDefinitions(securityService.getOrganization())
+            .sorted().collect(Collectors.toList());
   }
 
   /**
@@ -888,9 +885,11 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
   @Override
   public WorkflowDefinition getWorkflowDefinitionById(String id) throws NotFoundException {
-    WorkflowDefinition def = workflowDefinitionScanner.getWorkflowDefinition(id);
-    if (def == null)
-      throw new NotFoundException("Workflow definition '" + id + "' not found");
+    final WorkflowIdentifier workflowIdentifier = new WorkflowIdentifier(id, securityService.getOrganization().getId());
+    WorkflowDefinition def = workflowDefinitionScanner.getWorkflowDefinition(workflowIdentifier);
+    if (def == null) {
+      throw new NotFoundException("Workflow definition '" + workflowIdentifier + "' not found");
+    }
     return def;
   }
 

--- a/modules/workflow-service-impl/src/main/resources/OSGI-INF/workflow-definition-scanner.xml
+++ b/modules/workflow-service-impl/src/main/resources/OSGI-INF/workflow-definition-scanner.xml
@@ -7,4 +7,6 @@
     <provide interface="org.apache.felix.fileinstall.ArtifactInstaller"/>
     <provide interface="org.opencastproject.workflow.impl.WorkflowDefinitionScanner"/>
   </service>
+  <reference name="index" interface="org.opencastproject.security.api.OrganizationDirectoryService"
+             bind="setOrganizationDirectoryService"/>
 </scr:component>

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -69,6 +69,7 @@ import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.RetryStrategy;
 import org.opencastproject.workflow.api.WorkflowDefinition;
 import org.opencastproject.workflow.api.WorkflowDefinitionImpl;
+import org.opencastproject.workflow.api.WorkflowIdentifier;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 import org.opencastproject.workflow.api.WorkflowInstanceImpl;
@@ -264,7 +265,8 @@ public class WorkflowServiceImplTest {
 
       /* The exception handler workflow definition needs to be registered as the reference to it in 
          workflow-definition-3 will be checked */
-      scanner.putWorkflowDefinition("exception-handler", exceptionHandler);
+      scanner.putWorkflowDefinition(
+              new WorkflowIdentifier("exception-handler", securityService.getOrganization().getId()), exceptionHandler);
 
       is = WorkflowServiceImplTest.class.getResourceAsStream("/workflow-definition-1.xml");
       workingDefinition = WorkflowParser.parseWorkflowDefinition(is);


### PR DESCRIPTION
This PR adds a new (optional) `organization` field to workflow definitions. The principle behind this is as follows: There can be two workflows with the same id now, but the one corresponding to the user’s organization overrides the ‘global’ one. This pertains workflow dropdowns (for example, the “Add new event” dropdown) as well as workflows included from other workflows via the `include` workflow operation handler.

Note that I took the liberty of fixing a few more stylistics issues in the `WorkflowDefinitionScanner`.

This work was sponsored by SWITCH.