### PR TITLE
Fix Image Extraction From Short Videos

### DIFF
--- a/etc/encoding/engage-images.properties
+++ b/etc/encoding/engage-images.properties
@@ -33,7 +33,9 @@ profile.player-preview.http.name = cover image for engage
 profile.player-preview.http.input = visual
 profile.player-preview.http.output = image
 profile.player-preview.http.suffix = -player.jpg
-profile.player-preview.http.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=-1:480 #{out.dir}/#{out.name}#{out.suffix}
+profile.player-preview.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
+  -filter:v trim=0:#{time},fps=1,reverse,scale=-2:480 \
+  #{out.dir}/#{out.name}#{out.suffix}
 
 # Slide preview images as shown in the player
 profile.player-slides.http.name = slide preview image for engage
@@ -47,11 +49,12 @@ profile.search-cover.http.name = cover image for engage
 profile.search-cover.http.input = visual
 profile.search-cover.http.output = image
 profile.search-cover.http.suffix = -search.jpg
-profile.search-cover.http.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=160:-1 #{out.dir}/#{out.name}#{out.suffix}
+profile.search-cover.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
+  -filter:v trim=0:#{time},fps=1,reverse,scale=160:-2 \
+  #{out.dir}/#{out.name}#{out.suffix}
 
 profile.search-cover.http.downscale.name = Downscale to cover image for engage
 profile.search-cover.http.downscale.input = visual
 profile.search-cover.http.downscale.output = image
 profile.search-cover.http.downscale.suffix = -search.jpg
 profile.search-cover.http.downscale.ffmpeg.command = -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=160:-1 #{out.dir}/#{out.name}#{out.suffix}
-


### PR DESCRIPTION
This image extraction for preview images was always done from a few
seconds after the beginning of the video to avoid extracting black
images. This causes the process and thus the workflow to completely fail
on very short videos as we have lately seen multiple times on the public
test servers.

Instead of failing, this patch will make Opencast extract the last frame
before the specified time instead. This behavior can still be changed
since it is only configuration but it's likely a much better default
configuration.

This fixes #1219

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
