### PR TITLE
Temporarily Ignore Service Registry Test

### DIFF
--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -58,6 +58,7 @@ import org.easymock.IAnswer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Filter;
@@ -317,6 +318,7 @@ public class ServiceRegistryJpaImplTest {
   }
 
   @Test
+  @Ignore
   public void testIgnoreHostsInPriorityList() throws Exception {
     if (serviceRegistryJpaImpl.scheduledExecutor != null)
       serviceRegistryJpaImpl.scheduledExecutor.shutdown();


### PR DESCRIPTION
This patch makes Opencast's build system temporarily ignore a constantly
failing service registry test to avoid people loosing trust in the build
system.

Related to #1068


## Before you file, you pull request must...

* [ ] have a concise title.
* [ ] [closes an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop).
* [ ] include migration scripts and documentation, if appropriate.
* [ ] pass automated testing.
* [ ] have a clean commit history.
* [ ] have proper commit message (title and body) for all commits.
* [ ] have appropriate tags applied.
