### PR TITLE
MH-13513 Officially support URL signing keys that handle multiple URL prefixes

### DIFF
--- a/docs/guides/admin/docs/configuration/stream-security.md
+++ b/docs/guides/admin/docs/configuration/stream-security.md
@@ -43,9 +43,11 @@ Each signing key configuration consists of the following attributes:
 
 * **Key ID:** Key identifier, e.g. `demoKeyOne`
 * **Key secret:** Key value, e.g. `25DA2BA549CB62EF297977845259A`. The key-length is not predefined, but a key length of
-  at least 128 bit is recommended. Any larger value will not increase security of the underlying algorithm.
+  at least 128 bit is recommended. Any larger value will not increase security of the underlying algorithm
 * **URL prefix:** The URL signing provider will only sign URLs that start with this value. This allows to support
-  multiple distributions and different key pairs.
+  multiple distributions and different key pairs
+* **Organization:** Keys can be restricted to organizations so that different organizations use different keys.
+  This attribute is optional. If not specified, the key can be used by all organizations
 
 A typical configuration looks like this:
 
@@ -54,6 +56,16 @@ A typical configuration looks like this:
 
     key.demoKeyTwo.secret=6EDB5EDDCF994B7432C371D7C274F
     key.demoKeyTwo.url=http://download.opencast.org/custom
+    key.demoKeyTwo.organization=mh_default_org
+
+It is also possible to use one key for multiple URL prefixes:
+
+    key.demoKeyThree.secret=6EDB5EDDCF994B7432C371D7C274F
+    key.demoKeyThree.url.http=http://download.opencast.org/custom
+    key.demoKeyThree.url.https=https://download.opencast.org/custom
+    key.demoKeyThree.url.streaming=http://streaming.opencast.org/custom
+    key.demoKeyThree.organization=mh_default_org
+
 
 Configuration of URL Signing Timeout Values
 -------------------------------------------

--- a/etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg
+++ b/etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg
@@ -11,7 +11,9 @@
     # Key secret: Key value, e.g. ‘25DA2BA549CB62EF297977845259A’. The key-length is not predefined, but a key length of
         # at least 128 bit is recommended. Any larger value will not increase security of the underlying algorithm.
     # URL prefix: The URL Signing Provider will only sign URLs that start with this value. This allows to support
-        # multiple distributions and different key pairs.
+        # multiple distributions and different key pairs. Multiple URL prefixes can be assigned to one key
+    # Organization: Keys can be restricted to organizations so that different organizations use different keys.
+        # This attribute is optional. If not specified, the key can be used by all organizations
 
 # Important: For all URL prefixes, no URL prefix may be a prefix of any other URL prefix
 
@@ -22,8 +24,15 @@
 
 # key.demoKeyOne.secret=6EDB5EDDCF994B7432C371D7C274F
 # key.demoKeyOne.url=http://download.opencast.org/engage
-# key.demoKeyOne.organization=mh_default_org
 
 # key.demoKeyTwo.secret=6EDB5EDDCF994B7432C371D7C274F
 # key.demoKeyTwo.url=http://download.opencast.org/custom
 # key.demoKeyTwo.organization=mh_default_org
