### PR TITLE
Use JPA to auto-generate SQL schema

### DIFF
--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -45,6 +45,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common-jpa-impl</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -155,6 +161,10 @@
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>org.eclipse.persistence.core</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -197,7 +197,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
     try {
       for (SearchEntity entity : searchEntities) {
         MediaPackage mediaPackage = MediaPackageParser.getFromXml(entity.getMediaPackageXML());
-        mediaPackageList.add(Tuple.tuple(mediaPackage, entity.getOrganization()));
+        mediaPackageList.add(Tuple.tuple(mediaPackage, entity.getOrganization().getId()));
       }
     } catch (Exception e) {
       logger.error("Could not parse series entity: {}", e.getMessage());
@@ -257,7 +257,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
       if (entity == null) {
         // Create new search entity
         SearchEntity searchEntity = new SearchEntity();
-        searchEntity.setOrganization(securityService.getOrganization().getId());
+        searchEntity.setOrganization(securityService.getOrganization());
         searchEntity.setMediaPackageId(mediaPackageId);
         searchEntity.setMediaPackageXML(mediaPackageXML);
         searchEntity.setAccessControl(AccessControlParser.toXml(acl));
@@ -276,7 +276,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
                     + mediaPackageId);
           }
         }
-        entity.setOrganization(securityService.getOrganization().getId());
+        entity.setOrganization(securityService.getOrganization());
         entity.setMediaPackageId(mediaPackageId);
         entity.setMediaPackageXML(mediaPackageXML);
         entity.setAccessControl(AccessControlParser.toXml(acl));
@@ -448,7 +448,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, READ.toString()))
           throw new UnauthorizedException(currentUser + " is not authorized to read media package " + mediaPackageId);
       }
-      return searchEntity.getOrganization();
+      return searchEntity.getOrganization().getId();
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {

--- a/modules/search-service-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/search-service-impl/src/main/resources/META-INF/persistence.xml
@@ -9,6 +9,7 @@
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
     <non-jta-data-source>osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=jdbc/opencast)</non-jta-data-source>
     <class>org.opencastproject.search.impl.persistence.SearchEntity</class>
