### PR TITLE
MH-13706 fix the date cell of the events overview table in the admin UI

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -2126,8 +2126,8 @@ public abstract class AbstractEventEndpoint {
       if (EventListQuery.FILTER_STARTDATE_NAME.equals(name)) {
         try {
           Tuple<Date, Date> fromAndToCreationRange = RestUtils.getFromAndToDateRange(filters.get(name));
-          query.withTechnicalStartFrom(fromAndToCreationRange.getA());
-          query.withTechnicalStartTo(fromAndToCreationRange.getB());
+          query.withStartFrom(fromAndToCreationRange.getA());
+          query.withStartTo(fromAndToCreationRange.getB());
         } catch (IllegalArgumentException e) {
           return RestUtil.R.badRequest(e.getMessage());
         }

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventsController.js
@@ -61,7 +61,7 @@ angular.module('adminNg.controllers')
         label: 'EVENTS.EVENTS.TABLE.SERIES',
         sortable: true
       }, {
-        template: 'modules/events/partials/eventsTechnicalDateCell.html',
+        template: 'modules/events/partials/eventsDateCell.html',
         name:  'date',
         label: 'EVENTS.EVENTS.TABLE.DATE',
         sortable: true

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsDateCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventsDateCell.html
@@ -1,0 +1,5 @@
+<a class="crosslink"
+   ng-click="table.addFilterToStorage('startDate', table.dateToFilterValue(row.date_raw))"
+   title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.START' | translate }}">
+  {{row.date}}
+</a>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/eventsResource.js
@@ -62,6 +62,7 @@ angular.module('adminNg.resources')
         });
         row.workflow_state = r.workflow_state;
         row.date = Language.formatDate('short', r.start_date);
+        row.date_raw = r.start_date;
         row.technical_date = Language.formatDate('short', r.technical_start);
         row.technical_date_raw = r.technical_start;
         row.publications = r.publications;

--- a/modules/admin-ui/src/test/resources/test/unit/shared/resources/eventsResourceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/resources/eventsResourceSpec.js
@@ -37,9 +37,9 @@ describe('Events API Resource', function () {
                 location: 'Room 2',
                 agentId: 'Room 2',
                 start_date: '2012-12-02T10:00:00Z',
-                technical_start_date: '2012-12-02T10:00:00Z',
+                technical_start: '2012-12-02T09:55:00Z',
                 end_date: '2012-12-02T11:15:00Z',
-                technical_end_date: '2012-12-02T11:15:00Z',
+                technical_end: '2012-12-02T11:20:00Z',
                 status: 'processing',
                 comments: {
                     resolved: 0,
@@ -62,9 +62,9 @@ describe('Events API Resource', function () {
                 location: 'Room 3',
                 agentId: 'Room 3',
                 start_date: '2012-12-01T08:59:00Z',
-                technical_start_date: '2012-12-01T08:59:00Z',
+                technical_start: '2012-12-01T08:59:00Z',
                 end_date: '2012-12-01T08:59:00Z',
-                technical_end_date: '2012-12-01T08:59:00Z',
+                technical_end: '2012-12-01T08:59:00Z',
                 status: 'processed',
                 comments: {
                     resolved: 1,
@@ -94,6 +94,9 @@ describe('Events API Resource', function () {
             expect(data.rows[0].date).toBe(sampleJSON.results[0].start_date);
             expect(data.rows[0].start_date).toBe('2012-12-02T10:00:00Z');
             expect(data.rows[0].end_date).toBe('2012-12-02T11:15:00Z');
+            expect(data.rows[0].technical_date).toBe(sampleJSON.results[0].technical_start);
+            expect(data.rows[0].technical_start).toBe('2012-12-02T09:55:00Z');
+            expect(data.rows[0].technical_end).toBe('2012-12-02T11:20:00Z');
         });
 
         it('handles empty payload', function () {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/DublinCoreMetadataUtil.java
@@ -133,6 +133,16 @@ public final class DublinCoreMetadataUtil {
     for (DublinCoreValue periodString : periodStrings) {
       p = Opt.nul(EncodingSchemeUtils.decodePeriod(periodString.getValue()));
     }
+    if (p.isNone()) {
+      // fall back to created date with zero duration
+      // opencast keep the event start date and created date in sync
+      // if the start date isn't set, we can grab the created value
+      DublinCoreValue createdDCValue = dc.getFirstVal(DublinCore.PROPERTY_CREATED);
+      if (createdDCValue != null) {
+        Date createdDate = EncodingSchemeUtils.decodeDate(createdDCValue.getValue());
+        p = Opt.nul(new DCMIPeriod(createdDate, createdDate));
+      }
+    }
     return p;
   }
 


### PR DESCRIPTION
The PR #1049 doesn't fix the startdate column of the events overview table as it should. This was a reason to review the last patch more accurate. 

Changes:
- Show the bibliographic (not the technical) date of an event in the events overview table
- Fix the date filter (on click)
- Reintroduce sorting behaviour on the start and stop columns in the events overview table
- Fix event duration update on events without start date set
