### PR TITLE
MH-13540 Navigation of statistics broken

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/statistics/partials/index.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/statistics/partials/index.html
@@ -1,7 +1,10 @@
 <section class="action-nav-bar">
   <admin-ng-nav></admin-ng-nav>
   <nav>
-    <a href="#/statistics/organization" ng-class="{active: resource == 'organization'}" translate="STATISTICS.NAVIGATION.ORGANIZATION" with-role="ROLE_UI_STATISTICS_ORGANIZATION_VIEW">
+    <a href="#!/statistics/organization"
+       ng-class="{active: resource == 'organization'}"
+       translate="STATISTICS.NAVIGATION.ORGANIZATION"
+       with-role="ROLE_UI_STATISTICS_ORGANIZATION_VIEW">
       <!-- Statistics Organization View -->
     </a>
   </nav>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/mainNav.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/mainNav.html
@@ -31,7 +31,10 @@
          with-role="ROLE_UI_NAV_CONFIGURATION_VIEW">
         <i class="configuration" title="{{ 'NAV.CONFIGURATION.TITLE' | translate }}"></i>
       </a>
-      <a admin-ng-href-role="{'ROLE_UI_STATISTICS_ORGANIZATION_VIEW': '#/statistics/organization'}" ng-class="{ active: category == 'statistics' }" with-role="ROLE_UI_NAV_STATISTICS_VIEW" ng-if="hasStatisticsProviders">
+      <a admin-ng-href-role="{'ROLE_UI_STATISTICS_ORGANIZATION_VIEW': '#!/statistics/organization'}"
+         ng-class="{ active: category == 'statistics' }"
+         with-role="ROLE_UI_NAV_STATISTICS_VIEW"
+         ng-if="hasStatisticsProviders">
         <i class="statistics" data-title="{{ 'NAV.STATISTICS.TITLE' | translate }}"></i>
       </a>
     </div>


### PR DESCRIPTION

Steps to reproduce: 
1. Configure the random statistics provider of the resource type ORGANIZATION 
2. Try to navigate to the page "Statistics->Organization" 
  
 Actual Results: 
 The navigation does not work. 
  
 Expected Results: 
 The navigation should work. 
  
Analysis: 
This is caused by the update to AngularJS 1.7.8 which requires few adaptations in the statistics code. 