### PR TITLE
MH-13648, Asset Manager Concurrecy Issue

### DIFF
--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
@@ -176,7 +176,11 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
 
   /** Create this directory and all of its parents. */
   protected void mkDirs(File d) {
-    if (d != null && !d.exists() && !d.mkdirs()) {
+    if (d == null) {
+      return;
+    }
+    // mkdirs *may* not have succeeded if it returns false, so check if the directory exists in that case
+    if (!d.mkdirs() && !d.exists()) {
       final String msg = "Cannot create directory " + d;
       logger.error(msg);
       throw new AssetStoreException(msg);


### PR DESCRIPTION
The asset managers filesystem storage backend may fail to create
directories if it tries to create the directory multiple time in
parallel.

The reason for this is an unnecessary, non-synchronized check if the
directory already exists before trying the create the directory
(`mkdirs()` already includes this check) and the incorrect assumption
that `mkdirs()` returning false means that the directory is not created.