### PR TITLE
Fix AWS WOH OSGI dependencies

### DIFF
--- a/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-aws.xml
+++ b/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-aws.xml
@@ -16,8 +16,6 @@
   <reference name="ServiceRegistry" cardinality="1..1"
              interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
              policy="static" bind="setServiceRegistry"/>
-  <reference cardinality="1..1" interface="org.opencastproject.security.api.SecurityService"
-             name="SecurityService" policy="static" bind="setSecurityService"/>
   <reference name="organizationDirectoryService"
              interface="org.opencastproject.security.api.OrganizationDirectoryService"
              bind="setOrganizationDirectoryService"/>


### PR DESCRIPTION
PR #926 removed setSecurityService() from PublishEngageWOH, but didn't change publish-aws.xml.