### PR TITLE
MH-13654, Upgrade chromedriver

### DIFF
--- a/modules/admin-ui/package-lock.json
+++ b/modules/admin-ui/package-lock.json
@@ -821,9 +821,9 @@
       }
     },
     "chromedriver": {
-      "version": "75.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-75.0.0.tgz",
-      "integrity": "sha512-bUThqrWQn41agNxV58vT0uxUqDryhNKEcMiJ6Iu0KF8pDDH0vzlnlre9BRz+dO95cwoBAilgwQUx9ig91zIC/Q==",
+      "version": "75.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-75.0.1.tgz",
+      "integrity": "sha512-x94nKFBcvHHuDHJkRj94BuhGnLJcJE8G64yOkXrAEEmer5vjW7N7V+TF7CzVdT/Bb8G+37h6qT+zpLD9xbQ1og==",
       "dev": true,
       "requires": {
         "del": "^4.1.1",

--- a/modules/admin-ui/package.json
+++ b/modules/admin-ui/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "autoprefixer": "^9.6.0",
     "bower": "^1.8.8",
-    "chromedriver": "^75.0.0",
+    "chromedriver": "^75.0.1",
     "eslint": "^6.0.1",
     "eslint-plugin-header": "^3.0.0",
     "grunt": "^1.0.4",


### PR DESCRIPTION
This patch upgrades chromedriver to its latest version. To run the admin
interface frontend tests using Chrome, run:

    npm run test-chrome