### PR TITLE
Make Thumbnail Optional

### DIFF
--- a/etc/org.opencastproject.adminui.endpoint.ToolsEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.ToolsEndpoint.cfg
@@ -13,3 +13,10 @@
 # If this property is true then signed URLs for editing / previewing, such as videos accessed by the preview or editor
 # player will be limited to the IP address of the client making the original request.
 # url.signing.use.client.ip=true
+
+# Thumbnail Feature Configuration
+
+# The thumbnail feature can cause performance problems in some environments.
+# That is why it can be deactivated in here.
+# Default: true
+#thumbnail.enabled = true

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -109,6 +109,7 @@ import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -132,6 +133,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.stream.Collectors;
@@ -195,6 +197,9 @@ public class ToolsEndpoint implements ManagedService {
   private static final String THUMBNAIL_POSITION = "POSITION";
   private static final String THUMBNAIL_DEFAULT = "DEFAULT";
 
+  /** Option to enable/disable thumbnail support */
+  private static final String OPT_THUMBNAIL_ENABLED = "thumbnail.enabled";
+
   private long expireSeconds = UrlSigningServiceOsgiUtil.DEFAULT_URL_SIGNING_EXPIRE_DURATION;
 
   private Boolean signWithClientIP = UrlSigningServiceOsgiUtil.DEFAULT_SIGN_WITH_CLIENT_IP;
@@ -212,6 +217,7 @@ public class ToolsEndpoint implements ManagedService {
   private UrlSigningService urlSigningService;
   private WorkflowService workflowService;
   private Workspace workspace;
+  private boolean thumbnailEnabled = true;
 
   void setConfigurablePublicationService(ConfigurablePublicationService configurablePublicationService) {
     this.configurablePublicationService = configurablePublicationService;
@@ -283,6 +289,9 @@ public class ToolsEndpoint implements ManagedService {
     expireSeconds = UrlSigningServiceOsgiUtil.getUpdatedSigningExpiration(properties, this.getClass().getSimpleName());
     signWithClientIP = UrlSigningServiceOsgiUtil.getUpdatedSignWithClientIP(properties,
             this.getClass().getSimpleName());
+
+    thumbnailEnabled = BooleanUtils.toBoolean(Objects.toString(properties.get(OPT_THUMBNAIL_ENABLED), "true"));
+    logger.debug("Thumbnail feature enabled: {}", thumbnailEnabled);
   }
 
   @GET
@@ -428,22 +437,24 @@ public class ToolsEndpoint implements ManagedService {
 
     // Get thumbnail
     final List<Field> thumbnailFields = new ArrayList<>();
-    try {
-      final ThumbnailImpl thumbnailImpl = newThumbnailImpl();
-      final Optional<ThumbnailImpl.Thumbnail> optThumbnail = thumbnailImpl
-        .getThumbnail(mp, urlSigningService, expireSeconds);
+    if (thumbnailEnabled) {
+      try {
+        final ThumbnailImpl thumbnailImpl = newThumbnailImpl();
+        final Optional<ThumbnailImpl.Thumbnail> optThumbnail = thumbnailImpl
+          .getThumbnail(mp, urlSigningService, expireSeconds);
 
-      optThumbnail.ifPresent(thumbnail -> {
-        thumbnailFields.add(f("type", thumbnail.getType().name()));
-        thumbnailFields.add(f("url", thumbnail.getUrl().toString()));
-        thumbnailFields.add(f("defaultPosition",  thumbnailImpl.getDefaultPosition()));
-        thumbnail.getPosition().ifPresent(p -> thumbnailFields.add(f("position", p)));
-        thumbnail.getTrack().ifPresent(t -> thumbnailFields.add(f("track", t)));
-      });
-    } catch (UrlSigningException | URISyntaxException e) {
-      logger.error("Error while trying to serialize the thumbnail url because: {}", getStackTrace(e));
-      throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
+        optThumbnail.ifPresent(thumbnail -> {
+          thumbnailFields.add(f("type", thumbnail.getType().name()));
+          thumbnailFields.add(f("url", thumbnail.getUrl().toString()));
+          thumbnailFields.add(f("defaultPosition", thumbnailImpl.getDefaultPosition()));
+          thumbnail.getPosition().ifPresent(p -> thumbnailFields.add(f("position", p)));
+          thumbnail.getTrack().ifPresent(t -> thumbnailFields.add(f("track", t)));
+        });
+      } catch (UrlSigningException | URISyntaxException e) {
+        throw new WebApplicationException(e, SC_INTERNAL_SERVER_ERROR);
+      }
     }
+
 
     final Map<String, String> latestWfProperties = WorkflowPropertiesUtil
       .getLatestWorkflowProperties(assetManager, mediaPackageId);
@@ -508,6 +519,7 @@ public class ToolsEndpoint implements ManagedService {
             f("previews", arr(jPreviews)),
             f(TRACKS_KEY, arr(jTracks)),
             f("thumbnail", obj(thumbnailFields)),
+            f("thumbnail_enabled", v(thumbnailEnabled)),
             f("duration", v(previewDuration)),
             f(SEGMENTS_KEY, arr(jSegments)),
             f("workflows", arr(jWorkflows))));
@@ -525,6 +537,10 @@ public class ToolsEndpoint implements ManagedService {
   public Response changeThumbnail(@PathParam("mediapackageid") final String mediaPackageId,
     @Context HttpServletRequest request)
     throws IndexServiceException, NotFoundException, DistributionException, MediaPackageException {
+
+    if (!thumbnailEnabled) {
+      return R.badRequest("Thumbnail creation is prohibited");
+    }
 
     final Opt<Event> optEvent = getEvent(mediaPackageId);
     if (optEvent.isNone()) {
@@ -661,7 +677,7 @@ public class ToolsEndpoint implements ManagedService {
 
       // Update default thumbnail (if used) since position may change due to cutting
       MediaPackageElement distributedThumbnail = null;
-      if (editingInfo.getDefaultThumbnailPosition().isPresent()) {
+      if (thumbnailEnabled && editingInfo.getDefaultThumbnailPosition().isPresent()) {
         try {
           final ThumbnailImpl thumbnailImpl = newThumbnailImpl();
           final Optional<ThumbnailImpl.Thumbnail> optThumbnail = thumbnailImpl
@@ -673,8 +689,7 @@ public class ToolsEndpoint implements ManagedService {
         } catch (UrlSigningException | URISyntaxException e) {
           logger.error("Error while trying to serialize the thumbnail url because: {}", getStackTrace(e));
           return R.serverError();
-        } catch (IOException | DistributionException | EncoderException | PublicationException
-            | UnknownFileTypeException | MediaPackageException e) {
+        } catch (IOException | EncoderException | PublicationException | UnknownFileTypeException | MediaPackageException | DistributionException e) {
           logger.error("Error while updating default thumbnail because: {}", getStackTrace(e));
           return R.serverError();
         }

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/subresources/partials/tools.html
@@ -55,7 +55,7 @@
                                                             ng-click="openArea('segments')" translate>VIDEO_TOOL.AREAS.SEGMENTS</a>
                 <a ng-class="{active: area === 'metadata'}"
                    ng-click="openArea('metadata')" translate>VIDEO_TOOL.AREAS.METADATA</a>
-                <a ng-class="{active: area === 'thumbnail'}" ng-if="tab === 'editor'"
+                <a ng-class="{active: area === 'thumbnail'}" ng-if="tab === 'editor' && video.thumbnail_enabled"
                                                              ng-click="openArea('thumbnail')" translate>VIDEO_TOOL.AREAS.THUMBNAIL</a>
                 <a ng-class="{active: area === 'tracks'}" ng-if="tab === 'editor'"
                                                           ng-click="openArea('tracks')" translate>VIDEO_TOOL.AREAS.TRACKS</a>
@@ -86,7 +86,7 @@
               </div>
             </div>
 
-            <div ng-if="area === 'thumbnail'" class="editor-thumbnail">
+            <div ng-if="area === 'thumbnail' && video.thumbnail_enabled" class="editor-thumbnail">
               <div class="area-body">
                 <div class="full-col">
                   <div class="obj content-wrapper">


### PR DESCRIPTION
This patch makes the thumbnail generation in the video editor optional
since it causes major performance problems and/or failures on some
systems so that a number of Opencast adopters already ended up patching
or removing this in one way or another.

This does not change the default behavior of Opencast. With the default
configuration, this should make Opencast behave in the same way as
before.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
