### PR TITLE
In fast, don't cleanup acls (see other workflows)

### DIFF
--- a/etc/workflows/fast.xml
+++ b/etc/workflows/fast.xml
@@ -324,6 +324,8 @@
       <configurations>
         <configuration key="preserve-flavors">security/*</configuration>
         <configuration key="delete-external">true</configuration>
+        <!-- FixMe Don't clean up ACLs until workflow service no longer looks for them in the WFR. -->
+        <configuration key="preserve-flavors">security/*</configuration>
       </configurations>
     </operation>
 


### PR DESCRIPTION
If we cleanup the ACLs at the end of the workflow, the last workflow update that happens after will set an empty acl into the index. So set an exception as we do in other workflows.
