### PR TITLE
MH-13510 Fix conflict detection for non-admin users and for multiple events

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -287,6 +287,9 @@ public abstract class AbstractEventEndpoint {
   /** The default workflow identifier, if one is configured */
   protected String defaultWorkflowDefinionId = null;
 
+  /** The system user name (default set here for unit tests) */
+  private String systemUserName = "opencast_system_account";
+
   /**
    * Activates REST service.
    *
@@ -305,8 +308,9 @@ public abstract class AbstractEventEndpoint {
 
       if (StringUtils.isNotBlank(ccDefaultWorkflowDefinionId))
         this.defaultWorkflowDefinionId = ccDefaultWorkflowDefinionId;
-    }
 
+      systemUserName = SecurityUtil.getSystemUserName(cc);
+    }
   }
 
   /* As the list of event ids can grow large, we use a POST request to avoid problems with too large query strings */
@@ -2051,19 +2055,29 @@ public abstract class AbstractEventEndpoint {
 
   private List<JValue> convertToConflictObjects(final String eventId, final List<MediaPackage> events) throws SearchIndexException {
     final List<JValue> eventsJSON = new ArrayList<>();
-    for (final MediaPackage event : events) {
-      final Opt<Event> eventOpt = getIndexService().getEvent(event.getIdentifier().compact(), getIndex());
-      if (eventOpt.isSome()) {
-        final Event e = eventOpt.get();
-        if (StringUtils.isNotEmpty(eventId) && eventId.equals(e.getIdentifier())) {
-          continue;
+    final Organization organization = getSecurityService().getOrganization();
+    final User user = SecurityUtil.createSystemUser(systemUserName, organization);
+
+    SecurityUtil.runAs(getSecurityService(), organization, user, () -> {
+      try {
+        for (final MediaPackage event : events) {
+          final Opt<Event> eventOpt = getIndexService().getEvent(event.getIdentifier().compact(), getIndex());
+          if (eventOpt.isSome()) {
+            final Event e = eventOpt.get();
+            if (StringUtils.isNotEmpty(eventId) && eventId.equals(e.getIdentifier())) {
+              continue;
+            }
+            eventsJSON.add(convertEventToConflictingObject(e.getTechnicalStartTime(), e.getTechnicalEndTime(), e.getTitle()));
+          } else {
+            logger.warn("Index out of sync! Conflicting event catalog {} not found on event index!",
+              event.getIdentifier().compact());
+          }
         }
-        eventsJSON.add(convertEventToConflictingObject(e.getTechnicalStartTime(), e.getTechnicalEndTime(), e.getTitle()));
-      } else {
-        logger.warn("Index out of sync! Conflicting event catalog {} not found on event index!",
-          event.getIdentifier().compact());
+      } catch (Exception e) {
+         logger.error("Failed to get conflicting events", e);
       }
-    }
+    });
+
     return eventsJSON;
   }
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1081,7 +1081,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   public List<MediaPackage> findConflictingEvents(String captureDeviceID, Date startDate, Date endDate)
       throws SchedulerException {
     try {
-      final Organization organization = securityService.getOrganization();
+      final Organization organization = new DefaultOrganization();
       final User user = SecurityUtil.createSystemUser(systemUserName, organization);
       List<MediaPackage> conflictingEvents = new ArrayList();
 

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1088,7 +1088,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       SecurityUtil.runAs(securityService, organization, user, () -> {
         try {
           conflictingEvents.addAll(persistence.getEvents(captureDeviceID, startDate, endDate, Util.EVENT_MINIMUM_SEPARATION_MILLISECONDS)
-            .parallelStream().map(this::getEventMediaPackage).collect(Collectors.toList()));
+            .stream().map(this::getEventMediaPackage).collect(Collectors.toList()));
         } catch (SchedulerServiceDatabaseException e) {
           logger.error("Failed to get conflicting events", e);
         }


### PR DESCRIPTION
The scheduler service and Admin UI endpoints need to be able to get conflicting
events so as to return conflict information, even if the user attempting to
schedule a conflicting event does not have access to the events conflicted with.

https://opencast.jira.com/browse/MH-13510 for steps to reproduce.
