### PR TITLE
Provide access to file contents in the WFR

### DIFF
--- a/modules/working-file-repository-service-api/src/main/java/org/opencastproject/workingfilerepository/api/WorkingFileRepository.java
+++ b/modules/working-file-repository-service-api/src/main/java/org/opencastproject/workingfilerepository/api/WorkingFileRepository.java
@@ -24,6 +24,7 @@ package org.opencastproject.workingfilerepository.api;
 import org.opencastproject.storage.StorageUsage;
 import org.opencastproject.util.NotFoundException;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -193,6 +194,17 @@ public interface WorkingFileRepository extends StorageUsage {
    * @return the data as a stream, or null if not found
    */
   InputStream getFromCollection(String collectionId, String fileName) throws NotFoundException, IOException;
+
+  /**
+   * Gets data from a collection
+   *
+   * @param collectionId
+   *          the collection identifier
+   * @param fileName
+   *          The filename to retrieve
+   * @return File to the data
+   */
+   File getFileFromCollection(String collectionId, String fileName) throws NotFoundException, IllegalArgumentException;
 
   /**
    * Removes a file from a collection

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -475,7 +475,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
    * @throws NotFoundException
    *         if either the collection or the file don't exist
    */
-  protected File getFileFromCollection(String collectionId, String fileName) throws NotFoundException,
+  public File getFileFromCollection(String collectionId, String fileName) throws NotFoundException,
           IllegalArgumentException {
     checkPathSafe(collectionId);
 

--- a/modules/working-file-repository-service-remote/src/main/java/org/opencastproject/workingfilerepository/remote/WorkingFileRepositoryRemoteImpl.java
+++ b/modules/working-file-repository-service-remote/src/main/java/org/opencastproject/workingfilerepository/remote/WorkingFileRepositoryRemoteImpl.java
@@ -46,6 +46,7 @@ import org.json.simple.JSONValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -289,6 +290,11 @@ public class WorkingFileRepositoryRemoteImpl extends RemoteBase implements Worki
       throw new RuntimeException();
     }
     throw new RuntimeException("Error get from collection");
+  }
+
+  @Override
+  public File getFileFromCollection(String collectionId, String fileName) throws NotFoundException, IllegalArgumentException {
+    throw new RuntimeException("Unsupported");
   }
 
   /**


### PR DESCRIPTION
This enables custom REST endpoints to return the contents of
files in collections in the WFR, for example:

    return fileResponse(wfr.getFileFromCollection(collectionId, fileName), getMimeType(fileName), some(fileName)).build();

This minor API change is to support media submission for the Nibity
transcription service (MH-13308).
