### PR TITLE
MH-13528, Non-Interactive FFmpeg

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -341,6 +341,7 @@ public class EncoderEngine implements AutoCloseable {
           throws EncoderException {
     List<String> command = new ArrayList<>();
     command.add(binary);
+    command.add("-nostdin");
     command.add("-nostats");
 
     String commandline = profile.getExtension(CMD_SUFFIX);


### PR DESCRIPTION
It does not make sense for Opencast to launch FFmpeg in it's interactive
mode.