### PR TITLE
Do not use stack-overflow logo

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
@@ -56,7 +56,7 @@
 
 <a data-open-modal="event-details"
    data-resource-id="{{ row.id }}"
-   class="fa fa-stack-overflow"
+   class="fa fa-folder-open"
    data-tab="assets"
    title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.ASSETS' | translate }}"
    with-role="ROLE_UI_EVENTS_ASSETS_VIEW">


### PR DESCRIPTION
This patch removes the stack-overflow logo as icon from the admin
interface and replaces it with another icon. I'm pretty sure we are
legally prohibited from this use of the stack-overflow logo.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
