### PR TITLE
NOJIRA: Add `ALTER` to necessary MySQL permissions

### DIFF
--- a/docs/guides/admin/docs/configuration/database.md
+++ b/docs/guides/admin/docs/configuration/database.md
@@ -68,10 +68,19 @@ create a database called `opencast` by executing:
 
 Then create a user `opencast` with a password and grant it all necessary rights:
 
-    GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX,TRIGGER,CREATE TEMPORARY TABLES,REFERENCES ON opencast.*
+    GRANT SELECT,INSERT,UPDATE,DELETE ON opencast.*
       TO 'opencast'@'localhost' IDENTIFIED BY 'opencast_password';
 
-You can choose another name for the user and database and should use a different password.
+The rights granted here are all that is needed to *run* Opencast. To execute the migration scripts
+used to initialize (see next section) and upgrade the database schema upon releases of new versions
+of Opencast, you need more. If you don't want to do this using the `root` user (which normally
+can do anything), but with a dedicated user called `admin` for the sake of the example,
+you should grant that user the following rights:
+
+    GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,ALTER,DROP,INDEX,TRIGGER,CREATE TEMPORARY TABLES,REFERENCES ON opencast.*
+      TO 'admin'@'localhost' IDENTIFIED BY 'opencast_admin_password';
+
+You can choose other names for the users and the database, and you **should** use a different password.
 
 In a distributed system, apart from `'username'@'localhost'` (which would allow access from the local machine only),
 you should grant a external user access to the database by running the same command for a user like

--- a/docs/guides/admin/docs/configuration/database.md
+++ b/docs/guides/admin/docs/configuration/database.md
@@ -68,7 +68,7 @@ create a database called `opencast` by executing:
 
 Then create a user `opencast` with a password and grant it all necessary rights:
 
-    GRANT SELECT,INSERT,UPDATE,DELETE ON opencast.*
+    GRANT SELECT,INSERT,UPDATE,DELETE,CREATE TEMPORARY TABLES ON opencast.*
       TO 'opencast'@'localhost' IDENTIFIED BY 'opencast_password';
 
 The rights granted here are all that is needed to *run* Opencast. To execute the migration scripts


### PR DESCRIPTION
I just tried to upgrade an Opencast installation from 6 to 7. Running the database migration script failed, though, because I didn't have the right to `ALTER` tables. I used the docs to create my database user, which did not list this permission bit.

However, looking through other migration scripts, I saw that they also already used `ALTER` statements, so maybe this omission is intentional?