### PR TITLE
MH-13705, Revert "clean node, […] when running mvn clean"

### DIFF
--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -537,34 +537,6 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>node</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>node_modules</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>bower_components</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -201,27 +201,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>node</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>node_modules</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/modules/engage-ui/pom.xml
+++ b/modules/engage-ui/pom.xml
@@ -206,27 +206,6 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>node</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>node_modules</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/modules/lti/pom.xml
+++ b/modules/lti/pom.xml
@@ -249,27 +249,6 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>node</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>node_modules</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/modules/runtime-info-ui-ng/pom.xml
+++ b/modules/runtime-info-ui-ng/pom.xml
@@ -184,27 +184,6 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>node</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>node_modules</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/modules/runtime-info-ui/pom.xml
+++ b/modules/runtime-info-ui/pom.xml
@@ -223,27 +223,6 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>node</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-            <fileset>
-              <directory>node_modules</directory>
-              <includes>
-                <include>**</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This reverts commit a4660c57cb0b27a5e51f087f1dc184197a0b3237 (#1044)

There was no good explanation for this change. This should significantly
slow down build times for no apparent reason. mvn clean is not supposed
to remove repository caches. E.g. it will also not clear the local Maven
repository. Why should it remove the npm or Bower caches?