### PR TITLE
MH-13701 Interpret source-audio-name correctly for composite operation

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -1693,8 +1693,8 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
       // handle audio
       boolean lowerAudio = lowerLaidOutElement.getElement().hasAudio();
       boolean upperAudio = upperLaidOutElement.get().getElement().hasAudio();
-      // if not specfied or "both", use both videos
-      if (audioSourceName != null && ! ComposerService.BOTH.equalsIgnoreCase(audioSourceName)) {
+      // if audio source name is "both" or unspecified, use audio of both videos, otherwise pick one
+      if (StringUtils.isNotBlank(audioSourceName) && ! ComposerService.BOTH.equalsIgnoreCase(audioSourceName)) {
         lowerAudio = lowerAudio & ComposerService.LOWER.equalsIgnoreCase(audioSourceName);
         upperAudio = upperAudio & ComposerService.UPPER.equalsIgnoreCase(audioSourceName);
       }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
@@ -308,8 +308,14 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
 
     CompositeSettings(MediaPackage mediaPackage, WorkflowOperationInstance operation)
             throws WorkflowOperationException {
-      // Check which tags have been configured
+
       sourceAudioName = StringUtils.trimToNull(operation.getConfiguration(SOURCE_AUDIO_NAME));
+      if (sourceAudioName == null) {
+        sourceAudioName = ComposerService.BOTH; // default
+      } else if (!sourceAudioOption.matcher(sourceAudioName).matches()) {
+        throw new WorkflowOperationException("sourceAudioName if used, must be either upper, lower or both!");
+      }
+
       sourceTagsUpper = StringUtils.trimToNull(operation.getConfiguration(SOURCE_TAGS_UPPER));
       sourceFlavorUpper = StringUtils.trimToNull(operation.getConfiguration(SOURCE_FLAVOR_UPPER));
       sourceTagsLower = StringUtils.trimToNull(operation.getConfiguration(SOURCE_TAGS_LOWER));
@@ -353,10 +359,6 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
         singleSourceLayout = singleLayouts.getA();
         watermarkLayout = singleLayouts.getB();
       }
-
-      // Check that source audio is upper, lower or use a combination of both
-      if (sourceAudioName != null && !sourceAudioOption.matcher(sourceAudioName).matches())
-        throw new WorkflowOperationException("sourceAudioName if used, must be either upper, lower or both!");
 
       // Find the encoding profile
       if (encodingProfile == null)


### PR DESCRIPTION
If source-audio-name is not set on a composite operation, it's set to null, however this becomes an empty string when using the remote service, resulting in a composite video with no audio. To avoid this, consider the empty string as a possible value on interpretation.

_This work was sponsored by SWITCH._