### PR TITLE
MH-13530 Remove pseudo-mechanism for workflow definition registration

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -1,105 +1,31 @@
-Opencast 7: Release Notes
+Opencast 8: Release Notes
 =========================
 
 New Features
 ------------
 
-- Overhaul of the permission management with the newly added possibility to define how access control lists are
-  evaluated and how series permission changes are populated to episodes. For more details take a look at the [access
-  control configuration guide](configuration/acl.md).
-- Update Elasticsearch and make is possible to run Elasticsearch as an external service.
-- Per-Tenant Capture Agent Users
-- Asset manager snaphots clean-up to remove older snapshots for a given media package. In some cases, this can
-  drastically reduce Opencast's storage consumption. This feature is implemented as an option for the [asset-delete workflow
-  operation handler](workflowoperationhandlers/asset-delete-woh.md).
-- Allow the workflow to select the audio track for composite video
-- Add multi-tenant support for all list providers
-- Make waveform size configurable
-- Create a generic user interface configuration service
-- Add link to series details to the events table
-- Add Internationalization support for series LTI tools
-- Display responsible person for workflows
-- Allow the Ingest Service to make authenticated requests to other servers
-- Some modules are now plugins. These are not started by default to reduce the amount of code running unnecessarily.
-  They can easily be enabled in `etc/org.apache.karaf.features.cfg`. Modified modules are:
-    - Moodle user directory
-    - Sakai user directory
 
 Improvements
 ------------
 
-A non-comprehensive list of improvements:
-
-- Improvement of performance when scheduling new events or checking for conflicts, reducing the time for adding
-multiple schedules by up to 90% compared to the previous implementation. Please read the [upgrade guide](upgrade.md)
-to make sure you migrate your data properly.
 
 Configuration changes
 ---------------------
 
-- `KARAF_NOROOT` is now set to `true` by default, preventing Opencast to be started as root user unless the
-  configuration is changed.
-- The default configuration for the Paella player has been moved to `etc/ui-config/mh_default_org/paella/config.json`
-- By default, metadata catalogs and attachments sent by capture agents are discarded since this data is usually
-  controlled by Opencast and the routing through capture agents which existed for historical reasons was just an
-  additional source for errors. If you rely on the old behavior, it can be configured in
-  `etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg`.
-- By default, the Paella player now respects all tracks published to engage instead of having a hard-coded filter for
-  tracks with the sub-flavor `delivery` only.
-- The structure of the configuration files concerning URL signing has changed.
-  See [here](./configuration/stream-security.md). The affected files are:
-    - `etc/org.opencastproject.security.urlsigning.filter.UrlSigningFilter.cfg `
-    - `etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg`
-    - `etc/org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg`
-    - `etc/org.opencastproject.security.urlsigning.verifier.impl.UrlSigningVerifierImpl.cfg`
-- The configuration for the media module has been moved into the user interface configuration directory at
-  `etc/ui-config`.
 
 API changes
 -----------
 
