### PR TITLE
MH-13534 Add Hourly Data Resolution For Statistics

### DIFF
--- a/docs/guides/admin/docs/configuration/admin-ui/statistics.md
+++ b/docs/guides/admin/docs/configuration/admin-ui/statistics.md
@@ -75,9 +75,9 @@ For each provider, the following properties have to be configured:
     - **`resourceIdName`**, e.g. `episodeId` tells Opencast that the InfluxDB tag identifying the resource type this
        provider refers to is named `episodeId`.
     - **`resolutions`** is a list of resolutions supported by this provider. Opencast allows the user to select a
-      _resolution_ with which the data is displayed. Valid values are `DAILY`, `WEEKLY`, `MONTHLY` and `YEARLY`. E.g.
-      when a chart shows data of two years, a `DAILY` resolution will lead to 2x365=730 values to be plotted while a
-      `MONTHLY` resolution would leave us with 24 values being plotted in the chart.
+      _resolution_ with which the data is displayed. Valid values are `HOURLY`, `DAILY`, `WEEKLY`, `MONTHLY` and
+      `YEARLY`. E.g. when a chart shows data of two years, a `DAILY` resolution will lead to 2x365=730 values to be
+      plotted while a `MONTHLY` resolution would leave us with 24 values being plotted in the chart.
 - **`type`** defines the structure of the data provided by this provider. Currently, only `timeseries` is supported.
 
 Here is an example json configuration for a provider which generates charts for episodes showing the number of views:

--- a/docs/guides/admin/docs/configuration/admin-ui/statistics.md
+++ b/docs/guides/admin/docs/configuration/admin-ui/statistics.md
@@ -65,23 +65,19 @@ For each provider, the following properties have to be configured:
 - **`description`** is the description to be displayed with the chart. This can be a translation key.
 - **`resourceType`** tells Opencast to which type of entity the chart refers to. Valid values are `EPISODE`, `SERIES`,
   and`ORGANIZATION`. This is used by Opencast to decide where to display the chart.
-- **`resolutions`** is a list of resolutions supported by this provider. Opencast allows the user to select a
-  _resolution_ with which the data is displayed. Valid values are `DAILY`, `WEEKLY`, `MONTHLY` and `YEARLY`. E.g. when a
-  chart shows data of two years, a `DAILY` resolution will lead to 2x365=730 values to be plotted while a `MONTHLY`
-  resolution would leave us with 24 values being plotted in the chart.
-- **`source`** is a composite string which holds information about your data schema and how to calculate the
-  actual data to be displayed in the Admin UI. For InfluxDB, the `source` string consists of 5 parts, separated by
-  colons (:). A valid `source` string would be `influx:infinite.impressions_daily:SUM:value:episodeId` which has the
-  following meaning:
-
-    1. `influx` tells Opencast that InfluxDB is the data source.
-    2. `infinite.impressions_daily` tells Opencast that your InfluxDB data retention policy is named `infinite` and your
-        InfluxDB measurement name is `impressions_daily`.
-    3. `SUM` tells Opencast that InfluxDB's `SUM()` function should be used to calculate the values to display in the
-        chart.
-    4. `value` tells Opencast that the InfluxDB field which should be summed is named `value`.
-    5. `episodeId` tells Opencast that the InfluxDB tag identifying the resource type this provider refers to is named
-       `episodeId`.
+- **`sources`** is list of JSON objects, each containing the following fields:
+    - **`measurement`**, e.g. `infinite.impressions_daily` tells Opencast that your InfluxDB data retention policy is
+      named `infinite` and your InfluxDB measurement name is `impressions_daily`.
+    - **`aggregation`**, e.g. `SUM` tells Opencast that InfluxDB's `SUM()` function should be used to calculate the
+      values to display in the chart.
+    - **`aggregationVariable**, e.g. `value` tells Opencast that the InfluxDB field which should be summed is named
+      `value`.
+    - **`resourceIdName`**, e.g. `episodeId` tells Opencast that the InfluxDB tag identifying the resource type this
+       provider refers to is named `episodeId`.
+    - **`resolutions`** is a list of resolutions supported by this provider. Opencast allows the user to select a
+      _resolution_ with which the data is displayed. Valid values are `DAILY`, `WEEKLY`, `MONTHLY` and `YEARLY`. E.g.
+      when a chart shows data of two years, a `DAILY` resolution will lead to 2x365=730 values to be plotted while a
+      `MONTHLY` resolution would leave us with 24 values being plotted in the chart.
 - **`type`** defines the structure of the data provided by this provider. Currently, only `timeseries` is supported.
 
 Here is an example json configuration for a provider which generates charts for episodes showing the number of views:
@@ -94,13 +90,18 @@ Here is an example json configuration for a provider which generates charts for 
   "title": "STATISTICS.TITLE.VIEWS_SUM",
   "description": "STATISTICS.DESCRIPTION.VIEWS_SUM",
   "resourceType": "EPISODE",
-  "resolutions": [
-    "DAILY",
-    "WEEKLY",
-    "MONTHLY",
-    "YEARLY"
-  ],
-  "source": "influx:infinite.impressions_daily:SUM:value:episodeId",
+  "sources": [{
+    "measurement": "infinite.impressions_daily",
+    "aggregation": "SUM",
+    "aggregationVariable": "value",
+    "resourceIdName": "episodeId",
+    "resolutions": [
+      "DAILY",
+      "WEEKLY",
+      "MONTHLY",
+      "YEARLY"
+    ]
+  }],
   "type": "timeseries"
 }
 ```

