### PR TITLE
Remove Spring Request Logger Configuration

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -540,8 +540,4 @@
   <!-- Do not use a request cache -->
   <bean id="requestCache" class="org.springframework.security.web.savedrequest.NullRequestCache" />
 
-  <!-- Uncomment to enable logging interceptors -->
-  <!-- bean class="org.springframework.security.access.event.LoggerListener" / -->
-  <!-- bean class="org.springframework.security.authentication.event.LoggerListener" / -->
-
 </beans>


### PR DESCRIPTION
This patch removes the suggested configuration for a Spring request
logger which does not actually exist in Opencast and which thus causes
errors when configured.

This fixes #1213

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
