### PR TITLE
MH-13670, Shell information for developer distribution

### DIFF
--- a/assemblies/dist-develop/resources/shell.init.script.append
+++ b/assemblies/dist-develop/resources/shell.init.script.append
@@ -1,3 +1,5 @@
 
+echo "\u001B[1mDevelopment distribution\u001B[0m: Automatically launching \u001B[1m'log:tail'\u001B[0m.\n"
+
 sleep 1
 log:tail

--- a/etc/branding.properties
+++ b/etc/branding.properties
@@ -9,6 +9,7 @@ welcome = \
 \r\n\
 Hit '\u001B[1m<tab>\u001B[0m' for a list of available commands\r\n\
    and '\u001B[1m[cmd] --help\u001B[0m' for help on a specific command.\r\n\
+Hit '\u001B[1m<Ctrl-c>\u001B[0m' to terminale a running command.\r\n\
 Hit '\u001B[1m<ctrl-d>\u001B[0m' or '\u001B[1msystem:shutdown\u001B[0m' to shutdown Opencast.\r\n
 
 prompt = \u001B[1m${USER}@${APPLICATION}\u001B[0m>


### PR DESCRIPTION
Launching the developer distribution of Opencast, `log:tail` is invoked
automatically to make testing easier. This might confuse first-time
users of the development distribution since they need to know that they
can hit `ctrl-c` to leave the command.

This patch adds a comment about how to terminate a tool to all
distributions and a comment about automatically launching `log:tail` to
the development distribution.