### PR TITLE
MH-13714, Hide Column `Stop` By Default

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/tableService.js
@@ -169,7 +169,7 @@ angular.module('adminNg.services')
           // configure them from scratch
           me.columns = options.columns;
           angular.forEach(me.columns, function (column) {
-            column.deactivated = false;
+            column.deactivated = column.name === 'technical_end';
           });
         }
 


### PR DESCRIPTION
As discussed a few times already, the column containing the technical
end date of the events table is not very helpful for most people since
it exists only for parts of the recordings.

This patch thus updates the default settings of the admin interface,
hiding the column initially. Users are still able to configure the
columns like before and can still include the column if they want to.

This patch has no effect if a custom setting is already stored in the
user's local storage.