### PR TITLE
MH-13532 Role support for workflows

### DIFF
--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -57,6 +57,10 @@ Start by naming the workflow and giving it a meaningful description:
       <id>example</id>
       <!-- Optionally specify an organization -->
       <organization>mh_default_org</organization>
+      <!-- optionally specify roles for this workflow -->
+      <roles>
+        <role>ROLE_ADMIN</role>
+      </roles>
       <title>Encode Mp4, Distribute and Publish</title>
       <tags>
         <!-- Tell the UI where to show this workflow -->
@@ -84,6 +88,10 @@ Start by naming the workflow and giving it a meaningful description:
   installations). If there are two workflows with the same id, the one corresponding to the user’s organization is
   always chosen. This pertains workflow dropdowns (for example, the “Add new event” dropdown) as well as workflows
   included in other workflows via the `include` workflow operation handler.
+* The `roles` define which user roles are allowed to see and start this workflow (a user needs one of the roles provided
+  in the definition). If this is omitted or no roles are specified, everyone can see and start the workflow (provided
+  the `organization` constraints are satisfied). Also, users with `ROLE_ADMIN` can see and start every workflow. Note
+  that the workflows included in Opencast do not set roles.
 * The `tags` define where the user interfaces may use these workflows. Useful tags are:
     * *upload*: Usable for uploaded media
     * *schedule*: Usable for scheduled events

--- a/modules/common/src/main/java/org/opencastproject/security/api/RoleDirectoryService.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/RoleDirectoryService.java
@@ -22,6 +22,10 @@
 package org.opencastproject.security.api;
 
 import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * A marker interface for the federation of all {@link RoleProvider}s.
