### PR TITLE
MH-13529, Don't warn about expected behavior

### DIFF
--- a/modules/textextractor-tesseract/src/main/java/org/opencastproject/textextractor/tesseract/TesseractTextExtractor.java
+++ b/modules/textextractor-tesseract/src/main/java/org/opencastproject/textextractor/tesseract/TesseractTextExtractor.java
@@ -76,7 +76,8 @@ public class TesseractTextExtractor implements TextExtractor, ManagedService {
   private static final List<String> stderrFilter = java.util.Arrays.asList(
           "Page",
           "Tesseract Open Source OCR Engine",
-          "Warning. Invalid resolution 0 dpi. Using 70 instead.");
+          "Warning: Invalid resolution 0 dpi. Using 70 instead.",
+          "Estimating resolution as ");
 
   /**
    * Creates a new tesseract command wrapper that will be using the default binary.


### PR DESCRIPTION
Tesseract prints some messages to `stderr` which Opencast picks up as
warnings and logs them as such. This patch removes two of the expected
messages, cleaning up the logs.