### PR TITLE
MH-13547 Limit accepted file types when uploading assets

### DIFF
--- a/docs/guides/admin/docs/configuration/admin-ui/asset-upload.md
+++ b/docs/guides/admin/docs/configuration/admin-ui/asset-upload.md
@@ -172,6 +172,7 @@ displayOverride.SHORT | 'Video of a Presenter'    | A short source title which o
 displayFallback.SHORT | 'Video of a Presenter'    | A short source title which displays when no translation is found
 displayOverride.DETAIL | 'A recording that showing the lecturer speaking' | A longer source description which overrides all translation
 displayFallback.DETAIL | 'A recording that showing the lecturer speaking' | A longer source description which displays when no translation is found
+accept | 'video/*,.png' | A list of accepted file formats as taken by the HTML \<input\>'s `accept` field. This field is optional. This has to be a list of comma separated values. Each value of the list can either be a IANA MediaType or a file ending.
 
 
 The parameter key is internationalized as the display text in the admin UI

--- a/etc/listproviders/event.upload.asset.options.properties
+++ b/etc/listproviders/event.upload.asset.options.properties
@@ -30,17 +30,17 @@ list.name=eventUploadAssetOptions
 # Attachments and catalogs upload options are for new and existing events.
 # Only one file can be uploaded for each of these options: the uploaded file replaces existing elements of the same type and flavor in the mediapackage.
 # EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CLASS_HANDOUT_NOTES={"id": "attachment_class_handout_notes", "type": "attachment", "flavorType": "attachment", "flavorSubType": "notes", "displayOrder":1}
-# EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CAPTIONS_DFXP={"id":"attachment_captions_dfxp", "type": "attachment", "flavorType": "captions", "flavorSubType": "dfxp", "displayOrder":2}
-# EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CAPTIONS_WEBVTT={"id":"attachment_captions_webvtt", "type": "attachment", "flavorType": "text", "flavorSubType": "vtt", "displayOrder":3}
-# EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.PREVIEW_IMAGE={"id":"attachment_preview_image", "type":"attachment", "flavorType": "presenter","flavorSubType": "search+preview", "displayOrder":4}
+# EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CAPTIONS_DFXP={"id":"attachment_captions_dfxp", "type": "attachment", "flavorType": "captions", "flavorSubType": "dfxp", "displayOrder":2, "accept": ".ttml, .dfxp, .xml"}
+# EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.CAPTIONS_WEBVTT={"id":"attachment_captions_webvtt", "type": "attachment", "flavorType": "text", "flavorSubType": "vtt", "displayOrder":3, "accept": ".vtt"}
+# EVENTS.EVENTS.NEW.UPLOAD_ASSET.OPTION.PREVIEW_IMAGE={"id":"attachment_preview_image", "type":"attachment", "flavorType": "presenter","flavorSubType": "search+preview", "displayOrder":4, "accept": "image/*"}
 EVENTS.EVENTS.NEW.UPLOAD_ASSET.WORKFLOWDEFID=publish-uploaded-assets
 
 # The video source track upload options are only for new events.
 # Unlike the other assets, multiple source tracks can be uploaded for a single flavor.
 # The MULTIPLE_PARTS example shows how to enable choosing multiple source files for a single flavor. In this case, a fictional "multipart/part+source".
