### PR TITLE
Filter jobs by transcription service provider ID

### DIFF
--- a/etc/workflows/google-speech-attach-transcripts.xml
+++ b/etc/workflows/google-speech-attach-transcripts.xml
@@ -61,13 +61,16 @@
       </configurations>
     </operation>
 
-    <!-- Clean the system from work artifacts -->
+    <!-- Clean up work artifacts -->
 
     <operation
-      id="include"
-      description="Remove temporary processing artifacts">
+        id="cleanup"
+        fail-on-error="false"
+        description="Remove temporary processing artifacts">
       <configurations>
-        <configuration key="workflow-id">partial-cleanup</configuration>
+        <configuration key="delete-external">true</configuration>
+        <!-- FixMe Don't clean up ACLs until workflow service no longer looks for them in the WFR. -->
+        <configuration key="preserve-flavors">security/*</configuration>
       </configurations>
     </operation>
 

--- a/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
+++ b/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
@@ -50,6 +50,7 @@ import org.opencastproject.transcription.api.TranscriptionServiceException;
 import org.opencastproject.transcription.persistence.TranscriptionDatabase;
 import org.opencastproject.transcription.persistence.TranscriptionDatabaseException;
 import org.opencastproject.transcription.persistence.TranscriptionJobControl;
+import org.opencastproject.transcription.persistence.TranscriptionProviderControl;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.PathSupport;
@@ -951,9 +952,25 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
 
       try {
         // Find jobs that are in progress and jobs that had transcription complete
+
+        long providerId;
+        TranscriptionProviderControl providerInfo = database.findIdByProvider(PROVIDER);
+        if (providerInfo != null) {
+          providerId = providerInfo.getId();
+        } else {
+          logger.debug("No jobs yet for provider {}", PROVIDER);
+          return;
+        }
+
         List<TranscriptionJobControl> jobs = database.findByStatus(TranscriptionJobControl.Status.InProgress.name(),
                 TranscriptionJobControl.Status.TranscriptionComplete.name());
         for (TranscriptionJobControl j : jobs) {
+
+          // Don't process jobs for other services
+          if (j.getProviderId() != providerId) {
+            continue;
+          }
+
           String mpId = j.getMediaPackageId();
           String jobId = j.getTranscriptionJobId();
 


### PR DESCRIPTION
As the oc_transcription_service_job table may contain entries from multiple
services, each service needs to handle only its own jobs.
