### PR TITLE
Override all POSIX language variables in Gruntfile.js

### DIFF
--- a/modules/admin-ui-frontend/Gruntfile.js
+++ b/modules/admin-ui-frontend/Gruntfile.js
@@ -2,8 +2,9 @@
 'use strict';
 
 // Set a fixed locale required for running tests
-process.env.LANG='en_US.UTF-8';
+process.env.LANGUAGE='en_US.UTF-8';
 process.env.LC_ALL='en_US.UTF-8';
+process.env.LANG='en_US.UTF-8';
 
 // # Globbing
 // for performance reasons we're only matching one level down:


### PR DESCRIPTION
Fixes #1418 (third try). This commit adds overriding all locale
specific environment variables mentioned at
https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
