### PR TITLE
Fix workflow dropdown in start task

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/schedule-task-modal.html
@@ -83,7 +83,7 @@
                       not-empty-selection
                       ng-model="processing.ud.workflow"
                       ng-model-options="{ allowInvalid: true }"
-                      ng-options="w.title for w in processing.workflows | orderBy: 'displayOrder':true"
+                      ng-options="w.title for w in processing.workflows | orderBy: 'displayOrder':true track by w.id"
                       placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.PUBLICATIONS.SELECT_WORKFLOW' | translate }}'"
                       no-results-text="'{{ 'EVENTS.EVENTS.DETAILS.PUBLICATIONS.SELECT_WORKFLOW_EMPTY' | translate }}'"
                       >

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -464,7 +464,7 @@
                          ng-options="w.title for (obj, w) in wizard.step.workflows |
                                      filter: wizard.getStateControllerByName('source').ud.type === 'UPLOAD'
                                        ? 'upload' : 'schedule' |
-                                     orderBy: 'displayOrder':true"
+                                     orderBy: 'displayOrder':true track by w.id"
                          placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW' | translate }}'"
                          no-results-text="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY' | translate }}'"
                          >


### PR DESCRIPTION
When selecting a workflow in start task, new event or event details, the workflow being picked would
often not match the description and configuration panel shown. This is
fixed by using track by workflow id.

This fixes #1357 
