### PR TITLE
MH-13637 asset manager endpoint fix

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
@@ -230,7 +230,7 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
       Opt<MediaPackage> mp = getAssetManager().getMediaPackage(mediaPackageId);
 
       if (mp.isSome()) {
-        return ok(mp);
+        return ok(mp.get());
       } else {
         return notFound();
       }


### PR DESCRIPTION
The Asset Manager endpoint returns allways http 500 on calling /episode/{mediaPackageID} with a correct ID. In the log output the message "No message body writer has been found for class com.entwinemedia.fn.data.Opt$Some, ContentType: text/xml" appears.

Work sponsored by SWITCH