### PR TITLE
Remove ffmpeg banner by default

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -342,6 +342,7 @@ public class EncoderEngine implements AutoCloseable {
     command.add(binary);
     command.add("-nostdin");
     command.add("-nostats");
+    command.add("-hide_banner");
 
     String commandline = profile.getExtension(CMD_SUFFIX);
 


### PR DESCRIPTION
Adding -hide_banner to the ffmpeg commandline by default.  This removes a large chunk of text that ffmpeg spits out by default, which tends to clutter our log files with garbage.

Happy to rebase this to 8.x, or even 7.x if people think it's appropriate.