### PR TITLE
MH-13682, Logging

### DIFF
--- a/modules/static-file-service-impl/src/main/java/org/opencastproject/staticfiles/impl/StaticFileServiceImpl.java
+++ b/modules/static-file-service-impl/src/main/java/org/opencastproject/staticfiles/impl/StaticFileServiceImpl.java
@@ -291,7 +291,7 @@ public class StaticFileServiceImpl implements StaticFileService {
    *           if there was an error while deleting the files.
    */
   void purgeTemporaryStorageSection(final String org, final long lifetime) throws IOException {
-    logger.info("Purge temporary storage section of organization '{}'", org);
+    logger.debug("Purge temporary storage section of organization '{}'", org);
     final Path temporaryStorageDir = getTemporaryStorageDir(org);
     if (Files.exists(temporaryStorageDir)) {
       try (DirectoryStream<Path> tempFilesStream = Files.newDirectoryStream(temporaryStorageDir,


### PR DESCRIPTION
On systems with a lot of tenants, the log message

    2019-08-04T03:07:05,827 | INFO  | (StaticFileServiceImpl:294) - Purge temporary storage section of organization '...'

…often spams the log files, making it hard to get to the actually
important information while not providing a lot of helpful information
itself.