### PR TITLE
Fix Conflict Detection

### DIFF
--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/Util.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/Util.java
@@ -45,7 +45,7 @@ import java.util.TimeZone;
 
 public final class Util {
   /** The minimum separation between one event ending and the next starting */
-  public static final int EVENT_MINIMUM_SEPARATION_MILLISECONDS = 60 * 1000;
+  public static final int EVENT_MINIMUM_SEPARATION_MILLISECONDS = 0;
 
   private static final Logger logger = LoggerFactory.getLogger(Util.class);
   private static final TimeZoneRegistry registry = TimeZoneRegistryFactory.getInstance().createRegistry();

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1138,14 +1138,6 @@ public class SchedulerServiceImplTest {
       //Event A contains event B entirely
       conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(23)), new Date(currentTime + hours(26)));
       assertEquals(1, conflicts.size());
-
-      //Event A ends with less than one minute before event B starts
-      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(23)), new Date(currentTime + hours(24) - seconds(1)));
-      assertEquals(1, conflicts.size());
-
-      //Event A begins than one minute after event B ends
-      conflicts = schedSvc.findConflictingEvents("Device A", new Date(currentTime + hours(25) + seconds(1)), new Date(currentTime + hours(27)));
-      assertEquals(1, conflicts.size());
     }
   }
 


### PR DESCRIPTION
This patch fixes Opencast's conflict detection for scheduled events
which would marks two events (9am to 10am) and (10am to 11am) as
conflicting which is a very exexpected behavior.

Worse, even disjoind end/start times could cause conflicts with no sane
reason why they would. E.g. (8:00:00 - 9:00:00) and (9:00:10 to 9:30:00)
would be marked as conflicting.

This patchfixes this erratic behavior, returning to the iCal definition
for start dates, end dates and conflicts we have always used.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
