### PR TITLE
MH-13544 Video editor shows incorrect notification

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/toolsController.js
@@ -169,16 +169,16 @@ angular.module('adminNg.controllers')
     $scope.player = {};
     $scope.video  = ToolsResource.get({ id: $scope.id, tool: 'editor' });
 
-    $scope.activeTransaction = false;
+    $scope.activeSubmission = false;
 
     $scope.submit = function () {
-      $scope.activeTransaction = true;
+      $scope.activeSubmission = true;
       $scope.video.thumbnail.loading = $scope.video.thumbnail && $scope.video.thumbnail.type &&
               ($scope.video.thumbnail.type === 'DEFAULT');
       // Remember $scope.video.workflow as $scope.video.$save will potentially overwrite this value
       var closeVideoEditor = $scope.video.workflow;
       $scope.video.$save({ id: $scope.id, tool: $scope.tab }, function (response) {
-        $scope.activeTransaction = false;
+        $scope.activeSubmission = false;
         if (closeVideoEditor) {
           Notifications.add('success', 'VIDEO_CUT_PROCESSING');
           $location.url('/events/' + $scope.resource);
@@ -199,7 +199,7 @@ angular.module('adminNg.controllers')
           trackErrorMessageId = null;
         }
       }, function () {
-        $scope.activeTransaction = false;
+        $scope.activeSubmission = false;
         $scope.video.thumbnail.loading = false;
         trackErrorMessageId = Notifications.add('error', 'VIDEO_CUT_NOT_SAVED', LOCAL_CONTEXT);
       });

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/video/editController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/controllers/video/editController.js
@@ -146,6 +146,9 @@ angular.module('adminNg.controllers')
       $scope.replayEndOfSegment();
     });
 
+
+    $scope.activeTransaction = false;
+
     $scope.$on('ACTIVE_TRANSACTION', function () {
       if (!$scope.activeTransaction) {
         $scope.activeTransaction = true;
@@ -161,6 +164,10 @@ angular.module('adminNg.controllers')
           notificationId = 0;
         }
       }
+    });
+
+    $scope.$on('$destroy', function () {
+      Notifications.removeAll(NOTIFICATION_CONTEXT);
     });
 
     // This shows a confirmation dialog when the user leaves the editor while he has unsaved changes

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
@@ -27,14 +27,14 @@
         <div class="video-save-panel video-more-options video-editor-actions-toolbar" ng-if="tab === 'editor' && player.adapter">
           <div class="buttons">
             <select chosen pre-select-from="video.workflows" class="workflow"
-                                                             ng-disabled="!video.workflows || video.workflows.length === 0"
+                                                             ng-disabled="!video.workflows || video.workflows.length === 0 || activeTransaction || activeSubmission"
                                                              data-width="'175px'"
                                                              data-disable-search-threshold="0"
                                                              ng-model="video.workflow"
                                                              ng-options="workflow.id as workflow.name for workflow in video.workflows | orderBy: 'displayOrder':true" />
 
               <a ng-click="submit()"
-                 ng-class="{disabled: activeTransaction}"
+                 ng-class="{disabled: activeTransaction || activeSubmission}"
                  class="save-and-close-button"
                  translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
                 <!-- Save and Continue -->
@@ -144,7 +144,7 @@
                            translate="VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_VIDEO.LABEL"
                            title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_VIDEO.TOOLTIP' |translate  }}"
                            ng-click="changeThumbnail(undefined, 'single', player.adapter.getCurrentTime())"
-                           ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction}">
+                           ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                           <!-- Extract -->
                         </a>
                         <a class="extract-thumbnail"
@@ -152,7 +152,7 @@
                            translate="VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_LEFT_VIDEO.LABEL"
                            title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_LEFT_VIDEO.TOOLTIP' |translate  }}"
                            ng-click="changeThumbnail(undefined, 'left', player.adapter.getCurrentTime())"
-                           ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction}">
+                           ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                           <!-- Extract -->
                         </a>
                         <a class="extract-thumbnail"
@@ -160,7 +160,7 @@
                            translate="VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_RIGHT_VIDEO.LABEL"
                            title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_RIGHT_VIDEO.TOOLTIP' | translate }}"
                            ng-click="changeThumbnail(undefined, 'right', player.adapter.getCurrentTime())"
-                           ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction}">
+                           ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                           <!-- Extract from video -->
                         </a>
                         <form>
@@ -168,7 +168,7 @@
                              translate="VIDEO_TOOL.THUMBNAIL.ACTIONS.UPLOAD.LABEL"
                              title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.UPLOAD.TOOLTIP' | translate }}"
                              onclick="angular.element('#thumbnail-upload').click()"
-                             ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction}">
+                             ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                             <!-- Upload image -->
                           </a>
                           <input
@@ -184,7 +184,7 @@
                            title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.USE_DEFAULT.TOOLTIP' | translate }}"
                            ng-click="changeThumbnail(undefined, 'DEFAULT', calculateDefaultThumbnailPosition())"
                            ng-if="video.thumbnail.url && video.thumbnail.type !== 'DEFAULT'"
-                           ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction}">
+                           ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                           <!-- Use default thumbnail -->
                         </a>
                       </div>
@@ -405,14 +405,14 @@
             <div class="video-save-panel" ng-if="tab === 'editor' && player.adapter">
               <div class="buttons">
                 <select chosen pre-select-from="video.workflows" class="workflow"
-                                                                 ng-disabled="!video.workflows || video.workflows.length === 0"
+                                                                 ng-disabled="!video.workflows || video.workflows.length === 0 || activeTransaction || activeSubmission"
                                                                  data-width="'175px'"
                                                                  data-disable-search-threshold="0"
                                                                  ng-model="video.workflow"
                                                                  ng-options="workflow.id as workflow.name for workflow in video.workflows | orderBy: 'displayOrder':true" />
 
                   <a ng-click="submit()"
-                     ng-class="{disabled: activeTransaction || sanityCheckFlags()}"
+                     ng-class="{disabled: activeTransaction || activeSubmission || sanityCheckFlags()}"
                      class="save-and-close-button"
                      translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
                     <!-- Save and Continue -->


### PR DESCRIPTION
Steps to reproduce: 
1. Upload two events "Test1" and "Test2" and wait until processing is finished 
2. Start a workflow on event "Test 1" 
3. Open video editor for "Test 1" 
4. Close video editor for "Test 1" using the Close button 
5. Open video editor for "Test 2" 
  
 Actual Results: 
A notification in the video editor says that the event cannot be editing because it is being processed 
  
 Expected Results: 
The notification should not appear because the event "Test 2" is not being processed at this point of time. 

Workaround: 
Ignore. 


This pull requests also addresses:
- Disable workflow dropdown while a transaction or submission is active (the save button was already disabled)
- Don't reuse variable activeTransaction to indicate active submissions. That is not necessarily a bug but a clearer separation of concerns 