### PR TITLE
MH-13593: Incorrect default waveform colors

### DIFF
--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -44,6 +44,7 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
@@ -402,8 +403,10 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
       filterBuilder.append(waveformFilterPre);
       filterBuilder.append(",");
     }
-    if (color != null) {
-      waveformColor =  StringUtils.split(color, "|");
+    String[] waveformOperationColors = ArrayUtils.clone(waveformColor);
+    //If the color was set, override the defaults
+    if (StringUtils.isNotBlank(color)) {
+      waveformOperationColors = StringUtils.split(color, "|");
     }
     filterBuilder.append("showwavespic=");
     filterBuilder.append("split_channels=");
@@ -415,7 +418,7 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
     filterBuilder.append(":scale=");
     filterBuilder.append(waveformScale);
     filterBuilder.append(":colors=");
-    filterBuilder.append(StringUtils.join(Arrays.asList(waveformColor), "|"));
+    filterBuilder.append(StringUtils.join(Arrays.asList(waveformOperationColors), "|"));
     if (waveformFilterPost != null) {
       filterBuilder.append(",");
       filterBuilder.append(waveformFilterPost);

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -44,7 +44,6 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
@@ -403,10 +402,12 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
       filterBuilder.append(waveformFilterPre);
       filterBuilder.append(",");
     }
-    String[] waveformOperationColors = ArrayUtils.clone(waveformColor);
+    String[] waveformOperationColors = null;
     //If the color was set, override the defaults
     if (StringUtils.isNotBlank(color)) {
       waveformOperationColors = StringUtils.split(color, "|");
+    } else {
+      waveformOperationColors = waveformColor;
     }
     filterBuilder.append("showwavespic=");
     filterBuilder.append("split_channels=");

--- a/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
+++ b/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
@@ -159,7 +159,7 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
 
     String color = StringUtils.trimToNull(workflowInstance.getCurrentOperation().getConfiguration(COLOR_PROPERTY));
     if (StringUtils.isBlank(color)) {
-      logger.info("Waveform color setting is blank, defaulting to {}", DEFAULT_COLOR);
+      logger.debug("Waveform color setting is blank, defaulting to {}", DEFAULT_COLOR);
       color = DEFAULT_COLOR;
     }
 

--- a/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
+++ b/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
@@ -80,6 +80,9 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
   /** Default value of height configuration. */
   private static final int DEFAULT_HEIGHT = 500;
 
+  /** Default value for the waveform color to generate. */
+  private static final String DEFAULT_COLOR = "black";
+
   /** Pixel per minute of waveform image width configuration property name. */
   private static final String PIXELS_PER_MINUTE_PROPERTY = "pixels-per-minute";
 
@@ -155,6 +158,10 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
     );
 
     String color = StringUtils.trimToNull(workflowInstance.getCurrentOperation().getConfiguration(COLOR_PROPERTY));
+    if (StringUtils.isBlank(color)) {
+      logger.info("Waveform color setting is blank, defaulting to {}", DEFAULT_COLOR);
+      color = DEFAULT_COLOR;
+    }
 
     try {
       TrackSelector trackSelector = new TrackSelector();

--- a/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
+++ b/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
@@ -80,9 +80,6 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
   /** Default value of height configuration. */
   private static final int DEFAULT_HEIGHT = 500;
 
-  /** Default value for the waveform color to generate. */
-  private static final String DEFAULT_COLOR = "black";
-
   /** Pixel per minute of waveform image width configuration property name. */
   private static final String PIXELS_PER_MINUTE_PROPERTY = "pixels-per-minute";
 
@@ -158,10 +155,6 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
     );
 
     String color = StringUtils.trimToNull(workflowInstance.getCurrentOperation().getConfiguration(COLOR_PROPERTY));
-    if (StringUtils.isBlank(color)) {
-      logger.debug("Waveform color setting is blank, defaulting to {}", DEFAULT_COLOR);
-      color = DEFAULT_COLOR;
-    }
 
     try {
       TrackSelector trackSelector = new TrackSelector();


### PR DESCRIPTION
Resolving the white waveform image issue:

* This patch resolves an issue where the waveform workflow operation overwrote the service-wide defaults with its current settings.
* The waveform service's service wide setting was also (by default) blank, which leads to white images, which are invisible in the current UI.
* Set the default of black when the waveform WOH's color parameter was blank.