+
+# It is also possible to use one key for multiple URL prefixes:
+
+# key.demoKeyThree.secret=6EDB5EDDCF994B7432C371D7C274F
+# key.demoKeyThree.url.http=http://download.opencast.org/custom
+# key.demoKeyThree.url.https=https://download.opencast.org/custom
+# key.demoKeyThree.url.streaming=http://streaming.opencast.org/custom
+# key.demoKeyThree.organization=mh_default_org

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/AbstractUrlSigningProvider.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/AbstractUrlSigningProvider.java
@@ -159,9 +159,9 @@ public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, 
 
       if (propertyKey.startsWith(KEY_PROPERTY_PREFIX + ".")) {
 
-        // We expected the parts [KEY_PROPERTY_PREFIX, id, attribute]
+        // We expected the parts [KEY_PROPERTY_PREFIX, id, attribute] or [KEY_PROPERTY_PREFIX, id, URL, name]
         String[] parts = Arrays.stream(propertyKey.split("\\.")).map(String::trim).toArray(String[]::new);
-        if (parts.length != 3) {
+        if ((parts.length != 3) && !(parts.length == 4 && URL.equals(parts[2]))) {
           throw new ConfigurationException(propertyKey, "Wrong property key format");
         }
 
@@ -210,15 +210,19 @@ public abstract class AbstractUrlSigningProvider implements UrlSigningProvider, 
     this.urls = urls;
   }
 
-  @Override
-  public boolean accepts(String baseUrl) {
+  private boolean isValidUrl(String url) {
     try {
-      new URI(baseUrl);
+      new URI(url);
+      return true;
     } catch (URISyntaxException e) {
-      getLogger().debug("Unable to support url {} because", baseUrl, e);
+      getLogger().debug("Unable to support url {} because", url, e);
       return false;
     }
-    return getKey(baseUrl) != null;
+  }
+
+  @Override
+  public boolean accepts(String baseUrl) {
+    return isValidUrl(baseUrl) && getKey(baseUrl) != null;
   }
 
   @Override

--- a/modules/urlsigning-service-impl/src/test/java/org/opencastproject/security/urlsigning/provider/impl/GenericUrlSigningProviderTest.java
+++ b/modules/urlsigning-service-impl/src/test/java/org/opencastproject/security/urlsigning/provider/impl/GenericUrlSigningProviderTest.java
@@ -291,4 +291,33 @@ public class GenericUrlSigningProviderTest {
     }
     assertTrue(exceptionThrown);
   }
+
+  @Test
+  public void testMultipleUrlsPerKey() throws UrlSigningException, ConfigurationException {
+
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL + ".1"), MATCHING_URI);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.URL + ".2"), MATCHING_URI_2);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, GenericUrlSigningProvider.SECRET), SECRET);
+
+    signer.updated(properties);
+    assertEquals(2, signer.getUris().size());
+
+    DateTime before = new DateTime(2020, 03, 01, 00, 46, 17, 0, DateTimeZone.UTC);
+    // Uses KEY_ID for MATCHING_URI
+    Policy policy = Policy.mkSimplePolicy(RESOURCE_PATH, before);
+    String result = signer.sign(policy);
+    logger.info(result);
+    assertEquals(
+            "http://www.opencast.org/path/to/resource.mp4?policy=eyJTdGF0ZW1lbnQiOnsiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6MTU4MzAyMzU3NzAwMH0sIlJlc291cmNlIjoiaHR0cDpcL1wvd3d3Lm9wZW5jYXN0Lm9yZ1wvcGF0aFwvdG9cL3Jlc291cmNlLm1wNCJ9fQ&keyId=theId&signature=5b45e678275e6bc7b06a579f7f42e9a7ea5c58f1da130701db532f121e363e98",
+            result);
+
+    // Uses KEY_ID for MATCHING_URI_2, too
+    policy = Policy.mkSimplePolicy(RESOURCE_PATH_2, before);
+    result = signer.sign(policy);
+    logger.info(result);
+    assertEquals(
+            "http://docs.opencast.org/path/to/resource.mp4?policy=eyJTdGF0ZW1lbnQiOnsiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6MTU4MzAyMzU3NzAwMH0sIlJlc291cmNlIjoiaHR0cDpcL1wvZG9jcy5vcGVuY2FzdC5vcmdcL3BhdGhcL3RvXC9yZXNvdXJjZS5tcDQifX0&keyId=theId&signature=94a0a7c2e660dc5eaafca857e49a42a5b3857fe53353093873c8b41fa8d2b9b1",
+            result);
+  }
+
 }


### PR DESCRIPTION
The original URL signing implementation allowed multiple URL prefixes to be handled by the same URL signing key. This was, however, not an officially supported feature and it was removed in Opencast 7.0.

The goal of this task is to officially allow URL signing keys to support multiple URL prefixes.

This is mainly a convenience function (you could use different keys using the same secret to achieve the same), but it also keeps the number of keys that need to be tracked by the verifiers smaller.