### PR TITLE
Return bibliographic start date of event via API

### DIFF
--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -90,7 +90,7 @@ Field                | Type                                 | Description
 `presenter`\*        | [`array[string]`](types.md#array)    | The presenters of this event
 `created`\*          | [`datetime`](types.md#date-and-time) | The date and time this event was created
 `subjects`\*         | [`array[string]`](types.md#array)    | The subjects of this event
-`start`\*            | [`datetime`](types.md#date-and-time) | The bibliographic start date and time of this event
+`start`              | [`datetime`](types.md#date-and-time) | The technical (version < 1.4.0) or bibliographic (version >= 1.4.0) start date and time of this event
 `description`\*      | [`string`](types.md#basic)           | The description of this event
 `title`\*            | [`string`](types.md#basic)           | The title of this event
 `processing_state`   | [`string`](types.md#basic)           | The current processing state of this event
@@ -366,7 +366,7 @@ Field                | Type                                 | Description
 `presenter`\*        | [`array[string]`](types.md#array)    | The presenters of this event
 `created`\*          | [`datetime`](types.md#date-and-time) | The date and time this event was created
 `subjects`\*         | [`array[string]`](types.md#array)    | The subjects of this event
-`start`              | [`datetime`](types.md#date-and-time) | The technical start date and time of this event
+`start`              | [`datetime`](types.md#date-and-time) | The technical (version < 1.4.0) or bibliographic (version >= 1.4.0) start date and time of this event
 `description`\*      | [`string`](types.md#basic)           | The description of this event
 `title`\*            | [`string`](types.md#basic)           | The title of this event
 `processing_state`   | [`string`](types.md#basic)           | The current processing state of this event

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -28,6 +28,7 @@ import static com.entwinemedia.fn.data.json.Jsons.obj;
 import static com.entwinemedia.fn.data.json.Jsons.v;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.opencastproject.external.common.ApiVersion.VERSION_1_1_0;
+import static org.opencastproject.external.common.ApiVersion.VERSION_1_4_0;
 import static org.opencastproject.external.util.SchedulingUtils.SchedulingInfo;
 import static org.opencastproject.external.util.SchedulingUtils.convertConflictingEvents;
 import static org.opencastproject.external.util.SchedulingUtils.getConflictingEvents;
@@ -862,12 +863,19 @@ public class EventsEndpoint implements ManagedService {
     }
     fields.add(f("publication_status", arr(publicationIds)));
     fields.add(f("processing_state", v(event.getWorkflowState(), BLANK)));
-    fields.add(f("start", v(event.getTechnicalStartTime(), BLANK)));
-    if (event.getTechnicalEndTime() != null) {
-      long duration = new DateTime(event.getTechnicalEndTime()).getMillis()
-                    - new DateTime(event.getTechnicalStartTime()).getMillis();
-      fields.add(f("duration", v(duration)));
+
+    if (requestedVersion.isSmallerThan(VERSION_1_4_0)) {
+      fields.add(f("start", v(event.getTechnicalStartTime(), BLANK)));
+      if (event.getTechnicalEndTime() != null) {
+        long duration = new DateTime(event.getTechnicalEndTime()).getMillis()
+                - new DateTime(event.getTechnicalStartTime()).getMillis();
+        fields.add(f("duration", v(duration)));
+      }
+    } else {
+      fields.add(f("start", v(event.getRecordingStartDate(), BLANK)));
+      fields.add(f("duration", v(event.getDuration(), BLANK)));
     }
+
     if (StringUtils.trimToNull(event.getSubject()) != null) {
       fields.add(f("subjects", arr(splitSubjectIntoArray(event.getSubject()))));
     } else {


### PR DESCRIPTION
Instead of the technical date (which doesn't make much sense for
non-scheduled events), return the bibliographic start date of events in
the External API.
