### PR TITLE
Build failed on captions-impl tests for non english OS 

### DIFF
--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/GoogleSpeechCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/GoogleSpeechCaptionConverter.java
@@ -43,6 +43,7 @@ import java.io.OutputStream;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class GoogleSpeechCaptionConverter implements CaptionConverter {
 
@@ -114,13 +115,13 @@ public class GoogleSpeechCaptionConverter implements CaptionConverter {
                   JSONObject wordTSList = (JSONObject) timestampsArray.get(indexFirst);
                   if (wordTSList.size() == 3) {
                     // Remove 's' at the end
-                    Number startNumber = NumberFormat.getInstance().parse(removeEndCharacter((wordTSList.get("startTime").toString()), "s"));
+                    Number startNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("startTime").toString()), "s"));
                     start = startNumber.doubleValue();
                   }
                   // Get end time of last element
                   wordTSList = (JSONObject) timestampsArray.get(indexLast);
                   if (wordTSList.size() == 3) {
-                    Number endNumber = NumberFormat.getInstance().parse(removeEndCharacter((wordTSList.get("endTime").toString()), "s"));
+                    Number endNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("endTime").toString()), "s"));
                     end = endNumber.doubleValue();
                   }
                 }

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/IBMWatsonCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/IBMWatsonCaptionConverter.java
@@ -40,8 +40,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class IBMWatsonCaptionConverter implements CaptionConverter {
 
@@ -111,11 +113,13 @@ public class IBMWatsonCaptionConverter implements CaptionConverter {
                   // Get start time of first element
                   JSONArray wordTsArray = (JSONArray) timestampsArray.get(indexFirst);
                   if (wordTsArray.size() == 3)
-                    start = ((Number) wordTsArray.get(1)).doubleValue();
+                    start = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTsArray.get(1).toString()),
+                            "s")).doubleValue();
                   // Get end time of last element
                   wordTsArray = (JSONArray) timestampsArray.get(indexLast);
                   if (wordTsArray.size() == 3)
-                    end = ((Number) wordTsArray.get(2)).doubleValue();
+                    end = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTsArray.get(2).toString()),
+                            "s")).doubleValue();
                 }
                 if (start == -1 || end == -1) {
                   logger.warn("Could not build caption object for job {}, result index {}: start/end times not found",
@@ -170,6 +174,13 @@ public class IBMWatsonCaptionConverter implements CaptionConverter {
     ms = (int) (ms % 1000);
 
     return new TimeImpl(h, m, s, (int) ms);
+  }
+
+  private String removeEndCharacter(String str, String end) {
+    if (str.endsWith(end)) {
+      str = str.replace(end, "");
+    }
+    return str;
   }
 
 }


### PR DESCRIPTION
Fixed problem that captions-impl Google Speech test failed when locale was not using "." as a delimiter for double values (i.e. on german systems), as the parsing of the time failed. Adjusted time parsing for IBM Watson accordingly, although it did not fail in the tests.