-# EVENTS.EVENTS.NEW.SOURCE.UPLOAD.MULTIPLE_PARTS={"id": "track_parts","type":"track", "flavorType": "multipart","flavorSubType": "part+source", "multiple":true, "displayOrder":11}
-# EVENTS.EVENTS.NEW.SOURCE.UPLOAD.AUDIO_ONLY={"id": "track_audio","type":"track", "flavorType": "presenter-audio", "flavorSubType": "source", "multiple":false, "displayOrder":12}
-EVENTS.EVENTS.NEW.SOURCE.UPLOAD.NON_SEGMENTABLE={"id": "track_presenter","type":"track", "flavorType": "presenter","flavorSubType": "source", "multiple":false, "displayOrder":13}
-EVENTS.EVENTS.NEW.SOURCE.UPLOAD.SEGMENTABLE={"id": "track_presentation","type":"track", "flavorType": "presentation","flavorSubType": "source", "multiple":false, "displayOrder":14}
+# EVENTS.EVENTS.NEW.SOURCE.UPLOAD.MULTIPLE_PARTS={"id": "track_parts","type":"track", "flavorType": "multipart","flavorSubType": "part+source", "multiple":true, "displayOrder":11, "accept": "video/*,audio/*"}
+# EVENTS.EVENTS.NEW.SOURCE.UPLOAD.AUDIO_ONLY={"id": "track_audio","type":"track", "flavorType": "presenter-audio", "flavorSubType": "source", "multiple":false, "displayOrder":12, "accept": "audio/*"}
+EVENTS.EVENTS.NEW.SOURCE.UPLOAD.NON_SEGMENTABLE={"id": "track_presenter","type":"track", "flavorType": "presenter","flavorSubType": "source", "multiple":false, "displayOrder":13, "accept": "video/*,audio/*"}
+EVENTS.EVENTS.NEW.SOURCE.UPLOAD.SEGMENTABLE={"id": "track_presentation","type":"track", "flavorType": "presentation","flavorSubType": "source", "multiple":false, "displayOrder":14, "accept": "video/*,audio/*"}
 # Presenter and Presentation tracks uploaded in a single container
-# EVENTS.EVENTS.NEW.SOURCE.UPLOAD.MULTIPLE_TRACKS={"id": "track_multi","type":"track", "flavorType": "multitrack","flavorSubType": "source", "multiple":false, "displayOrder":15}
+# EVENTS.EVENTS.NEW.SOURCE.UPLOAD.MULTIPLE_TRACKS={"id": "track_multi","type":"track", "flavorType": "multitrack","flavorSubType": "source", "multiple":false, "displayOrder":15, "accept": "video/*,audio/*"}

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -77,6 +77,7 @@ import org.opencastproject.index.service.api.IndexService.Source;
 import org.opencastproject.index.service.catalog.adapter.MetadataList;
 import org.opencastproject.index.service.catalog.adapter.MetadataList.Locked;
 import org.opencastproject.index.service.exception.IndexServiceException;
+import org.opencastproject.index.service.exception.UnsupportedAssetException;
 import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.index.service.impl.index.event.EventIndexSchema;
 import org.opencastproject.index.service.impl.index.event.EventSearchQuery;
