### PR TITLE
MH-6610: Pushing to Maven Central

### DIFF
--- a/docs/guides/developer/docs/infrastructure/maven-repository.md
+++ b/docs/guides/developer/docs/infrastructure/maven-repository.md
@@ -93,7 +93,7 @@ transitioning to using Maven Central.  There are a few steps prior to being able
 
 - Create a GPG key, and push the public key to a key server
 - Sign up for an account on [Sonatype's JIRA instance](https://issues.sonatype.org)
-- Let the QA Coordinator know about your user, they will comment on [on our repo creation ticket](https://issues.sonatype.org/browse/OSSRH-36510) or create a new issue to give your user permissions
+- Let the QA Coordinator know about your user, they will comment on [our repo creation ticket](https://issues.sonatype.org/browse/OSSRH-36510) or create a new issue to give your user permissions
 - Put the following in your `.m2/settings.xml` file
 
 ```xml

--- a/docs/guides/developer/docs/infrastructure/maven-repository.md
+++ b/docs/guides/developer/docs/infrastructure/maven-repository.md
@@ -93,7 +93,8 @@ transitioning to using Maven Central.  There are a few steps prior to being able
 
 - Create a GPG key, and push the public key to a key server
 - Sign up for an account on [Sonatype's JIRA instance](https://issues.sonatype.org)
-- Let the QA Coordinator know about your user, they will comment on [our repo creation ticket](https://issues.sonatype.org/browse/OSSRH-36510) or create a new issue to give your user permissions
+- Let the QA Coordinator know about your user, they will comment on
+  [our repo creation ticket](https://issues.sonatype.org/browse/OSSRH-36510) or create a new issue to give your user permissions
 - Put the following in your `.m2/settings.xml` file
 
 ```xml

--- a/docs/guides/developer/docs/infrastructure/maven-repository.md
+++ b/docs/guides/developer/docs/infrastructure/maven-repository.md
@@ -59,8 +59,8 @@ This example would add a mirror for the primary Opencast Maven repository, causi
 preferred repository to use. You can find some example configurations in `docs/maven/`.
 
 
-Pushing artifacts to Maven
---------------------------
+Pushing artifacts to a Maven repository
+---------------------------------------
 
 #### Pushing to your local Maven repository
 
@@ -86,86 +86,109 @@ packaging   | The file type (effectively), this should match the filename's exte
 version     | The artifact's version                                                    | 1.1
 generatePom | Whether or not to generate a pom file automatically                       | true
 
-#### Pushing to the remote Nexus repository
+#### Pushing to Maven Central
 
-The following command will push a file to the remote Nexus repository.  Normally builds are pushed to to the remote
-automatically as part of the CI server build, however if there is a need to push to the repo this is the command you
-need. To deploy to the remote repository you will first need a username and password. This can be obtained from the QA
-coordinator. Once you have that, put them in your `.m2/settings.xml` file. It should look like this
+Opencast previously hosted our own Maven repository at nexus.opencast.org, however starting with Opencast 6.6 we are
+transitioning to using Maven Central.  There are a few steps prior to being able to push to Sonatype's repo:
 
+- Create a GPG key, and push the public key to a key server
+- Sign up for an account on [Sonatype's JIRA instance](https://issues.sonatype.org)
+- Let the QA Coordinator know about your user, they will comment on [on our repo creation ticket](https://issues.sonatype.org/browse/OSSRH-36510) or create a new issue to give your user permissions
+- Put the following in your `.m2/settings.xml` file
+
+```xml
     <settings>
       <servers>
         <server>
-          <id>opencast</id>
+          <id>ossrh</id>
           <username>$username</username>
           <password>$password</password>
         </server>
         ...
       </servers>
-      ....
+      <profiles>
+        <profile>
+          <id>ossrh</id>
+          <activation>
+            <activeByDefault>true</activeByDefault>
+          </activation>
+          <properties>
+            <gpg.keyname>$gpgKeyId</gpg.keyname>
+          </properties>
+        </profile>
+        ...
+      </profiles>
     </settings>
+```
 
-The command to push the file looks like this. Not that pushing files from your local Maven repository directly is not
-possible, instead you must copy them *outside* the repository and push from there. See below for help on that.
+##### Pushing Snapshots
 
-    mvn deploy:deploy-file \
-      -DrepositoryId=$repo_id \
-      -Durl=$url \
-      -Dfile=$filename \
-      -DgroupId=$groupId \
-      -DartifactId=$artifactId \
-      -Dpackaging=$packaging \
-      -Dversion=$version \
-      -DgeneratePom=$generatePom
+Snapshots are pushed automatically by the CI servers.  For historical purposes, this is accomplished by:
 
-Variable Map
+```bash
+mvn deploy
+```
 
-Variable    | What it does                                                               | Example
-------------|----------------------------------------------------------------------------|--------------------
-repo\_id    | Identifies which set of credentials from your .m2/settings.xml file to use | opencast
-url         | Where to push the file                                                     | http://nexus.virtuos.uos.de:8081/nexus/content/repositories/snapshots
-filename    | The path to the local file you want in your repository                     | audio\_out.mp2
-groupId     | The Opencast group ID                                                      | org.opencastproject
-artifactId  | The artifact ID. This is the name of the artifact according to Maven       | audio
-packaging   | The file type (effectively), this should match the filename's extension    | mp2
-version     | The artifact's version                                                     | 1.1
-generatePom | Whether or not to generate a pom file automatically                        | true
+To verify, your artifacts can be found [here](https://oss.sonatype.org/content/repositories/snapshots/org/opencastproject/)
+and [here](https://oss.sonatype.org/content/groups/staging/org/opencastproject/).  Note that you cannot (easily) drop
+bad snapshots.  Instead, fix it and redeploy!
 
-#### Help with push to the remote Nexus repository
+##### Pushing Releases
 
-Uploading to Nexus is more difficult than it should be: You can't just run deploy:deploy-file. This script is handy
-when you need to manually upload something like a previous release.  The script below checks out a version, then
-attempts to upload each module in the version.  Build Opencast, then run the script.  There will be numerous errors as
-it processes things that either don't have artifacts, or don't have artifacts in the version you're uploading, but
-those can be ignored.
+Note: Please read this section entirely before running any commands.  Maven Central does not allow you to change a
+release once it has been closed!
 
-    #!/bin/bash
+Pushing releases is similar to snapshots, with the added requirements that you also push:
 
-    CORE_NEXUS="nexus.virtuos.uos.de:8081"
-    SOURCE_FILES="nexus_copy"
-    VERSION=5.1
+- Javadocs
+- Sources
+- GPG signatures for the binaries, docs, and sources
 
-    uploadVersion() {
-      ls modules | while read line
-      do
-        fn="$SOURCE_FILES/opencast-$line/$1/opencast-$line-$1.jar"
-        if [ -f "$fn" ]; then
-          mvn deploy:deploy-file \
-            -DrepositoryId=opencast \
-            -Durl=http://$CORE_NEXUS/nexus/content/repositories/releases \
-            -Dfile=$fn \
-            -DgroupId=org.opencastproject -DartifactId=opencast-$line \
-            -Dversion=$1 \
-            -DgeneratePom=true \
-            -Dpackaging=jar
-        else
-          echo "$fn is missing"
-        fi
-      done
-    }
+This is automated with the `release` profile.  To push a release run
 
-    rm -f nexus_copy
-    ln -s ~/.m2/repository/org/opencastproject/ nexus_copy
-    git checkout $VERSION
-    uploadVersion $VERSION
+```bash
+mvn nexus-staging:deploy -P release
+```
 
+This creates a staging repository (https://oss.sonatype.org/content/groups/staging/org/opencastproject/) for your
+artifacts.  This is always safe to do - you can still rollback all changes with
+
+```bash
+mvn nexus-staging:drop
+```
+
+If things do not look ok, fix the issue and redeploy.  Once you are confident that everything is ok, you can run
+
+```bash
+mvn nexus-staging:close
+```
+
+This closes the staging repository, and runs the Sonatype-side tests for things like GPG signatures.  If this fails,
+correct the issue locally, and redeploy.  Once this succeeds, you have two options: drop (to destroy the release) or:
+
+```bash
+mvn nexus-staging:release
+```
+
+to permanently release the binaries in their current states.
+
+##### Troubleshooting
+
+Sometimes the deploy or close will fail, timing out after 5 minutes waiting for Sonatype.  It will complain about
+violations of deploy rules - this may or may not actually be true.  If you're confident that this is caused by a simple
+timeout and not something you have done use one of the following.
+
+To reattempt a deploy use
+
+```bash
+mvn nexus-staging:deploy-staged
+```
+
+This will avoid recompiling, retesting, and resigning all of the binaries.
+
+
+To reattempt a close use
+
+```bash
+mvn nexus-staging:close
+```

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -353,7 +353,7 @@ assume the final release should be based on `3.0-rc2`.
 11. Release the branch in JIRA, and create the next one. Talk to your JIRA administrators to have this done.
 
 12. Push the built artifacts to Maven. Bug the QA Coordinator to do this so that he remembers to set this up from the CI
-    servers.
+    servers.  If you want to do this yourself please read the [infra documentation](infrastructure/maven-repository.md#pushing-to-maven-central).
 
 13. Push the built artifacts back to GitHub. Create a new release using the
     [graphical user interface](https://github.com/opencast/opencast/releases) to upload the distribution tarballs

--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
         <configuration>
           <serverId>ossrh</serverId>
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.7</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,58 @@
     <module>modules/workspace-impl</module>
     <module>assemblies</module>
   </modules>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+      <plugins>
+        <!-- Attach sources for all builds -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.2.1</version>
+          <executions>
+            <execution>
+             <id>attach-sources</id>
+               <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- Attach javadocs for all builds -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+         <version>2.9.1</version>
+           <executions>
+             <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <!-- Sign the builds -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.5</version>
+          <executions>
+            <execution>
+              <id>sign-artifacts</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>sign</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+      </build>
+    </profile>
+  </profiles>
   <build>
     <defaultGoal>install</defaultGoal>
     <testResources>
@@ -374,6 +426,17 @@
           <check/>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
     </plugins>
     <!-- This defines the global plugin configurations. Plugins with configuration
       shared across multiple child poms should be configured here, and then referenced
@@ -486,6 +549,12 @@
                 <goal>javadoc</goal>
               </goals>
               <phase>site</phase>
+            </execution>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
             </execution>
           </executions>
         </plugin>
@@ -1757,6 +1826,14 @@
   </repositories>
 
   <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
     <site>
       <!-- Note that we do not deploy the site using maven, so this is totally fake -->
       <id>fakesite.opencast.org</id>


### PR DESCRIPTION
This pull request enables appropriately configured users to push to Maven central.  That's right, no more hacky script pushing to our own Nexus infrastructure!

I've already applied this to 6.6 and 7.2 to push them to Maven central, but have not walked backwards to apply it to the rest.