### PR TITLE
MH-13672, Editor Maximum Height

### DIFF
--- a/modules/admin-ui/src/main/webapp/styles/components/video/_video-player.scss
+++ b/modules/admin-ui/src/main/webapp/styles/components/video/_video-player.scss
@@ -29,6 +29,7 @@
     border-radius: 4px 4px 0 0;
 
     video {
+        max-height: 350px;
         max-width: 100%;
         height: auto;
     }


### PR DESCRIPTION
The player used in the video editor has no maximum height which max
cause the video to take more than the full height of the screen in
certain situations (e.g. high-res portrait mode smartphone recording).
This makes the editor extremely hard to use in these situations.

A simple solution is to enforce a maximum height, the player max not
exceed.