### PR TITLE
AngularJS Components 1.7.9

### DIFF
--- a/modules/admin-ui/bower.json
+++ b/modules/admin-ui/bower.json
@@ -6,10 +6,10 @@
     "jquery-ui": "1.12.1",
     "jqueryui-timepicker-addon": "1.6.3",
     "angular": "1.7.9",
-    "angular-route": "1.7.8",
-    "angular-resource": "1.7.8",
-    "angular-animate": "1.7.8",
-    "angular-messages": "1.7.8",
+    "angular-route": "1.7.9",
+    "angular-resource": "1.7.9",
+    "angular-animate": "1.7.9",
+    "angular-messages": "1.7.9",
     "angular-translate": "2.18.1",
     "angular-translate-loader-static-files": "2.18.1",
     "angular-local-storage": "0.7.1",
@@ -20,7 +20,7 @@
     "angular-chart.js": "^1.1.1"
   },
   "devDependencies": {
-    "angular-mocks": "1.7.8"
+    "angular-mocks": "1.7.9"
   },
   "overrides": {
     "angular-wizard": {
@@ -28,8 +28,5 @@
     }
   },
   "appPath": "src/main/webapp",
-  "moduleName": "adminNg",
-  "resolutions": {
-    "angular": "1.7.9"
-  }
+  "moduleName": "adminNg"
 }


### PR DESCRIPTION
The AngularJS security fix 1.7.9 caused some version conflicts which
were forcefully resolved since newer versions of the angular component
libraries were not available at that time. They are now and this bumps
all components to the library version again.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
