### PR TITLE
Spring Framework Dependency Specification

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -91,19 +91,19 @@
     <bundle>mvn:org.springframework.osgi/spring-osgi-core/1.2.1</bundle>
     <bundle>mvn:org.springframework.osgi/spring-osgi-extender/1.2.1</bundle>
     <bundle>mvn:org.springframework.osgi/spring-osgi-io/1.2.1</bundle>
-    <bundle>mvn:org.springframework.security/spring-security-config/3.1.7.RELEASE</bundle>
-    <bundle>mvn:org.springframework.security/spring-security-core/3.1.7.RELEASE</bundle>
-    <bundle>mvn:org.springframework.security/spring-security-ldap/3.1.7.RELEASE</bundle>
-    <bundle>mvn:org.springframework.security/spring-security-web/3.1.7.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-aop/3.1.4.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-asm/3.1.4.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-beans/3.1.4.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-context-support/3.1.4.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-context/3.1.4.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-core/3.1.4.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-expression/3.1.4.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-tx/3.1.4.RELEASE</bundle>
-    <bundle>mvn:org.springframework/spring-web/3.1.4.RELEASE</bundle>
+    <bundle>mvn:org.springframework.security/spring-security-config/${spring-security.version}</bundle>
+    <bundle>mvn:org.springframework.security/spring-security-core/${spring-security.version}</bundle>
+    <bundle>mvn:org.springframework.security/spring-security-ldap/${spring-security.version}</bundle>
+    <bundle>mvn:org.springframework.security/spring-security-web/${spring-security.version}</bundle>
+    <bundle>mvn:org.springframework/spring-aop/${spring.version}</bundle>
+    <bundle>mvn:org.springframework/spring-asm/${spring.version}</bundle>
+    <bundle>mvn:org.springframework/spring-beans/${spring.version}</bundle>
+    <bundle>mvn:org.springframework/spring-context-support/${spring.version}</bundle>
+    <bundle>mvn:org.springframework/spring-context/${spring.version}</bundle>
+    <bundle>mvn:org.springframework/spring-core/${spring.version}</bundle>
+    <bundle>mvn:org.springframework/spring-expression/${spring.version}</bundle>
+    <bundle>mvn:org.springframework/spring-tx/${spring.version}</bundle>
+    <bundle>mvn:org.springframework/spring-web/${spring.version}</bundle>
   </feature>
 
   <feature name="opencast-core" version="${project.version}">

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -65,7 +65,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.web</artifactId>
+      <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>

--- a/modules/oaipmh-persistence/pom.xml
+++ b/modules/oaipmh-persistence/pom.xml
@@ -58,7 +58,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.core</artifactId>
+      <artifactId>spring-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/modules/oaipmh/pom.xml
+++ b/modules/oaipmh/pom.xml
@@ -91,7 +91,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.core</artifactId>
+      <artifactId>spring-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/modules/security-ldap/pom.xml
+++ b/modules/security-ldap/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <spring-security.version>3.1.0.RELEASE</spring-security.version>
   </properties>
   <build>
     <plugins>

--- a/modules/userdirectory-ldap/pom.xml
+++ b/modules/userdirectory-ldap/pom.xml
@@ -26,6 +26,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -35,20 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.osgi</groupId>
-      <artifactId>org.springframework.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.jdbc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-ldap</artifactId>
-      <version>3.1.7.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -67,18 +58,6 @@
       <groupId>org.springframework.ldap</groupId>
       <artifactId>org.springframework.ldap</artifactId>
       <version>1.3.1.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.beans</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.transaction</artifactId>
     </dependency>
     <!-- Testing -->
     <dependency>
@@ -99,6 +78,22 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- provide a logger for tests -->
+            <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.springframework.ldap:org.springframework.ldap</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+          <ignoredUsedUndeclaredDependencies>
+            <!-- We want to switch the LDAP Spring libraries at some point but that requires a Spring update -->
+            <ignoredUsedUndeclaredDependency>org.springframework.ldap:spring-ldap-core</ignoredUsedUndeclaredDependency>
+          </ignoredUsedUndeclaredDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>

--- a/modules/userdirectory-sakai/pom.xml
+++ b/modules/userdirectory-sakai/pom.xml
@@ -25,22 +25,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.osgi</groupId>
-      <artifactId>org.springframework.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.jdbc</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
     </dependency>
@@ -51,18 +35,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.beans</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>org.springframework.transaction</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -96,6 +68,17 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- provide a logger for tests -->
+            <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
@@ -103,11 +86,6 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Embed-Dependency>
-              org.springframework.beans;inline=true,
-              org.springframework.core;inline=true,
-              org.springframework.transaction;inline=true
-            </Embed-Dependency>
             <Import-Package>
               !com.ibm.wsspi.uow,
               !javax.ejb,

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
     <osgi.core.version>5.0.0</osgi.core.version>
     <osgi.enterprise.version>5.0.0</osgi.enterprise.version>
     <querydsl.version>3.7.4</querydsl.version>
+    <spring.version>3.1.4.RELEASE</spring.version>
+    <spring-security.version>3.1.7.RELEASE</spring-security.version>
   </properties>
   <modules>
     <module>modules/admin-ui</module>
@@ -984,53 +986,43 @@
       <!-- Spring -->
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.aop</artifactId>
-        <version>3.1.4.RELEASE</version>
+        <artifactId>spring-aop</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.asm</artifactId>
-        <version>3.1.4.RELEASE</version>
+        <artifactId>spring-core</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.core</artifactId>
-        <version>3.1.4.RELEASE</version>
+        <artifactId>spring-beans</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.beans</artifactId>
-        <version>3.1.4.RELEASE</version>
+        <artifactId>spring-jdbc</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.jdbc</artifactId>
-        <version>3.1.4.RELEASE</version>
+        <artifactId>spring-expression</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.expression</artifactId>
-        <version>3.1.4.RELEASE</version>
+        <artifactId>spring-context</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.transaction</artifactId>
-        <version>3.1.4.RELEASE</version>
+        <artifactId>spring-context-support</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.context</artifactId>
-        <version>3.1.4.RELEASE</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.context.support</artifactId>
-        <version>3.1.4.RELEASE</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>org.springframework.web</artifactId>
-        <version>3.1.4.RELEASE</version>
+        <artifactId>spring-web</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.osgi</groupId>
@@ -1050,22 +1042,22 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
-        <version>3.1.7.RELEASE</version>
+        <version>${spring-security.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-config</artifactId>
-        <version>3.1.7.RELEASE</version>
+        <version>${spring-security.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-web</artifactId>
-        <version>3.1.7.RELEASE</version>
+        <version>${spring-security.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-openid</artifactId>
-        <version>3.1.7.RELEASE</version>
+        <version>${spring-security.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security.oauth</groupId>
@@ -1075,12 +1067,12 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-cas</artifactId>
-        <version>3.1.7.RELEASE</version>
+        <version>${spring-security.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-ldap</artifactId>
-        <version>3.1.7.RELEASE</version>
+        <version>${spring-security.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
This patch fixes and unifies a number of Spring Framework and Spring
Security dependency specifications always using the new artifact id
instead of mixing them and using a global version specification to fix a
few version definitions.

This pull request includes #1338 and #1340 which both remove Spring artifacts from modules.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