--- a/docs/guides/developer/docs/api/statistics-api.md
+++ b/docs/guides/developer/docs/api/statistics-api.md
@@ -248,7 +248,7 @@ Field name       |Type                                  | Description
 `resourceId`     | [`string`](#basic)                   | The technical identifier of the resource the data relates to
 `from`           | [`datetime`](types.md#date-and-time) | Start of time period this query relates to
 `to`             | [`datetime`](types.md#date-and-time) | End of time period this query relates to
-`dataResolution` | [`string`](#basic)                   | `daily`, `monthly` or `yearly` (as described by provider)
+`dataResolution` | [`string`](#basic)                   | `hourly`, `daily`, `monthly` or `yearly` (as described by provider)
 
 Query Result Data Field:
 

--- a/etc/statistics/influx.views.episode.sum.json
+++ b/etc/statistics/influx.views.episode.sum.json
@@ -1,0 +1,27 @@
+{
+  "id": "episode.views.sum.influx",
+  "title": "STATISTICS.TITLE.VIEWS_SUM",
+  "description": "STATISTICS.DESCRIPTION.VIEWS_SUM",
+  "resourceType": "EPISODE",
+  "sources": [{
+    "measurement": "infinite.impressions_daily",
+    "aggregation": "SUM",
+    "aggregationVariable": "value",
+    "resourceIdName": "episodeId",
+    "resolutions": [
+      "DAILY",
+      "WEEKLY",
+      "MONTHLY",
+      "YEARLY"
+    ]
+  }, {
+    "measurement": "one_year.impressions_hourly",
+    "aggregation": "SUM",
+    "aggregationVariable": "value",
+    "resourceIdName": "episodeId",
+    "resolutions": [
+      "HOURLY"
+    ]
+  }],
+  "type": "timeseries"
+}

--- a/etc/statistics/random.data.episode.json
+++ b/etc/statistics/random.data.episode.json
@@ -1,0 +1,7 @@
+{
+  "id": "episode.random",
+  "title": "STATISTICS.TITLE.RANDOM",
+  "description": "STATISTICS.DESCRIPTION.RANDOM",
+  "resourceType": "EPISODE",
+  "type": "timeseries"
+}

--- a/modules/admin-ui/src/main/webapp/scripts/shared/components/statisticsGraphComponent.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/components/statisticsGraphComponent.js
@@ -26,7 +26,8 @@ function StatisticsGraphController($scope, $element, $attrs, Language) {
   ctrl.dataResolutions = [
     { label: 'Yearly', value: 'yearly' },
     { label: 'Monthly', value: 'monthly' },
-    { label: 'Daily', value: 'daily' }
+    { label: 'Daily', value: 'daily' },
+    { label: 'Hourly', value: 'hourly' }
   ];
 
   ctrl.timeChooseModes = [

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/statisticsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/statisticsResource.js
@@ -52,12 +52,16 @@ angular.module('adminNg.resources')
   function createTickCallback(that, idx) {
     return function(value, index, values) {
       var chooseMode = that.statProviderData[idx].timeChooseMode;
+      var dataResolution = that.statProviderData[idx].dataResolution;
       var formatString = 'L';
       if (chooseMode == 'year') {
         formatString = 'MMMM';
-      }
-      if (chooseMode == 'month') {
+      } else if (chooseMode == 'month') {
         formatString = 'dddd, Do';
+      } else {
+        if (dataResolution === 'hourly') {
+          formatString = 'LLL';
+        }
       }
       return moment(value).locale(Language.getLanguageCode()).format(formatString);
     };
@@ -79,8 +83,10 @@ angular.module('adminNg.resources')
           formatString = 'MMMM YYYY';
         } else if (dataResolution === 'yearly') {
           formatString = 'YYYY';
-        } else {
+        } else if (dataResolution === 'daily') {
           formatString = 'dddd, MMMM Do, YYYY';
+        } else {
+          formatString = 'dddd, MMMM Do, YYYY HH:mm';
         }
       }
       var finalDate = moment(itemDate).locale(Language.getLanguageCode()).format(formatString);

--- a/modules/statistics-provider-influx/pom.xml
+++ b/modules/statistics-provider-influx/pom.xml
@@ -86,6 +86,10 @@
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/statistics-provider-influx/src/main/java/org/opencastproject/statistics/provider/influx/StatisticsProviderInfluxService.java
+++ b/modules/statistics-provider-influx/src/main/java/org/opencastproject/statistics/provider/influx/StatisticsProviderInfluxService.java
@@ -21,9 +21,9 @@
 
 package org.opencastproject.statistics.provider.influx;
 
-import org.opencastproject.statistics.api.ConfiguredProvider;
 import org.opencastproject.statistics.api.StatisticsProvider;
 import org.opencastproject.statistics.api.StatisticsProviderRegistry;
+import org.opencastproject.statistics.provider.influx.provider.InfluxProviderConfiguration;
 import org.opencastproject.statistics.provider.influx.provider.InfluxTimeSeriesStatisticsProvider;
 import org.opencastproject.util.ConfigurationException;
 
@@ -85,22 +85,15 @@ public class StatisticsProviderInfluxService implements ManagedService, Artifact
   @Override
   public void install(File file) throws Exception {
     final String json = new String(Files.readAllBytes(file.toPath()), Charset.forName("utf-8"));
-    final ConfiguredProvider providerCfg = ConfiguredProvider.fromJson(json);
-    if (!providerCfg.getSource().toUpperCase().startsWith("INFLUX:")) {
-      throw new ConfigurationException("Unexpected source string: " + providerCfg.getSource());
-    }
+    final InfluxProviderConfiguration providerCfg = InfluxProviderConfiguration.fromJson(json);
     if ("timeseries".equalsIgnoreCase(providerCfg.getType())) {
       final StatisticsProvider provider = new InfluxTimeSeriesStatisticsProvider(
           this,
           providerCfg.getId(),
           providerCfg.getResourceType(),
-          providerCfg.getResolutions(),
           providerCfg.getTitle(),
           providerCfg.getDescription(),
-          providerCfg.getSource().split(":")[2],
-          providerCfg.getSource().split(":")[3],
-          providerCfg.getSource().split(":")[1],
-          providerCfg.getSource().split(":")[4]
+          providerCfg.getSources()
       );
       fileNameToProvider.put(file.getName(), provider);
       if (influxDB != null) {

--- a/modules/statistics-provider-influx/src/main/java/org/opencastproject/statistics/provider/influx/provider/InfluxProviderConfiguration.java
+++ b/modules/statistics-provider-influx/src/main/java/org/opencastproject/statistics/provider/influx/provider/InfluxProviderConfiguration.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.statistics.provider.influx.provider;
+
+import org.opencastproject.statistics.api.DataResolution;
+import org.opencastproject.statistics.api.ProviderConfiguration;
+import org.opencastproject.statistics.api.ResourceType;
+
+import com.google.gson.Gson;
+
+import java.util.Set;
+
+public class InfluxProviderConfiguration extends ProviderConfiguration {
+  private static final Gson gson = new Gson();
+
+  public class InfluxProviderSource {
+    private String aggregation;
+    private String aggregationVariable;
+    private String measurement;
+    private String resourceIdName;
+    private Set<DataResolution> resolutions;
+
+    public InfluxProviderSource()  {
+      // needed for gson
+    }
+
+    public InfluxProviderSource(
+        String aggregation,
+        String aggregationVariable,
+        String measurement,
+        String resourceIdName,
+        Set<DataResolution> resolutions
+    ) {
+      this.aggregation = aggregation;
+      this.aggregationVariable = aggregationVariable;
+      this.measurement = measurement;
+      this.resourceIdName = resourceIdName;
+      this.resolutions = resolutions;
+    }
+
+    public String getAggregation() {
+      return aggregation;
+    }
+
+    public String getAggregationVariable() {
+      return aggregationVariable;
+    }
+
+    public String getMeasurement() {
+      return measurement;
+    }
+
+    public String getResourceIdName() {
+      return resourceIdName;
+    }
+
+    public Set<DataResolution> getResolutions() {
+      return resolutions;
+    }
+  }
+
+  private Set<InfluxProviderSource> sources;
+
+  public InfluxProviderConfiguration()  {
+    // needed for gson
+  }
+
+  public InfluxProviderConfiguration(
+      String id,
+      String title,
+      String description,
+      ResourceType resourceType,
+      String type,
+      Set<InfluxProviderSource> sources
+  ) {
+    super(id, title, description, resourceType, type);
+    this.sources = sources;
+  }
+
+
+  public Set<InfluxProviderSource> getSources() {
+    return sources;
+  }
+
+  public static InfluxProviderConfiguration fromJson(String json) {
+    return gson.fromJson(json, InfluxProviderConfiguration.class);
+  }
+}

--- a/modules/statistics-provider-influx/src/main/java/org/opencastproject/statistics/provider/influx/provider/InfluxStatisticsProvider.java
+++ b/modules/statistics-provider-influx/src/main/java/org/opencastproject/statistics/provider/influx/provider/InfluxStatisticsProvider.java
@@ -39,16 +39,13 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 
 public abstract class InfluxStatisticsProvider implements StatisticsProvider {
 
-
   protected StatisticsProviderInfluxService service;
   private String id;
   private ResourceType resourceType;
-  private Set<DataResolution> dataResolutions;
   private String title;
   private String description;
 
@@ -57,14 +54,12 @@ public abstract class InfluxStatisticsProvider implements StatisticsProvider {
       StatisticsProviderInfluxService service,
       String id,
       ResourceType resourceType,
-      Set<DataResolution> dataResolutions,
       String title,
       String description
   ) {
     this.service = service;
     this.id = id;
     this.resourceType = resourceType;
-    this.dataResolutions = dataResolutions;
     this.title = title;
     this.description = description;
   }
@@ -79,10 +74,6 @@ public abstract class InfluxStatisticsProvider implements StatisticsProvider {
     return resourceType;
   }
 
-  public Set<DataResolution> getDataResolutions() {
-    return dataResolutions;
-  }
-
   @Override
   public String getTitle() {
     return title;
@@ -95,6 +86,8 @@ public abstract class InfluxStatisticsProvider implements StatisticsProvider {
 
   protected static String dataResolutionToInfluxGrouping(DataResolution dataResolution) {
     switch (dataResolution) {
+      case HOURLY:
+        return " GROUP BY time(1h)";
       case DAILY:
         return " GROUP BY time(1d)";
       case WEEKLY:

--- a/modules/statistics-provider-random/pom.xml
+++ b/modules/statistics-provider-random/pom.xml
@@ -60,6 +60,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/statistics-provider-random/src/main/java/org/opencastproject/statistics/provider/random/StatisticsProviderRandomService.java
+++ b/modules/statistics-provider-random/src/main/java/org/opencastproject/statistics/provider/random/StatisticsProviderRandomService.java
@@ -21,9 +21,9 @@
 
 package org.opencastproject.statistics.provider.random;
 
-import org.opencastproject.statistics.api.ConfiguredProvider;
 import org.opencastproject.statistics.api.StatisticsProvider;
 import org.opencastproject.statistics.api.StatisticsProviderRegistry;
+import org.opencastproject.statistics.provider.random.provider.RandomProviderConfiguration;
 import org.opencastproject.statistics.provider.random.provider.RandomStatisticsProvider;
 import org.opencastproject.util.ConfigurationException;
 
@@ -65,15 +65,11 @@ public class StatisticsProviderRandomService implements ArtifactInstaller {
   @Override
   public void install(File file) throws Exception {
     final String json = new String(Files.readAllBytes(file.toPath()), Charset.forName("utf-8"));
-    final ConfiguredProvider providerCfg = ConfiguredProvider.fromJson(json);
-    if (!providerCfg.getSource().toUpperCase().startsWith("RANDOM:")) {
-      throw new ConfigurationException("Unexpected source string: " + providerCfg.getSource());
-    }
+    final RandomProviderConfiguration providerCfg = RandomProviderConfiguration.fromJson(json);
     if ("timeseries".equalsIgnoreCase(providerCfg.getType())) {
       final StatisticsProvider provider = new RandomStatisticsProvider(
           providerCfg.getId(),
           providerCfg.getResourceType(),
-          providerCfg.getResolutions(),
           providerCfg.getTitle(),
           providerCfg.getDescription()
       );

--- a/modules/statistics-provider-random/src/main/java/org/opencastproject/statistics/provider/random/provider/RandomProviderConfiguration.java
+++ b/modules/statistics-provider-random/src/main/java/org/opencastproject/statistics/provider/random/provider/RandomProviderConfiguration.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.statistics.provider.random.provider;
+
+import org.opencastproject.statistics.api.ProviderConfiguration;
+import org.opencastproject.statistics.api.ResourceType;
+
+import com.google.gson.Gson;
+
+
+public class RandomProviderConfiguration extends ProviderConfiguration {
+  private static final Gson gson = new Gson();
+
+  public RandomProviderConfiguration() {
+    // needed for gson
+  }
+
+  public RandomProviderConfiguration(
+      String id,
+      String title,
+      String description,
+      ResourceType resourceType,
+      String type
+  ) {
+    super(id, title, description, resourceType, type);
+  }
+
+  public static RandomProviderConfiguration fromJson(String json) {
+    return gson.fromJson(json, RandomProviderConfiguration.class);
+  }
+}

--- a/modules/statistics-provider-random/src/main/java/org/opencastproject/statistics/provider/random/provider/RandomStatisticsProvider.java
+++ b/modules/statistics-provider-random/src/main/java/org/opencastproject/statistics/provider/random/provider/RandomStatisticsProvider.java
@@ -26,6 +26,7 @@ import org.opencastproject.statistics.api.ResourceType;
 import org.opencastproject.statistics.api.StatisticsUtil;
 import org.opencastproject.statistics.api.TimeSeries;
 import org.opencastproject.statistics.api.TimeSeriesProvider;
+import org.opencastproject.util.data.Collections;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -39,20 +40,17 @@ public class RandomStatisticsProvider implements TimeSeriesProvider {
   private static final Random random = new Random();
   private String id;
   private ResourceType resourceType;
-  private Set<DataResolution> dataResolutions;
   private String title;
   private String description;
 
   public RandomStatisticsProvider(
       String id,
       ResourceType resourceType,
-      Set<DataResolution> dataResolutions,
       String title,
       String description
   ) {
     this.id = id;
     this.resourceType = resourceType;
-    this.dataResolutions = dataResolutions;
     this.title = title;
     this.description = description;
   }
@@ -81,7 +79,7 @@ public class RandomStatisticsProvider implements TimeSeriesProvider {
 
   @Override
   public Set<DataResolution> getDataResolutions() {
-    return dataResolutions;
+    return Collections.set(DataResolution.values());
   }
 
   @Override

--- a/modules/statistics-service-api/src/main/java/org/opencastproject/statistics/api/DataResolution.java
+++ b/modules/statistics-service-api/src/main/java/org/opencastproject/statistics/api/DataResolution.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
  * Resolution to get data with (e.g. daily. weekly, ...)
  */
 public enum DataResolution {
+  HOURLY,
   DAILY,
   WEEKLY,
   MONTHLY,

--- a/modules/statistics-service-api/src/main/java/org/opencastproject/statistics/api/ProviderConfiguration.java
+++ b/modules/statistics-service-api/src/main/java/org/opencastproject/statistics/api/ProviderConfiguration.java
@@ -21,42 +21,32 @@
 
 package org.opencastproject.statistics.api;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
-
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * Model for the json configurations files for statistics providers.
  */
-public final class ConfiguredProvider {
-  private static final JSONParser parser = new JSONParser();
+public abstract class ProviderConfiguration {
   private String id;
   private String title;
   private String description;
   private ResourceType resourceType;
-  private Set<DataResolution> resolutions;
   private String type;
-  private String source;
 
-  private ConfiguredProvider(
+  public ProviderConfiguration() {
+    // needed for gson
+  }
+
+  public ProviderConfiguration(
       String id,
       String title,
       String description,
       ResourceType resourceType,
-      Set<DataResolution> resolutions,
-      String type,
-      String source) {
+      String type
+  ) {
     this.id = id;
     this.title = title;
     this.description = description;
     this.resourceType = resourceType;
-    this.resolutions = resolutions;
     this.type = type;
-    this.source = source;
   }
 
   public String getId() {
@@ -75,33 +65,7 @@ public final class ConfiguredProvider {
     return resourceType;
   }
 
-  public Set<DataResolution> getResolutions() {
-    return resolutions;
-  }
-
   public String getType() {
     return type;
-  }
-
-  public String getSource() {
-    return source;
-  }
-
-  public static ConfiguredProvider fromJson(String json) throws ParseException {
-    final JSONObject jsonObject = (JSONObject) parser.parse(json);
-    final JSONArray resolutionsJson = (JSONArray) jsonObject.get("resolutions");
-    final Set<DataResolution> resolutions = new HashSet<>();
-    for (Object resolution : resolutionsJson) {
-      resolutions.add(DataResolution.fromString((String) resolution));
-    }
-    return new ConfiguredProvider(
-        (String) jsonObject.get("id"),
-        (String) jsonObject.get("title"),
-        (String) jsonObject.get("description"),
-        ResourceType.fromString((String) jsonObject.get("resourceType")),
-        resolutions,
-        (String) jsonObject.get("type"),
-        (String) jsonObject.get("source")
-    );
   }
 }

--- a/modules/statistics-service-api/src/main/java/org/opencastproject/statistics/api/StatisticsUtil.java
+++ b/modules/statistics-service-api/src/main/java/org/opencastproject/statistics/api/StatisticsUtil.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,6 +67,12 @@ public final class StatisticsUtil {
                   .withNano(0).toInstant(ZoneOffset.UTC);
           result.add(currentWeekStart); // No min, max here, because influx uses previous monday as bucket label
           localStart = localStart.plusDays(7).plusDays(daysOff).withHour(0).withMinute(0).withSecond(0).withNano(0);
+          break;
+        case HOURLY:
+          final Instant currentHourStart = ZonedDateTime.of(localStart.withMinute(0).withSecond(0).withNano(0), zoneId)
+              .toInstant();
+          result.add(Ordering.natural().min(to, Ordering.natural().max(from, currentHourStart)));
+          localStart = localStart.plusHours(1).withMinute(0).withSecond(0).withNano(0);
           break;
         default:
       }

--- a/modules/statistics-service-api/src/main/java/org/opencastproject/statistics/api/StatisticsUtil.java
+++ b/modules/statistics-service-api/src/main/java/org/opencastproject/statistics/api/StatisticsUtil.java
@@ -46,32 +46,32 @@ public final class StatisticsUtil {
         case MONTHLY:
           final Instant currentMonthStart = YearMonth.of(localStart.getYear(), localStart.getMonth())
                   .atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC);
-          result.add(Ordering.natural().min(to, Ordering.natural().max(from, currentMonthStart)));
+          result.add(Ordering.natural().max(from, currentMonthStart));
           localStart = localStart.plusMonths(1).withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
           break;
         case YEARLY:
           final Instant currentYearStart = YearMonth.of(localStart.getYear(), 1)
                   .atDay(1).atStartOfDay().toInstant(ZoneOffset.UTC);
-          result.add(Ordering.natural().min(to, Ordering.natural().max(from, currentYearStart)));
+          result.add(Ordering.natural().max(from, currentYearStart));
           localStart = localStart.plusYears(1).withMonth(1).withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
           break;
         case DAILY:
           final Instant currentDayStart = localStart.withHour(0).withMinute(0).withSecond(0).withNano(0)
                   .toInstant(ZoneOffset.UTC);
-          result.add(Ordering.natural().min(to, Ordering.natural().max(from, currentDayStart)));
+          result.add(Ordering.natural().max(from, currentDayStart));
           localStart = localStart.plusDays(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
           break;
         case WEEKLY:
           final int daysOff = 1 - localStart.getDayOfWeek().getValue();
           final Instant currentWeekStart = localStart.plusDays(daysOff).withHour(0).withMinute(0).withSecond(0)
                   .withNano(0).toInstant(ZoneOffset.UTC);
-          result.add(currentWeekStart); // No min, max here, because influx uses previous monday as bucket label
+          result.add(currentWeekStart); // No max here, because influx uses previous monday as bucket label
           localStart = localStart.plusDays(7).plusDays(daysOff).withHour(0).withMinute(0).withSecond(0).withNano(0);
           break;
         case HOURLY:
           final Instant currentHourStart = ZonedDateTime.of(localStart.withMinute(0).withSecond(0).withNano(0), zoneId)
               .toInstant();
-          result.add(Ordering.natural().min(to, Ordering.natural().max(from, currentHourStart)));
+          result.add(Ordering.natural().max(from, currentHourStart));
           localStart = localStart.plusHours(1).withMinute(0).withSecond(0).withNano(0);
           break;
         default:

--- a/modules/statistics-service-api/src/test/java/org/opencastproject/statistics/api/StatisticsUtilTest.java
+++ b/modules/statistics-service-api/src/test/java/org/opencastproject/statistics/api/StatisticsUtilTest.java
@@ -50,6 +50,31 @@ public class StatisticsUtilTest {
   }
 
   @Test
+  public void testGetBucketsHourly() {
+    for (int i = 0; i < repetitions / 24; i++) {
+      final Instant a = randomInstant();
+      final Instant b = randomInstant();
+      final Instant from = Ordering.natural().min(a, b);
+      final Instant to = Ordering.natural().max(a, b);
+      logger.info("from {} to {} {}", from, to, DataResolution.HOURLY.name());
+      final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.HOURLY, ZoneId.of("Z"));
+      assertEquals(from, buckets.get(0));
+      if (buckets.size() == 1) {
+        continue;
+      }
+      assertEquals(
+          LocalDateTime.ofInstant(
+              to,
+              ZoneOffset.UTC)
+              .withMinute(0)
+              .withSecond(0)
+              .withNano(0)
+              .toInstant(ZoneOffset.UTC),
+          buckets.get(buckets.size() - 1));
+    }
+  }
+
+  @Test
   public void testGetBucketsDaily() {
     for (int i = 0; i < repetitions; i++) {
       final Instant a = randomInstant();

--- a/modules/statistics-service-api/src/test/java/org/opencastproject/statistics/api/StatisticsUtilTest.java
+++ b/modules/statistics-service-api/src/test/java/org/opencastproject/statistics/api/StatisticsUtilTest.java
@@ -86,19 +86,19 @@ public class StatisticsUtilTest {
   private void testGetBucketsHourly(Instant from, Instant to) {
     logger.info("from {} to {} {}", from, to, DataResolution.HOURLY.name());
     final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.HOURLY, ZoneId.of("Z"));
-    assertEquals(from, buckets.get(0));
+    assertEquals("from: " + from + " to: " + to, from, buckets.get(0));
     if (buckets.size() == 1) {
       return;
     }
     for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
-      assertTrue(buckets.get(bucket).isAfter(from));
-      assertTrue(buckets.get(bucket).isBefore(to));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isAfter(from));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isBefore(to));
       final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
-      assertEquals(0, ldt.getMinute());
-      assertEquals(0, ldt.getSecond());
-      assertEquals(0, ldt.getNano());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getMinute());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getSecond());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getNano());
     }
-    assertEquals(
+    assertEquals("from: " + from + " to: " + to,
         LocalDateTime.ofInstant(
             to,
             ZoneOffset.UTC)
@@ -131,20 +131,20 @@ public class StatisticsUtilTest {
   private void testGetBucketsDaily(Instant from, Instant to) {
     logger.info("from {} to {} {}", from, to, DataResolution.DAILY.name());
     final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.DAILY, ZoneId.of("Z"));
-    assertEquals(from, buckets.get(0));
+    assertEquals("from: " + from + " to: " + to, from, buckets.get(0));
     if (buckets.size() == 1) {
       return;
     }
     for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
-      assertTrue(buckets.get(bucket).isAfter(from));
-      assertTrue(buckets.get(bucket).isBefore(to));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isAfter(from));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isBefore(to));
       final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
-      assertEquals(0, ldt.getHour());
-      assertEquals(0, ldt.getMinute());
-      assertEquals(0, ldt.getSecond());
-      assertEquals(0, ldt.getNano());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getHour());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getMinute());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getSecond());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getNano());
     }
-    assertEquals(
+    assertEquals("from: " + from + " to: " + to,
         LocalDateTime.ofInstant(
             to,
             ZoneOffset.UTC)
@@ -180,7 +180,7 @@ public class StatisticsUtilTest {
     final int fromOffMonday = 1 - LocalDateTime.ofInstant(from, ZoneOffset.UTC).getDayOfWeek().getValue();
     final int toOffMonday = 1 - LocalDateTime.ofInstant(to, ZoneOffset.UTC).getDayOfWeek().getValue();
     final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.WEEKLY, ZoneId.of("Z"));
-    assertEquals(LocalDateTime.ofInstant(
+    assertEquals("from: " + from + " to: " + to, LocalDateTime.ofInstant(
         from,
         ZoneOffset.UTC)
             .plusDays(fromOffMonday)
@@ -194,16 +194,16 @@ public class StatisticsUtilTest {
       return;
     }
     for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
-      assertTrue(buckets.get(bucket).isAfter(from));
-      assertTrue(buckets.get(bucket).isBefore(to));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isAfter(from));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isBefore(to));
       final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
-      assertEquals(DayOfWeek.MONDAY, ldt.getDayOfWeek());
-      assertEquals(0, ldt.getHour());
-      assertEquals(0, ldt.getMinute());
-      assertEquals(0, ldt.getSecond());
-      assertEquals(0, ldt.getNano());
+      assertEquals("from: " + from + " to: " + to, DayOfWeek.MONDAY, ldt.getDayOfWeek());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getHour());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getMinute());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getSecond());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getNano());
     }
-    assertEquals(
+    assertEquals("from: " + from + " to: " + to,
         LocalDateTime.ofInstant(
             to,
             ZoneOffset.UTC)
@@ -238,21 +238,21 @@ public class StatisticsUtilTest {
   private void testGetBucketsMonthly(Instant from, Instant to) {
     logger.info("from {} to {} {}", from, to, DataResolution.MONTHLY.name());
     final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.MONTHLY, ZoneId.of("Z"));
-    assertEquals(from, buckets.get(0));
+    assertEquals("from: " + from + " to: " + to, from, buckets.get(0));
     if (buckets.size() == 1) {
       return;
     }
     for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
-      assertTrue(buckets.get(bucket).isAfter(from));
-      assertTrue(buckets.get(bucket).isBefore(to));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isAfter(from));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isBefore(to));
       final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
-      assertEquals(1, ldt.getDayOfMonth());
-      assertEquals(0, ldt.getHour());
-      assertEquals(0, ldt.getMinute());
-      assertEquals(0, ldt.getSecond());
-      assertEquals(0, ldt.getNano());
+      assertEquals("from: " + from + " to: " + to, 1, ldt.getDayOfMonth());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getHour());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getMinute());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getSecond());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getNano());
     }
-    assertEquals(
+    assertEquals("from: " + from + " to: " + to,
         LocalDateTime.ofInstant(
             to,
             ZoneOffset.UTC)
@@ -287,22 +287,22 @@ public class StatisticsUtilTest {
   private void testGetBucketsYearly(Instant from, Instant to) {
     logger.info("from {} to {} {}", from, to, DataResolution.YEARLY.name());
     final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.YEARLY, ZoneId.of("Z"));
-    assertEquals(from, buckets.get(0));
+    assertEquals("from: " + from + " to: " + to, from, buckets.get(0));
     if (buckets.size() == 1) {
       return;
     }
     for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
-      assertTrue(buckets.get(bucket).isAfter(from));
-      assertTrue(buckets.get(bucket).isBefore(to));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isAfter(from));
+      assertTrue("from: " + from + " to: " + to, buckets.get(bucket).isBefore(to));
       final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
-      assertEquals(Month.JANUARY, ldt.getMonth());
-      assertEquals(1, ldt.getDayOfMonth());
-      assertEquals(0, ldt.getHour());
-      assertEquals(0, ldt.getMinute());
-      assertEquals(0, ldt.getSecond());
-      assertEquals(0, ldt.getNano());
+      assertEquals("from: " + from + " to: " + to, Month.JANUARY, ldt.getMonth());
+      assertEquals("from: " + from + " to: " + to, 1, ldt.getDayOfMonth());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getHour());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getMinute());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getSecond());
+      assertEquals("from: " + from + " to: " + to, 0, ldt.getNano());
     }
-    assertEquals(
+    assertEquals("from: " + from + " to: " + to,
         LocalDateTime.ofInstant(
             to,
             ZoneOffset.UTC)

--- a/modules/statistics-service-api/src/test/java/org/opencastproject/statistics/api/StatisticsUtilTest.java
+++ b/modules/statistics-service-api/src/test/java/org/opencastproject/statistics/api/StatisticsUtilTest.java
@@ -23,6 +23,7 @@ package org.opencastproject.statistics.api;
 
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Ordering;
 
@@ -30,10 +31,14 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 
@@ -50,147 +55,265 @@ public class StatisticsUtilTest {
   }
 
   @Test
+  public void testStartAfterEnd() {
+    // Test start after end
+    final Instant wrongFrom = Instant.parse("2019-04-01T00:00:00.000Z");
+    final Instant wrongTo = Instant.parse("2019-03-30T17:00:00.000Z");
+    Arrays.stream(DataResolution.values()).forEach(dr -> {
+      assertTrue(StatisticsUtil.getBuckets(wrongFrom, wrongTo, dr, ZoneId.of("Z")).isEmpty());
+    });
+  }
+
+  @Test
   public void testGetBucketsHourly() {
+    // Tests with pre-picked valid data
+    new HashMap<Instant, Instant>() {{
+      put(Instant.parse("2019-10-28T17:00:00.000Z"), Instant.parse("2020-01-02T11:30:00.000Z"));
+      put(Instant.parse("2019-03-30T17:00:00.000Z"), Instant.parse("2019-04-01T00:00:00.000Z"));
+      put(Instant.parse("2019-10-27T00:00:00.000Z"), Instant.parse("2019-10-28T00:00:00.000Z"));
+    }}.forEach(this::testGetBucketsHourly);
+
+    // Tests with random input
     for (int i = 0; i < repetitions / 24; i++) {
       final Instant a = randomInstant();
       final Instant b = randomInstant();
       final Instant from = Ordering.natural().min(a, b);
       final Instant to = Ordering.natural().max(a, b);
-      logger.info("from {} to {} {}", from, to, DataResolution.HOURLY.name());
-      final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.HOURLY, ZoneId.of("Z"));
-      assertEquals(from, buckets.get(0));
-      if (buckets.size() == 1) {
-        continue;
-      }
-      assertEquals(
-          LocalDateTime.ofInstant(
-              to,
-              ZoneOffset.UTC)
-              .withMinute(0)
-              .withSecond(0)
-              .withNano(0)
-              .toInstant(ZoneOffset.UTC),
-          buckets.get(buckets.size() - 1));
+      testGetBucketsHourly(from, to);
     }
+  }
+
+  private void testGetBucketsHourly(Instant from, Instant to) {
+    logger.info("from {} to {} {}", from, to, DataResolution.HOURLY.name());
+    final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.HOURLY, ZoneId.of("Z"));
+    assertEquals(from, buckets.get(0));
+    if (buckets.size() == 1) {
+      return;
+    }
+    for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
+      assertTrue(buckets.get(bucket).isAfter(from));
+      assertTrue(buckets.get(bucket).isBefore(to));
+      final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
+      assertEquals(0, ldt.getMinute());
+      assertEquals(0, ldt.getSecond());
+      assertEquals(0, ldt.getNano());
+    }
+    assertEquals(
+        LocalDateTime.ofInstant(
+            to,
+            ZoneOffset.UTC)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toInstant(ZoneOffset.UTC),
+        buckets.get(buckets.size() - 1));
   }
 
   @Test
   public void testGetBucketsDaily() {
+    // Tests with pre-picked valid data
+    new HashMap<Instant, Instant>() {{
+      put(Instant.parse("2019-10-28T17:00:00.000Z"), Instant.parse("2020-01-02T11:30:00.000Z"));
+      put(Instant.parse("2019-03-30T17:00:00.000Z"), Instant.parse("2019-04-01T00:00:00.000Z"));
+      put(Instant.parse("2019-10-27T00:00:00.000Z"), Instant.parse("2019-10-28T00:00:00.000Z"));
+    }}.forEach(this::testGetBucketsDaily);
+
+    // Tests with random input
     for (int i = 0; i < repetitions; i++) {
       final Instant a = randomInstant();
       final Instant b = randomInstant();
       final Instant from = Ordering.natural().min(a, b);
       final Instant to = Ordering.natural().max(a, b);
-      logger.info("from {} to {} {}", from, to, DataResolution.DAILY.name());
-      final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.DAILY, ZoneId.of("Z"));
-      assertEquals(from, buckets.get(0));
-      if (buckets.size() == 1) {
-        continue;
-      }
-      assertEquals(
-          LocalDateTime.ofInstant(
-              to,
-              ZoneOffset.UTC)
-              .withHour(0)
-              .withMinute(0)
-              .withSecond(0)
-              .withNano(0)
-              .toInstant(ZoneOffset.UTC),
-          buckets.get(buckets.size() - 1));
+      testGetBucketsDaily(from, to);
     }
+  }
+
+  private void testGetBucketsDaily(Instant from, Instant to) {
+    logger.info("from {} to {} {}", from, to, DataResolution.DAILY.name());
+    final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.DAILY, ZoneId.of("Z"));
+    assertEquals(from, buckets.get(0));
+    if (buckets.size() == 1) {
+      return;
+    }
+    for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
+      assertTrue(buckets.get(bucket).isAfter(from));
+      assertTrue(buckets.get(bucket).isBefore(to));
+      final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
+      assertEquals(0, ldt.getHour());
+      assertEquals(0, ldt.getMinute());
+      assertEquals(0, ldt.getSecond());
+      assertEquals(0, ldt.getNano());
+    }
+    assertEquals(
+        LocalDateTime.ofInstant(
+            to,
+            ZoneOffset.UTC)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toInstant(ZoneOffset.UTC),
+        buckets.get(buckets.size() - 1));
   }
 
   @Test
   public void testGetBucketsWeekly() {
+    // Tests with pre-picked valid data
+    new HashMap<Instant, Instant>() {{
+      put(Instant.parse("2019-10-28T17:00:00.000Z"), Instant.parse("2020-01-02T11:30:00.000Z"));
+      put(Instant.parse("2019-03-30T17:00:00.000Z"), Instant.parse("2019-04-01T00:00:00.000Z"));
+      put(Instant.parse("2019-01-01T00:00:00.000Z"), Instant.parse("2019-12-31T23:59:59.999Z"));
+    }}.forEach(this::testGetBucketsWeekly);
+
+    // Tests with random input
     for (int i = 0; i < repetitions; i++) {
       final Instant a = randomInstant();
       final Instant b = randomInstant();
       final Instant from = Ordering.natural().min(a, b);
       final Instant to = Ordering.natural().max(a, b);
-      logger.info("from {} to {} {}", from, to, DataResolution.WEEKLY.name());
-      final int fromOffMonday = 1 - LocalDateTime.ofInstant(from, ZoneOffset.UTC).getDayOfWeek().getValue();
-      final int toOffMonday = 1 - LocalDateTime.ofInstant(to, ZoneOffset.UTC).getDayOfWeek().getValue();
-      final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.WEEKLY, ZoneId.of("Z"));
-      assertEquals(LocalDateTime.ofInstant(
-          from,
-          ZoneOffset.UTC)
-              .plusDays(fromOffMonday)
-              .withHour(0)
-              .withMinute(0)
-              .withSecond(0)
-              .withNano(0)
-              .toInstant(ZoneOffset.UTC),
-          buckets.get(0));
-      if (buckets.size() == 1) {
-        continue;
-      }
-      assertEquals(
-          LocalDateTime.ofInstant(
-              to,
-              ZoneOffset.UTC)
-              .plusDays(toOffMonday)
-              .withHour(0)
-              .withMinute(0)
-              .withSecond(0)
-              .withNano(0)
-              .toInstant(ZoneOffset.UTC),
-          buckets.get(buckets.size() - 1));
+      testGetBucketsWeekly(from, to);
     }
+  }
+
+  private void testGetBucketsWeekly(Instant from, Instant to) {
+    logger.info("from {} to {} {}", from, to, DataResolution.WEEKLY.name());
+    final int fromOffMonday = 1 - LocalDateTime.ofInstant(from, ZoneOffset.UTC).getDayOfWeek().getValue();
+    final int toOffMonday = 1 - LocalDateTime.ofInstant(to, ZoneOffset.UTC).getDayOfWeek().getValue();
+    final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.WEEKLY, ZoneId.of("Z"));
+    assertEquals(LocalDateTime.ofInstant(
+        from,
+        ZoneOffset.UTC)
+            .plusDays(fromOffMonday)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toInstant(ZoneOffset.UTC),
+        buckets.get(0));
+    if (buckets.size() == 1) {
+      return;
+    }
+    for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
+      assertTrue(buckets.get(bucket).isAfter(from));
+      assertTrue(buckets.get(bucket).isBefore(to));
+      final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
+      assertEquals(DayOfWeek.MONDAY, ldt.getDayOfWeek());
+      assertEquals(0, ldt.getHour());
+      assertEquals(0, ldt.getMinute());
+      assertEquals(0, ldt.getSecond());
+      assertEquals(0, ldt.getNano());
+    }
+    assertEquals(
+        LocalDateTime.ofInstant(
+            to,
+            ZoneOffset.UTC)
+            .plusDays(toOffMonday)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toInstant(ZoneOffset.UTC),
+        buckets.get(buckets.size() - 1));
   }
 
   @Test
   public void testGetBucketsMonthly() {
+    // Tests with pre-picked valid data
+    new HashMap<Instant, Instant>() {{
+      put(Instant.parse("2019-05-28T17:00:00.000Z"), Instant.parse("2020-01-02T11:30:00.000Z"));
+      put(Instant.parse("2019-02-01T00:00:00.000Z"), Instant.parse("2019-04-30T23:59:59.999Z"));
+      put(Instant.parse("2019-10-27T00:00:00.000Z"), Instant.parse("2019-10-28T00:00:00.000Z"));
+    }}.forEach(this::testGetBucketsMonthly);
+
+    // Tests with random input
     for (int i = 0; i < repetitions; i++) {
       final Instant a = randomInstant();
       final Instant b = randomInstant();
       final Instant from = Ordering.natural().min(a, b);
       final Instant to = Ordering.natural().max(a, b);
-      logger.info("from {} to {} {}", from, to, DataResolution.MONTHLY.name());
-      final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.MONTHLY, ZoneId.of("Z"));
-      assertEquals(from, buckets.get(0));
-      if (buckets.size() == 1) {
-        continue;
-      }
-      assertEquals(
-          LocalDateTime.ofInstant(
-              to,
-              ZoneOffset.UTC)
-              .withDayOfMonth(1)
-              .withHour(0)
-              .withMinute(0)
-              .withSecond(0)
-              .withNano(0)
-              .toInstant(ZoneOffset.UTC),
-          buckets.get(buckets.size() - 1));
+      testGetBucketsMonthly(from, to);
     }
+  }
+
+  private void testGetBucketsMonthly(Instant from, Instant to) {
+    logger.info("from {} to {} {}", from, to, DataResolution.MONTHLY.name());
+    final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.MONTHLY, ZoneId.of("Z"));
+    assertEquals(from, buckets.get(0));
+    if (buckets.size() == 1) {
+      return;
+    }
+    for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
+      assertTrue(buckets.get(bucket).isAfter(from));
+      assertTrue(buckets.get(bucket).isBefore(to));
+      final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
+      assertEquals(1, ldt.getDayOfMonth());
+      assertEquals(0, ldt.getHour());
+      assertEquals(0, ldt.getMinute());
+      assertEquals(0, ldt.getSecond());
+      assertEquals(0, ldt.getNano());
+    }
+    assertEquals(
+        LocalDateTime.ofInstant(
+            to,
+            ZoneOffset.UTC)
+            .withDayOfMonth(1)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toInstant(ZoneOffset.UTC),
+        buckets.get(buckets.size() - 1));
   }
 
   @Test
   public void testGetBucketsYearly() {
+    // Tests with pre-picked valid data
+    new HashMap<Instant, Instant>() {{
+      put(Instant.parse("2018-10-28T17:00:00.000Z"), Instant.parse("2020-01-02T11:30:00.000Z"));
+      put(Instant.parse("2019-01-01T00:00:00.000Z"), Instant.parse("2019-12-31T23:59:59.999Z"));
+      put(Instant.parse("2019-10-27T00:00:00.000Z"), Instant.parse("2029-10-28T00:00:00.000Z"));
+    }}.forEach(this::testGetBucketsYearly);
+
+    // Tests with random input
     for (int i = 0; i < repetitions; i++) {
       final Instant a = randomInstant();
       final Instant b = randomInstant();
       final Instant from = Ordering.natural().min(a, b);
       final Instant to = Ordering.natural().max(a, b);
-      logger.info("from {} to {} {}", from, to, DataResolution.YEARLY.name());
-      final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.YEARLY, ZoneId.of("Z"));
-      assertEquals(from, buckets.get(0));
-      if (buckets.size() == 1) {
-        continue;
-      }
-      assertEquals(
-          LocalDateTime.ofInstant(
-              to,
-              ZoneOffset.UTC)
-              .withMonth(1)
-              .withDayOfMonth(1)
-              .withHour(0)
-              .withMinute(0)
-              .withSecond(0)
-              .withNano(0)
-              .toInstant(ZoneOffset.UTC),
-          buckets.get(buckets.size() - 1));
+      testGetBucketsYearly(from, to);
     }
