### PR TITLE
Update Studio (for bugfixes) and add docs for Studio

### DIFF
--- a/docs/guides/admin/docs/index.md
+++ b/docs/guides/admin/docs/index.md
@@ -34,6 +34,7 @@ The Opencast Release Documentation is the official Opencast documentation for ea
     * [AWS S3 Distribution](modules/awss3distribution.md)
     * [Media Module](modules/mediamodule.configuration.md)
     * [Stream Security](modules/stream-security.md)
+    * [Studio](modules/studio.md)
     * [Text Extraction](modules/textextraction.md)
     * [Video Segmentation](modules/videosegmentation.md)
     * [YouTube Publication](modules/youtubepublication.md)

--- a/docs/guides/admin/docs/modules/index.md
+++ b/docs/guides/admin/docs/modules/index.md
@@ -17,6 +17,7 @@ Documentation for modules included in Opencast.
     * [Solr](searchindex/solr.md)
     * [Elasticsearch](searchindex/elasticsearch.md)
 * [Stream Security](stream-security.md)
+* [Studio](studio.md)
 * [Text Extraction](textextraction.md)
 * Videoeditor
     * [Setup](videoeditor.setup.md)

--- a/docs/guides/admin/docs/modules/studio.md
+++ b/docs/guides/admin/docs/modules/studio.md
@@ -1,0 +1,22 @@
+Opencast Studio
+===============
+
+Studio is a small web application that runs in the browser and allows the user to record webcam video, the user's display and microphone audio. Afterwards, the user can easily upload their recording to an Opencast instance.
+
+Studio uses the recording capabilities built into modern browsers to record audio and video streams. The recording happens completely in the user's browser: no server is involved in that part. Network access is only needed to initially load the application and to (optionally) upload the videos to an Opencast instance.
+
+This module includes Studio directly into Opencast and pre-configures it accordingly. It is available at `https://yourserver/studio`. Note: Studio is developed [outside of the main repository](https://github.com/elan-ev/opencast-studio): you can find additional documentation in that repository. Please also report bugs and feature requests for Studio to that repository, unless it's a bug related to the integration in Opencast.
+
+
+## Giving users access to Studio
+
+The path `/studio` is accessible by users with the role `ROLE_ADMIN` or `ROLE_STUDIO`. The APIs used by Studio (`/ingest/*` and `info/me.json`) are also accessible if the user has `ROLE_STUDIO`.
+
+The preferred way to let your users access Studio is via LTI. Remember to configure your LTI users to have the role `ROLE_STUDIO` so that they can access Studio and all APIs used by Studio.
+
+
+## Configuring Studio
+
+Studio is pre-configured via `etc/ui-config/mh_default_org/studio/settings.json`. You can modify that file to change the configuration, but note that you probably don't want to touch `opencast.serverUrl` and `opencast.loginProvided`. For information on possible configuration values, please see [the Studio repository](https://github.com/elan-ev/opencast-studio).
+
+If you want to pre-configure the ACL that is sent by studio, place a file `acl.xml` in `etc/ui-config/mh_default_org/studio/` and set `upload.acl` in `settings.json` to `/ui/config/studio/acl.xml`.

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -102,8 +102,8 @@ nav:
       - Configuration: 'modules/player.configuration.md'
       - URL Parameters: 'modules/player.url.parameter.md'
       - Matomo Tracking: 'modules/player.matomo.tracking.md'
-   - Paella player: 
-      - Configuration: 'modules/paella.player/configuration.md'      
+   - Paella player:
+      - Configuration: 'modules/paella.player/configuration.md'
       - URL Parameters: 'modules/paella.player/url.parameter.md'
       - Paella plugins:
         - Overview: 'modules/paella.player/plugins.md'
@@ -120,6 +120,7 @@ nav:
       - Solr: 'modules/searchindex/solr.md'
       - Elasticsearch: 'modules/searchindex/elasticsearch.md'
    - Stream Security: 'modules/stream-security.md'
+   - Studio: 'modules/studio.md'
    - Termination State:
       - Basic: 'modules/terminationstate.md'
       - AWS AutoScaling: 'modules/terminationstate.aws.autoscaling.md'

--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2020-03-25/oc-studio-2020-03-25-integrated.tar.gz</opencast.studio.url>
-    <opencast.studio.sha256>de7bd6cbf215226b744f901abb9acc07c4b8d58e1184286d5ddb165435c6a540</opencast.studio.sha256>
+    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2020-03-26/oc-studio-2020-03-26-integrated.tar.gz</opencast.studio.url>
+    <opencast.studio.sha256>4ca7c2eb54ec8e6dcbdea7325d21b737098a01fcf37f63a33d29fc03edaa4719</opencast.studio.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
When testing the current `r/8.x` branch I noticed that it's not possible to configure the ACL for Studio. That's because XML files stored in the ui config are delivered with `Content-Type: text/xml` by Opencast. Studio incorrectly only allowed `application/xml`. This is fixed in Studio now. 

This PR updates studio to [this release](https://github.com/elan-ev/opencast-studio/releases/tag/2020-03-26). 

I also added some documentation as @mliradelc correctly [mentioned](https://github.com/opencast/opencast/pull/1436#issuecomment-604260223) that there isn't any right now. The documentation can surely still be improved, but I think it mentions the most important parts.