### PR TITLE
Show users with same mail address and name

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -168,11 +168,11 @@ prop.adminui.user.external_role_display=false
 # Name of the list to provide a user listing as used in the group editor of the admin ui.
 #
 # Values:
-# - USERS.INVERSE will list users by name (e.g. "John Sample")
-# - USERS.INVERSE.WITH.EMAIL will list users by name and email (e.g. "John Sample <j.sample@opencast.org>")
-# - USERS.INVERSE.WITH.USERNAME will list users by name and username (e.g. "John Sample (jsample)")
-# Default: USERS.INVERSE.WITH.USERNAME
-#prop.adminui.user.listname=USERS.INVERSE.WITH.USERNAME
+# - USERS.NAME will list users by name (e.g. "John Sample")
+# - USERS.NAME.AND.EMAIL will list users by name and email (e.g. "John Sample <j.sample@opencast.org>")
+# - USERS.NAME.AND.USERNAME will list users by name and username (e.g. "John Sample (jsample)")
+# Default: USERS.NAME.AND.USERNAME
+#prop.adminui.user.listname=USERS.NAME.AND.USERNAME
 
 # Path to the default video player used by the engage interfaces and the LTI tools. Parameters for selecting the
 # specific videos will be appended automatically.  Common values include:

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/groupController.js
@@ -32,13 +32,13 @@ angular.module('adminNg.controllers')
           // Now that we have the user users and the group users populate the selected and available
           $scope.user.selected = $scope.user.all.filter(function (user) {
             var foundUser = $scope.group.users.find(function (groupUser) {
-              return groupUser.username === user.value;
+              return groupUser.username === user.name;
             });
             return foundUser !== undefined;
           });
           $scope.user.available = $scope.user.all.filter(function (user) {
             var foundUser = $scope.user.selected.find(function (selectedUser) {
-              return selectedUser.value === user.value;
+              return selectedUser.name === user.name;
             });
             return foundUser === undefined;
           });
@@ -82,7 +82,7 @@ angular.module('adminNg.controllers')
       }
       $scope.user = {
         all: ResourcesListResource.query({
-          resource: $scope.orgProperties['adminui.user.listname'] || 'USERS.INVERSE.WITH.USERNAME'}),
+          resource: $scope.orgProperties['adminui.user.listname'] || 'USERS.NAME.AND.USERNAME'}),
         available: [],
         selected:  [],
         i18n: 'USERS.GROUPS.DETAILS.USERS',
