### PR TITLE
Load series ACL-list step by step

### DIFF
--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
@@ -997,7 +997,9 @@
                   "NEW": "Neue Richtlinie",
                   "DETAILS": "Details",
                   "REPLACE_EVENT_ACLS": "Zugriffsrechte der Einzelaufzeichnungen aktualisieren",
-                  "REPLACE_EVENT_ACLS_HINT": "Sicherstellen, dass alle Aufzeichnungen dieser Series genau diese Zugriffsrechte haben"
+                  "REPLACE_EVENT_ACLS_HINT": "Sicherstellen, dass alle Aufzeichnungen dieser Series genau diese Zugriffsrechte haben",
+                  "LOAD_MORE_LIMIT": "Zugriffsrechten geladen.",
+                  "LOAD_MORE_LINK": "Mehr laden"
                },
                "ROLES": {
                   "LABEL": "Rolle auswählen",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_GB.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_GB.json
@@ -997,7 +997,9 @@
                   "NEW": "New policy",
                   "DETAILS": "Details",
                   "REPLACE_EVENT_ACLS": "Update event permissions",
-                  "REPLACE_EVENT_ACLS_HINT": "Ensure all events of this series have these permissions in effect"
+                  "REPLACE_EVENT_ACLS_HINT": "Ensure all events of this series have these permissions in effect",
+                  "LOAD_MORE_LIMIT": "policies shown.",
+                  "LOAD_MORE_LINK": "Load more"
                },
                "ROLES": {
                   "LABEL": "Select a role",

--- a/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -998,7 +998,9 @@
              "NEW"         : "New policy",
              "DETAILS"     : "Details",
              "REPLACE_EVENT_ACLS": "Update event permissions",
-             "REPLACE_EVENT_ACLS_HINT": "Ensure all events of this series have these permissions in effect"
+             "REPLACE_EVENT_ACLS_HINT": "Ensure all events of this series have these permissions in effect",
+             "LOAD_MORE_LIMIT": "policies shown.",
+             "LOAD_MORE_LINK": "Load more"
            },
            "ROLES": {
               "LABEL": "Select a role",

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/serieController.js
@@ -458,4 +458,10 @@ angular.module('adminNg.controllers')
       }
     };
 
+    var POLICIES_LOAD_STEP = 50;
+    $scope.limit = POLICIES_LOAD_STEP;
+    $scope.loadmore = function () {
+      $scope.limit += POLICIES_LOAD_STEP;
+    };
+
   }]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
@@ -1,9 +1,9 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
   &nbsp;<ul ng-show="!editMode">
-  <li ng-repeat="value in params.value track by $index">
-    <span ng-if="value">{{ getText(value).value | translate }}</span>
-  </li>
-</ul>
+    <li ng-repeat="value in params.value track by $index">
+      <span ng-if="value">{{ getText(value).value | translate }}</span>
+    </li>
+  </ul>
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
   <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
@@ -15,12 +15,12 @@
     <datalist id="{{ data.list.id }}-data-list">
       <option ng-repeat="(item, label) in ::collection track by $index"
               value="{{ item }}">
-        {{ label | translate | limitTo : 70 }}
+      {{ label | translate | limitTo : 70 }}
       </option>
     </datalist>
   </div>
   <span ng-show="editMode" class="ng-multi-value"
-        ng-repeat="value in params.value track by $index">
+                           ng-repeat="value in params.value track by $index">
     {{ getText(value).value | translate | limitTo : 70 }}
     <a ng-mousedown="removeValue($index)">
       <i class="fa fa-times"></i>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/editableMultiSelect.html
@@ -1,9 +1,9 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
   &nbsp;<ul ng-show="!editMode">
-    <li ng-repeat="value in params.value track by $index">
-      <span ng-if="value">{{ getText(value).value | translate }}</span>
-    </li>
-  </ul>
+  <li ng-repeat="value in params.value track by $index">
+    <span ng-if="value">{{ getText(value).value | translate }}</span>
+  </li>
+</ul>
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
   <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
