### PR TITLE
Issue1068 DEBUG ONLY ServiceRegistryJpaImplTest persistent test fail on Travis

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/persistence/PersistenceUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/persistence/PersistenceUtil.java
@@ -26,6 +26,8 @@ import static org.opencastproject.util.data.Option.none;
 import static org.opencastproject.util.data.Option.option;
 import static org.opencastproject.util.data.Option.some;
 
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+
 import org.opencastproject.util.data.Either;
 import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Option;
@@ -418,9 +420,11 @@ public final class PersistenceUtil {
    */
   public static EntityManagerFactory newTestEntityManagerFactory(String emName) {
     Map<String, String> persistenceProperties = new HashMap<>();
-    persistenceProperties.put("eclipselink.ddl-generation", "create-tables");
-    persistenceProperties.put("eclipselink.ddl-generation.output-mode", "database");
-    return newEntityManagerFactory(emName, "Auto", "org.h2.Driver", "jdbc:h2:./target/db" + System.currentTimeMillis(),
+    persistenceProperties.put(PersistenceUnitProperties.DDL_GENERATION, PersistenceUnitProperties.DROP_AND_CREATE);
+    persistenceProperties.put(PersistenceUnitProperties.DDL_GENERATION_MODE, PersistenceUnitProperties.DDL_DATABASE_GENERATION);
+    //persistenceProperties.put("eclipselink.ddl-generation", "drop-and-create-tables");
+    //persistenceProperties.put("eclipselink.ddl-generation.output-mode", "database");
+    return newEntityManagerFactory(emName, "Auto", "org.h2.Driver", "jdbc:h2:./target/db" + System.currentTimeMillis() + ";IGNORECASE=TRUE",
             "sa", "sa", persistenceProperties, testPersistenceProvider());
   }
 

--- a/modules/common/src/main/java/org/opencastproject/util/persistence/PersistenceUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/persistence/PersistenceUtil.java
@@ -26,8 +26,6 @@ import static org.opencastproject.util.data.Option.none;
 import static org.opencastproject.util.data.Option.option;
 import static org.opencastproject.util.data.Option.some;
 
-import org.eclipse.persistence.config.PersistenceUnitProperties;
-
 import org.opencastproject.util.data.Either;
 import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Option;
@@ -35,6 +33,7 @@ import org.opencastproject.util.data.Tuple;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
+import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.osgi.service.component.ComponentContext;
 
 import java.beans.PropertyVetoException;

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -2946,7 +2946,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         // FIXME: the stats are not currently used and the queries are very
         // expense in database time.
         if (collectJobstats) {
-          logger.warn("About to do the stats query");
+          logger.debug("About to do the stats query");
           jobsStatistics.updateAvg(getAvgOperations(em));
           jobsStatistics.updateJobCount(getCountPerHostService(em));
         }

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -37,7 +37,6 @@ import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.TrustedHttpClientException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
-import org.opencastproject.serviceregistry.api.ServiceRegistration;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.serviceregistry.api.SystemLoad;
 import org.opencastproject.systems.OpencastConstants;
@@ -112,9 +111,9 @@ public class ServiceRegistryJpaImplTest {
     for (ObjectInstance mbean : serviceRegistryJpaImpl.jmxBeans) {
       JmxUtil.unregisterMXBean(mbean);
     }
-    for (ServiceRegistration service : serviceRegistryJpaImpl.getServiceRegistrations()) {
-      serviceRegistryJpaImpl.unRegisterService(service.getServiceType(), service.getHost());
-    }
+    //for (ServiceRegistration service : serviceRegistryJpaImpl.getServiceRegistrations()) {
+    //  serviceRegistryJpaImpl.unRegisterService(service.getServiceType(), service.getHost());
+    //}
     serviceRegistryJpaImpl.deactivate();
   }
 
@@ -219,17 +218,24 @@ public class ServiceRegistryJpaImplTest {
 
   @Test
   public void nullContextActivatesOkay() throws ServiceRegistryException {
+    logger.warn("++++++  Starting nullContextActivatesOkay ++++++ ");
     serviceRegistryJpaImpl.activate(null);
+    logger.warn("++++++  Ending nullContextActivatesOkay ++++++ ");
+
   }
 
   @Test(expected = NotFoundException.class)
   public void testDeleteJobInvalidJobId() throws Exception {
+    logger.warn("++++++  Starting testDeleteJobInvalidJobId ++++++ ");
     serviceRegistryJpaImpl.activate(null);
     serviceRegistryJpaImpl.removeJobs(Collections.singletonList(1L));
+    logger.warn("++++++  Ending testDeleteJobInvalidJobId ++++++ ");
   }
 
   @Test
   public void testCancelUndispatchablesOrphanedByActivatingNode() throws Exception {
+    logger.warn("++++++  Starting testCancelUndispatchablesOrphanedByActivatingNode ++++++ ");
+
     serviceRegistryJpaImpl.activate(null);
     registerTestHostAndService();
     setUpUndispatchableJobs();
@@ -252,10 +258,12 @@ public class ServiceRegistryJpaImplTest {
     logger.info("Undispatachable job 1 " + undispatchableJob2.getId());
     undispatchableJob2 = serviceRegistryJpaImpl.getJob(undispatchableJob2.getId());
     assertEquals(Status.RUNNING, undispatchableJob2.getStatus());
+    logger.warn("++++++  Ending testCancelUndispatchablesOrphanedByActivatingNode ++++++ ");
   }
 
   @Test
   public void testHostAddedToPriorityList() throws Exception {
+    logger.warn("++++++  Starting testHostAddedToPriorityList ++++++ ");
     if (serviceRegistryJpaImpl.scheduledExecutor != null)
       serviceRegistryJpaImpl.scheduledExecutor.shutdown();
     serviceRegistryJpaImpl.scheduledExecutor = Executors.newScheduledThreadPool(1);
@@ -272,10 +280,12 @@ public class ServiceRegistryJpaImplTest {
     } catch (Exception e) {
       Assert.assertEquals(1, serviceRegistryJpaImpl.dispatchPriorityList.size());
     }
+    logger.warn("++++++  End testHostAddedToPriorityList ++++++ ");
   }
 
   @Test
   public void testHostAddedToPriorityListExceptWorkflowType() throws Exception {
+    logger.warn("++++++  Starting testHostAddedToPriorityListExceptWorkflowType ++++++ ");
     if (serviceRegistryJpaImpl.scheduledExecutor != null)
       serviceRegistryJpaImpl.scheduledExecutor.shutdown();
     serviceRegistryJpaImpl.scheduledExecutor = Executors.newScheduledThreadPool(1);
@@ -293,10 +303,13 @@ public class ServiceRegistryJpaImplTest {
     } catch (Exception e) {
       Assert.assertEquals(0, serviceRegistryJpaImpl.dispatchPriorityList.size());
     }
+    logger.warn("++++++  Ending testHostAddedToPriorityListExceptWorkflowType ++++++ ");
+
   }
 
   @Test
   public void testHostsBeingRemovedFromPriorityList() throws Exception {
+    logger.warn("++++++  Starting testHostsBeingRemovedFromPriorityList ++++++ ");
     if (serviceRegistryJpaImpl.scheduledExecutor != null)
       serviceRegistryJpaImpl.scheduledExecutor.shutdown();
     serviceRegistryJpaImpl.scheduledExecutor = Executors.newScheduledThreadPool(1);
@@ -314,10 +327,13 @@ public class ServiceRegistryJpaImplTest {
     } catch (Exception e) {
       Assert.assertEquals(0, serviceRegistryJpaImpl.dispatchPriorityList.size());
     }
+    logger.warn("++++++  Ending testHostsBeingRemovedFromPriorityList ++++++ ");
   }
 
   @Test
   public void testIgnoreHostsInPriorityList() throws Exception {
+    logger.warn("++++++  Starting testIgnoreHostsInPriorityList ++++++ ");
+
     if (serviceRegistryJpaImpl.scheduledExecutor != null)
       serviceRegistryJpaImpl.scheduledExecutor.shutdown();
     serviceRegistryJpaImpl.scheduledExecutor = Executors.newScheduledThreadPool(1);
@@ -347,6 +363,8 @@ public class ServiceRegistryJpaImplTest {
       String blockingHost = serviceRegistryJpaImpl.dispatchPriorityList.get(testJob2.getId());
       Assert.assertEquals(TEST_HOST, blockingHost);
     }
+    logger.warn("++++++  Ending testIgnoreHostsInPriorityList ++++++ ");
+
   }
 
   private void assertHostloads(Job j, Float a, Float b, Float c) throws Exception {


### PR DESCRIPTION
***DO NOT Merge***

This pull is only to debug the Travis CI junit error for ServiceRegistryJpaImplTest. Issue #1068 

It uses WARN logs for DEBUG lines to force-speed debugging. 

The only code change is make the ServiceRegistryJpaImpl.deactivate() wait for the dispatcher thread to terminate before re-queuing jobs from de-registered hosts.

```
    logger.warn("===========  De-activate service registry =============");

    // Wait for job dispatcher to stop *BEFORE* re-queuing jobs from unregistered hosts below
    if (scheduledExecutor != null) {
      try {
        logger.warn("Waiting for Dispatcher to terminate");
        scheduledExecutor.awaitTermination(10, TimeUnit.SECONDS);
      } catch (InterruptedException e) {
        logger.error("Error shutting down the Dispatcher", e);
      }
    }
```