### PR TITLE
Allow Root In Bower (Again)

### DIFF
--- a/modules/admin-ui-frontend/pom.xml
+++ b/modules/admin-ui-frontend/pom.xml
@@ -46,6 +46,7 @@
                 <configuration>
                   <executable>node_modules/.bin/bower</executable>
                   <arguments>
+                    <argument>--allow-root</argument>
                     <argument>install</argument>
                   </arguments>
                 </configuration>
@@ -121,7 +122,7 @@
                   <goal>bower</goal>
                 </goals>
                 <configuration>
-                  <arguments>install</arguments>
+                  <arguments>--allow-root install</arguments>
                 </configuration>
               </execution>
               <execution>


### PR DESCRIPTION
Re-introduce 756f64a056de3f68bc625f87cb18ddea498b1aa2 (#1300)

This patch allows root users to build the admin interface which otherwise
may be problematic for test systems (e.g. Docker containers). This patch
was seemingly lost when splitting the admin interface module.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
