### PR TITLE
Make JPA Generated Database Match Script Generated Database

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/persistence/UserSettingDto.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/usersettings/persistence/UserSettingDto.java
@@ -29,6 +29,8 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Lob;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
@@ -36,13 +38,16 @@ import javax.persistence.UniqueConstraint;
 
 /** Entity object for user settings. */
 @Entity(name = "UserSettings")
-@Table(name = "oc_user_settings", uniqueConstraints = { @UniqueConstraint(columnNames = { "id"}) })
+@Table(name = "oc_user_settings", indexes = {
+    @Index(name = "IX_oc_user_setting_organization", columnList = "organization")
+  }, uniqueConstraints = {
+    @UniqueConstraint(columnNames = { "username", "organization" }) })
 @NamedQueries({
-        @NamedQuery(name = "UserSettings.countByUserName", query = "SELECT COUNT(us) FROM UserSettings us WHERE us.username = :username AND us.organization = :org"),
-        @NamedQuery(name = "UserSettings.findByIdAndUsernameAndOrg", query = "SELECT us FROM UserSettings us WHERE us.id = :id AND us.username = :username AND us.organization = :org"),
-        @NamedQuery(name = "UserSettings.findByUserName", query = "SELECT us FROM UserSettings us WHERE us.username = :username AND us.organization = :org"),
-        @NamedQuery(name = "UserSettings.findByKey", query = "SELECT us FROM UserSettings us WHERE us.key = :key AND us.username = :username AND us.organization = :org"),
-        @NamedQuery(name = "UserSettings.clear", query = "DELETE FROM UserSettings us WHERE us.organization = :org") })
+  @NamedQuery(name = "UserSettings.countByUserName", query = "SELECT COUNT(us) FROM UserSettings us WHERE us.username = :username AND us.organization = :org"),
+  @NamedQuery(name = "UserSettings.findByIdAndUsernameAndOrg", query = "SELECT us FROM UserSettings us WHERE us.id = :id AND us.username = :username AND us.organization = :org"),
+  @NamedQuery(name = "UserSettings.findByUserName", query = "SELECT us FROM UserSettings us WHERE us.username = :username AND us.organization = :org"),
+  @NamedQuery(name = "UserSettings.findByKey", query = "SELECT us FROM UserSettings us WHERE us.key = :key AND us.username = :username AND us.organization = :org"),
+  @NamedQuery(name = "UserSettings.clear", query = "DELETE FROM UserSettings us WHERE us.organization = :org") })
 public class UserSettingDto {
   @Id
   @GeneratedValue
@@ -52,10 +57,11 @@ public class UserSettingDto {
   @Column(name = "setting_key", nullable = false)
   private String key;
 
+  @Lob
   @Column(name = "setting_value", nullable = false)
   private String value;
 
-  @Column(name = "username", nullable = false)
+  @Column(name = "username", nullable = false, length = 128)
   private String username;
 
   @Column(name = "organization", nullable = false)

--- a/modules/annotation-impl/src/main/java/org/opencastproject/annotation/impl/AnnotationImpl.java
+++ b/modules/annotation-impl/src/main/java/org/opencastproject/annotation/impl/AnnotationImpl.java
@@ -33,6 +33,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Lob;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -50,24 +51,32 @@ import javax.xml.bind.annotation.XmlType;
  */
 @Entity(name = "Annotation")
 @Access(AccessType.FIELD)
-@Table(name = "oc_annotation")
+@Table(name = "oc_annotation", indexes = {
+    @Index(name = "IX_oc_annotation_created", columnList = "created"),
+    @Index(name = "IX_oc_annotation_inpoint", columnList = "inpoint"),
+    @Index(name = "IX_oc_annotation_outpoint", columnList = "outpoint"),
+    @Index(name = "IX_oc_annotation_mediapackage", columnList = "mediapackage"),
+    @Index(name = "IX_oc_annotation_private", columnList = "private"),
+    @Index(name = "IX_oc_annotation_user", columnList = "user_id"),
+    @Index(name = "IX_oc_annotation_session", columnList = "session"),
+    @Index(name = "IX_oc_annotation_type", columnList = "type")
+})
 @NamedQueries({
-
-        @NamedQuery(name = "findAnnotations", query = "SELECT a FROM Annotation a WHERE (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findAnnotationsByMediapackageId", query = "SELECT a FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findAnnotationsByType", query = "SELECT a FROM Annotation a WHERE a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findAnnotationsByTypeAndMediapackageId", query = "SELECT a FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findAnnotationsByTypeAndMediapackageIdOrderByOutpointDESC", query = "SELECT a FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE)) ORDER BY a.outpoint DESC"),
-        @NamedQuery(name = "findAnnotationsByIntervall", query = "SELECT a FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findAnnotationsByTypeAndIntervall", query = "SELECT a FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findTotal", query = "SELECT COUNT(a) FROM Annotation a WHERE (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findTotalByMediapackageId", query = "SELECT COUNT(a) FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findTotalByType", query = "SELECT COUNT(a) FROM Annotation a WHERE a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findTotalByTypeAndMediapackageId", query = "SELECT COUNT(a) FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findTotalByIntervall", query = "SELECT COUNT(a) FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findDistinctEpisodeIdTotalByIntervall", query = "SELECT COUNT(distinct a.mediapackageId) FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "findTotalByTypeAndIntervall", query = "SELECT COUNT(a) FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
-        @NamedQuery(name = "updateAnnotation", query = "UPDATE Annotation a SET a.value = :value WHERE a.annotationId = :annotationId") })
+    @NamedQuery(name = "findAnnotations", query = "SELECT a FROM Annotation a WHERE (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findAnnotationsByMediapackageId", query = "SELECT a FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findAnnotationsByType", query = "SELECT a FROM Annotation a WHERE a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findAnnotationsByTypeAndMediapackageId", query = "SELECT a FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findAnnotationsByTypeAndMediapackageIdOrderByOutpointDESC", query = "SELECT a FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE)) ORDER BY a.outpoint DESC"),
+    @NamedQuery(name = "findAnnotationsByIntervall", query = "SELECT a FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findAnnotationsByTypeAndIntervall", query = "SELECT a FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findTotal", query = "SELECT COUNT(a) FROM Annotation a WHERE (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findTotalByMediapackageId", query = "SELECT COUNT(a) FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findTotalByType", query = "SELECT COUNT(a) FROM Annotation a WHERE a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findTotalByTypeAndMediapackageId", query = "SELECT COUNT(a) FROM Annotation a WHERE a.mediapackageId = :mediapackageId AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findTotalByIntervall", query = "SELECT COUNT(a) FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findDistinctEpisodeIdTotalByIntervall", query = "SELECT COUNT(distinct a.mediapackageId) FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "findTotalByTypeAndIntervall", query = "SELECT COUNT(a) FROM Annotation a WHERE :begin <= a.created AND a.created <= :end AND a.type = :type AND (a.privateAnnotation = FALSE OR (a.userId = :userId AND a.privateAnnotation = TRUE))"),
+    @NamedQuery(name = "updateAnnotation", query = "UPDATE Annotation a SET a.value = :value WHERE a.annotationId = :annotationId") })
 @XmlType(name = "annotation", namespace = "http://annotation.opencastproject.org")
 @XmlRootElement(name = "annotation", namespace = "http://annotation.opencastproject.org")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -83,11 +92,11 @@ public class AnnotationImpl implements Annotation {
   @XmlElement(name = "mediapackageId")
   private String mediapackageId;
 
-  @Column(name = "user_id", length = 255)
+  @Column(name = "user_id")
   @XmlElement(name = "userId")
   private String userId;
 
-  @Column(name = "session", length = 50)
+  @Column(name = "session", length = 128)
   @XmlElement(name = "sessionId")
   private String sessionId;
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/AssetDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/AssetDto.java
@@ -31,6 +31,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
@@ -38,7 +39,9 @@ import javax.persistence.TableGenerator;
 
 /** JPA DTO modeling the asset database table. */
 @Entity(name = "Asset")
-@Table(name = "oc_assets_asset")
+@Table(name = "oc_assets_asset", indexes = {
+    @Index(name = "IX_oc_assets_asset_checksum", columnList = ("checksum")),
+    @Index(name = "IX_oc_assets_asset_mediapackage_element_id", columnList = ("mediapackage_element_id")) })
 // Maintain own generator to support database migrations from Archive to AssetManager
 // The generator's initial value has to be set after the data migration.
 // Otherwise duplicate key errors will most likely happen.
@@ -68,7 +71,7 @@ public class AssetDto {
   @Column(name = "size", nullable = false)
   private Long size;
 
-  @Column(name = "storage_id", nullable = false)
+  @Column(name = "storage_id", nullable = false, length = 256)
   private String storageId;
 
   /**

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/PropertyDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/PropertyDto.java
@@ -41,6 +41,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
@@ -49,7 +50,14 @@ import javax.persistence.TemporalType;
 import javax.persistence.TypedQuery;
 
 @Entity(name = "Property")
-@Table(name = "oc_assets_properties")
+@Table(name = "oc_assets_properties", indexes = {
+    @Index(name = "IX_oc_assets_properties_val_date", columnList = ("val_date")),
+    @Index(name = "IX_oc_assets_properties_val_long", columnList = ("val_long")),
+    @Index(name = "IX_oc_assets_properties_val_string", columnList = ("val_string")),
+    @Index(name = "IX_oc_assets_properties_val_bool", columnList = ("val_bool")),
+    @Index(name = "IX_oc_assets_properties_mediapackage_id", columnList = ("mediapackage_id")),
+    @Index(name = "IX_oc_assets_properties_namespace", columnList = ("namespace")),
+    @Index(name = "IX_oc_assets_properties_property_name", columnList = ("property_name")) })
 @NamedQueries({
     @NamedQuery(name = "Property.selectByMediaPackageAndNamespace", query = "select p from Property p where "
             + "p.mediaPackageId = :mediaPackageId and p.namespace = :namespace"),

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SnapshotDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SnapshotDto.java
@@ -46,6 +46,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Lob;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -59,8 +60,14 @@ import javax.persistence.UniqueConstraint;
 
 /** JPA DTO. */
 @Entity(name = "Snapshot")
-@Table(name = "oc_assets_snapshot",
-        uniqueConstraints = {@UniqueConstraint(columnNames = {"mediapackage_id", "version"})})
+@Table(name = "oc_assets_snapshot", indexes = {
+    @Index(name = "IX_oc_assets_snapshot_archival_date", columnList = ("archival_date")),
+    @Index(name = "IX_oc_assets_snapshot_mediapackage_id", columnList = ("mediapackage_id")),
+    @Index(name = "IX_oc_assets_snapshot_organization_id", columnList = ("organization_id")),
+    @Index(name = "IX_oc_assets_snapshot_owner", columnList = ("owner")),
+    @Index(name = "IX_oc_assets_snapshot_series", columnList = ("series_id, version"))
+  }, uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"mediapackage_id", "version"}) })
 @NamedQueries({
         @NamedQuery(name = "Snapshot.countByMediaPackage", query = "select count(s) from Snapshot s "
                 + "where s.mediaPackageId = :mediaPackageId"),
@@ -94,13 +101,13 @@ public class SnapshotDto {
   @Temporal(TemporalType.TIMESTAMP)
   private Date archivalDate;
 
-  @Column(name = "availability", nullable = false)
+  @Column(name = "availability", nullable = false, length = 32)
   private String availability;
 
-  @Column(name = "storage_id", nullable = false)
+  @Column(name = "storage_id", nullable = false, length = 256)
   private String storageId;
 
-  @Column(name = "owner", nullable = false)
+  @Column(name = "owner", nullable = false, length = 256)
   private String owner;
 
   @Lob

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/persistence/AwsAssetMappingDto.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/persistence/AwsAssetMappingDto.java
@@ -40,18 +40,22 @@ import javax.persistence.Query;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.UniqueConstraint;
 import javax.xml.bind.annotation.XmlAttribute;
 
 @Entity(name = "AwsAssetMapping")
-@Table(name = "oc_aws_asset_mapping")
+@Table(name = "oc_aws_asset_mapping", uniqueConstraints = @UniqueConstraint(
+    name = "UNQ_aws_archive_mapping_0",
+    columnNames = {"organization", "mediapackage", "mediapackage_element", "version"}
+))
 @NamedQueries({
-        // These exclude deleted mappings!
-        @NamedQuery(name = "AwsAssetMapping.findActiveMapping", query = "SELECT m FROM AwsAssetMapping m WHERE m.organizationId = :organizationId AND m.mediaPackageId = :mediaPackageId AND m.mediaPackageElementId = :mediaPackageElementId AND m.version = :version AND m.deletionDate IS NULL"),
-        @NamedQuery(name = "AwsAssetMapping.findAllActiveByObjectKey", query = "SELECT m FROM AwsAssetMapping m WHERE m.objectKey = :objectKey AND m.deletionDate IS NULL"),
-        @NamedQuery(name = "AwsAssetMapping.findAllActiveByMediaPackage", query = "SELECT m FROM AwsAssetMapping m WHERE m.organizationId = :organizationId AND m.mediaPackageId = :mediaPackageId  AND m.deletionDate IS NULL"),
-        @NamedQuery(name = "AwsAssetMapping.findAllActiveByMediaPackageAndVersion", query = "SELECT m FROM AwsAssetMapping m WHERE m.organizationId = :organizationId AND m.mediaPackageId = :mediaPackageId AND m.version = :version AND m.deletionDate IS NULL"),
-        // This is to be used when restoring/re-ingesting mps so includes deleted mapings!
-        @NamedQuery(name = "AwsAssetMapping.findAllByMediaPackage", query = "SELECT m FROM AwsAssetMapping m WHERE m.mediaPackageId = :mediaPackageId ORDER BY m.version DESC") })
+    // These exclude deleted mappings!
+    @NamedQuery(name = "AwsAssetMapping.findActiveMapping", query = "SELECT m FROM AwsAssetMapping m WHERE m.organizationId = :organizationId AND m.mediaPackageId = :mediaPackageId AND m.mediaPackageElementId = :mediaPackageElementId AND m.version = :version AND m.deletionDate IS NULL"),
+    @NamedQuery(name = "AwsAssetMapping.findAllActiveByObjectKey", query = "SELECT m FROM AwsAssetMapping m WHERE m.objectKey = :objectKey AND m.deletionDate IS NULL"),
+    @NamedQuery(name = "AwsAssetMapping.findAllActiveByMediaPackage", query = "SELECT m FROM AwsAssetMapping m WHERE m.organizationId = :organizationId AND m.mediaPackageId = :mediaPackageId  AND m.deletionDate IS NULL"),
+    @NamedQuery(name = "AwsAssetMapping.findAllActiveByMediaPackageAndVersion", query = "SELECT m FROM AwsAssetMapping m WHERE m.organizationId = :organizationId AND m.mediaPackageId = :mediaPackageId AND m.version = :version AND m.deletionDate IS NULL"),
+    // This is to be used when restoring/re-ingesting mps so includes deleted mapings!
+    @NamedQuery(name = "AwsAssetMapping.findAllByMediaPackage", query = "SELECT m FROM AwsAssetMapping m WHERE m.mediaPackageId = :mediaPackageId ORDER BY m.version DESC") })
 public final class AwsAssetMappingDto {
 
   @Id

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/persistence/ManagedAclEntity.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/persistence/ManagedAclEntity.java
@@ -68,7 +68,7 @@ public final class ManagedAclEntity implements ManagedAcl {
   @Column(name = "pk")
   private Long id;
 
-  @Column(name = "name", nullable = false)
+  @Column(name = "name", nullable = false, length = 128)
   private String name;
 
   @Lob
@@ -79,7 +79,7 @@ public final class ManagedAclEntity implements ManagedAcl {
   @Transient
   private AccessControlList parsedAcl;
 
-  @Column(name = "organization_id", nullable = false)
+  @Column(name = "organization_id", nullable = false, length = 128)
   private String organizationId;
 
   /** JPA constructor */

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/AgentImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/AgentImpl.java
@@ -41,6 +41,7 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.NamedQueries;
@@ -48,6 +49,7 @@ import javax.persistence.NamedQuery;
 import javax.persistence.PostLoad;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import javax.persistence.UniqueConstraint;
 
 /**
  * An in-memory construct to represent the state of a capture agent, and when it was last heard from.
@@ -96,10 +98,15 @@ public class AgentImpl implements Agent {
 
   /** The roles allowed to schedule this agent */
   @ElementCollection
-  @Column(name = "role")
-  @CollectionTable(name = "oc_capture_agent_role", joinColumns = { @JoinColumn(name = "id", referencedColumnName = "id"),
-          @JoinColumn(name = "organization", referencedColumnName = "organization") })
-  protected Set<String> schedulerRoles = new HashSet<String>();
+  @Column(name = "role", nullable = false)
+  @CollectionTable(name = "oc_capture_agent_role", indexes = {
+      @Index(name = "IX_oc_capture_agent_role_pk", columnList = "id, organization")
+    }, uniqueConstraints = {
+      @UniqueConstraint(name = "UNQ_capture_agent_role_id_org_role", columnNames = {"id", "organization", "role"})
+    }, joinColumns = {
+      @JoinColumn(name = "id", referencedColumnName = "id", nullable = false),
+      @JoinColumn(name = "organization", referencedColumnName = "organization", nullable = false) })
+  protected Set<String> schedulerRoles = new HashSet<>();
 
   /**
    * The capabilities the agent has Capabilities are the devices this agent can record from, with a friendly name

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
@@ -50,6 +50,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
@@ -70,7 +71,17 @@ import javax.persistence.Version;
  */
 @Entity(name = "Job")
 @Access(AccessType.FIELD)
-@Table(name = "oc_job")
+@Table(name = "oc_job", indexes = {
+    @Index(name = "IX_oc_job_parent", columnList = ("parent")),
+    @Index(name = "IX_oc_job_root", columnList = ("root")),
+    @Index(name = "IX_oc_job_creator_service", columnList = ("creator_service")),
+    @Index(name = "IX_oc_job_processor_service", columnList = ("processor_service")),
+    @Index(name = "IX_oc_job_status", columnList = ("status")),
+    @Index(name = "IX_oc_job_date_created", columnList = ("date_created")),
+    @Index(name = "IX_oc_job_date_completed", columnList = ("date_completed")),
+    @Index(name = "IX_oc_job_dispatchable", columnList = ("dispatchable")),
+    @Index(name = "IX_oc_job_operation", columnList = ("operation")),
+    @Index(name = "IX_oc_job_statistics", columnList = ("processor_service, status, queue_time, run_time")) })
 @NamedQueries({
         @NamedQuery(name = "Job", query = "SELECT j FROM Job j "
                 + "where j.status = :status and j.creatorServiceRegistration.serviceType = :serviceType "
@@ -146,7 +157,6 @@ public class JpaJob {
   @Column(name = "creator", nullable = false, length = 65535)
   private String creator;
 
-  @Lob
   @Column(name = "organization", nullable = false, length = 128)
   private String organization;
 
@@ -157,15 +167,15 @@ public class JpaJob {
   @Column(name = "status")
   private int status;
 
-  @Lob
-  @Column(name = "operation", length = 65535)
+  @Column(name = "operation", length = 128)
   private String operation;
 
   @Lob
   @Column(name = "argument", length = 2147483647)
   @OrderColumn(name = "argument_index")
   @ElementCollection(fetch = FetchType.EAGER)
-  @CollectionTable(name = "oc_job_argument", joinColumns = @JoinColumn(name = "id", referencedColumnName = "id"))
+  @CollectionTable(name = "oc_job_argument",
+      joinColumns = @JoinColumn(name = "id", referencedColumnName = "id", nullable = false))
   private List<String> arguments;
 
   @Column(name = "date_completed")
@@ -196,10 +206,10 @@ public class JpaJob {
   private String payload;
 
   @Column(name = "dispatchable")
-  private boolean dispatchable;
+  private boolean dispatchable = true;
 
-  @Column(name = "job_load")
-  private Float jobLoad;
+  @Column(name = "job_load", nullable = false)
+  private Float jobLoad = 1F;
 
   @ManyToOne
   @JoinColumn(name = "creator_service")

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaGroup.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaGroup.java
@@ -81,13 +81,18 @@ public final class JpaGroup implements Group {
   private String role;
 
   @ElementCollection
-  @CollectionTable(name = "oc_group_member", joinColumns = { @JoinColumn(name = "group_id") })
+  @CollectionTable(name = "oc_group_member", joinColumns = {
+      @JoinColumn(name = "group_id", nullable = false) })
   @Column(name = "member")
   private Set<String> members;
 
   @ManyToMany(cascade = { CascadeType.MERGE }, fetch = FetchType.LAZY)
-  @JoinTable(name = "oc_group_role", joinColumns = { @JoinColumn(name = "group_id") }, inverseJoinColumns = { @JoinColumn(name = "role_id") }, uniqueConstraints = { @UniqueConstraint(columnNames = {
-          "group_id", "role_id" }) })
+  @JoinTable(name = "oc_group_role", joinColumns = {
+      @JoinColumn(name = "group_id")
+    }, inverseJoinColumns = {
+      @JoinColumn(name = "role_id")
+    }, uniqueConstraints = {
+      @UniqueConstraint(name = "UNQ_oc_group_role", columnNames = { "group_id", "role_id" }) })
   private Set<JpaRole> roles;
 
   /**

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaOrganization.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaOrganization.java
@@ -33,12 +33,14 @@ import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 /**
  * JPA-annotated organization object.
@@ -61,9 +63,15 @@ public class JpaOrganization implements Organization {
   private String name;
 
   @ElementCollection
-  @MapKeyColumn(name = "name")
-  @Column(name = "port")
-  @CollectionTable(name = "oc_organization_node", joinColumns = @JoinColumn(name = "organization"))
+  @MapKeyColumn(name = "name", nullable = false)
+  @Column(name = "port", nullable = false)
+  @CollectionTable(name = "oc_organization_node", joinColumns = @JoinColumn(name = "organization", nullable = false),
+    indexes = {
+      @Index(name = "IX_oc_organization_node_pk", columnList = ("organization")),
+      @Index(name = "IX_oc_organization_node_name", columnList = ("name")),
+      @Index(name = "IX_oc_organization_node_port", columnList = ("port"))
+    }, uniqueConstraints =
+      @UniqueConstraint(columnNames = {"organization", "name", "port"}))
   private Map<String, Integer> servers;
 
   @Column(name = "admin_role")
@@ -74,9 +82,9 @@ public class JpaOrganization implements Organization {
 
   @Lob
   @ElementCollection
-  @MapKeyColumn(name = "name")
+  @MapKeyColumn(name = "name", nullable = false)
   @Column(name = "value", length = 65535)
-  @CollectionTable(name = "oc_organization_property", joinColumns = @JoinColumn(name = "organization"))
+  @CollectionTable(name = "oc_organization_property", joinColumns = @JoinColumn(name = "organization", nullable = false))
   private Map<String, String> properties;
 
   /**

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaRole.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaRole.java
@@ -31,6 +31,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -44,7 +45,9 @@ import javax.persistence.UniqueConstraint;
  */
 @Entity
 @Access(AccessType.FIELD)
-@Table(name = "oc_role", uniqueConstraints = @UniqueConstraint(columnNames = { "name", "organization" }))
+@Table(name = "oc_role", uniqueConstraints = @UniqueConstraint(columnNames = { "name", "organization" }), indexes = {
+    @Index(name = "IX_oc_role_pk", columnList = "name, organization")
+})
 @NamedQueries({
         @NamedQuery(name = "Role.findByQuery", query = "select r from JpaRole r where r.organization.id=:org and UPPER(r.name) like :query or UPPER(r.description) like :query"),
         @NamedQuery(name = "Role.findByName", query = "Select r FROM JpaRole r where r.name = :name and r.organization.id = :org"),

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUser.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUser.java
@@ -53,7 +53,8 @@ import javax.persistence.UniqueConstraint;
  */
 @Entity
 @Access(AccessType.FIELD)
-@Table(name = "oc_user", uniqueConstraints = { @UniqueConstraint(columnNames = { "username", "organization" }) })
+@Table(name = "oc_user", uniqueConstraints = {
+    @UniqueConstraint(name = "UNQ_oc_user", columnNames = { "username", "organization" }) })
 @NamedQueries({
   @NamedQuery(name = "User.findByQuery", query = "select u from JpaUser u where UPPER(u.username) like :query and u.organization.id = :org"),
   @NamedQuery(name = "User.findByIdAndOrg", query = "select u from JpaUser u where u.id=:id and u.organization.id = :org"),
@@ -73,13 +74,13 @@ public class JpaUser implements User {
   @Column(name = "username", length = 128)
   private String username;
 
-  @Column(name = "name")
+  @Column(name = "name", length = 256)
   private String name;
 
-  @Column(name = "email")
+  @Column(name = "email", length = 256)
   private String email;
 
-  @Column(name = "manageable")
+  @Column(name = "manageable", nullable = false)
   private boolean manageable = true;
 
   @Transient
@@ -94,8 +95,12 @@ public class JpaUser implements User {
   private JpaOrganization organization;
 
   @ManyToMany(cascade = { CascadeType.MERGE }, fetch = FetchType.LAZY)
-  @JoinTable(name = "oc_user_role", joinColumns = { @JoinColumn(name = "user_id") }, inverseJoinColumns = { @JoinColumn(name = "role_id") }, uniqueConstraints = { @UniqueConstraint(columnNames = {
-          "user_id", "role_id" }) })
+  @JoinTable(name = "oc_user_role", joinColumns = {
+      @JoinColumn(name = "user_id")
+    }, inverseJoinColumns = {
+      @JoinColumn(name = "role_id")
+    }, uniqueConstraints = {
+      @UniqueConstraint(name = "UNQ_oc_user_role", columnNames = { "user_id", "role_id" }) })
   private Set<JpaRole> roles;
 
   /**

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUserReference.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/security/impl/jpa/JpaUserReference.java
@@ -57,7 +57,8 @@ import javax.persistence.UniqueConstraint;
  */
 @Entity
 @Access(AccessType.FIELD)
-@Table(name = "oc_user_ref", uniqueConstraints = { @UniqueConstraint(columnNames = { "username", "organization" }) })
+@Table(name = "oc_user_ref", uniqueConstraints = {
+    @UniqueConstraint(name = "UNQ_oc_user_ref", columnNames = { "username", "organization" }) })
 @NamedQueries({
   @NamedQuery(name = "UserReference.findByQuery", query = "select u from JpaUserReference u where UPPER(u.username) like :query and u.organization.id = :org"),
   @NamedQuery(name = "UserReference.findByUsername", query = "select u from JpaUserReference u where u.username=:u and u.organization.id = :org"),
@@ -91,8 +92,9 @@ public class JpaUserReference {
   protected JpaOrganization organization;
 
   @ManyToMany(cascade = { CascadeType.MERGE }, fetch = FetchType.LAZY)
-  @JoinTable(name = "oc_user_ref_role", joinColumns = { @JoinColumn(name = "user_id") }, inverseJoinColumns = { @JoinColumn(name = "role_id") }, uniqueConstraints = { @UniqueConstraint(columnNames = {
-          "user_id", "role_id" }) })
+  @JoinTable(name = "oc_user_ref_role", joinColumns = {
+      @JoinColumn(name = "user_id") }, inverseJoinColumns = {
+      @JoinColumn(name = "role_id") })
   protected Set<JpaRole> roles;
 
   public User toUser(final String providerName) {

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/HostRegistrationJpaImpl.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/HostRegistrationJpaImpl.java
@@ -29,6 +29,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
@@ -39,7 +40,10 @@ import javax.persistence.UniqueConstraint;
  */
 @Entity(name = "HostRegistration")
 @Access(AccessType.FIELD)
-@Table(name = "oc_host_registration", uniqueConstraints = @UniqueConstraint(columnNames = "host"))
+@Table(name = "oc_host_registration", indexes = {
+    @Index(name = "IX_oc_host_registration_online", columnList = ("online")),
+    @Index(name = "IX_oc_host_registration_active", columnList = ("active"))
+  }, uniqueConstraints = @UniqueConstraint(columnNames = "host"))
 @NamedQueries({
         @NamedQuery(name = "HostRegistration.getMaxLoad", query = "SELECT sum(hr.maxLoad) FROM HostRegistration hr where hr.active = true"),
         @NamedQuery(name = "HostRegistration.getMaxLoadByHostName", query = "SELECT hr.maxLoad FROM HostRegistration hr where hr.baseUrl = :host and hr.active = true"),
@@ -52,13 +56,13 @@ public class HostRegistrationJpaImpl implements HostRegistration {
   @GeneratedValue
   private Long id;
 
-  @Column(name = "host", nullable = false, length = 255)
+  @Column(name = "host", nullable = false)
   private String baseUrl;
 
   @Column(name = "address", nullable = false, length = 39)
   private String ipAddress;
 
-  @Column(name = "node_name", length = 255)
+  @Column(name = "node_name")
   private String nodeName;
 
   @Column(name = "memory", nullable = false)

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
@@ -35,8 +35,8 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -52,8 +52,13 @@ import javax.persistence.UniqueConstraint;
  */
 @Entity(name = "ServiceRegistration")
 @Access(AccessType.FIELD)
-@Table(name = "oc_service_registration", uniqueConstraints = @UniqueConstraint(columnNames = { "host_registration",
-        "service_type" }))
+@Table(name = "oc_service_registration", indexes = {
+    @Index(name = "IX_oc_service_registration_service_type", columnList = ("service_type")),
+    @Index(name = "IX_oc_service_registration_service_state", columnList = ("service_state")),
+    @Index(name = "IX_oc_service_registration_active", columnList = ("active")),
+    @Index(name = "IX_oc_service_registration_host_registration", columnList = ("host_registration"))
+  }, uniqueConstraints =
+    @UniqueConstraint(name = "UNQ_oc_service_registration", columnNames = { "host_registration", "service_type" }))
 @NamedQueries({
         @NamedQuery(name = "ServiceRegistration.statistics", query = "SELECT job.processorServiceRegistration.id as serviceRegistration, job.status, "
                 + "count(job.status) as numJobs, "
@@ -102,11 +107,10 @@ public class ServiceRegistrationJpaImpl implements ServiceRegistration {
   @JoinColumn(name = "host_registration")
   private HostRegistrationJpaImpl hostRegistration;
 
-  @Lob
   @Column(name = "path", nullable = false, length = 255)
   private String path;
 
-  @Column(name = "service_state")
+  @Column(name = "service_state", nullable = false)
   private int serviceState = ServiceState.NORMAL.ordinal();
 
   @Column(name = "state_changed")

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDto.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDto.java
@@ -39,6 +39,8 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Lob;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
@@ -47,14 +49,16 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
 @Entity(name = "EventComment")
-@Table(name = "oc_event_comment")
+@Table(name = "oc_event_comment", indexes = {
+    @Index(name = "IX_oc_event_comment_event", columnList = "event, organization")
+})
 @NamedQueries({ @NamedQuery(name = "EventComment.countAll", query = "SELECT COUNT(e) FROM EventComment e"),
-        @NamedQuery(name = "EventComment.findAll", query = "SELECT e FROM EventComment e"),
-        @NamedQuery(name = "EventComment.findReasons", query = "SELECT e.reason FROM EventComment e WHERE e.organization = :org GROUP BY e.reason"),
-        @NamedQuery(name = "EventComment.findByEvent", query = "SELECT e FROM EventComment e WHERE e.eventId = :eventId AND e.organization = :org ORDER BY e.creationDate"),
-        @NamedQuery(name = "EventComment.findByCommentId", query = "SELECT e FROM EventComment e WHERE e.id = :commentId"),
-        @NamedQuery(name = "EventComment.findAllWIthOrg", query = "SELECT e.organization, e.eventId FROM EventComment e ORDER BY e.organization ASC"),
-        @NamedQuery(name = "EventComment.clear", query = "DELETE FROM EventComment e WHERE e.organization = :org") })
+    @NamedQuery(name = "EventComment.findAll", query = "SELECT e FROM EventComment e"),
+    @NamedQuery(name = "EventComment.findReasons", query = "SELECT e.reason FROM EventComment e WHERE e.organization = :org GROUP BY e.reason"),
+    @NamedQuery(name = "EventComment.findByEvent", query = "SELECT e FROM EventComment e WHERE e.eventId = :eventId AND e.organization = :org ORDER BY e.creationDate"),
+    @NamedQuery(name = "EventComment.findByCommentId", query = "SELECT e FROM EventComment e WHERE e.id = :commentId"),
+    @NamedQuery(name = "EventComment.findAllWIthOrg", query = "SELECT e.organization, e.eventId FROM EventComment e ORDER BY e.organization ASC"),
+    @NamedQuery(name = "EventComment.clear", query = "DELETE FROM EventComment e WHERE e.organization = :org") })
 public class EventCommentDto {
 
   @Id
@@ -68,6 +72,7 @@ public class EventCommentDto {
   @Column(name = "event", length = 128, nullable = false)
   private String eventId;
 
+  @Lob
   @Column(name = "text", nullable = false)
   private String text;
 

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentReplyDto.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentReplyDto.java
@@ -35,6 +35,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -61,6 +62,7 @@ public class EventCommentReplyDto {
   @JoinColumn(name = "event_comment_id", referencedColumnName = "id", nullable = false)
   private EventCommentDto eventComment;
 
+  @Lob
   @Column(name = "text", nullable = false)
   private String text;
 

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoJpa.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoJpa.java
@@ -58,6 +58,7 @@ import javax.persistence.criteria.Root;
         @NamedQuery(name = "BundleInfo.delete", query = "delete from BundleInfo where host = :host and bundleId = :bundleId") })
 public class BundleInfoJpa {
   @Id
+  @Column(name = "id")
   @GeneratedValue
   protected long id;
 

--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhElementEntity.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhElementEntity.java
@@ -45,7 +45,7 @@ public class OaiPmhElementEntity {
   private String elementType;
 
   /** The flavor of the media package element */
-  @Column(name = "flavor", length = 255, nullable = false)
+  @Column(name = "flavor", nullable = false)
   private String flavor;
 
   /** The XML serialized media package element content */

--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java
@@ -72,7 +72,7 @@ public class OaiPmhEntity {
   private String repositoryId;
 
   /** Series id */
-  @Column(name = "series_id")
+  @Column(name = "series_id",length = 128)
   private String series;
 
   /** Flag indicating deletion. */
@@ -91,7 +91,7 @@ public class OaiPmhEntity {
 
   /** Serialized media package */
   @Lob
-  @Column(name = "mediapackage_xml", length = 65535)
+  @Column(name = "mediapackage_xml", length = 65535, nullable = false)
   private String mediaPackageXML;
 
   /** List of serialized media package element entities */

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/persistence/LastModifiedDto.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/persistence/LastModifiedDto.java
@@ -25,12 +25,12 @@ import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-import javax.persistence.UniqueConstraint;
 
 /**
  * Entity object for storing scheduled last modified dates in persistence storage.
@@ -40,7 +40,8 @@ import javax.persistence.UniqueConstraint;
         @NamedQuery(name = "LastModified.findAll", query = "SELECT e FROM LastModified e "),
         @NamedQuery(name = "LastModified.findById", query = "SELECT e FROM LastModified e WHERE e.captureAgentId = :agentId"),
         @NamedQuery(name = "LastModified.countAll", query = "SELECT COUNT(e) FROM LastModified e ") })
-@Table(name = "oc_scheduled_last_modified", uniqueConstraints = { @UniqueConstraint(columnNames = { "capture_agent_id" }) })
+@Table(name = "oc_scheduled_last_modified", indexes = {
+    @Index(name = "IX_oc_scheduled_last_modified_last_modified", columnList = ("last_modified")) })
 public class LastModifiedDto {
 
   /** Capture agent ID */
@@ -48,7 +49,7 @@ public class LastModifiedDto {
   @Column(name = "capture_agent_id", length = 255)
   protected String captureAgentId;
 
-  @Column(name = "last_modified")
+  @Column(name = "last_modified", nullable = false)
   @Temporal(TemporalType.TIMESTAMP)
   protected Date lastModifiedDate;
 

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
@@ -41,6 +41,7 @@ import javax.persistence.MapKeyColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 /**
  * Enitity object for storing series in persistence storage. Series ID is stored as primary key, DUBLIN_CORE field is
@@ -79,20 +80,25 @@ public class SeriesEntity {
   @Column(name = "access_control", length = 65535)
   protected String accessControl;
 
+  @Lob
   @ElementCollection(targetClass = String.class)
-  @MapKeyColumn(name = "name")
-  @Column(name = "value")
-  @CollectionTable(name = "oc_series_property", joinColumns = {
-          @JoinColumn(name = "series", referencedColumnName = "id"),
-          @JoinColumn(name = "organization", referencedColumnName = "organization") })
+  @MapKeyColumn(name = "name", nullable = false)
+  @Column(name = "value", length = 65535)
+  @CollectionTable(name = "oc_series_property", uniqueConstraints = {
+      @UniqueConstraint(name = "UNQ_series_properties", columnNames = {"series", "organization", "name"})
+  }, joinColumns = {
+          @JoinColumn(name = "series", referencedColumnName = "id", nullable = false),
+          @JoinColumn(name = "organization", referencedColumnName = "organization", nullable = false) })
   protected Map<String, String> properties;
 
   @ElementCollection
-  @MapKeyColumn(name = "type")
+  @MapKeyColumn(name = "type", length = 128, nullable = false)
   @Column(name = "data")
-  @CollectionTable(name = "oc_series_elements", joinColumns = {
-          @JoinColumn(name = "series", referencedColumnName = "id"),
-          @JoinColumn(name = "organization", referencedColumnName = "organization") })
+  @CollectionTable(name = "oc_series_elements", uniqueConstraints = {
+      @UniqueConstraint(name = "UNQ_series_elements", columnNames = {"series", "organization", "type"})
+    }, joinColumns = {
+      @JoinColumn(name = "series", referencedColumnName = "id", nullable = false),
+      @JoinColumn(name = "organization", referencedColumnName = "organization", nullable = false) })
   protected Map<String, byte[]> elements;
 
   /**

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/IncidentDto.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/IncidentDto.java
@@ -49,6 +49,7 @@ import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Lob;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -58,7 +59,9 @@ import javax.persistence.TemporalType;
 
 @Entity(name = "Incident")
 @Access(AccessType.FIELD)
-@Table(name = "oc_incident")
+@Table(name = "oc_incident", indexes = {
+    @Index(name = "IX_oc_incident_jobid", columnList = ("jobid")),
+    @Index(name = "IX_oc_incident_severity", columnList = ("severity")) })
 @NamedQueries({@NamedQuery(name = "Incident.findByJobId",
                            query = "select a from Incident a where a.jobId = :jobId")})
 public class IncidentDto {

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/IncidentTextDto.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/IncidentTextDto.java
@@ -45,7 +45,7 @@ public class IncidentTextDto {
   @Column(name = "id")
   private String id;
 
-  @Column(name = "text")
+  @Column(name = "text", nullable = false, length = 2038)
   private String text;
 
   public String getId() {

--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemeDto.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemeDto.java
@@ -45,11 +45,11 @@ import javax.persistence.TemporalType;
 @Access(AccessType.FIELD)
 @Table(name = "oc_themes")
 @NamedQueries({
-        @NamedQuery(name = "Themes.count", query = "SELECT COUNT(t) FROM Themes t WHERE t.organization = :org"),
-        @NamedQuery(name = "Themes.findById", query = "SELECT t FROM Themes t WHERE t.id = :id AND t.organization = :org"),
-        @NamedQuery(name = "Themes.findByOrg", query = "SELECT t FROM Themes t WHERE t.organization = :org"),
-        @NamedQuery(name = "Themes.findByUserName", query = "SELECT t FROM Themes t WHERE t.username = :username AND t.organization = :org"),
-        @NamedQuery(name = "Themes.clear", query = "DELETE FROM Themes t WHERE t.organization = :org") })
+    @NamedQuery(name = "Themes.count", query = "SELECT COUNT(t) FROM Themes t WHERE t.organization = :org"),
+    @NamedQuery(name = "Themes.findById", query = "SELECT t FROM Themes t WHERE t.id = :id AND t.organization = :org"),
+    @NamedQuery(name = "Themes.findByOrg", query = "SELECT t FROM Themes t WHERE t.organization = :org"),
+    @NamedQuery(name = "Themes.findByUserName", query = "SELECT t FROM Themes t WHERE t.username = :username AND t.organization = :org"),
+    @NamedQuery(name = "Themes.clear", query = "DELETE FROM Themes t WHERE t.organization = :org") })
 public class ThemeDto {
 
   @Id
@@ -57,7 +57,7 @@ public class ThemeDto {
   @Column(name = "id", nullable = false)
   private long id;
 
-  @Column(name = "organization", nullable = false)
+  @Column(name = "organization", nullable = false, length = 128)
   private String organization;
 
   @Column(name = "creation_date", nullable = false)
@@ -67,7 +67,7 @@ public class ThemeDto {
   @Column(name = "isDefault", nullable = false)
   private boolean isDefault = false;
 
-  @Column(name = "username", nullable = false)
+  @Column(name = "username", nullable = false, length = 128)
   private String username;
 
   @Column(name = "name", nullable = false)
@@ -79,13 +79,13 @@ public class ThemeDto {
   @Column(name = "bumper_active", nullable = false)
   private boolean bumperActive = false;
 
-  @Column(name = "bumper_file")
+  @Column(name = "bumper_file", length = 128)
   private String bumperFile;
 
   @Column(name = "trailer_active", nullable = false)
   private boolean trailerActive = false;
 
-  @Column(name = "trailer_file")
+  @Column(name = "trailer_file", length = 128)
   private String trailerFile;
 
   @Column(name = "title_slide_active", nullable = false)
@@ -94,13 +94,13 @@ public class ThemeDto {
   @Column(name = "title_slide_metadata")
   private String titleSlideMetadata;
 
-  @Column(name = "title_slide_background")
+  @Column(name = "title_slide_background", length = 128)
   private String titleSlideBackground;
 
   @Column(name = "license_slide_active", nullable = false)
   private boolean licenseSlideActive = false;
 
-  @Column(name = "license_slide_background")
+  @Column(name = "license_slide_background", length = 128)
   private String licenseSlideBackground;
 
   @Column(name = "license_slide_description")
@@ -109,7 +109,7 @@ public class ThemeDto {
   @Column(name = "watermark_active", nullable = false)
   private boolean watermarkActive = false;
 
-  @Column(name = "watermark_file")
+  @Column(name = "watermark_file", length = 128)
   private String watermarkFile;
 
   @Column(name = "watermark_position")

--- a/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionJobControlDto.java
+++ b/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionJobControlDto.java
@@ -70,15 +70,15 @@ public class TranscriptionJobControlDto implements Serializable {
   @Temporal(TemporalType.TIMESTAMP)
   private Date dateCreated;
 
-  @Column(name = "date_expected", nullable = true)
+  @Column(name = "date_expected")
   @Temporal(TemporalType.TIMESTAMP)
   private Date dateExpected;
 
-  @Column(name = "date_completed", nullable = true)
+  @Column(name = "date_completed")
   @Temporal(TemporalType.TIMESTAMP)
   private Date dateCompleted;
 
-  @Column(name = "status", nullable = true, length = 128)
+  @Column(name = "status", length = 128)
   private String status;
 
   @Column(name = "track_duration", nullable = false)

--- a/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/impl/UserActionImpl.java
+++ b/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/impl/UserActionImpl.java
@@ -34,6 +34,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
@@ -53,28 +54,33 @@ import javax.xml.bind.annotation.XmlType;
  */
 @Entity(name = "UserAction")
 @Access(AccessType.FIELD)
-@Table(name = "oc_user_action")
+@Table(name = "oc_user_action", indexes = {
+    @Index(name = "IX_oc_user_action_created", columnList = "created"),
+    @Index(name = "IX_oc_user_action_inpoint", columnList = "inpoint"),
+    @Index(name = "IX_oc_user_action_outpoint", columnList = "outpoint"),
+    @Index(name = "IX_oc_user_action_mediapackage_id", columnList = "mediapackage"),
+    @Index(name = "IX_oc_user_action_type", columnList = "type")})
 @NamedQueries({
-        @NamedQuery(name = "findUserActions", query = "SELECT a FROM UserAction a"),
-        @NamedQuery(name = "countSessionsGroupByMediapackage", query = "SELECT a.mediapackageId, COUNT(distinct a.session), SUM(a.length) FROM UserAction a GROUP BY a.mediapackageId"),
-        @NamedQuery(name = "countSessionsGroupByMediapackageByIntervall", query = "SELECT a.mediapackageId, COUNT(distinct a.session.sessionId), SUM(a.length) FROM UserAction a WHERE :begin <= a.created AND a.created <= :end GROUP BY a.mediapackageId"),
-        @NamedQuery(name = "countSessionsOfMediapackage", query = "SELECT COUNT(distinct a.session) FROM UserAction a WHERE a.mediapackageId = :mediapackageId"),
-        @NamedQuery(name = "findLastUserFootprintOfSession", query = "SELECT a FROM UserAction a  WHERE a.session = :session AND a.type = \'FOOTPRINT\'  ORDER BY a.created DESC"),
-        @NamedQuery(name = "findLastUserActionsOfSession", query = "SELECT a FROM UserAction a  WHERE a.session = :session ORDER BY a.created DESC"),
-        @NamedQuery(name = "findUserActionsByType", query = "SELECT a FROM UserAction a WHERE a.type = :type"),
-        @NamedQuery(name = "findUserActionsByTypeAndMediapackageId", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type"),
-        @NamedQuery(name = "findUserActionsByTypeAndMediapackageIdOrderByOutpointDESC", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type ORDER BY a.outpoint DESC"),
-        @NamedQuery(name = "findUserActionsByTypeAndMediapackageIdByUserOrderByOutpointDESC", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type AND a.session.userId = :userid ORDER BY a.outpoint DESC"),
-        @NamedQuery(name = "findUserActionsByIntervall", query = "SELECT a FROM UserAction a WHERE :begin <= a.created AND a.created <= :end"),
-        @NamedQuery(name = "findUserActionsByTypeAndIntervall", query = "SELECT a FROM UserAction a WHERE :begin <= a.created AND a.created <= :end AND a.type = :type"),
-        @NamedQuery(name = "findTotal", query = "SELECT COUNT(a) FROM UserAction a"),
-        @NamedQuery(name = "findTotalByType", query = "SELECT COUNT(a) FROM UserAction a WHERE a.type = :type"),
-        @NamedQuery(name = "findTotalByTypeAndMediapackageId", query = "SELECT COUNT(a) FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type"),
-        @NamedQuery(name = "findTotalByIntervall", query = "SELECT COUNT(a) FROM UserAction a WHERE :begin <= a.created AND a.created <= :end"),
-        @NamedQuery(name = "findDistinctEpisodeIdTotalByIntervall", query = "SELECT COUNT(distinct a.mediapackageId) FROM UserAction a WHERE :begin <= a.created AND a.created <= :end"),
-        @NamedQuery(name = "findTotalByTypeAndIntervall", query = "SELECT COUNT(a) FROM UserAction a WHERE :begin <= a.created AND a.created <= :end AND a.type = :type"),
-        @NamedQuery(name = "findUserActionsByMediaPackageAndTypeAscendingByDate", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type ORDER BY a.created"),
-        @NamedQuery(name = "findUserActionsByMediaPackageAndTypeDescendingByDate", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type ORDER BY a.created DESC") })
+    @NamedQuery(name = "findUserActions", query = "SELECT a FROM UserAction a"),
+    @NamedQuery(name = "countSessionsGroupByMediapackage", query = "SELECT a.mediapackageId, COUNT(distinct a.session), SUM(a.length) FROM UserAction a GROUP BY a.mediapackageId"),
+    @NamedQuery(name = "countSessionsGroupByMediapackageByIntervall", query = "SELECT a.mediapackageId, COUNT(distinct a.session.sessionId), SUM(a.length) FROM UserAction a WHERE :begin <= a.created AND a.created <= :end GROUP BY a.mediapackageId"),
+    @NamedQuery(name = "countSessionsOfMediapackage", query = "SELECT COUNT(distinct a.session) FROM UserAction a WHERE a.mediapackageId = :mediapackageId"),
+    @NamedQuery(name = "findLastUserFootprintOfSession", query = "SELECT a FROM UserAction a  WHERE a.session = :session AND a.type = \'FOOTPRINT\'  ORDER BY a.created DESC"),
+    @NamedQuery(name = "findLastUserActionsOfSession", query = "SELECT a FROM UserAction a  WHERE a.session = :session ORDER BY a.created DESC"),
+    @NamedQuery(name = "findUserActionsByType", query = "SELECT a FROM UserAction a WHERE a.type = :type"),
+    @NamedQuery(name = "findUserActionsByTypeAndMediapackageId", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type"),
+    @NamedQuery(name = "findUserActionsByTypeAndMediapackageIdOrderByOutpointDESC", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type ORDER BY a.outpoint DESC"),
+    @NamedQuery(name = "findUserActionsByTypeAndMediapackageIdByUserOrderByOutpointDESC", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type AND a.session.userId = :userid ORDER BY a.outpoint DESC"),
+    @NamedQuery(name = "findUserActionsByIntervall", query = "SELECT a FROM UserAction a WHERE :begin <= a.created AND a.created <= :end"),
+    @NamedQuery(name = "findUserActionsByTypeAndIntervall", query = "SELECT a FROM UserAction a WHERE :begin <= a.created AND a.created <= :end AND a.type = :type"),
+    @NamedQuery(name = "findTotal", query = "SELECT COUNT(a) FROM UserAction a"),
+    @NamedQuery(name = "findTotalByType", query = "SELECT COUNT(a) FROM UserAction a WHERE a.type = :type"),
+    @NamedQuery(name = "findTotalByTypeAndMediapackageId", query = "SELECT COUNT(a) FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type"),
+    @NamedQuery(name = "findTotalByIntervall", query = "SELECT COUNT(a) FROM UserAction a WHERE :begin <= a.created AND a.created <= :end"),
+    @NamedQuery(name = "findDistinctEpisodeIdTotalByIntervall", query = "SELECT COUNT(distinct a.mediapackageId) FROM UserAction a WHERE :begin <= a.created AND a.created <= :end"),
+    @NamedQuery(name = "findTotalByTypeAndIntervall", query = "SELECT COUNT(a) FROM UserAction a WHERE :begin <= a.created AND a.created <= :end AND a.type = :type"),
+    @NamedQuery(name = "findUserActionsByMediaPackageAndTypeAscendingByDate", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type ORDER BY a.created"),
+    @NamedQuery(name = "findUserActionsByMediaPackageAndTypeDescendingByDate", query = "SELECT a FROM UserAction a WHERE a.mediapackageId = :mediapackageId AND a.type = :type ORDER BY a.created DESC") })
 @XmlType(name = "action", namespace = "http://usertracking.opencastproject.org")
 @XmlRootElement(name = "action", namespace = "http://usertracking.opencastproject.org")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -86,13 +92,12 @@ public class UserActionImpl implements UserAction {
   @XmlElement(name = "id")
   private Long id;
 
-  @Lob
   @Column(name = "mediapackage", length = 128)
   @XmlElement(name = "mediapackageId")
   private String mediapackageId;
 
   @ManyToOne(targetEntity = UserSessionImpl.class)
-  @JoinColumn(name = "session_id", nullable = false)
+  @JoinColumn(name = "session_id")
   @XmlElement(name = "sessionId")
   private UserSessionImpl session;
 

--- a/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/impl/UserSessionImpl.java
+++ b/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/impl/UserSessionImpl.java
@@ -28,7 +28,7 @@ import javax.persistence.AccessType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-import javax.persistence.Lob;
+import javax.persistence.Index;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
@@ -40,9 +40,11 @@ import javax.xml.bind.annotation.XmlType;
 
 @Entity(name = "UserSession")
 @Access(AccessType.FIELD)
-@Table(name = "oc_user_session")
+@Table(name = "oc_user_session", indexes = {
+    @Index(name = "IX_oc_user_session_user_id", columnList = "user_id")
+})
 @NamedQueries({
-        @NamedQuery(name = "findUserSessionBySessionId", query = "SELECT s FROM UserSession s WHERE s.sessionId = :sessionId") })
+    @NamedQuery(name = "findUserSessionBySessionId", query = "SELECT s FROM UserSession s WHERE s.sessionId = :sessionId") })
 @XmlType(name = "session", namespace = "http://usertracking.opencastproject.org")
 @XmlRootElement(name = "session", namespace = "http://usertracking.opencastproject.org")
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -53,18 +55,15 @@ public class UserSessionImpl implements UserSession {
   @XmlElement(name = "sessionId")
   private String sessionId;
 
-  @Lob
-  @Column(name = "user_id", length = 255)
+  @Column(name = "user_id")
   @XmlElement(name = "userId")
   private String userId;
 
-  @Lob
-  @Column(name = "user_ip", length = 255)
+  @Column(name = "user_ip")
   @XmlElement(name = "userIp")
   private String userIp;
 
-  @Lob
-  @Column(name = "user_agent", length = 255)
+  @Column(name = "user_agent")
   @XmlElement(name = "userAgent")
   private String userAgent;
 


### PR DESCRIPTION
This patch is the next step in making Opencast's JPA code generate a
proper and performant database schema. With this patch applied, column
sizes, names, indexes, and unique constraints should match the ones
generated by the ddl scripts.

This should already give you a well-performing database which is
auto-generated by Opencast using either MariaDB or PostgreSQL.

That said, a few foreign key constraints could still be improved, but
that is handled separately.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
