### PR TITLE
MH-12821 (#1008): Better crop detect test

### DIFF
--- a/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
+++ b/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
@@ -269,9 +269,9 @@ public class CropServiceImpl extends AbstractJobProducer implements CropService,
       exitCode = process.waitFor();
 
     } catch (IOException e) {
-      logger.error("Error executing FFmpeg", e);
+      throw new CropException("Error executing FFmpeg", e);
     } catch (InterruptedException e) {
-      logger.error("Waiting for encoder process exited was interrupted unexpected", e);
+      throw new CropException("Waiting for encoder process exited was interrupted unexpected", e);
     }
 
     if (exitCode != 0) {

--- a/modules/crop-ffmpeg/src/test/java/org/opencastproject/crop/CropServiceTest.java
+++ b/modules/crop-ffmpeg/src/test/java/org/opencastproject/crop/CropServiceTest.java
@@ -169,7 +169,7 @@ public class CropServiceTest {
 
     JobBarrier jobBarrier = new JobBarrier(null, serviceRegistry, 1000, receipt);
     JobBarrier.Result result = jobBarrier.waitForJobs();
-    Assert.assertTrue(result.isSuccess());
+    Assert.assertFalse(result.isSuccess());
   }
 
 


### PR DESCRIPTION
This change fixes the logic of a unit test, and throws errors when errors happen rather than relying on ffmpeg's return code
