### PR TITLE
MH-13650, Scheduler Migration Performance

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
@@ -111,8 +111,9 @@ public interface AssetManager {
    *
    * @param mediaPackageId
    *          Media package identifier
+   * @return Number of deleted properties
    */
-  void deleteProperties(String mediaPackageId);
+  int deleteProperties(String mediaPackageId);
 
   /**
    * Delete all properties for a given media package identifier and namespace.
@@ -121,8 +122,9 @@ public interface AssetManager {
    *          Media package identifier
    * @param namespace
    *          A namespace prefix to use for deletion
+   * @return Number of deleted properties
    */
-  void deleteProperties(String mediaPackageId, String namespace);
+  int deleteProperties(String mediaPackageId, String namespace);
 
   /**
    * Check if any snapshot with the given media package identifier exists.

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
@@ -162,13 +162,13 @@ public abstract class AbstractAssetManager implements AssetManager {
   }
 
   @Override
-  public void deleteProperties(final String mediaPackageId) {
-    getDb().deleteProperties(mediaPackageId);
+  public int deleteProperties(final String mediaPackageId) {
+    return getDb().deleteProperties(mediaPackageId);
   }
 
   @Override
-  public void deleteProperties(final String mediaPackageId, final String namespace) {
-    getDb().deleteProperties(mediaPackageId, namespace);
+  public int deleteProperties(final String mediaPackageId, final String namespace) {
+    return getDb().deleteProperties(mediaPackageId, namespace);
   }
 
   @Override

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerDecorator.java
@@ -70,13 +70,13 @@ public class AssetManagerDecorator<A extends TieredStorageAssetManager> implemen
   }
 
   @Override
-  public void deleteProperties(final String mediaPackageId) {
-    delegate.deleteProperties(mediaPackageId);
+  public int deleteProperties(final String mediaPackageId) {
+    return delegate.deleteProperties(mediaPackageId);
   }
 
   @Override
-  public void deleteProperties(final String mediaPackageId, final String namespace) {
-    delegate.deleteProperties(mediaPackageId, namespace);
+  public int deleteProperties(final String mediaPackageId, final String namespace) {
+    return delegate.deleteProperties(mediaPackageId, namespace);
   }
 
   @Override

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/OsgiAssetManager.java
@@ -210,13 +210,13 @@ public class OsgiAssetManager implements AssetManager, TieredStorageAssetManager
   }
 
   @Override
-  public void deleteProperties(final String mediaPackageId) {
-    delegate.deleteProperties(mediaPackageId);
+  public int deleteProperties(final String mediaPackageId) {
+    return delegate.deleteProperties(mediaPackageId);
   }
 
   @Override
-  public void deleteProperties(final String mediaPackageId, final String namespace) {
-    delegate.deleteProperties(mediaPackageId, namespace);
+  public int deleteProperties(final String mediaPackageId, final String namespace) {
+    return delegate.deleteProperties(mediaPackageId, namespace);
   }
 
   @Override

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
@@ -330,9 +330,10 @@ public class Database implements EntityPaths {
    *
    * @param mediaPackageId
    *          Media package identifier
+   * @return Number of deleted rows
    */
-  public void deleteProperties(final String mediaPackageId) {
-    PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId);
+  public int deleteProperties(final String mediaPackageId) {
+    return PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId);
   }
 
   /**
@@ -342,13 +343,13 @@ public class Database implements EntityPaths {
    *          Media package identifier
    * @param namespace
    *          A namespace prefix to use for deletion
+   * @return Number of deleted rows
    */
-  public void deleteProperties(final String mediaPackageId, final String namespace) {
+  public int deleteProperties(final String mediaPackageId, final String namespace) {
     if (StringUtils.isBlank(namespace)) {
-      PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId);
-    } else {
-      PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId, namespace);
+      return PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId);
     }
+    return PropertyDto.delete(entityManagerFactory.createEntityManager(), mediaPackageId, namespace);
   }
 
   /**

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/PropertyDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/PropertyDto.java
@@ -160,11 +160,11 @@ public class PropertyDto {
             }.toFn());
   }
 
-  public static void delete(EntityManager em, final String mediaPackageId) {
-    delete(em, mediaPackageId, null);
+  public static int delete(EntityManager em, final String mediaPackageId) {
+    return delete(em, mediaPackageId, null);
   }
 
-  public static void delete(EntityManager em, final String mediaPackageId, final String namespace) {
+  public static int delete(EntityManager em, final String mediaPackageId, final String namespace) {
     TypedQuery<PropertyDto> query;
     if (namespace == null) {
       query = em.createNamedQuery("Property.delete", PropertyDto.class)
@@ -177,8 +177,9 @@ public class PropertyDto {
     logger.debug("Executing query {}", query);
     EntityTransaction tx = em.getTransaction();
     tx.begin();
-    query.executeUpdate();
+    final int num = query.executeUpdate();
     tx.commit();
+    return num;
   }
 
   public static List<Property> select(EntityManager em, final String mediaPackageId, final String namespace) {

--- a/modules/migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
+++ b/modules/migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Dictionary;
 
@@ -246,9 +247,10 @@ public class SchedulerMigrationService {
       tx.commit();
       try {
         // Remove obsolete asset manager properties
-        final AQueryBuilder query = assetManager.createQuery();
-        final long deleted = query.delete(SNAPSHOT_OWNER, query.propertiesOf(SCHEDULER_NAMESPACE, CA_NAMESPACE, WORKFLOW_NAMESPACE))
-            .where(query.mediaPackageId(event.getMediaPackageId()).and(withOrganization(query))).run();
+        int deleted = 0;
+        for (String namespace: Arrays.asList(SCHEDULER_NAMESPACE, CA_NAMESPACE, WORKFLOW_NAMESPACE)) {
+          deleted += assetManager.deleteProperties(event.getMediaPackageId(), namespace);
+        }
         logger.debug("Deleted {} migrated properties", deleted);
       } catch (Exception e) {
         logger.error("Could not delete obsolete properties for event {}", event.getMediaPackageId());


### PR DESCRIPTION
Depending on the amount of asset manager properties in the system, the
migration of scheduled events between Opencast 6 and Opencast 7 can be
very slow.

In our tests on SWITCH's test cluster (approx. 1M properties in the
database) migration for a single event took 2-3 seconds. That makes a
full migration take forever.

This patch brings this time down to approx 0.01 seconds on the same
system by using the asset managers native queries which are a lot
faster.

*Work sponsored by SWITCH*