### PR TITLE
MH-13662, Update LTI Information

### DIFF
--- a/modules/lti/src/main/resources/tools/index.css
+++ b/modules/lti/src/main/resources/tools/index.css
@@ -1,0 +1,13 @@
+body {
+  font-size: 16px;
+  font-family: sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 25px;
+  border-left: 1px solid silver;
+  border-right: 1px solid silver;
+}
+
+code {
+  background: #ddd;
+}

--- a/modules/lti/src/main/resources/tools/index.html
+++ b/modules/lti/src/main/resources/tools/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <meta name="description" content="Opencast LTI Module">
   <meta name="author" content="Opencast">
+  <link rel=stylesheet type=text/css href=index.css />
   <title>LTI Module</title>
 </head>
 <body>
@@ -12,10 +13,12 @@
   <p>
   <ul>
     <li>More information about configuring LTI is available in the Administration Guide at
-      <a href="https://docs.opencast.org/" target="_blank">docs.opencast.org</a></li>
-    <li>Here is <a href="/lti" target="_blank">what we know about you and your context</a> from the tool consumer.</li>
-    <li>Here is <a href="/info/me.json" target="_blank">your organization, role and user information</a>.</li>
+      <a href="https://docs.opencast.org">docs.opencast.org</a></li>
+    <li>Here is <a href="/lti">what we know about you and your context</a> from the tool consumer.</li>
+    <li>Here is <a href="/info/me.json">your organization, role and user information</a>.</li>
     <li>Published videos can be found in the <a href="/engage/ui/">Media Module</a>.</li>
+    <li>For course integration, use the <a href=series/index.html>Series LTI Tool</a>.
+      Note that you can use the <code>?series=[series-id]</code> URL parameter to show just a single series.</li>
   </ul>
   </p>
 </body>


### PR DESCRIPTION
The default LTI page is displaying some basic information about LTI in
Opencast: The current log-in status, LTI connection information, and
links to possible LTI tools. The most commonly used series LTI tool is,
unfortunately, missing from this list.

This patch adds additional information and makes a few simple style
adjustments to make the page look a bit nicer.

*Work sponsored by SWITCH*