### PR TITLE
Override all LANG and LC_ environment variables for stable tests

### DIFF
--- a/modules/admin-ui-frontend/Gruntfile.js
+++ b/modules/admin-ui-frontend/Gruntfile.js
@@ -3,6 +3,7 @@
 
 // Set a fixed locale required for running tests
 process.env.LANG='en_US.UTF-8';
+process.env.LC_ALL='en_US.UTF-8';
 
 // # Globbing
 // for performance reasons we're only matching one level down:


### PR DESCRIPTION
The splitup of the admin-ui has introduced a dependency on the locales of the build environment. This PR fixes setting both LANG and all LC_ variables to ensure stable build and test environment. Closes #1418 
