### PR TITLE
MH-13642, Fix Index Update Logging

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImpl.java
@@ -139,7 +139,7 @@ public class AssetManagerMessageReceiverImpl extends BaseMessageReceiverImpl<Ass
     // Remove the archived entry from the search index
     try {
       getSearchIndex().deleteAssets(organization, user, eventId);
-      logger.debug("Archived media package {} removed from admin ui search index", eventId);
+      logger.debug("Archived media package {} removed from {} search index", eventId, getSearchIndex().getIndexName());
     } catch (NotFoundException e) {
       logger.warn("Archived media package {} not found for deletion", eventId);
     } catch (SearchIndexException e) {


### PR DESCRIPTION
Opencast contains two search indexes which are mainly updated by sending
messages via ActiveMQ to one or both indexes. This patch fixes the
logging of one such message receiver which had one of the indexes
hard-coded in its log message.

*Work sponsored by SWITCH*