### PR TITLE
Remove default storage_id setting from asset Manager

### DIFF
--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -360,7 +360,7 @@ CREATE TABLE oc_assets_snapshot (
   organization_id VARCHAR(128) NOT NULL,
   owner VARCHAR(256) NOT NULL,
   version BIGINT NOT NULL,
-  storage_id VARCHAR(256) NOT NULL DEFAULT 'local-filesystem',
+  storage_id VARCHAR(256) NOT NULL,
   --
   CONSTRAINT UNQ_oc_assets_snapshot UNIQUE (mediapackage_id, version),
   CONSTRAINT FK_oc_assets_snapshot_organization FOREIGN KEY (organization_id) REFERENCES oc_organization (id),
@@ -378,7 +378,7 @@ CREATE TABLE oc_assets_asset (
   mediapackage_element_id VARCHAR(128) NOT NULL,
   mime_type VARCHAR(64),
   size BIGINT NOT NULL,
-  storage_id VARCHAR(256) NOT NULL DEFAULT 'local-filesystem',
+  storage_id VARCHAR(256) NOT NULL,
   --
   CONSTRAINT FK_oc_assets_asset_snapshot_id FOREIGN KEY (snapshot_id) REFERENCES oc_assets_snapshot (id) ON DELETE CASCADE,
   INDEX IX_oc_assets_asset_checksum (checksum),


### PR DESCRIPTION
Setting the default with JPA proved to be difficult/impossible to do in a
cross platform way, and since the AM makes assumptions regarding everything
being in local-storage by default anyway, I'm removing the default from the
DDL.

Fixes #1244

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
