### PR TITLE
MH-13602, Update jackson-databind to fix CVE-2019-12086

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <guava.version>23.0</guava.version>
     <httpcomponents-httpclient.version>4.5.7</httpcomponents-httpclient.version>
     <httpcomponents-httpcore.version>4.4.11</httpcomponents-httpcore.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.9.9</jackson.version>
     <jdk.version>1.8</jdk.version>
     <joda-time.version>2.10.1</joda-time.version>
     <json-simple.version>1.1.1</json-simple.version>


### PR DESCRIPTION
- [CVE-2019-12086](https://nvd.nist.gov/vuln/detail/CVE-2019-12086)
- moderate severity
- Vulnerable versions: >= 2.0.0, < 2.9.9
- Patched version: 2.9.9

A Polymorphic Typing issue was discovered in FasterXML jackson-databind
2.x before 2.9.9. When Default Typing is enabled (either globally or for
a specific property) for an externally exposed JSON endpoint, the
service has the mysql-connector-java jar (8.0.14 or earlier) in the
classpath, and an attacker can host a crafted MySQL server reachable by
the victim, an attacker can send a crafted JSON message that allows them
to read arbitrary local files on the server. This occurs because of
missing com.mysql.cj.jdbc.admin.MiniAdmin validation.

---

Shouldn't be a high risk for Opencast but better safe than sorry.