### PR TITLE
Don't duplicate publications

### DIFF
--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -205,10 +205,11 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
     final Collection<Publication> internalPublications = new HashSet<>();
 
     for (MediaPackageElement e : mediaPackage.getElements()) {
-      if (e instanceof Publication && InternalPublicationChannel.CHANNEL_ID.equals(((Publication) e).getChannel())) {
-        internalPublications.add((Publication) e);
-        // Remove publications since they are cloned in another way than the other elements
-        elements.remove(e);
+      if (e instanceof Publication) {
+        if (InternalPublicationChannel.CHANNEL_ID.equals(((Publication) e).getChannel())) {
+          internalPublications.add((Publication) e);
+        }
+        elements.remove(e); // don't duplicate publications
       }
       if (MediaPackageElements.EPISODE.equals(e.getFlavor())) {
         // Remove episode DC since we will add a new one (with changed title)


### PR DESCRIPTION
When duplicating events via the duplicate workflow, we shouldn't duplicate publications since they then point to the same videos, leading to problems when one of the events is retracted.

This is NOT reproducible with the current configuration of the duplicate workflow of the community, since we only set source flavors to */* and publications don't have a flavor. If you also set the source-tags to "archive" though, the publications will be selected and duplicated.
