### PR TITLE
Implement StreamingDistributionService remotely

### DIFF
--- a/modules/distribution-service-streaming-remote/src/main/resources/OSGI-INF/distribution-remote-streaming.xml
+++ b/modules/distribution-service-streaming-remote/src/main/resources/OSGI-INF/distribution-remote-streaming.xml
@@ -8,6 +8,7 @@
   <property name="distribution.channel" value="streaming"/>
   <service>
     <provide interface="org.opencastproject.distribution.api.DistributionService"/>
+    <provide interface="org.opencastproject.distribution.api.StreamingDistributionService"/>
   </service>
   <reference name="trustedHttpClient" interface="org.opencastproject.security.api.TrustedHttpClient"
              cardinality="1..1" policy="static" bind="setTrustedHttpClient"/>


### PR DESCRIPTION
Since the dependency of the workflow operation handlers on the streaming service was changed in #1179 the remote service now also needs to offer the StreamingDistributionService interface.
