### PR TITLE
Add a new optional date_expected column to the transcription job table

### DIFF
--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -622,6 +622,7 @@ CREATE TABLE oc_transcription_service_job (
   track_id VARCHAR(128) NOT NULL,
   job_id  VARCHAR(128) NOT NULL,
   date_created DATETIME NOT NULL,
+  date_expected DATETIME DEFAULT NULL,
   date_completed DATETIME DEFAULT NULL,
   status VARCHAR(128) DEFAULT NULL,
   track_duration BIGINT NOT NULL,

--- a/docs/upgrade/7_to_8/mysql5.sql
+++ b/docs/upgrade/7_to_8/mysql5.sql
@@ -20,6 +20,7 @@ CREATE TABLE oc_transcription_service_job (
   track_id VARCHAR(128) NOT NULL,
   job_id  VARCHAR(128) NOT NULL,
   date_created DATETIME NOT NULL,
+  date_expected DATETIME NOT NULL,
   date_completed DATETIME DEFAULT NULL,
   status VARCHAR(128) DEFAULT NULL,
   track_duration BIGINT NOT NULL,

--- a/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
+++ b/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
@@ -519,7 +519,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
                   jobId));
 
           database.storeJobControl(mpId, track.getIdentifier(), jobId, TranscriptionJobControl.Status.InProgress.name(),
-                  track.getDuration() == null ? 0 : track.getDuration().longValue(), PROVIDER);
+                  track.getDuration() == null ? 0 : track.getDuration().longValue(), null, PROVIDER);
           EntityUtils.consume(entity);
           return;
         default:

