### PR TITLE
MH-13653, Fully Migrate Scheduled Events

### DIFF
--- a/modules/migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
+++ b/modules/migration/src/main/java/org/opencastproject/migration/SchedulerMigrationService.java
@@ -154,8 +154,7 @@ public class SchedulerMigrationService {
   private Stream<ARecord> getScheduledEvents() {
     final AQueryBuilder query = assetManager.createQuery();
     // query filter for organization could be helpful to split up big migrations
-    final Predicate predicate = withOrganization(query).and(withVersion(query)).and(withOwner(query))
-        .and(withProperties(query));
+    final Predicate predicate = withOrganization(query).and(withVersion(query)).and(withProperties(query));
     // select necessary properties when assembling query
     return query.select(query.propertiesOf(SCHEDULER_NAMESPACE, WORKFLOW_NAMESPACE, CA_NAMESPACE))
         .where(predicate).run().getRecords();
@@ -163,10 +162,6 @@ public class SchedulerMigrationService {
 
   private Predicate withOrganization(AQueryBuilder query) {
     return query.organizationId().eq(securityService.getOrganization().getId());
-  }
-
-  private Predicate withOwner(AQueryBuilder query) {
-    return query.owner().eq(SNAPSHOT_OWNER);
   }
 
   private Predicate withVersion(AQueryBuilder query) {


### PR DESCRIPTION
The 7.0 scheduler migration only migrated scheduled events which have
not been recorded yet, leaving the metadata of all other events lying
vacant in the asset manager properties store.

While this has no effect on recording and processing, it does mean that
this data is unavailable can cannot be used for filtering, etc. In
particular, this effects the external API where scheduling information
should be present:

```
  /api/events/1c009e2d-347f-4343-b356-3c07689c702f?withscheduling=true&...

  {
    "identifier": "1c009e2d-347f-4343-b356-3c07689c702f",
    ...
    "scheduling": {
      "agent_id": "pyca",
      "start": "2019-06-28T08:08:00Z",
      "end": "2019-06-28T08:09:00Z"
    },
    ...
  }
```

and the admin interface where you can filter events for capture agent
ids. Both will not work after the migration as those data have not been
migrated.

*Note that there is an additional bug in the admin interface filtering.*

*Work sponsored by SWITCH*