### PR TITLE
#1249 companion pull 2 of 2 for TravisCI concurrent build collision detection

### DIFF
--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -93,6 +93,7 @@ public class ServiceRegistryJpaImplTest {
   private static final String TEST_HOST = "http://localhost:8080";
   private static final String TEST_HOST_OTHER = "http://otherhost:8080";
   private static final String TEST_HOST_THIRD = "http://thirdhost:8080";
+  // #1249 companion pull 1 of 2 to identify Travis CI concurrent build collision hotspots
 
   @Before
   public void setUp() throws Exception {

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -93,7 +93,7 @@ public class ServiceRegistryJpaImplTest {
   private static final String TEST_HOST = "http://localhost:8080";
   private static final String TEST_HOST_OTHER = "http://otherhost:8080";
   private static final String TEST_HOST_THIRD = "http://thirdhost:8080";
-  // #1249 companion pull 1 of 2 to identify Travis CI concurrent build collision hotspots
+  // #1249 companion pull 2 of 2 to identify Travis CI concurrent build collision hotspots
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied

This pull is a companion build test pull (2 of 2), along with #1434, supporting #1430 on issue #1429. This pull is for concurrent Travis CI build tests in order to identify collision hot spots in Travis CI. The investigation is not specific to ServiceRegistryJpaImplTest, but for all modules containing junit tests. 

The goal is to gather information on the type of junits that encounter build collisions in order to reduce false negatives from junit tests that are valid but fail because of possible collision with shared resources in Travis CI.

The urgency of this work is that valid junit tests are stripped from Opencast because of false negatives from Travis CI builds. Example of ignoring because of Travis CI: https://github.com/opencast/opencast/pull/1427/files Example of the ignored test being stripped: https://github.com/opencast/opencast/pull/1291/files#diff-4cc24d934760760e2a998acd69c71080L318-L351