-Due to [MH-13397](https://opencast.jira.com/browse/MH-13397):
+Due to [MH-13530](https://opencast.jira.com/browse/MH-13530):
 
-- Modified GET /recordings/{id}/technical.json: Removed field `optOut`
-- Removed GET /recordings/{id}/optOut
-- Removed GET /recordings/{id}/reviewStatus
-- Removed PUT /recordings/{id}/reviewStatus
-- Modified POST /recordings: Removed form parameter `optOut`
-- Modified POST /recordings/multiple: Removed form parameter `optOut`
-- Modified PUT /recordings/{id}: Removed form parameters `optOut` and `updateOptOut`
-- Removed GET /series/{id}/optOut
+- Removed DELETE /workflow/definition/{id}
+- Removed PUT /workflow/definition
 
-Due to [MH-13446](https://opencast.jira.com/browse/MH-13446):
-
-- Removed GET /acl-manager/transitions.json
-- Removed GET /acl-manager/transitionsfor.json
-- Removed POST /acl-manager/episode/{id}
-- Removed POST /acl-manager/series/{id}
-- Modified POST /acl-manager/apply/episode/{id}: Removed form parameters workflowDefinitionId and workflowParams
-- Modified POST /acl-manager/apply/series/{id}: Removed form parameters workflowDefinitionId and workflowParams
-- Removed DELETE /acl-manager/episode/{transitionId}
-- Removed DELETE /acl-manager/series/{transitionId}
-- Removed PUT /acl-manager/episode/{transitionId}
-- Removed PUT /acl-manager/series/{transitionId}
-
-Additional Notes about 6.4
---------------------------
-
-Opencast 6.4 contains a number of bug fixes, some of which are security relevant. The following known vulnerability
-within Opencast's `org.springframework.security.oauth:spring-security-oauth` dependency have been fixed by this release:
-`CVE-2019-3778`.
-
-
-Additional Notes about 6.5
---------------------------
-
-Opencast 6.5 contains a change to the job dispatching logic, which will change how your cluster dispatches jobs to its
-workers.  This change means that workers with a higher maximum load will absorb more work before workers with lower
-maximum loads will accept heavy workloads.  This change does not require any configuration changes, however you may
-notice large changes in processing load distribution depending on your cluster configuration.
 
 Release Schedule
 ----------------
+
+TBD
 
 |Date                         |Phase
 |-----------------------------|------------------------------------------
@@ -111,5 +37,4 @@ Release Schedule
 Release Managers
 ----------------
 
-- Maximiliano Lira Del Canto (University of Cologne)
-- Katrin Ihler (ELAN e.V.)
+TBD

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowService.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowService.java
@@ -59,27 +59,6 @@ public interface WorkflowService {
   void removeWorkflowListener(WorkflowListener listener);
 
   /**
-   * Registers a new workflow definition. If a workflow definition with the same identifier is already registered, it
-   * will be replaced.
-   *
-   * @param workflow
-   *          the new workflow definition
-   * @throws WorkflowDatabaseException
-   *           if there is a problem registering the workflow definition
-   */
-  void registerWorkflowDefinition(WorkflowDefinition workflow) throws WorkflowDatabaseException;
-
-  /**
-   * Removes the workflow definition with this identifier.
-   *
-   * @throws NotFoundException
-   *           if there is no workflow registered with this identifier
-   * @throws WorkflowDatabaseException
-   *           if there is a problem unregistering the workflow definition
-   */
-  void unregisterWorkflowDefinition(String workflowDefinitionId) throws NotFoundException, WorkflowDatabaseException;
-
-  /**
    * Returns the {@link WorkflowDefinition} identified by <code>name</code>.
    *
    * @param id

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
@@ -23,12 +23,10 @@ package org.opencastproject.workflow.endpoint;
 
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
-import static javax.servlet.http.HttpServletResponse.SC_CREATED;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static javax.servlet.http.HttpServletResponse.SC_PRECONDITION_FAILED;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.INTEGER;
 import static org.opencastproject.util.doc.rest.RestParameter.Type.STRING;
@@ -86,8 +84,6 @@ import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,7 +95,6 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -706,51 +701,6 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
       jsonArray.add(jsonHandler);
     }
     return Response.ok(jsonArray.toJSONString()).header("Content-Type", MediaType.APPLICATION_JSON).build();
-  }
-
-  @PUT
-  @Path("/definition")
-  @RestQuery(name = "updatedefinition", description = "Updates a workflow definition.", returnDescription = "A location headers containing the URL to the updated workflow definition.", restParameters = { @RestParameter(name = "workflowDefinition", isRequired = true, description = "The XML representation of the updated workflow definition.", type = TEXT) }, reponses = {
-          @RestResponse(responseCode = SC_CREATED, description = "Workflow definition updated."),
-          @RestResponse(responseCode = SC_PRECONDITION_FAILED, description = "Workflow definition already registered.") })
-  public Response registerWorkflowDefinition(@FormParam("workflowDefinition") WorkflowDefinitionImpl workflowDefinition) {
-    if (workflowDefinition == null)
-      return Response.status(Status.BAD_REQUEST).build();
-
-    try {
-      service.getWorkflowDefinitionById(workflowDefinition.getId());
-      return Response.status(Status.PRECONDITION_FAILED).build(); // the workflow definition should be unregistered
-    } catch (NotFoundException notFoundException) {
-      try {
-        service.registerWorkflowDefinition(workflowDefinition);
-        return Response
-                .created(
-                        new URI(UrlSupport.concat(new String[] { serverUrl, "definition",
-                                workflowDefinition.getId() + ".xml" }))).build();
-      } catch (WorkflowDatabaseException e) {
-        return Response.status(Status.INTERNAL_SERVER_ERROR).build();
-      } catch (URISyntaxException e) {
-        throw new IllegalStateException("Unable to generate a URI for workflow definitions", e);
-      }
-    } catch (WorkflowDatabaseException e) {
-      return Response.status(Status.INTERNAL_SERVER_ERROR).build();
-    }
-  }
-
-  @DELETE
-  @Path("/definition/{id}")
-  @RestQuery(name = "deletedefinition", description = "Deletes a workflow definition.", returnDescription = "No content.", pathParameters = { @RestParameter(name = "id", isRequired = true, description = "The workflow definition identifier.", type = STRING) }, reponses = {
-          @RestResponse(responseCode = SC_NO_CONTENT, description = "Workflow definition deleted."),
-          @RestResponse(responseCode = SC_NOT_FOUND, description = "Workflow definition not found.") })
-  public Response unregisterWorkflowDefinition(@PathParam("id") String workflowDefinitionId) throws NotFoundException {
-    try {
-      service.unregisterWorkflowDefinition(workflowDefinitionId);
-      return Response.status(Status.NO_CONTENT).build();
-    } catch (NotFoundException e) {
-      return Response.status(Status.NOT_FOUND).build();
-    } catch (WorkflowDatabaseException e) {
-      return Response.status(Status.INTERNAL_SERVER_ERROR).build();
-    }
   }
 
   @Path("/cleanup")

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -470,35 +470,6 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   /**
    * {@inheritDoc}
    *
-   * @see org.opencastproject.workflow.api.WorkflowService#registerWorkflowDefinition(org.opencastproject.workflow.api.WorkflowDefinition)
-   */
-  @Override
-  public void registerWorkflowDefinition(WorkflowDefinition workflow) {
-    if (workflow == null || workflow.getId() == null) {
-      throw new IllegalArgumentException("Workflow must not be null, and must contain an ID");
-    }
-    String id = workflow.getId();
-    if (workflowDefinitionScanner.getWorkflowDefinitions().containsKey(id)) {
-      throw new IllegalStateException("A workflow definition with ID '" + id + "' is already registered.");
-    }
-    workflowDefinitionScanner.putWorkflowDefinition(id, workflow);
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowService#unregisterWorkflowDefinition(java.lang.String)
-   */
-  @Override
-  public void unregisterWorkflowDefinition(String workflowDefinitionId) throws NotFoundException {
-    boolean deleted = workflowDefinitionScanner.removeWorkflowDefinition(workflowDefinitionId) != null;
-    if (deleted)
-      throw new NotFoundException("Workflow definition not found");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
    * @see org.opencastproject.workflow.api.WorkflowService#getWorkflowById(long)
    */
   @Override

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
@@ -237,10 +237,8 @@ public class CountWorkflowsTest {
     is = CountWorkflowsTest.class.getResourceAsStream("/workflow-definition-holdstate.xml");
     def = WorkflowParser.parseWorkflowDefinition(is);
     IOUtils.closeQuietly(is);
-    service.registerWorkflowDefinition(def);
 
     serviceRegistry.registerService(service);
-
   }
 
   @After

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
@@ -244,7 +244,6 @@ public class HoldStateTest {
     is = HoldStateTest.class.getResourceAsStream("/workflow-definition-holdstate.xml");
     def = WorkflowParser.parseWorkflowDefinition(is);
     IOUtils.closeQuietly(is);
-    service.registerWorkflowDefinition(def);
   }
 
   @After

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
@@ -247,7 +247,6 @@ public class PauseFinalOperationTest {
     is = PauseFinalOperationTest.class.getResourceAsStream("/workflow-definition-pause-last.xml");
     def = WorkflowParser.parseWorkflowDefinition(is);
     IOUtils.closeQuietly(is);
-    service.registerWorkflowDefinition(def);
   }
 
   @After

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
@@ -219,7 +219,6 @@ public class PauseWorkflowTest {
     is = PauseWorkflowTest.class.getResourceAsStream("/workflow-definition-pause.xml");
     def = WorkflowParser.parseWorkflowDefinition(is);
     IOUtils.closeQuietly(is);
-    service.registerWorkflowDefinition(def);
   }
 
   @After

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingIntricateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingIntricateTest.java
@@ -234,7 +234,6 @@ public final class WorkflowOperationSkippingIntricateTest {
 
     try (InputStream is = getClass().getResourceAsStream("/workflow-definition-skipping-intricate.xml")) {
       workingDefinition = WorkflowParser.parseWorkflowDefinition(is);
-      service.registerWorkflowDefinition(workingDefinition);
 
       MediaPackageBuilder mediaPackageBuilder = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder();
       mediaPackageBuilder.setSerializer(new DefaultMediaPackageSerializerImpl(new File("target/test-classes")));

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
@@ -243,7 +243,6 @@ public class WorkflowOperationSkippingTest {
     try {
       is = getClass().getResourceAsStream("/workflow-definition-skipping.xml");
       workingDefinition = WorkflowParser.parseWorkflowDefinition(is);
-      service.registerWorkflowDefinition(workingDefinition);
       IOUtils.closeQuietly(is);
 
       MediaPackageBuilder mediaPackageBuilder = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder();

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -258,6 +258,14 @@ public class WorkflowServiceImplTest {
 
     InputStream is = null;
     try {
+      is = WorkflowServiceImplTest.class.getResourceAsStream("/workflow-definition-exception-handler.xml");
+      WorkflowDefinition exceptionHandler = WorkflowParser.parseWorkflowDefinition(is);
+      IOUtils.closeQuietly(is);
+
+      /* The exception handler workflow definition needs to be registered as the reference to it in 
+         workflow-definition-3 will be checked */
+      scanner.putWorkflowDefinition("exception-handler", exceptionHandler);
+
       is = WorkflowServiceImplTest.class.getResourceAsStream("/workflow-definition-1.xml");
       workingDefinition = WorkflowParser.parseWorkflowDefinition(is);
       IOUtils.closeQuietly(is);
@@ -273,11 +281,6 @@ public class WorkflowServiceImplTest {
       is = WorkflowServiceImplTest.class.getResourceAsStream("/workflow-definition-4.xml");
       pausingWorkflowDefinition = WorkflowParser.parseWorkflowDefinition(is);
       IOUtils.closeQuietly(is);
-
-      service.registerWorkflowDefinition(workingDefinition);
-      service.registerWorkflowDefinition(failingDefinitionWithoutErrorHandler);
-      service.registerWorkflowDefinition(failingDefinitionWithErrorHandler);
-      service.registerWorkflowDefinition(pausingWorkflowDefinition);
 
       MediaPackageBuilder mediaPackageBuilder = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder();
       mediaPackageBuilder.setSerializer(new DefaultMediaPackageSerializerImpl(new File("target/test-classes")));
@@ -674,7 +677,6 @@ public class WorkflowServiceImplTest {
     def.setId("workflow-definition-1");
     def.setTitle("workflow-definition-1");
     def.setDescription("workflow-definition-1");
-    service.registerWorkflowDefinition(def);
 
     WorkflowOperationDefinitionImpl opDef = new WorkflowOperationDefinitionImpl("failOneTime", "fails once", null, true);
     def.add(opDef);
@@ -694,7 +696,6 @@ public class WorkflowServiceImplTest {
     def.setId("workflow-definition-1");
     def.setTitle("workflow-definition-1");
     def.setDescription("workflow-definition-1");
-    service.registerWorkflowDefinition(def);
 
     WorkflowOperationDefinitionImpl opDef = new WorkflowOperationDefinitionImpl("failOneTime", "fails once", null, true);
     opDef.setRetryStrategy(RetryStrategy.RETRY);
@@ -715,7 +716,6 @@ public class WorkflowServiceImplTest {
     def.setId("workflow-definition-1");
     def.setTitle("workflow-definition-1");
     def.setDescription("workflow-definition-1");
-    service.registerWorkflowDefinition(def);
 
     WorkflowOperationDefinitionImpl opDef = new WorkflowOperationDefinitionImpl("failOneTime", "fails once", null, true);
     opDef.setRetryStrategy(RetryStrategy.HOLD);
@@ -745,7 +745,6 @@ public class WorkflowServiceImplTest {
     def.setId("workflow-definition-1");
     def.setTitle("workflow-definition-1");
     def.setDescription("workflow-definition-1");
-    service.registerWorkflowDefinition(def);
 
     WorkflowOperationDefinitionImpl opDef = new WorkflowOperationDefinitionImpl("failTwice", "fails twice", null, true);
     opDef.setRetryStrategy(RetryStrategy.HOLD);
@@ -801,7 +800,6 @@ public class WorkflowServiceImplTest {
     def.setId("workflow-definition-1");
     def.setTitle("workflow-definition-1");
     def.setDescription("workflow-definition-1");
-    service.registerWorkflowDefinition(def);
 
     WorkflowOperationDefinitionImpl opDef = new WorkflowOperationDefinitionImpl("failTwice", "fails twice", null, true);
     opDef.setRetryStrategy(RetryStrategy.HOLD);
@@ -859,7 +857,6 @@ public class WorkflowServiceImplTest {
     def.setId("workflow-definition-1");
     def.setTitle("workflow-definition-1");
     def.setDescription("workflow-definition-1");
-    service.registerWorkflowDefinition(def);
 
     WorkflowOperationDefinitionImpl opDef = new WorkflowOperationDefinitionImpl("failOnHost", "fails on host", null,
             true);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowStatisticsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowStatisticsTest.java
@@ -194,11 +194,6 @@ public class WorkflowStatisticsTest {
     EasyMock.replay(mds);
     service.addMetadataService(mds);
 
-    // Register the workflow definitions
-    for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
-      service.registerWorkflowDefinition(workflowDefinition);
-    }
-
     // Mock the workspace
     workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.getCollectionContents((String) EasyMock.anyObject())).andReturn(new URI[0]);

--- a/modules/workflow-service-impl/src/test/resources/workflow-definition-3.xml
+++ b/modules/workflow-service-impl/src/test/resources/workflow-definition-3.xml
@@ -10,7 +10,7 @@
     <operation
       id="op3"
       fail-on-error="true"
-      exception-handler-workflow="definition-1"
+      exception-handler-workflow="exception-handler"
       description="operation 3"/>
 
     <operation

--- a/modules/workflow-service-impl/src/test/resources/workflow-definition-exception-handler.xml
+++ b/modules/workflow-service-impl/src/test/resources/workflow-definition-exception-handler.xml
@@ -1,0 +1,17 @@
+<definition xmlns="http://workflow.opencastproject.org">
+  <id>exception-handler</id>
+  <title>Exception Handler Workflow</title>
+  <description>Exception Handler Workflow Definition for Unit Tests</description>
+  <operations>
+    <operation
+      id="op1"
+      fail-on-error="true"
+      description="operation 1"/>
+
+    <operation
+      id="op2"
+      fail-on-error="false"
+      description="operation 2"/>
+  </operations>
+
+</definition>

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -22,11 +22,9 @@
 package org.opencastproject.workflow.remote;
 
 import static org.apache.http.HttpStatus.SC_CONFLICT;
-import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
-import static org.apache.http.HttpStatus.SC_PRECONDITION_FAILED;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 
 import org.opencastproject.mediapackage.MediaPackage;
@@ -56,7 +54,6 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
@@ -609,66 +606,6 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     }
     throw new WorkflowDatabaseException(
             "Unable to read the registered workflow definitions from the remote workflow service");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowService#registerWorkflowDefinition(org.opencastproject.workflow.api.WorkflowDefinition)
-   */
-  @Override
-  public void registerWorkflowDefinition(WorkflowDefinition workflow) throws WorkflowDatabaseException {
-    HttpPut put = new HttpPut("/definition");
-    try {
-      List<BasicNameValuePair> params = new ArrayList<>();
-      params.add(new BasicNameValuePair("workflowDefinition", WorkflowParser.toXml(workflow)));
-      put.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
-    } catch (UnsupportedEncodingException e) {
-      throw new IllegalStateException("Unable to assemble a remote workflow service request", e);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to serialize workflow definition to xml");
-    }
-
-    HttpResponse response = getResponse(put, SC_CREATED, SC_PRECONDITION_FAILED);
-    try {
-      if (response != null) {
-        if (SC_PRECONDITION_FAILED == response.getStatusLine().getStatusCode()) {
-          throw new IllegalStateException("A workflow definition with ID '" + workflow.getId()
-                  + "' is already registered.");
-        } else {
-          logger.info("Workflow definition '{}' registered", workflow);
-          return;
-        }
-      }
-    } finally {
-      closeConnection(response);
-    }
-    throw new WorkflowDatabaseException("Unable to register workflow definition " + workflow.getId());
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.workflow.api.WorkflowService#unregisterWorkflowDefinition(java.lang.String)
-   */
-  @Override
-  public void unregisterWorkflowDefinition(String workflowDefinitionId) throws NotFoundException,
-          WorkflowDatabaseException {
-    HttpDelete delete = new HttpDelete("/definition/" + workflowDefinitionId);
-    HttpResponse response = getResponse(delete, SC_NO_CONTENT, SC_NOT_FOUND);
-    try {
-      if (response != null) {
-        if (SC_NOT_FOUND == response.getStatusLine().getStatusCode()) {
-          throw new NotFoundException("Workflow definition '" + workflowDefinitionId + "' not found.");
-        } else {
-          logger.info("Workflow definition '{}' unregistered", workflowDefinitionId);
-          return;
-        }
-      }
-    } finally {
-      closeConnection(response);
-    }
-    throw new WorkflowDatabaseException("Unable to delete workflow definition '" + workflowDefinitionId + "'");
   }
 
   /**


### PR DESCRIPTION
Opencast workflow definitions are stored as XML files in etc/workflows.

There is an additional mechanism that suggests that the workflow configuration can be managed used the REST endpoint of the workflow service that offers those two functions:

- DELETE /workflow/definition/{id} to unregister a workflow definition
- PUT /workflow/definition to add a workflow definition

While those functions are implemented, they aren't actually useful as there is no persistence layer that would in any way ensure that the changes survive a restart of Opencast where Opencast would simply start over with the configuration found in etc/workflows.

Instead of using those functions, administrators can delete the workflow definition XML file in etc/workflows to unregister a workflow definition or add a file to add a workflow definition.