### PR TITLE
MH-13660, Update Development Process Documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
       language: python
       python: "3.6"
       install:
-        - pip install mkdocs
+        - pip install mkdocs markdown_inline_graphviz_extension
         - (cd docs/guides && npm install)
       script:
         - (! grep -rn '	' modules assemblies pom.xml --include=pom.xml)

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -149,24 +149,18 @@ digraph G {
 %}
 
 As described above, `develop` is the branch used for preparing the next version. At some point marked in the release
-schedule, the release branch is cut from `develop`. This action also marks the feature freeze for such Opencast version,
-i.e. the moment when no new features will be included in that specific version. This is because all the new features
-must be merged only into the `develop` branch; therefore, the release branches (such as `r/7.x` in our example) can
-only contain features that were merged before the branch was forked off. Any features merged after the creation of the
-release branch can only make it into the next release, but not into this one.
+schedule, the release branch is cut from `develop`. This action also marks the feature freeze for that version since
+features may be merged only into the `develop` branch.
 
 After the release branch is cut, the development on the `develop` branch may continue as before. Features can (and
 should) be merged without waiting for the next version to be released. Thus, the creation of a release branch also marks
 the beginning of the development for the next version.
 
-In contrast to that, only bug fixes may be merged into the release branch. At this point, the code contained in this
-branch should be tested, so that bugs can be identified and fixed.
+In contrast to that, only bug fixes may be merged into the release branch. This branch should be tested with care, so
+that bugs can be identified and fixed before the release.
 
 During the whole process the release manager will regularly merge back the release branch into `develop` or, if
-existent, the next active release branch so that bug fixes from the release branch will automatically become part of the
-next Opencast versions and finally `develop`, without having to create additional pull requests. For example, a pull
-request may be merged into `r/3.x`, `r/3.x` will then be merged into `develop` or, if it already exists, `r/4.x` and
-from there into `develop`. That way patches bubble through all newer versions and finally end up in `develop`.
+existent, the next active release branch.
 
 The releases themselves are not part of the release branch. Instead, the release manager branches off, makes the
 necessary changes to the pom files (and possibly the UI) and creates a separately tagged commit.
@@ -177,6 +171,81 @@ if there are enough commits to be put into a maintenance release.
 Even after an Opencast version has been released, more bugs may be found and fixes for them merged into the release
 branch. When the release manager considers that the number or importance of such bug fixes is sufficient, he may decide
 to create a new maintenance release. The version `6.1` above is an example of that.
+
+With Opencast supporting two major releases, you may find not one, but up to three active release branches.
+
+{% dot branching-two-versions.svg
+
+/**
+    develop ---*-----*-----*------*-----*- ... -----------*------*------*---->
+                \         /      /       \               /             /
+                 \       /      /   r/7.x *---*---*-----*----- ... ---*--->
+                  \     /      /             /         /
+            r/6.x  *---*------*------*------*------*--*----- ... ---*-->
+                              \              \         \             \
+                           6.0 *          6.1 *     6.2 *         6.3 *
+**/
+
+digraph G {
+  rankdir="LR";
+  bgcolor="transparent";
+  node[width=0.1, height=0.1, shape=point,fontsize=8.0,color=black,fontcolor=black];
+  edge[weight=2, arrowhead=none,color=black];
+  node[group=develop];
+  dbegin -> d1 -> d2 -> d3 -> d4 -> d5 -> d6 -> d7 -> d8 -> d9 -> d10 -> d11;
+  node[group=releasebranch];
+  edge[color=transparent];
+  rbegin -> r1;
+  edge[color=black];
+  r1 -> r2 -> r3 -> r4 -> r5 -> r6;
+  d1 -> r1;
+
+  node[group=releasebranch2];
+  edge[color=transparent];
+  r2begin -> r21;
+  edge[color=black];
+  r21 -> r22 -> r23 -> r24 -> r25;
+  d5 -> r21;
+
+
+  // releases
+  node[group=released]
+  edge[color=gray];
+  release1[shape=point, xlabel="7.0", color=gray]
+  r3 -> release1;
+  release2[shape=point, xlabel="7.1", color=gray]
+  r5 -> release2;
+  release3[shape=point, xlabel="8.0", color=gray]
+  r24 -> release3;
+
+  // end arrows
+  edge[arrowhead=normal, color=black];
+  dend,rend,r2end[shape=none, label=""];
+  d11 -> dend;
+  r6 -> rend;
+  r25 -> r2end;
+
+  // branch names
+  dbegin[shape=plaintext,label=develop];
+  rbegin[shape=plain,label="r/7.x"];
+  r2begin[shape=plain,label="r/8.x"];
+
+  // merge backs
+  edge[style=dashed, arrowhead=none, color=black];
+  r2 -> d4;
+  r5 -> r22;
+  r23 -> d9;
+  r25 -> d11;
+}
+%}
+
+Mostly, this is just the same as the simpler model from before. The branches exist separately from each other and only
+interact through merges from older to newer versions so that bug fixes from a release branch will automatically become
+part of the next Opencast versions (and `develop`), without having to create additional pull requests.
+
+For example, a pull request may be merged into `r/7.x`, `r/7.x` will then be merged into `develop` or, if it already
+exists, `r/8.x` and from there into `develop`. That way patches bubble through all newer versions and finally end up in
+`develop`.
 
 
 Release Process

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -1,6 +1,8 @@
 Development Process
 ===================
 
