### PR TITLE
MH-13639, Admin interface does not handle missing metadata well

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -1583,7 +1583,6 @@ public class IndexServiceImpl implements IndexService {
       case WORKFLOW:
         Opt<WorkflowInstance> currentWorkflowInstance = getCurrentWorkflowInstance(event.getIdentifier());
         if (currentWorkflowInstance.isNone()) {
-          logger.error("No workflow instance for event {} found!", event.getIdentifier());
           throw new IndexServiceException("No workflow instance found for event " + event.getIdentifier());
         }
         return currentWorkflowInstance.get().getMediaPackage();
@@ -1593,7 +1592,6 @@ public class IndexServiceImpl implements IndexService {
           logger.debug("Found event in archive with id {}", event.getIdentifier());
           return mpOpt.get();
         }
-        logger.error("No event with id {} found from archive!", event.getIdentifier());
         throw new IndexServiceException("No archived event found with id " + event.getIdentifier());
       case SCHEDULE:
         try {
@@ -1601,16 +1599,11 @@ public class IndexServiceImpl implements IndexService {
           logger.debug("Found event in scheduler with id {}", event.getIdentifier());
           return mediaPackage;
         } catch (NotFoundException e) {
-          logger.error("No scheduled event with id {} found!", event.getIdentifier());
-          throw new IndexServiceException(e.getMessage(), e);
+          throw new IndexServiceException("No scheduled event with id " + event.getIdentifier(), e);
         } catch (UnauthorizedException e) {
-          logger.error("Unauthorized to get event with id {} from scheduler because {}", event.getIdentifier(),
-                  getStackTrace(e));
-          throw new IndexServiceException(e.getMessage(), e);
+          throw new IndexServiceException("Unauthorized to get event " + event.getIdentifier() + " from scheduler", e);
         } catch (SchedulerException e) {
-          logger.error("Unable to get event with id {} from scheduler because {}", event.getIdentifier(),
-                  getStackTrace(e));
-          throw new IndexServiceException(e.getMessage(), e);
+          throw new IndexServiceException("Unable to get event " + event.getIdentifier() + " from scheduler", e);
         }
       default:
         throw new IllegalStateException("Unknown event type!");


### PR DESCRIPTION
Some admin interface REST endpoints for retrieving event metadata handle
errors poorly and missing access right or missing data all result in
endless stack traces and internal server error return codes.

This patch avoids duplicated logging and tries to return the correct
HTTP status codes if possible.

*Work sponsored by SWITCH*