### PR TITLE
MH-13447 && MH-13425 - Feeds-Tab / adds a new tab in series properties.

### DIFF
--- a/etc/feeds/series.properties
+++ b/etc/feeds/series.properties
@@ -17,3 +17,4 @@ feed.rsstags=rss
 feed.rssmediatype=video,audio
 feed.atomflavors=presentation/delivery,presenter/delivery,presenter/feed+preview,presenter/search+preview
 feed.atomtags=atom
+feed.pattern=/feeds/<type>/<version>/series/<series_id>

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -512,6 +512,7 @@
               OSGI-INF/adminui_configuration.xml,
               OSGI-INF/captureagents_endpoint.xml,
               OSGI-INF/event_endpoint.xml,
+              OSGI-INF/feed_endpoint.xml,
               OSGI-INF/groups_endpoint.xml,
               OSGI-INF/index_endpoint.xml,
               OSGI-INF/job_endpoint.xml,

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/FeedEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/FeedEndpoint.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.adminui.endpoint;
+
+import org.opencastproject.serviceregistry.api.RemoteBase;
+import org.opencastproject.util.doc.rest.RestService;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/")
+@RestService(name = "FeedService", title = "Admin UI Feed Service",
+  abstractText = "Provides Feed Information",
+  notes = {"This service offers Feed information for the admin UI."})
+public class FeedEndpoint extends RemoteBase {
+
+  public FeedEndpoint() {
+    super("org.opencastproject.feed.impl.FeedServiceImpl");
+  }
+
+  /** Logging facility */
+  private static Logger logger = LoggerFactory.getLogger(FeedEndpoint.class);
+
+  @GET
+  @Path("/feeds")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String listFeedServices() {
+
+    HttpGet get = new HttpGet("/feeds");
+    HttpResponse response = null;
+    String result = null;
+
+    try {
+      response = getResponse(get);
+      result = IOUtils.toString(response.getEntity().getContent(), "utf-8");
+    } catch (Exception e) {
+      logger.error("Could not get /feeds request in FeedEndpoint. " + e.toString());
+    }
+
+    return result;
+  }
+
+}

