### PR TITLE
MH-13692 Load all roles in Admin UI at once

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/aclController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/aclController.js
@@ -24,10 +24,6 @@
 angular.module('adminNg.controllers')
 .controller('AclCtrl', ['$scope', 'AclResource', 'UserRolesResource', 'ResourcesListResource', 'Notifications', 'Modal',
   function ($scope, AclResource, UserRolesResource, ResourcesListResource, Notifications, Modal) {
-    var roleSlice = 100;
-    var roleOffset = 0;
-    var loading = false;
-    var rolePromise = null;
 
     var createPolicy = function (role) {
           return {
@@ -99,36 +95,6 @@ angular.module('adminNg.controllers')
       $scope.save();
     };
 
-    $scope.getMoreRoles = function (value) {
-
-      if (loading)
-        return rolePromise;
-
-      loading = true;
-      var queryParams = {limit: roleSlice, offset: roleOffset};
-
-      if ( angular.isDefined(value) && (value != '')) {
-        //Magic values here.  Filter is from ListProvidersEndpoint, role_name is from RolesListProvider
-        //The filter format is care of ListProvidersEndpoint, which gets it from EndpointUtil
-        queryParams['filter'] = 'role_name:' + value + ',role_target:ACL';
-        queryParams['offset'] = 0;
-      } else {
-        queryParams['filter'] = 'role_target:ACL';
-      }
-      rolePromise = UserRolesResource.query(queryParams);
-      rolePromise.$promise.then(function (data) {
-        angular.forEach(data, function (role) {
-          $scope.roles[role.name] = role.value;
-        });
-        roleOffset = Object.keys($scope.roles).length;
-      }).catch(
-        angular.noop
-      ).finally(function () {
-        loading = false;
-      });
-      return rolePromise;
-    };
-
     fetchChildResources = function (id) {
       //NB: roles is updated in both the functions for $scope.acl (MH-11716) and $scope.roles (MH-11715, MH-11717)
       $scope.roles = {};
@@ -159,7 +125,14 @@ angular.module('adminNg.controllers')
           }
         });
       });
