### PR TITLE
Fix for MP3 with embedded image

### DIFF
--- a/modules/common/src/main/resources/org/opencastproject/util/MimeTypes.xml
+++ b/modules/common/src/main/resources/org/opencastproject/util/MimeTypes.xml
@@ -117,7 +117,7 @@
   <MimeType>
     <Type>audio/mpeg</Type>
     <Description>MPEG audio</Description>
-    <Extensions>m1a,mp2,mpa,m2a,mp3,swa</Extensions>
+    <Extensions>mp3,m1a,mp2,mpa,m2a,swa</Extensions>
   </MimeType>
   <MimeType>
     <Type>audio/mpeg3</Type>

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspector.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspector.java
@@ -136,13 +136,6 @@ public class MediaInspector {
 
         // Mimetype
         MimeType mimeType = MimeTypes.fromString(file.getPath());
-
-        // The mimetype library doesn't know about audio/video metadata, so the type might be wrong.
-        if ("audio".equals(mimeType.getType()) && metadata.hasVideoStreamMetadata()) {
-          mimeType = MimeTypes.parseMimeType("video/" + mimeType.getSubtype());
-        } else if ("video".equals(mimeType.getType()) && !metadata.hasVideoStreamMetadata()) {
-          mimeType = MimeTypes.parseMimeType("audio/" + mimeType.getSubtype());
-        }
         track.setMimeType(mimeType);
 
         // Audio metadata
@@ -268,13 +261,6 @@ public class MediaInspector {
         if (track.getMimeType() == null || override) {
           try {
             MimeType mimeType = MimeTypes.fromURI(track.getURI());
-
-            // The mimetype library doesn't know about audio/video metadata, so the type might be wrong.
-            if ("audio".equals(mimeType.getType()) && metadata.hasVideoStreamMetadata()) {
-              mimeType = MimeTypes.parseMimeType("video/" + mimeType.getSubtype());
-            } else if ("video".equals(mimeType.getType()) && !metadata.hasVideoStreamMetadata()) {
-              mimeType = MimeTypes.parseMimeType("audio/" + mimeType.getSubtype());
-            }
             track.setMimeType(mimeType);
           } catch (UnknownFileTypeException e) {
             logger.info("Unable to detect the mimetype for track {} at {}", track.getIdentifier(), track.getURI());


### PR DESCRIPTION
While trying to generate a mp3 file with an embedded picture, I ran into the problem that the MediaInspector changed the mimetype incorrectly from `audio/mpeg` to `video/mpeg` because of the embedded picture. Afterwards the AssetManager changes the file extension from `.mp3` to `.m1a`.

Attached is the workflow and the encoding properties
[audio.zip](https://github.com/opencast/opencast/files/3960695/audio.zip)
