### PR TITLE
MH-13375 Handle empty-range errors correctly

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -2024,6 +2024,9 @@ public abstract class AbstractEventEndpoint {
   public Response createNewEvent(@Context HttpServletRequest request) {
     try {
       String result = getIndexService().createEvent(request);
+      if (StringUtils.isEmpty(result)) {
+        return RestUtil.R.badRequest("The date range provided did not include any events");
+      }
       return Response.status(Status.CREATED).entity(result).build();
     } catch (IllegalArgumentException e) {
       return RestUtil.R.badRequest(e.getMessage());

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -606,7 +606,7 @@ public class AbstractEventEndpointTest {
     given().expect().statusCode(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE).when().post(rt.host("new"));
 
     // TODO: finish this test
-    given().multiPart("metadata", "some content").expect().statusCode(HttpStatus.SC_CREATED).when()
+    given().multiPart("metadata", "some content").expect().statusCode(HttpStatus.SC_BAD_REQUEST).when()
             .post(rt.host("new"));
   }
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -547,6 +547,10 @@ public class EventsEndpoint implements ManagedService {
     try {
       final String eventId = indexService.createEvent(request);
 
+      if (StringUtils.isEmpty(eventId)) {
+        return RestUtil.R.badRequest("The date range provided did not include any events");
+      }
+
       if (eventId.contains(",")) {
         // This the case when SCHEDULE_MULTIPLE is performed.
         return ApiResponses.Json.ok(requestedVersion, arr(

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1098,6 +1098,11 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
     Util.adjustRrule(rrule, start, tz);
     final List<Period> periods =  Util.calculatePeriods(start, end, duration, rrule, tz);
+
+    if (periods.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     return findConflictingEvents(periods, captureAgentId, tz);
   }
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -489,6 +489,9 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     // input Rrule is UTC. Needs to be adjusted to tz
     Util.adjustRrule(rRule, start, tz);
     List<Period> periods = Util.calculatePeriods(start, end, duration, rRule, tz);
+    if (periods.isEmpty()) {
+      return Collections.emptyMap();
+    }
     return addMultipleEventInternal(periods, captureAgentId, userIds, templateMp, wfProperties, caMetadata,
             schedulingSource);
   }

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1075,6 +1075,12 @@ public class SchedulerServiceImplTest {
       assertEquals(2, events.size());
     }
     {
+      // No events are contained in the RRule and date range: 2019-02-16T16:00:00Z to 2019-02-16T16:55:00Z, FREQ=WEEKLY;BYDAY=WE;BYHOUR=16;BYMINUTE=0
+      List<MediaPackage> conflicts = schedSvc.findConflictingEvents("Device A",
+              new RRule("FREQ=WEEKLY;BYDAY=WE;BYHOUR=16;BYMINUTE=0"), new Date(1550332800000L), new Date(1550336100000L), 1000, TimeZone.getTimeZone("Africa/Johannesburg"));
+      assertEquals(0, conflicts.size());
+    }
+    {
       //Event A starts before event B, and ends during event B
       List<MediaPackage> conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(23) + minutes(30)), new Date(currentTime + hours(24) + minutes(30)));
       assertEquals(1, conflicts.size());

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -817,6 +817,40 @@ public class SchedulerServiceImplTest {
   }
 
   @Test
+  public void testAddMultipleEventsEmptyRange() throws Exception {
+    final RRule rrule = new RRule("FREQ=WEEKLY;BYDAY=WE;BYHOUR=7;BYMINUTE=0");
+    final Date start = new Date(1546844400000L); // 2019-01-07T07:00:00Z
+    final Date end = start;
+    final Long duration = 6900000L;
+    final TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
+    final String captureAgentId = "Device A";
+    final Set<String> userIds = Collections.emptySet();
+    final String id = "Recording1";
+    final String seriesId = "TestSeries";
+    final MediaPackage mpTemplate = generateEvent(Opt.some(id));
+    mpTemplate.setSeries(seriesId);
+    final DublinCoreCatalog dublinCoreCatalog = generateEvent(captureAgentId, Opt.some(mpTemplate.getIdentifier().toString()), Opt.some("Test Title"), start, end);
+    addDublinCore(Opt.some(mpTemplate.getIdentifier().toString()), mpTemplate, dublinCoreCatalog);
+    final Map<String, String> wfProperties = this.wfProperties;
+    final Map<String, String> caProperties = Collections.singletonMap("foo", "bar");
+    final Opt<String> schedulingSource = Opt.none();
+    final Map<String, Period> scheduled = schedSvc.addMultipleEvents(
+        rrule,
+        start,
+        end,
+        duration,
+        tz,
+        captureAgentId,
+        userIds,
+        mpTemplate,
+        wfProperties,
+        caProperties,
+        schedulingSource
+    );
+    assertTrue(scheduled.isEmpty());
+  }
+
+  @Test
   public void testAddMultipleEvents() throws Exception {
     final RRule rrule = new RRule("FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=7;BYMINUTE=0");
     final Date start = new Date(1546844400000L); // 2019-01-07T07:00:00Z


### PR DESCRIPTION
This addresses server-side issues when dealing with conflict checks and event creation attempts for an empty range, where the recurrence rule and the start/end dates do not include any events.

For example, start date = end date and the recurrence rule is only for a different day of the week than the start and end date.

The REST endpoints now return appropriate responses: empty response for conflict check (because there are no conflicts because there are no events to conflict with), and bad request to attempt to create an event, because no event was created because there were no valid dates provided.

Previously both conflict and event endpoints returned 500 server errors, with stack traces in the logs.

The Admin UI behaviour is unchanged and not optimal, and that is left to another JIRA/PR to resolve. The event creation wizard will run through and complete finally with a UI warning that the event could not be created. It would be better to adjust the wizard to detect this case earlier.
