### PR TITLE
MH-13536 OAI-PMH Remote Broken

### DIFF
--- a/modules/publication-service-oaipmh-remote/src/main/java/org/opencastproject/publication/oaipmh/remote/OaiPmhPublicationServiceRemoteImpl.java
+++ b/modules/publication-service-oaipmh-remote/src/main/java/org/opencastproject/publication/oaipmh/remote/OaiPmhPublicationServiceRemoteImpl.java
@@ -76,9 +76,7 @@ public class OaiPmhPublicationServiceRemoteImpl extends RemoteBase implements Oa
     final HttpPost post = new HttpPost();
     HttpResponse response = null;
     try {
-      final UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, UTF_8);
-      entity.setContentEncoding(UTF_8.toString());
-      post.setEntity(entity);
+      post.setEntity(new UrlEncodedFormEntity(params, UTF_8));
       response = getResponse(post);
       if (response != null) {
         logger.info("Publishing media package {} to OAI-PMH channel {} using a remote publication service",
@@ -193,9 +191,7 @@ public class OaiPmhPublicationServiceRemoteImpl extends RemoteBase implements Oa
     params.add(new BasicNameValuePair("channel", repository));
     HttpPost post = new HttpPost("/retract");
     HttpResponse response = null;
-    UrlEncodedFormEntity entity = new UrlEncodedFormEntity(params, UTF_8);
-    entity.setContentEncoding(UTF_8.toString());
-    post.setEntity(entity);
+    post.setEntity(new UrlEncodedFormEntity(params, UTF_8));
     try {
       response = getResponse(post);
       Job receipt = null;


### PR DESCRIPTION
Steps to reproduce: 
1. Try to publish or retract to/from OAI-PMH on a distributed cluster 
  
 **Actual Results:** 
Fails with 100% failure rate. 

Worker Node: 
`2019-05-07T18:10:42,394 | WARN | (HttpChannel:579) - /publication/oaipmh org.eclipse.jetty.http.BadMessageException: 501: Unsupported Content-Encoding `

Admin Node: 
```
2019-05-07T18:02:05,497 | ERROR | (WorkflowOperationWorker:180) - Workflow operation 'operation:'retract-oaipmh', position:2, state:'FAILED'' failed 
org.opencastproject.publication.api.PublicationException: Unable to retract media package fc9ca451-e75b-4a49-81d7-224a2e550125 from OAI-PMH channel default using a remote publication service 
at org.opencastproject.publication.oaipmh.remote.OaiPmhPublicationServiceRemoteImpl.retract(OaiPmhPublicationServiceRemoteImpl.java:217) [110:opencast-publication-service-oaipmh-remote:8.0.0.SNAPSHOT] 
at org.opencastproject.workflow.handler.distribution.RetractOaiPmhWorkflowOperationHandler.start(RetractOaiPmhWorkflowOperationHandler.java:92) [74:opencast-distribution-workflowoperation:8.0.0.SNAPSHOT] 
```
  
  
 **Expected Results:** 
 Should work. 

**Analysis:** 
It seems that with different versions of Karaf respectively its implied dependency versions the behavior and/or strictness when encountering encoding schemes has changed (the code definitely used to work before). 
Testing with opencast/develop, the line that causes the problem is: 
      entity.setContentEncoding(UTF_8.toString()); 

whereas UTF_8 is of type CharSet (java.nio.charset.StandardCharsets.UTF_8). 

The OAI-PMH remote is the only code in Opencast that uses setContentEncoding(). Without digging into further analysis, the toString() method of the Standard UTF-8 CharSet likely does not return "utf-8" but something similar. But as said, not digging further here as the obvious solution is to simply do the same as all other remotes which are known to work. 

While I did not test whether 6.x is affected, I'm sure this won't break anything and therefore "fix" this in 6.x. 