### PR TITLE
MH-13584, Jettison Dependency Management

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -70,7 +70,7 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlbeans/2.6.0_2</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
-    <bundle>mvn:org.codehaus.jettison/jettison/1.3.1</bundle>
+    <bundle>mvn:org.codehaus.jettison/jettison/1.4.0</bundle>
     <bundle>mvn:org.codehaus.groovy/groovy/2.4.3</bundle>
     <!-- At least ingest-service-impl need JDOM in version 1.x -->
     <!-- JDOM 1.x updates will be bug fixes as new features are gone to 2.x (see http://www.jdom.org/) -->

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -141,13 +141,6 @@
     <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
-      <version>1.3.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>stax</groupId>
-          <artifactId>stax-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -172,13 +172,6 @@
     <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
-      <version>1.3.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>stax</groupId>
-          <artifactId>stax-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -62,13 +62,6 @@
     <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
-      <version>1.3.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>stax</groupId>
-          <artifactId>stax-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/modules/statistics-service-remote/pom.xml
+++ b/modules/statistics-service-remote/pom.xml
@@ -40,13 +40,6 @@
     <dependency>
       <groupId>org.codehaus.jettison</groupId>
       <artifactId>jettison</artifactId>
-      <version>1.3.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>stax</groupId>
-          <artifactId>stax-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1263,6 +1263,17 @@
         <artifactId>android-mms</artifactId>
         <version>1.1</version>
       </dependency>
+      <dependency>
+        <groupId>org.codehaus.jettison</groupId>
+        <artifactId>jettison</artifactId>
+        <version>1.4.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>stax</groupId>
+            <artifactId>stax-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <!-- All non-build related project data below here -->


### PR DESCRIPTION
Jettison is defined as dependency in multiple modules including the
version which unfortunately differs from the version cxf depends on
which results in Opencast's distributions containing multiple versions
of this library.

This patch centralizes the dependency management of Jettison and
upgrades the library to the same version Karaf already contains.