### PR TITLE
Speedup silence detection in case there is a video stream

### DIFF
--- a/modules/silencedetection-impl/src/main/java/org/opencastproject/silencedetection/ffmpeg/FFmpegSilenceDetector.java
+++ b/modules/silencedetection-impl/src/main/java/org/opencastproject/silencedetection/ffmpeg/FFmpegSilenceDetector.java
@@ -152,7 +152,7 @@ public class FFmpegSilenceDetector {
     DecimalFormat decimalFmt = new DecimalFormat("0.000", new DecimalFormatSymbols(Locale.US));
     String minSilenceLengthInSeconds = decimalFmt.format((double) minSilenceLength / 1000.0);
     String filter = "silencedetect=noise=" + thresholdDB + ":duration=" + minSilenceLengthInSeconds;
-    String[] command = new String[] {binary, "-nostats", "-i", mediaPath, "-filter:a", filter, "-f", "null", "-"};
+    String[] command = new String[] {binary, "-nostats", "-i", mediaPath, "-vn", "-filter:a", filter, "-f", "null", "-"};
     String commandline = StringUtils.join(command, " ");
 
     logger.info("Running {}", commandline);


### PR DESCRIPTION
When you use a video for silence detection, it will be really slow because ffmpeg also handles the video tracks (i.e. decoding, and so on). This patch simply tells ffmpeg to not handle all video streams.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
