### PR TITLE
Fix Role For Assets Quick Access

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/eventActionsCell.html
@@ -59,6 +59,6 @@
    class="fa fa-folder-open"
    data-tab="assets"
    title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.ASSETS' | translate }}"
-   with-role="ROLE_UI_EVENTS_ASSETS_VIEW">
+   with-role="ROLE_UI_EVENTS_DETAILS_ASSETS_VIEW">
 </a>
 


### PR DESCRIPTION
This patch fixes the role for the new quick-access icon which should
have been the same as the role required for the assets dialog.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