+    <class>org.opencastproject.security.impl.jpa.JpaOrganization</class>
     <shared-cache-mode>NONE</shared-cache-mode>
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables" />

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
@@ -64,6 +64,7 @@ import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
+import org.opencastproject.security.impl.jpa.JpaOrganization;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.serviceregistry.api.IncidentService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
@@ -90,6 +91,9 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 /**
  * Tests the functionality of the search service.
@@ -156,6 +160,8 @@ public class SearchServiceImplTest {
 
   @Before
   public void setUp() throws Exception {
+    EntityManagerFactory emf = newTestEntityManagerFactory(SearchServiceDatabaseImpl.PERSISTENCE_UNIT);
+    EntityManager em = emf.createEntityManager();
     // workspace
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.get((URI) EasyMock.anyObject())).andAnswer(new IAnswer<File>() {
@@ -180,10 +186,15 @@ public class SearchServiceImplTest {
     EasyMock.expect(userDirectoryService.loadUser((String) EasyMock.anyObject())).andReturn(anonymous).anyTimes();
     EasyMock.replay(userDirectoryService);
 
-    Organization organization = new DefaultOrganization();
+    em.getTransaction().begin();
+    Organization defaultOrg = new DefaultOrganization();
+    Organization org = new JpaOrganization(defaultOrg.getId(), defaultOrg.getName(), defaultOrg.getServers(),
+        defaultOrg.getAdminRole(), defaultOrg.getAnonymousRole(), defaultOrg.getProperties());
+    em.merge(org);
+    em.getTransaction().commit();
     OrganizationDirectoryService organizationDirectoryService = EasyMock.createMock(OrganizationDirectoryService.class);
     EasyMock.expect(organizationDirectoryService.getOrganization((String) EasyMock.anyObject()))
-    .andReturn(organization).anyTimes();
+    .andReturn(org).anyTimes();
     EasyMock.replay(organizationDirectoryService);
 
     // mpeg7 service
@@ -191,7 +202,7 @@ public class SearchServiceImplTest {
 
     // Persistence storage
     searchDatabase = new SearchServiceDatabaseImpl();
-    searchDatabase.setEntityManagerFactory(newTestEntityManagerFactory(SearchServiceDatabaseImpl.PERSISTENCE_UNIT));
+    searchDatabase.setEntityManagerFactory(emf);
     searchDatabase.activate(null);
     searchDatabase.setSecurityService(securityService);
 

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
@@ -30,10 +30,12 @@ import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
+import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.impl.jpa.JpaOrganization;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple;
 
@@ -45,6 +47,9 @@ import org.junit.Test;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
 
 /**
  * Tests persistence: storing, merging, retrieving and removing.
@@ -61,8 +66,16 @@ public class SearchServicePersistenceTest {
    */
   @Before
   public void setUp() throws Exception {
+    EntityManagerFactory emf = newTestEntityManagerFactory(SearchServiceDatabaseImpl.PERSISTENCE_UNIT);
+    EntityManager em = emf.createEntityManager();
     securityService = EasyMock.createNiceMock(SecurityService.class);
     DefaultOrganization defaultOrganization = new DefaultOrganization();
+    em.getTransaction().begin();
+    Organization org = new JpaOrganization(defaultOrganization.getId(), defaultOrganization.getName(),
+        defaultOrganization.getServers(), defaultOrganization.getAdminRole(), defaultOrganization.getAnonymousRole(),
+        defaultOrganization.getProperties());
+    em.merge(org);
+    em.getTransaction().commit();
     User user = new JaxbUser("admin", "test", defaultOrganization, new JaxbRole(SecurityConstants.GLOBAL_ADMIN_ROLE,
             defaultOrganization));
     EasyMock.expect(securityService.getOrganization()).andReturn(new DefaultOrganization()).anyTimes();
@@ -70,7 +83,7 @@ public class SearchServicePersistenceTest {
     EasyMock.replay(securityService);
 
     searchDatabase = new SearchServiceDatabaseImpl();
-    searchDatabase.setEntityManagerFactory(newTestEntityManagerFactory(SearchServiceDatabaseImpl.PERSISTENCE_UNIT));
+    searchDatabase.setEntityManagerFactory(emf);
     searchDatabase.setSecurityService(securityService);
     searchDatabase.activate(null);
 


### PR DESCRIPTION
This patch shows how the JPA code can be changed to make Opencast
automatically generate a database schema on the same level as the
manually created DDL scripts do. This patch does not yet make the
full change but is limited to `oc_search` as an example.

The main differences we see and need to overcome are:

1. The ordering is different
2. Indexes are missing in the generated version
3. Constraints are missing in the generated version
4. Field types and sizes are different
5. Fields may be named slightly different

Ordering
--------

Unfortunately, it seems like [hibernate always sorts columns
alphabetically](https://stackoverflow.com/a/1298327) and there is no way
to change that. Thus, the only option would be to re-order the database
tables previously generated by Opencast's DDL script. That leads to a
long database migration.

However, the good thing about this is that, in theory, the ordering does
not matter to Opencast. But you never know for which tool it later does.

Generate Indexes
----------------

As this code shows, indexes can easily be generated using a few
additional JPA annotations.

Constraints
-----------

Again, this can easily be archived using JPA annotations although this
might be a little more complex and involve slight changes in Opencast's
Java code since the relations need to be modeled in Java as well.

Field Types
-----------

While it's a bit harder to get an exact type, exact types usually do not
matter and it is easy to ensure a fitting type is used by using the
correct Java type and annotations.

Field Names
-----------

In a few cases, the names in Opencast's code and in the DDL scripts are
slightly different (e.g. upper- vs lowercase letters being used). For
most databases this should not matter, but it's also easily fixed.

*Note that while this changes only parts of the JPA code it still
improves the overall situation (albeit slightly) and is worth merging.
Also note that this does not require any database migration since it
only brings the auto-generated SQL closer to the DDL scripts.*

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