@@ -103,7 +103,7 @@ angular.module('adminNg.controllers')
       $scope.group.roles = [];
 
       angular.forEach($scope.user.selected, function (item) {
-        $scope.group.users.push(item.value);
+        $scope.group.users.push(item.name);
       });
 
       angular.forEach($scope.role.selected, function (item) {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/selectBoxDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/selectBoxDirective.js
@@ -28,6 +28,7 @@ angular.module('adminNg.directives')
     scope: {
       resource: '=',
       groupBy:  '@',
+      display: '@',
       disabled: '=',
       loader: '=',
       ignore: '@',
@@ -35,6 +36,9 @@ angular.module('adminNg.directives')
     },
     controller: function ($scope) {
 
+      if (!$scope.display) {
+        $scope.display = 'name';
+      }
       $scope.searchField = '';
 
       $scope.customFilter = function () {
@@ -43,11 +47,11 @@ angular.module('adminNg.directives')
 
           var result = true;
           if (!angular.isUndefined($scope.ignore)) {
-            result = !(item.name.substring(0, ($scope.ignore).length) ===  $scope.ignore);
+            result = !(item[$scope.display].substring(0, ($scope.ignore).length) ===  $scope.ignore);
           }
 
           if (result && ($scope.searchField != '')) {
-            result = (item.name.toLowerCase().indexOf($scope.searchField.toLowerCase()) >= 0);
+            result = (item[$scope.display].toLowerCase().indexOf($scope.searchField.toLowerCase()) >= 0);
           }
 
           return result;

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/group-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/group-modal.html
@@ -55,7 +55,7 @@
       <div class="modal-body">
         <div class="form-container">
           <div data-admin-ng-notifications="" context="group-form"></div>
-          <admin-ng-select-box resource="user" data-height="21em" group-by="provider"></admin-ng-select-box>
+          <admin-ng-select-box resource="user" data-height="21em" group-by="provider" display="value"></admin-ng-select-box>
         </div>
       </div>
     </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/selectContainer.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/selectContainer.html
@@ -20,7 +20,7 @@
                 ng-disabled="disabled"
                 ng-init="markedForAddition = []"
                 ng-class="{ disabled: disabled , scrollable: 'true'}"
-                ng-options="item.name group by item[groupBy] for item in resource.available | filter: customFilter() | orderBy: 'name' : false"
+                ng-options="item[display] group by item[groupBy] for item in resource.available | filter: customFilter() | orderBy: display : false"
                 loading-scroller="loadMore()"
                 style="min-height: 11em;"
                 ng-style="getHeight()"
@@ -46,7 +46,7 @@
                 ng-model="markedForRemoval"
                 ng-init="markedForRemoval = []"
                 ng-class="{ disabled: disabled }"
-                ng-options="item.name group by item[groupBy] for item in resource.selected | filter: customSelectedFilter() | orderBy: 'name' : false"
+                ng-options="item[display] group by item[groupBy] for item in resource.selected | filter: customSelectedFilter() | orderBy: display : false"
                 style="min-height: 11em;"
                 ng-style="getHeight()"
                 ng-dblclick="remove()">

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-group.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-group.html
@@ -32,7 +32,8 @@
 <div class="modal-content" data-modal-tab-content="users" data-level="1">
   <div class="modal-body">
     <div class="form-container">
-      <admin-ng-select-box resource="wizard.states[2].stateController.users" data-height="21em" group-by="provider"></admin-ng-select-box>
+      <admin-ng-select-box resource="wizard.states[2].stateController.users" data-height="21em" group-by="provider"
+                           display="value"></admin-ng-select-box>
     </div>
   </div>
 </div>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/users.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/wizards/new-group/users.js
@@ -41,7 +41,7 @@ angular.module('adminNg.services')
           searchable: true
         };
         listName.then(function (listName) {
-          me.users.available = ResourcesListResource.query({ resource: listName || 'USERS.INVERSE.WITH.USERNAME'});
+          me.users.available = ResourcesListResource.query({ resource: listName || 'USERS.NAME.AND.USERNAME'});
         });
       };
 

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/USERS.INVERSE.WITH.USERNAME.json
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/USERS.INVERSE.WITH.USERNAME.json
@@ -1,6 +1,0 @@
-{
-  "ROLE_USER_MATT_SMIHT"   : "Matt Smith (msmith)",
-  "ROLE_USER_CHUCK_NORRIS" : "Chuck Norris (cnorris)",
-  "ROLE_USER_FRANZ_KAFKA"  : "Franz Kafka (fkafka)",
-  "ROLE_USER_A_MORRIS"     : "A. Morris (amorris)"
-}

--- a/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/USERS.NAME.AND.USERNAME.json
+++ b/modules/admin-ui/src/test/resources/app/GET/admin-ng/resources/USERS.NAME.AND.USERNAME.json
@@ -1,0 +1,6 @@
+{
+  "msmith"   : "Matt Smith (msmith)",
+  "cnorris" : "Chuck Norris (cnorris)",
+  "fkafka"  : "Franz Kafka (fkafka)",
+  "amorris"     : "A. Morris (amorris)"
+}

--- a/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/groupControllerSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/modules/users/controllers/groupControllerSpec.js
@@ -29,7 +29,7 @@ describe('Group controller', function () {
     beforeEach(function () {
         jasmine.getJSONFixtures().fixturesPath = 'base/app/GET';
         $httpBackend.whenGET('/admin-ng/resources/ROLES.json?filter=role_target:USER&limit=0&offset=0').respond(JSON.stringify(getJSONFixture('roles/roles.json')));
-        $httpBackend.whenGET('/admin-ng/resources/USERS.INVERSE.WITH.USERNAME.json').respond(JSON.stringify(getJSONFixture('admin-ng/resources/USERS.INVERSE.WITH.USERNAME.json')));
+        $httpBackend.whenGET('/admin-ng/resources/USERS.NAME.AND.USERNAME.json').respond(JSON.stringify(getJSONFixture('admin-ng/resources/USERS.NAME.AND.USERNAME.json')));
         $httpBackend.whenGET('/info/me.json').respond(JSON.stringify(getJSONFixture('info/me.json')));
         $httpBackend.whenGET('modules/events/partials/index.html').respond('');
         $controller('GroupCtrl', {$scope: $scope});

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/UsersListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/UsersListProvider.java
@@ -40,20 +40,19 @@ public class UsersListProvider implements ResourceListProvider {
 
   private static final String PROVIDER_PREFIX = "USERS";
 
-  public static final String DEFAULT = PROVIDER_PREFIX;
-  public static final String DEFAULT_WITH_EMAIL = DEFAULT + ".WITH.EMAIL";
-  public static final String DEFAULT_WITH_USERNAME = DEFAULT + ".WITH.USERNAME";
-  public static final String INVERSE = PROVIDER_PREFIX + ".INVERSE";
-  public static final String INVERSE_WITH_EMAIL = INVERSE + ".WITH.EMAIL";
-  public static final String INVERSE_WITH_USERNAME = INVERSE + ".WITH.USERNAME";
-  public static final String USERNAME = PROVIDER_PREFIX + ".USERNAME";
-  public static final String NAME = PROVIDER_PREFIX + ".NAME";
-  public static final String EMAIL = PROVIDER_PREFIX + ".EMAIL";
-  public static final String ROLE = PROVIDER_PREFIX + ".ROLE";
-  public static final String USERDIRECTORY = PROVIDER_PREFIX + ".USERDIRECTORY";
+  public static final String NAME = PROVIDER_PREFIX + ".NAME"; // Username : Name
+  public static final String NAME_AND_EMAIL = PROVIDER_PREFIX + ".NAME.AND.EMAIL"; // Username: Name <Email>
+  public static final String NAME_AND_USERNAME = PROVIDER_PREFIX + ".NAME.AND.USERNAME"; // Username: Name (Username)
+  public static final String USERNAME = PROVIDER_PREFIX + ".USERNAME"; // UserName: UserName
+  public static final String EMAIL = PROVIDER_PREFIX + ".EMAIL"; // UserName: Email
 
-  protected static final String[] NAMES = { DEFAULT, DEFAULT_WITH_EMAIL, DEFAULT_WITH_USERNAME, INVERSE,
-          INVERSE_WITH_EMAIL, INVERSE_WITH_USERNAME, USERNAME, NAME, EMAIL, ROLE, USERDIRECTORY };
+  public static final String NAME_ONLY = PROVIDER_PREFIX + ".NAME.ONLY"; // Name : Name
+  public static final String EMAIL_ONLY = PROVIDER_PREFIX + ".EMAIL.ONLY"; // Email: Email
+  public static final String ROLE_ONLY = PROVIDER_PREFIX + ".ROLE.ONLY"; // Role: Role
+  public static final String USERDIRECTORY_ONLY = PROVIDER_PREFIX + ".USERDIRECTORY.ONLY"; // UserDirectory: UserDirectory
+
+  protected static final String[] NAMES = { NAME, NAME_AND_EMAIL, NAME_AND_USERNAME, USERNAME, EMAIL, NAME_ONLY,
+          EMAIL_ONLY, ROLE_ONLY, USERDIRECTORY_ONLY };
 
   private static final Logger logger = LoggerFactory.getLogger(UsersListProvider.class);
 
@@ -75,7 +74,7 @@ public class UsersListProvider implements ResourceListProvider {
 
   @Override
   public Map<String, String> getList(String listName, ResourceListQuery query) {
-    Map<String, String> usersList = new HashMap<String, String>();
+    Map<String, String> usersList = new HashMap<>();
     int offset = 0;
     int limit = 0;
 
@@ -92,22 +91,22 @@ public class UsersListProvider implements ResourceListProvider {
     while (users.hasNext()) {
       User u = users.next();
       if (EMAIL.equals(listName) && StringUtils.isNotBlank(u.getEmail())) {
-        usersList.put(u.getEmail(), u.getEmail());
+        usersList.put(u.getUsername(), u.getEmail());
       } else if (USERNAME.equals(listName) && StringUtils.isNotBlank(u.getUsername())) {
         usersList.put(u.getUsername(), u.getUsername());
-      } else if (USERDIRECTORY.equals(listName) && StringUtils.isNotBlank(u.getProvider())) {
-        usersList.put(u.getProvider(), u.getProvider());
       } else if (NAME.equals(listName) && StringUtils.isNotBlank(u.getName())) {
-        usersList.put(u.getName(), u.getName());
-      } else if (INVERSE.equals(listName)
-              || INVERSE_WITH_EMAIL.equals(listName)
-              || INVERSE_WITH_USERNAME.equals(listName)) {
-        usersList.put(createDisplayName(u, listName), u.getUsername());
-      } else if (DEFAULT.equals(listName)
-              || DEFAULT_WITH_EMAIL.equals(listName)
-              || DEFAULT_WITH_USERNAME.equals(listName)) {
+        usersList.put(u.getUsername(), u.getName());
+      } else if (NAME.equals(listName)
+              || NAME_AND_EMAIL.equals(listName)
+              || NAME_AND_USERNAME.equals(listName)) {
         usersList.put(u.getUsername(), createDisplayName(u, listName));
-      } else if (ROLE.equals(listName) && u.getRoles().size() > 0) {
+      } else if (NAME_ONLY.equals(listName) && StringUtils.isNotBlank(u.getName())) {
+        usersList.put(u.getName(), u.getName());
+      } else if (EMAIL_ONLY.equals(listName) && StringUtils.isNotBlank(u.getEmail())) {
+        usersList.put(u.getEmail(), u.getEmail());
+      } else if (USERDIRECTORY_ONLY.equals(listName) && StringUtils.isNotBlank(u.getProvider())) {
+        usersList.put(u.getProvider(), u.getProvider());
+      } else if (ROLE_ONLY.equals(listName) && u.getRoles().size() > 0) {
         for (Role role : u.getRoles()) {
           usersList.put(role.getName(), role.getName());
         }
@@ -129,10 +128,9 @@ public class UsersListProvider implements ResourceListProvider {
   private String createDisplayName(User user, String listName) {
     assert ((user != null) && (user.getUsername() != null));
     String name = StringUtils.isNotBlank(user.getName()) ? user.getName() : user.getUsername();
-    if (StringUtils.isNotBlank(user.getEmail())
-            && (DEFAULT_WITH_EMAIL.equals(listName) || INVERSE_WITH_EMAIL.equals(listName))) {
+    if (StringUtils.isNotBlank(user.getEmail()) && NAME_AND_EMAIL.equals(listName)) {
       name = name + " <" + user.getEmail() + ">";
-    } else if ((DEFAULT_WITH_USERNAME.equals(listName) || INVERSE_WITH_USERNAME.equals(listName))) {
+    } else if (NAME_AND_USERNAME.equals(listName)) {
       name = name + " (" + user.getUsername() + ")";
     }
     assert (name != null);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/ThemesListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/ThemesListQuery.java
@@ -75,7 +75,7 @@ public class ThemesListQuery extends ResourceListQueryImpl {
    */
   public static ResourceListFilter<String> createCreatorFilter(Option<String> creator) {
     return FiltersUtils.generateFilter(creator, FILTER_CREATOR_NAME, FILTER_CREATOR_LABEL, SourceType.SELECT,
-            Option.some(UsersListProvider.NAME));
+            Option.some(UsersListProvider.NAME_ONLY));
   }
 
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/UsersListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/UsersListQuery.java
@@ -123,7 +123,7 @@ public class UsersListQuery extends ResourceListQueryImpl {
    */
   public static ResourceListFilter<String> createNameFilter(Option<String> name) {
     return FiltersUtils.generateFilter(name, FILTER_NAME_NAME, FILTER_NAME_LABEL, SourceType.SELECT,
-            Option.some(UsersListProvider.NAME));
+            Option.some(UsersListProvider.NAME_ONLY));
   }
 
   /**
@@ -135,7 +135,7 @@ public class UsersListQuery extends ResourceListQueryImpl {
    */
   public static ResourceListFilter<String> createRoleFilter(Option<String> role) {
     return FiltersUtils.generateFilter(role, FILTER_ROLE_NAME, FILTER_ROLE_LABEL, SourceType.SELECT,
-            Option.some(UsersListProvider.ROLE));
+            Option.some(UsersListProvider.ROLE_ONLY));
   }
 
   /**
@@ -147,7 +147,7 @@ public class UsersListQuery extends ResourceListQueryImpl {
    */
   public static ResourceListFilter<String> createProviderFilter(Option<String> provider) {
     return FiltersUtils.generateFilter(provider, FILTER_PROVIDER_NAME, FILTER_PROVIDER_LABEL, SourceType.SELECT,
-            Option.some(UsersListProvider.USERDIRECTORY));
+            Option.some(UsersListProvider.USERDIRECTORY_ONLY));
   }
 
 }

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/UsersListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/UsersListProviderTest.java
@@ -114,7 +114,7 @@ public class UsersListProviderTest {
 
   @Test
   public void testListSimple() throws ListProviderException {
-    Map<String, String> list = usersListProvider.getList(UsersListProvider.NAME, null);
+    Map<String, String> list = usersListProvider.getList(UsersListProvider.NAME_ONLY, null);
     Assert.assertTrue(list.containsKey(user1.getName()));
     Assert.assertTrue(list.containsKey(user2.getName()));
     Assert.assertTrue(list.containsKey(user3.getName()));
@@ -127,12 +127,12 @@ public class UsersListProviderTest {
     Assert.assertTrue(list.containsKey(user4.getUsername()));
     Assert.assertEquals(4, list.size());
 
-    list = usersListProvider.getList(UsersListProvider.EMAIL, null);
+    list = usersListProvider.getList(UsersListProvider.EMAIL_ONLY, null);
     Assert.assertTrue(list.containsKey(user1.getEmail()));
     Assert.assertTrue(list.containsKey(user4.getEmail()));
     Assert.assertEquals(2, list.size());
 
-    list = usersListProvider.getList(UsersListProvider.USERDIRECTORY, null);
+    list = usersListProvider.getList(UsersListProvider.USERDIRECTORY_ONLY, null);
     Assert.assertTrue(list.containsKey(user1.getProvider()));
     Assert.assertEquals(1, list.size());
   }


### PR DESCRIPTION
Always use the username as key when sending users lists to the admin ui since only that is supposed to be unique. If it's the other way around, users with the same name and mail address cannot be added to a group that a similar user is already in.