### PR TITLE
MH-13562, ReferenceError in Media Module

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -489,8 +489,6 @@ function($, bootbox, _, alertify) {
                             setAnonymousUser();
                         }
                     }
-
-                    log("Chosen player: " + player);
                 }
             })
         }


### PR DESCRIPTION
The media module tries to log it's player selection which does not exist
any longer, causing a JavaScript error:

```
Uncaught ReferenceError: player is not defined
    at Object.success (engage-ui.js:493)
    at j (jquery.js:2)
    at Object.fireWith [as resolveWith] (jquery.js:2)
    at x (jquery.js:4)
    at XMLHttpRequest.<anonymous> (jquery.js:4)
```