### PR TITLE
Add option to remove running workflows, fix restdocs for delete requests

### DIFF
--- a/modules/common/src/main/resources/ui/restdocs/template.xhtml
+++ b/modules/common/src/main/resources/ui/restdocs/template.xhtml
@@ -108,7 +108,7 @@
     </tr>
     </#if>
     <tr class="method">
-      <th scope="row">Optional (<#if (endpoint.method == "GET")>query<#else>form</#if>) params:</th>
+      <th scope="row">Optional (<#if (endpoint.method == "GET" || endpoint.method == "DELETE")>query<#else>form</#if>) params:</th>
       <td>
         <#list endpoint.optionalParams as param>
         <tt>${param.name}<#if param.defaultValue??>&#40;Default value=${param.escapedDefaultValue}&#41;</#if></tt>:
@@ -212,7 +212,7 @@
                          name="${item.name}"
                          class="form_field <#if item.path>form_param_path<#else>form_param_submit</#if><#if item.required> form_param_required</#if>"
                          type="checkbox"
-                         value="true" <#if item.defaultValue??>checked="${item.defaultValue}" defaultChecked="${item.defaultValue}"</#if> />
+                         value="true" <#if item.defaultValue == "true">checked</#if> />
                 </td>
                 <td class="form_field_description">${item.description!}</td>
                 <#elseif item.type == "file">

--- a/modules/runtime-info-ui-ng/src/main/resources/ui/docs.js
+++ b/modules/runtime-info-ui-ng/src/main/resources/ui/docs.js
@@ -191,13 +191,20 @@ $(document).ready(function() {
             responseBody.hide();
             responseBody.find('pre').text('');
 
-            // make the request
-            $.ajax({
+            var queryString = '';
+            if (method === 'DELETE') {
+              queryString = $.param(submitParams);
+            }
+
+            if (queryString !== '') {
+              url = url + '?' + queryString;
+            }
+
+            var request = {
               type: method,
               url: url,
               processData: true,
               dataType: 'text',
-              data: submitParams,
               success: function(data, textStatus, request) {
                 $form.parent().find('.test_form_working').hide();
                 var responseBody = $form.parent().find('.test_form_response');
@@ -213,7 +220,14 @@ $(document).ready(function() {
                 responseBody.show();
                 responseBody.find('pre').text(msg);
               }
-            });
+            };
+
+            if (method !== 'DELETE') {
+              request.data = submitParams;
+            }
+
+            // make the request
+            $.ajax(request);
           } else {
             alert('Fill out all required fields first');
           }

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowService.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowService.java
@@ -233,6 +233,25 @@ public interface WorkflowService {
           UnauthorizedException, WorkflowStateException;
 
   /**
+   * Permanently removes a workflow instance. Option to remove a workflow instance regardless of its status.
+   *
+   * @param workflowInstanceId
+   *          the workflow instance identifier
+   * @param force
+   *          remove the workflow instance no matter the status
+   * @throws WorkflowDatabaseException
+   *           if there is a problem writing to the database
+   * @throws NotFoundException
+   *           if no workflow instance with the given identifier could be found
+   * @throws UnauthorizedException
+   *           if the current user does not have write permissions on the workflow instance
+   * @throws WorkflowStateException
+   *           if the workflow instance is in a disallowed state
+   */
+  void remove(long workflowInstanceId, boolean force) throws WorkflowDatabaseException, WorkflowParsingException,
+          NotFoundException, UnauthorizedException, WorkflowStateException;
+
+  /**
    * Temporarily suspends a started workflow instance.
    *
    * @param workflowInstanceId

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -84,6 +84,7 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workflow.api.WorkflowParser;
 import org.opencastproject.workflow.api.WorkflowQuery;
 import org.opencastproject.workflow.api.WorkflowSet;
+import org.opencastproject.workflow.api.WorkflowStateException;
 import org.opencastproject.workflow.api.WorkflowStateListener;
 import org.opencastproject.workflow.handler.workflow.ErrorResolutionWorkflowOperationHandler;
 import org.opencastproject.workflow.impl.WorkflowServiceImpl.HandlerRegistration;
@@ -966,7 +967,7 @@ public class WorkflowServiceImplTest {
   }
 
   /**
-   * Test for {@link WorkflowServiceImpl#remove(long)}
+   * Test for {@link WorkflowServiceImpl#remove(long, boolean)}
    *
    * @throws Exception
    *           if anything fails
@@ -975,19 +976,34 @@ public class WorkflowServiceImplTest {
   public void testRemove() throws Exception {
     WorkflowInstance wi1 = startAndWait(workingDefinition, mediapackage1, WorkflowState.SUCCEEDED);
     WorkflowInstance wi2 = startAndWait(workingDefinition, mediapackage2, WorkflowState.SUCCEEDED);
+    WorkflowInstance wi3 = startAndWait(pausingWorkflowDefinition, mediapackage1, WorkflowState.PAUSED);
 
     // reload instances, because operations have no id before
     wi1 = service.getWorkflowById(wi1.getId());
     wi2 = service.getWorkflowById(wi2.getId());
 
     service.remove(wi1.getId());
-    assertEquals(1, service.getWorkflowInstances(new WorkflowQuery()).size());
+    assertEquals(2, service.getWorkflowInstances(new WorkflowQuery()).size());
     for (WorkflowOperationInstance op : wi1.getOperations()) {
       assertEquals(0, serviceRegistry.getChildJobs(op.getId()).size());
     }
 
-    service.remove(wi2.getId());
-    assertEquals(0, service.getWorkflowInstances(new WorkflowQuery()).size());
+    service.remove(wi2.getId(), false);
+    assertEquals(1, service.getWorkflowInstances(new WorkflowQuery()).size());
+
+    try {
+      service.remove(wi3.getId(), false);
+      Assert.fail("A paused workflow shouldn't be removed without using force");
+    } catch (WorkflowStateException e) {
+      assertEquals(1, service.getWorkflowInstances(new WorkflowQuery()).size());
+    }
+
+    try {
+      service.remove(wi3.getId(), true);
+      assertEquals(0, service.getWorkflowInstances(new WorkflowQuery()).size());
+    } catch (WorkflowStateException e) {
+      Assert.fail(e.getMessage());
+    }
   }
 
   /**

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -570,7 +570,26 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
    */
   @Override
   public void remove(long workflowInstanceId) throws WorkflowDatabaseException, NotFoundException {
-    HttpDelete delete = new HttpDelete("/remove/" + Long.toString(workflowInstanceId));
+    remove(workflowInstanceId, false);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see org.opencastproject.workflow.api.WorkflowService#remove(long, boolean)
+   */
+  @Override
+  public void remove(long workflowInstanceId, boolean force) throws WorkflowDatabaseException, NotFoundException {
+    String deleteString = "/remove/" + Long.toString(workflowInstanceId);
+
+    if (force) {
+      List<NameValuePair> queryStringParams = new ArrayList<NameValuePair>();
+      queryStringParams.add(new BasicNameValuePair("force", "true"));
+      deleteString = deleteString + "?" + URLEncodedUtils.format(queryStringParams, "UTF_8");
+    }
+
+    HttpDelete delete = new HttpDelete(deleteString);
+
     HttpResponse response = getResponse(delete, SC_NO_CONTENT, SC_NOT_FOUND);
     try {
       if (response != null) {


### PR DESCRIPTION
This PR does two things:

- Send parameter as query for delete requests in rest docs
    
    Form parameters for DELETE requests are currently not used and are not even
    possible because we can't set them in the remote implementations in the
    backend. However the rest docs currently use form parameters for everything
    but GET, resulting in some endpoints with query parameters not working
    correctly. This commit makes the rest docs send query parameters for
    DELETE requests.

- Add a force parameter to remove running workflows
    
    If a workflow gets stuck, the affected event can't be deleted. In that
    case, it can make sense to delete a workflow even though it's still
    running.