### PR TITLE
Add option to enable ExecuteMany WOH to set workflow properties

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/execute-many-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/execute-many-woh.md
@@ -1,8 +1,9 @@
 Execute Many Workflow Operation
 -------------------------------
 
-This operation handler filters a set of MediaPackageElements that match certain input conditions and runs a command on
-each of them.
+This operation handler filters a set of MediaPackageElements that match certain input conditions
+and runs a command on each of them. The command may be used to create a new mediapackage element,
+or to add configuration properties to the running workflow.
 
 To run a command only once for the whole mediapackage, use the [Execute Once](execute-once-woh.md) operation.
 
@@ -19,6 +20,7 @@ in [Execute Service: Parameter Substitution](../modules/execute.md#parameter-sub
 |exec              |qtfaststart           |The command to run |Yes      |
 |params            |-f -t 15 #{in} #{out} |The arguments to the command. This string allows some placeholders for input and output MediaPackage elements (see Parameter Substitution) |Yes|
 |load              |1.5                   |A floating point estimate of the load imposed on the node by this job|No|
+|set-workflow-properties|true / false     |Import workflow properties from the output file|No|
 |source-flavor     |presentation/source   |Run the command for any MediaPackage elements with this flavor. Elements must also match the source-tags condition, if present |No|
 |source-tag        |rss, trim, -engage    |Run the command for any MediaPackage elements with one of these (comma- separated) tags. If any of them starts with '-', MediaPackage elements containing this tag will be excluded. Elements must also match the source-flavor condition, if present|No|
 |output-filename   |outfile.mp4           |Specifies the name of the file created by the command (if any), without path information. Used as the last part of the #{out} parameter|No|
@@ -26,7 +28,18 @@ in [Execute Service: Parameter Substitution](../modules/execute.md#parameter-sub
 |target-flavor     |presentation/processed|Specifies the flavor of the resulting Mediapackage element created by the command |Required if output- filename is present|
 |target-tags       |execservice, -trim    |List of tags that will be applied to the resulting Mediapackage element. Tags starting with "-" will be deleted from the element instead, if present. The resulting element may be the same as the input element |No|
 
+If `set-workflow-properties` is true, the command should write a plain-text properties file to the
+location specified by #{out} in the key-value format supported by the [Java Properties](http://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-)
+class, for example:
+
+````
+key1=value1
+key2=value2
+````
+
 ### Operation Example
+
+Run a command which creates a new version of a track:
 
 ````
 <operation
@@ -47,3 +60,23 @@ in [Execute Service: Parameter Substitution](../modules/execute.md#parameter-sub
 </operation>
 ````
 
+Run a command which inspects a track and adds new configuration properties to the running workflow,
+leaving the mediapackage unchanged:
+
+
+````
+<operation
+  id="execute-many"
+  fail-on-error="true"
+  exception-handler-workflow="error"
+  description="Inspect track and update workflow properties">
+  <configurations>
+    <configuration key="exec">/usr/local/bin/oc-track-inspect.sh</configuration>
+    <configuration key="source-flavor">presenter/source</configuration>
+    <configuration key="params">#{in} #{out}</configuration>
+    <configuration key="set-workflow-properties">true</configuration>
+    <configuration key="output-filename">wf.properties</configuration>
+    <configuration key="expected-type">Attachment</configuration>
+  </configurations>
+</operation>
+````


### PR DESCRIPTION
This adds the ability for the ExecuteMany workflow operation handler to set workflow properties as output rather than creating a new track.

This is similar to the support for workflow properties for ExecuteOnce introduced in MH-12286.
