### PR TITLE
Smarter etc/ hints in documentation

### DIFF
--- a/docs/guides/admin/docs/javascript/extra.js
+++ b/docs/guides/admin/docs/javascript/extra.js
@@ -35,14 +35,14 @@ function addTitleToCodeTag() {
     var SPAN = document.createElement("SPAN");
     SPAN.innerText = "etc";
     SPAN.classList.add("etc-span");
-    SPAN.title = '"etc" represents the configuration directory of Opencast. This directory is often located at "/etc/opencast".';
+    SPAN.title = '"etc" represents the configuration directory of Opencast.\nThis directory is often located at "/etc/opencast".';
 
     var codeElementList = document.getElementsByTagName("CODE");
     for (var i = 0; i < codeElementList.length; i++) {
         var CODE = codeElementList[i];
         if (typeof CODE.innerText !== 'undefined') {
-            if (CODE.innerText.includes("etc/")) {
-                CODE.innerHTML = CODE.innerHTML.replace("etc/", SPAN.outerHTML + "/");
+            if (CODE.innerText.startsWith('etc/')) {
+                CODE.innerHTML = CODE.innerHTML.replace(/^etc/, SPAN.outerHTML);
             }
         }
     }

--- a/docs/guides/developer/docs/javascript/extra.js
+++ b/docs/guides/developer/docs/javascript/extra.js
@@ -35,14 +35,14 @@ function addTitleToCodeTag() {
     var SPAN = document.createElement("SPAN");
     SPAN.innerText = "etc";
     SPAN.classList.add("etc-span");
-    SPAN.title = '"etc" represents the configuration directory of Opencast. This directory is often located at "/etc/opencast".';
+    SPAN.title = '"etc" represents the configuration directory of Opencast.\nThis directory is often located at "/etc/opencast".';
 
     var codeElementList = document.getElementsByTagName("CODE");
     for (var i = 0; i < codeElementList.length; i++) {
         var CODE = codeElementList[i];
         if (typeof CODE.innerText !== 'undefined') {
-            if (CODE.innerText.includes("etc/")) {
-                CODE.innerHTML = CODE.innerHTML.replace("etc/", SPAN.outerHTML + "/");
+            if (CODE.innerText.startsWith('etc/')) {
+                CODE.innerHTML = CODE.innerHTML.replace(/^etc/, SPAN.outerHTML);
             }
         }
     }

--- a/docs/guides/user/docs/javascript/extra.js
+++ b/docs/guides/user/docs/javascript/extra.js
@@ -35,14 +35,14 @@ function addTitleToCodeTag() {
     var SPAN = document.createElement("SPAN");
     SPAN.innerText = "etc";
     SPAN.classList.add("etc-span");
-    SPAN.title = '"etc" represents the configuration directory of Opencast. This directory is often located at "/etc/opencast".';
+    SPAN.title = '"etc" represents the configuration directory of Opencast.\nThis directory is often located at "/etc/opencast".';
 
     var codeElementList = document.getElementsByTagName("CODE");
     for (var i = 0; i < codeElementList.length; i++) {
         var CODE = codeElementList[i];
         if (typeof CODE.innerText !== 'undefined') {
-            if (CODE.innerText.includes("etc/")) {
-                CODE.innerHTML = CODE.innerHTML.replace("etc/", SPAN.outerHTML + "/");
+            if (CODE.innerText.startsWith('etc/')) {
+                CODE.innerHTML = CODE.innerHTML.replace(/^etc/, SPAN.outerHTML);
             }
         }
     }


### PR DESCRIPTION
This patches slightly changes the way tooltips for the configuration
directory are added to the docs. Instead of attaching it to every
occurrence of etc/, this patch only attaches it when the code starts with
etc/.

This is to avoid attaching this to blocks like `/etc/nginx/…` where we
already have an absolute path.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
