### PR TITLE
MH-13559, Disable User Tracking By Default

### DIFF
--- a/etc/ui-config/mh_default_org/paella/config.json
+++ b/etc/ui-config/mh_default_org/paella/config.json
@@ -348,7 +348,7 @@
         "enabled": true
       },
       "es.upv.paella.opencast.userTrackingSaverPlugIn": {
-        "enabled": true
+        "enabled": false
       }
     }
   }


### PR DESCRIPTION
User tracking should be a deliberate choice and not enabled by default
since it may have legal implications.