### PR TITLE
Fix Theodul quality selection

### DIFF
--- a/modules/engage-theodul-core/src/main/resources/ui/js/engage/models/engage.js
+++ b/modules/engage-theodul-core/src/main/resources/ui/js/engage/models/engage.js
@@ -58,24 +58,8 @@ define(['jquery', 'backbone', 'bowser', 'basil', 'engage/models/pluginInfo', 'en
         }
         // set quality
         if (this.get('urlParameters').quality) {
-          switch (this.get('urlParameters').quality) {
-          case 'low':
-            this.set('quality', 'low');
-            break;
-          case 'medium':
-            this.set('quality', 'medium');
-            break;
-          case 'high':
-            this.set('quality', 'high');
-            break;
-          default:
-            this.set('quality', 'medium');
-            break;
-          }
-        } else {
-          this.set('quality', 'medium');
+          this.set('quality', this.get('urlParameters').quality);
         }
-
         // check mode, if no mode param given try to discover browser
         if (this.get('urlParameters').mode == 'desktop') {
           this.set('mode', 'desktop');

--- a/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
@@ -1336,11 +1336,7 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
           }
 
           // init video.js
-          videojs(id, videoOptions, function () {
-            var videodisplay = this;
-            // set sources
-            videodisplay.src(videoSource);
-          });
+          videojs(id, videoOptions);
           // URL to the flash swf
           if (videojs_swf) {
             Engage.log('Video: Loaded flash component');

--- a/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
@@ -393,7 +393,7 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
     }
     var sortedResolutionsList = [];
     sortedResolutionsList = _.map(qualitiesList, function(quality) {
-      var currentTrack = filterTracksByTag(tracks, quality + '-quality')[0];
+      var currentTrack = filterTracksByTag(tracks, [quality + '-quality'])[0];
       if (currentTrack !== undefined && currentTrack.resolution !== undefined)
         return [quality, currentTrack.resolution.substring(0, currentTrack.resolution.indexOf('x'))];
     });
@@ -505,7 +505,7 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
       for (var i = 0; i < tuples.length; ++i) {
         var value = tuples[i][1];
         if (value[1][0]) {
-          var track = filterTracksByTag(value[1], quality);
+          var track = filterTracksByTag(value[1], [quality]);
           if (track && track.length > 0) {
             videojs(value[0]).src(track[0].src);
           }

--- a/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
@@ -257,6 +257,7 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
   var overlayTimer;
 
   var foundQualities = undefined;
+  var sortedResolutionsList = undefined;
   var zoomTimeout = 500;
 
   function initTranslate(language, funcSuccess, funcError) {
@@ -310,7 +311,7 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
     return true;
   }
 
-  function filterTracksByTag(tracks, filterTags) {
+  function filterTracksByTag(tracks, filterTags, strict = false) {
     if (filterTags == undefined) {
       return tracks;
     }
@@ -332,10 +333,39 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
     }
 
     // avoid filtering to an empty list, better play something than nothing
-    if (newTracksArray.length < 1) {
+    if (newTracksArray.length < 1 && !strict) {
       return tracks;
     }
     return newTracksArray;
+  }
+
+  function getTrackResolutionWidth(track) {
+    return track.resolution.split('x')[1]
+  }
+
+  function getTrackClosestToResolution(tracks, quality) {
+    // match quality tag to resolution
+    var desiredWidth;
+    for (var i = 0; i < sortedResolutionsList.length; i++) {
+      if (sortedResolutionsList[i][0] == quality) {
+        desiredWidth = sortedResolutionsList[i][1];
+        break;
+      }
+    }
+
+    if (desiredWidth == undefined) {
+      // This should not happen. quality should be found in sortedResolutionsList
+      // after it got populated by getQualities.
+      return tracks[0];
+    }
+
+    // find track
+    var widthAbsDifferences = tracks.map(function (track) {
+      return Math.abs(getTrackResolutionWidth(track) - desiredWidth);
+    });
+
+    var closestIndex = widthAbsDifferences.indexOf(Math.min(...widthAbsDifferences));
+    return tracks[closestIndex];
   }
 
   /**
@@ -384,20 +414,20 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
     tagsList.forEach(function(quality) {
       qualitiesList.push(quality.substring(0, quality.indexOf('-quality')));
     });
-    var tracks;
+    var tracks = [];
     for (var source in videoSources) {
       if (videoSources[source] !== undefined) {
-        tracks = videoSources[source];
-        break;
+        tracks = tracks.concat(videoSources[source]);
       }
     }
-    var sortedResolutionsList = [];
+    sortedResolutionsList = [];
     sortedResolutionsList = _.map(qualitiesList, function(quality) {
       var currentTrack = filterTracksByTag(tracks, [quality + '-quality'])[0];
       if (currentTrack !== undefined && currentTrack.resolution !== undefined)
-        return [quality, currentTrack.resolution.substring(0, currentTrack.resolution.indexOf('x'))];
+        return [quality, getTrackResolutionWidth(currentTrack)];
     });
     sortedResolutionsList.sort(compareQuality);
+    sortedResolutionsList.reverse();
     foundQualities = [];
     for (var i = 0; i < sortedResolutionsList.length; ++i) {
       foundQualities.push(sortedResolutionsList[i][0]);
@@ -498,21 +528,23 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
     }
   }
 
-  function changeQuality(q) {
-    if (q) {
+  function changeQuality(quality) {
+    if (quality) {
       var isPaused = videodisplayMaster.paused();
       Engage.trigger(plugin.events.pause.getName(), false);
-      var quality = q + '-quality';
-      Engage.model.set('quality', q);
-      Engage.log('Video: Setting quality to: ' + q);
+      var qualityTag = quality + '-quality';
+      Engage.model.set('quality', quality);
+      Engage.log('Video: Setting quality to: ' + quality);
       var tuples = getSortedVideosourcesArray(globalVideoSource);
       for (var i = 0; i < tuples.length; ++i) {
         var value = tuples[i][1];
         if (value[1][0]) {
-          var track = filterTracksByTag(value[1], [quality]);
-          if (track && track.length > 0) {
-            videojs(value[0]).src(track[0].src);
+          var track = filterTracksByTag(value[1], [qualityTag], true);
+          if (track.length == 0) {
+            // couldn't find track with exact tag; search with resolution
+            track = [getTrackClosestToResolution(value[1], quality)];
           }
+          videojs(value[0]).src(track[0].src);
         }
       }
       if (pressedPlayOnce && (currentTime > 0)) {

--- a/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
@@ -1368,7 +1368,16 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
           }
 
           // init video.js
-          videojs(id, videoOptions);
+          videojs(id, videoOptions, function () {
+            var videodisplay = this;
+            if (videoSource.length == 1 || foundQualities == undefined || foundQualities.length == 0) {
+              // set sources if there
+              //   * is only a single video (other video sets could have quality tags)
+              //   * are no quality tags in any video set
+              videodisplay.src(videoSource);
+            }
+          });
+
           // URL to the flash swf
           if (videojs_swf) {
             Engage.log('Video: Loaded flash component');

--- a/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
@@ -487,8 +487,12 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
         changeQuality(q);
       });
       Engage.trigger(plugin.events.videoFormatsFound.getName(), qualities);
-      if (isMobileMode) {
-        Engage.model.set('quality', 'low');
+      if (!Engage.model.get('quality')) {
+        if (isMobileMode) {
+          Engage.model.set('quality', qualities[qualities.length - 1]);
+        } else {
+          Engage.model.set('quality', qualities[Math.floor(qualities.length / 2)]);
+        }
       }
       changeQuality(Engage.model.get('quality'));
     }


### PR DESCRIPTION
The Theodul quality selection has a couple of bugs that are fixed in this PR, but let's describe our usage scenario first. We create delivery versions based on the source resolution. This differs between `presenter` and `presentation` (for CA recordings always; for LMS uploads possibly). In a normal recording we thus have:

* `presenter`: `720p-quality`, `480p-quality`
* `presentation`: `1080p-quality`, `720p-quality`, `480p-quality`

Next to some generic bugs, Theodul does not correctly handle this particular case well. When selecting `1080p` as quality, I would expect the player chooses `720p` for `presenter` (the closest available resolution). In addition, Theodul can handle non-standard tags only partially i.e not during initialization where it defaults to `medium-quality` (or `low-quality` for mobile).

In individual commits, I patched the following:

* General bug in track filtering (string argument instead of an array)
* Fix for non-standard quality tags
* Fix for setting the initial quality twice and thus possible the incorrect one
* Fix for the described scenario above by considering the resolution and choosing the closest one to the selected quality level

Front-end development is not my area so be extra careful when reviewing my JavaScript skills 😄.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
