### PR TITLE
MH-13716, Update xmlsec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -959,7 +959,7 @@
       <dependency>
         <groupId>org.apache.santuario</groupId>
         <artifactId>xmlsec</artifactId>
-        <version>2.1.2</version>
+        <version>2.1.4</version>
       </dependency>
       <dependency>
         <groupId>org.owasp.esapi</groupId>


### PR DESCRIPTION
This patch fixes CVE-2019-12400

In version 2.0.3 Apache Santuario XML Security for Java, a caching
mechanism was introduced to speed up creating new XML documents using a
static pool of DocumentBuilders. However, if some untrusted code can
register a malicious implementation with the thread context class loader
first, then this implementation might be cached and re-used by Apache
Santuario - XML Security for Java, leading to potential security flaws
when validating signed documents, etc. The vulnerability affects Apache
Santuario - XML Security for Java 2.0.x releases from 2.0.3 and all
2.1.x releases before 2.1.4.