-      $scope.getMoreRoles();
+
+      var queryParams = {limit: -1, filter: 'role_target:ACL'};
+      UserRolesResource.query(queryParams).$promise.then(function (data) {
+        angular.forEach(data, function (role) {
+          $scope.roles[role.name] = role.value;
+        });
+      });
+
     };
 
 

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupController.js
@@ -64,7 +64,7 @@ angular.module('adminNg.controllers')
 
     var reloadRoles = function () {
       $scope.role = {
-        available: UserRolesResource.query({limit: 0, offset: 0, filter: 'role_target:USER'}),
+        available: UserRolesResource.query({limit: -1, filter: 'role_target:USER'}),
         selected:  [],
         i18n: 'USERS.GROUPS.DETAILS.ROLES',
         searchable: true

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
@@ -26,14 +26,9 @@ angular.module('adminNg.controllers')
   function ($scope, Table, UserRolesResource, UserResource, UsersResource, JsHelper, Notifications, Modal,
     AuthService, _) {
     $scope.manageable = true;
-    $scope.roleSlice = 100;
-    // Note that the initial offset is the same size as the initial slice so that the *next* slice starts at the right
-    // place
-    $scope.roleOffset = $scope.roleSlice;
-    var loading = false;
+
     // Should the External Roles tab be visible
     var showExternalRoles = false;
-
     var EXTERNAL_ROLE_DISPLAY = 'adminui.user.external_role_display';
 
     AuthService.getUser().$promise.then(function(user) {
@@ -55,25 +50,6 @@ angular.module('adminNg.controllers')
 
     $scope.searchFieldExternal = '';
     $scope.searchFieldEffective = '';
-
-    $scope.getMoreRoles = function() {
-      if (loading)
-        return;
-
-      loading = true;
-      UserRolesResource.query({
-        limit: $scope.roleSlice,
-        offset: $scope.roleOffset,
-        filter: 'role_target:USER'
-      }).$promise.then(function (data) {
-        $scope.role.available = $scope.role.available.concat(data);
-        $scope.roleOffset = $scope.roleOffset + $scope.roleSlice;
-      }, this).catch(
-        angular.noop
-      ).finally(function () {
-        loading = false;
-      });
-    };
 
     $scope.groupSort = function(role) {
 
@@ -118,7 +94,7 @@ angular.module('adminNg.controllers')
     if ($scope.action === 'edit') {
       fetchChildResources($scope.resourceId);
     } else if ($scope.action === 'add') {
-      $scope.role.available = UserRolesResource.query({limit: $scope.roleSlice, offset: 0, filter: 'role_target:USER'});
+      $scope.role.available = UserRolesResource.query({limit: -1, filter: 'role_target:USER'});
     }
 
 
@@ -154,7 +130,7 @@ angular.module('adminNg.controllers')
        * @param id the id of the user
        */
     function fetchChildResources(id) {
-      $scope.role.available = UserRolesResource.query({limit: $scope.roleSlice, offset: 0, filter: 'role_target:USER'});
+      $scope.role.available = UserRolesResource.query({limit: -1, filter: 'role_target:USER'});
       $scope.user = UserResource.get({ username: id });
       $scope.user.$promise.then(function () {
         $scope.manageable = $scope.user.manageable;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/acl-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/acl-details.html
@@ -130,7 +130,6 @@
                                       data-width="'360px'"
                                       ng-model="policy.role"
                                       ng-options="id as id for (id, type) in roles"
-                                      ng-get-more="getMoreRoles"
                                       placeholder-text-single="'{{ 'USERS.ACLS.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
                                       no-results-text="'{{ 'USERS.ACLS.DETAILS.ACCESS.ROLES.EMPTY' | translate }}'"
                                       />

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -605,7 +605,6 @@
                                       ng-model="policy.role"
                                       ng-change="accessChanged(policy.role)"
                                       ng-options="id as id for (id, type) in roles"
-                                      ng-get-more="getMoreRoles"
                                       placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
                                       no-results-text="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ROLES.EMPTY' | translate }}'"
                                       />

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
@@ -202,7 +202,6 @@
                                     ng-model="policy.role"
                                     ng-change="accessChanged(policy.role)"
                                     ng-options="id as id for (id, type) in roles"
-                                    ng-get-more="getMoreRoles"
                                     placeholder-text-single="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
                                     no-results-text="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ROLES.EMPTY' | translate }}'"
                                     />

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/user-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/user-modal.html
@@ -110,7 +110,7 @@
       <div class="modal-body">
         <div class="form-container">
           <div data-admin-ng-notifications="" context="user-form"></div>
-          <admin-ng-select-box resource="role" data-disabled="!manageable" data-loader="getMoreRoles" data-height="21em"></admin-ng-select-box>
+          <admin-ng-select-box resource="role" data-disabled="!manageable" data-height="21em"></admin-ng-select-box>
         </div>
       </div>
     </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-acl.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-acl.html
@@ -102,7 +102,6 @@
                           <select chosen pre-select-from="wizard.step.roles"
                                          data-width="'360px'"
                                          ng-model="policy.role"
-                                         ng-get-more="wizard.step.getMoreRoles"
                                          ng-options="id as id for (id, type) in wizard.step.roles"
                                          placeholder-text-single="'{{ 'USERS.ACLS.NEW.ACCESS.ROLES.LABEL' | translate }}'"
                                          no-results-text="'{{ 'USERS.ACLS.NEW.ACCESS.ROLES.EMPTY' | translate }}'"

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -564,7 +564,6 @@
                           <select chosen
                                   data-width="'360px'"
                                   ng-model="policy.role"
-                                  ng-get-more="wizard.step.getMoreRoles"
                                   ng-options="id as id for (id, type) in wizard.step.roles"
                                   placeholder-text-single="'{{ 'EVENTS.SERIES.NEW.ACCESS.ROLES.LABEL' | translate }}'"
                                   no-results-text="'{{ 'EVENTS.SERIES.NEW.ACCESS.ROLES.EMPTY' | translate }}'">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-series.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-series.html
@@ -127,7 +127,6 @@
                           <select chosen
                                   data-width="'360px'"
                                   ng-model="policy.role"
-                                  ng-get-more="wizard.step.getMoreRoles"
                                   ng-options="id as id for (id, type) in wizard.step.roles"
                                   data-placeholder=" "
                                   no-results-text="'{{ 'EVENTS.SERIES.NEW.ACCESS.ROLES.EMPTY' | translate }}'"
@@ -256,7 +255,7 @@
         </div>
       </div>
 
-      <div class="obj tbl-list" ng-if="wizard.getStateControllerByName('theme').ud.theme 
+      <div class="obj tbl-list" ng-if="wizard.getStateControllerByName('theme').ud.theme
           && wizard.getStateControllerByName('theme').themes.hasOwnProperty(wizard.getStateControllerByName('theme').ud.theme)">
         <header class="no-expand" translate="EVENTS.SERIES.NEW.THEME.CAPTION"><!-- Caption --></header>
         <div class="obj-container">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/access.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-acl/access.js
@@ -25,11 +25,6 @@ angular.module('adminNg.services')
   UserRolesResource, AclResource) {
   var Access = function () {
 
-    var roleSlice = 100;
-    var roleOffset = 0;
-    var loading = false;
-    var rolePromise = null;
-
     var me = this,
         createPolicy = function (role) {
           return {
@@ -113,36 +108,12 @@ angular.module('adminNg.services')
 
     me.roles = {};
 
-    me.getMoreRoles = function (value) {
-
-      if (loading)
-        return rolePromise;
-
-      loading = true;
-      var queryParams = {limit: roleSlice, offset: roleOffset};
-
-      if ( angular.isDefined(value) && (value != '')) {
-        //Magic values here.  Filter is from ListProvidersEndpoint, role_name is from RolesListProvider
-        //The filter format is care of ListProvidersEndpoint, which gets it from EndpointUtil
-        queryParams['filter'] = 'role_name:' + value + ',role_target:ACL';
-        queryParams['offset'] = 0;
-      } else {
-        queryParams['filter'] = 'role_target:ACL';
-      }
-      rolePromise = UserRolesResource.query(queryParams);
-      rolePromise.$promise.then(function (data) {
-        angular.forEach(data, function (role) {
-          me.roles[role.name] = role.value;
-        });
-        roleOffset = Object.keys(me.roles).length;
-      }).catch(angular.noop
-      ).finally(function () {
-        loading = false;
+    var queryParams = {limit: -1, filter: 'role_target:ACL'};
+    UserRolesResource.query(queryParams).$promise.then(function (data) {
+      angular.forEach(data, function (role) {
+        me.roles[role.name] = role.value;
       });
-      return rolePromise;
-    };
-
-    me.getMoreRoles();
+    });
 
     this.reset = function () {
       me.ud = {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-event/access.js
@@ -27,11 +27,6 @@ angular.module('adminNg.services')
     Notifications, $timeout) {
     var Access = function () {
 
-      var roleSlice = 100;
-      var roleOffset = 0;
-      var loading = false;
-      var rolePromise = null;
-
       var me = this;
       var NOTIFICATION_CONTEXT = 'events-access';
       var createPolicy = function (role) {
@@ -235,37 +230,12 @@ angular.module('adminNg.services')
       });
 
       me.roles = {};
-
-      me.getMoreRoles = function (value) {
-
-        if (me.loading)
-          return rolePromise;
-
-        me.loading = true;
-        var queryParams = {limit: roleSlice, offset: roleOffset};
-
-        if ( angular.isDefined(value) && (value != '')) {
-          //Magic values here.  Filter is from ListProvidersEndpoint, role_name is from RolesListProvider
-          //The filter format is care of ListProvidersEndpoint, which gets it from EndpointUtil
-          queryParams['filter'] = 'role_name:' + value + ',role_target:ACL';
-          queryParams['offset'] = 0;
-        } else {
-          queryParams['filter'] = 'role_target:ACL';
-        }
-        rolePromise = UserRolesResource.query(queryParams);
-        rolePromise.$promise.then(function (data) {
-          angular.forEach(data, function (role) {
-            me.roles[role.name] = role.value;
-          });
-          roleOffset = Object.keys(me.roles).length;
-        }).catch(angular.noop
-        ).finally(function () {
-          me.loading = false;
+      var queryParams = {limit: -1, filter: 'role_target:ACL'};
+      UserRolesResource.query(queryParams).$promise.then(function (data) {
+        angular.forEach(data, function (role) {
+          me.roles[role.name] = role.value;
         });
-        return rolePromise;
-      };
-
-      me.getMoreRoles();
+      });
 
       this.reset = function () {
         me.ud = {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/roles.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/roles.js
@@ -28,7 +28,7 @@ angular.module('adminNg.services')
 
       this.reset = function () {
         me.roles = {
-          available: UserRolesResource.query({limit: 0, offset: 0, filter: 'role_target:USER'}),
+          available: UserRolesResource.query({limit: -1, filter: 'role_target:USER'}),
           selected:  [],
           i18n: 'USERS.GROUPS.DETAILS.ROLES',
           searchable: true

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/eventControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/eventControllerSpec.js
@@ -48,7 +48,7 @@ describe('Event controller', function () {
         $httpBackend.whenGET('/admin-ng/resources/ACL.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/resources/ACL.ACTIONS.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/resources/PUBLICATION.CHANNELS.json').respond('{}');
-        $httpBackend.whenGET('/admin-ng/resources/ROLES.json').respond('{}');
+        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=-1').respond('{}');
         $httpBackend.whenGET('/admin-ng/resources/PUBLICATION.CHANNELS.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/event/new/processing?tags=schedule')
             .respond(JSON.stringify(getJSONFixture('admin-ng/event/new/processing')));

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/newEventControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/newEventControllerSpec.js
@@ -17,7 +17,7 @@ describe('New Event Controller', function () {
         Table = _Table_;
         Notifications = _Notifications_;
 
-        $httpBackend.expectGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=100&offset=0').respond('{"ROLE_ANONYMOUS": "ROLE_ANONYMOUS"}');
+        $httpBackend.expectGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=-1').respond('{"ROLE_ANONYMOUS": "ROLE_ANONYMOUS"}');
 
         $parentScope = $rootScope.$new();
         $scope = $parentScope.$new();

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/newSeriesControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/newSeriesControllerSpec.js
@@ -15,7 +15,7 @@ describe('New Series Controller', function () {
         $httpBackend = _$httpBackend_;
 
         $httpBackend.whenGET('modules/events/partials/index.html').respond('');
-        $httpBackend.expectGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=100&offset=0').respond('{"ROLE_ANONYMOUS": "ROLE_ANONYMOUS"}');
+        $httpBackend.expectGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=-1').respond('{"ROLE_ANONYMOUS": "ROLE_ANONYMOUS"}');
 
         $parentScope = $rootScope.$new();
         $scope = $parentScope.$new();

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/serieControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/serieControllerSpec.js
@@ -39,8 +39,7 @@ describe('Serie controller', function () {
         $httpBackend.whenGET('/admin-ng/resources/THEMES.DESCRIPTION.json').respond({901: 'theme1 description', 902: 'theme2 desc\nsecond line'});
         $httpBackend.whenGET('/admin-ng/resources/ACL.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/resources/ACL.ACTIONS.json').respond('{}');
-        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=100&offset=0').respond('{"ROLE_ANONYMOUS": "ROLE_ANONYMOUS"}');
-        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=100&offset=2').respond('{}');
+        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=-1').respond('{"ROLE_ANONYMOUS": "ROLE_ANONYMOUS"}');
         $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
         // Until we're actually testing the statistics endpoint, just return an empty set here
         $httpBackend.whenGET(/\/admin-ng\/statistics.*/).respond('[]');

--- a/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/groupControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/groupControllerSpec.js
@@ -28,7 +28,7 @@ describe('Group controller', function () {
 
     beforeEach(function () {
         jasmine.getJSONFixtures().fixturesPath = 'base/app/GET';
-        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:USER&limit=0&offset=0').respond(JSON.stringify(getJSONFixture('roles/roles.json')));
+        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:USER&limit=-1').respond(JSON.stringify(getJSONFixture('roles/roles.json')));
         $httpBackend.whenGET('/admin-ng/resources/USERS.INVERSE.WITH.USERNAME.json').respond(JSON.stringify(getJSONFixture('admin-ng/resources/USERS.INVERSE.WITH.USERNAME.json')));
         $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
         $httpBackend.whenGET('modules/events/partials/index.html').respond('');

--- a/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/userControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/userControllerSpec.js
@@ -31,7 +31,7 @@ describe('User controller', function () {
         $httpBackend.whenGET('/roles/roles.json').respond(JSON.stringify(getJSONFixture('roles/roles.json')));
         $httpBackend.whenGET('/admin-ng/users/matterhorn_system_account.json')
             .respond(JSON.stringify(getJSONFixture('admin-ng/users/matterhorn_system_account.json')));
-        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:USER&limit=100&offset=0').respond('{}');
+        $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:USER&limit=-1').respond('{}');
         $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
         $controller('UserCtrl', {$scope: $scope});
         $httpBackend.whenGET('modules/events/partials/index.html').respond('');


### PR DESCRIPTION
Load all roles at once in the admin UI instead of loading them in increments of 100 when the user is scrolling through the dropdown menu since this doesn't provide a real benefit and makes the search function unreliable: A role that isn't loaded yet cannot be searched for, so for search results to be accurate, one first has to scroll through all the roles...which kind of defeats its purpose.

_This work was sponsored by the ETH Zürich._