### PR TITLE
Fix REST Documentation

### DIFF
--- a/modules/common/src/main/resources/ui/restdocs/template.xhtml
+++ b/modules/common/src/main/resources/ui/restdocs/template.xhtml
@@ -212,7 +212,8 @@
                          name="${item.name}"
                          class="form_field <#if item.path>form_param_path<#else>form_param_submit</#if><#if item.required> form_param_required</#if>"
                          type="checkbox"
-                         value="true" <#if item.defaultValue == "true">checked</#if> />
+                         value="true"
+                         <#if item.defaultValue?? && item.defaultValue == "true">checked</#if> />
                 </td>
                 <td class="form_field_description">${item.description!}</td>
                 <#elseif item.type == "file">


### PR DESCRIPTION
This patch fixes the REST documentation which is fromen for endpoints
which do not define default values like the admin interface or external
api event endpoints.

This fixes #1422

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
