### PR TITLE
Documentation: Metadata fixes

### DIFF
--- a/docs/guides/admin/docs/configuration/metadata.md
+++ b/docs/guides/admin/docs/configuration/metadata.md
@@ -1,18 +1,18 @@
 Overview
 ========================
 
-In Opencast, metadata is stored in so-called metadata catalogs. For each event or series, an arbiraty number of
-such configurable metadata catalog can be managed. A common set of metadata has been standarized to form a
+In Opencast, metadata is stored in so-called metadata catalogs. For each event or series, an arbitrary number of
+such configurable metadata catalogs can be managed. A common set of metadata has been standardized to form a
 common basis (standard metadata), whereas administrators can configure Opencast to support other metadata sets
 (extended metadata).
 
-This document provides an overview over Opencast's metadata capabilities and its configuration.
+This document provides an overview of Opencast's metadata capabilities and its configuration.
 
 ## Standard Metadata
 
-For both events and series, a common set of metadata is supported by Opencast out-of-the box. Since metadata catalogs
+For both events and series, a common set of metadata is supported by Opencast out of the box. Since metadata catalogs
 are referenced from within media package, flavors can be used to identify a specific metadata catalog. The following
-flavors are treated by Opencast as standard metadata in means of Opencast expects them to be present:
+flavors are treated by Opencast as standard metadata, meaning Opencast expects them to be present:
 
 * `dublincore/episode` holds the standard metadata of an event
 * `dublincore/series` holds the standard metadata of a series
@@ -21,13 +21,13 @@ Opencast assumes specific metadata fields to be present in the standard metadata
 filters, table columns and search indices.
 
 To adjust the standard metadata to your specific needs, you can configure them in
-`/opt/opencast/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg` and
-`/opt/opencast/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-series-common.cfg`.
+`etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg` and
+`etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-series-common.cfg`.
 
-For details on how to configure metadata catalogs, see section Configuring Metadata Catalogs.
+For details on how to configure metadata catalogs, see the section Metadata Catalog Configuration.
 
-As mentioned above, however, Opencast expects specific metafields to be present to work correctly. In case you want
-to map metadata specific to your use case, you might consider to use the extended metadata capbilities of Opencast
+As mentioned above, however, Opencast expects specific metadata fields to be present to work correctly. In case you want
+to map metadata specific to your use case, you might consider using the extended metadata capbilities of Opencast
 described in the next section.
 
 ## Extended Metadata
@@ -35,9 +35,9 @@ described in the next section.
 For both events and series, Opencast support an arbitrary number of customized metadata catalogs.
 
 To add extended metadata catalogs, create a configuration file with a valid filename of the form
-`org.opencastproject.ui.metadata.CatalogUIAdapterFactory-<name>.cfg` in `/opt/opencast/etc.` on the admin node.
+`org.opencastproject.ui.metadata.CatalogUIAdapterFactory-<name>.cfg` in `etc/`. on the admin node.
 
-For details on how to configure metadata catalogs, see section Configuring Metadata Catalogs.
+For details on how to configure metadata catalogs, see the section Metadata Catalog Configuration.
 
 Limitations:
 
@@ -84,22 +84,22 @@ output id to make it easy to find.
 
 |Configuration key |Example |Description |
 |------------------|--------|------------|
-|property.{field-id}.inputID\* |title |The id used to identify this property in the catalog e.g. The name of the property inside the xml file of a Dublin Core catalog. If an outputID is not specified then this inputID is used for both the catalog and the front end id. This value is mandatory.|
+|property.{field-id}.inputID¹ |title |The id used to identify this property in the catalog e.g. The name of the property inside the xml file of a Dublin Core catalog. If an outputID is not specified then this inputID is used for both the catalog and the front end id. This value is mandatory.|
 |property.{field-id}.outputID |title |The id used inside the json for this property. If this value is missing then the inputID will be used instead.|
 |property.{field-id}.namespace |http://purl.org/dc/terms/ |The URL that represents the namespace for this property. Different properties in the same catalog can have different namespaces.|
-|property.{field-id}.label |"EVENTS.EVENTS.DETAILS.METADATA.TITLE" or "Event Title" |The label to show for this property in the UI. If there is a i18n support for a label that should be the value used so that it will be translated, if you don't mind it being locked to one translation just put that single value in.|
-|property.{field-id}.type |text |The type of the metadata field. |
-|property.{field-id}.pattern |yyyy-MM-dd |Applies to date and time types for now. It is used to format their values using the java DateTimeFormatter values\**|
+|property.{field-id}.label¹ |"EVENTS.EVENTS.DETAILS.METADATA.TITLE" or "Event Title" |The label to show for this property in the UI. If there is a i18n support for a label that should be the value used so that it will be translated, if you don't mind it being locked to one translation just put that single value in.|
+|property.{field-id}.type¹ |text |The type of the metadata field. |
+|property.{field-id}.pattern |yyyy-MM-dd |Applies to date and time types for now. It is used to format their values using the java DateTimeFormatter values²|
 |property.{field-id}.delimiter |;|For mixed_text and iterable_text type fields, a string at which inputs into the corresponding fields are split into individual values for easier bulk entry of lists. The default is no delimiter, in which case no splitting takes place.|
-|property.{field-id}.readOnly |false |If the property can be edited in the UI or if it should only be displayed. |
-|property.{field-id}.required |true |If the property has to have a value before the metadata can be saved (the UI's save button will be disabled until all of the required fields are entered)|
+|property.{field-id}.readOnly¹ |false |If the property can be edited in the UI or if it should only be displayed. |
+|property.{field-id}.required¹ |true |If the property has to have a value before the metadata can be saved (the UI's save button will be disabled until all of the required fields are entered)|
 |property.{field-id}.collectionID |USERS |The id of the list provider that will be used to validate the input in the backend. So for example entering a username that doesn't exist will throw an error in this case.|
 |property.{field-id}.listprovider |USERS  |The id of the list provider that will be used as a drop down option for that field. So for example using the USERS list provider means that in the front end the user will be able to choose the field value from the list of users in Opencast.|
 |property.{field-id}.order |3 |Defines the order of properties where this property should be oriented in the UI i.e. 0 means the property should come first, 1 means it should come second etc. Giving two properties the same number will cause them to be next to one another but doesn't guarantee one above or below the other.|
 
-\* Mandatory field attribute
+¹ Mandatory field attribute
 
-\** See https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html
+² See [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html)
 
 **Field types**
 


### PR DESCRIPTION
I was reading the metadata section of the Admin Guide and noticed that the section "Configuring Metadata Catalogs", although mentioned twice, didn't exist.
I know it might be a small thing, but it was confusing for me. The only section beginning with "Configuring" is called "Configuring the events publisher metadata field", which I guess is the wrong one?

I also fixed some typos, changed the rather confusing asterisks (my first thought were that those were globs/regex patterns) and replaced `/opt/opencast/etc` by `/etc` (the latter simply because later in the docs, just `/etc` is mentioned, without `/opt` prefix, it should at least be consistent).

Also, there are lots more fields that are technically mandatory, like `readOnly`. If you omit them, you'll get a `NullPointerException` as indicated by IntelliJs "unboxing might trigger NPE". Now, we could fix the code for that, and I intend to in the course of the "Metadata Crowdfunding". But since it's not completely clear how (or when) it'll be fixed, at least the doucmentation should be accurate.