### PR TITLE
MH-13612, Tag elements retrieved from asset manager

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -9,6 +9,9 @@ Features
 Improvements
 ------------
 
+- Media package elements retrieved from the asset manager (e.g. using “start task”) now always get tagged `archive` even
+  when they have not been tagged thus before.
+
 
 Configuration changes
 ---------------------

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SnapshotDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SnapshotDto.java
@@ -27,12 +27,14 @@ import org.opencastproject.assetmanager.api.Snapshot;
 import org.opencastproject.assetmanager.impl.SnapshotImpl;
 import org.opencastproject.assetmanager.impl.VersionImpl;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageParser;
 
 import org.eclipse.persistence.annotations.CascadeOnDelete;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Set;
 
@@ -181,6 +183,14 @@ public class SnapshotDto {
   }
 
   public Snapshot toSnapshot() {
+    MediaPackage mediaPackage = Conversions.toMediaPackage(mediaPackageXml);
+    // ensure elements are tagged `archive`
+    for (MediaPackageElement element: mediaPackage.getElements()) {
+      if (!Arrays.asList(element.getTags()).contains("archive")) {
+        logger.debug("Adding additional tag `archive` to element {} retrieved from asset manager", element);
+        element.addTag("archive");
+      }
+    }
     return new SnapshotImpl(
             id,
             Conversions.toVersion(version),
@@ -189,7 +199,7 @@ public class SnapshotDto {
             Availability.valueOf(availability),
             storageId,
             owner,
-            Conversions.toMediaPackage(mediaPackageXml));
+            mediaPackage);
   }
 
   /**


### PR DESCRIPTION
By now, it seems to be the general assumptions that elements stored in
and then retrieved from the asset manager have the tag `archive`.

While this is often the case as the `archive` tag is widely used to
flag elements for archival, this is by no means guaranteed and this
misconception has lead to multiple issues over the last years.

Multiple workarounds and partial fixes have been added for this, e.g.:

  https://github.com/opencast/opencast/blob/49fe433b42d6dd1ec59c7364d23ff1060f19040a/etc/workflows/fast.xml#L81-L83

…but this can still easily happen again.

This patch finally ensures that all elements which are retrieved from
the asset manager as part of a media package are guaranteed to have the
`archive` tag, finally bringing an end to workarounds and uncertainty.