### PR TITLE
Additional logging for ACL parse errors

### DIFF
--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -277,7 +277,7 @@ public class XACMLAuthorizationService implements AuthorizationService, ManagedS
     } catch (NotFoundException e) {
       logger.debug("URI {} not found", uri);
     } catch (Exception e) {
-      logger.warn("Unable to load or parse Acl", e);
+      logger.warn("Unable to load or parse Acl from URI {}", uri, e);
     }
     return Optional.empty();
   }


### PR DESCRIPTION
Log the URI of an ACL that failed to parse correctly, to make troubleshooting easier.
