### PR TITLE
MH-13523 Allow removal of locations anytime

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/recordings/partials/recordingActionsCell.html
@@ -7,7 +7,6 @@
 <a data-confirmation-modal="confirm-modal"
    data-callback="table.delete"
    data-object="row"
-   ng-if="row.removable"
    class="remove"
    title="{{ 'RECORDINGS.RECORDINGS.TABLE.TOOLTIP.DELETE' | translate }}"
    with-role="ROLE_UI_LOCATIONS_DELETE">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/captureAgentsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/captureAgentsResource.js
@@ -41,7 +41,6 @@ angular.module('adminNg.resources')
           row.inputs = r.inputs;
           row.roomId = r.roomId;
           row.type = 'LOCATION';
-          row.removable = 'AGENTS.STATUS.OFFLINE' === r.Status || 'AGENTS.STATUS.UNKNOWN' === r.Status;
           return row;
         };
 


### PR DESCRIPTION
Currently, the Admin UI will not show the "Remove location" button in the table Capture->Locations unless the capture agent is in status OFFLINE or UNKNOWN.

At least at our side, this is annoying organization administrators that expect to be able to remove a capture agent at any time they want.

As removing the capture agent doesn't actually do much (the capture agent just register itself again in case it is still there), there does not seem to be much benefit in preventing users from removing a location in case it is not OFFLINE or UNKNOWN.
Also, the backend would not prevent anybody from removing the location - it is just the front-end that does not show the button.

The goal of this task is to allow uses to always remove locations if they want to.