### PR TITLE
Switch To HTTPS Maven Repository

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -143,6 +143,8 @@
                   <concat destfile="target/assembly/etc/system.properties" append="true">
                     <filelist dir="../resources" files="system.properties.append"/>
                   </concat>
+                  <!-- Quick-fix for invalid Maven repository. Can be removed after upgrading to Karaf >4.2.8 -->
+                  <replace file="target/assembly/etc/org.ops4j.pax.url.mvn.cfg" token="http:" value="https:"/>
                   <!-- Adding extra OSGi system packages to configuration -->
                   <replace file="target/assembly/etc/config.properties" token="org.osgi.framework.system.packages= \" value="org.osgi.framework.system.packages= com.sun.image.codec.jpeg, com.sun.jndi.ldap, \"/>
                   <!-- Disabled write permissions on karaf configuration by deactivating config saves -->


### PR DESCRIPTION
Sonartype has discontinued their HTTP only maven repositories making
Opencast fail to start up unless some Karaf components are already
cached locally. This quick-fix updates the URL schema for the repository
to match the new repository location.

This fixes #1356

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
