### PR TITLE
MH-13548, Unnecessary LineReader

### DIFF
--- a/modules/videosegmenter-ffmpeg/pom.xml
+++ b/modules/videosegmenter-ffmpeg/pom.xml
@@ -18,6 +18,11 @@
     <!-- Opencast dependencies -->
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-videosegmenter-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -33,8 +38,12 @@
     </dependency>
     <!--  Thirdparty dependencies -->
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -43,10 +52,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -68,11 +73,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
@@ -80,6 +80,17 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- provide a logger for tests -->
+            <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
This patch removes the LineReader and as such the guava dependency from
Opencast's videosegmenter implementation. To cite from the guava
documentation, the LineReader is:

> A class for reading lines of text. Provides the same functionality as
> BufferedReader.readLine() but for all Readable objects, not just
> instances of Reader.

But we use it to actually read lines from a buffered reader.

---

This patch also fixes the rest of the dependencies along the way.