### PR TITLE
Move to GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Opencast is not working as expected
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what you see:
+*When I click on X I get an error message that looks like Y instead of …*
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Environment Information**
+ - OS: [e.g. iOS 8.1, CentOS 7]
+ - Browser [e.g. Safari, Chrome]
+ - Opencast version with minor release [e.g. 7.0, 7.2, 7.x if using a branch]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+
+## Before you file, you pull request must...
+
+* [ ] have a concise title.
+* [ ] [closes an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
+* [ ] be against the correct branch (features can only go into develop).
+* [ ] include migration scripts and documentation, if appropriate.
+* [ ] pass automated testing.
+* [ ] have a clean commit history.
+* [ ] have proper commit message (title and body) for all commits.
+* [ ] have appropriate tags applied.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ not be concerned.
 Checklist
 ---------
 
-- [ ] [closes an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
+- [ ] [Closes an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
 - [ ] Pull request has a proper title and description
 - [ ] Appropriate documentation is included
 - [ ] Code passes automatic tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ not be concerned.
 Checklist
 ---------
 
-- [ ] Jira ticket created (use ticket number in pull request and commit messages)
+- [ ] GitHub issue created (use ticket number in pull request and commit messages)
 - [ ] Pull request has a proper title and description
 - [ ] Appropriate documentation is included
 - [ ] Code passes automatic tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,6 @@ at [the development process documentation](https://docs.opencast.org/develop/dev
 guide should suffice for most contributions.
 
 
-Issue Tracker
--------------
-
-Opencast uses [GitHub](https://github.com/opencast/opencast/issues) for tracking issues. Each pull request should be
-accompanied by a ticket in GitHub. The issue identifier should also be used in the title of the pull request and the
-commit message.
-
-
 Bug Fixes and Feature
 ---------------------
 
@@ -48,7 +40,7 @@ not be concerned.
 Checklist
 ---------
 
-- [ ] GitHub issue created (use ticket number in pull request and commit messages)
+- [ ] [closes an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
 - [ ] Pull request has a proper title and description
 - [ ] Appropriate documentation is included
 - [ ] Code passes automatic tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ guide should suffice for most contributions.
 Issue Tracker
 -------------
 
-Opencast uses [Jira](https://opencast.jira.com) for tracking issues. Each pull request should be accompanied by a ticket
-in Jira. The issue identifier should also be used in the title of the pull request and the commit message.
+Opencast uses [GitHub](https://github.com/opencast/opencast/issues) for tracking issues. Each pull request should be
+accompanied by a ticket in GitHub. The issue identifier should also be used in the title of the pull request and the
+commit message.
 
 
 Bug Fixes and Feature

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Issue Tracker
 -------------
 
 If you have found a bug, please file a ticket in our [issue tracker
-](https://opencast.jira.com).
+](https://github.com/opencast/opencast/issues).
 
 
 Community

--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ Installation instructions can be found locally at `docs/guides/admin/docs` or in
 our [online documentation](https://docs.opencast.org).
 
 
-Issue Tracker
--------------
-
-If you have found a bug, please file a ticket in our [issue tracker
-](https://github.com/opencast/opencast/issues).
-
-
 Community
 ---------
 

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -23,9 +23,10 @@ this repository are explained later in this guide.
 ### GitHub
 
 * Opencast uses [GitHub](https://github.com/opencast/opencast/issues) for tracking issues. Each pull request should be
-  accompanied by a ticket in GitHub. The issue identifier should also be used in the title of the pull request and the
-  commits. E.g.: `#12345, Fixing Something Somewhere`. Creating a GitHub issue is usually the first step when fixing
-  something.
+  accompanied by a ticket in GitHub unless it is a very small fix. The issue identifier should also be in the
+  description of the pull request, which will automatically close the issue (if any) when the PR is merged.  See
+  [here](https://help.github.com/en/articles/closing-issues-using-keywords) for more details. Creating a GitHub issue
+  is usually the first step when fixing something.
 
 * Opencast uses [GitHub](https://github.com/opencast) for code hosting. Please
   [fork](https://help.github.com/articles/fork-a-repo/) the [official repository](https://github.com/opencast/opencast)
@@ -37,12 +38,10 @@ this repository are explained later in this guide.
 Opencast distinguishes between bug fix and feature pull requests.
 
 * Features are *only* allowed to be merged into `develop`, which will let them automatically become part of the next
-  major/minor release, given that the release branch for the next release has not been cut yet. If possible, please name
-  branches containing features according to the pattern `f/XXXXX-short-description`, where XXXXX is the relevant
-  GitHub issue number.
+  major/minor release, given that the release branch for the next release has not been cut yet.
 
-* Bug fixes can be merged both into `develop` and into release branches. If possible, please name branches containing
-  bug fixes according to the pattern `t/XXXXX-short-description`, where XXXXX is the relevant GitHub issue number.
+* Bug fixes can be merged both into `develop` and into release branches.
+
 
 ### Reviews
 
@@ -60,7 +59,6 @@ Requests](reviewing-and-merging.md).
 When reviewing a pull request, it is always easier if the reviewer knows what the ticket is about, and has a rough idea
 of what work has been done. To this end, there are a few expectations for all pull requests:
 
-* For each pull request a GitHub issue should be created
 * The GitHub issue  title should match the pull request title
 * The pull request description should contain a summary of the work done, along with reasoning for any major change
     * The GitHub issue should contain the same information
@@ -352,12 +350,9 @@ community will be requested to participate in this testing.
 
 ### Reporting Bugs
 
-If you identify any bugs, please report them! To do that, register yourself in the [Opencast issue
-tracker](https://github.com/opencast/opencast/issues) and create a new ticket. Please describe in detail how to
-reproduce the problem, and which version of Opencast you are experiencing the issue on.
-
-If in doubt of any items in the ticket, please assign it for review to either the current release manager or to the
-quality assurance manager. They will check the issue fields and adjust if necessary.
+If you identify any bugs, please [report them on Github](https://github.com/opencast/opencast/issues)!. Please make
+sure to  describe in detail how to reproduce the problem, and which version of Opencast you are experiencing the issue
+on.
 
 #### Security Issues
 

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -22,9 +22,10 @@ this repository are explained later in this guide.
 
 ### Jira and GitHub
 
-* Opencast uses [Jira](https://opencast.jira.com) for tracking issues. Each pull request should be accompanied by a
-  ticket in Jira. The issue identifier should also be used in the title of the pull request and the commits. E.g.:
-  `MH-12345, Fixing Something Somewhere`. Creating a Jira ticket is usually the first step when fixing something.
+* Opencast uses [GitHub](https://github.com/opencast/opencast/issues) for tracking issues. Each pull request should be
+  accompanied by a ticket in GitHub. The issue identifier should also be used in the title of the pull request and the
+  commits. E.g.: `#12345, Fixing Something Somewhere`. Creating a GitHub issue is usually the first step when fixing
+  something.
 
 * Opencast uses [GitHub](https://github.com/opencast) for code hosting. Please
   [fork](https://help.github.com/articles/fork-a-repo/) the [official repository](https://github.com/opencast/opencast)
@@ -59,10 +60,10 @@ Requests](reviewing-and-merging.md).
 When reviewing a pull request, it is always easier if the reviewer knows what the ticket is about, and has a rough idea
 of what work has been done. To this end, there are a few expectations for all pull requests:
 
-* For each pull request a JIRA ticket should be created
-* The JIRA ticket and JIRA ticket title should be the pull request title
+* For each pull request a GitHub issue should be created
+* The GitHub issue  title should match the pull request title
 * The pull request description should contain a summary of the work done, along with reasoning for any major change
-    * The JIRA ticket should contain the same information
+    * The GitHub issue should contain the same information
 * For feature pull requests, accompanying documentation should be included
 * The pull request should have a clean commit history
 * In the case of major user interface changes, it is good practice to include screenshots of the change
@@ -351,12 +352,12 @@ community will be requested to participate in this testing.
 
 ### Reporting Bugs
 
-If you identify any bugs, please report them! To do that, register yourself in the [Opencast
-Jira](https://opencast.jira.com) and create a new ticket. Please describe in detail how to reproduce the problem and
-especially set the *Affects Version* and "Fix Version", where *Fix Version* should be the next Opencast release.
+If you identify any bugs, please report them! To do that, register yourself in the [Opencast issue
+tracker](https://github.com/opencast/opencast/issues) and create a new ticket. Please describe in detail how to
+reproduce the problem, and which version of Opencast you are experiencing the issue on.
 
 If in doubt of any items in the ticket, please assign it for review to either the current release manager or to the
-quality assurance manager. They will check the issue fields and adjust *fix version*, *severity*, etc. if necessary.
+quality assurance manager. They will check the issue fields and adjust if necessary.
 
 #### Security Issues
 

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -20,7 +20,7 @@ Opencast sources can be found on [GitHub](https://github.com/opencast). The easi
 project is by creating a pull request against the project's official repository. More details about the structure of
 this repository are explained later in this guide.
 
-### Jira and GitHub
+### GitHub
 
 * Opencast uses [GitHub](https://github.com/opencast/opencast/issues) for tracking issues. Each pull request should be
   accompanied by a ticket in GitHub. The issue identifier should also be used in the title of the pull request and the
@@ -38,11 +38,11 @@ Opencast distinguishes between bug fix and feature pull requests.
 
 * Features are *only* allowed to be merged into `develop`, which will let them automatically become part of the next
   major/minor release, given that the release branch for the next release has not been cut yet. If possible, please name
-  branches containing features according to the pattern `f/MH-XXXXX-short-description`, where MH-XXXXX is the relevant
-  Jira ticket.
+  branches containing features according to the pattern `f/XXXXX-short-description`, where XXXXX is the relevant
+  GitHub issue number.
 
 * Bug fixes can be merged both into `develop` and into release branches. If possible, please name branches containing
-  bug fixes according to the pattern `t/MH-XXXXX-short-description`, where MH-XXXXX is the relevant Jira ticket.
+  bug fixes according to the pattern `t/XXXXX-short-description`, where XXXXX is the relevant GitHub issue number.
 
 ### Reviews
 

--- a/docs/guides/developer/docs/infrastructure/index.md
+++ b/docs/guides/developer/docs/infrastructure/index.md
@@ -66,7 +66,7 @@ include:
 
 - Adding new committers to the relevant group(s)
 - Removing old committers from the relevant group(s)
-- Contacting support when required for hosted projects (Crowdin, Google)
+- Contacting support when required for hosted projects (Atlassian, Crowdin, Google)
 
 ### Adding or removing Committers
 

--- a/docs/guides/developer/docs/infrastructure/index.md
+++ b/docs/guides/developer/docs/infrastructure/index.md
@@ -56,7 +56,6 @@ Administrators
 An administrator is someone within the Opencast community who has administrative access to one or more of our major
 tools.  These tools are
 
-- JIRA
 - GitHub
 - Google Groups
 - Crowdin
@@ -67,7 +66,7 @@ include:
 
 - Adding new committers to the relevant group(s)
 - Removing old committers from the relevant group(s)
-- Contacting support when required for hosted projects (Atlassian, Crowdin, Google)
+- Contacting support when required for hosted projects (Crowdin, Google)
 
 ### Adding or removing Committers
 
@@ -75,7 +74,6 @@ While the committer body manages its own membership, it does not directly have t
 from the appropriate groups across all of our hosted products.  Administrators are required to modify the various
 groups in multiple places when a change is necessary.  These changes are
 
-- Modifying the [JIRA committers group](https://opencast.jira.com/admin/groups/view?groupname=committers-matterhorn)
 - Modifying the [GitHub committers group](https://github.com/orgs/opencast/teams/committers/members) upon request
 - Modifying the [Google committers group](https://admin.google.com/opencast.org/AdminHome?hl=de&pli=1&fral=1&groupId=committers@opencast.org&chromeless=1#OGX:Group?hl=de)
 - Modifying the [Crowdin committers group](https://crowdin.com/project/opencast-community/settings#members)

--- a/docs/guides/developer/docs/reviewing-and-merging.md
+++ b/docs/guides/developer/docs/reviewing-and-merging.md
@@ -52,8 +52,8 @@ The exact review process heavily depends on the type, size and purpose of the pu
 Here are some things a reviewer should usually do:
 
 * Check if code looks sensible (e.g. no nonsensical files, no obvious formatting errors, no large binary files, …)
-* Locally run Opencast and verify that the issue has been fixed (as described in the pull request and/or the Jira
-  ticket) or the feature does what it is supposed
+* Locally run Opencast and verify that the issue has been fixed (as described in the pull request and/or the GitHub
+  issue) or the feature does what it is supposed
 * Check the documentation
 
 Some changes require special attention:

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -164,7 +164,7 @@
           <h4>Bugs</h4>
           <p>Please report <em>security</em> related bugs by sending an email to
           <a href="mailto:security@opencast.org">security@opencast.org</a>.
-          Everything else should be filed as a ticket in our <a href="https://opencast.jira.com">issue tracker</a>.</p>
+          Everything else should be filed as a ticket in our <a href="https://github.com/opencast/opencast/issues">issue tracker</a>.</p>
         </div>
       </div>
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/TasksEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/TasksEndpoint.java
@@ -82,7 +82,7 @@ import javax.ws.rs.core.Response.Status;
               + "not working and is either restarting or has failed",
             "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
               + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-              + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>",
+              + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>",
             "<strong>Important:</strong> "
               + "<em>This service is for exclusive use by the module admin-ui. Its API might change "
               + "anytime without prior notice. Any dependencies other than the admin UI will be strictly ignored. "

--- a/modules/annotation-impl/src/main/java/org/opencastproject/annotation/impl/AnnotationRestService.java
+++ b/modules/annotation-impl/src/main/java/org/opencastproject/annotation/impl/AnnotationRestService.java
@@ -74,7 +74,7 @@ import javax.ws.rs.core.Response.Status;
         + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
         + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+        + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class AnnotationRestService {
 
   /** The logger */

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
@@ -98,7 +98,7 @@ import javax.ws.rs.core.Response;
         "All paths are relative to the REST endpoint base (something like http://your.server/files)",
         "If you notice that this service is not working as expected, there might be a bug! "
             + "You should file an error report with your server logs from the time when the error occurred: "
-            + "<a href=\"http://opencast.jira.com\">Opencast Issue Tracker</a>"
+            + "<a href=\"http://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>"
     },
     abstractText = "This service indexes and queries available (distributed) episodes.")
 public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProducerEndpoint {

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/endpoint/CaptionServiceRestEndpoint.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/endpoint/CaptionServiceRestEndpoint.java
@@ -69,7 +69,7 @@ import javax.xml.transform.stream.StreamResult;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class CaptionServiceRestEndpoint extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
@@ -87,7 +87,7 @@ import javax.ws.rs.core.Response;
       + "not working and is either restarting or has failed",
     "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
       + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-      + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+      + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class CaptureAgentStateRestService {
 
   private static final Logger logger = LoggerFactory.getLogger(CaptureAgentStateRestService.class);

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -87,7 +87,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class ComposerRestService extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/endpoint/CoverImageEndpoint.java
+++ b/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/endpoint/CoverImageEndpoint.java
@@ -56,7 +56,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class CoverImageEndpoint extends AbstractJobProducerEndpoint {
 
   /** Reference to the service registry service */

--- a/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/endpoint/WowzaAdaptiveStreamingDistributionRestService.java
+++ b/modules/distribution-service-adaptive-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/endpoint/WowzaAdaptiveStreamingDistributionRestService.java
@@ -71,7 +71,7 @@ import javax.ws.rs.core.Response.Status;
         + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
         + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+        + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class WowzaAdaptiveStreamingDistributionRestService extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/endpoint/AwsS3DistributionRestService.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/endpoint/AwsS3DistributionRestService.java
@@ -68,7 +68,7 @@ import javax.ws.rs.core.Response.Status;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class AwsS3DistributionRestService extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/endpoint/DownloadDistributionRestService.java
+++ b/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/endpoint/DownloadDistributionRestService.java
@@ -73,7 +73,7 @@ import javax.ws.rs.core.Response.Status;
         + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
         + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+        + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class DownloadDistributionRestService extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/engage-theodul-core/src/main/java/org/opencastproject/engage/theodul/manager/impl/EngagePluginManagerRestService.java
+++ b/modules/engage-theodul-core/src/main/java/org/opencastproject/engage/theodul/manager/impl/EngagePluginManagerRestService.java
@@ -47,7 +47,7 @@ import javax.ws.rs.core.Response;
             + "not working and is either restarting or has failed",
             "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
             + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-            + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>"})
+            + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>"})
 public class EngagePluginManagerRestService {
 
     private static final Logger log = LoggerFactory.getLogger(EngagePluginManagerRestService.class);

--- a/modules/fileupload/src/main/java/org/opencastproject/fileupload/rest/FileUploadRestService.java
+++ b/modules/fileupload/src/main/java/org/opencastproject/fileupload/rest/FileUploadRestService.java
@@ -69,7 +69,7 @@ import javax.ws.rs.core.Response;
         + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
         + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+        + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class FileUploadRestService {
 
   // message field names

--- a/modules/hello-world-impl/src/main/java/org/opencastproject/helloworld/impl/endpoint/HelloWorldRestEndpoint.java
+++ b/modules/hello-world-impl/src/main/java/org/opencastproject/helloworld/impl/endpoint/HelloWorldRestEndpoint.java
@@ -50,7 +50,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated."
                 + "In other words, there is a bug! You should file an error report with your server logs from the time"
-                + "when the error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "when the error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class HelloWorldRestEndpoint {
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(HelloWorldRestEndpoint.class);

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -117,7 +117,7 @@ import javax.ws.rs.core.Response.Status;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class IngestRestService extends AbstractJobProducerEndpoint {
 
   private static final Logger logger = LoggerFactory.getLogger(IngestRestService.class);

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/endpoints/MediaInspectionRestEndpoint.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/endpoints/MediaInspectionRestEndpoint.java
@@ -60,7 +60,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class MediaInspectionRestEndpoint extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/endpoint/YouTubePublicationRestService.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/endpoint/YouTubePublicationRestService.java
@@ -65,7 +65,7 @@ import javax.ws.rs.core.Response.Status;
             + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
             + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-            + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+            + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class YouTubePublicationRestService extends AbstractJobProducerEndpoint {
 
   private final Logger logger = LoggerFactory.getLogger(YouTubePublicationRestService.class);

--- a/modules/runtime-info-ui/src/main/resources/ui/index.html
+++ b/modules/runtime-info-ui/src/main/resources/ui/index.html
@@ -80,7 +80,7 @@
             <li><a href="https://groups.google.com/a/opencast.org/forum/#!myforums">Mailing Lists (Google
                 Groups)</a></li>
             <li><a href="http://webchat.freenode.net/?channels=opencast">IRC-Channel (Webinterface)</a></li>
-            <li><a href="https://opencast.jira.com/browse/MH">Issue Tracker</a></li>
+            <li><a href="https://github.com/opencast/opencast/issues">Issue Tracker</a></li>
           </ul>
 
         </div>

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
@@ -150,7 +150,7 @@ import javax.ws.rs.core.Response.Status;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class SchedulerRestService {
 
   private static final Logger logger = LoggerFactory.getLogger(SchedulerRestService.class);

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -67,7 +67,7 @@ import javax.ws.rs.core.Response.ResponseBuilder;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class SearchRestService extends AbstractJobProducerEndpoint {
 
   private static final Logger logger = LoggerFactory.getLogger(SearchRestService.class);

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
@@ -110,7 +110,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class SeriesRestService {
 
   private static final String SERIES_ELEMENT_CONTENT_TYPE_PREFIX = "series/";

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -104,7 +104,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService {
 
   private static final Logger logger = LoggerFactory.getLogger(SeriesServiceRemoteImpl.class);

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/IncidentServiceEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/IncidentServiceEndpoint.java
@@ -99,7 +99,7 @@ import javax.ws.rs.core.Response.Status;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>"})
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>"})
 public class IncidentServiceEndpoint {
   /** Logging utility */
   private static final Logger logger = LoggerFactory.getLogger(IncidentServiceEndpoint.class);

--- a/modules/sox-impl/src/main/java/org/opencastproject/sox/impl/endpoint/SoxRestService.java
+++ b/modules/sox-impl/src/main/java/org/opencastproject/sox/impl/endpoint/SoxRestService.java
@@ -62,7 +62,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class SoxRestService extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/static-file-service-api/src/main/java/org/opencastproject/staticfiles/endpoint/StaticFileRestService.java
+++ b/modules/static-file-service-api/src/main/java/org/opencastproject/staticfiles/endpoint/StaticFileRestService.java
@@ -84,7 +84,7 @@ import javax.ws.rs.core.Response.Status;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class StaticFileRestService {
 
   /** The logging facility */

--- a/modules/statistics-service-impl/src/main/java/org/opencastproject/statistics/endpoint/StatisticsRestService.java
+++ b/modules/statistics-service-impl/src/main/java/org/opencastproject/statistics/endpoint/StatisticsRestService.java
@@ -68,7 +68,7 @@ import javax.ws.rs.core.Response;
         + "not working and is either restarting or has failed",
     "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
         + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>"})
+        + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>"})
 public class StatisticsRestService {
 
   /** Logging utility */

--- a/modules/statistics-service-remote/src/main/java/org/opencastproject/statistics/remote/StatisticsServiceRemoteImpl.java
+++ b/modules/statistics-service-remote/src/main/java/org/opencastproject/statistics/remote/StatisticsServiceRemoteImpl.java
@@ -68,7 +68,7 @@ import javax.ws.rs.Path;
         + "not working and is either restarting or has failed",
     "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
         + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>"})
+        + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>"})
 public class StatisticsServiceRemoteImpl extends RemoteBase implements StatisticsService {
 
   private static final JSONParser jsonParser = new JSONParser();

--- a/modules/termination-state-aws/src/main/java/org/opencastproject/terminationstate/endpoint/aws/AutoScalingTerminationStateRestService.java
+++ b/modules/termination-state-aws/src/main/java/org/opencastproject/terminationstate/endpoint/aws/AutoScalingTerminationStateRestService.java
@@ -57,7 +57,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class AutoScalingTerminationStateRestService implements TerminationStateRestService {
 
   private static final Log logger = new Log(LoggerFactory.getLogger(AutoScalingTerminationStateRestService.class));

--- a/modules/termination-state-impl/src/main/java/org/opencastproject/terminationstate/endpoint/impl/TerminationStateRestServiceImpl.java
+++ b/modules/termination-state-impl/src/main/java/org/opencastproject/terminationstate/endpoint/impl/TerminationStateRestServiceImpl.java
@@ -56,7 +56,7 @@ import javax.ws.rs.core.Response;
           + "not working and is either restarting or has failed",
           "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
           + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-          + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>"})
+          + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>"})
 public class TerminationStateRestServiceImpl implements TerminationStateRestService {
 
   private static final Log logger = new Log(LoggerFactory.getLogger(TerminationStateRestServiceImpl.class));

--- a/modules/textanalyzer-impl/src/main/java/org/opencastproject/textanalyzer/impl/endpoint/TextAnalysisRestEndpoint.java
+++ b/modules/textanalyzer-impl/src/main/java/org/opencastproject/textanalyzer/impl/endpoint/TextAnalysisRestEndpoint.java
@@ -61,7 +61,7 @@ import javax.ws.rs.core.Response.Status;
         + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
         + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+        + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class TextAnalysisRestEndpoint extends AbstractJobProducerEndpoint {
 
   /** The logging facility */

--- a/modules/timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/endpoint/TimelinePreviewsRestEndpoint.java
+++ b/modules/timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/endpoint/TimelinePreviewsRestEndpoint.java
@@ -61,7 +61,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time "
-                + "when the error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "when the error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class TimelinePreviewsRestEndpoint extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/user-interface-configuration/src/main/java/org/opencastproject/uiconfig/UIConfigRest.java
+++ b/modules/user-interface-configuration/src/main/java/org/opencastproject/uiconfig/UIConfigRest.java
@@ -62,7 +62,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated."
                 + "In other words, there is a bug! You should file an error report with your server logs from the time"
-                + "when the error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "when the error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class UIConfigRest {
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(UIConfigRest.class);

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/GroupRoleEndpoint.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/GroupRoleEndpoint.java
@@ -69,7 +69,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
                 "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                         + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                        + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                        + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class GroupRoleEndpoint {
 
   /** The logger */

--- a/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/endpoint/UserTrackingRestService.java
+++ b/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/endpoint/UserTrackingRestService.java
@@ -75,7 +75,7 @@ import javax.ws.rs.core.Response.Status;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class UserTrackingRestService {
 
   private static final Logger logger = LoggerFactory.getLogger(UserTrackingRestService.class);

--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/endpoint/VideoSegmenterRestEndpoint.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/endpoint/VideoSegmenterRestEndpoint.java
@@ -59,7 +59,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class VideoSegmenterRestEndpoint extends AbstractJobProducerEndpoint {
 
   /** The logger */

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
@@ -114,7 +114,7 @@ import javax.ws.rs.core.Response.Status;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class WorkflowRestService extends AbstractJobProducerEndpoint {
 
   /** The default number of results returned */

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryRestEndpoint.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryRestEndpoint.java
@@ -79,7 +79,7 @@ import javax.ws.rs.core.Response;
                 + "not working and is either restarting or has failed",
         "A status code 500 means a general failure has occurred which is not recoverable and was not anticipated. In "
                 + "other words, there is a bug! You should file an error report with your server logs from the time when the "
-                + "error occurred: <a href=\"https://opencast.jira.com\">Opencast Issue Tracker</a>" })
+                + "error occurred: <a href=\"https://github.com/opencast/opencast/issues\">Opencast Issue Tracker</a>" })
 public class WorkingFileRepositoryRestEndpoint extends WorkingFileRepositoryImpl {
 
   private static final Logger logger = LoggerFactory.getLogger(WorkingFileRepositoryRestEndpoint.class);

--- a/pom.xml
+++ b/pom.xml
@@ -1748,8 +1748,8 @@
     <url>https://github.com/opencast/opencast/</url>
   </scm>
   <issueManagement>
-    <system>jira</system>
-    <url>https://opencast.jira.com</url>
+    <system>GitHub</system>
+    <url>https://github.com/opencast/opencast</url>
   </issueManagement>
   <!-- Site Report generation settings -->
   <reporting>


### PR DESCRIPTION
This PR (finally!) moves our issue tracking over to GitHub.  I will be enabling GH issues in a minute, and will lock JIRA and send out the notifications once this has been merged.