### PR TITLE
Consider file extension of uploaded asset

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -509,6 +509,7 @@ public class IndexServiceImpl implements IndexService {
 
         for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
           FileItemStream item = iter.next();
+
           String fieldName = item.getFieldName();
           if (item.isFormField()) {
             if ("metadata".equals(fieldName)) {
@@ -534,7 +535,8 @@ public class IndexServiceImpl implements IndexService {
             // AngularJS file upload lib appends ".0" to field name, so we cut that off
             fieldName = fieldName.substring(0, fieldName.lastIndexOf("."));
             final MediaType mediaType = MediaType.parse(item.getContentType());
-            final boolean accepted = RequestUtils.typeIsAccepted(fieldName, mediaType, listProvidersService);
+            final boolean accepted = RequestUtils.typeIsAccepted(item.getName(), fieldName, mediaType,
+                    listProvidersService);
             if (!accepted) {
               throw new UnsupportedAssetException("Provided file format " + mediaType.toString() + " not allowed.");
             }
@@ -632,7 +634,8 @@ public class IndexServiceImpl implements IndexService {
           // AngularJS file upload lib appends ".0" to field name, so we cut that off
           fieldName = fieldName.substring(0, fieldName.lastIndexOf("."));
           final MediaType mediaType = MediaType.parse(item.getContentType());
-          final boolean accepted = RequestUtils.typeIsAccepted(fieldName, mediaType, listProvidersService);
+          final boolean accepted = RequestUtils.typeIsAccepted(item.getName(), fieldName, mediaType,
+                  listProvidersService);
           if (!accepted) {
             throw new UnsupportedAssetException("Provided file format " + mediaType.toString() + " not allowed.");
           }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/RequestUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/RequestUtils.java
@@ -94,11 +94,20 @@ public final class RequestUtils {
    *
    * @return true if the given mediatype is accepted, false otherwise.
    */
-  public static boolean typeIsAccepted(String assetUploadId, MediaType mediaType, ListProvidersService listProvidersService) {
+  public static boolean typeIsAccepted(String fileName, String assetUploadId, MediaType mediaType,
+          ListProvidersService listProvidersService) {
     if (mediaType.is(MediaType.OCTET_STREAM)) {
       // No detailed info, so we have to accept...
       return true;
     }
+
+    // get file extension with .
+    String fileExtension = null;
+    int dot = fileName.lastIndexOf('.');
+    if (dot != -1) {
+      fileExtension = fileName.substring(dot);
+    }
+
     try {
       final Collection<String> assetUploadJsons = listProvidersService.getList("eventUploadAssetOptions",
           new ResourceListQueryImpl(),false).values();
@@ -115,7 +124,7 @@ public final class RequestUtils {
           for (String accept : accepts) {
             if (accept.contains("/") && mediaType.is(MediaType.parse(accept))) {
               return true;
-            } else if (mediaType.subtype().equalsIgnoreCase(accept.replace(".", ""))) {
+            } else if (fileExtension != null && accept.contains(".") && fileExtension.equalsIgnoreCase(accept)) {
               return true;
             }
           }


### PR DESCRIPTION
When checking the file type of an uploaded asset, don't only check the media type, but also the file extension since these don't necessarily match.

Example: A video might have the extension .mov, but the media type video/quicktime, which is rejected even though .mov files are allowed.
