### PR TITLE
MH-13636 Improve setting values from dublin core catalog

### DIFF
--- a/modules/admin-ui/src/test/resources/episode-catalog.properties
+++ b/modules/admin-ui/src/test/resources/episode-catalog.properties
@@ -52,16 +52,6 @@ property.startDate.required=false
 property.startDate.pattern=yyyy-MM-dd'T'HH:mm:ssX
 property.startDate.order=3
 
-# A Start Time property
-property.startTime.inputID=temporal
-property.startTime.outputID=startTime
-property.startTime.label=EVENTS.EVENTS.DETAILS.METADATA.START_TIME
-property.startTime.type=start_time
-property.startTime.readOnly=false
-property.startTime.required=false
-property.startTime.pattern=yyyy-MM-dd'T'HH:mm:ssX
-property.startTime.order=4
-
 # Series
 property.series.inputID=isPartOf
 property.series.label=EVENTS.EVENTS.DETAILS.METADATA.SERIES

--- a/modules/dublincore/pom.xml
+++ b/modules/dublincore/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
     </dependency>

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
@@ -34,6 +34,7 @@ import com.entwinemedia.fn.data.json.Field;
 import com.entwinemedia.fn.data.json.JObject;
 import com.entwinemedia.fn.data.json.JValue;
 import com.entwinemedia.fn.data.json.Jsons;
+import com.google.common.collect.Iterables;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
@@ -983,6 +984,65 @@ public class MetadataField<A> {
       default:
         throw new IllegalArgumentException("Unknown metadata type! " + type);
     }
