### PR TITLE
Add Missing Karaf Features

### DIFF
--- a/assemblies/dist-admin/pom.xml
+++ b/assemblies/dist-admin/pom.xml
@@ -100,11 +100,13 @@
             <feature>http</feature>
             <feature>http-whiteboard</feature>
             <feature>scr</feature>
+            <feature>cxf-commands</feature>
             <feature>cxf-jaxrs</feature>
             <feature>cxf-http-jetty</feature>
             <feature>transaction</feature>
             <feature>jndi</feature>
             <feature>eclipselink</feature>
+            <feature>wrap</feature>
             <!-- Opencast features -->
             <feature>opencast-admin</feature>
           </bootFeatures>

--- a/assemblies/dist-adminpresentation/pom.xml
+++ b/assemblies/dist-adminpresentation/pom.xml
@@ -100,11 +100,13 @@
             <feature>http</feature>
             <feature>http-whiteboard</feature>
             <feature>scr</feature>
+            <feature>cxf-commands</feature>
             <feature>cxf-jaxrs</feature>
             <feature>cxf-http-jetty</feature>
             <feature>transaction</feature>
             <feature>jndi</feature>
             <feature>eclipselink</feature>
+            <feature>wrap</feature>
             <!-- Opencast features -->
             <feature>opencast-adminpresentation</feature>
           </bootFeatures>

--- a/assemblies/dist-allinone/pom.xml
+++ b/assemblies/dist-allinone/pom.xml
@@ -100,11 +100,13 @@
             <feature>http</feature>
             <feature>http-whiteboard</feature>
             <feature>scr</feature>
+            <feature>cxf-commands</feature>
             <feature>cxf-jaxrs</feature>
             <feature>cxf-http-jetty</feature>
             <feature>transaction</feature>
             <feature>jndi</feature>
             <feature>eclipselink</feature>
+            <feature>wrap</feature>
             <!-- Opencast features -->
             <feature>opencast-allinone</feature>
           </bootFeatures>

--- a/assemblies/dist-develop/pom.xml
+++ b/assemblies/dist-develop/pom.xml
@@ -108,11 +108,13 @@
             <feature>http</feature>
             <feature>http-whiteboard</feature>
             <feature>scr</feature>
+            <feature>cxf-commands</feature>
             <feature>cxf-jaxrs</feature>
             <feature>cxf-http-jetty</feature>
             <feature>transaction</feature>
             <feature>jndi</feature>
             <feature>eclipselink</feature>
+            <feature>wrap</feature>
             <!-- Opencast features -->
             <feature>opencast-allinone</feature>
           </bootFeatures>

--- a/assemblies/dist-ingest/pom.xml
+++ b/assemblies/dist-ingest/pom.xml
@@ -100,11 +100,13 @@
             <feature>http</feature>
             <feature>http-whiteboard</feature>
             <feature>scr</feature>
+            <feature>cxf-commands</feature>
             <feature>cxf-jaxrs</feature>
             <feature>cxf-http-jetty</feature>
             <feature>transaction</feature>
             <feature>jndi</feature>
             <feature>eclipselink</feature>
+            <feature>wrap</feature>
             <!-- Opencast features -->
             <feature>opencast-ingest</feature>
           </bootFeatures>

--- a/assemblies/dist-presentation/pom.xml
+++ b/assemblies/dist-presentation/pom.xml
@@ -100,11 +100,13 @@
             <feature>http</feature>
             <feature>http-whiteboard</feature>
             <feature>scr</feature>
+            <feature>cxf-commands</feature>
             <feature>cxf-jaxrs</feature>
             <feature>cxf-http-jetty</feature>
             <feature>transaction</feature>
             <feature>jndi</feature>
             <feature>eclipselink</feature>
+            <feature>wrap</feature>
             <!-- Opencast features -->
             <feature>opencast-presentation</feature>
           </bootFeatures>

--- a/assemblies/dist-worker/pom.xml
+++ b/assemblies/dist-worker/pom.xml
@@ -100,11 +100,13 @@
             <feature>http</feature>
             <feature>http-whiteboard</feature>
             <feature>scr</feature>
+            <feature>cxf-commands</feature>
             <feature>cxf-jaxrs</feature>
             <feature>cxf-http-jetty</feature>
             <feature>transaction</feature>
             <feature>jndi</feature>
             <feature>eclipselink</feature>
+            <feature>wrap</feature>
             <!-- Opencast features -->
             <feature>opencast-worker</feature>
           </bootFeatures>


### PR DESCRIPTION
This patch adds some missing Karaf feature to all distributions since
they are used during run-time and will otherwise be downloaded by
Opencast if that is possible or cause a startup failure otherwise.

In other words, this patch essentially ensures that Opencast can boot
without a network connection.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
