### PR TITLE
Keep generated SMIL for partial tracks

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -1379,7 +1379,9 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     // drop catalogs sent by the capture agent in favor of Opencast's own metadata
     if (skipCatalogs) {
       for (MediaPackageElement element : mp.getCatalogs()) {
-        mp.remove(element);
+        if (!element.getFlavor().equals(MediaPackageElements.SMIL)) {
+          mp.remove(element);
+        }
       }
     }
 


### PR DESCRIPTION
If one uses the IngestService and adds so called "partial"-tracks to a media package, the ingest service generates a SMIL-Catalog for these partial tracks. Unfortunately this generated SMIL-Catalog is removed if the option "skip.catalogs.for.existing.events" is set to true, which is the default. This pull request fixes this behaviour.