### PR TITLE
Elasticsearch access_policy field increased in size

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -11,5 +11,8 @@ How to Upgrade
 2. Replace Opencast with the new version
 3. Back-up Opencast files and database (optional)
 4. [Upgrade the database](#database-migration)
+5. Remove search index data folder
+6. Start Opencast
+7. Rebuild Admin UI and External API index
 
 You can find the database upgrade script in `docs/upgrade/7_to_8/`.

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/EventIndexUtils.java
@@ -183,7 +183,7 @@ public final class EventIndexUtils {
     }
 
     if (StringUtils.isNotBlank(event.getAccessPolicy())) {
-      metadata.addField(EventIndexSchema.ACCESS_POLICY, event.getAccessPolicy(), true);
+      metadata.addField(EventIndexSchema.ACCESS_POLICY, event.getAccessPolicy(), false);
       addAuthorization(metadata, event.getAccessPolicy());
     }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java
@@ -133,7 +133,7 @@ public final class SeriesIndexUtils {
     }
 
     if (StringUtils.trimToNull(series.getAccessPolicy()) != null) {
-      metadata.addField(SeriesIndexSchema.ACCESS_POLICY, series.getAccessPolicy(), true);
+      metadata.addField(SeriesIndexSchema.ACCESS_POLICY, series.getAccessPolicy(), false);
       addAuthorization(metadata, series.getAccessPolicy());
     }
 

--- a/modules/search/src/main/resources/elasticsearch/event-mapping.json
+++ b/modules/search/src/main/resources/elasticsearch/event-mapping.json
@@ -56,7 +56,7 @@
 
             "rights": { "type" : "keyword" },
 
-            "access_policy": { "type" : "keyword" },
+            "access_policy": { "type" : "text", "index" : false, "store" : false },
 
             "managed_acl": { "type" : "keyword" },
 

--- a/modules/search/src/main/resources/elasticsearch/series-mapping.json
+++ b/modules/search/src/main/resources/elasticsearch/series-mapping.json
@@ -24,7 +24,7 @@
 
             "license": { "type" : "keyword" },
 
-            "access_policy": { "type" : "keyword" },
+            "access_policy": { "type" : "text", "index" : false, "store" : false },
 
             "managed_acl": { "type" : "keyword" },
 

--- a/modules/search/src/main/resources/elasticsearch/version-mapping.json
+++ b/modules/search/src/main/resources/elasticsearch/version-mapping.json
@@ -6,7 +6,7 @@
     "properties": {
       "version": {
         "type": "integer",
-        "index": "not_analyzed"
+        "index": false
       }
     }
   }

--- a/modules/search/src/test/resources/elasticsearch/content-mapping.json
+++ b/modules/search/src/test/resources/elasticsearch/content-mapping.json
@@ -2,7 +2,7 @@
 	"content" : {
 	    "_source" : { "enabled" : false },
 	    "properties" : {
-	        "title" : { "type" : "string", "index" : "analyzed" }
+	        "title" : { "type" : "text", "index" : true }
 	    }
 	}
 }

--- a/modules/search/src/test/resources/elasticsearch/version-mapping.json
+++ b/modules/search/src/test/resources/elasticsearch/version-mapping.json
@@ -2,7 +2,7 @@
 	"version" : {
 	    "_source" : { "enabled" : false },
 	    "properties" : {
-	        "version" : { "type" : "integer", "index" : "not_analyzed" }
+	        "version" : { "type" : "integer", "index" : false }
 	    }
 	}
 }


### PR DESCRIPTION
This patch change the type of the `access_policy` event and series field to not analyzed `text`, same type as the source document (xml serialized event or series).

Note: changing mappings require an index rebuild

This work is sponsored by SWITCH