### PR TITLE
MH-13717: Only events with write access

### DIFF
--- a/etc/org.opencastproject.adminui.endpoint.OsgiEventEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.OsgiEventEndpoint.cfg
@@ -27,3 +27,8 @@ preview.subtype=preview
 # within the new event wizard or event details.
 # Default: false
 # eventModal.onlySeriesWithWriteAccess=false
+
+# If this property is true, we only see the events to which we have write access
+# to in the events tab.
+# Default: false
+# eventsTab.onlyEventsWithWriteAccess=false

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -119,6 +119,7 @@ import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
@@ -274,6 +275,8 @@ public abstract class AbstractEventEndpoint {
   public abstract Boolean signWithClientIP();
 
   public abstract Boolean getOnlySeriesWithWriteAccessEventModal();
+
+  public abstract Boolean getOnlyEventsWithWriteAccessEventsTab();
 
   /** Default server URL */
   protected String serverUrl = "http://localhost:8080";
@@ -2210,6 +2213,13 @@ public abstract class AbstractEventEndpoint {
             throw new WebApplicationException(Status.BAD_REQUEST);
         }
       }
+    }
+
+    // We search for write actions
+    if (getOnlyEventsWithWriteAccessEventsTab()) {
+      query.withoutActions();
+      query.withAction(Permissions.Action.WRITE);
+      query.withAction(Permissions.Action.READ);
     }
 
     if (optLimit.isSome())

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -65,7 +65,9 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   private Boolean signWithClientIP = UrlSigningServiceOsgiUtil.DEFAULT_SIGN_WITH_CLIENT_IP;
 
   public static final String EVENTMODAL_ONLYSERIESWITHWRITEACCESS_KEY = "eventModal.onlySeriesWithWriteAccess";
+  public static final String EVENTSTAB_ONLYEVENTSWITHWRITEACCESS_KEY = "eventsTab.onlyEventsWithWriteAccess";
   private Boolean onlySeriesWithWriteAccessEventModal = false;
+  private Boolean onlyEventsWithWriteAccessEventsTab = false;
 
   @Override
   public AdminUIConfiguration getAdminUIConfiguration() {
@@ -212,6 +214,11 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
     if (dictionaryValue != null) {
       onlySeriesWithWriteAccessEventModal = BooleanUtils.toBoolean(dictionaryValue.toString());
     }
+
+    dictionaryValue = properties.get(EVENTSTAB_ONLYEVENTSWITHWRITEACCESS_KEY);
+    if (dictionaryValue != null) {
+      onlyEventsWithWriteAccessEventsTab = BooleanUtils.toBoolean(dictionaryValue.toString());
+    }
   }
 
   @Override
@@ -227,6 +234,11 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   @Override
   public Boolean getOnlySeriesWithWriteAccessEventModal() {
     return onlySeriesWithWriteAccessEventModal;
+  }
+
+  @Override
+  public Boolean getOnlyEventsWithWriteAccessEventsTab() {
+    return onlyEventsWithWriteAccessEventsTab;
   }
 
 }

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -777,4 +777,9 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
   public Boolean getOnlySeriesWithWriteAccessEventModal() {
     return false;
   }
+
+  @Override
+  public Boolean getOnlyEventsWithWriteAccessEventsTab() {
+    return false;
+  }
 }


### PR DESCRIPTION
Show only the events with write access on the Events Tab.
This is configurable with a property in _OsgiEventEndpoint.cfg_.

It is the same that the ticket:
**MH-12782: As an unprivileged user, I only want to see series and events that I have write access to**  does with Series.