### PR TITLE
MH-13617 Re-introduce Prepare AV

### DIFF
--- a/etc/org.opencastproject.adminui.cfg
+++ b/etc/org.opencastproject.adminui.cfg
@@ -202,15 +202,15 @@
 #
 # The default workflows use presenter/source, so that's the recommended default value.
 #
-# Default: presenter/source
-#sourcetrack.left.flavor=presenter/source
+# Default: presenter/prepared
+sourcetrack.left.flavor=presenter/prepared
 
 # Flavor that identifies the right hand stream, for use in the "Tracks" and "Thumbnail" panels of the video editor.
 #
 # The default workflows use presentation/source, so that's the recommended default value.
 #
-# Default: presentation/source
-#sourcetrack.right.flavor=presentation/source
+# Default: presentation/prepared
+sourcetrack.right.flavor=presentation/prepared
 
 # Flavor subtype that identifies audio preview elements, for use in the
 # "Tracks" panel of the video editor.

--- a/etc/workflows/cleanup-publish-placeholder.xml
+++ b/etc/workflows/cleanup-publish-placeholder.xml
@@ -73,7 +73,7 @@
       exception-handler-workflow="error"
       description="Tagging media package elements for deletion">
       <configurations>
-        <configuration key="source-flavors">*/source,*/player+preview</configuration>
+        <configuration key="source-flavors">*/source,*/prepared,*/player+preview</configuration>
         <configuration key="target-tags">-archive</configuration>
       </configurations>
     </operation>

--- a/etc/workflows/partial-preview.xml
+++ b/etc/workflows/partial-preview.xml
@@ -22,17 +22,17 @@
       exception-handler-workflow="partial-error"
       description="Analyze tracks in media package and set control variables">
       <configurations>
-        <configuration key="source-flavor">*/work</configuration>
+        <configuration key="source-flavor">*/prepared</configuration>
       </configurations>
     </operation>
 
     <operation id="compose"
       description="Create single-stream video preview"
-      if="NOT (${presenter_work_video} AND ${presentation_work_video})"
+      if="NOT (${presenter_prepared_video} AND ${presentation_prepared_video})"
       fail-on-error="true"
       exception-handler-workflow="partial-error">
       <configurations>
-        <configuration key="source-flavors">*/work</configuration>
+        <configuration key="source-flavors">*/prepared</configuration>
         <configuration key="target-flavor">*/preview</configuration>
         <configuration key="target-tags">preview</configuration>
         <configuration key="encoding-profile">mp4-preview.http</configuration>
@@ -42,12 +42,12 @@
     <operation
       id="composite"
       description="Create dual-stream video preview"
-      if="${presenter_work_video} AND ${presentation_work_video}"
+      if="${presenter_prepared_video} AND ${presentation_prepared_video}"
       fail-on-error="true"
       exception-handler-workflow="partial-error">
       <configurations>
-        <configuration key="source-flavor-lower">presentation/work</configuration>
-        <configuration key="source-flavor-upper">presenter/work</configuration>
+        <configuration key="source-flavor-lower">presentation/prepared</configuration>
+        <configuration key="source-flavor-upper">presenter/prepared</configuration>
         <configuration key="encoding-profile">mp4-preview.dual.http</configuration>
         <configuration key="target-flavor">composite/preview</configuration>
         <configuration key="target-tags">preview</configuration>
@@ -89,7 +89,7 @@
       description="Create video preview images for presenter and presentation"
       exception-handler-workflow="partial-error">
       <configurations>
-        <configuration key="source-flavor">*/work</configuration>
+        <configuration key="source-flavor">*/prepared</configuration>
         <configuration key="target-flavor">*/video+preview</configuration>
         <configuration key="target-tags">preview</configuration>
         <configuration key="encoding-profile">editor.tracks.preview</configuration>
@@ -102,7 +102,7 @@
       fail-on-error="false"
       description="Generating waveform">
       <configurations>
-        <configuration key="source-flavor">*/work</configuration>
+        <configuration key="source-flavor">*/prepared</configuration>
         <configuration key="target-flavor">*/audio+preview</configuration>
         <configuration key="target-tags">preview</configuration>
         <configuration key="min-width">688</configuration>
