### PR TITLE
MH-13646, Delete scheduled events

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/AbstractSearchIndex.java
@@ -438,7 +438,7 @@ public abstract class AbstractSearchIndex extends AbstractElasticsearchIndex {
     if (event == null)
       throw new NotFoundException("No event with id " + uid + " found.");
 
-    event.setRecordingStatus(null);
+    event.setAgentId(null);
 
     if (toDelete(event)) {
       delete(Event.DOCUMENT_TYPE, uid.concat(organization));


### PR DESCRIPTION
Deleting scheduled events does not work properly: The entry in the
Elasticsearch index still remains even after the event has been deleted
and disappears only when rebuilding the whole index.

The reason for this is that the check for an event being a scheduled
event has changed but when the scheduling information are removed, the
old field was modified so that Opencast would always find existing
scheduler information and never remove the event from the index.

*Work sponsored by SWITCH*