### PR TITLE
Drop X-Opencast-Matterhorn-Authorization

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/security/api/SecurityConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/SecurityConstants.java
@@ -26,9 +26,6 @@ package org.opencastproject.security.api;
  */
 public interface SecurityConstants {
 
-  /** Header name for the digest authorization */
-  String AUTHORIZATION_HEADER = "X-Opencast-Matterhorn-Authorization";
-
   /** Header name for the desired organization */
   String ORGANIZATION_HEADER = "X-Opencast-Matterhorn-Organization";
 

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/DelegatingAuthenticationEntryPoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/DelegatingAuthenticationEntryPoint.java
@@ -38,7 +38,6 @@ import javax.servlet.http.HttpServletResponse;
 public class DelegatingAuthenticationEntryPoint implements AuthenticationEntryPoint {
   public static final String REQUESTED_AUTH_HEADER = "X-Requested-Auth";
   public static final String DIGEST_AUTH = "Digest";
-  public static final String OAUTH_SIGNATURE = "oauth_signature";
   public static final String INITIAL_REQUEST_PATH = "initial_request_path";
 
   protected AuthenticationEntryPoint userEntryPoint;

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedAnonymousAuthenticationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedAnonymousAuthenticationFilter.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.kernel.security;
 
-import org.opencastproject.security.api.SecurityConstants;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
 
@@ -44,10 +42,7 @@ public class TrustedAnonymousAuthenticationFilter extends AnonymousAuthenticatio
   @Override
   @Deprecated
   protected boolean applyAnonymousForThisRequest(HttpServletRequest request) {
-    if (StringUtils.isNotBlank(request.getHeader(SecurityConstants.AUTHORIZATION_HEADER))) {
-      return false;
-    }
-    return true;
+    return StringUtils.isBlank(request.getHeader(DelegatingAuthenticationEntryPoint.REQUESTED_AUTH_HEADER));
   }
 
 }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedHttpClientImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedHttpClientImpl.java
@@ -381,7 +381,6 @@ public class TrustedHttpClientImpl implements TrustedHttpClient, HttpConnectionM
     final HttpClient httpClient = makeHttpClient(connectionTimeout, socketTimeout);
     // Add the request header to elicit a digest auth response
     httpUriRequest.setHeader(REQUESTED_AUTH_HEADER, DIGEST_AUTH);
-    httpUriRequest.setHeader(SecurityConstants.AUTHORIZATION_HEADER, "true");
 
     if (serviceRegistry != null && serviceRegistry.getCurrentJob() != null) {
       httpUriRequest.setHeader(CURRENT_JOB_HEADER, Long.toString(serviceRegistry.getCurrentJob().getId()));

--- a/modules/kernel/src/test/java/org/opencastproject/kernel/security/TrustedAnonymousAthenticationFilterTest.java
+++ b/modules/kernel/src/test/java/org/opencastproject/kernel/security/TrustedAnonymousAthenticationFilterTest.java
@@ -60,8 +60,8 @@ public class TrustedAnonymousAthenticationFilterTest {
   @SuppressWarnings("deprecation")
   public void testTrusedAnonymousAuthenticationFilter() {
     HttpServletRequest request = EasyMock.createNiceMock(HttpServletRequest.class);
-    EasyMock.expect(request.getHeader(SecurityConstants.AUTHORIZATION_HEADER)).andReturn("true");
-    EasyMock.expect(request.getHeader(SecurityConstants.AUTHORIZATION_HEADER)).andReturn(null);
+    EasyMock.expect(request.getHeader(DelegatingAuthenticationEntryPoint.REQUESTED_AUTH_HEADER)).andReturn("true");
+    EasyMock.expect(request.getHeader(DelegatingAuthenticationEntryPoint.REQUESTED_AUTH_HEADER)).andReturn(null);
     EasyMock.replay(request);
 
     TrustedAnonymousAuthenticationFilter filter = new TrustedAnonymousAuthenticationFilter();


### PR DESCRIPTION
The `X-Opencast-Matterhorn-Authorization` header was used by Opencast to
identify that anonymous access should never be assumed, even if that
works according to the security specification to avoid ending up with
a wrong user internally.

This is necessary since HTTP Digest is a special case for Opencast
authentication and is handled separately from all other authentication.

But at the same time, HTTP Digest authentication also requires sending
the `X-Requested-Auth` header indicating that a particular authentication
type (HTTP Digest) is requested. This basically makes one of the two
headers redundant.

Worse, simply using X-Requested-Auth works in all cases where
authentication is required, making it seem as if just using this will
always work (which it mostly does) but there are some weird edge-cases
like calling `/info/me.json` which will return `anonymous` as a user.

To avoid this inconsistent behavior, this patch drops the header
`X-Opencast-Matterhorn-Authorization`. Sending it will not result in any
error, but the header will simply be ignored. This should ensure that
this change will not hurt any existing integrations using this header.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
