### PR TITLE
Gracefully crash if there is no password stored

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/CustomPasswordEncoder.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/CustomPasswordEncoder.java
@@ -22,6 +22,7 @@
 package org.opencastproject.kernel.security;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.encoding.PasswordEncoder;
@@ -75,7 +76,7 @@ public class CustomPasswordEncoder implements PasswordEncoder {
     // Test BCrypt encoded hash
     logger.debug("Verifying bcrypt hash {}", encodedPassword);
     try {
-      return encodedPassword.charAt(0) == '$' && BCrypt.checkpw(rawPassword, encodedPassword);
+      return StringUtils.startsWith(encodedPassword, "$") && BCrypt.checkpw(rawPassword, encodedPassword);
     } catch (IllegalArgumentException e) {
       logger.debug("bcrypt hash verification failed", e);
     }


### PR DESCRIPTION
This is a follow up of  #1399 where in the case that there are
no password stored in the local database. Now will fail with bad
credentials error and not with a java crash page.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
