### PR TITLE
MH-13633, Update spring-security-oauth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -922,7 +922,7 @@
       <dependency>
         <groupId>org.springframework.security.oauth</groupId>
         <artifactId>spring-security-oauth</artifactId>
-        <version>2.3.5.RELEASE</version>
+        <version>2.3.6.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
- [CVE-2019-11269](https://nvd.nist.gov/vuln/detail/CVE-2019-11269) moderate severity
- Vulnerable versions: >= 2.3.0, < 2.3.6
- Patched version: 2.3.6

Spring Security OAuth versions 2.3 prior to 2.3.6, 2.2 prior to 2.2.5,
2.1 prior to 2.1.5, and 2.0 prior to 2.0.18, as well as older
unsupported versions could be susceptible to an open redirector attack
that can leak an authorization code. A malicious user or attacker can
craft a request to the authorization endpoint using the authorization
code grant type, and specify a manipulated redirection URI via the
redirect_uri parameter. This can cause the authorization server to
redirect the resource owner user-agent to a URI under the control of the
attacker with the leaked authorization code.