### PR TITLE
Fix PostreSQL Support

### DIFF
--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
@@ -66,7 +66,7 @@ import javax.persistence.UniqueConstraint;
                 + "WHERE job.processorServiceRegistration.online=true and job.processorServiceRegistration.active=true and job.processorServiceRegistration.hostRegistration.maintenanceMode=false "
                 + "AND job.status in :statuses "
                 + "AND job.creatorServiceRegistration.serviceType != :workflow_type "
-                + "GROUP BY job.processorServiceRegistration.hostRegistration.baseUrl, job.status"),
+                + "GROUP BY job.processorServiceRegistration.hostRegistration.baseUrl, job.status, job.processorServiceRegistration.hostRegistration.maxLoad"),
         @NamedQuery(name = "ServiceRegistration.getRegistration", query = "SELECT r from ServiceRegistration r "
                 + "where r.hostRegistration.baseUrl = :host and r.serviceType = :serviceType"),
         @NamedQuery(name = "ServiceRegistration.getAll", query = "SELECT rh FROM ServiceRegistration rh WHERE rh.hostRegistration.active = true"),

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -66,8 +66,13 @@
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>postgresql</groupId>
+      <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>4.1.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -86,6 +91,7 @@
               !org.apache.lucene.*,
               !org.jboss.resource.adapter.jdbc.*,
               !org.hibernate.*,
+              !com.sun.jna.platform.win32,
               org.w3c.dom;version=0,
               *
             </Import-Package>
@@ -95,6 +101,7 @@
               h2;inline=true,
               mchange-commons-java;inline=true,
               mysql-connector-java;inline=true,
+              jna,
               postgresql;inline=true
             </Embed-Dependency>
             <Export-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -1324,9 +1324,9 @@
         <version>5.1.43</version>
       </dependency>
       <dependency>
-        <groupId>postgresql</groupId>
+        <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>9.1-901-1.jdbc4</version>
+        <version>42.2.8.jre7</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Fix PostreSQL Support

This patch fixes a few issues with Opencast's PostgreSQL compatibility,
upgrading the Postgres driver and fixing a few SQL statements.

Note that the OAI-PMH code still contains a hack with makes
auto-generated tables for OAI-PMH not work with MariaDB, MySQL or
PostgreSQL:

https://github.com/opencast/opencast/blob/8938bc896d837c6687345b3f674fc15321f012ec/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java#L87-L88

But simply removing this hack will break our internal H2 database right
now so I'm leaving it like this.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
