### PR TITLE
MH-13651 Don't call submit of SingleSelect twice

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/editableSingleSelectDirective.js
@@ -105,7 +105,7 @@ angular.module('adminNg.directives')
       });
 
       element.on('chosen:hiding_dropdown', 'select', function(evt, params) {
-        scope.submit();
+        scope.leaveEditMode();
       });
 
       // get tab event before chosen can swallow it so we don't have to hit tab twice


### PR DESCRIPTION
Leave edit mode if the drop down menu was closed, but only submit data if a user hits Enter or clicks on a value.

_This work was sponsored by SWITCH._