### PR TITLE
Fix event delete with existing publications

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/RetractionListener.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/RetractionListener.java
@@ -60,7 +60,8 @@ public final class RetractionListener implements WorkflowListener {
       logger.warn("The retract workflow \"{}\" (id: {}, created by: {}) does not have a media package.",
               workflow.getTitle(), workflow.getId(), workflow.getCreatorName());
     } else if (mediaPackage.getPublications() != null && mediaPackage.getPublications().length > 0) {
-      logger.warn("The retract workflow \"{}\" (id: {}, created by: {}, media package {}) has leave some publications.",
+      logger.warn("The retract workflow \"{}\" (id: {}, created by: {}, media package {}) "
+                      + "has some non-retracted publications, refusing to orphan them.",
               workflow.getTitle(), workflow.getId(), workflow.getCreatorName(), mediaPackage.getIdentifier().compact());
     } else {
       final Retraction retraction = retractions.get(workflow.getId());

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/RetractionListener.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/RetractionListener.java
@@ -22,6 +22,7 @@
 package org.opencastproject.index.service.impl.index.event;
 
 import org.opencastproject.index.service.api.IndexService;
+import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.util.SecurityUtil;
@@ -54,22 +55,32 @@ public final class RetractionListener implements WorkflowListener {
     if (!retractions.containsKey(workflow.getId())) {
       return;
     }
-    final Retraction retraction = retractions.get(workflow.getId());
-    SecurityUtil.runAs(securityService, retraction.getOrganization(), retraction.getUser(), () -> {
-      final String mpId = workflow.getMediaPackage().getIdentifier().compact();
-      try {
-        final boolean result = indexService.removeEvent(mpId);
-        if (!result) {
-          logger.warn("Could not delete retracted media package {}. removeEvent returned false.", mpId);
+    MediaPackage mediaPackage = workflow.getMediaPackage();
+    if (mediaPackage == null) {
+      logger.warn("The retract workflow \"{}\" (id: {}, created by: {}) does not have a media package.",
+              workflow.getTitle(), workflow.getId(), workflow.getCreatorName());
+    } else if (mediaPackage.getPublications() != null && mediaPackage.getPublications().length > 0) {
+      logger.warn("The retract workflow \"{}\" (id: {}, created by: {}, media package {}) has leave some publications.",
+              workflow.getTitle(), workflow.getId(), workflow.getCreatorName(), mediaPackage.getIdentifier().compact());
+    } else {
+      final Retraction retraction = retractions.get(workflow.getId());
+      SecurityUtil.runAs(securityService, retraction.getOrganization(), retraction.getUser(), () -> {
+        final String mpId = mediaPackage.getIdentifier().compact();
+        try {
+          if (!indexService.removeEvent(mpId)) {
+            logger.warn("Could not delete retracted media package {}. removeEvent returned false.", mpId);
+          }
+        } catch (UnauthorizedException e) {
+          logger.warn("Not authorized to delete retracted media package {}", mpId);
+        } catch (NotFoundException e) {
+          logger.warn("Unable to delete retracted media package {} because it could not be found", mpId);
+          retraction.getDoOnNotFound().run();
+        } catch (Exception e) {
+          logger.warn("Unable to delete retracted media package {}:", mpId, e);
         }
-        retractions.remove(workflow.getId());
-      } catch (UnauthorizedException e) {
-        logger.warn("Not authorized to delete retracted media package {}",  mpId);
-      } catch (NotFoundException e) {
-        logger.warn("Unable to delete retracted media package {} because it could not be found",  mpId);
-        retraction.getDoOnNotFound().run();
-      }
-    });
+      });
+    }
+    retractions.remove(workflow.getId());
   }
 }
 


### PR DESCRIPTION
The new event delete behavior of the admin UI does only check, if the retract workflow succeeded but not if the resulting event does have any publications. This patch fix this. Any existing publications will produce a warning in the log output and stop deletion process of the event.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
