### PR TITLE
MH-13524 Empty node name causes exception

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServerEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServerEndpoint.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.adminui.endpoint;
 
+import static com.entwinemedia.fn.data.json.Jsons.BLANK;
 import static com.entwinemedia.fn.data.json.Jsons.f;
 import static com.entwinemedia.fn.data.json.Jsons.obj;
 import static com.entwinemedia.fn.data.json.Jsons.v;
@@ -341,8 +342,8 @@ public class ServerEndpoint {
 
       jsonServers.add(obj(f(KEY_ONLINE, v(vOnline)),
               f(KEY_MAINTENANCE, v(vMaintenance)),
-              f(KEY_HOSTNAME, v(vHostname)),
-              f(KEY_NODE_NAME, v(vNodeName)),
+              f(KEY_HOSTNAME, v(vHostname, BLANK)),
+              f(KEY_NODE_NAME, v(vNodeName, BLANK)),
               f(KEY_CORES, v(vCores)),
               f(KEY_RUNNING, v(vRunning)),
               f(KEY_QUEUED, v(vQueued)),


### PR DESCRIPTION

Steps to reproduce: 
1. Ensure oc_host_registration has node_name = NULL 
2. Go to System->Servers 
  
 Actual Results: 
The table does not show any results. In the Opencast log, you find: 

Caused by: java.lang.IllegalArgumentException: Value of field 'nodeName' must not be null 
at com.entwinemedia.fn.data.json.Field.<init>(Field.java:31) ~[?:?] 
at com.entwinemedia.fn.data.json.Jsons.f(Jsons.java:89) ~[?:?] 
at org.opencastproject.adminui.endpoint.ServerEndpoint.getServersListAsJson(ServerEndpoint.java:345) ~[?:?] 
at org.opencastproject.adminui.endpoint.ServerEndpoint.getServers(ServerEndpoint.java:317) ~[?:?] 
  
 Expected Results: 
The Admin UI should still display the servers even if the backend does not deliver a valid nodename 
  