@@ -126,11 +126,11 @@
     <!-- If we have a presenter track, we extract the default thumbnail from the presenter track -->
 
     <operation id="image"
-               if="${thumbnailType} == 0 AND ${presenter_work_video}"
+               if="${thumbnailType} == 0 AND ${presenter_prepared_video}"
                exception-handler-workflow="partial-error"
                description="Extract default thumbnail preview image from presenter track">
       <configurations>
-        <configuration key="source-flavor">presenter/work</configuration>
+        <configuration key="source-flavor">presenter/prepared</configuration>
         <configuration key="target-flavor">thumbnail/preview</configuration>
         <configuration key="target-tags">preview</configuration>
         <configuration key="encoding-profile">editor.thumbnail.preview</configuration>
@@ -142,11 +142,11 @@
          presentation track -->
 
     <operation id="image"
-               if="${thumbnailType} == 0 AND ${presentation_work_video} AND NOT (${presenter_work_video})"
+               if="${thumbnailType} == 0 AND ${presentation_prepared_video} AND NOT (${presenter_prepared_video})"
               exception-handler-workflow="partial-error"
               description="Extract thumbnail preview image from presentation track">
       <configurations>
-        <configuration key="source-flavor">presentation/work</configuration>
+        <configuration key="source-flavor">presentation/prepared</configuration>
         <configuration key="target-flavor">thumbnail/preview</configuration>
         <configuration key="target-tags">preview</configuration>
         <configuration key="encoding-profile">editor.thumbnail.preview</configuration>
@@ -171,14 +171,14 @@
 
     <!-- Snapshot Thumbnail (2)
          The snapshot thumbnail is extracted from the flavor type as provided by the variable
-         thumbnailTrack at position thumbnailPosition relative to the uncutted media. -->
+         thumbnailTrack at position thumbnailPosition relative to the uncut media. -->
 
     <operation id="image"
                if="${thumbnailType} == 2"
                exception-handler-workflow="partial-error"
                description="Extract snapshot thumbnail preview image">
       <configurations>
-        <configuration key="source-flavor">${thumbnailTrack}/source</configuration>
+        <configuration key="source-flavor">${thumbnailTrack}/prepared</configuration>
         <configuration key="target-flavor">thumbnail/preview</configuration>
         <configuration key="target-tags">preview</configuration>
         <configuration key="encoding-profile">editor.thumbnail.preview</configuration>
@@ -201,7 +201,7 @@
       <configurations>
         <configuration key="source-flavors">*/preview</configuration>
         <configuration key="smil-flavor-subtype">silence</configuration>
-        <configuration key="reference-tracks-flavor">*/work</configuration>
+        <configuration key="reference-tracks-flavor">*/prepared</configuration>
       </configurations>
     </operation>
 

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -11,6 +11,17 @@
   <operations>
 
     <operation
+        id="select-tracks"
+        exception-handler-workflow="partial-error"
+        description="Preparing presenter (camera) audio and video work versions">
+      <configurations>
+        <configuration key="source-flavor">*/prepared</configuration>
+        <configuration key="target-flavor">*/work</configuration>
+        <configuration key="target-tags">-archive</configuration>
+      </configurations>
+    </operation>
+
+    <operation
         id="analyze-tracks"
         exception-handler-workflow="partial-error"
         description="Analyze tracks in media package a set control variables">

--- a/etc/workflows/publish-after-cutting.xml
+++ b/etc/workflows/publish-after-cutting.xml
@@ -44,25 +44,6 @@
     </operation>
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <!-- Prepare the work media                                            -->
-    <!--                                                                   -->
-    <!-- Ensure the work media is in a format that allows Opencast to do   -->
-    <!-- its work. This includes potentially rewriting the container and   -->
-    <!-- making sure that the audio track is part of each video track.     -->
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-    <operation
-        id="select-tracks"
-        exception-handler-workflow="partial-error"
-        description="Preparing presenter (camera) audio and video work versions">
-      <configurations>
-        <configuration key="source-flavor">*/source</configuration>
-        <configuration key="target-flavor">*/work</configuration>
-        <configuration key="target-tags">-archive</configuration>
-      </configurations>
-    </operation>
-
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- Publish                                                           -->
     <!--                                                                   -->
     <!-- Encode and publish the recording to the selected publication      -->

