### PR TITLE
Single image video fix

### DIFF
--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/FFmpegAnalyzer.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/FFmpegAnalyzer.java
@@ -344,10 +344,18 @@ public class FFmpegAnalyzer implements MediaAnalyzer {
   private float parseFloat(String val) {
     if (val.contains("/")) {
       String[] v = val.split("/");
-      return Float.parseFloat(v[0]) / Float.parseFloat(v[1]);
+      if (Float.parseFloat(v[1]) == 0) {
+        return 0;
+      } else {
+        return Float.parseFloat(v[0]) / Float.parseFloat(v[1]);
+      }
     } else if (val.contains(":")) {
       String[] v = val.split(":");
-      return Float.parseFloat(v[0]) / Float.parseFloat(v[1]);
+      if (Float.parseFloat(v[1]) == 0) {
+        return 0;
+      } else {
+        return Float.parseFloat(v[0]) / Float.parseFloat(v[1]);
+      }
     } else {
       return Float.parseFloat(val);
     }


### PR DESCRIPTION
If one uploads an MP3 file with a picture integrated in the metadata, the picture will be detected as video stream with a frame count of one and a frame rate of zero. This causes an error in the FFmpegAnalyzer. 
Also it is not possible to generate an image at a certain position of the video track, as the only image is available at the beginning of the track. Thus if the video contains only one frame, it is not useful to search for an image at another position. 
