### PR TITLE
Fix Crowdin Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,4 +151,4 @@ jobs:
         script: bash .upload-crowdin.sh
         on:
           all_branches: true
-          condition: $TRAVIS_BRANCH =~ ^develop|r/
+          condition: $TRAVIS_BRANCH =~ ^develop|^r/


### PR DESCRIPTION
This patch fixes the Crowdin deployment rule which should let the
deployment run only on develop and on release branches.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
