### PR TITLE
MH-13560, Admin Role in Moodle User Provider

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/security/api/SecurityConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/SecurityConstants.java
@@ -62,4 +62,7 @@ public interface SecurityConstants {
   /** The roles associated with the Opencast capture agent account */
   String[] GLOBAL_CAPTURE_AGENT_ROLES = new String[] { GLOBAL_CAPTURE_AGENT_ROLE };
 
+  /** The administrator user configuration option */
+  String GLOBAL_ADMIN_USER_PROPERTY = "org.opencastproject.security.admin.user";
+
 }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/LtiLaunchAuthenticationHandler.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.kernel.security;
 
+import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.util.SecurityUtil;
 
 import org.apache.commons.lang3.BooleanUtils;
@@ -86,9 +87,6 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
   /** The default learner for LTI **/
   private static final String DEFAULT_LEARNER = "USER";
 
-  /** The key to look up the admin username **/
-  private static final String ADMIN_USER_KEY = "org.opencastproject.security.admin.user";
-
   /** The prefix of the key to look up a consumer key. */
   private static final String HIGHLY_TRUSTED_CONSUMER_KEY_PREFIX = "lti.oauth.highly_trusted_consumer_key.";
 
@@ -149,7 +147,8 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
 
     // User blacklist
     if (!BooleanUtils.toBoolean(StringUtils.trimToNull((String) properties.get(ALLOW_SYSTEM_ADMINISTRATOR_KEY)))) {
-      String adminUsername = StringUtils.trimToNull(componentContext.getBundleContext().getProperty(ADMIN_USER_KEY));
+      String adminUsername = StringUtils.trimToNull(
+              componentContext.getBundleContext().getProperty(SecurityConstants.GLOBAL_ADMIN_USER_PROPERTY));
       if (adminUsername != null) {
         usernameBlacklist.add(adminUsername);
       }

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
@@ -24,6 +24,7 @@ package org.opencastproject.userdirectory.moodle;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.RoleProvider;
+import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.UserProvider;
 import org.opencastproject.util.NotFoundException;
 
@@ -168,6 +169,8 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
   public void updated(String pid, Dictionary properties) throws ConfigurationException {
     logger.debug("updated MoodleUserProviderFactory");
 
+    String adminUserName = StringUtils.trimToNull(bundleContext.getProperty(SecurityConstants.GLOBAL_ADMIN_USER_PROPERTY));
+
     String organization = (String) properties.get(ORGANIZATION_KEY);
     if (StringUtils.isBlank(organization))
       throw new ConfigurationException(ORGANIZATION_KEY, "is not set");
@@ -226,7 +229,7 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
 
     logger.debug("creating new MoodleUserProviderInstance for pid=" + pid);
     MoodleUserProviderInstance provider = new MoodleUserProviderInstance(pid, new MoodleWebServiceImpl(url, token), org,
-            coursePattern, userPattern, groupPattern, groupRoles, cacheSize, cacheExpiration);
+            coursePattern, userPattern, groupPattern, groupRoles, cacheSize, cacheExpiration, adminUserName);
 
     providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
     providerRegistrations.put(pid, bundleContext.registerService(RoleProvider.class.getName(), provider, null));

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderInstance.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderInstance.java
@@ -29,6 +29,7 @@ import org.opencastproject.security.api.JaxbUser;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.RoleProvider;
+import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserProvider;
 import org.opencastproject.userdirectory.moodle.MoodleWebService.CoreUserGetUserByFieldFilters;
@@ -39,6 +40,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,26 +144,39 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
    */
   private AtomicLong moodleWebServiceRequests;
 
+  private final List<String> ignoredUsernames;
+
   /**
    * Constructs an Moodle user provider with the needed settings.
    *
    * @param pid             The pid of this service.
-   * @param client          The Moodle web serivce client.
+   * @param client          The Moodle web service client.
    * @param organization    The organization.
    * @param coursePattern   The pattern of a Moodle course ID.
    * @param userPattern     The pattern of a Moodle user ID.
+   * @param groupPattern    The pattern of a Moodle group ID.
    * @param groupRoles      Whether to activate groupRoles
    * @param cacheSize       The number of users to cache.
    * @param cacheExpiration The number of minutes to cache users.
+   * @param adminUserName   Name of the global admin user.
    */
   public MoodleUserProviderInstance(String pid, MoodleWebService client, Organization organization,
-          String coursePattern, String userPattern, String groupPattern, boolean groupRoles, int cacheSize, int cacheExpiration) {
+          String coursePattern, String userPattern, String groupPattern, boolean groupRoles, int cacheSize,
+          int cacheExpiration, String adminUserName) {
     this.client = client;
     this.organization = organization;
     this.groupRoles = groupRoles;
     this.coursePattern = coursePattern;
     this.userPattern = userPattern;
     this.groupPattern = groupPattern;
+
+    // initialize user filter
+    this.ignoredUsernames = new ArrayList<>();
+    this.ignoredUsernames.add("");
+    this.ignoredUsernames.add(SecurityConstants.GLOBAL_ANONYMOUS_USERNAME);
+    if (StringUtils.isNoneEmpty(adminUserName)) {
+      ignoredUsernames.add(adminUserName);
+    }
 
     logger.info("Creating new MoodleUserProviderInstance(pid={}, url={}, cacheSize={}, cacheExpiration={})", pid,
             client.getURL(), cacheSize, cacheExpiration);
@@ -359,7 +374,7 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
     List<Role> roles = new LinkedList<>();
 
     // Don't answer for admin, anonymous or empty user
-    if ("admin".equals(username) || "".equals(username) || "anonymous".equals(username)) {
+    if (ignoredUsernames.stream().anyMatch(u -> u.equals(username))) {
       logger.debug("we don't answer for: {}", username);
       return roles;
     }
@@ -474,7 +489,7 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
       throw new IllegalStateException("The Moodle user detail service has not yet been configured");
 
     // Don't answer for admin, anonymous or empty user
-    if ("admin".equals(username) || "".equals(username) || "anonymous".equals(username)) {
+    if (ignoredUsernames.stream().anyMatch(u -> u.equals(username))) {
       logger.debug("We don't answer for: " + username);
       return null;
     }

--- a/modules/userdirectory-moodle/src/test/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderTest.java
+++ b/modules/userdirectory-moodle/src/test/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderTest.java
@@ -45,7 +45,7 @@ public class MoodleUserProviderTest {
   public void setUp() throws Exception {
     moodleProvider = new MoodleUserProviderInstance("sample_pid",
             new MoodleWebServiceImpl(new URI("http://moodle/webservice/rest/server.php"), "myToken"),
-            new DefaultOrganization(), "^[0-9]+$", "^[0-9a-zA-Z_]+$", "^[0-9]+$", true, 100, 10);
+            new DefaultOrganization(), "^[0-9]+$", "^[0-9a-zA-Z_]+$", "^[0-9]+$", true, 100, 10, "admin");
   }
 
   @Test

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
@@ -62,9 +62,6 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(AdminUserAndGroupLoader.class);
 
-  /** The administrator user configuration option */
-  public static final String OPT_ADMIN_USER = "org.opencastproject.security.admin.user";
-
   /** The administrator password configuration option */
   public static final String OPT_ADMIN_PASSWORD = "org.opencastproject.security.admin.pass";
 
@@ -125,7 +122,7 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
   public void activate(ComponentContext cc) throws Exception {
     logger.debug("Activating admin group loader");
     BundleContext bundleCtx = cc.getBundleContext();
-    adminUserName = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_USER));
+    adminUserName = StringUtils.trimToNull(bundleCtx.getProperty(SecurityConstants.GLOBAL_ADMIN_USER_PROPERTY));
     adminPassword = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_PASSWORD));
     adminEmail = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_EMAIL));
     adminRoles = StringUtils.trimToNull(bundleCtx.getProperty(OPT_ADMIN_ROLES));


### PR DESCRIPTION
The Moodle user provider assumed the username of the global admin user
to always be `admin` but the name is configurable.