### PR TITLE
MH-13645, Only send delete comments message if we delete something

### DIFF
--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -229,11 +229,13 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
 
     // Similar to deleteComment but we want to avoid sending a message for each deletion
 
+    int count = 0;
     EntityManager em = emf.createEntityManager();
     EntityTransaction tx = em.getTransaction();
     try {
       tx.begin();
       List<EventComment> comments = getComments(eventId);
+      count = comments.size();
 
       for (EventComment comment : comments) {
         long commentId = comment.getId().get().intValue();
@@ -253,11 +255,13 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
 
       throw new EventCommentDatabaseException(e);
     } finally {
-      if (em != null)
-        em.close();
+      em.close();
     }
 
-    sendMessageUpdate(eventId);
+    // send updates only if we actually modified anything
+    if (count > 0) {
+      sendMessageUpdate(eventId);
+    }
   }
 
   @Override


### PR DESCRIPTION
Every time a delete is triggered a message is dispatched to all search
indexes, notifying them about the removal of comments belonging to an
event. This happens even if the event has no comments which is obviously
completely unnecessary.

This patch makes Opencast now only send out notifications for index
updates if some comments have actually been deleted.

*Work sponsored by SWITCH*