### PR TITLE
MH-13587, Metadata Transfer Operation

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -90,5 +90,6 @@ The following table contains the workflow operations that are available in an ou
 |tag-by-dcterm       |Modify the tags if dublincore term matches value               |[Documentation](tag-by-dcterm-woh.md)|
 |theme               |Make settings of themes available to processing                |[Documentation](theme-woh.md)|
 |timelinepreviews    |Create a preview image stream from a given video track         |[Documentation](timelinepreviews-woh.md)|
+|transfer-metadata   |Transfer metadata fields between catalogs                      |[Documentation](transfer-metadata-woh.md)|
 |waveform            |Create a waveform image of the audio of the mediapackage       |[Documentation](waveform-woh.md)|
 |zip                 |Create zipped archive of the current state of the mediapackage |[Documentation](zip-woh.md)|

--- a/docs/guides/admin/docs/workflowoperationhandlers/transfer-metadata-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/transfer-metadata-woh.md
@@ -1,0 +1,58 @@
+Transfer Metadata Workflow Operation
+====================================
+
+Description
+-----------
+
+The transfer metadata operation allows to transfer arbitrary metadata fields from one metadata catalog to another one.
+
+Parameter Table
+---------------
+
+|configuration key|example                           |description
+|-----------------|----------------------------------|-------------------------------
+|source-flavor    |dublincore/episode                |The catalog from which the metadata is copied
+|target-flavor    |myterms/episode                   |The catalog to which the data is copied
+|source-element   |{http://purl.org/dc/terms/}creator|The XML element to copy
+|target-element   |{http://purl.org/dc/terms/}creator|The XML element to which the values are copied
+|force            |false                             |Overwrite existing targets
+|concat           |,                                 |Join multiple values by set delimiter
+|target-prefix    |dcterms                           |Prefix to use for the given namespace
+
+
+### force
+
+By default, the operation will fail if a target element already exists at the specified location. If `force` is set, all
+existing target elements will be removed before copying the new elements.
+
+
+### concat
+
+If multiple source elements are selected (e.g. the title in multiple languages), by default, all elements are copied to
+the destination. The language information are preserved in this operation. If `concat` is defined, the value of this
+option will be used as a delimiter for joining all selected source elements and only ever one element will be written.
+All language information for this combined element will be discarded in the process.
+
+
+### target-prefix
+
+This option lets you specify the XML namespace identifier for the target elements namespace. For example, Opencast
+usually uses `dcterms` for elements from the set of DublinCore terms, resulting in elements like `<dcterms:creator>`.
+
+
+Operation Example
+-----------------
+
+```xml
+<operation
+  id="transfer-metadata"
+  description="Transfer dcterms:creator to myterms:owner">
+  <configurations>
+    <configuration key="source-flavor">dublincore/episode</configuration>
+    <configuration key="target-flavor">myterms/episode</configuration>
+    <configuration key="source-element">{http://purl.org/dc/terms/}creator</configuration>
+    <configuration key="target-element">{http://my-institution.edu/metadata}owner</configuration>
+    <configuration key="force">true</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -170,6 +170,7 @@ nav:
    - Tag: 'workflowoperationhandlers/tag-woh.md'
    - Tag-By-DCTerm: 'workflowoperationhandlers/tag-by-dcterm-woh.md'
    - Timelinepreviews: 'workflowoperationhandlers/timelinepreviews-woh.md'
+   - Transfer Metadata: 'workflowoperationhandlers/transfer-metadata-woh.md'
    - Theme: 'workflowoperationhandlers/theme-woh.md'
    - Waveform: 'workflowoperationhandlers/waveform-woh.md'
    - Zip: 'workflowoperationhandlers/zip-woh.md'

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/EName.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/EName.java
@@ -169,6 +169,9 @@ public final class EName implements Serializable, Comparable<EName> {
    *          NameSpace **is** a NameSpace. If this argument is blank or {@code null}, it has no effect.
    */
   public static EName fromString(String strEName, String defaultNameSpace) throws IllegalArgumentException {
+    if (strEName == null) {
+      throw new IllegalArgumentException("Cannot parse 'null' as EName");
+    }
     Matcher m = pattern.matcher(strEName);
 
     if (m.matches()) {

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -158,6 +158,7 @@
               OSGI-INF/operations/start-workflow.xml,
               OSGI-INF/operations/tag.xml,
               OSGI-INF/operations/tag-by-dcterm.xml,
+              OSGI-INF/operations/transfer-metadata.xml,
               OSGI-INF/operations/zip.xml
             </Service-Component>
           </instructions>

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TransferMetadataWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TransferMetadataWorkflowOperationHandler.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.workflow.handler.workflow;
+
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.Catalog;
+import org.opencastproject.mediapackage.EName;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
+import org.opencastproject.metadata.dublincore.DublinCoreUtil;
+import org.opencastproject.metadata.dublincore.DublinCoreValue;
+import org.opencastproject.util.XmlNamespaceContext;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The workflow definition for handling "transfer-metadata" operations
+ */
+public class TransferMetadataWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+
+  private static Logger logger = LoggerFactory.getLogger(TransferMetadataWorkflowOperationHandler.class);
+
+  /** Reference to the workspace */
+  private Workspace workspace = null;
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see org.opencastproject.workflow.api.WorkflowOperationHandler#start(org.opencastproject.workflow.api.WorkflowInstance,
+   *      JobContext)
+   */
+  @Override
+  public WorkflowOperationResult start(final WorkflowInstance workflowInstance, JobContext context)
+          throws WorkflowOperationException {
+    logger.debug("Running transfer-metadata workflow operation");
+
+    MediaPackage mediaPackage = workflowInstance.getMediaPackage();
+    Configuration configuration = new Configuration(workflowInstance.getCurrentOperation());
+
+    // select source metadata catalog
+    Metadata sourceMetadata;
+    try {
+      sourceMetadata = new Metadata(mediaPackage, configuration.sourceFlavor);
+    } catch (Metadata.NoMetadataFoundException e) {
+      logger.debug("No catalog with flavor {}. Skipping operation.", configuration.sourceFlavor);
+      return createResult(mediaPackage, Action.SKIP);
+    }
+    Metadata targetMetadata;
+    try {
+      targetMetadata = new Metadata(mediaPackage, configuration.targetFlavor);
+    } catch (Metadata.NoMetadataFoundException e) {
+      throw new WorkflowOperationException(e);
+    }
+
+    // fail if the target exists and we did not configure to override it
+    if (targetMetadata.dcCatalog.get(configuration.targetElement).size() > 0 && !configuration.force) {
+      throw new WorkflowOperationException("The target metadata field already exists and forcing was not configured");
+    }
+
+    // either transfer all values or generate one field by joining all values.
+    // all language information will get lost if we join the values.
+    if (configuration.concatDelimiter == null) {
+      final List<DublinCoreValue> values = sourceMetadata.dcCatalog.get(configuration.sourceElement);
+      targetMetadata.dcCatalog.set(configuration.targetElement, values);
+      logger.info("Transferred {} metadata elements", values.size());
+    } else {
+      final String value = sourceMetadata.dcCatalog.get(configuration.sourceElement)
+              .stream()
+              .map(DublinCoreValue::getValue)
+              .collect(Collectors.joining(configuration.concatDelimiter));
+      targetMetadata.dcCatalog.set(configuration.targetElement, value);
+      logger.info("Transferred concatenated metadata element(s)");
+    }
+
+    // set prefix used for the target element's namespace
+    if (configuration.targetPrefix != null) {
+      final XmlNamespaceContext namespace = XmlNamespaceContext.mk(configuration.targetPrefix,
+              configuration.targetElement.getNamespaceURI());
+      targetMetadata.dcCatalog.addBindings(namespace);
+    }
+
+    try {
+      targetMetadata.save();
+    } catch (IOException e) {
+      throw new WorkflowOperationException("Error saving updated metadata catalog", e);
+    }
+
+    return createResult(mediaPackage, Action.CONTINUE);
+  }
+
+  private class Metadata {
+    private final MediaPackage mediaPackage;
+    private final Catalog catalog;
+    private final DublinCoreCatalog dcCatalog;
+
+    /**
+     * Initialize Metadata object by selecting a specified metadata catalog from a given media package.
+     *
+     * @param mediaPackage
+     *          Media package to work on
+     * @param flavor
+     *          Flavor specifying the catalog to select
+     * @throws NoMetadataFoundException
+     *          Could not find catalog with given flavor
+     */
+    Metadata(final MediaPackage mediaPackage, final MediaPackageElementFlavor flavor) throws NoMetadataFoundException {
+      this.mediaPackage = mediaPackage;
+
+      Catalog[] catalogs = mediaPackage.getCatalogs(flavor);
+      if (catalogs.length < 1) {
+        throw new NoMetadataFoundException();
+      }
+
+      if (catalogs.length > 1) {
+        logger.warn("More than one metadata catalog of flavor {} found; using the first one", flavor);
+      }
+      catalog = catalogs[0];
+      dcCatalog = DublinCoreUtil.loadDublinCore(workspace, catalog);
+    }
+
+    /**
+     * Save the modified metadata and update the media package to refer to the new catalog.
+     *
+     * @throws IOException
+     *          Error storing the metadata catalog
+     */
+    private void save() throws IOException {
+      String filename = FilenameUtils.getName(catalog.getURI().toString());
+      InputStream stream = IOUtils.toInputStream(dcCatalog.toXmlString(), StandardCharsets.UTF_8);
+      catalog.setURI(workspace.put(mediaPackage.getIdentifier().toString(), catalog.getIdentifier(), filename, stream));
+      catalog.setChecksum(null);
+    }
+
+    /**
+     * Exception to throw if no catalog with a specified flavor exists in the media package.
+     */
+    class NoMetadataFoundException extends Exception {
+    }
+  }
+
+  /**
+   * Storage for this operation's configuration
+   */
+  private class Configuration {
+    private final MediaPackageElementFlavor sourceFlavor;
+    private final MediaPackageElementFlavor targetFlavor;
+    private final EName sourceElement;
+    private final EName targetElement;
+    private final boolean force;
+    private final String concatDelimiter;
+    private final String targetPrefix;
+
+    /**
+     * Load configuration from given operation.
+     *
+     * @param operation
+     *          Operation to load configuration from
+     * @throws IllegalArgumentException
+     *          Invalid configuration
+     */
+    Configuration(WorkflowOperationInstance operation)
+            throws IllegalArgumentException {
+      // required
+      // will throw IllegalArgumentException if not defined
+      sourceFlavor = MediaPackageElementFlavor.parseFlavor(operation.getConfiguration("source-flavor"));
+      targetFlavor = MediaPackageElementFlavor.parseFlavor(operation.getConfiguration("target-flavor"));
+      sourceElement = EName.fromString(operation.getConfiguration("source-element"));
+      targetElement = EName.fromString(operation.getConfiguration("target-element"));
+
+      // optional arguments
+      force = BooleanUtils.toBoolean(operation.getConfiguration("force"));
+      concatDelimiter = operation.getConfiguration("concat");
+      targetPrefix = operation.getConfiguration("target-prefix");
+    }
+  }
+
+  /** OSGi callback to inject the workspace */
+  public void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
+  }
+
+}

--- a/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/transfer-metadata.xml
+++ b/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/transfer-metadata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.workflow.handler.workflow.TransferMetadataWorkflowOperationHandler"
+               immediate="true">
+
+  <implementation class="org.opencastproject.workflow.handler.workflow.TransferMetadataWorkflowOperationHandler" />
+  <property name="service.description" value="Transfer metadata fields between catalogs" />
+  <property name="workflow.operation" value="transfer-metadata" />
+
+  <service>
+    <provide interface="org.opencastproject.workflow.api.WorkflowOperationHandler" />
+  </service>
+
+  <reference name="Workspace"
+             interface="org.opencastproject.workspace.api.Workspace"
+             bind="setWorkspace" />
+</scr:component>

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/TransferMetadataOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/TransferMetadataOperationHandlerTest.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import org.opencastproject.mediapackage.Catalog;
+import org.opencastproject.mediapackage.CatalogImpl;
+import org.opencastproject.mediapackage.EName;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
+import org.opencastproject.metadata.dublincore.DublinCores;
+import org.opencastproject.workflow.api.WorkflowInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationInstanceImpl;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workspace.api.Workspace;
+
+import org.apache.commons.io.IOUtils;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+public class TransferMetadataOperationHandlerTest {
+
+  private TransferMetadataWorkflowOperationHandler handler;
+  private WorkflowInstanceImpl instance;
+  private WorkflowOperationInstanceImpl operation;
+  private DublinCoreCatalog resultCatalog = null;
+
+  @Before
+  public void setUp() throws Exception {
+    handler = new TransferMetadataWorkflowOperationHandler();
+
+    operation = new WorkflowOperationInstanceImpl("test", WorkflowOperationInstance.OperationState.RUNNING);
+
+    String dc = IOUtils.toString(getClass().getResourceAsStream("/dublincore.xml"), StandardCharsets.UTF_8);
+    Workspace workspace = EasyMock.createMock(Workspace.class);
+    EasyMock.expect(workspace.read(EasyMock.anyObject()))
+            .andAnswer(() -> getClass().getResourceAsStream("/dublincore.xml")).anyTimes();
+    EasyMock.expect(workspace.put(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyObject()))
+            .andAnswer(() -> {
+              resultCatalog = DublinCores.read((InputStream) EasyMock.getCurrentArguments()[3]);
+              return new URI("http://example.opencast.org/xy");
+            }).once();
+    EasyMock.replay(workspace);
+    handler.setWorkspace(workspace);
+
+    MediaPackage mediaPackage = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
+    Catalog catalog = CatalogImpl.fromURI(new URI("http://example.com"));
+    catalog.setFlavor(MediaPackageElementFlavor.parseFlavor("dublincore/episode"));
+    mediaPackage.add(catalog);
+    instance = EasyMock.createMock(WorkflowInstanceImpl.class);
+    EasyMock.expect(instance.getCurrentOperation()).andReturn(operation).anyTimes();
+    EasyMock.expect(instance.getMediaPackage()).andReturn(mediaPackage).anyTimes();
+    EasyMock.replay(instance);
+  }
+
+  @Test
+  public void testNoConfiguration() throws WorkflowOperationException {
+    try {
+      handler.start(instance, null);
+      Assert.fail("Operation should fail");
+    } catch (IllegalArgumentException e) {
+      // this is expected
+    }
+
+    operation.setConfiguration("source-flavor", "dublincore/episode");
+    operation.setConfiguration("target-flavor", "lk/episode");
+
+    try {
+      handler.start(instance, null);
+      Assert.fail("Operation should fail");
+    } catch (IllegalArgumentException e) {
+      // this is expected
+    }
+  }
+
+  @Test
+  public void testExistingElement() throws WorkflowOperationException {
+    // setup
+    operation.setConfiguration("source-flavor", "dublincore/episode");
+    operation.setConfiguration("target-flavor", "dublincore/episode");
+    operation.setConfiguration("source-element", "{http://purl.org/dc/terms/}title");
+    operation.setConfiguration("target-element", "{http://purl.org/dc/terms/}description");
+
+    // execution
+    try {
+      handler.start(instance, null);
+      Assert.fail("Operation should have failed");
+    } catch (WorkflowOperationException e) {
+      // expected
+    }
+
+    // force
+    operation.setConfiguration("force", "true");
+    WorkflowOperationResult result = handler.start(instance, null);
+
+    // checks
+    Assert.assertEquals(WorkflowOperationResult.Action.CONTINUE, result.getAction());
+    Assert.assertNotNull(resultCatalog);
+    EName src = EName.mk("http://purl.org/dc/terms/", "title");
+    EName dest = EName.mk("http://purl.org/dc/terms/", "description");
+    Assert.assertEquals(resultCatalog.get(src).size(), resultCatalog.get(dest).size());
+    Assert.assertEquals(resultCatalog.getFirst(src), resultCatalog.getFirst(dest));
+  }
+
+  @Test
+  public void testSkip() throws WorkflowOperationException {
+    // setup
+    operation.setConfiguration("source-flavor", "does-not/exist");
+    operation.setConfiguration("target-flavor", "dublincore/episode");
+    operation.setConfiguration("source-element", "does-not-exist");
+    operation.setConfiguration("target-element", "{http://purl.org/dc/terms/}description");
+
+    // skip since source catalog does not exists
+    WorkflowOperationResult result = handler.start(instance, null);
+    Assert.assertEquals(WorkflowOperationResult.Action.SKIP, result.getAction());
+  }
+
+}


### PR DESCRIPTION
It is sometimes useful to transfer metadata from one catalog or one
element to another metadata element. For example, one could transfer the
people involved in a series to the episode metadata.

This workflow operation allows us to transfer arbitrary elements to
arbitrary locations within the metadata catalogs.