### PR TITLE
MH-13704: Multiple audio tracks support on paella

### DIFF
--- a/docs/guides/admin/docs/modules/paella.player/configuration.md
+++ b/docs/guides/admin/docs/modules/paella.player/configuration.md
@@ -42,3 +42,12 @@ Tracks to be played
 
 An event can have many tracks, but an institution can configure which of these tracks are played and which are not.
 To do it, you need to configure [es.upv.paella.opencast.loader](plugins/es.upv.paella.opencast.loader.md) plugin.
+
+Multiple audio tracks
+---------------------
+
+An event can have multiple audio tracks. Paella only plays one at a time, but you can configure paella to allow the user to 
+decide which one to play. Read the [es.upv.paella.opencast.loader](plugins/es.upv.paella.opencast.loader.md) documentation
+plugin for more information.
+
+This feature is usefull when you have multiple audio languages, so the users can switch to the audio language they want.

--- a/docs/guides/admin/docs/modules/paella.player/plugins/es.upv.paella.opencast.loader.md
+++ b/docs/guides/admin/docs/modules/paella.player/plugins/es.upv.paella.opencast.loader.md
@@ -6,6 +6,10 @@ This plugin configures how events are loaded into paella player.
 The configurations for this plugin are done for each tenant. So you need to modify the `plugins`
 section of the [paella config file](../configuration.md).
 
+
+Control which flavors to play
+-----------------------------
+
 An event can have many tracks, but an institution can configure which of these tracks are played and which are not.
 
 To do it, you need to configure the `streams` property. The `streams` property is an array of rules. The first that
@@ -40,10 +44,36 @@ Example:
 ```
 
 
+Multiple audio tracks
+---------------------
+
+An event can have multiple audio tracks. Paella only plays one at a time, but you can configure paella 
+to allow the user to decide which one to play. 
+
+You need to configure the `audioTag` property. It is an object where the *key* is the flavor to configure
+and the *value* is the label that will be shown in the player interface.
+
+Example:
+
+Your mediapackage has three audio tracks for english, spanish and german languages
+
+```json
+{
+    "audioTag": {
+        "audio_en/delivery" : "en",
+        "audio_es/delivery" : "es",
+        "audio_de/delivery" : "de"
+    }
+}
+```
+
+
+
 Examples
 --------
 
-An institution whant to play only `*/delivery` media tracks
+An institution whant to play only `*/delivery` media tracks and has two audio tracks for 
+english and spanish languages
 
 ```json
 {
@@ -58,7 +88,11 @@ An institution whant to play only `*/delivery` media tracks
                     "tags": []
                 }
             }
-        ]
+        ],
+        "audioTag": {
+            "audio_en/delivery" : "en",
+            "audio_es/delivery" : "es"
+        }
     }    
 }
 ```
@@ -88,7 +122,9 @@ and `presenter/delivery` and `presentation/delivery` on the other devices
                     "tags": []
                 }
             }
-        ]
+        ],
+        "audioTag": {
+        }
     }    
 }
 ```

--- a/etc/ui-config/mh_default_org/paella/config.json
+++ b/etc/ui-config/mh_default_org/paella/config.json
@@ -142,7 +142,7 @@
             }
           }
         ],
-        "audioTag": {         
+        "audioTag": {
         }
       },
       "//**** Video profile plugins": "",

--- a/etc/ui-config/mh_default_org/paella/config.json
+++ b/etc/ui-config/mh_default_org/paella/config.json
@@ -141,7 +141,9 @@
               "tags": []
             }
           }
-        ]
+        ],
+        "audioTag": {         
+        }
       },
       "//**** Video profile plugins": "",
       "es.upv.paella.singleStreamProfilePlugin": {
@@ -150,7 +152,6 @@
             { "icon":"professor_icon.svg", "id":"presenter", "content":["presenter"]},
             { "icon":"slide_icon.svg", "id":"presentation", "content":["presentation"]}
           ]
