### PR TITLE
MH-13616, Fix bundle versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,8 @@ jobs:
         - (! grep -rn ' $' modules assemblies pom.xml --include=pom.xml)
         - (! grep -rn '	' etc)
         - (! grep -rn ' $' etc)
-        # build number must be present in all but four modules
-        - grep -L '<Build-Number>${buildNumber}</Build-Number>' modules/*/pom.xml | wc -l | grep -q 4
+        # build number must be present in all modules
+        - grep -L '<Build-Number>${buildNumber}</Build-Number>' modules/*/pom.xml | wc -l | grep -q '^0$'
         - >
           ( cd docs/guides/admin &&
             mkdocs build > mkdocs.log 2>&1 &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,8 @@ jobs:
         - (! grep -rn ' $' modules assemblies pom.xml --include=pom.xml)
         - (! grep -rn '	' etc)
         - (! grep -rn ' $' etc)
+        # build number must be present in all but four modules
+        - grep -L '<Build-Number>${buildNumber}</Build-Number>' modules/*/pom.xml | wc -l | grep -q 4
         - >
           ( cd docs/guides/admin &&
             mkdocs build > mkdocs.log 2>&1 &&

--- a/modules/engage-theodul-plugin-archetype/pom.xml
+++ b/modules/engage-theodul-plugin-archetype/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- <Build-Number>${buildNumber}</Build-Number> not necessary since this is no OSGi bundle -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.opencastproject</groupId>
   <artifactId>opencast-theodul-plugin</artifactId>

--- a/modules/hello-world-api/pom.xml
+++ b/modules/hello-world-api/pom.xml
@@ -33,6 +33,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Build-Number>${buildNumber}</Build-Number>
             <Export-Package>org.opencastproject.helloworld.api;version=${project.version}</Export-Package>
           </instructions>
         </configuration>

--- a/modules/hello-world-impl/pom.xml
+++ b/modules/hello-world-impl/pom.xml
@@ -99,6 +99,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,

--- a/modules/ingest-download-service-api/pom.xml
+++ b/modules/ingest-download-service-api/pom.xml
@@ -35,6 +35,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Build-Number>${buildNumber}</Build-Number>
             <Export-Package>org.opencastproject.ingestdownloadservice.api.*;version=${project.version}</Export-Package>
           </instructions>
         </configuration>

--- a/modules/ingest-download-service-impl/pom.xml
+++ b/modules/ingest-download-service-impl/pom.xml
@@ -104,6 +104,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,

--- a/modules/rest-test-environment/pom.xml
+++ b/modules/rest-test-environment/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- <Build-Number>${buildNumber}</Build-Number> not necessary since this is no OSGi bundle -->
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opencast-rest-test-environment</artifactId>
   <name>Opencast :: rest-test-environment</name>

--- a/modules/workflow-condition-parser/pom.xml
+++ b/modules/workflow-condition-parser/pom.xml
@@ -56,6 +56,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
               *
             </Import-Package>


### PR DESCRIPTION
This patch adds a few missing build versions, fixing the display of the
build version in the admin interface. It also adds a simple check for
this, ensuring that new modules will not forget about this any longer.