@@ -1795,7 +1796,7 @@ public abstract class AbstractEventEndpoint {
       return Response.status(Status.CREATED).entity(result).build();
     }  catch (NotFoundException e) {
       return notFound("Cannot find an event with id '%s'.", eventId);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | UnsupportedAssetException e) {
       return RestUtil.R.badRequest(e.getMessage());
     } catch (Exception e) {
       return RestUtil.R.serverError();
@@ -2025,7 +2026,7 @@ public abstract class AbstractEventEndpoint {
     try {
       String result = getIndexService().createEvent(request);
       return Response.status(Status.CREATED).entity(result).build();
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | UnsupportedAssetException e) {
       return RestUtil.R.badRequest(e.getMessage());
     } catch (Exception e) {
       return RestUtil.R.serverError();

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/uploadAsset.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/uploadAsset.html
@@ -8,8 +8,16 @@
       <!-- File upload -->
       <td>
         <div class="file-upload">
-          <input id="{{asset.id}}" class="blue-btn file-select-btn" admin-ng-file-upload data-ng-file-select data-ng-multiple="asset.multiple"
-                                                                                                             type="file" file="$parent.assets.{{asset.id}}" tabindex="" />
+          <input
+            id="{{asset.id}}"
+            class="blue-btn file-select-btn"
+            admin-ng-file-upload
+            accept="{{asset.accept}}"
+            data-ng-file-select
+            data-ng-multiple="asset.multiple"
+            type="file"
+            file="$parent.assets.{{asset.id}}"
+            tabindex="" />
         </div>
       </td>
       <!-- Delete option -->

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -110,8 +110,16 @@
           <ul>
             <li  ng-repeat="asset in wizard.sharedData.uploadAssetOptions | filter:{type:'track'}| orderBy: 'displayOrder' track by asset.id">
               <div class="file-upload">
-                <input id="{{asset.id}}" class="blue-btn file-select-btn" admin-ng-file-upload data-ng-file-select data-ng-multiple="asset.multiple"
-                                                                                                                   type="file" file="$parent.wizard.step.ud.UPLOAD.tracks.{{asset.id}}" tabindex="" />
+                <input
+                  id="{{asset.id}}"
+                  class="blue-btn file-select-btn"
+                  admin-ng-file-upload
+                  accept="{{asset.accept}}"
+                  data-ng-file-select
+                  data-ng-multiple="asset.multiple"
+                  type="file"
+                  file="$parent.wizard.step.ud.UPLOAD.tracks.{{asset.id}}"
+                  tabindex="" />
               </div>
               <span>{{asset | translateOverrideFallback: 'SHORT'}}</span>
               <span class="ui-helper-hidden"> ({{asset.type}} "{{asset.flavorType}}/{{asset.flavorSubType}}")</span>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -240,6 +240,7 @@
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
               net.fortuna.ical4j.*,
+              com.google.common.net,
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,
               *

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
@@ -24,6 +24,7 @@ package org.opencastproject.index.service.api;
 import org.opencastproject.event.comment.EventComment;
 import org.opencastproject.index.service.catalog.adapter.MetadataList;
 import org.opencastproject.index.service.exception.IndexServiceException;
+import org.opencastproject.index.service.exception.UnsupportedAssetException;
 import org.opencastproject.index.service.impl.index.AbstractSearchIndex;
 import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.index.service.impl.index.event.EventHttpServletRequest;
@@ -159,8 +160,10 @@ public interface IndexService {
    *           Thrown if there was an internal server error while creating the event.
    * @throws IllegalArgumentException
    *           Thrown if the provided request was inappropriate.
+   * @throws UnsupportedAssetException
+   *           Thrown if the provided asset file type is not accepted.
    */
-  String createEvent(HttpServletRequest request) throws IndexServiceException, IllegalArgumentException;
+  String createEvent(HttpServletRequest request) throws IndexServiceException, IllegalArgumentException, UnsupportedAssetException;
 
   /**
    * Creates a new event based on a json string and a media package.
@@ -250,9 +253,11 @@ public interface IndexService {
    *           Thrown if the current user is unable to create the new event.
    * @throws IndexServiceException
    *            Thrown if the update assets workflow cannot be started
+   * @throws UnsupportedAssetException
+   *           Thrown if the provided asset file type is not accepted.
    */
   String updateEventAssets(MediaPackage mp, HttpServletRequest request) throws ParseException, IOException,
-          MediaPackageException, NotFoundException, UnauthorizedException, IndexServiceException;
+          MediaPackageException, NotFoundException, UnauthorizedException, IndexServiceException, UnsupportedAssetException;
 
   /**
    * Update an event's metadata using a {@link MetadataList}

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/exception/UnsupportedAssetException.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/exception/UnsupportedAssetException.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.index.service.exception;
+
+/**
+ * Exception to indicate that the file type of an asset provided by the user is not accepted by opencast.
+ */
+public class UnsupportedAssetException extends Exception {
+  public UnsupportedAssetException(final String s) {
+    super(s);
+  }
+}

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -48,6 +48,7 @@ import org.opencastproject.index.service.catalog.adapter.MetadataUtils;
 import org.opencastproject.index.service.catalog.adapter.events.CommonEventCatalogUIAdapter;
 import org.opencastproject.index.service.catalog.adapter.series.CommonSeriesCatalogUIAdapter;
 import org.opencastproject.index.service.exception.IndexServiceException;
+import org.opencastproject.index.service.exception.UnsupportedAssetException;
 import org.opencastproject.index.service.impl.index.AbstractSearchIndex;
 import org.opencastproject.index.service.impl.index.event.Event;
 import org.opencastproject.index.service.impl.index.event.EventHttpServletRequest;
@@ -475,7 +476,7 @@ public class IndexServiceImpl implements IndexService {
   }
 
   @Override
-  public String createEvent(HttpServletRequest request) throws IndexServiceException {
+  public String createEvent(HttpServletRequest request) throws IndexServiceException, UnsupportedAssetException {
     JSONObject metadataJson = null;
     MediaPackage mp = null;
     // regex for form field name matching an attachment or a catalog
@@ -517,7 +518,7 @@ public class IndexServiceImpl implements IndexService {
             final MediaType mediaType = MediaType.parse(item.getContentType());
             final boolean accepted = RequestUtils.typeIsAccepted(fieldName, mediaType, listProvidersService);
             if (!accepted) {
-              throw new IllegalArgumentException("Provided file format " + mediaType.toString() + " not allowed.");
+              throw new UnsupportedAssetException("Provided file format " + mediaType.toString() + " not allowed.");
             }
             if ("presenter".equals(item.getFieldName())) {
               mp = ingestService.addTrack(item.openStream(), item.getName(), MediaPackageElements.PRESENTER_SOURCE, mp);
@@ -581,7 +582,7 @@ public class IndexServiceImpl implements IndexService {
   }
 
   @Override
-  public String updateEventAssets(MediaPackage mp, HttpServletRequest request) throws IndexServiceException {
+  public String updateEventAssets(MediaPackage mp, HttpServletRequest request) throws IndexServiceException, UnsupportedAssetException {
     JSONObject metadataJson = null;
     // regex for form field name matching an attachment or a catalog
     // The first sub items identifies if the file is an attachment or catalog
@@ -615,7 +616,7 @@ public class IndexServiceImpl implements IndexService {
           final MediaType mediaType = MediaType.parse(item.getContentType());
           final boolean accepted = RequestUtils.typeIsAccepted(fieldName, mediaType, listProvidersService);
           if (!accepted) {
-            throw new IllegalArgumentException("Provided file format " + mediaType.toString() + " not allowed.");
+            throw new UnsupportedAssetException("Provided file format " + mediaType.toString() + " not allowed.");
           }
           if (item.getFieldName().toLowerCase().matches(attachmentRegex)) {
             assetList.add(item.getFieldName());

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -514,7 +514,11 @@ public class IndexServiceImpl implements IndexService {
           } else {
             // AngularJS file upload lib appends ".0" to field name, so we cut that off
             fieldName = fieldName.substring(0, fieldName.lastIndexOf("."));
-            RequestUtils.checkAcceptedTypes(fieldName, MediaType.parse(item.getContentType()), listProvidersService);
+            final MediaType mediaType = MediaType.parse(item.getContentType());
+            final boolean accepted = RequestUtils.typeIsAccepted(fieldName, mediaType, listProvidersService);
+            if (!accepted) {
+              throw new IllegalArgumentException("Provided file format " + mediaType.toString() + " not allowed.");
+            }
             if ("presenter".equals(item.getFieldName())) {
               mp = ingestService.addTrack(item.openStream(), item.getName(), MediaPackageElements.PRESENTER_SOURCE, mp);
             } else if ("presentation".equals(item.getFieldName())) {
@@ -572,7 +576,7 @@ public class IndexServiceImpl implements IndexService {
     } catch (FileUploadException | UnauthorizedException | ParseException | IngestException | SchedulerException
         | MediaPackageException | IOException | NotFoundException e) {
       logger.error("Unable to create event: {}", getStackTrace(e));
-      throw new IndexServiceException(e.getMessage());
+      throw new IndexServiceException("Unable to create event", e);
     }
   }
 
@@ -608,7 +612,11 @@ public class IndexServiceImpl implements IndexService {
         } else {
           // AngularJS file upload lib appends ".0" to field name, so we cut that off
           fieldName = fieldName.substring(0, fieldName.lastIndexOf("."));
-          RequestUtils.checkAcceptedTypes(fieldName, MediaType.parse(item.getContentType()), listProvidersService);
+          final MediaType mediaType = MediaType.parse(item.getContentType());
+          final boolean accepted = RequestUtils.typeIsAccepted(fieldName, mediaType, listProvidersService);
+          if (!accepted) {
+            throw new IllegalArgumentException("Provided file format " + mediaType.toString() + " not allowed.");
+          }
           if (item.getFieldName().toLowerCase().matches(attachmentRegex)) {
             assetList.add(item.getFieldName());
             // Add attachment with field name as temporary flavor
@@ -644,7 +652,7 @@ public class IndexServiceImpl implements IndexService {
       return startAddAssetWorkflow(metadataJson, mp);
     } catch (MediaPackageException | FileUploadException | IOException | IngestException e) {
       logger.error("Unable to create event: {}", getStackTrace(e));
-      throw new IndexServiceException(e.getMessage());
+      throw new IndexServiceException("Unable to create event", e);
     }
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/RequestUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/RequestUtils.java
@@ -82,10 +82,22 @@ public final class RequestUtils {
     return fieldMap;
   }
 
-  public static void checkAcceptedTypes(String assetUploadId, MediaType mediaType, ListProvidersService listProvidersService) {
+  /**
+   * Check if an uploaded asset conforms to the configured list of accepted file types.
+   *
+   * @param assetUploadId
+   *          The id of the uploaded asset
+   * @param mediaType
+   *          The media type sent by the browser
+   * @param listProvidersService
+   *          The ListProviderService to get the configured accepted types from
+   *
+   * @return true if the given mediatype is accepted, false otherwise.
+   */
+  public static boolean typeIsAccepted(String assetUploadId, MediaType mediaType, ListProvidersService listProvidersService) {
     if (mediaType.is(MediaType.OCTET_STREAM)) {
       // No detailed info, so we have to accept...
-      return;
+      return true;
     }
     try {
       final Collection<String> assetUploadJsons = listProvidersService.getList("eventUploadAssetOptions",
@@ -102,12 +114,12 @@ public final class RequestUtils {
               .map(String::trim).collect(Collectors.toList());
           for (String accept : accepts) {
             if (accept.contains("/") && mediaType.is(MediaType.parse(accept))) {
-              return;
+              return true;
             } else if (mediaType.subtype().equalsIgnoreCase(accept.replace(".", ""))) {
-              return;
+              return true;
             }
           }
-          throw new IllegalArgumentException("Provided file format " + mediaType.toString() + " not allowed.");
+          return false;
         }
       }
     } catch (ListProviderException e) {

--- a/modules/index-service/src/main/resources/OSGI-INF/index_service.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/index_service.xml
@@ -44,6 +44,11 @@
              cardinality="1..1"
              policy="static"
              bind="setIngestService"/>
+  <reference name="ListProvidersService"
+             interface="org.opencastproject.index.service.resources.list.api.ListProvidersService"
+             cardinality="1..1"
+             policy="static"
+             bind="setListProvidersService"/>
   <reference bind="setAssetManager"
              cardinality="1..1"
              interface="org.opencastproject.assetmanager.api.AssetManager"


### PR DESCRIPTION
This patch allows the admin to limit the accepted file types for asset
uploads. For each asset type, the allowed file types can be configured.

This work is sponsored by SWITCH.