### PR TITLE
Fix Studio login redirect

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/AuthenticationSuccessHandler.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/AuthenticationSuccessHandler.java
@@ -66,12 +66,11 @@ public class AuthenticationSuccessHandler implements
           Authentication authentication) throws IOException, ServletException {
 
     /* If the user originally attempted to access a specific URI other than /, but was forwarded to the login page,
-     * redirect the user back to that initial URI. But only if the request target was a user interface any not some kind
-     * of data. */
+     * redirect the user back to that initial URI. */
     HttpSession session = request.getSession();
     String initialRequestUri = (String) session.getAttribute(INITIAL_REQUEST_PATH);
     session.removeAttribute(INITIAL_REQUEST_PATH);
-    if (initialRequestUri != null && initialRequestUri.toLowerCase().contains(".htm")) {
+    if (initialRequestUri != null) {
       response.sendRedirect(initialRequestUri);
       return;
     }


### PR DESCRIPTION
This pull request fixes #1471 by removing a check, which tries to identify, whether the login redirect URL is a user interface. As the check relies on the file extension and Studio uses the `/studio/` path the check fails and the redirect isn't performed.
