### PR TITLE
MH-12618, SMIL tests fail when doctype url can't be resolved

### DIFF
--- a/modules/smil-impl/src/test/java/org/opencastproject/smil/impl/SmilServiceImplTest.java
+++ b/modules/smil-impl/src/test/java/org/opencastproject/smil/impl/SmilServiceImplTest.java
@@ -66,8 +66,7 @@ public class SmilServiceImplTest {
   /**
    * Test SMIL document
    */
-  private static final String TEST_SMIL = "<!DOCTYPE smil PUBLIC \"-//W3C//DTD SMIL 3.0 Language//EN\" \"http://www.w3.org/2008/SMIL30/SMIL30Language.dtd\">\n"
-          + "<smil xmlns=\"http://www.w3.org/ns/SMIL\" baseProfile=\"Language\" version=\"3.0\" xml:id=\"s-c4af7197-8496-46ae-a80b-bc15ead58c87\">\n"
+  private static final String TEST_SMIL = "<smil xmlns=\"http://www.w3.org/ns/SMIL\" baseProfile=\"Language\" version=\"3.0\" xml:id=\"s-c4af7197-8496-46ae-a80b-bc15ead58c87\">\n"
           + "  <head xml:id=\"h-37abdf0c-95e8-4d39-a574-a71c927e7381\">\n"
           + "    <paramGroup xml:id=\"pg-19fc18d1-e94b-401a-91a7-08f8242642a8\">\n"
           + "      <param value=\"track-1\" name=\"track-id\" valuetype=\"data\" xml:id=\"param-04677935-3868-404c-bf1e-0f0559d718b3\"/>\n"


### PR DESCRIPTION
remove the doctype with the dtd url and it's flakey http protocol in the test smil file. live smil files have no doctype anyway