+  }
+
+  /**
+   * Set value to a metadata field of unknown type
+   *
+   * @param filteredValues
+   * @param metadataField
+   */
+  public static MetadataField setValueFromDCCatalog(List<String> filteredValues, MetadataField metadataField) {
+
+    if (filteredValues.isEmpty()) {
+      throw new IllegalArgumentException("Values cannot be empty");
+    }
+
+    if (filteredValues.size() > 1
+            && metadataField.getType() != MetadataField.Type.MIXED_TEXT
+            && metadataField.getType() != MetadataField.Type.ITERABLE_TEXT) {
+      logger.warn("Cannot put multiple values into a single-value field, only the last value is used. {}",
+              Arrays.toString(filteredValues.toArray()));
+    }
+
+    switch (metadataField.type) {
+      case BOOLEAN:
+        ((MetadataField<Boolean>)metadataField).setValue(Boolean.parseBoolean(Iterables.getLast(filteredValues)));
+        break;
+      case DATE:
+        if (metadataField.getPattern().isNone()) {
+          metadataField.setPattern(Opt.some("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+        }
+        ((MetadataField<Date>)metadataField).setValue(EncodingSchemeUtils.decodeDate(Iterables.getLast(filteredValues)));
+        break;
+      case DURATION:
+        String value = Iterables.getLast(filteredValues);
+        DCMIPeriod period = EncodingSchemeUtils.decodePeriod(value);
+        Long longValue = period.getEnd().getTime() - period.getStart().getTime();
+        ((MetadataField<String>)metadataField).setValue(longValue.toString());
+        break;
+      case ITERABLE_TEXT:
+      case MIXED_TEXT:
+        ((MetadataField<Iterable<String>>)metadataField).setValue(filteredValues);
+        break;
+      case LONG:
+        ((MetadataField<Long>)metadataField).setValue(Long.parseLong(Iterables.getLast(filteredValues)));
+        break;
+      case START_DATE:
+        if (metadataField.getPattern().isNone()) {
+          metadataField.setPattern(Opt.some("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+        }
+        ((MetadataField<String>)metadataField).setValue(Iterables.getLast(filteredValues));
+        break;
+      case TEXT:
+      case ORDERED_TEXT:
+      case TEXT_LONG:
+        ((MetadataField<String>)metadataField).setValue(Iterables.getLast(filteredValues));
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown metadata type! " + metadataField.getType());
+    }
+    return metadataField;
   }
 
   public Opt<String> getCollectionID() {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/ConfigurableDCCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/ConfigurableDCCatalogUIAdapter.java
@@ -88,10 +88,11 @@ public abstract class ConfigurableDCCatalogUIAdapter implements CatalogUIAdapter
 
   @Override
   public DublinCoreMetadataCollection getRawFields() {
+
     DublinCoreMetadataCollection rawFields = new DublinCoreMetadataCollection();
     for (MetadataField metadataField : dublinCoreProperties.values()) {
       try {
-        rawFields.addField(metadataField, listProvidersService);
+        rawFields.addEmptyField(new MetadataField(metadataField), listProvidersService);
       } catch (IllegalArgumentException e) {
         logger.error("Skipping metadata field '{}' because of error", metadataField, e);
       }
@@ -132,7 +133,8 @@ public abstract class ConfigurableDCCatalogUIAdapter implements CatalogUIAdapter
             List<DublinCoreValue> values = dc.get(propertyKey);
             if (!values.isEmpty()) {
               try {
-                dublinCoreMetadata.addField(metadataField, values.stream().map(DublinCoreValue::getValue).collect(Collectors.toList()),
+                dublinCoreMetadata.addField(new MetadataField(metadataField),
+                        values.stream().map(DublinCoreValue::getValue).collect(Collectors.toList()),
                         getListProvidersService());
                 emptyFields.remove(metadataField);
               } catch (IllegalArgumentException e) {
@@ -148,7 +150,7 @@ public abstract class ConfigurableDCCatalogUIAdapter implements CatalogUIAdapter
     // Add all of the rest of the fields that didn't have values as empty.
     for (MetadataField metadataField: emptyFields) {
       try {
-        dublinCoreMetadata.addField(metadataField, getListProvidersService());
+        dublinCoreMetadata.addEmptyField(new MetadataField(metadataField), getListProvidersService());
       } catch (IllegalArgumentException e) {
         logger.error("Skipping metadata field '{}' because of error", metadataField, e);
       }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
@@ -24,22 +24,18 @@ package org.opencastproject.index.service.catalog.adapter;
 import org.opencastproject.index.service.exception.ListProviderException;
 import org.opencastproject.index.service.resources.list.api.ListProvidersService;
 import org.opencastproject.index.service.resources.list.query.ResourceListQueryImpl;
-import org.opencastproject.metadata.dublincore.DCMIPeriod;
-import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
 import org.opencastproject.metadata.dublincore.MetadataCollection;
 import org.opencastproject.metadata.dublincore.MetadataField;
 
 import com.entwinemedia.fn.data.Opt;
-import com.google.common.collect.Iterables;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -95,19 +91,25 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
           return Opt.some(collection);
         }
       }
-      return Opt.<Map<String, String>> none();
+      return Opt.none();
     } catch (ListProviderException e) {
       logger.warn("Unable to set collection on metadata because {}", ExceptionUtils.getStackTrace(e));
-      return Opt.<Map<String, String>> none();
+      return Opt.none();
     }
+  }
+
+  public void addEmptyField(MetadataField<?> metadataField, ListProvidersService listProvidersService) {
+    List<String> values = new ArrayList(1);
+    String defaultKey = getCollectionDefault(metadataField, listProvidersService); // check for default value
+
+    if (StringUtils.isNotBlank(defaultKey)) {
+      values.add(defaultKey);
+    }
+    addField(metadataField, values, listProvidersService);
   }
 
   public void addField(MetadataField<?> metadataField, String value, ListProvidersService listProvidersService) {
     addField(metadataField, Collections.singletonList(value), listProvidersService);
-  }
-
-  public void addField(MetadataField<?> metadataField, ListProvidersService listProvidersService) {
-    addField(metadataField, Collections.emptyList(), listProvidersService);
   }
 
   public void addField(MetadataField<?> metadataField, List<String> values, ListProvidersService listProvidersService) {
@@ -116,162 +118,13 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
             .filter(StringUtils::isNotBlank)
             .collect(Collectors.toList());
 
-    String defaultKey = getCollectionDefault(metadataField, listProvidersService);
-
-    if (StringUtils.isNotBlank(defaultKey) && filteredValues.isEmpty()) {
-      filteredValues.add(defaultKey);
+    if (!filteredValues.isEmpty()) {
+      metadataField = MetadataField.setValueFromDCCatalog(filteredValues, metadataField);
     }
 
-    if (filteredValues.size() > 1
-            && metadataField.getType() != MetadataField.Type.MIXED_TEXT
-            && metadataField.getType() != MetadataField.Type.ITERABLE_TEXT) {
-      logger.warn("Cannot put multiple values into a single-value field, only the last value is used. {}",
-              Arrays.toString(filteredValues.toArray()));
-    }
+    metadataField.setIsTranslatable(getCollectionIsTranslatable(metadataField, listProvidersService));
+    metadataField.setCollection(getCollection(metadataField, listProvidersService));
 
-    switch (metadataField.getType()) {
-      case BOOLEAN:
-        MetadataField<Boolean> booleanField = MetadataField.createBooleanMetadata(metadataField.getInputID(),
-                Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
-                metadataField.isRequired(), metadataField.getOrder(), metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          booleanField.setValue(Boolean.parseBoolean(Iterables.getLast(filteredValues)));
-        }
-        addField(booleanField);
-        break;
-      case DATE:
-        if (metadataField.getPattern().isNone()) {
-          metadataField.setPattern(Opt.some("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
-        }
-        MetadataField<Date> dateField = MetadataField.createDateMetadata(metadataField.getInputID(),
-                Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
-                metadataField.isRequired(), metadataField.getPattern().get(), metadataField.getOrder(),
-                metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          dateField.setValue(EncodingSchemeUtils.decodeDate(Iterables.getLast(filteredValues)));
-        }
-        addField(dateField);
-        break;
-      case DURATION:
-        MetadataField<String> durationField = MetadataField.createDurationMetadataField(metadataField.getInputID(),
-                Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
-                metadataField.isRequired(), getCollectionIsTranslatable(metadataField, listProvidersService),
-                getCollection(metadataField, listProvidersService),
-                metadataField.getCollectionID(), metadataField.getOrder(), metadataField.getNamespace());
-
-        if (!filteredValues.isEmpty()) {
-          String value = Iterables.getLast(filteredValues);
-          DCMIPeriod period = EncodingSchemeUtils.decodePeriod(value);
-          Long longValue = -1L;
-
-          // Check to see if it is from the front end
-          String[] durationParts = value.split(":");
-          if (durationParts.length == 3) {
-            Integer hours = Integer.parseInt(durationParts[0]);
-            Integer minutes = Integer.parseInt(durationParts[1]);
-            Integer seconds = Integer.parseInt(durationParts[2]);
-            longValue = ((hours.longValue() * 60 + minutes.longValue()) * 60 + seconds.longValue()) * 1000;
-          } else if (period != null && period.hasStart() && period.hasEnd()) {
-            longValue = period.getEnd().getTime() - period.getStart().getTime();
-          } else {
-            try {
-              longValue = Long.parseLong(value);
-            } catch (NumberFormatException e) {
-              logger.debug("Unable to parse duration '{}' value as either a period or millisecond duration.", value);
-              longValue = -1L;
-            }
-          }
-          if (longValue > 0) {
-            durationField.setValue(longValue.toString());
-          }
-        }
-        addField(durationField);
-        break;
-      case ITERABLE_TEXT:
-        // Add an iterable text style field
-        MetadataField<Iterable<String>> iterableTextField = MetadataField.createIterableStringMetadataField(
-                metadataField.getInputID(), Opt.some(metadataField.getOutputID()), metadataField.getLabel(),
-                metadataField.isReadOnly(), metadataField.isRequired(),
-                getCollectionIsTranslatable(metadataField, listProvidersService),
-                getCollection(metadataField, listProvidersService), metadataField.getCollectionID(),
-                metadataField.getDelimiter(), metadataField.getOrder(), metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          iterableTextField.setValue(filteredValues);
-        }
-        addField(iterableTextField);
-        break;
-      case MIXED_TEXT:
-        // Add an iterable text style field
-        MetadataField<Iterable<String>> mixedIterableTextField = MetadataField.createMixedIterableStringMetadataField(
-                metadataField.getInputID(), Opt.some(metadataField.getOutputID()), metadataField.getLabel(),
-                metadataField.isReadOnly(), metadataField.isRequired(),
-                getCollectionIsTranslatable(metadataField, listProvidersService),
-                getCollection(metadataField, listProvidersService), metadataField.getCollectionID(),
-                metadataField.getDelimiter(), metadataField.getOrder(), metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          mixedIterableTextField.setValue(filteredValues);
-        }
-        addField(mixedIterableTextField);
-        break;
-      case LONG:
-        MetadataField<Long> longField = MetadataField.createLongMetadataField(metadataField.getInputID(),
-                Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
-                metadataField.isRequired(), getCollectionIsTranslatable(metadataField, listProvidersService),
-                getCollection(metadataField, listProvidersService),
-                metadataField.getCollectionID(), metadataField.getOrder(), metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          longField.setValue(Long.parseLong(Iterables.getLast(filteredValues)));
-        }
-        addField(longField);
-        break;
-      case TEXT:
-        MetadataField<String> textField = MetadataField.createTextMetadataField(metadataField.getInputID(),
-                Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
-                metadataField.isRequired(), getCollectionIsTranslatable(metadataField, listProvidersService),
-                getCollection(metadataField, listProvidersService),
-                metadataField.getCollectionID(), metadataField.getOrder(), metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          textField.setValue(Iterables.getLast(filteredValues));
-        }
-        addField(textField);
-        break;
-      case TEXT_LONG:
-        MetadataField<String> textLongField = MetadataField.createTextLongMetadataField(metadataField.getInputID(),
-                Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
-                metadataField.isRequired(), getCollectionIsTranslatable(metadataField, listProvidersService),
-                getCollection(metadataField, listProvidersService),
-                metadataField.getCollectionID(), metadataField.getOrder(), metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          textLongField.setValue(Iterables.getLast(filteredValues));
-        }
-        addField(textLongField);
-        break;
-      case START_DATE:
-        if (metadataField.getPattern().isNone()) {
-          metadataField.setPattern(Opt.some("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
-        }
-        MetadataField<String> startDate = MetadataField.createTemporalStartDateMetadata(metadataField.getInputID(),
-                Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
-                metadataField.isRequired(), metadataField.getPattern().get(), metadataField.getOrder(),
-                metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          startDate.setValue(Iterables.getLast(filteredValues));
-        }
-        addField(startDate);
-        break;
-      case ORDERED_TEXT:
-        MetadataField<String> orderedTextField = MetadataField.createOrderedTextMetadataField(metadataField.getInputID(),
-            Opt.some(metadataField.getOutputID()), metadataField.getLabel(), metadataField.isReadOnly(),
-            metadataField.isRequired(), getCollectionIsTranslatable(metadataField, listProvidersService),
-            getCollection(metadataField, listProvidersService),
-            metadataField.getCollectionID(), metadataField.getOrder(), metadataField.getNamespace());
-        if (!filteredValues.isEmpty()) {
-          orderedTextField.setValue(Iterables.getLast(filteredValues));
-        }
-        addField(orderedTextField);
-        break;
-      default:
-        throw new IllegalArgumentException("Unknown metadata type! " + metadataField.getType());
-    }
+    addField(metadataField);
   }
 }

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/DublinCoreCatalogUIAdapterTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/DublinCoreCatalogUIAdapterTest.java
@@ -80,7 +80,6 @@ public class DublinCoreCatalogUIAdapterTest {
   private static final String INPUT_PERIOD = "start=2014-11-04T19:35:19Z; end=2014-11-04T20:48:23Z; scheme=W3C-DTF;";
   private static final String CHANGED_DURATION_PERIOD = "start=2014-11-04T19:35:19Z; end=2014-11-04T20:18:23Z; scheme=W3C-DTF;";
   private static final String CHANGED_START_DATE_PERIOD = "start=2013-10-29T19:35:19Z; end=2013-10-29T20:48:23Z; scheme=W3C-DTF;";
-  private static final String CHANGED_START_TIME_PERIOD = "start=2014-11-04T18:35:19Z; end=2014-11-04T19:48:23Z; scheme=W3C-DTF;";
 
   private static final String label = "The Label";
   private static final String title = "title";
@@ -270,7 +269,8 @@ public class DublinCoreCatalogUIAdapterTest {
 
     MetadataField<String> durationField = MetadataField.createDurationMetadataField(temporal, Opt.some("duration"),
             label, true, true, Opt.<Integer> none(), Opt.<String> none());
-    dublinCoreMetadata.addField(durationField, "02:15:37", listProvidersService);
+    dublinCoreMetadata.addField(durationField, "start=2016-03-01T09:27:35Z; end=2016-03-01T11:43:12Z; scheme=W3C-DTF;",
+            listProvidersService);
 
     MetadataField<String> startDate = MetadataField.createTemporalStartDateMetadata(temporal, Opt.some("startDate"),
             label, true, true, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Opt.<Integer> none(), Opt.<String> none());
@@ -321,7 +321,7 @@ public class DublinCoreCatalogUIAdapterTest {
 
   @Test
   public void testSetStartDateInputEmptyValueExpectsNoChange() throws IOException, URISyntaxException {
-    metadata.addField(startDateMetadataField, "2013-10-29T19:35:19.000Z", listProvidersService);
+    metadata.addField(new MetadataField<>(startDateMetadataField), "2013-10-29T19:35:19.000Z", listProvidersService);
     DublinCoreMetadataUtil.setStartDate(dc, startDateMetadataField, temporalEname);
     List<DublinCoreValue> result = dc.get(temporalEname);
     assertEquals(1, result.size());
@@ -350,7 +350,7 @@ public class DublinCoreCatalogUIAdapterTest {
 
   @Test
   public void testSetDurationInputNewValueExpectsChange() throws IOException, URISyntaxException {
-    metadata.addField(durationMetadataField, "2584000", listProvidersService);
+    metadata.addField(new MetadataField(durationMetadataField), CHANGED_DURATION_PERIOD, listProvidersService);
     DublinCoreMetadataUtil.setDuration(dc, metadata.getOutputFields().get("duration"), temporalEname);
     List<DublinCoreValue> result = dc.get(temporalEname);
     assertEquals(1, result.size());


### PR DESCRIPTION
Don't use a switch-case to recreate each metadata field, instead use the copy constructor to avoid side effects.
Move switch-case for value setting to Metadatafield class where it can hopefully disappear in the future. Remove condition for duration from frontend since this can never happen, values set here are either a
default from a listprovider or from a dublincore catalog.

~~This PR also contains #967 and should be merged afterwards!~~