### PR TITLE
MH-13549, Drop Custom Logger Configuration

### DIFF
--- a/modules/statistics-service-api/src/test/resources/log4j.properties
+++ b/modules/statistics-service-api/src/test/resources/log4j.properties
@@ -1,5 +1,0 @@
-log4j.rootLogger=ERROR,stdout
-log4j.logger.org.opencastproject=INFO
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss} %5p (%C{1}:%L) - %m%n


### PR DESCRIPTION
The statistics service API module contains a custom logger configuration
for testing although there is no apparent reason for overwriting the
common logger settings.