### PR TITLE
MH-13619, Fix Logging in Video Segmenter

### DIFF
--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
@@ -636,7 +636,7 @@ VideoSegmenterService, ManagedService {
     String[] command = new String[] { binary, "-nostats", "-i", mediaFile.getAbsolutePath(),
       "-filter:v", "select=gt(scene\\," + changesThreshold + "),showinfo", "-f", "null", "-"};
 
-    logger.info("Detecting video segments using command: {}", command);
+    logger.info("Detecting video segments using command: {}", (Object) command);
 
     ProcessBuilder pbuilder = new ProcessBuilder(command);
     List<String> segmentsStrings = new LinkedList<String>();


### PR DESCRIPTION
The FFmpeg command run by the video segmenter is passed to the logger as
array of strings which is interpreted as variable argument instead of a
single argument.