### PR TITLE
Custom Roles for LTI users

### DIFF
--- a/etc/org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.cfg
+++ b/etc/org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.cfg
@@ -54,3 +54,10 @@
 #
 # Default: false
 #lti.create_jpa_user_reference=false
+
+# Add Custom Roles to users who has the role with custom_role_name
+# Default: empty no custom roles
+
+#lti.custom_role_name=Instructor
+#This Role set is an example for a user which can open the editor for an event and upload videos via opencast studio.
+#lti.custom_roles=ROLE_ADMIN_UI,ROLE_API_EVENTS_METADATA_DELETE,ROLE_API_EVENTS_METADATA_EDIT,ROLE_API_EVENTS_METADATA_VIEW,ROLE_UI_EVENTS_DETAILS_COMMENTS_CREATE,ROLE_UI_EVENTS_DETAILS_COMMENTS_DELETE,ROLE_UI_EVENTS_DETAILS_COMMENTS_EDIT,ROLE_UI_EVENTS_DETAILS_COMMENTS_REPLY,ROLE_UI_EVENTS_DETAILS_COMMENTS_RESOLVE,ROLE_UI_EVENTS_DETAILS_COMMENTS_VIEW,ROLE_UI_EVENTS_EDITOR_EDIT,ROLE_UI_EVENTS_EDITOR_VIEW,ROLE_STUDIO

--- a/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
+++ b/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
@@ -113,10 +113,10 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
   /** The user reference provider */
   private UserReferenceProvider userReferenceProvider = null;
 
-  /** If the Role exists add CUSTOM_ROLES to this user **/
+  /** The role name of the user to add custom Roles to **/
   private static final String CUSTOM_ROLE_NAME = "lti.custom_role_name";
 
-  /** If the Role exists add CUSTOM_ROLES to this user **/
+  /** A List of Roles to add to the user if he has the custom role name **/
   private static final String CUSTOM_ROLES = "lti.custom_roles";
 
   private String customRoleName = "";

--- a/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
+++ b/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
@@ -113,6 +113,16 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
   /** The user reference provider */
   private UserReferenceProvider userReferenceProvider = null;
 
+  /** If the Role exists add CUSTOM_ROLES to this user **/
+  private static final String CUSTOM_ROLE_NAME = "lti.custom_role_name";
+
+  /** If the Role exists add CUSTOM_ROLES to this user **/
+  private static final String CUSTOM_ROLES = "lti.custom_roles";
+
+  private String customRoleName = "";
+
+  private String[] customRoles;
+
   /** The user details service */
   private UserDetailsService userDetailsService;
 
@@ -201,6 +211,13 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
     createJpaUserReference = BooleanUtils.toBooleanDefaultIfNull(
       BooleanUtils.toBooleanObject(StringUtils.trimToNull((String) properties.get(CREATE_JPA_USER_REFERENCE_KEY))),
       false);
+
+    customRoleName = StringUtils.trimToNull((String) properties.get(CUSTOM_ROLE_NAME));
+    if (customRoleName != null) {
+      String custumRolesString = StringUtils.trimToNull((String) properties.get(CUSTOM_ROLES));
+      customRoles = custumRolesString.split(",");
+    }
+
   }
 
   /**
@@ -352,10 +369,19 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
       for (String learner : roleList) {
         // Build the role
         String role;
+        String group;
+        if (learner.equals(customRoleName)) {
+          for (String rolename : customRoles) {
+            userAuthorities.add(new SimpleGrantedAuthority(rolename));
+          }
+        }
+
         if (StringUtils.isBlank(learner)) {
           role = context + "_" + DEFAULT_LEARNER;
         } else {
           role = context + "_" + learner;
+          group = "ROLE_GROUP_" + learner.toUpperCase();
+          logger.debug("Adding group: {}", group);
         }
 
         // Make sure to not accept ROLE_…


### PR DESCRIPTION
With this patch it is possible to translate a LTI-Role to several
Opencast Roles.
With this it is possible for example, to show adminui parts like the editor to
LTI users.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
