### PR TITLE
MH-13695 Direct link to assets tab

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
@@ -482,6 +482,7 @@
             "PUBLISHED": "Veröffentlicht",
             "WEEKDAY": "Wochentag",
             "TOOLTIP": {
+               "ASSETS": "Assets anzeigen",
                "START": "Nach diesem Startdatum filtern",
                "SERIES": "Nach dieser Serie filtern",
                "STATUS": "Nach diesem Verarbeitungsstatus filtern",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_GB.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_GB.json
@@ -482,6 +482,7 @@
             "PUBLISHED": "Published",
             "WEEKDAY": "Weekday",
             "TOOLTIP": {
+               "ASSETS" : "Open asset detials",
                "START": "Filter for this start date",
                "SERIES": "Filter for this series",
                "STATUS": "Filter for this event status",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_GB.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_GB.json
@@ -482,7 +482,7 @@
             "PUBLISHED": "Published",
             "WEEKDAY": "Weekday",
             "TOOLTIP": {
-               "ASSETS" : "Open asset detials",
+               "ASSETS" : "Open asset details",
                "START": "Filter for this start date",
                "SERIES": "Filter for this series",
                "STATUS": "Filter for this event status",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -483,6 +483,7 @@
          "PUBLISHED": "Published",
          "WEEKDAY": "Weekday",
          "TOOLTIP": {
+           "ASSETS" : "Open asset detials",
            "START": "Filter for this start date",
            "SERIES": "Filter for this series",
            "STATUS": "Filter for this event status",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -483,7 +483,7 @@
          "PUBLISHED": "Published",
          "WEEKDAY": "Weekday",
          "TOOLTIP": {
-           "ASSETS" : "Open asset detials",
+           "ASSETS" : "Open asset details",
            "START": "Filter for this start date",
            "SERIES": "Filter for this series",
            "STATUS": "Filter for this event status",

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
@@ -53,3 +53,12 @@
    title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.PAUSED_WORKFLOW' | translate }}"
    class="fa fa-warning">
 </a>
+
+<a data-open-modal="event-details"
+   data-resource-id="{{ row.id }}"
+   class="fa fa-stack-overflow"
+   data-tab="assets"
+   title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.ASSETS' | translate }}"
+   with-role="ROLE_UI_EVENTS_ASSETS_VIEW">
+</a>
+

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -1001,7 +1001,7 @@
               </thead>
               <tbody>
                 <tr ng-repeat="item in subNavData">
-                  <td>{{ item.id }}</td>
+                  <td><a ng-href="{{item.url}}">{{item.id}}</a></td>
                   <td>{{ item.type }}</td>
                   <td>{{ item.mimetype }}</td>
                   <td>{{ item.tags|joinBy:', ' }}</td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -1001,7 +1001,7 @@
               </thead>
               <tbody>
                 <tr ng-repeat="item in subNavData">
-                  <td><a ng-href="{{item.url}}">{{item.id}}</a></td>
+                  <td>{{ item.id }}</td>
                   <td>{{ item.type }}</td>
                   <td>{{ item.mimetype }}</td>
                   <td>{{ item.tags|joinBy:', ' }}</td>
@@ -1038,7 +1038,7 @@
               </thead>
               <tbody>
                 <tr ng-repeat="item in subNavData">
-                  <td>{{ item.id }}</td>
+                  <td><a ng-href="{{item.url}}">{{item.id}}</a></td>
                   <td>{{ item.type }}</td>
                   <td>{{ item.mimetype }}</td>
                   <td>{{ item.tags|joinBy:', ' }}</td>


### PR DESCRIPTION
It would be useful to have a direct link  to the asset tab out of the action cell of an event.

The solution was originally implemented by @CGreweling  for the ETH.