### PR TITLE
Drop Unused Tables

### DIFF
--- a/docs/scripts/ddl/mysql5.sql
+++ b/docs/scripts/ddl/mysql5.sql
@@ -183,26 +183,6 @@ CREATE TABLE oc_job_argument (
 
 CREATE INDEX IX_oc_job_argument_id ON oc_job_argument (id);
 
-CREATE TABLE oc_job_context (
-  id BIGINT NOT NULL,
-  name VARCHAR(255) NOT NULL,
-  value TEXT(65535),
-  CONSTRAINT UNQ_oc_job_context UNIQUE (id, name),
-  CONSTRAINT FK_oc_job_context_id FOREIGN KEY (id) REFERENCES oc_job (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX IX_oc_job_context_id ON oc_job_context (id);
-
-CREATE TABLE oc_job_oc_service_registration (
-  Job_id BIGINT NOT NULL,
-  servicesRegistration_id BIGINT NOT NULL,
-  PRIMARY KEY (Job_id, servicesRegistration_id),
-  CONSTRAINT FK_oc_job_oc_service_registration_Job_id FOREIGN KEY (Job_id) REFERENCES oc_job (id) ON DELETE CASCADE,
-  CONSTRAINT FK_oc_job_oc_service_registration_servicesRegistration_id FOREIGN KEY (servicesRegistration_id) REFERENCES oc_service_registration (id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-CREATE INDEX IX_oc_job_oc_service_registration_servicesRegistration_id ON oc_job_oc_service_registration (servicesRegistration_id);
-
 CREATE TABLE oc_incident (
   id BIGINT NOT NULL,
   jobid BIGINT,

--- a/docs/upgrade/8_to_9/mysql5.sql
+++ b/docs/upgrade/8_to_9/mysql5.sql
@@ -1,0 +1,3 @@
+-- Drop unused tables
+drop table oc_job_oc_service_registration;
+drop table oc_job_context;


### PR DESCRIPTION
This patch drops a few database tables which are not and may never have
been in active use:

- `oc_job_context`
- `oc_job_oc_service_registration`

The tables are not referenced in our code in any way and they are empty
on several production systems I checked.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
