### PR TITLE
MH-13676, start on used port

### DIFF
--- a/assemblies/resources/bin/check_ports
+++ b/assemblies/resources/bin/check_ports
@@ -41,7 +41,7 @@ if [ "$PROGNAME" = "start-opencast" ] && [ "$nargs" -eq "0" ]; then
       return 0;
     fi
     if [ -d /proc/net ] ; then
-      if grep -q "$hexPort" /proc/net/tcp*; then
+      if cat /proc/net/tcp* | awk '{print $2, $3, $4}' | grep " 0[1A]$" | grep -q "$hexPort"; then
         return 1;
       fi
     else


### PR DESCRIPTION
When you stop opencast and restart it quickly afterwards the port is still in the /proc list as closing
the first version did not check the state. 
This fix only stops the startup if the port state is "LISTEN (0A)" or "ESTABLISHED (01)"
