### PR TITLE
Fix Theodul Matomo plugin after configuration data structure change

### DIFF
--- a/modules/engage-theodul-plugin-custom-matomo/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-custom-matomo/src/main/resources/static/main.js
@@ -123,7 +123,9 @@ define(["jquery", "backbone", "engage/core"], function($, Backbone, Engage) {
           track_events = Engage.model.get("meInfo").get("matomo.track_events"),
           translations = [];
 
-      if (track_events) track_events = track_events.toLowerCase();
+      if (track_events) {
+        track_events = track_events.map(function (e) { return e.toLowerCase() })
+      }
 
       if (Engage.model.get("meInfo").get("matomo.notification"))
         notification = JSON.parse(Engage.model.get("meInfo").get("matomo.notification"));
@@ -303,8 +305,8 @@ define(["jquery", "backbone", "engage/core"], function($, Backbone, Engage) {
         tracker.trackPageView(mediapackage.get("title") + " - " + presenter);
         if (Piwik && Piwik.MediaAnalytics) Piwik.MediaAnalytics.scanForMedia();
         if (heartbeat > 0) tracker.enableHeartBeatTimer(heartbeat);
-	if (notification) {      
-	  Engage.trigger(plugin.events.customNotification.getName(),
+        if (notification) {
+          Engage.trigger(plugin.events.customNotification.getName(),
             translate('matomo_tracking',
               'Usage data will be collected with Matomo. You can use the Do-Not-Track settings of your browser to prevent this.'));
         }


### PR DESCRIPTION
In 8.x Theodul configuration moved to a new YAML configuration file. Instead of a string, `track_events` became an array leading to an exception when the Theodul Matomo plugin loads. Users only see the loading bar and never even come to the player.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