--- a/modules/admin-ui/src/main/resources/OSGI-INF/feed_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/feed_endpoint.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.adminui.endpoint.FeedEndpoint" immediate="true">
+  <implementation class="org.opencastproject.adminui.endpoint.FeedEndpoint"/>
+  <property name="service.description" value="Admin UI - Feed Endpoint"/>
+
+  <property name="opencast.service.type" value="org.opencastproject.adminui.endpoint.FeedEndpoint"/>
+  <property name="opencast.service.path" value="/admin-ng/feeds"/>
+  <service>
+    <provide interface="org.opencastproject.adminui.endpoint.FeedEndpoint"/>
+  </service>
+
+  <reference name="trustedHttpClient" interface="org.opencastproject.security.api.TrustedHttpClient"
+             cardinality="1..1" policy="static" bind="setTrustedHttpClient"/>
+  <reference name="remoteServiceManager" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
+             cardinality="1..1" policy="static" bind="setRemoteServiceManager"/>
+</scr:component>

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/serieController.js
@@ -24,9 +24,9 @@
 angular.module('adminNg.controllers')
 .controller('SerieCtrl', ['$scope', 'SeriesMetadataResource', 'SeriesEventsResource', 'SeriesAccessResource',
   'SeriesThemeResource', 'ResourcesListResource', 'UserRolesResource', 'Notifications', 'AuthService',
-  'StatisticsReusable',
+  'StatisticsReusable', '$http',
   function ($scope, SeriesMetadataResource, SeriesEventsResource, SeriesAccessResource, SeriesThemeResource,
-    ResourcesListResource, UserRolesResource, Notifications, AuthService, StatisticsReusable) {
+    ResourcesListResource, UserRolesResource, Notifications, AuthService, StatisticsReusable, $http) {
 
     var roleSlice = 100;
     var roleOffset = 0;
@@ -180,6 +180,45 @@ angular.module('adminNg.controllers')
         if (angular.isDefined(seriesCatalogIndex)) {
           metadata.entries.splice(seriesCatalogIndex, 1);
         }
+
+        $http.get('/admin-ng/feeds/feeds')
+        .then( function(response) {
+          $scope.feedContent = response.data;
+          for (var i = 0; i < $scope.seriesCatalog.fields.length; i++) {
+            if($scope.seriesCatalog.fields[i].id === 'identifier'){
+              $scope.uid = $scope.seriesCatalog.fields[i].value;
+            }
+          }
+          for (var j = 0; j < response.data.length; j++) {
+            if(response.data[j].name === 'Series') {
+              var pattern = response.data[j].identifier.split('/series')[0] + response.data[j].pattern;
+              var uidLink = pattern.split('<series_id>')[0] + $scope.uid;
+              var typeLink = uidLink.split('<type>');
+              var versionLink = typeLink[1].split('<version>');
+              $scope.feedsLinks = [
+                {
+                  type: 'atom',
+                  version: '0.3',
+                  link: typeLink[0] + 'atom' + versionLink[0] + '0.3' + versionLink[1]
+                },
+                {
+                  type: 'atom',
+                  version: '1.0',
+                  link: typeLink[0] + 'atom' + versionLink[0] + '1.0' + versionLink[1]
+                },
+                {
+                  type: 'rss',
+                  version: '2.0',
+                  link: typeLink[0] + 'rss' + versionLink[0] + '2.0' + versionLink[1]
+                }
+              ];
+            }
+          }
+
+        }).catch(function(error) {
+          $scope.feedContent = null;
+        });
+
       });
 
       $scope.roles = {};

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
@@ -49,6 +49,13 @@
        ng-if="statReusable.hasStatistics()">
       <!-- Statistics -->
     </a>
+    <a ng-if="feedContent" ng-click="openTab('feeds')"
+      data-modal-tab="feeds"
+      ng-class="{ active: tab == 'feeds' }"
+      translate="Feeds"
+      with-role="Feeds">
+      <!-- Feeds -->
+    </a>
   </nav>
 
   <!-- Left and right arrows to switch between series -->
@@ -333,6 +340,30 @@
                 <p ng-if="selectedTheme.description">{{ selectedTheme.description }}</p>
               </li>
             </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Feeds view -->
+  <div ng-if="feedsLinks" class="modal-content" data-modal-tab-content="feeds">
+    <div class="modal-body">
+      <div class="full-col">
+        <div class="obj">
+          <div class="obj-container">
+            <table class="main-tbl">
+              <tr>
+                <th>Type</th>
+                <th>Version</th>
+                <th>Link</th>
+              </tr>
+              <tr ng-repeat="row in feedsLinks">
+                <td> {{ row.type }} </td>
+                <td> {{ row.version }} </td>
+                <td> <a href="{{ row.link }}"> {{ row.link }} </a> </td>
+              </tr>
+            </table>
           </div>
         </div>
       </div>

--- a/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/serieControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/events/controllers/serieControllerSpec.js
@@ -38,6 +38,7 @@ describe('Serie controller', function () {
         $httpBackend.whenGET('/admin-ng/resources/THEMES.NAME.json').respond({1001: 'Heinz das Pferd', 1002: 'Full Fledged', 401: 'Doc Test'});
         $httpBackend.whenGET('/admin-ng/resources/THEMES.DESCRIPTION.json').respond({901: 'theme1 description', 902: 'theme2 desc\nsecond line'});
         $httpBackend.whenGET('/admin-ng/resources/ACL.json').respond('{}');
+        $httpBackend.whenGET('/admin-ng/feeds/feeds').respond('{}');
         $httpBackend.whenGET('/admin-ng/resources/ACL.ACTIONS.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=100&offset=0').respond('{"ROLE_ANONYMOUS": "ROLE_ANONYMOUS"}');
         $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:ACL&limit=100&offset=2').respond('{}');

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/FeedGenerator.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/FeedGenerator.java
@@ -56,6 +56,11 @@ public interface FeedGenerator {
   String getDescription();
 
   /**
+   * Return the feed pattern
+   */
+  String getPattern();
+
+  /**
    * Return the feed link.
    *
    * @param organization

--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -16,6 +16,10 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-search-service-api</artifactId>
       <version>${project.version}</version>

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/AbstractFeedGenerator.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/AbstractFeedGenerator.java
@@ -118,6 +118,9 @@ public abstract class AbstractFeedGenerator implements FeedGenerator {
   /** Property key for the feed atom media element flavor */
   public static final String PROP_ATOMTAGS = "feed.atomtags";
 
+  /** Property key for the feed atom media element flavor */
+  public static final String PROP_PATTERN = "feed.pattern";
+
   /** A default value for limit */
   protected static final int DEFAULT_LIMIT = 100;
 
@@ -171,6 +174,9 @@ public abstract class AbstractFeedGenerator implements FeedGenerator {
 
   /** The feed name */
   private String name = null;
+
+  /** The feed pattern */
+  private String pattern = null;
 
   /** Url to the cover image */
   private String cover = null;
@@ -253,6 +259,7 @@ public abstract class AbstractFeedGenerator implements FeedGenerator {
     description = (String) properties.get(PROP_DESCRIPTION);
     copyright = (String) properties.get(PROP_COPYRIGHT);
     home = (String) properties.get(PROP_HOME);
+    pattern = (String) properties.get(PROP_PATTERN);
     // feed.cover can be unset if no branding is required
     if (StringUtils.isBlank((String) properties.get(PROP_COVER))) {
       cover = null;
@@ -304,6 +311,15 @@ public abstract class AbstractFeedGenerator implements FeedGenerator {
    */
   public String getIdentifier() {
     return uri;
+  }
+
+  /**
+   * Returns the pattern.
+   *
+   * @return the pattern
+   */
+  public String getPattern() {
+    return this.pattern;
   }
 
   /**

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
@@ -32,6 +32,7 @@ import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
+import com.google.gson.Gson;
 import com.rometools.rome.io.FeedException;
 import com.rometools.rome.io.SyndFeedOutput;
 import com.rometools.rome.io.WireFeedOutput;
@@ -41,7 +42,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -93,6 +96,40 @@ public class FeedServiceImpl {
 
   /** The security service */
   private SecurityService securityService = null;
+
+  /** For Feedlinks */
+  private Gson gson = new Gson();
+
+  /*
+   *
+   * Feedlinks for Admin UI
+   * /feeds/feeds
+   *
+   */
+
+  @GET
+  @Path("/feeds")
+  @Produces(MediaType.APPLICATION_JSON)
+  public String listFeedServices() {
+
+    List<Map<String, String>> feedServices = new ArrayList<>();
+
+    for (FeedGenerator generator : feeds) {
+      if (generator.getName().equals("Series")
+              || generator.getName().equals("Series episodes containing audio files")) {
+        Map<String, String> details = new HashMap<>();
+        details.put("identifier", generator.getIdentifier());
+        details.put("name", generator.getName());
+        details.put("description", generator.getDescription());
+        details.put("copyright", generator.getCopyright());
+        details.put("pattern", generator.getPattern());
+        details.put("type", generator.getClass().getSimpleName());
+        feedServices.add(details);
+      }
+    }
+
+    return gson.toJson(feedServices);
+  }
 
   /*
    * Note: We're using Regex matching for the path here, instead of normal JAX-RS paths.  Previously this class was a servlet,


### PR DESCRIPTION
I got some errors due to very old branches, I decided to create a new PR from a current upstream.

related to #845 #912 

In this pullrequest I do add a feed tab to the series modal window, the new links in the tab are clickable and they guide you to the atom/rss xml. To achieve this I had to add the feed function to the backend and to adjust the configuration file in etc/feeds/series.properties.

(see an example image below this comment)