### PR TITLE
Log the proper index name when updating the asset manager index

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/message/AssetManagerMessageReceiverImpl.java
@@ -114,7 +114,8 @@ public class AssetManagerMessageReceiverImpl extends BaseMessageReceiverImpl<Ass
     // Persist the scheduling event
     try {
       getSearchIndex().addOrUpdate(event);
-      logger.debug("Asset manager entry {} updated in the admin ui search index", event.getIdentifier());
+      logger.debug("Asset manager entry {} updated in the {} search index", event.getIdentifier(),
+              getSearchIndex().getIndexName());
     } catch (SearchIndexException e) {
       logger.error("Error retrieving the recording event from the search index: {}", e.getMessage());
     }


### PR DESCRIPTION
When rebuilding the external API indices,
the log is full of messages about updated asset manager items
in the **admin ui** search index.
This is confusing, especially when this takes a long time;
we just thought for a brief moment that we accidentally rebuilt
the admin UI index twice, instead of admin UI and external API,
and because that takes like 3 hours in this case,
that shocked us quite a bit. ;)

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
