### PR TITLE
Fix Image Extraction At Position Zero

### DIFF
--- a/etc/encoding/engage-images.properties
+++ b/etc/encoding/engage-images.properties
@@ -34,7 +34,7 @@ profile.player-preview.http.input = visual
 profile.player-preview.http.output = image
 profile.player-preview.http.suffix = -player.jpg
 profile.player-preview.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
-  -filter:v trim=0:#{time},fps=1,reverse,scale=-2:480 \
+  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),fps=1,reverse,scale=-2:480 \
   #{out.dir}/#{out.name}#{out.suffix}
 
 # Slide preview images as shown in the player
@@ -50,7 +50,7 @@ profile.search-cover.http.input = visual
 profile.search-cover.http.output = image
 profile.search-cover.http.suffix = -search.jpg
 profile.search-cover.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
-  -filter:v trim=0:#{time},fps=1,reverse,scale=160:-2 \
+  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),fps=1,reverse,scale=160:-2 \
   #{out.dir}/#{out.name}#{out.suffix}
 
 profile.search-cover.http.downscale.name = Downscale to cover image for engage


### PR DESCRIPTION
This patch fixes the image extraction at a position of zero seconds
which would fail due to the trim filter not including the first frame.

This is an `r/8.x` port of  #1395 to better support Opencast Studio

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
