### PR TITLE
Don't add the internal publication of the original event twice

### DIFF
--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -207,6 +207,8 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
     for (MediaPackageElement e : mediaPackage.getElements()) {
       if (e instanceof Publication && InternalPublicationChannel.CHANNEL_ID.equals(((Publication) e).getChannel())) {
         internalPublications.add((Publication) e);
+        // Remove publications since they are cloned in another way than the other elements
+        elements.remove(e);
       }
       if (MediaPackageElements.EPISODE.equals(e.getFlavor())) {
         // Remove episode DC since we will add a new one (with changed title)


### PR DESCRIPTION
When one duplicates an event, the duplicated event contains two internal publications. One of them references the original event. (see attached screenshot)
![doubleInteral](https://user-images.githubusercontent.com/52449143/70330352-afd0f480-183d-11ea-867f-212c0cecf1ee.png)
I guess this is relevant for the releases 8.x and 7.x  either