### PR TITLE
MH-13606 Don't archive smil on publication

### DIFF
--- a/etc/workflows/partial-publish-process-smil.xml
+++ b/etc/workflows/partial-publish-process-smil.xml
@@ -23,33 +23,11 @@
         <configuration key="source-flavors">*/work</configuration>
         <configuration key="preview-flavors">*/preview</configuration>
         <configuration key="smil-flavors">smil/cutting</configuration>
-        <configuration key="target-smil-flavor">smil/cutting</configuration>
+        <configuration key="target-smil-flavor">smil/publish</configuration>
         <configuration key="target-flavor-subtype">trimmed</configuration>
         <configuration key="interactive">false</configuration>
         <!-- skip the built in editor transcode to use process-smil-->
         <configuration key="skip-processing">true</configuration>
-      </configurations>
-    </operation>
-
-    <!-- Tag smil/cutting for later re-use in case of re-publishing of the event
-         Note that WOH editor will re-use target-smil-flavor instead of adding a new one -->
-
-    <operation
-      id="tag"
-      description="Tagging cutting information for archival">
-      <configurations>
-        <configuration key="source-flavors">smil/cutting</configuration>
-        <configuration key="target-tags">archive</configuration>
-      </configurations>
-    </operation>
-
-    <!-- Archive smil/cutting right now information to ensure we don't loose it in case later operations fail -->
-
-    <operation
-      id="snapshot"
-      description="Archive cutting information">
-      <configurations>
-        <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>
 
@@ -64,7 +42,7 @@
        <!-- 2 independent operations are defined here separated by a semi colon -->
        <!-- They will run concurrently as two encoding operations on 2 workers using the correponding profiles -->
        <configuration key="source-flavors">presenter/work;presentation/work</configuration>
-       <configuration key="smil-flavor">smil/cutting</configuration>
+       <configuration key="smil-flavor">smil/publish</configuration>
        <!-- Both operations are tagged and flavored the same way -->
        <configuration key="target-flavors">*/delivery</configuration>
        <configuration key="target-tags">engage-download,engage-streaming</configuration>

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -31,31 +31,9 @@
       <configurations>
         <configuration key="source-flavors">*/work</configuration>
         <configuration key="smil-flavors">smil/cutting</configuration>
-        <configuration key="target-smil-flavor">smil/cutting</configuration>
+        <configuration key="target-smil-flavor">smil/publish</configuration>
         <configuration key="target-flavor-subtype">trimmed</configuration>
         <configuration key="interactive">false</configuration>
-      </configurations>
-    </operation>
-
-    <!-- Tag smil/cutting for later re-use in case of re-publishing of the event
-         Note that WOH editor will re-use target-smil-flavor instead of adding a new one -->
-
-    <operation
-      id="tag"
-      description="Tagging cutting information for archival">
-      <configurations>
-        <configuration key="source-flavors">smil/cutting</configuration>
-        <configuration key="target-tags">archive</configuration>
-      </configurations>
-    </operation>
-
-    <!-- Archive smil/cutting right now information to ensure we don't loose it in case later operations fail -->
-
-    <operation
-      id="snapshot"
-      description="Archive cutting information">
-      <configurations>
-        <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>
 


### PR DESCRIPTION
Don't overwrite the original smil with the one created on publication, since the later might have a different base than the former (e.g. longer tracks might have been hidden, changing the length of the video),
leading to strange effects in the video editor afterwards (e.g. cut segments appearing). Instead, recreate the second smil every time we publish.

_This work was sponsored by SWITCH._