### PR TITLE
MH-13671 OAI-PMH autorepublish fails due to invalid urls

### DIFF
--- a/modules/conductor/src/main/resources/OSGI-INF/events/episode-updated.xml
+++ b/modules/conductor/src/main/resources/OSGI-INF/events/episode-updated.xml
@@ -24,6 +24,9 @@
       <provide interface="org.osgi.service.cm.ManagedService"/>
       <provide interface="org.opencastproject.event.handler.OaiPmhUpdatedEventHandler"/>
     </service>
+
+    <reference name="assetManager" interface="org.opencastproject.assetmanager.api.AssetManager"
+               cardinality="1..1" policy="static" bind="setAssetManager"/>
     <reference name="oaiPmhPersistence" interface="org.opencastproject.oaipmh.persistence.OaiPmhDatabase"
                cardinality="1..1" policy="static" bind="setOaiPmhPersistence"/>
     <reference name="oaiPmhPublicationService"


### PR DESCRIPTION
The OAI-PMH publication service and download distribution service are often in error state if you run some fix-metadata-and-republish-to-oaipmh workflows. In case of error you will see an error message like: can not distribute catalog, with inner message: file not found. The mediapackage, the oaipmh autorepublish code get from the asset manager (through ActiveMQ) contains URLs pointing to the working file repository. But in some situations, the workflow instance is finished and the associated files are removed. This is the root cause of the problem.

Changed behaviour: query the asset manager for the snapshot and uses the media package from the snapshot for further processing.