### PR TITLE
MH-13533 Document parameter "sign" of GET /api/events/{id}/publications/*

### DIFF
--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -758,6 +758,10 @@ __Response__
 
 Returns an event's list of publications.
 
+Query String Parameter     |Type                         | Description
+:--------------------------|:----------------------------|:-----------
+`sign`                     | [`boolean`](types.md#basic) | Whether public distribution urls should be signed
+
 __Response__
 
 `200 (OK)`: The list of publications is returned.<br/>
@@ -783,6 +787,10 @@ __Response__
 ### GET /api/events/{event_id}/publications/{publication_id}
 
 Returns a single publication.
+
+Query String Parameter     |Type                         | Description
+:--------------------------|:----------------------------|:-----------
+`sign`                     | [`boolean`](types.md#basic) | Whether public distribution urls should be signed
 
 __Response__
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1386,8 +1386,16 @@ public class EventsEndpoint implements ManagedService {
 
   @GET
   @Path("{eventId}/publications")
-  @RestQuery(name = "geteventpublications", description = "Returns an event's list of publications.", returnDescription = "", pathParameters = {
-          @RestParameter(name = "eventId", description = "The event id", isRequired = true, type = STRING) }, reponses = {
+  @RestQuery(name = "geteventpublications", description = "Returns an event's list of publications.",
+             returnDescription = "",
+             pathParameters = {
+               @RestParameter(name = "eventId", description = "The event id", isRequired = true, type = STRING)
+             },
+             restParameters = {
+               @RestParameter(name = "sign", description = "Whether public distribution urls should be signed.",
+                              isRequired = false, type = Type.BOOLEAN)
+             },
+             reponses = {
                   @RestResponse(description = "The list of publications is returned.", responseCode = HttpServletResponse.SC_OK),
                   @RestResponse(description = "The specified event does not exist.", responseCode = HttpServletResponse.SC_NOT_FOUND) })
   public Response getEventPublications(@HeaderParam("Accept") String acceptHeader, @PathParam("eventId") String id,
@@ -1511,9 +1519,16 @@ public class EventsEndpoint implements ManagedService {
 
   @GET
   @Path("{eventId}/publications/{publicationId}")
-  @RestQuery(name = "geteventpublication", description = "Returns a single publication.", returnDescription = "", pathParameters = {
-          @RestParameter(name = "eventId", description = "The event id", isRequired = true, type = STRING),
-          @RestParameter(name = "publicationId", description = "The publication id", isRequired = true, type = STRING) }, reponses = {
+  @RestQuery(name = "geteventpublication", description = "Returns a single publication.", returnDescription = "",
+             pathParameters = {
+               @RestParameter(name = "eventId", description = "The event id", isRequired = true, type = STRING),
+               @RestParameter(name = "publicationId", description = "The publication id", isRequired = true, type = STRING)
+             },
+             restParameters = {
+               @RestParameter(name = "sign", description = "Whether public distribution urls should be signed.",
+                              isRequired = false, type = Type.BOOLEAN)
+             },
+             reponses = {
                   @RestResponse(description = "The track details are returned.", responseCode = HttpServletResponse.SC_OK),
                   @RestResponse(description = "The specified event or publication does not exist.", responseCode = HttpServletResponse.SC_NOT_FOUND) })
   public Response getEventPublication(@HeaderParam("Accept") String acceptHeader, @PathParam("eventId") String eventId,


### PR DESCRIPTION
The External API methods GET /api/events/{id}/publications and GET /api/events/{id}/publications/{id} both support the query parameter "sign", but neither the External API specification nor the REST docs are aware of that fact