### PR TITLE
Workflow title: Update editor previews

### DIFF
--- a/etc/workflows/update-previews.xml
+++ b/etc/workflows/update-previews.xml
@@ -2,7 +2,7 @@
 <definition xmlns="http://workflow.opencastproject.org">
 
   <id>update-previews</id>
-  <title>Update previews</title>
+  <title>Update editor previews</title>
   <tags>
     <tag>archive</tag>
   </tags>


### PR DESCRIPTION
Now that the preview feature, an eye symbol previously prominently 
located on each event's action cell, is hidden in favour of the editor, 
"update previews" is a counter-intuitive name for that WF. Can we call
it "Update Editor Previews"? It doesn't update thumbnails of engage
publications or similar.

### Your pull request should…

* [x] have a concise title
* ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] be against the correct branch (features can only go into develop)
* ~include migration scripts and documentation, if appropriate~
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* ~have appropriate tags applied~