--- a/modules/transcription-service-google-speech-impl/src/test/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionServiceTest.java
+++ b/modules/transcription-service-google-speech-impl/src/test/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionServiceTest.java
@@ -87,6 +87,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -100,6 +101,7 @@ public class GoogleSpeechTranscriptionServiceTest {
   private static final String TRACK_ID = "audioTrack1";
   private static final String JOB_ID = "jobId1";
   private static final long TRACK_DURATION = 60000;
+  private static final Date DATE_EXPECTED = null;
   private static final String CLIENT_ID = "clientId";
   private static final String CLIENT_SECRET = "secret";
   private static final String CLIENT_TOKEN = "token";
@@ -285,7 +287,7 @@ public class GoogleSpeechTranscriptionServiceTest {
   @Test
   public void testTranscriptionDone() throws Exception {
     InputStream stream = GoogleSpeechTranscriptionServiceTest.class.getResourceAsStream("/" + PULLED_TRANSCRIPTION_FILE);
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     JSONObject obj = (JSONObject) jsonParser.parse(new InputStreamReader(stream));
 
     Capture<String> capturedCollection = Capture.newInstance();
@@ -311,7 +313,7 @@ public class GoogleSpeechTranscriptionServiceTest {
   @Test
   public void testTranscriptionError() throws Exception {
     InputStream stream = GoogleSpeechTranscriptionServiceTest.class.getResourceAsStream("/" + PULLED_TRANSCRIPTION_FILE);
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     JSONObject obj = (JSONObject) jsonParser.parse(new InputStreamReader(stream));
 
     service.transcriptionError(MP_ID, obj);
@@ -326,7 +328,7 @@ public class GoogleSpeechTranscriptionServiceTest {
   @Test
   public void testGetAndSaveJobResults() throws Exception {
     InputStream stream = GoogleSpeechTranscriptionServiceTest.class.getResourceAsStream("/" + PULLED_TRANSCRIPTION_FILE);
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, DATE_EXPECTED, PROVIDER);
 
     Capture<String> capturedCollection = Capture.newInstance();
     Capture<String> capturedFileName = Capture.newInstance();
@@ -405,9 +407,9 @@ public class GoogleSpeechTranscriptionServiceTest {
 
   @Test
   public void testGetGeneratedTranscriptionNoJobId() throws Exception {
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     database.storeJobControl(MP_ID, "audioTrack2", "jobId2", TranscriptionJobControl.Status.InProgress.name(),
-            TRACK_DURATION, PROVIDER);
+            TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     database.updateJobControl(JOB_ID, TranscriptionJobControl.Status.TranscriptionComplete.name());
 
     URI uri = new URI("http://ADMIN_SERVER/collection/" + GoogleSpeechTranscriptionService.TRANSCRIPT_COLLECTION + "/"
@@ -427,7 +429,7 @@ public class GoogleSpeechTranscriptionServiceTest {
   public void testGetGeneratedTranscriptionNotInWorkspace() throws Exception {
     InputStream stream = GoogleSpeechTranscriptionServiceTest.class.getResourceAsStream("/" + PULLED_TRANSCRIPTION_FILE);
 
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, DATE_EXPECTED, PROVIDER);
 
     URI uri = new URI("http://ADMIN_SERVER/collection/" + GoogleSpeechTranscriptionService.TRANSCRIPT_COLLECTION + "/"
             + JOB_ID + ".json");
@@ -461,9 +463,9 @@ public class GoogleSpeechTranscriptionServiceTest {
   public void testWorkflowDispatcherRunTranscriptionCompletedState() throws Exception {
     service.activate(cc);
 
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     database.storeJobControl("mpId2", "audioTrack2", "jobId2", TranscriptionJobControl.Status.InProgress.name(),
-            TRACK_DURATION, PROVIDER);
+            TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     database.updateJobControl(JOB_ID, TranscriptionJobControl.Status.TranscriptionComplete.name());
 
     Capture<Set<String>> capturedMpIds = mockAssetManagerAndWorkflow(GoogleSpeechTranscriptionService.DEFAULT_WF_DEF,
@@ -488,9 +490,9 @@ public class GoogleSpeechTranscriptionServiceTest {
 
     InputStream stream = GoogleSpeechTranscriptionServiceTest.class.getResourceAsStream("/" + PULLED_TRANSCRIPTION_FILE);
 
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), 0, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), 0, null, PROVIDER);
     database.storeJobControl("mpId2", "audioTrack2", "jobId2", TranscriptionJobControl.Status.InProgress.name(),
-            TRACK_DURATION, PROVIDER);
+            TRACK_DURATION, DATE_EXPECTED, PROVIDER);
 
     EasyMock.expect(workspace.putInCollection(EasyMock.anyObject(String.class), EasyMock.anyObject(String.class),
             EasyMock.anyObject(InputStream.class))).andReturn(new URI("http://anything"));

--- a/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionDatabase.java
+++ b/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionDatabase.java
@@ -20,6 +20,7 @@
  */
 package org.opencastproject.transcription.persistence;
 
+import java.util.Date;
 import java.util.List;
 
 /*
@@ -31,7 +32,7 @@ public interface TranscriptionDatabase {
    * Store transcription service job
    */
   TranscriptionJobControl storeJobControl(String mpId, String trackId, String jobId, String jobStatus,
-          long trackDuration, String provider) throws TranscriptionDatabaseException;
+          long trackDuration, Date dateExpected, String provider) throws TranscriptionDatabaseException;
 
   /*
    * Store transcription provider

--- a/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionDatabaseImpl.java
+++ b/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionDatabaseImpl.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import javax.persistence.EntityManagerFactory;
@@ -68,11 +69,11 @@ public class TranscriptionDatabaseImpl implements TranscriptionDatabase {
   }
 
   public TranscriptionJobControl storeJobControl(String mpId, String trackId, String jobId, String jobStatus,
-          long trackDuration, String provider) throws TranscriptionDatabaseException {
+          long trackDuration, Date dateExpected, String provider) throws TranscriptionDatabaseException {
     long providerId = getProviderId(provider);
     if (providerId != noProviderId) {
       TranscriptionJobControlDto dto = TranscriptionJobControlDto.store(emf.createEntityManager(), mpId, trackId, jobId,
-              jobStatus, trackDuration, providerId);
+              jobStatus, trackDuration, dateExpected, providerId);
       if (dto != null) {
         return dto.toTranscriptionJobControl();
       }

--- a/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionJobControl.java
+++ b/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionJobControl.java
@@ -38,6 +38,8 @@ public class TranscriptionJobControl {
   private String status;
   // Date/time of google speech job creation
   private Date dateCreated;
+  // Date/time that the transcription job is expected to be complete
+  private Date dateExpected;
   // Date/time of google speech job completion
   private Date dateCompleted;
   // Duration of track
@@ -46,12 +48,13 @@ public class TranscriptionJobControl {
   private long providerId;
 
   public TranscriptionJobControl(String mediaPackageId, String trackId, String transcriptionJobId, Date dateCreated,
-          Date dateCompleted, String status, long trackDuration, long providerId) {
+          Date dateExpected, Date dateCompleted, String status, long trackDuration, long providerId) {
     super();
     this.mediaPackageId = mediaPackageId;
     this.trackId = trackId;
     this.transcriptionJobId = transcriptionJobId;
     this.dateCreated = dateCreated;
+    this.dateExpected = dateExpected;
     this.dateCompleted = dateCompleted;
     this.status = status;
     this.trackDuration = trackDuration;
@@ -88,6 +91,14 @@ public class TranscriptionJobControl {
 
   public void setDateCreated(Date dateCreated) {
     this.dateCreated = dateCreated;
+  }
+
+  public Date getDateExpected() {
+    return dateExpected;
+  }
+
+  public void setDateExpected(Date dateExpected) {
+    this.dateExpected = dateExpected;
   }
 
   public Date getDateCompleted() {

--- a/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionJobControlDto.java
+++ b/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionJobControlDto.java
@@ -69,6 +69,10 @@ public class TranscriptionJobControlDto implements Serializable {
   @Temporal(TemporalType.TIMESTAMP)
   private Date dateCreated;
 
+  @Column(name = "date_expected", nullable = true)
+  @Temporal(TemporalType.TIMESTAMP)
+  private Date dateExpected;
+
   @Column(name = "date_completed", nullable = true)
   @Temporal(TemporalType.TIMESTAMP)
   private Date dateCompleted;
@@ -89,12 +93,13 @@ public class TranscriptionJobControlDto implements Serializable {
    * Constructor with all fields.
    */
   public TranscriptionJobControlDto(String mediaPackageId, String trackId, String transcriptionJobId, Date dateCreated,
-          Date dateCompleted, String status, long trackDuration, long providerId) {
+          Date dateExpected, Date dateCompleted, String status, long trackDuration, long providerId) {
     super();
     this.mediaPackageId = mediaPackageId;
     this.trackId = trackId;
     this.transcriptionJobId = transcriptionJobId;
     this.dateCreated = dateCreated;
+    this.dateExpected = dateExpected;
     this.dateCompleted = dateCompleted;
     this.status = status;
     this.trackDuration = trackDuration;
@@ -105,7 +110,7 @@ public class TranscriptionJobControlDto implements Serializable {
    * Convert into business object.
    */
   public TranscriptionJobControl toTranscriptionJobControl() {
-    return new TranscriptionJobControl(mediaPackageId, trackId, transcriptionJobId, dateCreated, dateCompleted, status,
+    return new TranscriptionJobControl(mediaPackageId, trackId, transcriptionJobId, dateCreated, dateExpected, dateCompleted, status,
             trackDuration, providerId);
   }
 
@@ -113,9 +118,9 @@ public class TranscriptionJobControlDto implements Serializable {
    * Store new job control
    */
   public static TranscriptionJobControlDto store(EntityManager em, String mediaPackageId, String trackId,
-          String transcriptionJobId, String jobStatus, long trackDuration, long providerId) throws TranscriptionDatabaseException {
+          String transcriptionJobId, String jobStatus, long trackDuration, Date dateExpected, long providerId) throws TranscriptionDatabaseException {
     TranscriptionJobControlDto dto = new TranscriptionJobControlDto(mediaPackageId, trackId, transcriptionJobId,
-            new Date(), null, jobStatus, trackDuration, providerId);
+            new Date(), dateExpected, null, jobStatus, trackDuration, providerId);
 
     EntityTransaction tx = em.getTransaction();
     try {

--- a/modules/transcription-service-persistence/src/test/java/org/opencastproject/transcription/persistence/TranscriptionDatabaseTest.java
+++ b/modules/transcription-service-persistence/src/test/java/org/opencastproject/transcription/persistence/TranscriptionDatabaseTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.sql.SQLException;
+import java.util.Date;
 import java.util.List;
 
 public class TranscriptionDatabaseTest {
@@ -47,6 +48,7 @@ public class TranscriptionDatabaseTest {
   private static final String TRACK_ID3 = "track3";
   private static final String JOB_ID3 = "job3";
   private static final String PROVIDER = "Provider";
+  private static final Date DATE_EXPECTED = null;
   private static final long PROVIDER_ID = 1;
 
   @Before
@@ -69,7 +71,7 @@ public class TranscriptionDatabaseTest {
   @Test
   public void testStoreJobControl() throws Exception {
     long dt1 = System.currentTimeMillis();
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     long dt2 = System.currentTimeMillis();
 
     TranscriptionJobControl j = database.findByJob(JOB_ID);
@@ -85,7 +87,7 @@ public class TranscriptionDatabaseTest {
   @Test
   public void testFindByJob() throws Exception {
     long dt1 = System.currentTimeMillis();
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     long dt2 = System.currentTimeMillis();
 
     TranscriptionJobControl j = database.findByJob(JOB_ID);
@@ -99,9 +101,9 @@ public class TranscriptionDatabaseTest {
 
   @Test
   public void testFindByMediaPackage() throws Exception {
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, PROVIDER);
-    database.storeJobControl(MP_ID, TRACK_ID2, JOB_ID2, STATUS, TRACK_DURATION, PROVIDER);
-    database.storeJobControl("another_mp_id", "track3", "job3", STATUS, TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID2, JOB_ID2, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
+    database.storeJobControl("another_mp_id", "track3", "job3", STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
 
     List<TranscriptionJobControl> list = database.findByMediaPackage(MP_ID);
     Assert.assertEquals(2, list.size());
@@ -111,9 +113,9 @@ public class TranscriptionDatabaseTest {
 
   @Test
   public void testFindByOneStatus() throws Exception {
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, PROVIDER);
-    database.storeJobControl(MP_ID2, TRACK_ID2, JOB_ID2, STATUS2, TRACK_DURATION, PROVIDER);
-    database.storeJobControl(MP_ID3, TRACK_ID3, JOB_ID3, STATUS, TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
+    database.storeJobControl(MP_ID2, TRACK_ID2, JOB_ID2, STATUS2, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
+    database.storeJobControl(MP_ID3, TRACK_ID3, JOB_ID3, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
 
     List<TranscriptionJobControl> list = database.findByStatus(STATUS);
     Assert.assertEquals(2, list.size());
@@ -123,9 +125,9 @@ public class TranscriptionDatabaseTest {
 
   @Test
   public void testFindByManyStatus() throws Exception {
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, PROVIDER);
-    database.storeJobControl(MP_ID2, TRACK_ID2, JOB_ID2, STATUS2, TRACK_DURATION, PROVIDER);
-    database.storeJobControl(MP_ID3, TRACK_ID3, JOB_ID3, STATUS, TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
+    database.storeJobControl(MP_ID2, TRACK_ID2, JOB_ID2, STATUS2, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
+    database.storeJobControl(MP_ID3, TRACK_ID3, JOB_ID3, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
 
     List<TranscriptionJobControl> list = database.findByStatus(STATUS, STATUS2);
     Assert.assertEquals(3, list.size());
@@ -134,7 +136,7 @@ public class TranscriptionDatabaseTest {
   @Test
   public void testDeleteJobControl() throws Exception {
     long dt1 = System.currentTimeMillis();
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     long dt2 = System.currentTimeMillis();
 
     TranscriptionJobControl j = database.findByJob(JOB_ID);
@@ -152,7 +154,7 @@ public class TranscriptionDatabaseTest {
   @Test
   public void testUpdateJobControl() throws Exception {
     long dt1 = System.currentTimeMillis();
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
     long dt2 = System.currentTimeMillis();
 
     TranscriptionJobControl j = database.findByJob(JOB_ID);
@@ -174,7 +176,7 @@ public class TranscriptionDatabaseTest {
 
   @Test
   public void testUpdateJobControlToTranscriptionComplete() throws Exception {
-    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, PROVIDER);
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, STATUS, TRACK_DURATION, DATE_EXPECTED, PROVIDER);
 
     TranscriptionJobControl j = database.findByJob(JOB_ID);
     Assert.assertNotNull(j);


### PR DESCRIPTION
This enables transcription service implementations to record the date/time
that a transcription job is expected to be completed.

This is to support the forthcoming Nibity API implementation.
