### PR TITLE
MH-13566 Accept duration as either string or number in scheduling JSON

### DIFF
--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -275,14 +275,25 @@ acl:
 ]
 ```
 
-scheduling (`rrule` is optional and can be used to schedule multiple events):
+scheduling a single event:
 ```
 {
   "agent_id": "ca24",
   "start": "2018-03-27T16:00:00Z",
   "end": "2018-03-27T19:00:00Z",
   "inputs": ["default"],
-  "rrule":"FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=16;BYMINUTE=0"
+}
+```
+
+scheduling multiple events:
+```
+{
+  "agent_id": "ca24",
+  "start": "2019-05-20T16:00:00Z",
+  "end": "2019-06-10T19:00:00Z",
+  "inputs": ["default"],
+  "rrule":"FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=16;BYMINUTE=0",
+  "duration":1080000;
 }
 ```
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/util/SchedulingUtils.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/util/SchedulingUtils.java
@@ -60,6 +60,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.TimeZone;
 
@@ -256,10 +257,13 @@ public final class SchedulingUtils {
       final SchedulingInfo schedulingInfo = new SchedulingInfo();
       final String startDate = (String) json.get(JSON_KEY_START_DATE);
       final String endDate = (String) json.get(JSON_KEY_END_DATE);
-      final String durationString = (String) json.get(JSON_KEY_DURATION);
       final String agentId = (String) json.get(JSON_KEY_AGENT_ID);
       final JSONArray inputs = (JSONArray) json.get(JSON_KEY_INPUTS);
       final String rrule = (String) json.get(JSON_KEY_RRULE);
+
+      // Special handling because the original implementation required String but now we require long
+      final String durationString = Objects.toString(json.get(JSON_KEY_DURATION), null);
+
       if (isNotBlank(startDate)) {
         schedulingInfo.startDate = Opt.some(Date.from(Instant.from(dateFormatter.parse(startDate))));
       }
@@ -291,6 +295,9 @@ public final class SchedulingUtils {
           schedulingInfo.rrule = Opt.some(parsedRrule);
         } catch (Exception e) {
           throw new IllegalArgumentException("Invalid RRule: " + rrule);
+        }
+        if (isBlank(durationString) || isBlank(startDate) || isBlank(endDate)) {
+          throw new IllegalArgumentException("'start', 'end' and 'duration' must be specified when 'rrule' is specified");
         }
       }
       return schedulingInfo;


### PR DESCRIPTION
The implementation released in 6.0 requires a string duration, but
the docs say Integer, which is consistent with usage elsewhere.

So accept both formats, enforce presence of duration when rrule is
specified, and update the docs to show correct examples.