### PR TITLE
MH-13684, Do not include auth token in republished URLs

### DIFF
--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchQuery.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchQuery.java
@@ -42,9 +42,15 @@ public class SearchQuery {
   protected Date deletedDate = null;
   protected Sort sort = Sort.DATE_CREATED;
   protected boolean sortAscending = true;
+  protected boolean signURL = false;
 
   public enum Sort {
     DATE_CREATED, DATE_PUBLISHED, TITLE, SERIES_ID, MEDIA_PACKAGE_ID, CREATOR, CONTRIBUTOR, LANGUAGE, LICENSE, SUBJECT, DESCRIPTION, PUBLISHER
+  }
+
+  public SearchQuery signURLs(final boolean sign) {
+    this.signURL = sign;
+    return this;
   }
 
   public SearchQuery includeEpisodes(boolean includeEpisode) {
@@ -109,6 +115,10 @@ public class SearchQuery {
 
   public String getSeriesId() {
     return seriesId;
+  }
+
+  public boolean isSignURLs() {
+    return signURL;
   }
 
   public boolean isIncludeEpisodes() {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -159,7 +159,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
       @PathParam("format")    String  format
       ) throws SearchException, UnauthorizedException {
 
-    SearchQuery query = new SearchQuery();
+    SearchQuery query = new SearchQuery().signURLs(true);
 
     // If id is specified, do a search based on id
     if (StringUtils.isNotBlank(id))
@@ -252,9 +252,13 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     }
 
     SearchQuery search = new SearchQuery();
-    search.withId(id).withSeriesId(seriesId)
-            .withElementFlavors(flavorSet.toArray(new MediaPackageElementFlavor[flavorSet.size()]))
-            .withElementTags(tags).withLimit(limit).withOffset(offset);
+    search.withId(id)
+        .withSeriesId(seriesId)
+        .withElementFlavors(flavorSet.toArray(new MediaPackageElementFlavor[0]))
+        .withElementTags(tags)
+        .withLimit(limit)
+        .withOffset(offset)
+        .signURLs(true);
 
     if (StringUtils.isNotBlank(text)) {
       search.withText(text);
@@ -314,7 +318,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
   public Response getByLuceneQuery(@QueryParam("q") String q, @QueryParam("sort") String sort, @QueryParam("limit") int limit,
           @QueryParam("offset") int offset, @QueryParam("admin") boolean admin, @PathParam("format") String format)
           throws SearchException, UnauthorizedException {
-    SearchQuery query = new SearchQuery();
+    SearchQuery query = new SearchQuery().signURLs(true);
     if (!StringUtils.isBlank(q))
       query.withQuery(q);
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -37,12 +37,14 @@ import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DELETE;
@@ -147,7 +149,10 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
                   + "CONTRIBUTOR, LANGUAGE, LICENSE, SUBJECT, DESCRIPTION, PUBLISHER.  Add '_DESC' to reverse the sort order (e.g. TITLE_DESC).", type = RestParameter.Type.STRING),
           @RestParameter(defaultValue = "20", description = "The maximum number of items to return per page.", isRequired = false, name = "limit", type = RestParameter.Type.STRING),
           @RestParameter(defaultValue = "0", description = "The page number.", isRequired = false, name = "offset", type = RestParameter.Type.STRING),
-          @RestParameter(defaultValue = "false", description = "Whether this is an administrative query", isRequired = false, name = "admin", type = RestParameter.Type.BOOLEAN) }, reponses = { @RestResponse(description = "The request was processed succesfully.", responseCode = HttpServletResponse.SC_OK) }, returnDescription = "The search results, expressed as xml or json.")
+          @RestParameter(defaultValue = "false", description = "Whether this is an administrative query", isRequired = false, name = "admin", type = RestParameter.Type.BOOLEAN),
+          @RestParameter(defaultValue = "true", description = "If results are to be signed", isRequired = false,
+              name = "sign", type = RestParameter.Type.BOOLEAN)
+    }, reponses = { @RestResponse(description = "The request was processed succesfully.", responseCode = HttpServletResponse.SC_OK) }, returnDescription = "The search results, expressed as xml or json.")
   public Response getEpisodeAndSeriesById(
       @QueryParam("id")       String  id,
       @QueryParam("q")        String  text,
@@ -156,10 +161,12 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
       @QueryParam("limit")    int     limit,
       @QueryParam("offset")   int     offset,
       @QueryParam("admin")    boolean admin,
+      @QueryParam("sign")     String  sign,
       @PathParam("format")    String  format
       ) throws SearchException, UnauthorizedException {
 
-    SearchQuery query = new SearchQuery().signURLs(true);
+    final boolean signURLs = BooleanUtils.toBoolean(Objects.toString(sign, "true"));
+    SearchQuery query = new SearchQuery().signURLs(signURLs);
 
     // If id is specified, do a search based on id
     if (StringUtils.isNotBlank(id))
@@ -233,11 +240,14 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
                   + "CONTRIBUTOR, LANGUAGE, LICENSE, SUBJECT, DESCRIPTION, PUBLISHER.  Add '_DESC' to reverse the sort order (e.g. TITLE_DESC).", type = RestParameter.Type.STRING),          
           @RestParameter(defaultValue = "20", description = "The maximum number of items to return per page.", isRequired = false, name = "limit", type = RestParameter.Type.STRING),
           @RestParameter(defaultValue = "0", description = "The page number.", isRequired = false, name = "offset", type = RestParameter.Type.STRING),
