### PR TITLE
Fix Crowdin Upload

### DIFF
--- a/.upload-crowdin.sh
+++ b/.upload-crowdin.sh
@@ -4,12 +4,12 @@ set -eux
 # Check for pull requests
 if [ "${TRAVIS_PULL_REQUEST}" != false ]; then
   echo "No crowdin upload on pull requests"
-  return 0
+  exit 0
 fi
 # Check for non release branches or develop
 if ! echo "${TRAVIS_BRANCH}" | grep -Eq '^(r/[0-9]+\.x|develop)$'; then
   echo "crowdin upload is only allowrd on release branches and develop, not on $TRAVIS_BRANCH"
-  return 0
+  exit 0
 fi
 # Crowdin branches do not use the `r/` prefix
 CROWDIN_BRANCH="${TRAVIS_BRANCH//r\//}"


### PR DESCRIPTION
This patch fixes the Crowdin upload script which fails on non-release
branches right now:

    return 0
    .upload-crowdin.sh: line 12: return: can only `return' from a function or sourced script

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
