### PR TITLE
Allow to overwrite setenv variables

### DIFF
--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -34,9 +34,9 @@
 # export KARAF_DEBUG       # Enable debug mode
 # export KARAF_REDIRECT    # Enable/set the std/err redirection when using bin/start
 
-export EXTRA_JAVA_OPTS="-Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
-export JAVA_MAX_MEM=1G
-export JAVA_PERM_MEM=256M
+export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
+export JAVA_MAX_MEM="${JAVA_MAX_MEM:-1G}"
+export JAVA_PERM_MEM="${JAVA_PERM_MEM:-256M}"
 export KARAF_NOROOT=true
 
 


### PR DESCRIPTION
Changes `setenv` such that variables can be overwritten by already present environment variables passed to the Opencast process.

`JAVA_MAX_MEM` and `JAVA_PERM_MEM` can be overwritten entirely, but default to the previous values. Note that Karaf currently does not honor `JAVA_PERM_MEM` ([fix](https://github.com/apache/karaf/commit/7fa1d274bda958e5ff24d0ab74aa6c19b534a35e) for [KARAF-5641](https://issues.apache.org/jira/browse/KARAF-5641) removed the corresponding code for 4.2.x).

`EXTRA_JAVA_OPTS` will append to the already existing settings.

Our main use case: set HTTP proxy parameters for Opencast.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
