### PR TITLE
MH-13677, IDEA Settings

### DIFF
--- a/docs/intellij_settings/codestyle.xml
+++ b/docs/intellij_settings/codestyle.xml
@@ -2,7 +2,7 @@
   <option name="OTHER_INDENT_OPTIONS">
     <value>
       <option name="INDENT_SIZE" value="2" />
-      <option name="CONTINUATION_INDENT_SIZE" value="8" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
       <option name="TAB_SIZE" value="2" />
       <option name="USE_TAB_CHARACTER" value="false" />
       <option name="SMART_TABS" value="false" />


### PR DESCRIPTION
By default the continuation indent size is IDEA is eight spaces, making
it double the size of a usual ident. For Opencast, we reduced the common
indentation to two spaces so that in turn, a continuation indent size of
four would make sense.