### PR TITLE
MH-13577 Don't consider raw fields updated

### DIFF
--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/MetadataField.java
@@ -290,10 +290,17 @@ public class MetadataField<A> {
   }
 
   public void setValue(A value) {
-    if (value == null)
+    setValue(value, true);
+  }
+
+  public void setValue(A value, boolean setUpdated) {
+    if (value == null) {
       this.value = Opt.none();
-    else {
+    } else {
       this.value = Opt.some(value);
+    }
+
+    if (setUpdated) {
       this.updated = true;
     }
   }
@@ -1007,37 +1014,37 @@ public class MetadataField<A> {
 
     switch (metadataField.type) {
       case BOOLEAN:
-        ((MetadataField<Boolean>)metadataField).setValue(Boolean.parseBoolean(Iterables.getLast(filteredValues)));
+        ((MetadataField<Boolean>)metadataField).setValue(Boolean.parseBoolean(Iterables.getLast(filteredValues)), false);
         break;
       case DATE:
         if (metadataField.getPattern().isNone()) {
           metadataField.setPattern(Opt.some("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
         }
-        ((MetadataField<Date>)metadataField).setValue(EncodingSchemeUtils.decodeDate(Iterables.getLast(filteredValues)));
+        ((MetadataField<Date>)metadataField).setValue(EncodingSchemeUtils.decodeDate(Iterables.getLast(filteredValues)), false);
         break;
       case DURATION:
         String value = Iterables.getLast(filteredValues);
         DCMIPeriod period = EncodingSchemeUtils.decodePeriod(value);
         Long longValue = period.getEnd().getTime() - period.getStart().getTime();
-        ((MetadataField<String>)metadataField).setValue(longValue.toString());
+        ((MetadataField<String>)metadataField).setValue(longValue.toString(), false);
         break;
       case ITERABLE_TEXT:
       case MIXED_TEXT:
-        ((MetadataField<Iterable<String>>)metadataField).setValue(filteredValues);
+        ((MetadataField<Iterable<String>>)metadataField).setValue(filteredValues, false);
         break;
       case LONG:
-        ((MetadataField<Long>)metadataField).setValue(Long.parseLong(Iterables.getLast(filteredValues)));
+        ((MetadataField<Long>)metadataField).setValue(Long.parseLong(Iterables.getLast(filteredValues)), false);
         break;
       case START_DATE:
         if (metadataField.getPattern().isNone()) {
           metadataField.setPattern(Opt.some("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
         }
-        ((MetadataField<String>)metadataField).setValue(Iterables.getLast(filteredValues));
+        ((MetadataField<String>)metadataField).setValue(Iterables.getLast(filteredValues), false);
         break;
       case TEXT:
       case ORDERED_TEXT:
       case TEXT_LONG:
-        ((MetadataField<String>)metadataField).setValue(Iterables.getLast(filteredValues));
+        ((MetadataField<String>)metadataField).setValue(Iterables.getLast(filteredValues), false);
         break;
       default:
         throw new IllegalArgumentException("Unknown metadata type! " + metadataField.getType());
@@ -1138,6 +1145,10 @@ public class MetadataField<A> {
 
   public void setRequired(boolean required) {
     this.required = required;
+  }
+
+  public void setUpdated(boolean updated) {
+    this.updated = updated;
   }
 
   public Type getType() {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataCollection.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -67,20 +66,6 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
     return copiedCollection;
   }
 
-  private String getCollectionDefault(MetadataField<?> metadataField,
-          ListProvidersService listProvidersService) {
-    if (listProvidersService != null && metadataField.getListprovider().isSome()) {
-      try {
-        return listProvidersService.getDefault(metadataField.getListprovider().get());
-
-      } catch (ListProviderException ex) {
-        // failed to get default property on list-provider-service
-        // as this field is optional, it is fine to pass here
-      }
-    }
-    return null;
-  }
-
   private Opt<Map<String, String>> getCollection(MetadataField<?> metadataField,
           ListProvidersService listProvidersService) {
     try {
@@ -99,13 +84,7 @@ public class DublinCoreMetadataCollection extends AbstractMetadataCollection {
   }
 
   public void addEmptyField(MetadataField<?> metadataField, ListProvidersService listProvidersService) {
-    List<String> values = new ArrayList(1);
-    String defaultKey = getCollectionDefault(metadataField, listProvidersService); // check for default value
-
-    if (StringUtils.isNotBlank(defaultKey)) {
-      values.add(defaultKey);
-    }
-    addField(metadataField, values, listProvidersService);
+    addField(metadataField, Collections.emptyList(), listProvidersService);
   }
 
   public void addField(MetadataField<?> metadataField, String value, ListProvidersService listProvidersService) {

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/DublinCoreCatalogUIAdapterTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/catalog/adapter/DublinCoreCatalogUIAdapterTest.java
@@ -258,23 +258,25 @@ public class DublinCoreCatalogUIAdapterTest {
     DublinCoreMetadataCollection dublinCoreMetadata = new DublinCoreMetadataCollection();
 
     MetadataField<String> titleField = MetadataField.createTextMetadataField(title, Opt.some(title),
-            "New Label for Title", true, false, Opt.<Boolean> none(), Opt.<Map<String, String>> none(),
-            Opt.<String> none(), Opt.<Integer> none(), Opt.<String> none());
+            "New Label for Title", true, false, Opt.none(), Opt.none(), Opt.none(), Opt.none(), Opt.none());
     dublinCoreMetadata.addField(titleField, expectedTitle, listProvidersService);
+    titleField.setUpdated(true);
 
-    MetadataField<String> missingField = MetadataField.createTextMetadataField("missing", Opt.<String> none(),
-            "The Missing's Label", false, false, Opt.<Boolean> none(), Opt.<Map<String, String>> none(),
-            Opt.<String> none(), Opt.<Integer> none(), Opt.<String> none());
+    MetadataField<String> missingField = MetadataField.createTextMetadataField("missing", Opt.none(),
+            "The Missing's Label", false, false, Opt.none(), Opt.none(), Opt.none(), Opt.none(), Opt.none());
     dublinCoreMetadata.addField(missingField, expectedMissing, listProvidersService);
+    missingField.setUpdated(true);
 
     MetadataField<String> durationField = MetadataField.createDurationMetadataField(temporal, Opt.some("duration"),
-            label, true, true, Opt.<Integer> none(), Opt.<String> none());
+            label, true, true, Opt.none(), Opt.none());
     dublinCoreMetadata.addField(durationField, "start=2016-03-01T09:27:35Z; end=2016-03-01T11:43:12Z; scheme=W3C-DTF;",
             listProvidersService);
+    durationField.setUpdated(true);
 
     MetadataField<String> startDate = MetadataField.createTemporalStartDateMetadata(temporal, Opt.some("startDate"),
-            label, true, true, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Opt.<Integer> none(), Opt.<String> none());
+            label, true, true, "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Opt.none(), Opt.none());
     dublinCoreMetadata.addField(startDate, "2016-03-01T09:27:35.000Z", listProvidersService);
+    startDate.setUpdated(true);
 
     configurationDublinCoreCatalogUIAdapter.storeFields(mediapackage, dublinCoreMetadata);
     assertTrue(writtenCatalog.hasCaptured());


### PR DESCRIPTION
Metadata fields in a dublincore collection are not considered updated anymore when the initial value is set (either a default value or a value from a dublin core catalog). This fixes the problem of metadata fields resetting to their default value when other fields are changed.

~~Be aware that this PR includes #972 and should be merged afterwards!~~