### PR TITLE
Fix Remember-Me Authentication

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -353,6 +353,11 @@
     <property name="key" value="opencast"/>
   </bean>
 
+  <bean id="rememberMeAuthenticationProvider"
+        class="org.opencastproject.kernel.security.SystemTokenBasedRememberMeAuthenticationProvider">
+    <property name="key" value="opencast"/>
+  </bean>
+
   <!-- ############################# -->
   <!-- # Authentication Filters    # -->
   <!-- ############################# -->
@@ -539,6 +544,7 @@
 
   <!-- The JPA user directory stores md5 hashed, salted passwords, so we must use a username-salted md5 password encoder. -->
   <sec:authentication-manager alias="authenticationManager">
+    <sec:authentication-provider ref="rememberMeAuthenticationProvider"/>
     <!-- Uncomment this if using Shibboleth authentication -->
     <!--sec:authentication-provider ref="preauthAuthProvider" /-->
     <sec:authentication-provider user-service-ref="userDetailsService">

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenBasedRememberMeAuthenticationProvider.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenBasedRememberMeAuthenticationProvider.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.kernel.security;
+
+import org.springframework.security.authentication.RememberMeAuthenticationProvider;
+
+/**
+ * Authentication provider based on the remember-me cookie.
+ */
+public class SystemTokenBasedRememberMeAuthenticationProvider extends RememberMeAuthenticationProvider {
+
+  @Deprecated
+  public SystemTokenBasedRememberMeAuthenticationProvider() {
+    super();
+  }
+
+  public SystemTokenBasedRememberMeAuthenticationProvider(String key) {
+    super(SystemTokenRememberMeUtils.augmentKey(key));
+  }
+
+  @Override
+  public void setKey(String key) {
+    super.setKey(SystemTokenRememberMeUtils.augmentKey(key));
+  }
+}

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenBasedRememberMeService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenBasedRememberMeService.java
@@ -21,23 +21,14 @@
 
 package org.opencastproject.kernel.security;
 
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.codec.Hex;
 import org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-import java.util.Objects;
 
 /**
  * This implements a zero-configuration version Spring Security's token based remember-me service. While the key can
@@ -46,17 +37,14 @@ import java.util.Objects;
  */
 public class SystemTokenBasedRememberMeService extends TokenBasedRememberMeServices {
   private Logger logger = LoggerFactory.getLogger(SystemTokenBasedRememberMeService.class);
-  private String key;
 
   @Deprecated
   public SystemTokenBasedRememberMeService() {
     super();
-    setKey(null);
   }
 
   public SystemTokenBasedRememberMeService(String key, UserDetailsService userDetailsService) {
-    super(key, userDetailsService);
-    setKey(key);
+    super(SystemTokenRememberMeUtils.augmentKey(key), userDetailsService);
   }
 
   /**
@@ -68,53 +56,7 @@ public class SystemTokenBasedRememberMeService extends TokenBasedRememberMeServi
    */
   @Override
   public void setKey(String key) {
-    // Start with a user key if provided
-    StringBuilder keyBuilder = new StringBuilder(Objects.toString(key, ""));
-
-    // This will give us the hostname and IP address as something which should be unique per system.
-    // For example: lk.elan-ev.de/10.10.10.31
-    try {
-      keyBuilder.append(InetAddress.getLocalHost());
-    } catch (UnknownHostException e) {
-      // silently ignore this
-    }
-
-    // Gather additional system properties as key
-    // This requires a proc-fs which should generally be available under Linux.
-    // But even without, we have fallbacks above and below.
-    for (String procFile: Arrays.asList("/proc/version", "/proc/partitions")) {
-      try (FileInputStream fileInputStream = new FileInputStream(new File(procFile))) {
-        keyBuilder.append(IOUtils.toString(fileInputStream, StandardCharsets.UTF_8));
-      } catch (IOException e) {
-        // ignore this
-      }
-    }
-
-    // If we still have no proper key, just generate a random one.
-    // This will work just fine with the single drawback that restarting Opencast invalidates all remember-me tokens.
-    // But it should be a sufficiently good fallback.
-    key = keyBuilder.toString();
-    if (key.isEmpty()) {
-      logger.warn("Could not generate semi-persistent remember-me key. Will generate a non-persistent random one.");
-      key = Double.toString(Math.random());
-    }
-    logger.debug("Remember me key before hashing: {}", key);
-
-    // Use a SHA-512 hash as key to have a more sane key.
-    try {
-      MessageDigest digest = MessageDigest.getInstance("SHA-512");
-      key = new String(Hex.encode(digest.digest(key.getBytes())));
-    } catch (NoSuchAlgorithmException e) {
-      logger.warn("No SHA-512 algorithm available!");
-    }
-    logger.debug("Calculated remember me key: {}", key);
-    this.key = key;
-    super.setKey(key);
-  }
-
-  @Override
-  public String getKey() {
-    return this.key;
+    super.setKey(SystemTokenRememberMeUtils.augmentKey(key));
   }
 
   /**

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenRememberMeUtils.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenRememberMeUtils.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.kernel.security;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.codec.Hex;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ *
+ */
+public final class SystemTokenRememberMeUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(SystemTokenRememberMeUtils.class);
+
+  private SystemTokenRememberMeUtils() {
+  }
+
+  public static String augmentKey(String key) {
+    // Start with a user key if provided
+    StringBuilder keyBuilder = new StringBuilder(Objects.toString(key, ""));
+
+    // This will give us the hostname and IP address as something which should be unique per system.
+    // For example: lk.elan-ev.de/10.10.10.31
+    try {
+      keyBuilder.append(InetAddress.getLocalHost());
+    } catch (UnknownHostException e) {
+      // silently ignore this
+    }
+
+    // Gather additional system properties as key
+    // This requires a proc-fs which should generally be available under Linux.
+    // But even without, we have fallbacks above and below.
+    for (String procFile: Arrays.asList("/proc/version", "/proc/partitions")) {
+      try (FileInputStream fileInputStream = new FileInputStream(new File(procFile))) {
+        keyBuilder.append(IOUtils.toString(fileInputStream, StandardCharsets.UTF_8));
+      } catch (IOException e) {
+        // ignore this
+      }
+    }
+
+    // If we still have no proper key, just generate a random one.
+    // This will work just fine with the single drawback that restarting Opencast invalidates all remember-me tokens.
+    // But it should be a sufficiently good fallback.
+    key = keyBuilder.toString();
+    if (key.isEmpty()) {
+      logger.warn("Could not generate semi-persistent remember-me key. Will generate a non-persistent random one.");
+      key = Double.toString(Math.random());
+    }
+    logger.debug("Remember me key before hashing: {}", key);
+
+    // Use a SHA-512 hash as key to have a more sane key.
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-512");
+      key = new String(Hex.encode(digest.digest(key.getBytes())));
+    } catch (NoSuchAlgorithmException e) {
+      logger.warn("No SHA-512 algorithm available!");
+    }
+    logger.debug("Calculated remember me key: {}", key);
+    return key;
+  }
+}


### PR DESCRIPTION
This patch fixes a bug in the verification of remember me cookies which
would previously just fail due to a mismatch in the internal secrets
used for generating and verifying the token.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
