### PR TITLE
MH-13569 Change of PlayerRedirection variable from {{id}} to #{id}

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -66,6 +66,8 @@ Configuration Changes
   option.
 - `etc/org.opencastproject.scheduler.impl.SchedulerServiceImpl.cfg` has a new option `maintenance` which temporarily
   disables the scheduler if set to `true`.
+- `etc/org.opencastproject.organization-mh_default_org.cfg` the variable `{{id}}` 
+  from `prop.player` has changed to `#{id}`.
 
 Scheduler Migration
 -------------------

--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -66,8 +66,7 @@ Configuration Changes
   option.
 - `etc/org.opencastproject.scheduler.impl.SchedulerServiceImpl.cfg` has a new option `maintenance` which temporarily
   disables the scheduler if set to `true`.
-- `etc/org.opencastproject.organization-mh_default_org.cfg` the variable `{{id}}` 
-  from `prop.player` has changed to `#{id}`.
+
 
 Scheduler Migration
 -------------------

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -225,11 +225,11 @@ prop.adminui.user.external_role_display=false
 # Path to the default video player used by the engage interfaces and the LTI tools. Parameters for selecting the
 # specific videos will be appended automatically.  Common values include:
 #
-# - theodul player: /engage/theodul/ui/core.html?id={{id}}
-# - paella  player: /paella/ui/watch.html?id={{id}}
+# - theodul player: /engage/theodul/ui/core.html?id=#{id}
+# - paella  player: /paella/ui/watch.html?id=#{id}
 #
-# Default: /engage/theodul/ui/core.html?id={{id}}
-#prop.player=/engage/theodul/ui/core.html?id={{id}}
+# Default: /engage/theodul/ui/core.html?id=#{id}
+#prop.player=/engage/theodul/ui/core.html?id=#{id}
 
 # The default flavor of the master video (the video on the "left side" in the video display)
 prop.player.mastervideotype=presenter/delivery

--- a/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
+++ b/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
@@ -55,7 +55,7 @@ public class PlayerRedirect {
 
   private static final Logger logger = LoggerFactory.getLogger(PlayerRedirect.class);
 
-  private static final String PLAYER_DEFAULT = "/engage/theodul/ui/core.html?id={{id}}";
+  private static final String PLAYER_DEFAULT = "/engage/theodul/ui/core.html?id=#{id}";
 
   private SecurityService securityService;
 
@@ -74,7 +74,7 @@ public class PlayerRedirect {
   public Response redirect(@PathParam("id") String id) {
     final Organization org = securityService.getOrganization();
     final String playerPath = Objects.toString(org.getProperties().get("player"), PLAYER_DEFAULT)
-            .replace("{{id}}", id);
+            .replace("#{id}", id);
     logger.debug("redirecting to player: {}", playerPath);
     return Response
             .status(Response.Status.TEMPORARY_REDIRECT)


### PR DESCRIPTION
This PR is created to modify the part from the organization configuration file, where the event id variable for the player redirection is actually {{id}}, this definition can create problem with Provisioning and orchestration software like Ansible.

The new definition is #{id} to avoid this problem. 