### PR TITLE
Fixed config case mismatch and track construction in extractVideoSourcesAndDuration

### DIFF
--- a/etc/ui-config/mh_default_org/theodul/config.yml
+++ b/etc/ui-config/mh_default_org/theodul/config.yml
@@ -22,7 +22,7 @@ allowedTags:
 # The browser's format setting will be engaged only after this filter has been applied.
 # Default: don't filter video/streaming formats
 # Allowed values: hls, dash, rtmp, mp4, webm, audio
-#allowedformats:
+#allowedFormats:
 #  - hls
 #  - dash
 #  - mp4


### PR DESCRIPTION
This pull request closes [Case mismatch for theodul allowedformats config value #1302]([https://github.com/opencast/opencast/issues/1302)

Also fixes a bug with the filtering of the main flavors in extractVideoSourcesAndDuration to use the filtered tracks contained in mediaInfo.

It also simplifies the filterTracksByTag and filterTracksByFormat functions and improves error handling.