-          @RestParameter(defaultValue = "false", description = "Whether this is an administrative query", isRequired = false, name = "admin", type = RestParameter.Type.BOOLEAN) }, reponses = { @RestResponse(description = "The request was processed succesfully.", responseCode = HttpServletResponse.SC_OK) }, returnDescription = "The search results, expressed as xml or json.")
+          @RestParameter(defaultValue = "false", description = "Whether this is an administrative query", isRequired = false, name = "admin", type = RestParameter.Type.BOOLEAN),
+          @RestParameter(defaultValue = "true", description = "If results are to be signed", isRequired = false,
+              name = "sign", type = RestParameter.Type.BOOLEAN)
+  }, reponses = { @RestResponse(description = "The request was processed successfully.", responseCode = HttpServletResponse.SC_OK) }, returnDescription = "The search results, expressed as xml or json.")
   public Response getEpisode(@QueryParam("id") String id, @QueryParam("q") String text,
           @QueryParam("sid") String seriesId, @QueryParam("sort") String sort, @QueryParam("tag") String[] tags, @QueryParam("flavor") String[] flavors,
           @QueryParam("limit") int limit, @QueryParam("offset") int offset, @QueryParam("admin") boolean admin,
-          @PathParam("format") String format) throws SearchException, UnauthorizedException {
+          @QueryParam("sign") String sign, @PathParam("format") String format) throws SearchException, UnauthorizedException {
     // CHECKSTYLE:ON
     // Prepare the flavors
     List<MediaPackageElementFlavor> flavorSet = new ArrayList<MediaPackageElementFlavor>();
@@ -251,6 +261,8 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
       }
     }
 
+    final boolean signURLs = BooleanUtils.toBoolean(Objects.toString(sign, "true"));
+
     SearchQuery search = new SearchQuery();
     search.withId(id)
         .withSeriesId(seriesId)
@@ -258,7 +270,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
         .withElementTags(tags)
         .withLimit(limit)
         .withOffset(offset)
-        .signURLs(true);
+        .signURLs(signURLs);
 
     if (StringUtils.isNotBlank(text)) {
       search.withText(text);
@@ -314,11 +326,16 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
                   + "CONTRIBUTOR, LANGUAGE, LICENSE, SUBJECT, DESCRIPTION, PUBLISHER.  Add '_DESC' to reverse the sort order (e.g. TITLE_DESC).", type = RestParameter.Type.STRING),
           @RestParameter(defaultValue = "20", description = "The maximum number of items to return per page.", isRequired = false, name = "limit", type = RestParameter.Type.STRING),
           @RestParameter(defaultValue = "0", description = "The page number.", isRequired = false, name = "offset", type = RestParameter.Type.STRING),
