### PR TITLE
Change bibliographicdate if technicaldate is changed.

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -169,9 +169,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -629,39 +627,6 @@ public abstract class AbstractEventEndpoint {
     if (!start.isNone() || !end.isNone() || !agentId.isNone() || !agentConfiguration.isNone()) {
       getSchedulerService()
         .updateEvent(event.getIdentifier(), start, end, agentId, Opt.none(), Opt.none(), Opt.none(), agentConfiguration);
-      // We want to keep the bibliographic meta data in sync
-      updateBibliographicMetadata(event, agentId, start, end);
-    }
-  }
-
-  private void updateBibliographicMetadata(Event event, Opt<String> agentId, Opt<Date> start, Opt<Date> end)
-    throws IndexServiceException, SearchIndexException, NotFoundException, UnauthorizedException {
-    final MetadataList metadataList = getIndexService().getMetadataListWithAllEventCatalogUIAdapters();
-    final Opt<MetadataCollection> optMetadataByAdapter = metadataList
-      .getMetadataByAdapter(getIndexService().getCommonEventCatalogUIAdapter());
-    if (optMetadataByAdapter.isSome()) {
-      final MetadataCollection collection = optMetadataByAdapter.get();
-      if (start.isSome() && collection.getOutputFields().containsKey("startDate")) {
-        final Opt<String> pattern = collection.getOutputFields().get("startDate").getPattern();
-        if (pattern.isSome()) {
-          final SimpleDateFormat sdf = new SimpleDateFormat(pattern.get());
-          sdf.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")));
-          final MetadataField.Type type = collection.getOutputFields().get("startDate").getType();
-          collection.updateStringField(collection.getOutputFields().get("startDate"), sdf.format(start.get()));
-          collection.getOutputFields().get("startDate").setPattern(pattern);
-          collection.getOutputFields().get("startDate").setType(type);
-        }
-      }
-      if (start.isSome() && end.isSome() && collection.getOutputFields().containsKey("duration")) {
-        final MetadataField.Type type = collection.getOutputFields().get("duration").getType();
-        final long duration = end.get().getTime() - start.get().getTime();
-        collection.updateStringField(collection.getOutputFields().get("duration"), duration + "");
-        collection.getOutputFields().get("duration").setType(type);
-      }
-      if (agentId.isSome() && collection.getOutputFields().containsKey("location")) {
-        collection.updateStringField(collection.getOutputFields().get("location"), agentId.get());
-      }
-      getIndexService().updateEventMetadata(event.getIdentifier(), metadataList, getIndex());
     }
   }
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -687,6 +687,8 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       if (dublinCoreOpt.isNone())
         throw new NotFoundException("No dublincore found while updating event " + mpId);
 
+
+
       final ExtendedEventDto extendedEventDto = optExtEvent.get();
       Date start = extendedEventDto.getStartDate();
       Date end = extendedEventDto.getEndDate();
@@ -741,6 +743,19 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       Opt<AccessControlList> acl = Opt.none();
       Opt<DublinCoreCatalog> dublinCore = Opt.none();
       Opt<AccessControlList> aclOld = loadEpisodeAclFromAsset(record.getSnapshot().get());
+
+      //update metadata for dublincore
+      if (startDateTime.isSome() && endDateTime.isSome()) {
+        DublinCoreValue eventTime = EncodingSchemeUtils
+                .encodePeriod(new DCMIPeriod(startDateTime.get(), endDateTime.get()), Precision.Second);
+        dublinCoreOpt.get().set(DublinCore.PROPERTY_TEMPORAL, eventTime);
+        if (captureAgentId.isSome()) {
+          dublinCoreOpt.get().set(DublinCore.PROPERTY_SPATIAL, captureAgentId.get());
+        }
+        dublinCore = dublinCoreOpt;
+        dublinCoreChanged = true;
+      }
+
       for (MediaPackage mpToUpdate : mediaPackage) {
         // Check for series change
         if (ne(record.getSnapshot().get().getMediaPackage().getSeries(), mpToUpdate.getSeries())) {


### PR DESCRIPTION
Since 7.3 at the metadata Tab the Biographical date is shown.
This date is only changed when you edit the technical Date out of the Adminui(Scheduling-Tab).
But not within the Rest-APIs.

This Patch fixes this behaviour. The bibliographical date is always updated if the scheduling technical date is edited through the scheduler-service.
