### PR TITLE
Autodetect browsers for admin ui tests, fix phantomJS openssl issue

### DIFF
--- a/docs/guides/developer/docs/installation/source-linux.md
+++ b/docs/guides/developer/docs/installation/source-linux.md
@@ -25,6 +25,7 @@ Required:
     ffmpeg >= 3.2.4
     maven >= 3.1
     python >= 2.6, < 3.0
+    firefox/chrome/some other major browser
     unzip
     gcc-c++
     tar

--- a/modules/admin-ui/Gruntfile.js
+++ b/modules/admin-ui/Gruntfile.js
@@ -1,6 +1,10 @@
 // Generated on 2016-03-07 using generator-angular 0.15.1
 'use strict';
 
+// Prevents Debian 10 (at least) from erroring out if PhantomJS is being used
+// Appears to be related to something in the config file, but we can't exactly ship our own config
+process.env.OPENSSL_CONF='';
+
 // # Globbing
 // for performance reasons we're only matching one level down:
 // 'test/spec/{,*/}*.js'
@@ -454,8 +458,7 @@ module.exports = function (grunt) {
       },
       coverage: {
         singleRun : true,
-        reporters : ['dots', 'coverage'],
-        browsers  : ['PhantomJS']
+        reporters : ['dots', 'coverage']
       }
     }
   });

--- a/modules/admin-ui/Gruntfile.js
+++ b/modules/admin-ui/Gruntfile.js
@@ -1,10 +1,6 @@
 // Generated on 2016-03-07 using generator-angular 0.15.1
 'use strict';
 
-// Prevents Debian 10 (at least) from erroring out if PhantomJS is being used
-// Appears to be related to something in the config file, but we can't exactly ship our own config
-process.env.OPENSSL_CONF='';
-
 // # Globbing
 // for performance reasons we're only matching one level down:
 // 'test/spec/{,*/}*.js'

--- a/modules/admin-ui/package-lock.json
+++ b/modules/admin-ui/package-lock.json
@@ -1422,12 +1422,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
-      "dev": true
-    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -3554,16 +3548,6 @@
         }
       }
     },
-    "hasha": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true,
-      "requires": {
-        "is-stream": "^1.0.1",
-        "pinkie-promise": "^2.0.0"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -4137,12 +4121,6 @@
         "is-unc-path": "^1.0.0"
       }
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -4515,36 +4493,11 @@
       "integrity": "sha1-ENjIz6pBNvHIp22RpMvO7evsSjE=",
       "dev": true
     },
-    "karma-phantomjs-launcher": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
-      "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.0.1",
-        "phantomjs-prebuilt": "^2.1.7"
-      }
-    },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "dev": true
-    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
-    },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
-      }
     },
     "lazy.js": {
       "version": "0.4.3",
@@ -5509,51 +5462,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "phantomjs-prebuilt": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
-      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "dev": true
-        }
-      }
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -5953,15 +5861,6 @@
         "bluebird": "^3.3.3",
         "lodash": "^4.17.11",
         "request": "^2.88.0"
-      }
-    },
-    "request-progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true,
-      "requires": {
-        "throttleit": "^1.0.0"
       }
     },
     "require-directory": {
@@ -6851,12 +6750,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "throttleit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {

--- a/modules/admin-ui/package-lock.json
+++ b/modules/admin-ui/package-lock.json
@@ -4493,6 +4493,12 @@
       "integrity": "sha1-ENjIz6pBNvHIp22RpMvO7evsSjE=",
       "dev": true
     },
+    "karma-safari-launcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
+      "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",

--- a/modules/admin-ui/package-lock.json
+++ b/modules/admin-ui/package-lock.json
@@ -4488,6 +4488,15 @@
         }
       }
     },
+    "karma-detect-browsers": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/karma-detect-browsers/-/karma-detect-browsers-2.3.3.tgz",
+      "integrity": "sha512-ltFVyA3ijThv9l9TQ+TKnccoMk6YAWn8OMaccL+n8pO2LGwMOcy6tUWy3Mnv9If29jqvVHDCWntj7wBQpPtv7Q==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.4"
+      }
+    },
     "karma-firefox-launcher": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz",

