### PR TITLE
MH-13557, Login Response for JavaScript

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/AuthenticationSuccessHandler.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/AuthenticationSuccessHandler.java
@@ -32,7 +32,6 @@ import org.springframework.security.core.Authentication;
 import java.io.IOException;
 import java.util.Map;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -63,7 +62,12 @@ public class AuthenticationSuccessHandler implements
    */
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-          Authentication authentication) throws IOException, ServletException {
+          Authentication authentication) throws IOException {
+
+    if ("application/json".equalsIgnoreCase(request.getHeader("Accept"))) {
+      response.sendRedirect("/info/me.json");
+      return;
+    }
 
     /* If the user originally attempted to access a specific URI other than /, but was forwarded to the login page,
      * redirect the user back to that initial URI. But only if the request target was a user interface any not some kind


### PR DESCRIPTION
All JavaScript code letting user log-in to Opencast are using some kind
of ugly hack right now. For example, the engage interface is evaluating
if the response HTML contains a particular string.

For JavaScript, it would be much easier, better and more reliable if we
could be a proper HTTP status and JSON response.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
