### PR TITLE
MH-13685: Added dublincore, security to publish (merge) and replublish-oaimph

### DIFF
--- a/etc/workflows/attach-watson-transcripts.xml
+++ b/etc/workflows/attach-watson-transcripts.xml
@@ -33,9 +33,21 @@
       exception-handler-workflow="partial-error"
       description="Distribute and publish to engage server">
       <configurations>
+        <configuration key="download-source-flavors">dublincore/*,security/*</configuration>
         <configuration key="download-source-tags">engage-download</configuration>
         <configuration key="strategy">merge</configuration>
         <configuration key="check-availability">true</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="republish-oaipmh"
+      exception-handler-workflow="partial-error"
+      description="Update recording metadata in default OAI-PMH repository">
+      <configurations>
+        <configuration key="source-flavors">dublincore/*,security/*</configuration>
+        <configuration key="download-source-tags">engage-download</configuration>
+        <configuration key="repository">default</configuration>
       </configurations>
     </operation>
 

--- a/etc/workflows/publish-uploaded-assets.xml
+++ b/etc/workflows/publish-uploaded-assets.xml
@@ -49,7 +49,8 @@
       exception-handler-workflow="partial-error"
       description="Update recording in Opencast Media Module">
       <configurations>
-        <configuration key="download-source-flavors">${download-source-flavors}</configuration>
+        <configuration key="download-source-flavors">${download-source-flavors},dublincore/*,security/*</configuration>
+        <configuration key="download-source-tags">engage-download</configuration>
         <configuration key="strategy">merge</configuration>
         <configuration key="check-availability">false</configuration>
       </configurations>
@@ -63,7 +64,8 @@
       exception-handler-workflow="partial-error"
       description="Update recording metadata in default OAI-PMH repository">
       <configurations>
-        <configuration key="source-flavors">${download-source-flavors}</configuration>
+       <configuration key="source-flavors">${download-source-flavors},dublincore/*,security/*</configuration>
+        <configuration key="download-source-tags">engage-download</configuration>
         <configuration key="repository">default</configuration>
       </configurations>
     </operation>

--- a/modules/engage-theodul-plugin-custom-mhConnection/src/main/resources/static/models/mediaPackage.js
+++ b/modules/engage-theodul-plugin-custom-mhConnection/src/main/resources/static/models/mediaPackage.js
@@ -86,6 +86,8 @@ define(["backbone", "engage/core"], function(Backbone, Engage) {
                             }
                             if (mediaPackage.dcCreated) {
                                 model.attributes.date = mediaPackage.dcCreated;
+                            } else {
+                                model.attributes.date = mediaPackage.mediapackage.start;
                             }
                             if (mediaPackage.dcDescription) {
                                 model.attributes.description = mediaPackage.dcDescription;

--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -669,6 +669,8 @@ function($, bootbox, _, alertify, jsyaml) {
 
         if (data.dcCreated) {
           date = new Date(data.dcCreated);
+        } else {
+          date = new Date(data.mediapackage.start);
         }
         tile = tile + '<div class="date">' + date.toLocaleDateString() + '</div>';
 


### PR DESCRIPTION
Added dublincore and security to publish (merge) and replublish-oaimph, and small ui updates to use mediapackage.start or dcCreated.

This fixes the bug where dcCreated is not filled in correctly and the ACL's are not merged in for events where a caption gets added from an attachment workflow.