### PR TITLE
MH-13697, Workflow Index Rebuild Memory

### DIFF
--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
@@ -113,6 +113,8 @@ import javax.persistence.Version;
         @NamedQuery(name = "Job.countByOperation", query = "SELECT COUNT(j) FROM Job j "
                 + "where j.status = :status and j.operation = :operation and "
                 + "j.creatorServiceRegistration.serviceType = :serviceType"),
+        @NamedQuery(name = "Job.countByOperationOnly", query = "SELECT COUNT(j) FROM Job j "
+                + "where j.operation = :operation"),
         @NamedQuery(name = "Job.fullMonty", query = "SELECT COUNT(j) FROM Job j "
                 + "where j.status = :status and j.operation = :operation "
                 + "and j.processorServiceRegistration is not null and "

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistry.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistry.java
@@ -504,6 +504,31 @@ public interface ServiceRegistry {
   List<String> getJobPayloads(String operation) throws ServiceRegistryException;
 
   /**
+   * Return the payload of a specified number of jobs for a specified operation type.
+   *
+   * @param operation
+   *          Operation type to get payload for
+   * @param limit
+   *          How many results to return
+   * @param offset
+   *          Offset for the set of returned results
+   * @return Serialized workflows
+   * @throws ServiceRegistryException
+   *          if there is a problem accessing the service registry
+   */
+  List<String> getJobPayloads(String operation, int limit, int offset) throws ServiceRegistryException;
+
+  /**
+   * Return the number of jobs for a specified operation type.
+   *
+   * @param operation
+   *          Operation type to check for
+   * @return Number of jobs for the specified operation type.
+   * @throws ServiceRegistryException
+   */
+  int getJobCount(String operation) throws ServiceRegistryException;
+
+  /**
    * Get the list of active jobs.
    *
    * @return list of active jobs

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
@@ -725,6 +725,16 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
     return result;
   }
 
+  @Override
+  public List<String> getJobPayloads(String operation, int limit, int offset) throws ServiceRegistryException {
+    return null;
+  }
+
+  @Override
+  public int getJobCount(String operation) throws ServiceRegistryException {
+    return 0;
+  }
+
   /**
    * {@inheritDoc}
    *

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -1793,6 +1793,38 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     }
   }
 
+  @Override
+  public List<String> getJobPayloads(String operation, int limit, int offset) throws ServiceRegistryException {
+    EntityManager em = emf.createEntityManager();
+    try {
+      TypedQuery<String> query = em.createNamedQuery("Job.payload", String.class);
+      query.setParameter("operation", operation);
+      query.setMaxResults(limit);
+      query.setFirstResult(offset);
+      logger.debug("Requesting job payloads using query: {}", query);
+      return query.getResultList();
+    } catch (Exception e) {
+      throw new ServiceRegistryException(e);
+    }
+  }
+
+  @Override
+  public int getJobCount(final String operation) throws ServiceRegistryException {
+    EntityManager em = null;
+    try {
+      em = emf.createEntityManager();
+      Query query = em.createNamedQuery("Job.countByOperationOnly");
+      query.setParameter("operation", operation);
+      final Number countResult = (Number) query.getSingleResult();
+      return countResult.intValue();
+    } catch (Exception e) {
+      throw new ServiceRegistryException(e);
+    } finally {
+      if (em != null)
+        em.close();
+    }
+  }
+
   /**
    * {@inheritDoc}
    *


### PR DESCRIPTION
For an index rebuild, the workflow service will load all workflows into
memory at once. Depending on the number of workflows in the system, this
can cause a huge, sudden spike in memory usage which may even cause the
whole process to fail. E.g. on one larger system we managed to kill the
process on a machine with 64GB memory…

This patch introduces pagination for the workflows. This means that only
a limited number of workflows are loaded from the database and processed
at the same time.

*Work sponsored by SWITCH*