### PR TITLE
MH-13658, Composer Should Not Overwrite Files

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -965,7 +965,6 @@ public class EncoderEngine implements AutoCloseable {
         clauses.add(outmaps.getVideoFilter());
       }
       clauses.removeIf(Objects::isNull); // remove all empty filters
-      command.add("-y"); // overwrite old files
       command.add("-nostats"); // no progress report
       for (File o : inputs) {
         command.add("-i"); // Add inputfile in the order of entry


### PR DESCRIPTION
FFmpeg's `-y` option causes it to silently overwrite any output files if
they already exists. Opencast's composer injects this option in a few
cases. This options should never be needed unless something else is very
wrong in which case the process should rather fail than to cause a
potential data loss or corruption.