### PR TITLE
Preserve ACL On Workflow Errors

### DIFF
--- a/etc/workflows/partial-error.xml
+++ b/etc/workflows/partial-error.xml
@@ -31,7 +31,7 @@
       fail-on-error="false"
       description="Preserve the current recording state">
       <configurations>
-        <configuration key="source-flavors">*/source,dublincore/*</configuration>
+        <configuration key="source-flavors">*/source,dublincore/*,security/*</configuration>
       </configurations>
     </operation>
 
@@ -41,6 +41,11 @@
       id="cleanup"
       fail-on-error="false"
       description="Cleaning up">
+      <configurations>
+        <configuration key="delete-external">true</configuration>
+        <!-- FixMe Don't clean up ACLs until workflow service no longer looks for them in the WFR. -->
+        <configuration key="preserve-flavors">security/*</configuration>
+      </configurations>
     </operation>
 
   </operations>


### PR DESCRIPTION
This patch ensures ACLs are archived in case of a workflow error.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