+  }
+
+  private void testGetBucketsYearly(Instant from, Instant to) {
+    logger.info("from {} to {} {}", from, to, DataResolution.YEARLY.name());
+    final List<Instant> buckets = StatisticsUtil.getBuckets(from, to, DataResolution.YEARLY, ZoneId.of("Z"));
+    assertEquals(from, buckets.get(0));
+    if (buckets.size() == 1) {
+      return;
+    }
+    for (int bucket = 1; bucket < buckets.size() - 1; bucket++) {
+      assertTrue(buckets.get(bucket).isAfter(from));
+      assertTrue(buckets.get(bucket).isBefore(to));
+      final LocalDateTime ldt = LocalDateTime.ofInstant(buckets.get(bucket), ZoneOffset.UTC);
+      assertEquals(Month.JANUARY, ldt.getMonth());
+      assertEquals(1, ldt.getDayOfMonth());
+      assertEquals(0, ldt.getHour());
+      assertEquals(0, ldt.getMinute());
+      assertEquals(0, ldt.getSecond());
+      assertEquals(0, ldt.getNano());
+    }
+    assertEquals(
+        LocalDateTime.ofInstant(
+            to,
+            ZoneOffset.UTC)
+            .withMonth(1)
+            .withDayOfMonth(1)
+            .withHour(0)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+            .toInstant(ZoneOffset.UTC),
+        buckets.get(buckets.size() - 1));
   }
 
 }


### PR DESCRIPTION
This PR consists of two parts:

The first part allows for different sources for different resolutions with influx. This changes the handling of statistics configurations such that for each provider type, there can be a different configuration format. This makes the mechanism more flexible and reflects the actual variety of options that might come with different sources. This way, we also get rid of the "source" property of the configuration which used to be a compisite string. This didn't make too much sense since we were using JSON already. The new configuration format allows to specify different sources for one influx provider, so that one can use specific measuemrents for certain data resolutions. In practice you might want to use shorter retentions for finer-grained measurements. This change enables you to do so.

This makes it possible to implement the second part: Hourly data resolution for statistics. This adds a new data resolution "hourly" to support finer-grained charts.

Also, I have included two sample configs for an easy review. I will remove these configs before this PR gets merged.

This work is sponsored by SWITCH.