### PR TITLE
Mh 13617 Duplicate encoding profiles for PrepareAV/SelectStreams

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/prepareav-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/prepareav-woh.md
@@ -20,10 +20,10 @@ in the pipeline (encoding to flash, mjpeg etc.).
 |------------------|-------|-----------|
 |source-flavor|presenter/source|Specifies which media should be processed.|
 |target-flavor|presenter/work|Specifies the flavor the new files will get.|
-|mux-encoding-profile    |mux-av.work    |The encoding profile to use for media that needs to be muxed (default is 'mux-av.work')|
-|audio-video-encoding-profile    |av.work    |The encoding profile to use for media that is audio-video already and needs to be re-encodend (default is av.work)     |
-|video-encoding-profile    |video-only.work    |The encoding profile to use for media that is only video and needs to be re-encodend (default is video-only.work)     |
-|audio-encoding-profile    |audio-only.work    |The encoding profile to use for media that is only audio and needs to be re-encodend (default is audio-only.work)     |
+|mux-encoding-profile    |mux-av.prepared    |The encoding profile to use for media that needs to be muxed (default is 'mux-av.work')|
+|audio-video-encoding-profile    |av.prepared    |The encoding profile to use for media that is audio-video already and needs to be re-encodend (default is av.work)     |
+|video-encoding-profile    |video-only.prepared    |The encoding profile to use for media that is only video and needs to be re-encodend (default is video-only.work)     |
+|audio-encoding-profile    |audio-only.prepared    |The encoding profile to use for media that is only audio and needs to be re-encodend (default is audio-only.work)     |
 |rewrite    |true    |Should files be rewritten     |
 |audio-muxing-source-flavors|presentation/source,presentation/\*,\*/\*    |If there is no matching flavor to mux, search for a track with audio that can be muxed by going from left to right through this comma-separated list of source flavors|
 

--- a/etc/encoding/opencast-movies.properties
+++ b/etc/encoding/opencast-movies.properties
@@ -33,22 +33,34 @@
 #   file and muxes them into the same kind of container they were in before. A
 #   general re-encoding will not happen, but if the duration of both streams
 #   differ, the longer one will be cut.
-profile.av.work.name = Re-encode audiovisual track
-profile.av.work.input = stream
-profile.av.work.output = audiovisual
-profile.av.work.suffix = -work.#{in.video.suffix}
-profile.av.work.ffmpeg.command = -i #{in.video.path} -shortest -c copy #{out.dir}/#{out.name}#{out.suffix}
+profile.av.prepared.name = Re-encode audiovisual track
+profile.av.prepared.input = stream
+profile.av.prepared.output = audiovisual
+profile.av.prepared.suffix = -prepared.#{in.video.suffix}
+profile.av.prepared.ffmpeg.command = -i #{in.video.path} -shortest -c copy #{out.dir}/#{out.name}#{out.suffix}
 
 # Mux one audio and one video stream
-#   This command will take two files (video and audio) and mux the contained
+#   These commands will take two files (video and audio) and mux the contained
 #   streams.  The container format used is the same as it was for the source
 #   video file. The streams will not be re-encoded, but if the duration of both
 #   streams differ, the longer one will be cut.
+#   Since this is used by multiple workflow operation handlers, the encoding
+#   profile is duplicated to allow an independent configuration.
+
+# Used by PrepareAV workflow operation
+profile.mux-av.prepared.name = mux audio and video
+profile.mux-av.prepared.input = stream
+profile.mux-av.prepared.output = visual
+profile.mux-av.prepared.suffix = -prepared.#{in.video.suffix}
+profile.mux-av.prepared.ffmpeg.command = -i #{in.video.path} -i #{in.audio.path} -shortest -c copy -map 0:v:0 -map 1:a:0 #{out.dir}/#{out.name}#{out.suffix}
+
+# Used by SelectTracks workflow operation
 profile.mux-av.work.name = mux audio and video
 profile.mux-av.work.input = stream
 profile.mux-av.work.output = visual
 profile.mux-av.work.suffix = -work.#{in.video.suffix}
 profile.mux-av.work.ffmpeg.command = -i #{in.video.path} -i #{in.audio.path} -shortest -c copy -map 0:v:0 -map 1:a:0 #{out.dir}/#{out.name}#{out.suffix}
+
 
 # Trim a stream
 #   This command will trim and input stream. Trimming will be fast, as no
@@ -76,6 +88,17 @@ profile.sox-audio-replace.work.ffmpeg.command = -strict -2 -i #{in.audio.path} -
 # Audio only (strip video)
 #   This command will copy the audio streams into a new container. The
 #   container type will be the same as it was used for the source video.
+#   Since this is used by multiple workflow operation handlers, the encoding
+#   profile is duplicated to allow an independent configuration.
+
+# Used by PrepareAV workflow operation
+profile.audio-only.prepared.name = audio only
+profile.audio-only.prepared.input = visual
+profile.audio-only.prepared.output = audio
+profile.audio-only.prepared.suffix = -prepared.#{in.video.suffix}
+profile.audio-only.prepared.ffmpeg.command = -i #{in.video.path} -c:a copy -vn #{out.dir}/#{out.name}#{out.suffix}
+
+# Used by SelectTracks workflow operation
 profile.audio-only.work.name = audio only
 profile.audio-only.work.input = visual
 profile.audio-only.work.output = audio
