### PR TITLE
MH-13553, Fix Paella Track Selection

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -44,6 +44,7 @@ Configuration changes
   controlled by Opencast and the routing through capture agents which existed for historical reasons was just an
   additional source for errors. If you rely on the old behavior, it can be configured in
   `etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg`.
+- The Paella player now respects all tracks published to engage instead of tracks with the flavor `*/delivery` only.
 
 API changes
 -----------

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -102,8 +102,9 @@ class OpencastToPaellaConverter {
     return source;
   }
 
-  getStreamFromFlavour(episode, mainFlavour) {
-    var currentStream = { sources:{}, preview: '', content: mainFlavour };
+  getStreamFromFlavour(episode, flavour) {
+    var mainFlavour = flavour.split('/')[0],
+        currentStream = { sources:{}, preview: '', content: mainFlavour };
 
     var tracks = episode.mediapackage.media.track;
     var attachments = episode.mediapackage.attachments.attachment;
@@ -112,7 +113,7 @@ class OpencastToPaellaConverter {
 
     // Read the tracks!!
     tracks.forEach((currentTrack) => {
-      if (currentTrack.type == `${mainFlavour}/delivery`) {
+      if (currentTrack.type == flavour) {
         var videoType = this.getVideoTypeFromTrack(currentTrack);
         if (videoType){
           if ( !(currentStream.sources[videoType]) || !(currentStream.sources[videoType] instanceof Array)){
@@ -180,11 +181,7 @@ class OpencastToPaellaConverter {
     var paellaStreams = [];
     var flavours = this.getContentToImport(episode);
     flavours.forEach((flavour) => {
-      var flavourSplit = flavour.split('/');
-      if (flavourSplit[1] == 'delivery') {
-        var s = this.getStreamFromFlavour(episode, flavourSplit[0]);
-        paellaStreams.push(s);
-      }
+      paellaStreams.push(this.getStreamFromFlavour(episode, flavour));
     });
     return paellaStreams;
   }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -102,6 +102,12 @@ class OpencastToPaellaConverter {
     return source;
   }
 
+  /**
+   * Extract a stream identified by a given flavor from the media packages track list and try to find a corresponding
+   * image attachment for the selected track.
+   * @param episode  result structure from search service
+   * @param flavor   flavor used for track selection
+   */
   getStreamFromFlavour(episode, flavour) {
     var mainFlavour = flavour.split('/')[0],
         currentStream = { sources:{}, preview: '', content: mainFlavour };
@@ -181,7 +187,8 @@ class OpencastToPaellaConverter {
     var paellaStreams = [];
     var flavours = this.getContentToImport(episode);
     flavours.forEach((flavour) => {
-      paellaStreams.push(this.getStreamFromFlavour(episode, flavour));
+      var stream = this.getStreamFromFlavour(episode, flavour);
+      paellaStreams.push(stream);
     });
     return paellaStreams;
   }


### PR DESCRIPTION
While flavors published to engage are completely configurable, the
Paella player has parts of them hard-coded making it unable to copy with
any but some very specific configurations.

For example, videos produced and published by the fast workflow will not
play in Paella while they play without problem in the Theodul player.

This patch fixes the problem by removing the hard-coded parts of the
flavor based track selection.

---

*PS: I'll raise a separate pull request fixing the spelling of flavor*