### PR TITLE
MH-13710: Fix a bug in paella loader plugin when a track has no tags

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -143,8 +143,8 @@ class OpencastToPaellaConverter {
 
     var tracks = episode.mediapackage.media.track;
     var attachments = episode.mediapackage.attachments.attachment;
-    if (!(tracks instanceof Array)) { tracks = [tracks]; }
-    if (!(attachments instanceof Array)) { attachments = [attachments]; }
+    if (!(tracks instanceof Array)) { tracks = tracks ? [tracks] : []; }
+    if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
 
     // Read the tracks!!
     tracks.forEach((currentTrack) => {
@@ -254,8 +254,8 @@ class OpencastToPaellaConverter {
 
     var attachments = episode.mediapackage.attachments.attachment;
     var catalogs = episode.mediapackage.metadata.catalog;
-    if (!(attachments instanceof Array)) { attachments = [attachments]; }
-    if (!(catalogs instanceof Array)) { catalogs = [catalogs]; }
+    if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
+    if (!(catalogs instanceof Array)) { catalogs = catalogs ? [catalogs] : []; }
 
 
     // Read the attachments
@@ -338,7 +338,7 @@ class OpencastToPaellaConverter {
     var segments = [];
 
     var attachments = episode.mediapackage.attachments.attachment;
-    if (!(attachments instanceof Array)) { attachments = [attachments]; }
+    if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
 
     // Read the attachments
     var opencastFrameList = {};
@@ -391,7 +391,7 @@ class OpencastToPaellaConverter {
     let otherPreview;
 
     var attachments = episode.mediapackage.attachments.attachment;
-    if (!(attachments instanceof Array)) { attachments = [attachments]; }
+    if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
     attachments.forEach((currentAttachment) => {
       if (currentAttachment.type == 'presenter/player+preview') {
         presenterPreview = currentAttachment.url;

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -215,10 +215,16 @@ class OpencastToPaellaConverter {
         return (((smask[0] == '*') || (smask[0] == sflavour[0])) && ((smask[1] == '*') || (smask[1] == sflavour[1])));
       });
 
-      let importT = filterStream.tracks.tags.some(function(cTag) {
-        return currentTrack.tags.tag.some(function(t){
-          return ((cTag == '*') || (cTag == t));
-        });
+      let importT = false;
+      let tags = [];
+      if ( (currentTrack.tags) && (currentTrack.tags.tag) ) {
+        tags = [currentTrack.tags.tag];
+        if (!(currentTrack.tags.tag instanceof Array)) {
+          tags = [currentTrack.tags.tag];
+        }
+      }
+      importT = filterStream.tracks.tags.some(function(cTag) {
+        return (cTag == '*') || tags.some(function(t){ return (cTag == t); });
       });
 
       if (importF || importT) {
@@ -385,6 +391,7 @@ class OpencastToPaellaConverter {
     let otherPreview;
 
     var attachments = episode.mediapackage.attachments.attachment;
+    if (!(attachments instanceof Array)) { attachments = [attachments]; }
     attachments.forEach((currentAttachment) => {
       if (currentAttachment.type == 'presenter/player+preview') {
         presenterPreview = currentAttachment.url;


### PR DESCRIPTION
Jira ticket: https://opencast.jira.com/browse/MH-13710

**Steps to reproduce:**
1. Process a mediapackage with a track without tags
2. Try to play with paella

**Actual Results:**
Paella fails to load the video

**Expected Results:**
Paella should play the video