### PR TITLE
MH-13644: Sometimes paella does not play audio

### DIFF
--- a/modules/engage-paella-player/package-lock.json
+++ b/modules/engage-paella-player/package-lock.json
@@ -2317,8 +2317,8 @@
       "dev": true
     },
     "paellaplayer": {
-      "version": "github:polimediaupv/paella#c2531e563332f015060ecb175e7153eb48d1b086",
-      "from": "github:polimediaupv/paella#6.1.3",
+      "version": "github:polimediaupv/paella#46a789de9ec9e4903d1a3035c674092a4ec03287",
+      "from": "github:polimediaupv/paella#6.1.4",
       "dev": true
     },
     "parse-filepath": {

--- a/modules/engage-paella-player/package.json
+++ b/modules/engage-paella-player/package.json
@@ -10,6 +10,6 @@
     "eslint-plugin-header": "^2.0.0",
     "gulp": "^3.9.1",
     "merge-stream": "^1.0.1",
-    "paellaplayer": "github:polimediaupv/paella#6.1.3"
+    "paellaplayer": "github:polimediaupv/paella#6.1.4"
   }
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -118,6 +118,9 @@ class OpencastToPaellaConverter {
           if ( !(currentStream.sources[videoType]) || !(currentStream.sources[videoType] instanceof Array)){
             currentStream.sources[videoType] = [];
           }
+          if (currentTrack.audio) {
+            currentStream.audioTag = base.dictionary.currentLanguage();
+          }
           currentStream.sources[videoType].push(this.getStreamSourceFromTrack(currentTrack));
         }
       }


### PR DESCRIPTION
JIRA ticket: https://opencast.jira.com/browse/MH-13644

If there are multiple video tracks and some have audio and others don't, sometimes paella does not play audio. 

Paella uses the audio from the track marked as the same language that the navigator language. In Opencast version, none track is marked for audio, then paella uses the first track as audio source.

If the first track has no audio, then paella does not play audio.

This PR needs #979 to be merged first