-          @RestParameter(defaultValue = "false", description = "Whether this is an administrative query", isRequired = false, name = "admin", type = RestParameter.Type.BOOLEAN) }, reponses = { @RestResponse(description = "The request was processed succesfully.", responseCode = HttpServletResponse.SC_OK) }, returnDescription = "The search results, expressed as xml or json")
+          @RestParameter(defaultValue = "false", description = "Whether this is an administrative query", isRequired = false, name = "admin", type = RestParameter.Type.BOOLEAN),
+          @RestParameter(defaultValue = "true", description = "If results are to be signed", isRequired = false,
+              name = "sign", type = RestParameter.Type.BOOLEAN)
+    }, reponses = { @RestResponse(description = "The request was processed succesfully.", responseCode = HttpServletResponse.SC_OK) }, returnDescription = "The search results, expressed as xml or json")
   public Response getByLuceneQuery(@QueryParam("q") String q, @QueryParam("sort") String sort, @QueryParam("limit") int limit,
-          @QueryParam("offset") int offset, @QueryParam("admin") boolean admin, @PathParam("format") String format)
+          @QueryParam("offset") int offset, @QueryParam("admin") boolean admin,
+          @QueryParam("sign") String sign, @PathParam("format") String format)
           throws SearchException, UnauthorizedException {
-    SearchQuery query = new SearchQuery().signURLs(true);
+    final boolean signURLs = BooleanUtils.toBoolean(Objects.toString(sign, "true"));
+    SearchQuery query = new SearchQuery().signURLs(signURLs);
     if (!StringUtils.isBlank(q))
       query.withQuery(q);
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -152,7 +152,7 @@ public class SolrRequester {
    * @throws SolrServerException
    *           if the solr server is not working as expected
    */
-  private SearchResult createSearchResult(final SolrQuery query) throws SolrServerException {
+  private SearchResult createSearchResult(final SolrQuery query, final boolean signed) throws SolrServerException {
 
     // Execute the query and try to get hold of a query response
     QueryResponse solrResponse = null;
@@ -192,8 +192,9 @@ public class SolrRequester {
         @Override
         public MediaPackage getMediaPackage() {
           MediaPackageBuilder builder = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder();
-          if (serializer != null)
+          if (signed && serializer != null) {
             builder.setSerializer(serializer);
+          }
           String mediaPackageFieldValue = Schema.getOcMediapackage(doc);
           if (mediaPackageFieldValue != null) {
             try {
@@ -776,7 +777,7 @@ public class SolrRequester {
    */
   public SearchResult getForAdministrativeRead(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, READ.toString(), false);
-    return createSearchResult(query);
+    return createSearchResult(query, q.isSignURLs());
   }
 
   /**
@@ -789,7 +790,7 @@ public class SolrRequester {
    */
   public SearchResult getForRead(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, READ.toString(), true);
-    return createSearchResult(query);
+    return createSearchResult(query, q.isSignURLs());
   }
 
   /**
@@ -802,7 +803,7 @@ public class SolrRequester {
    */
   public SearchResult getForWrite(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, WRITE.toString(), true);
-    return createSearchResult(query);
+    return createSearchResult(query, q.isSignURLs());
   }
 
   /**

--- a/modules/search-service-remote/src/main/java/org/opencastproject/search/remote/SearchServiceRemoteImpl.java
+++ b/modules/search-service-remote/src/main/java/org/opencastproject/search/remote/SearchServiceRemoteImpl.java
@@ -194,6 +194,7 @@ public class SearchServiceRemoteImpl extends RemoteBase implements SearchService
   private String getSearchUrl(SearchQuery q, boolean admin) {
     StringBuilder url = new StringBuilder();
     List<NameValuePair> queryStringParams = new ArrayList<NameValuePair>();
+    queryStringParams.add(new BasicNameValuePair("sign", "false"));
 
     // MH-10216, Choose "/expisode.xml" endpoint when querying by mediapackage id (i.e. episode id ) to recieve full mp data
     if (q.getId() != null || q.getSeriesId() != null || q.getElementFlavors() != null || q.getElementTags() != null) {


### PR DESCRIPTION
Using Opencast's token based authorization system, users may require a
valid token for accessing resources like videos (this is configurable,
of course, but that would be a common use case). Access without a token
will always be denied in such a case, regardless of the users login
status.

To obtain the token, the search service will include then in search
results for users with valid access as part of the returned URLs. This
means that there is no need for any special handling of search results
if tokens are required in contrast to them not being required.

Unfortunately, this has the side-effect that for re-publication of
metadata, tokens will end up in the published data since they look just
like regular URLs, causing the URLs to become permanently invalid.

This patch ensures that signatures will only be attached to requests via
the REST interfaces, but not to requests made internally to the search
service, ensuring that no tokens get mangled in published URLs.