-
       },
       "es.upv.paella.dualStreamProfilePlugin": { "enabled":true,
         "videoSets": [
@@ -246,7 +247,7 @@
       "es.upv.paella.ratePlugin": {
         "enabled": false
       },
-      "es.upv.paella.audioLanguage": {
+      "es.upv.paella.audioSelector": {
         "enabled": true
       },
       "es.upv.paella.videoZoomPlugin": {

--- a/modules/engage-paella-player/devserver.js
+++ b/modules/engage-paella-player/devserver.js
@@ -3,8 +3,6 @@ var httpProxy = require('http-proxy');
 var createError = require('http-errors');
 
 var app = express();
-
-
 var proxy = httpProxy.createProxyServer({secure:false});
  
 function proxyFunc(req, res, next) {
@@ -15,6 +13,7 @@ function proxyFunc(req, res, next) {
 }
 
 app.use('/paella/ui', express.static('target/gulp/paella-opencast'));
+app.use('/ui/config/paella', express.static('../../etc/ui-config/mh_default_org/paella'))
 app.use(proxyFunc);
 
 

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -143,8 +143,8 @@ class OpencastToPaellaConverter {
 
     var tracks = episode.mediapackage.media.track;
     var attachments = episode.mediapackage.attachments.attachment;
-    if (!(tracks instanceof Array)) { tracks = [tracks]; }
-    if (!(attachments instanceof Array)) { attachments = [attachments]; }
+    if (!(tracks instanceof Array)) { tracks = tracks ? [tracks] : []; }
+    if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
 
     // Read the tracks!!
     tracks.forEach((currentTrack) => {
@@ -254,8 +254,8 @@ class OpencastToPaellaConverter {
 
     var attachments = episode.mediapackage.attachments.attachment;
     var catalogs = episode.mediapackage.metadata.catalog;
-    if (!(attachments instanceof Array)) { attachments = [attachments]; }
-    if (!(catalogs instanceof Array)) { catalogs = [catalogs]; }
+    if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
+    if (!(catalogs instanceof Array)) { catalogs = catalogs ? [catalogs] : []; }
 
 
     // Read the attachments
@@ -338,7 +338,7 @@ class OpencastToPaellaConverter {
     var segments = [];
 
     var attachments = episode.mediapackage.attachments.attachment;
-    if (!(attachments instanceof Array)) { attachments = [attachments]; }
+    if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
 
     // Read the attachments
     var opencastFrameList = {};
@@ -391,7 +391,7 @@ class OpencastToPaellaConverter {
     let otherPreview;
 
     var attachments = episode.mediapackage.attachments.attachment;
-    if (!(attachments instanceof Array)) { attachments = [attachments]; }
+    if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
     attachments.forEach((currentAttachment) => {
       if (currentAttachment.type == 'presenter/player+preview') {
         presenterPreview = currentAttachment.url;

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -144,10 +144,14 @@ class OpencastToPaellaConverter {
     let audioTagConfig = this.getAudioTagConfig();
     let audioTag;
 
-    if (!(currentTrack.tags.tag instanceof Array)) {
-      currentTrack.tags.tag = [currentTrack.tags.tag];
+    let tags = [];
+    if ( (currentTrack.tags) && (currentTrack.tags.tag) ) {
+      tags = [currentTrack.tags.tag];
+      if (!(currentTrack.tags.tag instanceof Array)) {
+        tags = [currentTrack.tags.tag];
+      }
     }
-    currentTrack.tags.tag.some(function(tag){
+    tags.some(function(tag){
       if (tag.startsWith('audioTag:')){
         audioTag = tag.slice(9);
         return true;

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -95,7 +95,7 @@ class OpencastToPaellaConverter {
           break;
         case 'audio/m4a':
           sourceType = 'audio';
-            break;  
+          break;
         default:
           paella.debug.log(`OpencastToPaellaConverter: MimeType (${track.mimetype}) not supported!`);
           break;
@@ -164,8 +164,8 @@ class OpencastToPaellaConverter {
         }
       });
     }
-    
-    return audioTag
+
+    return audioTag;
   }
 
   /**
@@ -197,10 +197,10 @@ class OpencastToPaellaConverter {
           currentStream.sources[sourceType].push(this.getStreamSourceFromTrack(currentTrack));
 
           if (currentTrack.video) {
-            currentStream.type="video";
+            currentStream.type = 'video';
           }
           else if (currentTrack.audio) {
-            currentStream.type="audio";
+            currentStream.type = 'audio';
           }
         }
       }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -215,10 +215,16 @@ class OpencastToPaellaConverter {
         return (((smask[0] == '*') || (smask[0] == sflavour[0])) && ((smask[1] == '*') || (smask[1] == sflavour[1])));
       });
 
-      let importT = filterStream.tracks.tags.some(function(cTag) {
-        return currentTrack.tags.tag.some(function(t){
-          return ((cTag == '*') || (cTag == t));
-        });
+      let importT = false;
+      let tags = [];
+      if ( (currentTrack.tags) && (currentTrack.tags.tag) ) {
+        tags = [currentTrack.tags.tag];
+        if (!(currentTrack.tags.tag instanceof Array)) {
+          tags = [currentTrack.tags.tag];
+        }
+      }
+      importT = filterStream.tracks.tags.some(function(cTag) {
+        return (cTag == '*') || tags.some(function(t){ return (cTag == t); });
       });
 
       if (importF || importT) {
@@ -385,6 +391,7 @@ class OpencastToPaellaConverter {
     let otherPreview;
 
     var attachments = episode.mediapackage.attachments.attachment;
+    if (!(attachments instanceof Array)) { attachments = [attachments]; }
     attachments.forEach((currentAttachment) => {
       if (currentAttachment.type == 'presenter/player+preview') {
         presenterPreview = currentAttachment.url;


### PR DESCRIPTION
Paella supports multiple audio tracks. See: https://paellaplayer.upv.es/demos/multi-audio-tracks/

This PR adds this feature to opencast. 

To test this feature you need to:

1. Upload multiple audio tracks to opencast
2. Configure the available languages in paella (see documentation)

**This PR contains PR #1054 , so shouldn't be merged before that one!**