### PR TITLE
Warn about using H2

### DIFF
--- a/modules/db/src/main/java/org/opencastproject/db/Activator.java
+++ b/modules/db/src/main/java/org/opencastproject/db/Activator.java
@@ -60,6 +60,20 @@ public class Activator implements BundleActivator {
             "org.h2.Driver");
     String jdbcUrl = getConfigProperty(bundleContext.getProperty("org.opencastproject.db.jdbc.url"),
             "jdbc:h2:" + rootDir);
+    if ("org.h2.Driver".equals(jdbcDriver)) {
+      logger.warn("\n"
+          + "######################################################\n"
+          + "#                                                    #\n"
+          + "# WARNING: Opencast is using an H2 database.         #\n"
+          + "#          Never do this in production.              #\n"
+          + "#                                                    #\n"
+          + "#          For more information about database       #\n"
+          + "#          configuration, see:                       #\n"
+          + "#                                                    #\n"
+          + "#          https://docs.opencast.org                 #\n"
+          + "#                                                    #\n"
+          + "######################################################");
+    }
     String jdbcUser = getConfigProperty(bundleContext.getProperty("org.opencastproject.db.jdbc.user"), "sa");
     String jdbcPass = getConfigProperty(bundleContext.getProperty("org.opencastproject.db.jdbc.pass"), "sa");
 


### PR DESCRIPTION
This patch makes Opencast log a warning message when using the internal
H2 database as it is not qualified for use in production:

    2019-11-01 00:18:23,006 | WARN  | (Activator:64) -
    ######################################################
    #                                                    #
    # WARNING: Opencast is using an H2 database.         #
    #          Never do this in production.              #
    #                                                    #
    #          For more information about database       #
    #          configuration, see:                       #
    #                                                    #
    #          https://docs.opencast.org                 #
    #                                                    #
    ######################################################

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