--- a/modules/admin-ui/package.json
+++ b/modules/admin-ui/package.json
@@ -36,6 +36,7 @@
     "karma": "^4.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.2",
+    "karma-detect-browsers": "^2.0",
     "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "^1.1.2",
     "karma-ng-html2js-preprocessor": "^1.0.0",

--- a/modules/admin-ui/package.json
+++ b/modules/admin-ui/package.json
@@ -40,8 +40,6 @@
     "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "^1.1.2",
     "karma-ng-html2js-preprocessor": "^1.0.0",
-    "karma-phantomjs-launcher": "^1.0.4",
-    "phantomjs-prebuilt": "^2.1.16",
     "request": "^2.88.0",
     "request-digest": "^1.0.13",
     "selenium-server-standalone-jar": "3.141.5",

--- a/modules/admin-ui/package.json
+++ b/modules/admin-ui/package.json
@@ -40,6 +40,7 @@
     "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "^1.1.2",
     "karma-ng-html2js-preprocessor": "^1.0.0",
+    "karma-safari-launcher": "^1.0.0",
     "request": "^2.88.0",
     "request-digest": "^1.0.13",
     "selenium-server-standalone-jar": "3.141.5",

--- a/modules/admin-ui/phantomjs-path.sh
+++ b/modules/admin-ui/phantomjs-path.sh
@@ -1,6 +1,0 @@
-# If we have phantomjs installed on our machine (i.e. if it's in the PATH), use
-# that instead of the prebuilt version.
-if command -v phantomjs >/dev/null 2>&1; then
-  export PHANTOMJS_BIN
-  PHANTOMJS_BIN="$(command -v phantomjs)"
-fi

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -329,8 +329,6 @@
                 </goals>
                 <phase>compile</phase>
                 <configuration>
-                  <!-- bring PHANTOMJS_BIN into scope -->
-                  <environmentScript>phantomjs-path.sh</environmentScript>
                   <executable>node_modules/grunt-cli/bin/grunt</executable>
                   <arguments>
                     <argument>build</argument>

--- a/modules/admin-ui/src/test/resources/karma.conf.js
+++ b/modules/admin-ui/src/test/resources/karma.conf.js
@@ -81,16 +81,6 @@ module.exports = function (config) {
             }
         },
 
-        plugins : [
-            'karma-chrome-launcher',
-            'karma-coverage',
-            'karma-detect-browsers',
-            'karma-firefox-launcher',
-            'karma-jasmine',
-            'karma-ng-html2js-preprocessor',
-            'karma-safari-launcher'
-        ],
-
         captureTimeout: 60000,
         browserDisconnectTimeout : 10000,
         browserDisconnectTolerance : 1,

