### PR TITLE
Editor Thumbnail Default

### DIFF
--- a/etc/org.opencastproject.adminui.endpoint.ToolsEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.ToolsEndpoint.cfg
@@ -18,5 +18,5 @@
 
 # The thumbnail feature can cause performance problems in some environments.
 # That is why it can be deactivated in here.
-# Default: true
-#thumbnail.enabled = true
+# Default: false
+#thumbnail.enabled=false

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -290,7 +290,7 @@ public class ToolsEndpoint implements ManagedService {
     signWithClientIP = UrlSigningServiceOsgiUtil.getUpdatedSignWithClientIP(properties,
             this.getClass().getSimpleName());
 
-    thumbnailEnabled = BooleanUtils.toBoolean(Objects.toString(properties.get(OPT_THUMBNAIL_ENABLED), "true"));
+    thumbnailEnabled = BooleanUtils.toBoolean(Objects.toString(properties.get(OPT_THUMBNAIL_ENABLED), "false"));
     logger.debug("Thumbnail feature enabled: {}", thumbnailEnabled);
   }
 


### PR DESCRIPTION
This patch changes the default value for enabling the thumbnail
generation in the video editor.  The new default is for the thumbnail
generation to be deactivated since it causes major performance problems
and/or failures on some systems so that a number of Opencast adopters
already ended up patching or removing this in one way or another.

The thumbnail generation was added in Opencast 6 and later made optional
due to ongoing issues in Opencast 7.x:

  https://github.com/opencast/opencast/pull/1220

Having this deactivated by default means that people need to
conscientiously activate this and will not accidentally run into
problems causing workflows to fail.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
