### PR TITLE
Disable 2 more instances of jmxremote param, #1445

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -129,9 +129,8 @@
               <phase>prepare-package</phase>
               <configuration>
                 <target>
-                  <!-- Make sure to deactivate JMX by default, comment out these three lines to enable JMX from the build -->
+                  <!-- Make sure to deactivate JMX by default -->
                   <replaceregexp file="target/assembly/bin/karaf" match="-Dcom.sun.management.jmxremote" replace="" byline="true"/>
-                  <replaceregexp file="target/assembly/bin/karaf.bat" match="-Dcom.sun.management.jmxremote" replace="" byline="true"/>
                   <replaceregexp file="target/assembly/bin/inc" match="-Dcom.sun.management.jmxremote" replace="" byline="true"/>
                   <!-- Correct the start script name -->
                   <replaceregexp file="target/assembly/bin/karaf" match="^KARAF_SCRIPT=.*$" replace="KARAF_SCRIPT='start-opencast'" byline="true"/>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -129,8 +129,10 @@
               <phase>prepare-package</phase>
               <configuration>
                 <target>
-                  <!-- Make sure to deactivate JMX by default -->
+                  <!-- Make sure to deactivate JMX by default, comment out these three lines to enable JMX from the build -->
                   <replaceregexp file="target/assembly/bin/karaf" match="-Dcom.sun.management.jmxremote" replace="" byline="true"/>
+                  <replaceregexp file="target/assembly/bin/karaf.bat" match="-Dcom.sun.management.jmxremote" replace="" byline="true"/>
+                  <replaceregexp file="target/assembly/bin/inc" match="-Dcom.sun.management.jmxremote" replace="" byline="true"/>
                   <!-- Correct the start script name -->
                   <replaceregexp file="target/assembly/bin/karaf" match="^KARAF_SCRIPT=.*$" replace="KARAF_SCRIPT='start-opencast'" byline="true"/>
                   <!-- Mitigation for https://issues.apache.org/jira/browse/KARAF-5526 -->


### PR DESCRIPTION
### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied

See #1445 for details of this pull. The karaf v4.2.7 assembly outputs JAVA_OPTS with com.sun.management.jmxremote in  2 additional areas that cause the option to be included in the Opencast run parameters. This pull helps disable JMX by default again for sites that use SUN java.
