### PR TITLE
MH-13706 Show bibliographic event dates on the events overview page

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -62,15 +62,15 @@ angular.module('adminNg.controllers')
         sortable: true
       }, {
         template: 'modules/events/partials/eventsTechnicalDateCell.html',
-        name:  'technical_date',
+        name:  'date',
         label: 'EVENTS.EVENTS.TABLE.DATE',
         sortable: true
       }, {
-        name:  'technical_start',
+        name:  'start_date',
         label: 'EVENTS.EVENTS.TABLE.START',
         sortable: true
       }, {
-        name:  'technical_end',
+        name:  'end_date',
         label: 'EVENTS.EVENTS.TABLE.STOP',
         sortable: true
       }, {


### PR DESCRIPTION
Since Opencast 7 the event may have an bibliographic and a technical start and end date. The bibliographic dates will be published in the episode dublincore catalog and can be changed in the event metadata tab. The technical start and end date is currently used by the scheduler and they represent the dates which recording should be started and stopped by the capture agent. The technical dates can be changed in the event scheduling tab. The events overview showes the tecnical dates. This is realy confusing. If the event is uploaded directly to opencast without schedule, the technical dates can not be changed because the scheduling tab is hidden. Even for scheduled events, showing the technical dates is also confusing.