### PR TITLE
MH-13663 Access org properties from publish-configure WOH

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-configure-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-configure-woh.md
@@ -49,6 +49,16 @@ execution of the workflow operation.
 |`${publication_id}`|The id of this publication.               |`54f6c12d-8e68-4ec8-badf-cd045b33d01e`|
 |`${series_id}`     |The id of the series if available         |`36f3c5d8-ad4d-4dab-beb1-1400ffab4a69`|
 
+The organization properties are also available and can be accessed with the `org_` prefix followed by the property name,
+eg. `${org_player}` will be replaced by the value of the organization property named `player`.
+
+Note some organization properties contain an `.` (period) in their name (e.g. `org.opencastproject.external.api.url`).
+As this character have an special meaning in the FreeMarker library (used for substitution), all occurrences are replaced
+with `_` (underscore).
+
+Additional to the organization properties you can use `org_id`, `org_name`, `org_admin_role` and
+`org_anonymous_role` as well.
+
 ## Publication Channel Labels and Icons
 
 Using this workflow operation, you can create arbitrary custom publication channels. Without further action, the

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
@@ -81,6 +81,8 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
   protected static final String SERIES_ID_TEMPLATE_KEY = "series_id";
   /** The configuration property value for the player location. */
   protected static final String PLAYER_PROPERTY = "player";
+  /** The template key name prefix for organization keys */
+  protected static final String ORG_TEMPLATE_KEY_PREFIX = "org_";
   // service references
   private DownloadDistributionService distributionService;
 
@@ -145,6 +147,15 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
     String playerPath = securityService.getOrganization().getProperties().get(PLAYER_PROPERTY);
     values.put(PLAYER_PATH_TEMPLATE_KEY, playerPath);
     values.put(SERIES_ID_TEMPLATE_KEY, StringUtils.trimToEmpty(mp.getSeries()));
+    Map<String, String> orgProperties = securityService.getOrganization().getProperties();
+    orgProperties.put("id", securityService.getOrganization().getId());
+    orgProperties.put("name", securityService.getOrganization().getName());
+    orgProperties.put("admin_role", securityService.getOrganization().getAdminRole());
+    orgProperties.put("anonymous_role", securityService.getOrganization().getAnonymousRole());
+    for (Map.Entry<String, String> orgProperty : orgProperties.entrySet()) {
+      values.put(ORG_TEMPLATE_KEY_PREFIX + orgProperty.getKey().replace('.', '_').toLowerCase(),
+              orgProperty.getValue());
+    }
     String uriWithVariables = DocUtil.processTextTemplate("Replacing Variables in Publish URL", urlPattern, values);
     URI publicationURI;
     try {


### PR DESCRIPTION
The `publish-configure` WOH can be used to publish the recording to an uncommon channel. You have to configure the `url-pattern` how the publication can be accessed after publishing. In the `url-pattern` configuration you can use the substitution for some values like `event_id`, see [documentation](https://docs.opencast.org/develop/admin/workflowoperationhandlers/publish-configure-woh/#url-pattern-variables). 

With this patch you can also use the organization specific properties (e.g. org id, external api url, player path,…) in the `url-pattern` as well.

Work sponsored by SWITCH