### PR TITLE
MH-13675: ServiceRegistry not updating database correctly when dispatching jobs

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -1010,7 +1010,8 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     try {
       tx.begin();
       fromDb = em.find(JpaJob.class, job.getId());
-      originalJob = JpaJob.from(fromDb.toJob());
+      // MH-13675 This resets the job state in the 'job' variable back to the previous value so commenting it out
+      // originalJob = JpaJob.from(fromDb.toJob());
       if (fromDb == null) {
         throw new NoResultException();
       }
@@ -1022,7 +1023,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       setJobUri(job);
       return job;
     } catch (PersistenceException e) {
-      dumpJobs(originalJob, fromDb);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -1129,6 +1129,8 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       ServiceRegistrationJpaImpl processingService = (ServiceRegistrationJpaImpl) getServiceRegistration(
               job.getJobType(), job.getProcessingHost());
       fromDb.setProcessorServiceRegistration(processingService);
+    } else {
+      fromDb.setProcessorServiceRegistration(null);
     }
     if (Status.RUNNING.equals(status) && !Status.WAITING.equals(fromDbStatus)) {
       if (job.getDateStarted() == null) {

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -1005,13 +1005,10 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    */
   protected JpaJob updateInternal(EntityManager em, JpaJob job) throws PersistenceException {
     EntityTransaction tx = em.getTransaction();
-    JpaJob originalJob = null;
     JpaJob fromDb = null;
     try {
       tx.begin();
       fromDb = em.find(JpaJob.class, job.getId());
-      // MH-13675 This resets the job state in the 'job' variable back to the previous value so commenting it out
-      // originalJob = JpaJob.from(fromDb.toJob());
       if (fromDb == null) {
         throw new NoResultException();
       }


### PR DESCRIPTION
I've seen 2 cases where the database is not correctly updated:

1) When the job cannot be dispatched and is put into the dispatchPriorityList: the job's processor service is never set to null in the database.

2) When the job changes status from QUEUED to DISPATCHING: the value DISPATCHING never makes it to the database.

Note that these are not critical because #1 will "fix itself" in one of the next runs of the dispatcher and #2 will "fix itself" by the worker when it accepts the job, but it has caused us at DCE some trouble because of our horizontal scaling mechanism that needs to have accurate info in the database :)
