### PR TITLE
MH-13541 Remove inclusion of non-existent scripts in Admin UI

### DIFF
--- a/modules/admin-ui/src/main/webapp/index.html
+++ b/modules/admin-ui/src/main/webapp/index.html
@@ -146,7 +146,6 @@
     <script src="scripts/shared/services/services.js"></script>
     <script src="scripts/shared/services/resourceHelperService.js"></script>
     <script src="scripts/shared/services/authService.js"></script>
-    <script src="scripts/shared/services/cryptService.js"></script>
     <script src="scripts/shared/services/relativeDatesService.js"></script>
     <script src="scripts/shared/services/jsHelperService.js"></script>
     <script src="scripts/shared/services/languageService.js"></script>
@@ -230,7 +229,6 @@
     <script src="scripts/shared/resources/workflowsResource.js"></script>
     <script src="scripts/shared/resources/themesResource.js"></script>
     <script src="scripts/shared/resources/newThemeResource.js"></script>
-    <script src="scripts/shared/resources/signatureResource.js"></script>
     <script src="scripts/shared/resources/taskResource.js"></script>
     <script src="scripts/shared/services/wizards/new-event/access.js"></script>
     <script src="scripts/shared/services/wizards/new-event/metadata.js"></script>
@@ -317,8 +315,6 @@
     <script src="scripts/shared/controllers/controllers.js"></script>
     <script src="scripts/shared/controllers/navigationController.js"></script>
     <script src="scripts/shared/controllers/applicationController.js"></script>
-    <script src="scripts/shared/controllers/applicationController.js"></script>
-    <script src="scripts/shared/controllers/userPreferencesController.js"></script>
     <script src="scripts/shared/controllers/tablePreferencesController.js"></script>
     <script src="scripts/shared/controllers/hotkeyCheatSheetController.js"></script>
     <script src="scripts/modules/events/controllers/eventsController.js"></script>
@@ -328,7 +324,6 @@
     <script src="scripts/modules/events/controllers/newSeriesController.js"></script>
     <script src="scripts/modules/events/controllers/seriesController.js"></script>
     <script src="scripts/modules/events/controllers/serieController.js"></script>
-    <script src="scripts/modules/events/controllers/bulkMessageController.js"></script>
     <script src="scripts/modules/events/controllers/bulkDeleteController.js"></script>
     <script src="scripts/modules/events/controllers/retractEventController.js"></script>
     <script src="scripts/modules/events/controllers/scheduleTaskController.js"></script>

--- a/modules/admin-ui/src/main/webapp/login.html
+++ b/modules/admin-ui/src/main/webapp/login.html
@@ -84,11 +84,6 @@
     <!-- endbower -->
     <!-- endbuild -->
 
-    <!-- build:js(src/main/webapp) scripts/vendor.js -->
-    <script src="scripts/lib/chosen.js"></script>
-    <script src="scripts/lib/javascript-md5/js/md5.min.js"></script>
-    <!-- endbuild -->
-
     <!-- build:js(src/main/webapp) scripts/scripts.js -->
     <script src="scripts/app.js"></script>
     <script src="scripts/shared/controllers/controllers.js"></script>
@@ -101,7 +96,6 @@
     <script src="scripts/shared/services/jsHelperService.js"></script>
     <script src="scripts/shared/resources/resources.js"></script>
     <script src="scripts/shared/resources/identityResource.js"></script>
-    <script src="scripts/shared/services/cryptService.js"></script>
     <script src="scripts/shared/resources/versionResource.js"></script>
     <script src="scripts/shared/directives/oldDropdownDirective.js"></script>
     <!-- endbuild -->


### PR DESCRIPTION
When starting the Admin UI with "grunt serve" or "grunt proxy", there are 404 NOT FOUND errors reported in the browser console.

Analysis:
The scripts referenced in index.html indeed to not exists.