### PR TITLE
Silence Detector Cleanup

### DIFF
--- a/modules/silencedetection-impl/pom.xml
+++ b/modules/silencedetection-impl/pom.xml
@@ -53,10 +53,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-silencedetection-api</artifactId>
       <version>${project.version}</version>

--- a/modules/silencedetection-impl/src/main/java/org/opencastproject/silencedetection/ffmpeg/FFmpegSilenceDetector.java
+++ b/modules/silencedetection-impl/src/main/java/org/opencastproject/silencedetection/ffmpeg/FFmpegSilenceDetector.java
@@ -30,8 +30,6 @@ import org.opencastproject.silencedetection.impl.SilenceDetectionProperties;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workspace.api.Workspace;
 
-import com.google.common.io.LineReader;
-
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
@@ -84,7 +82,7 @@ public class FFmpegSilenceDetector {
         if (binaryFile.exists()) {
           binary = binaryFile.getAbsolutePath();
         } else {
-          logger.warn("FFMPEG binary file {} does not exist", StringUtils.trim(binaryPath));
+          logger.warn("FFmpeg binary file {} does not exist", StringUtils.trim(binaryPath));
         }
       }
     } catch (Exception ex) {
@@ -145,46 +143,40 @@ public class FFmpegSilenceDetector {
     if (track.getDuration() == null) {
       throw new MediaPackageException("Track " + trackId + " does not have a duration");
     }
-    logger.info("Track {} loaded, duration is {} s", filePath, track.getDuration() / 1000);
-
+    logger.debug("Track {} loaded, duration is {} s", filePath, track.getDuration() / 1000);
     logger.info("Starting silence detection of {}", filePath);
-    String mediaPath = filePath.replaceAll(" ", "\\ ");
     DecimalFormat decimalFmt = new DecimalFormat("0.000", new DecimalFormatSymbols(Locale.US));
     String minSilenceLengthInSeconds = decimalFmt.format((double) minSilenceLength / 1000.0);
     String filter = "silencedetect=noise=" + thresholdDB + ":duration=" + minSilenceLengthInSeconds;
-    String[] command = new String[] {binary, "-nostats", "-i", mediaPath, "-vn", "-filter:a", filter, "-f", "null", "-"};
-    String commandline = StringUtils.join(command, " ");
+    String[] command = new String[] {
+        binary, "-nostats", "-nostdin", "-i", filePath, "-vn", "-filter:a", filter, "-f", "null", "-"};
 
-    logger.info("Running {}", commandline);
+    logger.info("Running {}", (Object) command);
 
     ProcessBuilder pbuilder = new ProcessBuilder(command);
     List<String> segmentsStrings = new LinkedList<String>();
     Process process = pbuilder.start();
-    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
-    try {
-      LineReader lr = new LineReader(reader);
-      String line = lr.readLine();
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
+      String line = reader.readLine();
       while (null != line) {
         /* We want only lines from the silence detection filter */
         logger.debug("FFmpeg output: {}", line);
         if (line.startsWith("[silencedetect ")) {
           segmentsStrings.add(line);
         }
-        line = lr.readLine();
+        line = reader.readLine();
       }
     } catch (IOException e) {
-      logger.error("Error executing ffmpeg: {}", e.getMessage());
-    } finally {
-      reader.close();
+      logger.error("Error executing ffmpeg", e);
     }
 
-    /**
+    /*
      * Example output:
      * [silencedetect @ 0x2968e40] silence_start: 466.486
      * [silencedetect @ 0x2968e40] silence_end: 469.322 | silence_duration: 2.83592
      */
 
-    LinkedList<MediaSegment> segmentsTmp = new LinkedList<MediaSegment>();
+    LinkedList<MediaSegment> segmentsTmp = new LinkedList<>();
     if (segmentsStrings.size() == 0) {
       /* No silence found -> Add one segment for the whole track */
       logger.info("No silence found. Adding one large segment.");

--- a/modules/silencedetection-impl/src/test/java/org/opencastproject/silencedetection/ffmpeg/SilenceDetectorTest.java
+++ b/modules/silencedetection-impl/src/test/java/org/opencastproject/silencedetection/ffmpeg/SilenceDetectorTest.java
@@ -28,13 +28,12 @@ import static org.junit.Assert.fail;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.silencedetection.api.SilenceDetectionFailedException;
 import org.opencastproject.silencedetection.impl.SilenceDetectionProperties;
-import org.opencastproject.util.IoSupport;
-import org.opencastproject.util.StreamHelper;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.easymock.EasyMock;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,37 +47,29 @@ public class SilenceDetectorTest {
   private static final Logger logger = LoggerFactory.getLogger(SilenceDetectorTest.class);
 
 
-  private static boolean skipTests = false;
+  /** True to run the tests */
+  private static boolean ffmpegInstalled = true;
 
 
   @BeforeClass
   public static void setupClass() {
-    StreamHelper stdout = null;
-    StreamHelper stderr = null;
-    Process p = null;
     try {
-      p = new ProcessBuilder(FFmpegSilenceDetector.FFMPEG_BINARY_DEFAULT, "-help").start();
-      stdout = new StreamHelper(p.getInputStream());
-      stderr = new StreamHelper(p.getErrorStream());
-      int exitCode = p.waitFor();
-      stdout.stopReading();
-      stderr.stopReading();
-      if (exitCode != 0) {
-        throw new IllegalStateException("process returned " + exitCode);
-      }
+      Process p = new ProcessBuilder(FFmpegSilenceDetector.FFMPEG_BINARY_DEFAULT, "-version").start();
+      if (p.waitFor() != 0)
+        throw new IllegalStateException();
     } catch (Throwable t) {
-      logger.warn("Skipping silence detection tests due to unsatisfied FFmpeg installation: " + t.getMessage());
-      skipTests = true;
-    } finally {
-      IoSupport.closeQuietly(stdout);
-      IoSupport.closeQuietly(stderr);
-      IoSupport.closeQuietly(p);
+      logger.warn("Skipping composer tests due to missing ffmpeg");
+      ffmpegInstalled = false;
     }
   }
 
+  @Before
+  public void setUp() throws Exception {
+    // Skip tests if FFmpeg is not installed
+    Assume.assumeTrue(ffmpegInstalled);
+  }
 
   /** Setup test. */
-  @Ignore
   private FFmpegSilenceDetector init(URI resource, Boolean hasAudio, Properties props) throws Exception {
     final File f = new File(resource);
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
@@ -95,20 +86,11 @@ public class SilenceDetectorTest {
 
 
   /** Setup test. */
-  @Ignore
   private FFmpegSilenceDetector init(URI resource, Boolean hasAudio) throws Exception {
     Properties props = new Properties();
     props.setProperty(SilenceDetectionProperties.VOICE_MIN_LENGTH, "4000");
     return init(resource, hasAudio, props);
   }
-
-
-  /** Setup test. */
-  @Ignore
-  private FFmpegSilenceDetector init(URI resource) throws Exception {
-    return init(resource, true);
-  }
-
 
   private URI getResource(String resource) throws URISyntaxException {
     return FFmpegSilenceDetector.class.getResource(resource).toURI();
@@ -117,9 +99,8 @@ public class SilenceDetectorTest {
 
   @Test
   public void testSilenceDetection() throws Exception {
-    if (this.skipTests) return;
     final URI trackUri = getResource("/testspeech.mp4");
-    FFmpegSilenceDetector sd = init(trackUri);
+    FFmpegSilenceDetector sd = init(trackUri, true);
     assertNotNull(sd.getMediaSegments());
     assertEquals(2, sd.getMediaSegments().getMediaSegments().size());
   }
@@ -127,10 +108,9 @@ public class SilenceDetectorTest {
 
   @Test
   public void testSilenceDetectionLongVoice() throws Exception {
-    if (this.skipTests) return;
     final URI trackUri = getResource("/testspeech.mp4");
     Properties props = new Properties();
-    /* Set minumum voice length to something longer than the actual recording */
+    // Set minimum voice length to something longer than the actual recording
     props.setProperty(SilenceDetectionProperties.VOICE_MIN_LENGTH, "600000");
     FFmpegSilenceDetector sd = init(trackUri, true, props);
     assertNotNull(sd.getMediaSegments());
@@ -140,9 +120,8 @@ public class SilenceDetectorTest {
 
   @Test
   public void testSilenceDetectionOnSilence() throws Exception {
-    if (this.skipTests) return;
     final URI trackUri = getResource("/silent.mp4");
-    FFmpegSilenceDetector sd = init(trackUri);
+    FFmpegSilenceDetector sd = init(trackUri, true);
     assertNotNull(sd.getMediaSegments());
     assertEquals(0, sd.getMediaSegments().getMediaSegments().size());
   }
@@ -150,7 +129,6 @@ public class SilenceDetectorTest {
 
   @Test
   public void testMisconfiguration() throws Exception {
-    if (this.skipTests) return;
     final URI trackUri = getResource("/nostreams.mp4");
     Properties props = new Properties();
     props.setProperty(SilenceDetectionProperties.SILENCE_PRE_LENGTH, "6000");
@@ -159,18 +137,19 @@ public class SilenceDetectorTest {
       FFmpegSilenceDetector sd = init(trackUri, true, props);
       fail("Silence detection of media without audio should fail");
     } catch (SilenceDetectionFailedException e) {
+      // we expect an exception
     }
   }
 
 
   @Test
   public void testNoAudio() throws Exception {
-    if (this.skipTests) return;
     final URI trackUri = getResource("/nostreams.mp4");
     try {
       FFmpegSilenceDetector sd = init(trackUri, false);
       fail("Silence detection of media without audio should fail");
     } catch (SilenceDetectionFailedException e) {
+      // we expect an exception
     }
   }
 


### PR DESCRIPTION
This patch cleans up the silence detector code, removing and/or
replacing deprecated methods and simplifying tests:

- Add `-nostdin` FFmpeg option
- Remove unstable `LineReader`
- Use modern ´try-with-resource`
- Simplify test detection for FFmpeg

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