--- a/modules/admin-ui/src/test/resources/karma.conf.js
+++ b/modules/admin-ui/src/test/resources/karma.conf.js
@@ -56,20 +56,13 @@ module.exports = function (config) {
 
         detectBrowsers: {
             enabled: true,
-            usePhantomJS: true,
+            usePhantomJS: false,
             preferHeadless: true,
+            /* Leaving this commented out as an example.
+               If we ever want to disable an installed browser (c.f: IE) we can exclude it like this
             // post processing of browsers list
             // here you can edit the list of browsers used by karma
             postDetection: function(availableBrowsers) {
-                /* Karma configuration with custom launchers
-                customLaunchers: {
-                    IE9: {
-                        base: 'IE',
-                        'x-ua-compatible': 'IE=EmulateIE9'
-                    }
-                }
-                */
- 
                 var result = availableBrowsers;
                 //Remove PhantomJS if another browser has been detected
                 if (availableBrowsers.length > 1 && availableBrowsers.indexOf('PhantomJS')>-1) {
@@ -80,11 +73,11 @@ module.exports = function (config) {
                 }
                 return result;
             }
+            */
         },
 
         plugins : [
             'karma-chrome-launcher',
-            'karma-phantomjs-launcher',
             'karma-coverage',
             'karma-detect-browsers',
             'karma-firefox-launcher',

--- a/modules/admin-ui/src/test/resources/karma.conf.js
+++ b/modules/admin-ui/src/test/resources/karma.conf.js
@@ -58,12 +58,12 @@ module.exports = function (config) {
             enabled: true,
             usePhantomJS: false,
             preferHeadless: true,
-            /* Leaving this commented out as an example.
-               If we ever want to disable an installed browser (c.f: IE) we can exclude it like this
             // post processing of browsers list
             // here you can edit the list of browsers used by karma
             postDetection: function(availableBrowsers) {
                 var result = availableBrowsers;
+                /* Leaving this commented out as an example.
+                   If we ever want to disable an installed browser (c.f: IE) we can exclude it like this
                 //Remove PhantomJS if another browser has been detected
                 if (availableBrowsers.length > 1 && availableBrowsers.indexOf('PhantomJS')>-1) {
                     var i = result.indexOf('PhantomJS');
@@ -71,9 +71,14 @@ module.exports = function (config) {
                         result.splice(i, 1);
                     }
                 }
+		*/
+		if (availableBrowsers.length < 1) {
+                    console.error("No browsers detected");
+                    console.error("Suggest installing Firefox or other FOSS browser");
+                    throw "No browsers detected";
+	        }
                 return result;
             }
-            */
         },
 
         plugins : [

--- a/modules/admin-ui/src/test/resources/karma.conf.js
+++ b/modules/admin-ui/src/test/resources/karma.conf.js
@@ -87,7 +87,8 @@ module.exports = function (config) {
             'karma-detect-browsers',
             'karma-firefox-launcher',
             'karma-jasmine',
-            'karma-ng-html2js-preprocessor'
+            'karma-ng-html2js-preprocessor',
+            'karma-safari-launcher'
         ],
 
         captureTimeout: 60000,

--- a/modules/admin-ui/src/test/resources/karma.conf.js
+++ b/modules/admin-ui/src/test/resources/karma.conf.js
@@ -52,14 +52,41 @@ module.exports = function (config) {
 
         autoWatch : true,
 
-        frameworks: ['jasmine'],
+        frameworks: ['detectBrowsers', 'jasmine'],
 
-        browsers : ['PhantomJS'],
+        detectBrowsers: {
+            enabled: true,
+            usePhantomJS: true,
+            preferHeadless: true,
+            // post processing of browsers list
+            // here you can edit the list of browsers used by karma
+            postDetection: function(availableBrowsers) {
+                /* Karma configuration with custom launchers
+                customLaunchers: {
+                    IE9: {
+                        base: 'IE',
+                        'x-ua-compatible': 'IE=EmulateIE9'
+                    }
+                }
+                */
+ 
+                var result = availableBrowsers;
+                //Remove PhantomJS if another browser has been detected
+                if (availableBrowsers.length > 1 && availableBrowsers.indexOf('PhantomJS')>-1) {
+                    var i = result.indexOf('PhantomJS');
+                    if (i !== -1) {
+                        result.splice(i, 1);
+                    }
+                }
+                return result;
+            }
+        },
 
         plugins : [
             'karma-chrome-launcher',
             'karma-phantomjs-launcher',
             'karma-coverage',
+            'karma-detect-browsers',
             'karma-firefox-launcher',
             'karma-jasmine',
             'karma-ng-html2js-preprocessor'


### PR DESCRIPTION
This PR introduces autodetection for the admin ui unit tests.  If no browsers are detected it falls back to PhantomJS, but if a real browser is installed it prefers that.  If multiple browsers are installed it tests with *all* of them.

This PR also resolves the Debian 10 OpenSSL issue, where the config file breaks PhantomJS.  It works around this by setting the config file location to blank, which causes file load warnings/errors, but does not affect the build.

Fixes #1424