### PR TITLE
MH-13611 duplicate events fix

### DIFF
--- a/etc/workflows/duplicate-event.xml
+++ b/etc/workflows/duplicate-event.xml
@@ -51,7 +51,7 @@
         <configuration key="source-flavors">*/*</configuration>
         <configuration key="number-of-events">${numberOfEvents}</configuration>
         <configuration key="target-tags"></configuration>
-        <configuration key="property-namespaces">org.opencastproject.assetmanager.security</configuration>
+        <configuration key="property-namespaces">org.opencastproject.assetmanager.security,org.opencastproject.workflow.configuration</configuration>
         <configuration key="copy-number-prefix">copy</configuration>
       </configurations>
     </operation>


### PR DESCRIPTION
As I posted in Jira, This patch modifies the Duplicate workflow to add the parameters that were set by the user in the original event when this was created.

Thanks to @staubesv for the suggestion.