@@ -34,6 +38,11 @@ public interface RoleDirectoryService {
    * @return the roles
    */
   Iterator<Role> getRoles();
+
+  default Stream<Role> getRolesStream() {
+    return StreamSupport
+            .stream(Spliterators.spliteratorUnknownSize(getRoles(), Spliterator.NONNULL), false);
+  }
 
   /**
    * Return the found role's as an iterator.

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinition.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinition.java
@@ -150,6 +150,13 @@ public interface WorkflowDefinition extends Comparable<WorkflowDefinition> {
   String[] getTags();
 
   /**
+   * Returns the roles for this workflow definition
+   *
+   * @return the tags
+   */
+  Collection<String> getRoles();
+
+  /**
    * Removes all tags associated with this workflow definition
    */
   void clearTags();

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinitionImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowDefinitionImpl.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -66,7 +67,11 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
 
   @XmlElementWrapper(name = "tags")
   @XmlElement(name = "tag")
-  protected SortedSet<String> tags = new TreeSet<String>();
+  protected SortedSet<String> tags = new TreeSet<>();
+
+  @XmlElementWrapper(name = "roles")
+  @XmlElement(name = "role")
+  protected SortedSet<String> roles = new TreeSet<>();
 
   @XmlElement(name = "description")
   private String description;
@@ -165,7 +170,7 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
    */
   public List<WorkflowOperationDefinition> getOperations() {
     if (operations == null)
-      operations = new ArrayList<WorkflowOperationDefinition>();
+      operations = new ArrayList<>();
     return operations;
   }
 
@@ -185,7 +190,7 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
   @Override
   public WorkflowOperationDefinition get(int position) throws IndexOutOfBoundsException {
     if (operations == null)
-      operations = new ArrayList<WorkflowOperationDefinition>();
+      operations = new ArrayList<>();
     if (position < 0 || position >= operations.size())
       throw new IndexOutOfBoundsException();
     return operations.get(position);
@@ -199,7 +204,7 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
   @Override
   public void add(WorkflowOperationDefinition operation) {
     if (operations == null)
-      operations = new ArrayList<WorkflowOperationDefinition>();
+      operations = new ArrayList<>();
     add(operation, this.operations.size());
   }
 
@@ -212,7 +217,7 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
   @Override
   public void add(WorkflowOperationDefinition operation, int position) {
     if (operations == null)
-      operations = new ArrayList<WorkflowOperationDefinition>();
+      operations = new ArrayList<>();
 
     if (operation == null)
       throw new IllegalArgumentException("Workflow operation cannot be null");
@@ -233,7 +238,7 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
   @Override
   public WorkflowOperationDefinition remove(int position) throws IndexOutOfBoundsException {
     if (operations == null)
-      operations = new ArrayList<WorkflowOperationDefinition>();
+      operations = new ArrayList<>();
     return operations.remove(position);
   }
 
@@ -286,7 +291,7 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
    */
   @Override
   public String[] getTags() {
-    return tags.toArray(new String[tags.size()]);
+    return tags.toArray(new String[0]);
   }
 
   /**
@@ -326,11 +331,11 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
   }
 
   static class Adapter extends XmlAdapter<WorkflowDefinitionImpl, WorkflowDefinition> {
-    public WorkflowDefinitionImpl marshal(WorkflowDefinition op) throws Exception {
+    public WorkflowDefinitionImpl marshal(WorkflowDefinition op) {
       return (WorkflowDefinitionImpl) op;
     }
 
-    public WorkflowDefinition unmarshal(WorkflowDefinitionImpl op) throws Exception {
+    public WorkflowDefinition unmarshal(WorkflowDefinitionImpl op) {
       return op;
     }
   }
@@ -353,6 +358,14 @@ public class WorkflowDefinitionImpl implements WorkflowDefinition {
   @Override
   public String getOrganization() {
     return organization;
+  }
+
+  @Override
+  public Collection<String> getRoles() {
+    if (roles == null) {
+      return Collections.emptySet();
+    }
+    return roles;
   }
 
   /**

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
@@ -247,8 +247,9 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
   @RestQuery(name = "definitionasjson", description = "Returns a single workflow definition", returnDescription = "Returns a JSON representation of the workflow definition with the specified identifier", pathParameters = { @RestParameter(name = "id", isRequired = true, description = "The workflow definition identifier", type = STRING) }, reponses = {
           @RestResponse(responseCode = SC_OK, description = "The workflow definition."),
           @RestResponse(responseCode = SC_NOT_FOUND, description = "Workflow definition not found.") })
-  public Response getWorkflowDefinitionAsJson(@PathParam("id") String workflowDefinitionId) throws NotFoundException {
-    WorkflowDefinition def = null;
+  public Response getWorkflowDefinitionAsJson(@PathParam("id") String workflowDefinitionId)
+          throws NotFoundException {
+    WorkflowDefinition def;
     try {
       def = service.getWorkflowDefinitionById(workflowDefinitionId);
     } catch (WorkflowDatabaseException e) {
@@ -263,7 +264,8 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
   @RestQuery(name = "definitionasxml", description = "Returns a single workflow definition", returnDescription = "Returns an XML representation of the workflow definition with the specified identifier", pathParameters = { @RestParameter(name = "id", isRequired = true, description = "The workflow definition identifier", type = STRING) }, reponses = {
           @RestResponse(responseCode = SC_OK, description = "The workflow definition."),
           @RestResponse(responseCode = SC_NOT_FOUND, description = "Workflow definition not found.") })
-  public Response getWorkflowDefinitionAsXml(@PathParam("id") String workflowDefinitionId) throws NotFoundException {
+  public Response getWorkflowDefinitionAsXml(@PathParam("id") String workflowDefinitionId)
+          throws NotFoundException {
     return getWorkflowDefinitionAsJson(workflowDefinitionId);
   }
 
@@ -277,11 +279,11 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
   @Produces(MediaType.TEXT_HTML)
   @Path("configurationPanel")
   @RestQuery(name = "configpanel", description = "Get the configuration panel for a specific workflow", returnDescription = "The HTML workflow configuration panel", restParameters = { @RestParameter(name = "definitionId", isRequired = false, description = "The workflow definition identifier", type = STRING) }, reponses = { @RestResponse(responseCode = SC_OK, description = "The workflow configuration panel.") })
-  public Response getConfigurationPanel(@QueryParam("definitionId") String definitionId) throws NotFoundException {
-    WorkflowDefinition def = null;
+  public Response getConfigurationPanel(@QueryParam("definitionId") String definitionId)
+          throws NotFoundException {
     try {
-      def = service.getWorkflowDefinitionById(definitionId);
-      String out = def.getConfigurationPanel();
+      final WorkflowDefinition def = service.getWorkflowDefinitionById(definitionId);
+      final String out = def.getConfigurationPanel();
       return Response.ok(out).build();
     } catch (WorkflowDatabaseException e) {
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -359,8 +359,10 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    */
   @Override
   public List<WorkflowDefinition> listAvailableWorkflowDefinitions() {
-    return workflowDefinitionScanner.getAvailableWorkflowDefinitions(securityService.getOrganization())
-            .sorted().collect(Collectors.toList());
+    return workflowDefinitionScanner
+            .getAvailableWorkflowDefinitions(securityService.getOrganization(), securityService.getUser())
+            .sorted()
+            .collect(Collectors.toList());
   }
 
   /**
@@ -886,9 +888,10 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   @Override
   public WorkflowDefinition getWorkflowDefinitionById(String id) throws NotFoundException {
     final WorkflowIdentifier workflowIdentifier = new WorkflowIdentifier(id, securityService.getOrganization().getId());
-    WorkflowDefinition def = workflowDefinitionScanner.getWorkflowDefinition(workflowIdentifier);
+    final WorkflowDefinition def = workflowDefinitionScanner
+            .getWorkflowDefinition(securityService.getUser(), workflowIdentifier);
     if (def == null) {
-      throw new NotFoundException("Workflow definition '" + workflowIdentifier + "' not found");
+      throw new NotFoundException("Workflow definition '" + workflowIdentifier + "' not found or inaccessible");
     }
     return def;
   }


### PR DESCRIPTION
This PR adds the ability to define roles for workflows, as such:

- A workflow definition can specify a list of roles.
- If the workflow does not specify roles, the previous behavior is in effect: everyone can use this workflow.
- Users with `ROLE_ADMIN` can also use all workflows.
- Otherwise, if the current user has roles in common with the roles specified in the workflow, the workflow can be started.

Note that the PR depends on #864, as it was easier to implement this way.

This work is sponsored by SWITCH.