### PR TITLE
Fix processing of odd video width

### DIFF
--- a/etc/encoding/fast-movies.properties
+++ b/etc/encoding/fast-movies.properties
@@ -27,5 +27,7 @@ profile.fast.http.name = fast processed mp4
 profile.fast.http.input = visual
 profile.fast.http.output = visual
 profile.fast.http.suffix = .mp4
-profile.fast.http.ffmpeg.command = -i #{in.video.path} -c:a aac -c:v libx264 -preset veryfast -g 30 -pix_fmt yuv420p \
-                                   #{out.dir}/#{out.name}#{out.suffix}
+profile.fast.http.ffmpeg.command = -i #{in.video.path} \
+  -filter:v crop=in_w/2*2:in_h/2*2 \
+  -c:a aac -c:v libx264 -preset faster -g 30 -pix_fmt yuv420p \
+  #{out.dir}/#{out.name}#{out.suffix}


### PR DESCRIPTION
Due to the selected chroma subsampling in combination with the libx264
video encoder, processing wideos using the fast test workflow fails if
the video has an odd resolution (e.g. 2560x1337).

This patch fixes the issue by cropping to the nearest even resolution is
these cases.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