@@ -85,11 +108,23 @@ profile.audio-only.work.ffmpeg.command = -i #{in.video.path} -c:a copy -vn #{out
 # Video only (strip audio)
 #   This command will copy the video streams into a new container. The
 #   container type will be the same as it was used for the source video.
+#   Since this is used by multiple workflow operation handlers, the encoding
+#   profile is duplicated to allow an independent configuration.
+
+# Used by PrepareAV workflow operation
+profile.video-only.prepared.name = video only
+profile.video-only.prepared.input = visual
+profile.video-only.prepared.output = visual
+profile.video-only.prepared.suffix = -prepared.#{in.video.suffix}
+profile.video-only.prepared.ffmpeg.command = -i #{in.video.path} -c:v copy -an #{out.dir}/#{out.name}#{out.suffix}
+
+# Used by SelectTracks workflow operation
 profile.video-only.work.name = video only
 profile.video-only.work.input = visual
 profile.video-only.work.output = visual
 profile.video-only.work.suffix = -work.#{in.video.suffix}
 profile.video-only.work.ffmpeg.command = -i #{in.video.path} -c:v copy -an #{out.dir}/#{out.name}#{out.suffix}
+
 
 # Composite
 #   This profile is used for the composite workflow operation which puts

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
@@ -57,17 +57,17 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
   private static final Logger logger = LoggerFactory.getLogger(ComposeWorkflowOperationHandler.class);
   private static final String QUESTION_MARK = "?";
 
-  /** Name of the 'encode to a/v work copy' encoding profile */
-  public static final String PREPARE_AV_PROFILE = "av.work";
+  /** Name of the 'encode to a/v prepared copy' encoding profile */
+  public static final String PREPARE_AV_PROFILE = "av.prepared";
 
   /** Name of the muxing encoding profile */
-  public static final String MUX_AV_PROFILE = "mux-av.work";
+  public static final String MUX_AV_PROFILE = "mux-av.prepared";
 
-  /** Name of the 'encode to audio only work copy' encoding profile */
-  public static final String PREPARE_AONLY_PROFILE = "audio-only.work";
+  /** Name of the 'encode to audio only prepared copy' encoding profile */
+  public static final String PREPARE_AONLY_PROFILE = "audio-only.prepared";
 
-  /** Name of the 'encode to video only work copy' encoding profile */
-  public static final String PREPARE_VONLY_PROFILE = "video-only.work";
+  /** Name of the 'encode to video only prepared copy' encoding profile */
+  public static final String PREPARE_VONLY_PROFILE = "video-only.prepared";
 
   /** Name of the 'rewrite' configuration key */
   public static final String OPT_REWRITE = "rewrite";
@@ -208,7 +208,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
     // Make sure we have a matching combination
     if (audioTrack == null && videoTrack != null) {
       if (rewrite) {
-        logger.info("Encoding video only track {} to work version", videoTrack);
+        logger.info("Encoding video only track {} to prepared version", videoTrack);
         if (videoOnlyEncodingProfileName == null)
           videoOnlyEncodingProfileName = PREPARE_VONLY_PROFILE;
         // Find the encoding profile to make sure the given profile exists
@@ -223,7 +223,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
       }
     } else if (videoTrack == null && audioTrack != null) {
       if (rewrite) {
-        logger.info("Encoding audio only track {} to work version", audioTrack);
+        logger.info("Encoding audio only track {} to prepared version", audioTrack);
         if (audioOnlyEncodingProfileName == null)
           audioOnlyEncodingProfileName = PREPARE_AONLY_PROFILE;
         // Find the encoding profile to make sure the given profile exists
@@ -238,7 +238,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
       }
     } else if (audioTrack == videoTrack) {
       if (rewrite) {
-        logger.info("Encoding audiovisual track {} to work version", videoTrack);
+        logger.info("Encoding audiovisual track {} to prepared version", videoTrack);
         if (audioVideoEncodingProfileName == null)
           audioVideoEncodingProfileName = PREPARE_AV_PROFILE;
         // Find the encoding profile to make sure the given profile exists
@@ -252,7 +252,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
         mediaPackage.add(composedTrack);
       }
     } else {
-      logger.info("Muxing audio and video only track {} to work version", videoTrack);
+      logger.info("Muxing audio and video only track {} to prepared version", videoTrack);
 
       if (audioTrack.hasVideo()) {
         logger.info("Stripping video from track {}", audioTrack);
@@ -310,7 +310,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
   private Track prepare(Track videoTrack, MediaPackage mediaPackage, String encodingProfile)
           throws WorkflowOperationException, NotFoundException, IOException, EncoderException, MediaPackageException {
     Track composedTrack = null;
-    logger.info("Encoding video only track {} to work version", videoTrack);
+    logger.info("Encoding video only track {} to prepared version", videoTrack);
     Job job = composerService.encode(videoTrack, encodingProfile);
     if (!waitForStatus(job).isSuccess()) {
       throw new WorkflowOperationException("Rewriting container for video track " + videoTrack + " failed");


### PR DESCRIPTION
PrepareAV and SelectStreams share a number of encoding profiles, including that for muxing audio and video. Considering that these WOH serve different purposes, an independent configuration could be desired. This PR allows this by duplicating the encoding profiles, which also allows a correct format to be set (work vs. prepared).

~~Be aware that his PR also contains #956!~~

_This work was sponsored by SWITCH._