### PR TITLE
MH-13604 color "blue" for links in the admin ui

### DIFF
--- a/modules/admin-ui/src/main/webapp/styles/base/_layout.scss
+++ b/modules/admin-ui/src/main/webapp/styles/base/_layout.scss
@@ -42,7 +42,7 @@ body {
 // Resets
 
 a {
-    color: $color-link;
+    color: #1d5888;
     text-decoration: none;
 
     &:hover {


### PR DESCRIPTION
A user can not see directly which parts of the admin-ui are links or actions.
This patch adds color "blue" as used for Links Details/Edit for all links
in the admin ui.

![Links_blue](https://user-images.githubusercontent.com/3499600/58966886-64b52680-87b3-11e9-8efb-9de63ab06429.png)
