### PR TITLE
Remove State Mapping “Importing”

### DIFF
--- a/etc/workflows/schedule-and-upload.xml
+++ b/etc/workflows/schedule-and-upload.xml
@@ -355,9 +355,4 @@
 
   </operations>
 
-  <state-mappings>
-    <state-mapping state="running">EVENTS.EVENTS.STATE_MAPPING.IMPORTING</state-mapping>
-    <state-mapping state="failing">EVENTS.EVENTS.STATE_MAPPING.IMPORTING</state-mapping>
-  </state-mappings>
-
 </definition>


### PR DESCRIPTION
This patch removes the state mapping “Importing” from the default
workflow since it can be pretty confusing if it is used to directly
publish material and the workflow state is forever shown as “Importing”
only to jump to finish right at the end.

While “Importing” is nice when the editor is used, the more general
default mapping “Running” fits better when both use-cases are
considered.


### Your pull request should…

* [ ] have a concise title
* [ ] [closes an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
