### PR TITLE
MH-12821 (#1008): Better crop detect test #1085

### DIFF
--- a/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
+++ b/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
@@ -264,14 +264,14 @@ public class CropServiceImpl extends AbstractJobProducer implements CropService,
           }
         }
       } catch (IllegalStateException | IllegalArgumentException e) {
-        logger.error("Error extracting crop information from FFmpeg output", e);
+        throw new CropException("Error extracting crop information from FFmpeg output", e);
       }
       exitCode = process.waitFor();
 
     } catch (IOException e) {
-      logger.error("Error executing FFmpeg", e);
+      throw new CropException("Error executing FFmpeg", e);
     } catch (InterruptedException e) {
-      logger.error("Waiting for encoder process exited was interrupted unexpected", e);
+      throw new CropException("Waiting for encoder process exited was interrupted unexpected", e);
     }
 
     if (exitCode != 0) {

--- a/modules/crop-ffmpeg/src/test/java/org/opencastproject/crop/CropServiceTest.java
+++ b/modules/crop-ffmpeg/src/test/java/org/opencastproject/crop/CropServiceTest.java
@@ -171,7 +171,7 @@ public class CropServiceTest {
 
     JobBarrier jobBarrier = new JobBarrier(null, serviceRegistry, 1000, receipt);
     JobBarrier.Result result = jobBarrier.waitForJobs();
-    Assert.assertTrue(result.isSuccess());
+    Assert.assertFalse(result.isSuccess());
   }
 
 

--- a/modules/crop-ffmpeg/src/test/java/org/opencastproject/crop/CropServiceTest.java
+++ b/modules/crop-ffmpeg/src/test/java/org/opencastproject/crop/CropServiceTest.java
@@ -47,7 +47,6 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -159,7 +158,6 @@ public class CropServiceTest {
   }
 
   @Test
-  @Ignore
   public void testEncoderProblem() throws Exception {
     Track track = createTrack(MEDIA_RESOURCE, MEDIA_DURATION);
     cropService.setWorkspace(createWorkspace(track));


### PR DESCRIPTION
This change fixes the logic of a unit test, and throws errors when errors happen rather than relying on ffmpeg's return code