--- a/etc/workflows/publish.xml
+++ b/etc/workflows/publish.xml
@@ -150,35 +150,6 @@
     </operation>
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <!-- Prepare asset                                                     -->
-    <!--                                                                   -->
-    <!-- Prepare the recording for asset management, including creation of -->
-    <!-- previews, audio waveforms and storing of the recording data in    -->
-    <!-- the asset area for further processing.                            -->
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-    <!-- Prepare work versions of the source material for further processing -->
-
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <!-- Prepare the work media                                            -->
-    <!--                                                                   -->
-    <!-- Ensure the work media is in a format that allows Opencast to do   -->
-    <!-- its work. This includes potentially rewriting the container and   -->
-    <!-- making sure that the audio track is part of each video track.     -->
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-    <operation
-        id="select-tracks"
-        exception-handler-workflow="partial-error"
-        description="Preparing presenter (camera) audio and video work versions">
-      <configurations>
-        <configuration key="source-flavor">*/source</configuration>
-        <configuration key="target-flavor">*/work</configuration>
-        <configuration key="target-tags">-archive</configuration>
-      </configurations>
-    </operation>
-
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
     <!-- Publish                                                           -->
     <!--                                                                   -->
     <!-- Encode and publish the recording to the selected publication      -->

--- a/etc/workflows/schedule-and-upload.xml
+++ b/etc/workflows/schedule-and-upload.xml
@@ -221,14 +221,33 @@
     <!-- making sure that the audio track is part of each video track.     -->
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 
+    <!-- Prepare presenter track -->
+
     <operation
-        id="select-tracks"
+        id="prepare-av"
         exception-handler-workflow="partial-error"
         description="Preparing presenter (camera) audio and video work versions">
       <configurations>
-        <configuration key="source-flavor">*/source</configuration>
-        <configuration key="target-flavor">*/work</configuration>
-        <configuration key="target-tags">-archive</configuration>
+        <configuration key="source-flavor">presenter/source</configuration>
+        <configuration key="target-flavor">presenter/prepared</configuration>
+        <configuration key="target-tags">archive</configuration>
+        <configuration key="rewrite">false</configuration>
+        <configuration key="audio-muxing-source-flavors">*/?,*/*</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Prepare presentation track -->
+
+    <operation
+        id="prepare-av"
+        exception-handler-workflow="partial-error"
+        description="Preparing presentation (screen) audio and video work version">
+      <configurations>
+        <configuration key="source-flavor">presentation/source</configuration>
+        <configuration key="target-flavor">presentation/prepared</configuration>
+        <configuration key="rewrite">false</configuration>
+        <configuration key="target-tags">archive</configuration>
+        <configuration key="audio-muxing-source-flavors">*/?,*/*</configuration>
       </configurations>
     </operation>
 

--- a/etc/workflows/update-previews.xml
+++ b/etc/workflows/update-previews.xml
@@ -23,19 +23,6 @@
         </configurations>
       </operation>
 
-    <!-- Prepare the work media                                            -->
-
-    <operation
-        id="select-tracks"
-        exception-handler-workflow="partial-error"
-        description="Preparing presenter (camera) audio and video work versions">
-      <configurations>
-        <configuration key="source-flavor">*/source</configuration>
-        <configuration key="target-flavor">*/work</configuration>
-        <configuration key="target-tags">-archive</configuration>
-      </configurations>
-    </operation>
-
       <!-- Create preview artifacts -->
 
       <operation


### PR DESCRIPTION
The Select-Tracks WO replaced prepare-av at parts of the standard workflow where it doesn't make sense. This also archives the media created by prepare-av so they don't have to be re-created.

~This PR includes #952.~

_This work was sponsored by SWITCH._