### PR TITLE
Wrong encoding in video editor zoom box

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/timelineDirective.js
@@ -163,7 +163,7 @@ angular.module('adminNg.directives')
         scope.displayZoomLevel = function (ms) {
 
           var date = new Date(ms),
-              st = '&#8776; ';
+              st = '\u2248 ';
 
           if (date.getUTCHours() > 0) {
             st += (date.getUTCHours() + (date.getUTCMinutes() >= 30 ? 1 : 0)) + ' h';


### PR DESCRIPTION
If one chooses an element in the video-editor zoom box, the 'almost equal to'-character has the wrong encoding.  (see attached screenshot). 
<img width="320" alt="ZoomBox" src="https://user-images.githubusercontent.com/52449143/70127679-cb8c9d00-167b-11ea-8362-82f45c842c5b.png">

