### PR TITLE
MH-13581, Streaming Module Cleanup

### DIFF
--- a/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/endpoint/WowzaAdaptiveStreamingDistributionRestService.java
+++ b/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/endpoint/WowzaAdaptiveStreamingDistributionRestService.java
@@ -78,10 +78,10 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
   private static final Logger logger = LoggerFactory.getLogger(WowzaAdaptiveStreamingDistributionRestService.class);
 
   /** The distribution service */
-  protected StreamingDistributionService service;
+  private StreamingDistributionService service;
 
   /** The service registry */
-  protected ServiceRegistry serviceRegistry = null;
+  private ServiceRegistry serviceRegistry = null;
 
   private static final Gson gson = new Gson();
 
@@ -124,9 +124,8 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
           @RestResponse(responseCode = SC_NO_CONTENT, description = "There is no streaming distribution service available")})
   public Response distribute(@FormParam("mediapackage") String mediaPackageXml,
                              @FormParam("channelId") String channelId,
-                             @FormParam("elementIds") String elementIds)
-          throws Exception {
-    Job job = null;
+                             @FormParam("elementIds") String elementIds) {
+    Job job;
     try {
       Set<String> setElementIds = gson.fromJson(elementIds, new TypeToken<Set<String>>() { }.getType());
       MediaPackage mediapackage = MediaPackageParser.getFromXml(mediaPackageXml);
@@ -137,7 +136,7 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
         return Response.ok(new JaxbJob(job)).build();
       }
     } catch (IllegalArgumentException e) {
-      logger.debug("Unable to distribute element: {}", e.getMessage());
+      logger.debug("Unable to distribute element", e);
       return status(Status.BAD_REQUEST).build();
     } catch (Exception e) {
       logger.warn("Error distributing element", e);
@@ -156,9 +155,8 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
       @RestResponse(responseCode = SC_NO_CONTENT, description = "There is no streaming distribution service available")})
   public Response distributeSync(@FormParam("mediapackage") String mediaPackageXml,
                              @FormParam("channelId") String channelId,
-                             @FormParam("elementIds") String elementIds)
-      throws Exception {
-    List<MediaPackageElement> result = null;
+                             @FormParam("elementIds") String elementIds) {
+    List<MediaPackageElement> result;
     try {
       Set<String> setElementIds = gson.fromJson(elementIds, new TypeToken<Set<String>>() { }.getType());
       MediaPackage mediapackage = MediaPackageParser.getFromXml(mediaPackageXml);
@@ -169,7 +167,7 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
         return Response.ok(MediaPackageElementParser.getArrayAsXml(result)).build();
       }
     } catch (IllegalArgumentException e) {
-      logger.debug("Unable to distribute element: {}", e.getMessage());
+      logger.debug("Unable to distribute element", e);
       return status(Status.BAD_REQUEST).build();
     } catch (Exception e) {
       logger.warn("Error distributing element", e);
@@ -188,9 +186,8 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
           @RestResponse(responseCode = SC_NO_CONTENT, description = "There is no streaming distribution service available")})
   public Response retract(@FormParam("mediapackage") String mediaPackageXml,
                           @FormParam("channelId") String channelId,
-                          @FormParam("elementIds") String elementIds)
-          throws Exception {
-    Job job = null;
+                          @FormParam("elementIds") String elementIds) {
+    Job job;
     try {
       Set<String> setElementIds = gson.fromJson(elementIds, new TypeToken<Set<String>>() { }.getType());
       MediaPackage mediapackage = MediaPackageParser.getFromXml(mediaPackageXml);
@@ -204,7 +201,8 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
       logger.debug("Unable to retract element: {}", e.getMessage());
       return status(Status.BAD_REQUEST).build();
     } catch (Exception e) {
-      logger.warn("Unable to retract mediapackage '{}' from streaming channel: {}", new Object[] { mediaPackageXml, e });
+      logger.warn("Unable to retract media package '{}' from streaming channel: {}", new Object[] { mediaPackageXml,
+              e });
       return Response.serverError().status(Status.INTERNAL_SERVER_ERROR).build();
     }
   }
