### PR TITLE
MH-13582 Support for exclusion pattern for URL signing

### DIFF
--- a/docs/guides/admin/docs/configuration/stream-security.md
+++ b/docs/guides/admin/docs/configuration/stream-security.md
@@ -67,6 +67,12 @@ It is also possible to use one key for multiple URL prefixes:
     key.demoKeyThree.organization=mh_default_org
 
 
+A Java regular expression can be defined to identify URLs to be excluded from URL signing.
+Any URL that matches this anchored regex will not be signed.
+
+    exclude.url.pattern=.*/.*/unprotected/.*/.*
+
+
 Configuration of URL Signing Timeout Values
 -------------------------------------------
 

--- a/etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg
+++ b/etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg
@@ -36,3 +36,8 @@
 # key.demoKeyThree.url.https=https://download.opencast.org/custom
 # key.demoKeyThree.url.streaming=http://streaming.opencast.org/custom
 # key.demoKeyThree.organization=mh_default_org
+
+# A Java regular expression can be defined to identify URLs to be excluded from URL signing.
+# Any URL that matches this anchored regex will not be signed.
+
+# exclude.url.pattern=.*/.*/unprotected/.*/.*


### PR DESCRIPTION
While stream security allows to protect files on Opencast distribution servers, there are situations where this is undesired. One often encountered use case is that people want to integrate a video into 3rd-party tools that don't support stream security (e.g. other video players like h5p).

By introducing an exclusion pattern, admins can configure Opencast to not sign specific URLs. Since the publication channel ID is part of the URL, this enables admins to disable stream security for specific publication channels, hence allowing unsafe publications.