### PR TITLE
LDAP User Directory Dependencies

### DIFF
--- a/modules/userdirectory-ldap/pom.xml
+++ b/modules/userdirectory-ldap/pom.xml
@@ -26,6 +26,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -35,20 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.osgi</groupId>
-      <artifactId>org.springframework.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.jdbc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-ldap</artifactId>
-      <version>3.1.7.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -67,18 +58,6 @@
       <groupId>org.springframework.ldap</groupId>
       <artifactId>org.springframework.ldap</artifactId>
       <version>1.3.1.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.beans</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.transaction</artifactId>
     </dependency>
     <!-- Testing -->
     <dependency>
@@ -99,6 +78,22 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- provide a logger for tests -->
+            <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.ldap:org.springframework.ldap</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+          <ignoredUsedUndeclaredDependencies>
+            <!-- We want to switch the LDAP Spring libraries at some point but that requires a Spring update -->
+            <ignoredUsedUndeclaredDependency>org.springframework.ldap:spring-ldap-core</ignoredUsedUndeclaredDependency>
+          </ignoredUsedUndeclaredDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
This patch removes a number of seemingly unrelated dependencies from the
LDAP user directory.

If you have no LDAP server at hand, you can use the [public forumsys test server](https://www.forumsys.com/tutorials/integration-how-to/ldap/online-ldap-test-server/) by simply applying the following configuration:

- https://data.lkiesow.io/opencast/ldapconfig/mh_default_org.xml
- https://data.lkiesow.io/opencast/ldapconfig/org.opencastproject.userdirectory.ldap-forumsys.cfg

Apart from the usual u/p `admin`/`opencast` you should then be able to login with all available LDAP users e.g.:

    user: jmacy
    pass: password

This closes #1337

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
