### PR TITLE
Fix Player ID Parameter Parsing

### DIFF
--- a/modules/engage-theodul-plugin-custom-mhConnection/src/main/resources/static/models/mediaPackage.js
+++ b/modules/engage-theodul-plugin-custom-mhConnection/src/main/resources/static/models/mediaPackage.js
@@ -30,9 +30,10 @@ define(["backbone", "engage/core"], function(Backbone, Engage) {
 
     var SEARCH_ENDPOINT = "/search/episode.json";
 
-    var mediaPackageID = Engage.model.get("urlParameters").id;
-    if (!mediaPackageID) {
-        mediaPackageID = "";
+    var mediaPackageID = '';
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.has('id')) {
+      mediaPackageID = urlParams.get('id');
     }
 
     var MediaPackageModel = Backbone.Model.extend({


### PR DESCRIPTION
This patch fixes the parsing and processing of media package IDs which
may not be loaded with the previous code, causing the player to
completely fail (it now fails all the time with the new configuration).

### Your pull request should…

* [x] have a concise title
* [x] be against the correct branch (features can only go into develop)
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
* [ ] include migration scripts and documentation, if appropriate
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
