### PR TITLE
Issue 1068, Stop job dispatcher before unregistering hosts, junit MH-13675

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
@@ -142,7 +142,17 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
    * This method shuts down the service registry.
    */
   public void dispose() {
-    dispatcher.shutdownNow();
+    if (dispatcher != null) {
+      try {
+        dispatcher.shutdownNow();
+        if (!dispatcher.isShutdown()) {
+          logger.info("Waiting for Dispatcher to terminate");
+          dispatcher.awaitTermination(10, TimeUnit.SECONDS);
+        }
+      } catch (InterruptedException e) {
+        logger.error("Error shutting down the Dispatcher", e);
+      }
+    }
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/util/persistence/PersistenceUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/persistence/PersistenceUtil.java
@@ -33,6 +33,7 @@ import org.opencastproject.util.data.Tuple;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
+import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.osgi.service.component.ComponentContext;
 
 import java.beans.PropertyVetoException;
@@ -418,8 +419,8 @@ public final class PersistenceUtil {
    */
   public static EntityManagerFactory newTestEntityManagerFactory(String emName) {
     Map<String, String> persistenceProperties = new HashMap<>();
-    persistenceProperties.put("eclipselink.ddl-generation", "create-tables");
-    persistenceProperties.put("eclipselink.ddl-generation.output-mode", "database");
+    persistenceProperties.put(PersistenceUnitProperties.DDL_GENERATION, PersistenceUnitProperties.DROP_AND_CREATE);
+    persistenceProperties.put(PersistenceUnitProperties.DDL_GENERATION_MODE, PersistenceUnitProperties.DDL_DATABASE_GENERATION);
     return newEntityManagerFactory(emName, "Auto", "org.h2.Driver", "jdbc:h2:./target/db" + System.currentTimeMillis(),
             "sa", "sa", persistenceProperties, testPersistenceProvider());
   }

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -37,7 +37,6 @@ import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.TrustedHttpClientException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
-import org.opencastproject.serviceregistry.api.ServiceRegistration;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.serviceregistry.api.SystemLoad;
 import org.opencastproject.systems.OpencastConstants;
@@ -112,9 +111,7 @@ public class ServiceRegistryJpaImplTest {
     for (ObjectInstance mbean : serviceRegistryJpaImpl.jmxBeans) {
       JmxUtil.unregisterMXBean(mbean);
     }
-    for (ServiceRegistration service : serviceRegistryJpaImpl.getServiceRegistrations()) {
-      serviceRegistryJpaImpl.unRegisterService(service.getServiceType(), service.getHost());
-    }
+    // Deactivate unregisters services
     serviceRegistryJpaImpl.deactivate();
   }
 
@@ -293,6 +290,7 @@ public class ServiceRegistryJpaImplTest {
     } catch (Exception e) {
       Assert.assertEquals(0, serviceRegistryJpaImpl.dispatchPriorityList.size());
     }
+
   }
 
   @Test
@@ -334,8 +332,15 @@ public class ServiceRegistryJpaImplTest {
       barrier.waitForJobs(2000);
       Assert.fail();
     } catch (Exception e) {
-      Assert.assertTrue(StringUtils.isBlank(serviceRegistryJpaImpl.getJob(testJob.getId()).getProcessingHost()));
-      Assert.assertTrue(StringUtils.isNotBlank(serviceRegistryJpaImpl.getJob(testJob2.getId()).getProcessingHost()));
+      // Mock http client always returns 503 for this path so it won't be dispatched anyway
+      testJob = serviceRegistryJpaImpl.getJob(testJob.getId());
+      Assert.assertTrue(StringUtils.isBlank(testJob.getProcessingHost()));
+      Assert.assertEquals(Job.Status.QUEUED, testJob.getStatus());
+      // Mock http client always returns 204 for this path, but it should not be dispatched
+      // because the host is in the dispatchPriorityList
+      testJob2 = serviceRegistryJpaImpl.getJob(testJob2.getId());
+      Assert.assertTrue(StringUtils.isBlank(testJob2.getProcessingHost()));
+      Assert.assertEquals(Job.Status.QUEUED, testJob2.getStatus());
       Assert.assertEquals(1, serviceRegistryJpaImpl.dispatchPriorityList.size());
       String blockingHost = serviceRegistryJpaImpl.dispatchPriorityList.get(testJob2.getId());
       Assert.assertEquals(TEST_HOST, blockingHost);
@@ -401,7 +406,7 @@ public class ServiceRegistryJpaImplTest {
     properties.put("dispatchinterval", "1000");
     serviceRegistryJpaImpl.updated(properties);
     registerTestHostAndService();
-    Job testJob = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE, TEST_OPERATION, null, null, true, null,
+    Job testJob = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE_FAIRNESS, TEST_OPERATION, null, null, true, null,
             10.0f);
     JobBarrier barrier = new JobBarrier(null, serviceRegistryJpaImpl, testJob);
     try {
@@ -413,7 +418,7 @@ public class ServiceRegistryJpaImplTest {
       //Some explanation here: If the load exceeds the global maximum node load (ie, jobLoad > all individual node max
       // loads), then we dispatch to the biggest, even if it's not going to normally accept the job.  That node may still
       // reject the job, but that's AbstractJobProducer's job, not the service registry's
-      Assert.assertEquals(TEST_HOST_OTHER, testJob.getProcessingHost());
+      Assert.assertEquals(TEST_HOST_THIRD, testJob.getProcessingHost());
     }
   }
 


### PR DESCRIPTION
This pull closes #1068. 

This pull addresses the randomly failing BuildBot build for ServiceRegistryJpaImpl, caused by the junit of the bug fix for MH-13675. The junit's assert-fail exposed that the ServiceRegistry's Job Dispatcher continues to attempt to dispatch newly queued jobs from services being unregistered in the ServiceRegistryJpaImpl deactivate().

Halting the local Job Dispatcher ensures that services can be safely unregistered, and jobs re-queued, without the havoc of the Job Dispatcher requeuing newly queued jobs onto services that are about to be unregistered.

This pull includes the MH-13675 junit and the fix to prevent a job from being persisted with an incorrect processor host (previously peer review and merged in develop branch). 

This pull includes additional debug and trace logs.
