### PR TITLE
Set fixed LANG for stable tests. Fixes #1418

### DIFF
--- a/modules/admin-ui-frontend/Gruntfile.js
+++ b/modules/admin-ui-frontend/Gruntfile.js
@@ -1,6 +1,9 @@
 // Generated on 2016-03-07 using generator-angular 0.15.1
 'use strict';
 
+// Set a fixed locale required for running tests
+process.env.LANG='en_US.UTF-8';
+
 // # Globbing
 // for performance reasons we're only matching one level down:
 // 'test/spec/{,*/}*.js'


### PR DESCRIPTION
A change is detecting the best available language in the splitup of the admin-ui caused the test to become depended on the locale of the user running the test. This sets a fixed value if en_US. Closes #1418 