### PR TITLE
MH-13568 Catch exception from overlapping RRule and return bad request

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -521,7 +521,7 @@ public class EventsEndpoint implements ManagedService {
     } catch (IllegalArgumentException | DateTimeParseException e) {
       logger.debug("Unable to create event", e);
       return RestUtil.R.badRequest(e.getMessage());
-    } catch (IndexServiceException e) {
+    } catch (SchedulerException | IndexServiceException e) {
       if (e.getCause() != null && e.getCause() instanceof NotFoundException
               || e.getCause() instanceof IllegalArgumentException) {
         logger.debug("Unable to create event", e);

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1124,7 +1124,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     // the external API, for example; the admin ui should prevent this from happening). Then check for conflicts with
     // existing events.
     if (checkPeriodOverlap(periods)) {
-      throw new SchedulerException("RRULE periods overlap");
+      throw new IllegalArgumentException("RRULE periods overlap");
     }
 
     try {


### PR DESCRIPTION
Clients can submit any RRule and duration to the external API POST /api/event endpoint.
If the RRule and duration specify overlapping events, an exception is thrown.

Here we catch this exception and return a bad request rather than allow it to be propagated
producing a 500 internal server error response.

The exception type is changed to IllegalArgumentException because it is an illegal argument,
and we can catch it specifically rather than converting all SchedulerExceptions to bad request
responses.