### PR TITLE
Fix hourly statistics export

### DIFF
--- a/modules/statistics-export-service-impl/src/main/java/org/opencastproject/statistics/export/impl/StatisticsExportServiceImpl.java
+++ b/modules/statistics-export-service-impl/src/main/java/org/opencastproject/statistics/export/impl/StatisticsExportServiceImpl.java
@@ -151,6 +151,9 @@ public class StatisticsExportServiceImpl implements StatisticsExportService, Man
     final LocalDateTime ldt = LocalDateTime.ofInstant(Instant.parse(dateStr), zoneId);
     DateTimeFormatter formatter = null;
     switch (dataResolution) {
+      case HOURLY:
+        formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:00");
+        return formatter.format(ldt);
       case DAILY:
         formatter = DateTimeFormatter.ofPattern("uuuu-MM-dd");
         return formatter.format(ldt);


### PR DESCRIPTION
This patch just adds a missing switch-case to avoid an exception being
thrown when exporting hourly statistics.

This work is sponsored by SWITCH.