@@ -13,14 +13,14 @@
            list="{{ data.list.id }}-data-list" ng-keyup="keyUp($event)" name="{{ params.name }}" ng-model="data.value"
            placeholder="{{ 'EDITABLE.MULTI.PLACEHOLDER' | translate}}">
     <datalist id="{{ data.list.id }}-data-list">
-      <option ng-repeat="(item, label) in collection track by $index"
+      <option ng-repeat="(item, label) in ::collection track by $index"
               value="{{ item }}">
-      {{ label | translate | limitTo : 70 }}
+        {{ label | translate | limitTo : 70 }}
       </option>
     </datalist>
   </div>
   <span ng-show="editMode" class="ng-multi-value"
-                           ng-repeat="value in params.value track by $index">
+        ng-repeat="value in params.value track by $index">
     {{ getText(value).value | translate | limitTo : 70 }}
     <a ng-mousedown="removeValue($index)">
       <i class="fa fa-times"></i>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/series-details.html
@@ -200,15 +200,15 @@
                         </tr>
                       </thead>
                       <tbody>
-                        <tr ng-repeat="policy in policies">
+                        <tr ng-repeat="policy in policies | limitTo: limit">
                           <td>
                             <select chosen
-                                    pre-select-from="roles"
+                                    pre-select-from="::roles"
                                     ng-disabled="(tab == 'permissions') && (!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT') || aclLocked)"
                                     data-width="'360px'"
                                     ng-model="policy.role"
                                     ng-change="accessChanged(policy.role)"
-                                    ng-options="id as id for (id, type) in roles"
+                                    ng-options="id as id for (id, type) in ::roles"
                                     ng-get-more="getMoreRoles"
                                     placeholder-text-single="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
                                     no-results-text="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ROLES.EMPTY' | translate }}'"
@@ -216,14 +216,14 @@
                           </td>
                           <td class="fit text-center">
                             <input type="checkbox"
-                                   ng-disabled="aclLocked"
+                                   ng-disabled="::aclLocked"
                                    ng-model="policy.read"
                                    ng-change="accessSave()"
                                    ng-disabled="!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT')"/>
                           </td>
                           <td class="fit text-center">
                             <input type="checkbox"
-                                   ng-disabled="aclLocked"
+                                   ng-disabled="::aclLocked"
                                    ng-model="policy.write"
                                    ng-change="accessSave()"
                                    ng-disabled="!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT')"/>
@@ -233,16 +233,22 @@
                                  save="accessSave"
                                  admin-ng-editable-multi-select
                                  mixed="false"
-                                 params="policy.actions"
-                                 collection="actions">
+                                 params="::policy.actions"
+                                 collection="::actions">
                             </div>
                             <div ng-if="(!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT')) || aclLocked"
-                                 ng-repeat="customAction in policy.actions.value">
+                                 ng-repeat="customAction in ::policy.actions.value">
                               {{ customAction }}
                             </div>
                           </td>
                           <td class="fit" ng-if="$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT') && !aclLocked">
                             <a ng-click="deletePolicy(policy)" class="remove"></a>
+                          </td>
+                        </tr>
+                        <tr ng-if="limit < policies.length">
+                          <td colspan="5" >
+                            {{ limit }} / {{ policies.length }} {{ 'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.LOAD_MORE_LIMIT' | translate }}
+                            <a ng-click="loadmore()">{{ 'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.LOAD_MORE_LINK' | translate }}</a>
                           </td>
                         </tr>
                         <tr ng-if="$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT') && !aclLocked">


### PR DESCRIPTION
If a series contains a large number of ACLs (more than 300) and one wants to edit the ACL-list or any other metadata of the series the UI is no longer responding. Especially if you are using the Chrome browser.

The problem is related to the way AngularJS tracks changes in the displayed items. The long list creates a very high number of so-called watchers that are polled regularly.
I have made some changes in the code to reduce the number of watchers.
In addition, initially only the first 50 ACL entries are loaded, by clicking on a link it is possible to reload 50 additional ACL entries until all ACL entries are loaded.