### PR TITLE
Secure FPS For Smil Processing

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -787,8 +787,7 @@ public class EncoderEngine implements AutoCloseable {
    */
   private List<String> makeEdits(List<VideoClip> clips, int transitionDuration, Boolean hasVideo,
           Boolean hasAudio) throws Exception {
-    double vfade = transitionDuration / 1000; // video and audio have the same transition duration
-    double afade = vfade;
+    double fade = transitionDuration / 1000.; // video and audio have the same transition duration
     DecimalFormatSymbols ffmpegFormat = new DecimalFormatSymbols();
     ffmpegFormat.setDecimalSeparator('.');
     DecimalFormat f = new DecimalFormat("0.00", ffmpegFormat);
@@ -812,14 +811,15 @@ public class EncoderEngine implements AutoCloseable {
         int fileindx = vclip.getSrc(); // get source file by index
         double inpt = vclip.getStart(); // get in points
         double duration = vclip.getDuration();
-        double vend = Math.max(duration - vfade, 0);
-        double aend = Math.max(duration - afade, 0);
+        double vend = Math.max(duration - fade, 0);
+        double aend = Math.max(duration - fade, 0);
         if (hasVideo) {
           String vvclip;
           vvclip = "[" + fileindx + ":v]trim=" + f.format(inpt) + ":duration=" + f.format(duration)
                   + ",setpts=PTS-STARTPTS"
-                  + ((vfade > 0) ? ",fade=t=in:st=0:d=" + vfade + ",fade=t=out:st=" + f.format(vend) + ":d=" + vfade
+                  + ((fade > 0) ? ",fade=t=in:st=0:d=" + fade + ",fade=t=out:st=" + f.format(vend) + ":d=" + fade
                           : "")
+                  + ",fps=25"
                   + "[" + outmap + "v" + i + "]";
           clauses.add(vvclip);
         }
@@ -827,8 +827,8 @@ public class EncoderEngine implements AutoCloseable {
           String aclip;
           aclip = "[" + fileindx + ":a]atrim=" + f.format(inpt) + ":duration=" + f.format(duration)
                   + ",asetpts=PTS-STARTPTS"
-                  + ((afade > 0)
-                          ? ",afade=t=in:st=0:d=" + afade + ",afade=t=out:st=" + f.format(aend) + ":d=" + +afade
+                  + ((fade > 0)
+                          ? ",afade=t=in:st=0:d=" + fade + ",afade=t=out:st=" + f.format(aend) + ":d=" + +fade
                           : "")
                   + "[" + outmap + "a" + i + "]";
           clauses.add(aclip);
@@ -844,15 +844,15 @@ public class EncoderEngine implements AutoCloseable {
       int fileindx = vclip.getSrc(); // get source file by index
       double inpt = vclip.getStart(); // get in points
       double duration = vclip.getDuration();
-      double vend = Math.max(duration - vfade, 0);
-      double aend = Math.max(duration - afade, 0);
+      double vend = Math.max(duration - fade, 0);
+      double aend = Math.max(duration - fade, 0);
 
       if (hasVideo) {
         String vvclip;
 
         vvclip = "[" + fileindx + ":v]trim=" + f.format(inpt) + ":duration=" + f.format(duration)
                 + ",setpts=PTS-STARTPTS,"
-                + ((vfade > 0) ? "fade=t=in:st=0:d=" + vfade + ",fade=t=out:st=" + f.format(vend) + ":d=" + vfade : "")
+                + ((fade > 0) ? "fade=t=in:st=0:d=" + fade + ",fade=t=out:st=" + f.format(vend) + ":d=" + fade : "")
                 + "[ov]";
 
         clauses.add(vvclip);
@@ -861,8 +861,8 @@ public class EncoderEngine implements AutoCloseable {
         String aclip;
         aclip = "[" + fileindx + ":a]atrim=" + f.format(inpt) + ":duration=" + f.format(duration)
                 + ",asetpts=PTS-STARTPTS,"
-                + ((afade > 0) ? "afade=t=in:st=0:d=" + afade + ",afade=t=out:st=" + f.format(aend) + ":d=" : "")
-                + afade + "[oa]";
+                + ((fade > 0) ? "afade=t=in:st=0:d=" + fade + ",afade=t=out:st=" + f.format(aend) + ":d=" : "")
+                + fade + "[oa]";
 
         clauses.add(aclip);
       }


### PR DESCRIPTION
The `unsafe` option in FFmpeg's concat filter allows videos with
different frame rates and sample aspect rations to be concatenated
instead of failing. FFmpeg tries do guess the best options.

In some edge cases, this can lead to somewhat insane frame rates. In my
specific case, I had a frame rate of 1000000 frames per second,
essentially causing the whole process to seemingly hang forever.

To avoid that and still be able to process videos with different frame
sizes, this patch enforces a common frame rate for all input videos.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
