### PR TITLE
Workaround early lti session timeout

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -83,6 +83,8 @@ Additional Notes About 8.3
 
 - The configuration file `etc/org.opencastproject.kernel.security.LtiLaunchAuthenticationHandler.cfg` was moved
    to `etc/org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.cfg`.
+- The configuration file `etc/org.ops4j.pax.web.cfg` was updated to include the `org.ops4j.pax.web.session.timeout`
+   option with value `240`.
 
 Additional Notes About 8.2
 --------------------------

--- a/etc/org.ops4j.pax.web.cfg
+++ b/etc/org.ops4j.pax.web.cfg
@@ -41,3 +41,6 @@ org.ops4j.pax.web.ssl.keypassword=password
 # Custom jetty config file. Uncomment this if necessary to configure the jetty http connector idleTimeout value (MH-12329)
 # Adjust the settings in the file below to match the listening address and port settings above.
 #org.ops4j.pax.web.config.file=${karaf.etc}/jetty-opencast.xml
+
+# Session timeout
+org.ops4j.pax.web.session.timeout=240


### PR DESCRIPTION
This increases the lti session timeout so Studio can upload even after a longer period of recording.