### PR TITLE
Log progress of solr search reindex

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabase.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabase.java
@@ -59,6 +59,15 @@ public interface SearchServiceDatabase {
   String getOrganizationId(String mediaPackageId) throws NotFoundException, SearchServiceDatabaseException;
 
   /**
+   * Returns the number of mediapackages in persistent storage, including deleted entries.
+   *
+   * @return the number of mediapackages in storage
+   * @throws SearchServiceDatabaseException
+   *           if an error occurs
+   */
+  int countMediaPackages() throws SearchServiceDatabaseException;
+
+  /**
    * Gets a single media package by its identifier.
    *
    * @param mediaPackageId

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -176,6 +176,27 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
   /**
    * {@inheritDoc}
    *
+   * @see org.opencastproject.search.impl.persistence.SearchServiceDatabase#countMediaPackages()
+   */
+  @Override
+  public int countMediaPackages() throws SearchServiceDatabaseException {
+    EntityManager em = emf.createEntityManager();
+    Query query = em.createNamedQuery("Search.getCount");
+    try {
+      Long total = (Long) query.getSingleResult();
+      return total.intValue();
+    } catch (Exception e) {
+      logger.error("Could not find number of mediapackages", e);
+      throw new SearchServiceDatabaseException(e);
+    } finally {
+      em.close();
+    }
+  }
+
+
+  /**
+   * {@inheritDoc}
+   *
    * @see org.opencastproject.search.impl.persistence.SearchServiceDatabase#getAllMediaPackages()
    */
   @Override

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -297,6 +297,7 @@ public class SolrIndexManager {
       solrServer.commit();
       return true;
     } catch (Exception e) {
+      logger.error("Unable to add mediapackage {} to index", sourceMediaPackage.getIdentifier());
       throw new SolrServerException(e);
     }
   }
@@ -337,6 +338,7 @@ public class SolrIndexManager {
       solrServer.commit();
       return true;
     } catch (Exception e) {
+      logger.error("Unable to add mediapackage {} to index", sourceMediaPackage.getIdentifier());
       try {
         solrServer.rollback();
       } catch (IOException e1) {

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/persistence/SearchServicePersistenceTest.java
@@ -96,8 +96,10 @@ public class SearchServicePersistenceTest {
 
   @Test
   public void testAdding() throws Exception {
-    Date modifictaionDate = new Date();
-    searchDatabase.storeMediaPackage(mediaPackage, accessControlList, modifictaionDate);
+    int mpCount = searchDatabase.countMediaPackages();
+    Date modificationDate = new Date();
+    searchDatabase.storeMediaPackage(mediaPackage, accessControlList, modificationDate);
+    Assert.assertEquals(searchDatabase.countMediaPackages(), mpCount + 1);
 
     Iterator<Tuple<MediaPackage, String>> mediaPackages = searchDatabase.getAllMediaPackages();
     while (mediaPackages.hasNext()) {
@@ -109,7 +111,7 @@ public class SearchServicePersistenceTest {
       Assert.assertEquals(accessControlList.getEntries().size(), acl.getEntries().size());
       Assert.assertEquals(accessControlList.getEntries().get(0), acl.getEntries().get(0));
       Assert.assertNull(searchDatabase.getDeletionDate(mediaPackageId));
-      Assert.assertEquals(modifictaionDate, searchDatabase.getModificationDate(mediaPackageId));
+      Assert.assertEquals(modificationDate, searchDatabase.getModificationDate(mediaPackageId));
       Assert.assertEquals(mediaPackage.getA(), searchDatabase.getMediaPackage(mediaPackageId));
       Assert.assertEquals(securityService.getOrganization().getId(), mediaPackage.getB());
       Assert.assertEquals(securityService.getOrganization().getId(), searchDatabase.getOrganizationId(mediaPackageId));


### PR DESCRIPTION
This logs progress when reindexing the solr search index, which can be quite large and take a long time.

Similar to how the series solr index logs progress.

Also log the mediapackage ID for any item that can't be added to the index.