### PR TITLE
Fix Adaptive Encoding

### DIFF
--- a/etc/encoding/adaptive-streaming-movies.properties
+++ b/etc/encoding/adaptive-streaming-movies.properties
@@ -125,9 +125,9 @@ profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-900 = \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1080p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
-  #{if-height-geq-2160} \
-  #{if-height-geq-1440} \
-  #{if-height-geq-1080} \
+  #{if-height-geq-1800} \
+  #{if-height-geq-1260} \
+  #{if-height-geq-900} \
   -filter:v scale=w=1280:h=trunc(1280/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -preset slower -tune film -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -crf 20 -maxrate 2400k -bufsize 2400k \


### PR DESCRIPTION
This patch fixes the adaptive encoding used by the Studio workflow with
did use mismatching name causing videos to never be encoded with
resolutions wither than 720p regardless of the input resolution.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
