### PR TITLE
MH-13656, Fix Scheduler Index Rebuild

### DIFF
--- a/modules/index-service/src/test/java/org/opencastproject/index/service/message/SchedulerMessageReceiverImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/message/SchedulerMessageReceiverImplTest.java
@@ -50,7 +50,7 @@ public class SchedulerMessageReceiverImplTest {
   @Test
   public void testUpdateCreator() throws Exception {
     DublinCoreCatalog catalog = DublinCores.read(getClass().getResourceAsStream("/dublincore.xml"));
-    SchedulerItemList schedulerItem = SchedulerItemList.singleton("uuid", SchedulerItem.updateCatalog(catalog));
+    SchedulerItemList schedulerItem = new SchedulerItemList("uuid", SchedulerItem.updateCatalog(catalog));
 
     // Test initial set of creator
     scheduler.execute(schedulerItem);

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/scheduler/SchedulerItemList.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/scheduler/SchedulerItemList.java
@@ -24,18 +24,20 @@ package org.opencastproject.message.broker.api.scheduler;
 import org.opencastproject.message.broker.api.MessageItem;
 
 import java.io.Serializable;
+import java.util.List;
 
 public class SchedulerItemList implements MessageItem, Serializable {
   private final String id;
   private final SchedulerItem[] items;
 
-  public static SchedulerItemList singleton(final String id, final SchedulerItem item) {
-    return new SchedulerItemList(id, new SchedulerItem[] {item});
-  }
-
-  public SchedulerItemList(final String id, final SchedulerItem[] items) {
+  public SchedulerItemList(final String id, final SchedulerItem ... items) {
     this.id = id;
     this.items = items;
+  }
+
+  public SchedulerItemList(final String id, final List<SchedulerItem> items) {
+    this.id = id;
+    this.items = items.toArray(new SchedulerItem[0]);
   }
 
   public SchedulerItem[] getItems() {

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceDatabase.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceDatabase.java
@@ -206,6 +206,16 @@ public interface SchedulerServiceDatabase {
   Opt<ExtendedEventDto> getEvent(String mediapackageId, String orgId) throws SchedulerServiceDatabaseException;
 
   /**
+   * Get all events from the scheduler for the current organizations.
+   *
+   * @return The list of events.
+   *
+   * @throws SchedulerServiceDatabaseException
+   *           If the database cannot be queried.
+   */
+  List<ExtendedEventDto> getEvents() throws SchedulerServiceDatabaseException;
+
+  /**
    * Nulls recording state and recording last heard of of the given media package.
    * @param mediapackageId
    *          The mediapackage id to look for

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/persistence/SchedulerServiceDatabaseImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/persistence/SchedulerServiceDatabaseImpl.java
@@ -43,6 +43,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 
 /**
  * Implements {@link SchedulerServiceDatabase}.
@@ -322,6 +323,23 @@ public class SchedulerServiceDatabaseImpl implements SchedulerServiceDatabase {
     } catch (Exception e) {
       if (tx.isActive())
         tx.rollback();
+      throw new SchedulerServiceDatabaseException(e);
+    } finally {
+      if (em != null)
+        em.close();
+    }
+  }
+
+  @Override
+  public List<ExtendedEventDto> getEvents() throws SchedulerServiceDatabaseException {
+    EntityManager em = null;
+    final String organization = securityService.getOrganization().getId();
+    try {
+      em = emf.createEntityManager();
+      TypedQuery<ExtendedEventDto> query = em.createNamedQuery("ExtendedEvent.findAll", ExtendedEventDto.class)
+                      .setParameter("org", organization);
+      return query.getResultList();
+    } catch (Exception e) {
       throw new SchedulerServiceDatabaseException(e);
     } finally {
       if (em != null)

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1594,7 +1594,8 @@ public class SchedulerServiceImplTest {
     MessageSender messageSender = schedSvc.getMessageSender();
     EasyMock.reset(messageSender);
     Capture<SchedulerItemList> schedulerItemsCapture = Capture.newInstance(CaptureType.ALL);
-    messageSender.sendObjectMessage(eq(SchedulerItem.SCHEDULER_QUEUE), eq(MessageSender.DestinationType.Queue),
+    messageSender.sendObjectMessage(eq(SchedulerItem.SCHEDULER_QUEUE_PREFIX + "Adminui"),
+            eq(MessageSender.DestinationType.Queue),
             capture(schedulerItemsCapture));
     EasyMock.expectLastCall().anyTimes();
     EasyMock.replay(messageSender);


### PR DESCRIPTION
The new scheduler has two problems which causes index rebuilds to not
work properly:

1. The index is rebuild only from objects which have the scheduler set
   as owner in the asset manager. This is true only for upcoming
   recordings but not for those which have already been processed,
   causing technical metadata to not be present in the indexes which in
   turn causes features like filtering for a capture agent identifier in
   the admin interface to fail.

2. Updates are sent to all scheduler receivers. This means that if
   someone rebuilds the admin interface Elasticsearch index, the
   messages are sent to all other indexes as well and the data are
   received by, processed and stored in the External API index as well.
   When doing a full rebuild, in the end, this cases twice the amount of
   messages to be sent for scheduler updates (essentially building both
   indexes twice).

This patch addresses both issues, fixing issue 1 by using the
scheduler's own database backend as data source instead of the asset
manager and fixing issue 2 by (simply) sending the correct message type
intended for the specific index.

*Work sponsored by SWITCH*