+[TOC]
+
 This document defines rules and recommendations for Opencast development. In particular, it defines how patches can be
 contributed, how they are merged and how releases are done.
 
@@ -14,10 +16,9 @@ contributed, how they are merged and how releases are done.
 Contributing Code
 -----------------
 
-Opencast sources can be found on [GitHub](https://github.com/opencast) and some of its ancillary projects
-on [BitBucket](https://bitbucket.org/opencast-community/). The easiest way to contribute code to the project
-is by creating a pull request against the project's official repository. More details about the structure
-of this repository are explained later in this guide.
+Opencast sources can be found on [GitHub](https://github.com/opencast). The easiest way to contribute code to the
+project is by creating a pull request against the project's official repository. More details about the structure of
+this repository are explained later in this guide.
 
 ### Jira and GitHub
 
@@ -29,9 +30,6 @@ of this repository are explained later in this guide.
   [fork](https://help.github.com/articles/fork-a-repo/) the [official repository](https://github.com/opencast/opencast)
   on GitHub to [create pull requests](https://help.github.com/articles/creating-a-pull-request/) from your repository
   which will show up on the project's list of open pull requests.
-
-* All open pull requests are listed on the [Opencast Pull Request Filter](http://pullrequests.opencast.org). It
-  mighttake a couple of minutes for a new pull request to show up.
 
 ### Bugfix vs Feature
 
@@ -47,8 +45,8 @@ Opencast distinguishes between bug fix and feature pull requests.
 
 ### Reviews
 
-Before a patch is merged, it needs to be reviewed by a committer. The reviewer makes sure that the patch merges
-without conflicts, that it works as expected and that it does not break anything else.
+Before a patch is merged, it needs to be reviewed. The reviewer tries to make sure that the patch merges without
+conflicts, that it works as expected and that it does not break anything else.
 
 If the reviewer discovers any kind of issue, he should comment on the pull request in GitHub, so that the author can
 fix the problem.
@@ -59,20 +57,17 @@ Requests](reviewing-and-merging.md).
 #### Pull Request Guidelines
 
 When reviewing a pull request, it is always easier if the reviewer knows what the ticket is about, and has a rough idea
-of what work has been done.  To this end, there are a few expectations for all pull requests:
+of what work has been done. To this end, there are a few expectations for all pull requests:
 
 * For each pull request a JIRA ticket should be created
 * The JIRA ticket and JIRA ticket title should be the pull request title
 * The pull request description should contain a summary of the work done, along with reasoning for any major change
     * The JIRA ticket should contain the same information
 * For feature pull requests, accompanying documentation should be included
-* It is encouraged, but not required that the pull request have a clean commit history
-* In the case of major user interface changes, it is good practice to include screenshots of the affect sections of
-  the interface
-* If you add or modify any external libraries ensure that those additions and modifications are also applied to the
-  NOTICES file
+* The pull request should have a clean commit history
+* In the case of major user interface changes, it is good practice to include screenshots of the change
 * Any actions that would be required for a version upgrade (e.g: from 3.x to 4.x) must be documented in
-  docs/guides/admin/docs/upgrade.md
+  `docs/guides/admin/docs/upgrade.md`
 * The commands `mvn clean install`, `mvn javadoc:javadoc javadoc:aggregate`, and `mvn site` should all succeed
 * The licenses of any external libraries used in the pull request comply with the [licensing rules](license.md) both
   in terms of the license itself as well as its listing in NOTICES
@@ -94,31 +89,69 @@ Swift overview:
 * The `develop` branch represents the latest state of development. Features may be merged into this branch and into
   this branch only. Release branches are branched off from `develop`. It is basically the preparation for the next big
   release at all times.
-* The release branches are named `r/<a>.<b>.x` (e.g. `r/1.6.x`). They are the latest state of development for a
-  specific release. Only bug fixes and no features may be added to these branches. All beta versions, release
-  candidates and final releases are made from these branches. The branch lives on as long as there may be additional
-  maintenance releases for a given version.
-* Git tags are created to indicate official releases. These may be:
-    * `x.y.z-betaX` marks a beta release. This is usually a version which may still have bugs but is good enough for
-      testing, so that further issues or bugs can be identified before an actual release.
-    * `x.y.z-rcX` marks a release candidate. This is a version that seems to be ready to be released as a final
-      version. It will become the final version if testing does not reveal any severe issues.
-    * `x.y.z` marks a final release.
+* The release branches are named `r/<a>.x` (e.g. `r/6.x`). They are the latest state of development for a specific
+  release. Only bug fixes and no features may be added to these branches. All releases are created from these branches.
+  The branches live on as long as there may be additional maintenance releases for a given version.
+* Git tags in the form of `a.b` are created to indicate official releases.
 
 
 To get a closer look at the branching model, let us consider a simple example with a single release:
 
 
+{% dot branching-simple.svg
+
+/**
     develop ---*----*----*------*------- ... -----------*-->
                 \       /      /                       /
-        r/1.6.x  *-----*------*-------------*---------*----- ... ---*-->
+          r/6.x  *-----*------*-------------*---------*----- ... ---*-->
                                \             \         \             \
-                    1.6.0-beta1 *   1.6.0-rc1 *   1.6.0 *       1.6.1 *
+                            6.0 *         6.1 *     6.2 *         6.3 *
+**/
+
+digraph G {
+  rankdir="LR";
+  bgcolor="transparent";
+  node[width=0.1, height=0.1, shape=point,fontsize=8.0,color=black,fontcolor=black];
+  edge[weight=2, arrowhead=none,color=black];
+  node[group=develop];
+  dbegin -> d1 -> d2 -> d3 -> d4 -> d5 -> d6 -> d7 -> d8 -> d9;
+  node[group=releasebranch];
+  edge[color=transparent];
+  rbegin -> r1;
+  edge[color=black];
+  r1 -> r2 -> r3 -> r4 -> r5 -> r6;
+  d1 -> r1;
+
+
+  // releases
+  node[group=released]
+  edge[color=gray];
+  release1[shape=point, xlabel="7.0", color=gray]
+  r3 -> release1;
+  release2[shape=point, xlabel="7.1", color=gray]
+  r5 -> release2;
+
+  // end arrows
+  edge[arrowhead=normal, color=black];
+  dend,rend[shape=none, label=""];
+  d9 -> dend;
+  r6 -> rend;
+
+  // branch names
+  dbegin[shape=plaintext,label=develop];
+  rbegin[shape=plain,label="r/7.x"];
+
+  // merge backs
+  edge[style=dashed, arrowhead=none, color=black];
+  r2 -> d4;
+  r5 -> d7;
+}
+%}
 
 As described above, `develop` is the branch used for preparing the next version. At some point marked in the release
 schedule, the release branch is cut from `develop`. This action also marks the feature freeze for such Opencast version,
 i.e. the moment when no new features will be included in that specific version. This is because all the new features
-must be merged only into the `develop` branch; therefore, the release branches (such as `r/1.6.x` in our example) can
+must be merged only into the `develop` branch; therefore, the release branches (such as `r/7.x` in our example) can
 only contain features that were merged before the branch was forked off. Any features merged after the creation of the
 release branch can only make it into the next release, but not into this one.
 
@@ -127,10 +160,7 @@ should) be merged without waiting for the next version to be released. Thus, the
 the beginning of the development for the next version.
 
 In contrast to that, only bug fixes may be merged into the release branch. At this point, the code contained in this
-branch should be tested, so that bugs can be identified and fixed. The release manager can tag different beta versions
-during the QA process (such as `1.6.0-beta1`) to mark the code evolution as bug fixes are merged. Once the branch status
-seems to be stable enough to be released, a release candidate (RC) is tagged and tested (`1.6.0-rc1`). New RCs can be
-tagged as long as new issues are found and fixed. When no severe issues are found, the final release is tagged.
+branch should be tested, so that bugs can be identified and fixed.
 
 During the whole process the release manager will regularly merge back the release branch into `develop` or, if
 existent, the next active release branch so that bug fixes from the release branch will automatically become part of the
@@ -146,7 +176,7 @@ if there are enough commits to be put into a maintenance release.
 
 Even after an Opencast version has been released, more bugs may be found and fixes for them merged into the release
 branch. When the release manager considers that the number or importance of such bug fixes is sufficient, he may decide
-to create a new maintenance release. The version `1.6.1` above is an example of that.
+to create a new maintenance release. The version `6.1` above is an example of that.
 
 
 Release Process
@@ -174,24 +204,19 @@ to identify phases for internal and public testing.
 
 Usually, a release schedule will look like this:
 
-|Date                          |What is happening
-|------------------------------|-------------------------------------------------
-|April 6th                     |Feature Freeze *(release branch is cut)*
-|April 6th - 24th              |Internal QA and bug fixing phase
-|&nbsp; *April 11th - 17th*    |Review Test Cases *(handles by a dedicated team)*
-|&nbsp; *April 18th - 24th*    |Documentation Review
-|April 25th - May 15th         |Public QA phase
-|May 15th - June 1st           |Additional bug fixing phase
-|&nbsp; *May 25th - June 1st*  |Translation week *(encourage translators to do their work)*
-|June 2nd - June 12th          |Final QA phase *(checking release readiness)*
-|June 15th                     |Final Release
+|Date                     |Phase
+|-------------------------|------------------------------------------
+|April 1st                |Feature Freeze
+|May 6th - May 12th       |Translation week
+|May 13th - May 26th      |Public QA phase
+|June 15th                |Release of Opencast 7.0
 
 
 ### Release Branch
 
-The release branch is created from `develop`. The release branch is named `r/A.B.x` (e.g. `r/2.1.x`) to indicate that it
-is the origin of all releases with the major and minor version of `A.B`. The creation of the release branch marks the
-feature freeze for a given version, as no more features can be merged into a release branch.
+The release branch is created from `develop`. The release branch is named `r/A.x` (e.g. `r/7.x`) to indicate that it is
+the origin of all releases with the major version of `A`. The creation of the release branch marks the feature freeze
+for a given version, as no more features can be merged into a release branch.
 
 To ensure that all fixes that go into the release branch will become part of `develop` (and thus part of the next version
 of Opencast) with a minimum amount of work, the release manager will merge the release branch into `develop` on a
@@ -200,33 +225,42 @@ the next release branch is cut.
 
 ### Tags
 
-Git tags are used to mark explicit Opencast versions or releases. Here is how a release should look like in the history:
+Git tags are used to mark Opencast releases. Here is how a release looks like in the history:
 
-    r/A.B.x  ------------(A)---->
-                           \
-               A.B.0-beta1 (B)
+{% dot branching-tags.svg
 
-To create a version based on a given state of the release branch (commit A), the release manager will branch off from
-this commit, make the necessary version changes to all `pom.xml` files and to the UI and create a commit and a *signed*
-git tag on this commit. He would then push the commit and the tag (not the branch) to the community repository.
+/**
+    r/7.x  ------------(A)---->
+                         \
+                     7.0 (B)
+**/
+
+digraph G {
+  rankdir="LR";
+  bgcolor="transparent";
+  node[shape=circle, fixedsize=true, width=0.2, fontsize=8.0, fontcolor=black, group=branch, fontname=helvetica];
+  edge[weight=2, arrowhead=none, color=black];
+  begin -> A;
+
+  // end arrows
+  end[shape=none, label=""];
+  A -> end [arrowhead=normal, color=black, minlen=3];
+
+
+  // releases
+  B[group=release, xlabel="7.0", color=gray, fontcolor=gray]
+  A -> B [color=gray];
+
+  // branch names
+  begin[shape=plaintext, label="r/7.x", fixedsize=false];
+}
+%}
+
+To create a version based on a given state of the release branch (commit `A`), the release manager will branch off from
+this commit, make the necessary version changes to all `pom.xml` files and create a commit which is then finally tagged.
+This tag is then pushed to the community repository.
 
 For more details about how to create a release, have a look at the [Release Manager Guide](release-manager.md).
-
-#### Beta Versions/Release Candidates
-
-A beta release (`A.B.C-betaX`) should be cut before the public QA phase. It indicates a specific version of Opencast for
-users to test. It is expected to still have bugs. Beta releases should continue until all bugs with a severity of
-`Blocker` have been fixed.
-
-If the code seems to be ready for a release, a *release candidate* (`A.B.C-rcX`) should be cut for final testing. The
-commit from which a release candidate is created is expected to become the final release if no severe bugs are found.
-
-#### Final Release
-
-Once a release candidate seems to be stable during the QA phase (no issues left marked as `Blocker`), the release manager
-will propose this release candidate to become the final release. If the proposal is approved (i.e. no serious bugs are
-found before the proposal deadline is met), the final release is then created from the same commit the
-release candidate was cut from.
 
 ### Maintenance Releases
 
@@ -234,9 +268,7 @@ After a final release, additional issues may show up. These issues may be fixed 
 some point released as maintenance release.
 
 There is usually no release schedule for maintenance releases. It is up to the release manager to decide when it is
-worthwhile to create a maintenance release with the fixes for bugs affecting a given release. He would then announce his
-intention to create such a release, cut a release candidate and, should no severe issues with this candidate show up, cut
-the maintenance release.
+worthwhile to create a maintenance release with the fixes for bugs affecting a given release.
 
 Quality Assurance
 -----------------
@@ -285,8 +317,6 @@ process.
 ### Test Server
 
 Some institutions provide public testing infrastructure for Opencast. Use them to try out the most recent development
-version of Opencast. They are meant for testing. Do not fear to break them.  If you manage to do it, please contact the
-QA manager or send a notice to the list.
+version of Opencast. They are meant for testing. Do not fear to break them. They are meant for testing.
 
-Remember that they are usually not running a stable version of Opencast but the latest development release (beta version
-or release candidate) instead. If you discover any bugs on these systems, please take a minute to report them.
+For a list of test servers, take a look at the [infrastructure documentation](infrastructure/index.md).

--- a/docs/guides/developer/mkdocs.yml
+++ b/docs/guides/developer/mkdocs.yml
@@ -2,6 +2,9 @@ site_name: Opencast - Developer Guide
 repo_url: https://github.com/opencast/opencast
 edit_uri: edit/develop/docs/guides/developer/docs/
 
+markdown_extensions:
+  - markdown_inline_graphviz
+
 # Default theme used is readthedocs
 theme: readthedocs
 

--- a/docs/guides/package.json
+++ b/docs/guides/package.json
@@ -5,6 +5,6 @@
     "markdownlint-cli": "^0.17.0"
   },
   "scripts": {
-    "test": "markdownlint ./admin/**/*.md ./developer/**/*.md ./user/**/*.md ../../*.md"
+    "test": "markdownlint *.md ./admin/**/*.md ./developer/**/*.md ./user/**/*.md ../../*.md"
   }
 }

--- a/docs/guides/readme.md
+++ b/docs/guides/readme.md
@@ -1,0 +1,38 @@
+Opencast Documentation Sources
+==============================
+
+The documentation uses `mkdocs` and the `markdown_inline_graphviz` extension as static site generator. The documentation
+on [docs.opencast.org](https://docs.opencast.org) is updated once a day from these sources. For details about the
+automated build, check out:
+
+- <https://github.com/opencast/docs.opencast.org>
+
+
+Quick-build
+-----------
+
+A quick example on how to build/serve the docs locally.
+Requires python virtual environment.
+
+```sh
+% cd guides
+% virtualenv venv
+% . ./venv/bin/activate
+% pip install mkdocs
+% pip install markdown_inline_graphviz_extension
+% cd developer
+% python -m mkdocs serve
+```
+
+
+Tests
+-----
+
+The guides come with a few automated style checks. They are executed on pull requests automatically but you can also run
+them locally:
+
+```sh
+% cd guides
+% npm install
+% npm test
+```


### PR DESCRIPTION
The development process documentation has grown old in some places and
does not completely reflect current practice any longer. Since the
document was written, the version numbers have changed, we do not use
Bitbucket any longer and we usually do not cut beta releases or release
candidates.

Additionally, to updating that, this patch includes a Markdown extension
to write inline Graphviz code for rendering vector graphics. We've
discussed adding something like this a while ago and this seemed a good
opportunity to get it done.

For a rendered version of the page including the graphics, visit:

- [data.lkiesow.io/…/development-process/#git-repository-branching-model](https://data.lkiesow.io/opencast/docs-developer-2019-07-07/development-process/#git-repository-branching-model)