### PR TITLE
Asset Upload Title

### DIFF
--- a/docs/guides/admin/docs/configuration/admin-ui/asset-upload.md
+++ b/docs/guides/admin/docs/configuration/admin-ui/asset-upload.md
@@ -23,13 +23,21 @@ listprovider properties file:
 
 Two source types are enabled by default for use in the Admin UI.
 
-    EVENTS.EVENTS.NEW.SOURCE.UPLOAD.NON_SEGMENTABLE={
-       "id":"track_presenter", "type":"track", "flavorType":"presenter",
-       "flavorSubType":"source", "multiple":false, "displayOrder": 1}
+    EVENTS.EVENTS.NEW.SOURCE.UPLOAD.NON_SEGMENTABLE={\
+      "id":"track_presenter",\
+      "type":"track",\
+      "flavorType":"presenter",\
+      "flavorSubType":"source",\
+      "multiple":false,\
+      "displayOrder": 1}
 
-    EVENTS.EVENTS.NEW.SOURCE.UPLOAD.SEGMENTABLE={
-       "id":"track_presentation", "type":"track", "flavorType":"presentation",
-       "flavorSubType":"source", "multiple":false, "displayOrder": 2}
+    EVENTS.EVENTS.NEW.SOURCE.UPLOAD.SEGMENTABLE={\
+      "id":"track_presentation",\
+      "type":"track",\
+      "flavorType":"presentation",\
+      "flavorSubType":"source",\
+      "multiple":false,\
+      "displayOrder": 2}
 
 Source upload options as displayed in the Admin UI Create event:
     ![assetUploadSource](images/assetUploadSource.png)
@@ -48,17 +56,17 @@ download-source-flavors    | comma separated list | A convenience variable that 
 Example of variables in a workflow:
 
 ```xml
-    <!-- Tag any optionally uploaded assets -->
-    <operation
-      id="tag"
-      if="${downloadSourceflavorsExist}"
-      exception-handler-workflow="partial-error"
-      description="Tagging uploaded assets for distribution">
-      <configurations>
-        <configuration key="source-flavors">${download-source-flavors}</configuration>
-        <configuration key="target-tags">+engage-download</configuration>
-      </configurations>
-    </operation>
+<!-- Tag any optionally uploaded assets -->
+<operation
+  id="tag"
+  if="${downloadSourceflavorsExist}"
+  exception-handler-workflow="partial-error"
+  description="Tagging uploaded assets for distribution">
+  <configurations>
+    <configuration key="source-flavors">${download-source-flavors}</configuration>
+    <configuration key="target-tags">+engage-download</configuration>
+  </configurations>
+</operation>
 ```
 
 How to Enable Preconfigured Asset Options
@@ -123,11 +131,13 @@ attachments can be added to existing events. New source types can be added to ne
 
 Tasks:
 
-* Modify `etc/listproviders/event.upload.asset.options.properties`
-* Add Admin UI translation for the new asset name
-  `modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/...`
-* Modify your workflow from `etc/workflows/...`
-* Test your changes
+- Modify `etc/listproviders/event.upload.asset.options.properties`
+- For the title of the options displayed in the admin interface, either:
+    - add a translation for the new asset name to
+      `modules/admin-ui/src/main/resources/public/org/opencastproject/adminui/languages/...`
+    - or add a `title` field to the upload specification
+- Modify your workflow from `etc/workflows/...`
+- Test your changes
 
 The following steps describe how to change the properties configuration.
 

--- a/modules/admin-ui/src/main/webapp/scripts/shared/services/uploadAssetOptionsService.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/services/uploadAssetOptionsService.js
@@ -53,7 +53,9 @@ angular.module('adminNg.services').service('UploadAssetOptions',[ 'ResourcesList
               if ((assetKey.indexOf(_OptionPrefixAsset) >= 0) || (assetKey.indexOf(_OptionPrefixSource) >= 0)) {
                 // parse upload asset options
                 var options = JSON.parse(assetOption);
-                options[ 'title'] = assetKey;
+                if (!options['title']) {
+                  options['title'] = assetKey;
+                }
                 _uploadOptions.push(options);
               } else if (assetKey.indexOf(_WorkflowPrefix) >= 0) {
                 // parse upload workflow definition id


### PR DESCRIPTION
Configuring custom asset uploads without rebuilding Opencast is nearly
impossible since the title for the upload options is always taken from
the translation files which are build into Opencast.

This minimal patch allows the title to also be specified as part of the
upload configuration, allowing for configuration-only specifications of
new upload options.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
