### PR TITLE
Read published files direct from filesystem if possible

### DIFF
--- a/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/DistributionPathUtils.java
+++ b/modules/asset-manager-util/src/main/java/org/opencastproject/assetmanager/util/DistributionPathUtils.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.assetmanager.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Paths;
+
+/**
+ *
+ */
+public final class DistributionPathUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(DistributionPathUtils.class);
+
+  /** Key defining the distribution root directory */
+  private static final String CONFIG_DOWNLOAD_ROOT = "org.opencastproject.download.directory";
+
+  /** Key defining the distribution URL prefix */
+  private static final String CONFIG_DOWNLOAD_URL = "org.opencastproject.download.url";
+
+  private DistributionPathUtils() {
+  }
+
+  /**
+   * Get the local mount point of the distribution files if it exists.
+   *
+   * @param componentContext
+   *        The OSGI component context
+   * @return Path to the local distribution directory if it exists
+   */
+  public static String getDownloadPath(final ComponentContext componentContext) {
+    if (componentContext == null || componentContext.getBundleContext() == null) {
+      return null;
+    }
+    final BundleContext bundleContext = componentContext.getBundleContext();
+
+    String downloadDir = StringUtils.trimToNull(bundleContext.getProperty(CONFIG_DOWNLOAD_ROOT));
+
+    // Is the distribution download available locally?
+    if (downloadDir != null && new File(downloadDir).isDirectory()) {
+      logger.debug("Found local distribution directory at {}", downloadDir);
+      return downloadDir;
+    }
+
+    return null;
+  }
+
+  /**
+   * Get the local mount point of the distribution files if it exists.
+   *
+   * @param componentContext
+   *        The OSGI component context
+   * @return Path to the local distribution directory if it exists
+   */
+  public static String getDownloadUrl(final ComponentContext componentContext) {
+    if (componentContext == null || componentContext.getBundleContext() == null) {
+      return null;
+    }
+    final BundleContext bundleContext = componentContext.getBundleContext();
+
+    String downloadUrl = StringUtils.trimToNull(bundleContext.getProperty(CONFIG_DOWNLOAD_URL));
+
+    // Is the distribution download available locally?
+    if (downloadUrl != null) {
+      logger.debug("Local distribution URL is {}", downloadUrl);
+      return downloadUrl;
+    }
+
+    return null;
+  }
+
+
+  /**
+   * Splits up a distribution URI and returns a local path instead.
+   *
+   * @param localPath
+   *          Path to the local distribution directory
+   * @param organizationId
+   *          Organization identifier
+   * @param uri
+   *          URI to the asset
+   * @return Local file
+   */
+  public static File getLocalFile(final String localPath, final String downloadUrl, final String organizationId, final URI uri) {
+    if (localPath == null
+            || organizationId == null
+            || !uri.toString().startsWith(downloadUrl)) {
+      return null;
+    }
+
+    final File file = Paths.get(localPath, uri.toString().substring(downloadUrl.length())).toFile();
+
+    if (file.isFile()) {
+      logger.debug("Converted {} to local file at {}", uri, file);
+      return file;
+    }
+    logger.debug("Local file for {} not available. {} does not exist.", uri, file);
+    return null;
+  }
+
+}

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImpl.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImpl.java
@@ -65,8 +65,6 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
@@ -388,8 +386,7 @@ public class StaticMetadataServiceDublinCoreImpl implements StaticMetadataServic
   private Option<DublinCoreCatalog> load(Catalog catalog) {
     InputStream in = null;
     try {
-      File f = workspace.get(catalog.getURI());
-      in = new FileInputStream(f);
+      in = workspace.read(catalog.getURI());
       return some((DublinCoreCatalog) DublinCores.read(in));
     } catch (Exception e) {
       logger.warn("Unable to load metadata from catalog '{}'", catalog);

--- a/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImplTest.java
+++ b/modules/dublincore/src/test/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImplTest.java
@@ -38,7 +38,6 @@ import org.opencastproject.workspace.api.Workspace;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
 
@@ -72,11 +71,11 @@ public final class StaticMetadataServiceDublinCoreImplTest {
   private Workspace newWorkspace() throws Exception {
     // mock workspace
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
-    final File dcFile = new File(getClass().getResource("/dublincore.xml").toURI());
-    final File dcFileDefect = new File(getClass().getResource("/dublincore-defect.xml").toURI());
+    InputStream dcFile = getClass().getResourceAsStream("/dublincore.xml");
+    InputStream dcFileDefect = getClass().getResourceAsStream("/dublincore-defect.xml");
     assertNotNull(dcFile);
     // set expectations
-    EasyMock.expect(workspace.get(EasyMock.anyObject())).andAnswer(
+    EasyMock.expect(workspace.read(EasyMock.anyObject())).andAnswer(
             () -> EasyMock.getCurrentArguments()[0].toString().contains("-defect") ? dcFileDefect : dcFile).anyTimes();
     // put into replay mode
     EasyMock.replay(workspace);

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
@@ -81,6 +81,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
@@ -158,10 +159,10 @@ public class SearchServiceImplTest {
   public void setUp() throws Exception {
     // workspace
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.get((URI) EasyMock.anyObject())).andAnswer(new IAnswer<File>() {
+    EasyMock.expect(workspace.read((URI) EasyMock.anyObject())).andAnswer(new IAnswer<InputStream>() {
       @Override
-      public File answer() throws Throwable {
-        return new File(new URI(EasyMock.getCurrentArguments()[0].toString()));
+      public InputStream answer() throws Throwable {
+        return new FileInputStream(new File(new URI(EasyMock.getCurrentArguments()[0].toString())));
       }
     }).anyTimes();
     EasyMock.replay(workspace);

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -364,9 +364,6 @@ public final class WorkspaceImpl implements Workspace {
       return new File(inWs.getAbsolutePath());
     }
 
-    Throwable ex = new Throwable();
-    logger.warn("http download here", ex);
-
     // do HTTP transfer
     return locked(inWs, downloadIfNecessary(uri));
   }

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -37,6 +37,7 @@ import static org.opencastproject.util.data.Prelude.sleep;
 import static org.opencastproject.util.data.Tuple.tuple;
 
 import org.opencastproject.assetmanager.util.AssetPathUtils;
+import org.opencastproject.assetmanager.util.DistributionPathUtils;
 import org.opencastproject.mediapackage.identifier.Id;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.TrustedHttpClient;
@@ -147,6 +148,10 @@ public final class WorkspaceImpl implements Workspace {
 
   /** the asset manager directory if locally available */
   private String assetManagerPath = null;
+
+  /** the download url and directory if locally available */
+  private String downloadUrl = null;
+  private String downloadPath = null;
 
   /** The workspce cleaner */
   private WorkspaceCleaner workspaceCleaner = null;
@@ -297,6 +302,10 @@ public final class WorkspaceImpl implements Workspace {
 
     // Check if we can read from the asset manager locally to avoid downloading files via HTTP
     assetManagerPath = AssetPathUtils.getAssetManagerPath(cc);
+
+    // Check if we can read published files locally to avoid downloading files via HTTP
+    downloadUrl = DistributionPathUtils.getDownloadUrl(cc);
+    downloadPath = DistributionPathUtils.getDownloadPath(cc);
   }
 
   /** Callback from OSGi on service deactivation. */
@@ -355,6 +364,9 @@ public final class WorkspaceImpl implements Workspace {
       return new File(inWs.getAbsolutePath());
     }
 
+    Throwable ex = new Throwable();
+    logger.warn("http download here", ex);
+
     // do HTTP transfer
     return locked(inWs, downloadIfNecessary(uri));
   }
@@ -381,6 +393,12 @@ public final class WorkspaceImpl implements Workspace {
     final File asset = AssetPathUtils.getLocalFile(assetManagerPath, securityService.getOrganization().getId(), uri);
     if (asset != null) {
       return new FileInputStream(asset);
+    }
+
+    // Check if we can get the files directly from the distribution download directory
+    final File publishedFile = DistributionPathUtils.getLocalFile(downloadPath, downloadUrl, securityService.getOrganization().getId(), uri);
+    if (publishedFile != null) {
+      return new FileInputStream(publishedFile);
     }
 
     // fall back to get() which should download the file into local workspace if necessary


### PR DESCRIPTION
This addresses a performance issue when building the solr search index with a large number of published events. The event metadata files and catalogs (e.g. dublincore.xml, segments.xml, slidetext.xml) are loaded into the workspace from http requests which is relatively slow, especially if Opencast is configured with https.

With a large number of events (60K+), this change reduced indexing time from > 6 hours to just over 1 hour on a test system.

This uses a similar implementation to the technique used to read asset manager files directly, though the location of DistributionPathUtils in asset-manager-utils is probably questionable and I'm open to suggestions there.