@@ -220,9 +218,8 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
       @RestResponse(responseCode = SC_NO_CONTENT, description = "There is no streaming distribution service available")})
   public Response retractSync(@FormParam("mediapackage") String mediaPackageXml,
                           @FormParam("channelId") String channelId,
-                          @FormParam("elementIds") String elementIds)
-      throws Exception {
-    List<MediaPackageElement> result = null;
+                          @FormParam("elementIds") String elementIds) {
+    List<MediaPackageElement> result;
     try {
       Set<String> setElementIds = gson.fromJson(elementIds, new TypeToken<Set<String>>() { }.getType());
       MediaPackage mediapackage = MediaPackageParser.getFromXml(mediaPackageXml);
@@ -233,7 +230,7 @@ public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobPr
         return Response.ok(MediaPackageElementParser.getArrayAsXml(result)).build();
       }
     } catch (IllegalArgumentException e) {
-      logger.debug("Unable to retract element: {}", e.getMessage());
+      logger.debug("Unable to retract element", e);
       return status(Status.BAD_REQUEST).build();
     } catch (Exception e) {
       logger.warn("Unable to retract mediapackage '{}' from streaming channel: {}", new Object[] { mediaPackageXml, e });

--- a/modules/distribution-service-adaptive-streaming-wowza/src/test/java/org/opencastproject/distribution/streaming/wowza/StreamingDistributionServiceTest.java
+++ b/modules/distribution-service-adaptive-streaming-wowza/src/test/java/org/opencastproject/distribution/streaming/wowza/StreamingDistributionServiceTest.java
@@ -25,11 +25,12 @@ import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
-import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.ComponentException;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -37,7 +38,7 @@ import java.net.URISyntaxException;
 public class StreamingDistributionServiceTest {
 
   // List of URLs for testing
-  static final String[] inputStreamingUrls = new String[] {
+  private static final String[] inputStreamingUrls = new String[] {
           "noschema.myserver.com/my/path/to/server",
           "http://withhttp.example.com/path",
           "https://withhttps.testing.com/this/is/a/path",
@@ -47,11 +48,10 @@ public class StreamingDistributionServiceTest {
   };
 
   @Test
-  public void testInitializationException() throws URISyntaxException {
+  public void testInitializationException() {
 
     // Set up mocks for testing
-    BundleContext bc = createNiceMock(BundleContext.class);
-    ComponentContext cc = createNiceMock(ComponentContext.class);
+    BundleContext bundleContext = createNiceMock(BundleContext.class);
 
     final String[] inputStreamingUrls = new String[] {
             "incorrect url :"
@@ -64,28 +64,23 @@ public class StreamingDistributionServiceTest {
     // Try all combinations
     for (String streamingUrl : inputStreamingUrls) {
       for (String adaptiveStreamingUrl : inputAdaptiveStreamingUrls) {
-        expect(bc.getProperty(WowzaAdaptiveStreamingDistributionService.STREAMING_URL_KEY)).andReturn(streamingUrl);
-        expect(bc.getProperty(WowzaAdaptiveStreamingDistributionService.ADAPTIVE_STREAMING_URL_KEY)).andReturn(adaptiveStreamingUrl);
+        expect(bundleContext.getProperty(WowzaAdaptiveStreamingDistributionService.STREAMING_URL_KEY)).andReturn(streamingUrl);
+        expect(bundleContext.getProperty(WowzaAdaptiveStreamingDistributionService.ADAPTIVE_STREAMING_URL_KEY)).andReturn(adaptiveStreamingUrl);
       }
     }
 
-    expect(cc.getBundleContext()).andReturn(bc).anyTimes();
-
-    replay(bc);
-    replay(cc);
+    replay(bundleContext);
 
     // Test service instance
-    for (int i = 0; i < inputStreamingUrls.length; i++) {
-      for (int j = 0; j < inputAdaptiveStreamingUrls.length; j++) {
+    for (String inputStreamingUrl : inputStreamingUrls) {
+      for (String inputAdaptiveStreamingUrl : inputAdaptiveStreamingUrls) {
         WowzaAdaptiveStreamingDistributionService sds = new WowzaAdaptiveStreamingDistributionService();
         try {
-          sds.activate(cc);
-          fail(format(
-                  "Error. The Streaming Distribution Service should not initialize when the streaming URL is \"%s\" "
-                          + "and the adaptive streaming URL is \"%s\"",
-                  inputStreamingUrls[i], inputAdaptiveStreamingUrls[j]));
+          sds.activate(bundleContext);
+          fail(format("Error. The Streaming Distribution Service should not initialize when the streaming URL is "
+                  + "\"%s\" and the adaptive streaming URL is \"%s\"", inputStreamingUrl, inputAdaptiveStreamingUrl));
 
-        } catch (IllegalArgumentException e) {
+        } catch (ComponentException e) {
           // OK!
         }
       }
@@ -107,26 +102,29 @@ public class StreamingDistributionServiceTest {
     };
 
     // Set up mocks for testing
-    BundleContext bc = createNiceMock(BundleContext.class);
-    ComponentContext cc = createNiceMock(ComponentContext.class);
+    BundleContext bundleContext = createNiceMock(BundleContext.class);
 
     for (String url : inputStreamingUrls)
-      expect(bc.getProperty(WowzaAdaptiveStreamingDistributionService.STREAMING_URL_KEY)).andReturn(url);
-    expect(bc.getProperty(WowzaAdaptiveStreamingDistributionService.ADAPTIVE_STREAMING_URL_KEY)).andReturn("a/valid/url").anyTimes();
+      expect(bundleContext.getProperty(WowzaAdaptiveStreamingDistributionService.STREAMING_URL_KEY)).andReturn(url);
+    expect(bundleContext.getProperty(WowzaAdaptiveStreamingDistributionService.ADAPTIVE_STREAMING_URL_KEY)).andReturn("a/valid/url").anyTimes();
+    expect(bundleContext.getProperty(WowzaAdaptiveStreamingDistributionService.STREAMING_DIRECTORY_KEY)).andReturn("/").anyTimes();
 
-    expect(cc.getBundleContext()).andReturn(bc).anyTimes();
-
-    replay(bc);
-    replay(cc);
+    replay(bundleContext);
 
     // Test service instance
     for (int i = 0; i < inputStreamingUrls.length; i++) {
       WowzaAdaptiveStreamingDistributionService sds = new WowzaAdaptiveStreamingDistributionService();
-      sds.activate(cc);
-      if (outputStreamingUrls[i] == null)
-        assertEquals(null, sds.streamingUri);
-      else
+      if (outputStreamingUrls[i] == null) {
+        try {
+          sds.activate(bundleContext);
+          fail("Should fail on invalid streaming URL");
+        } catch (ComponentException e) {
+          // this is expected
+        }
+      } else {
+        sds.activate(bundleContext);
         assertEquals(new URI(outputStreamingUrls[i]), sds.streamingUri);
+      }
     }
   }
 
@@ -144,28 +142,30 @@ public class StreamingDistributionServiceTest {
     };
 
     // Set up mocks for testing
-    BundleContext bc = createNiceMock(BundleContext.class);
-    ComponentContext cc = createNiceMock(ComponentContext.class);
+    BundleContext bundleContext = createNiceMock(BundleContext.class);
 
-    expect(bc.getProperty(WowzaAdaptiveStreamingDistributionService.STREAMING_URL_KEY)).andReturn("a/valid/url").anyTimes();
+    expect(bundleContext.getProperty(WowzaAdaptiveStreamingDistributionService.STREAMING_URL_KEY)).andReturn("a/valid/url").anyTimes();
     for (String url : inputStreamingUrls)
-      expect(bc.getProperty(WowzaAdaptiveStreamingDistributionService.ADAPTIVE_STREAMING_URL_KEY)).andReturn(url);
+      expect(bundleContext.getProperty(WowzaAdaptiveStreamingDistributionService.ADAPTIVE_STREAMING_URL_KEY)).andReturn(url);
+    expect(bundleContext.getProperty(WowzaAdaptiveStreamingDistributionService.STREAMING_DIRECTORY_KEY)).andReturn("/").anyTimes();
 
-    expect(cc.getBundleContext()).andReturn(bc).anyTimes();
-
-    replay(bc);
-    replay(cc);
+    replay(bundleContext);
 
     // Test service instance
     for (int i = 0; i < inputStreamingUrls.length; i++) {
       WowzaAdaptiveStreamingDistributionService sds = new WowzaAdaptiveStreamingDistributionService();
-      sds.activate(cc);
-      if (outputAdaptiveStreamingUrls[i] == null)
-        assertEquals(null, sds.adaptiveStreamingUri);
-      else
+      if (outputAdaptiveStreamingUrls[i] == null) {
+        try {
+          sds.activate(bundleContext);
+          fail("Should fail on invalid streaming URL");
+        } catch (ComponentException e) {
+          // expected
+        }
+        assertNull(sds.adaptiveStreamingUri);
+      } else {
+        sds.activate(bundleContext);
         assertEquals(new URI(outputAdaptiveStreamingUrls[i]), sds.adaptiveStreamingUri);
+      }
     }
   }
-
-  // Test port
 }


### PR DESCRIPTION
The adaptive streaming module of Opencast contains a lot of unnecessary,
outdated or somewhat risky code. This patch strives to improve the
module by:

- letting the module activation fail on invalid configurations
- removing duplicated code and checks
- removing unnecessary array/list conversions

---

@mliradelc, since you have an actual streaming server set-up and I don't, would youn mind testing this under real conditions?