### PR TITLE
Delete option of series for the SearchService

### DIFF
--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchService.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchService.java
@@ -70,6 +70,19 @@ public interface SearchService {
   Job delete(String mediaPackageId) throws SearchException, UnauthorizedException, NotFoundException;
 
   /**
+   * Removes the series identified by <code>seriesId</code> from the search index.
+   *
+   * @param seriesId
+   *          id of the series to remove
+   * @return <code>true</code> if the Series was found and deleted
+   * @throws SearchException
+   *           if an error occurs while removing the Series
+   * @throws UnauthorizedException
+   *           if the current user is not authorized to remove this series from the search index
+   */
+  Job deleteSeries(String seriesId) throws SearchException, UnauthorizedException, NotFoundException;
+
+  /**
    * Find search results based on the specified query object
    *
    * @param q

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -203,7 +203,6 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
     }
   }
 
-
   /**
    * {@inheritDoc}
    *

--- a/modules/search-service-remote/src/main/java/org/opencastproject/search/remote/SearchServiceRemoteImpl.java
+++ b/modules/search-service-remote/src/main/java/org/opencastproject/search/remote/SearchServiceRemoteImpl.java
@@ -115,6 +115,31 @@ public class SearchServiceRemoteImpl extends RemoteBase implements SearchService
     throw new SearchException("Unable to remove " + mediaPackageId + " from a remote search service");
   }
 
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see org.opencastproject.search.api.SearchService#deleteSeries(java.lang.String)
+   */
+  @Override
+  public Job deleteSeries(String seriesId) throws SearchException {
+    HttpDelete del = new HttpDelete("/deleteSeries/" + seriesId);
+    HttpResponse response = getResponse(del);
+    try {
+      if (response != null) {
+        Job job = JobParser.parseJob(response.getEntity().getContent());
+        logger.info("Removing Series '{}' from a remote search service", seriesId);
+        return job;
+      }
+    } catch (Exception e) {
+      throw new SearchException("Unable to remove " + seriesId + " from a remote search service", e);
+    } finally {
+      closeConnection(response);
+    }
+
+    throw new SearchException("Unable to remove " + seriesId + " from a remote search service");
+  }
+
   /**
    * {@inheritDoc}
    *


### PR DESCRIPTION
This commit implements the deletion option of a series for the search service.

If all episodes of a series a retracted from the search service,
the empty series still appears at the search service.

Therse was no way to delete a Series from the searchservice.

