### PR TITLE
Add a list of download buttons for each episode to the LTI series list

### DIFF
--- a/etc/ui-config/mh_default_org/ltitools/series.css
+++ b/etc/ui-config/mh_default_org/ltitools/series.css
@@ -23,6 +23,13 @@ div.loading {
   color: #666;
 }
 
+div.episode-container {
+  display: flex;
+  background-color: #eee;
+  align-items: center | stretch;
+  margin: 15px;
+}
+
 a.episode {
   display: block;
   text-decoration: none;
@@ -30,6 +37,7 @@ a.episode {
   background-color: #eee;
   padding: 5px;
   margin: 15px;
+  flex-grow: 1;
 }
 
 a.episode:hover {
@@ -45,32 +53,59 @@ a.episode div.preview {
   width: 200px;
 }
 
-div.episode-container {
-  display: flex;
-  background-color: #eee;
-  padding: 5px;
-  margin: 15px;
-}
-
-div.download {
-  display: flex;
-  background-color: red;
-  flex-direction: column;
-  justify-content: center;
-  margin-left: auto;
-  margin-right: 5px;
-}
-
-div.download button.downloadButton {
-  width: 100%;
-  margin-top: 1px;
-  margin-bottom: 5px;
-}
-
-
 a.episode div.desc h2 {
   margin: 0;
   margin-bottom: 5px;
+}
+
+/* Style The Dropdown Button */
+.dropbtn {
+  background-color: #eee;
+  color: black;
+  padding: 16px;
+  font-size: 16px;
+  border: 2px solid black;
+  border-radius: 2px;
+  cursor: pointer;
+  margin-top: 5px;
+  margin-right: 5px;
+}
+
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+  display: none;
+  position: absolute;
+  background-color: #f9f9f9;
+  min-width: 160px;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+}
+
+/* Links inside the dropdown */
+.dropdown-content a {
+  color: black;
+  padding: 12px 16px;
+  text-decoration: none;
+  display: block;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content a:hover {background-color: #f1f1f1}
+
+/* Show the dropdown menu on hover */
+.dropdown:hover .dropdown-content {
+  display: block;
+}
+
+/* Change the background color of the dropdown button when the dropdown content is shown */
+.dropdown:hover .dropbtn {
+  background-color: #fafafa;
 }
 
 footer  {

--- a/etc/ui-config/mh_default_org/ltitools/series.css
+++ b/etc/ui-config/mh_default_org/ltitools/series.css
@@ -59,7 +59,7 @@ a.episode div.desc h2 {
 }
 
 /* Style The Dropdown Button */
-.dropbtn {
+.drop-button {
   background-color: #eee;
   color: black;
   padding: 16px;
@@ -67,10 +67,7 @@ a.episode div.desc h2 {
   border: 2px solid black;
   border-radius: 2px;
   cursor: pointer;
-  margin-top: 10px;
-  margin-right: 10px;
-  margin-left: 10px;
-  margin-bottom: 10px;
+  margin: 10px;
 }
 
 /* The container <div> - needed to position the dropdown content */
@@ -98,7 +95,9 @@ a.episode div.desc h2 {
 }
 
 /* Change color of dropdown links on hover */
-.dropdown-content a:hover {background-color: #f1f1f1}
+.dropdown-content a:hover {
+  background-color: #f1f1f1
+}
 
 /* Show the dropdown menu on hover */
 .dropdown:hover .dropdown-content {

--- a/etc/ui-config/mh_default_org/ltitools/series.css
+++ b/etc/ui-config/mh_default_org/ltitools/series.css
@@ -25,8 +25,8 @@ div.loading {
 
 div.episode-container {
   display: flex;
+  flex-wrap: wrap;
   background-color: #eee;
-  align-items: center | stretch;
   margin: 15px;
 }
 
@@ -69,6 +69,8 @@ a.episode div.desc h2 {
   cursor: pointer;
   margin-top: 5px;
   margin-right: 5px;
+  margin-left: 10px;
+  margin-bottom: 10px;
 }
 
 /* The container <div> - needed to position the dropdown content */

--- a/etc/ui-config/mh_default_org/ltitools/series.css
+++ b/etc/ui-config/mh_default_org/ltitools/series.css
@@ -67,8 +67,8 @@ a.episode div.desc h2 {
   border: 2px solid black;
   border-radius: 2px;
   cursor: pointer;
-  margin-top: 5px;
-  margin-right: 5px;
+  margin-top: 10px;
+  margin-right: 10px;
   margin-left: 10px;
   margin-bottom: 10px;
 }
@@ -84,7 +84,7 @@ a.episode div.desc h2 {
   display: none;
   position: absolute;
   background-color: #f9f9f9;
-  min-width: 160px;
+  min-width: 200px;
   box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
   z-index: 1;
 }

--- a/etc/ui-config/mh_default_org/ltitools/series.css
+++ b/etc/ui-config/mh_default_org/ltitools/series.css
@@ -45,6 +45,29 @@ a.episode div.preview {
   width: 200px;
 }
 
+div.episode-container {
+  display: flex;
+  background-color: #eee;
+  padding: 5px;
+  margin: 15px;
+}
+
+div.download {
+  display: flex;
+  background-color: red;
+  flex-direction: column;
+  justify-content: center;
+  margin-left: auto;
+  margin-right: 5px;
+}
+
+div.download button.downloadButton {
+  width: 100%;
+  margin-top: 1px;
+  margin-bottom: 5px;
+}
+
+
 a.episode div.desc h2 {
   margin: 0;
   margin-bottom: 5px;

--- a/modules/lti/src/main/resources/tools/series/index.html
+++ b/modules/lti/src/main/resources/tools/series/index.html
@@ -32,14 +32,18 @@
         {{created}}
       </div>
     </a>
-    <div class=download>
-    {{#download}}
-      <a href={{path-to-file}} download="">
-        <button type="button" class=downloadButton>{{download-button-name}}</button>
-      </a>
-      <br>
-    {{/download}}
+    <div class=dropdown>
+      <button class=dropbtn>Direct Download</button>
+      <div class=dropdown-content>
+      {{#download}}
+        <a href={{path-to-file}} download="">
+        {{download-button-name}}
+        </a>
+        <br>
+      {{/download}}
+      </div>
     </div>
+
   </div>
 </script>
 

--- a/modules/lti/src/main/resources/tools/series/index.html
+++ b/modules/lti/src/main/resources/tools/series/index.html
@@ -43,7 +43,6 @@
       {{/download}}
       </div>
     </div>
-
   </div>
 </script>
 

--- a/modules/lti/src/main/resources/tools/series/index.html
+++ b/modules/lti/src/main/resources/tools/series/index.html
@@ -23,14 +23,24 @@
 
 <!-- Template for episodes -->
 <script id=template-episode type=x-tmpl-mustache>
-  <a class=episode href={{player}}>
-    <div class=preview><img alt=Preview src={{image}} /></div>
-    <div class=desc>
-      <h2>{{title}}</h2>
-      {{i18ncreator}}<br />
-      {{created}}
+  <div class=episode-container>
+    <a class=episode href={{player}}>
+      <div class=preview><img alt=Preview src={{image}}></div>
+      <div class=desc>
+        <h2>{{title}}</h2>
+        {{i18ncreator}}<br>
+        {{created}}
+      </div>
+    </a>
+    <div class=download>
+    {{#download}}
+      <a href={{path-to-file}} download="">
+        <button type="button" class=downloadButton>{{download-button-name}}</button>
+      </a>
+      <br>
+    {{/download}}
     </div>
-  </a>
+  </div>
 </script>
 
 <!-- Template for spinner -->

--- a/modules/lti/src/main/resources/tools/series/index.html
+++ b/modules/lti/src/main/resources/tools/series/index.html
@@ -28,18 +28,17 @@
       <div class=preview><img alt=Preview src={{image}}></div>
       <div class=desc>
         <h2>{{title}}</h2>
-        {{i18ncreator}}<br>
+        {{i18ncreator}}<br />
         {{created}}
       </div>
     </a>
     <div class=dropdown>
-      <button class=dropbtn>Direct Download</button>
+      <button class=drop-button>Direct Download</button>
       <div class=dropdown-content>
       {{#download}}
         <a href={{path-to-file}} download="">
-        {{{download-button-name}}}
+          {{{download-button-name}}}
         </a>
-        <br>
       {{/download}}
       </div>
     </div>

--- a/modules/lti/src/main/resources/tools/series/index.html
+++ b/modules/lti/src/main/resources/tools/series/index.html
@@ -36,8 +36,9 @@
       <button class=drop-button>Direct Download</button>
       <div class=dropdown-content>
       {{#download}}
-        <a href={{path-to-file}} download="">
-          {{{download-button-name}}}
+        <a href={{path-to-file}} download>
+          {{download-button-name}}<br />
+          {{download-button-description}}
         </a>
       {{/download}}
       </div>

--- a/modules/lti/src/main/resources/tools/series/index.html
+++ b/modules/lti/src/main/resources/tools/series/index.html
@@ -37,7 +37,7 @@
       <div class=dropdown-content>
       {{#download}}
         <a href={{path-to-file}} download="">
-        {{download-button-name}}
+        {{{download-button-name}}}
         </a>
         <br>
       {{/download}}

--- a/modules/lti/src/main/resources/tools/series/series.js
+++ b/modules/lti/src/main/resources/tools/series/series.js
@@ -115,6 +115,25 @@ function loadPage(page) {
         }
       }
 
+      // Download buttons
+      // Create a button for each track that contains a link to a mp4 or webm
+      var buttonData = [];
+      var tracks = episode.mediapackage.media.track;
+      tracks = Array.isArray(tracks) ? tracks : [tracks];
+      for (var k = 0; k < tracks.length; k++)
+      {
+        if( tracks[k].url.endsWith('mp4') || tracks[0].url.endsWith('webm')) {
+          var dlBtnTplData = {};
+          dlBtnTplData['download-button-name'] = tracks[k].type.split('/')[0] + ' ' + tracks[k].video.resolution;
+          dlBtnTplData['path-to-file'] = tracks[k].url;
+
+          buttonData.push ({
+            'download-button-name' : tracks[k].type.split('/')[0] + ' ' + tracks[k].video.resolution,
+            'path-to-file' : tracks[k].url });
+        }
+      }
+      tpldata['download'] = buttonData;
+
       // render template
       rendered += Mustache.render(template, tpldata);
     }

--- a/modules/lti/src/main/resources/tools/series/series.js
+++ b/modules/lti/src/main/resources/tools/series/series.js
@@ -68,6 +68,12 @@ function getSeries() {
   return '';
 }
 
+function capitalize(s) {
+  if (typeof s !== 'string')
+    return '';
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 function loadPage(page) {
 
   var limit = 15,
@@ -123,12 +129,10 @@ function loadPage(page) {
       for (var k = 0; k < tracks.length; k++)
       {
         if( tracks[k].url.endsWith('mp4') || tracks[0].url.endsWith('webm')) {
-          var dlBtnTplData = {};
-          dlBtnTplData['download-button-name'] = tracks[k].type.split('/')[0] + ' ' + tracks[k].video.resolution;
-          dlBtnTplData['path-to-file'] = tracks[k].url;
-
           buttonData.push ({
-            'download-button-name' : tracks[k].type.split('/')[0] + ' ' + tracks[k].video.resolution,
+            'download-button-name' : capitalize( tracks[k].type.split('/')[0] )
+            + ' ' +
+            tracks[k].video.resolution,
             'path-to-file' : tracks[k].url });
         }
       }

--- a/modules/lti/src/main/resources/tools/series/series.js
+++ b/modules/lti/src/main/resources/tools/series/series.js
@@ -69,8 +69,9 @@ function getSeries() {
 }
 
 function capitalize(s) {
-  if (typeof s !== 'string')
+  if (typeof s !== 'string') {
     return '';
+  }
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
@@ -126,23 +127,14 @@ function loadPage(page) {
       var buttonData = [];
       var tracks = episode.mediapackage.media.track;
       tracks = Array.isArray(tracks) ? tracks : [tracks];
-      for (var k = 0; k < tracks.length; k++)
-      {
-        if( tracks[k].url.endsWith('mp4') || tracks[0].url.endsWith('webm')) {
-
-          // Calculate filesize
-          var fileSize = (tracks[k].video.bitrate / 8 / 1000 / 1000)      // Converts to byte, kilobyte, megabyte /s
-            * (tracks[k].video.framecount / tracks[k].video.framerate);
+      for (const track of tracks) {
+        if( track.url.endsWith('mp4') || track.url.endsWith('webm')) {
 
           // Collect output to mustache
           buttonData.push ({
-            'download-button-name' : capitalize( tracks[k].type.split('/')[0] )
-            + '<br /> ('
-            + tracks[k].video.resolution
-            + ', '
-            + fileSize.toFixed(2) + 'MB'
-            + ')',
-            'path-to-file' : tracks[k].url });
+            'download-button-name' : capitalize( track.type.split('/')[0] ),
+            'download-button-description': track.video.resolution,
+            'path-to-file' : track.url });
         }
       }
       tpldata['download'] = buttonData;

--- a/modules/lti/src/main/resources/tools/series/series.js
+++ b/modules/lti/src/main/resources/tools/series/series.js
@@ -129,10 +129,19 @@ function loadPage(page) {
       for (var k = 0; k < tracks.length; k++)
       {
         if( tracks[k].url.endsWith('mp4') || tracks[0].url.endsWith('webm')) {
+
+          // Calculate filesize
+          var fileSize = (tracks[k].video.bitrate / 8 / 1000 / 1000)      // Converts to byte, kilobyte, megabyte /s
+            * (tracks[k].video.framecount / tracks[k].video.framerate);
+
+          // Collect output to mustache
           buttonData.push ({
             'download-button-name' : capitalize( tracks[k].type.split('/')[0] )
-            + ' ' +
-            tracks[k].video.resolution,
+            + '<br /> ('
+            + tracks[k].video.resolution
+            + ', '
+            + fileSize.toFixed(2) + 'MB'
+            + ')',
             'path-to-file' : tracks[k].url });
         }
       }

--- a/modules/runtime-info-ui/src/main/resources/ui/index.html
+++ b/modules/runtime-info-ui/src/main/resources/ui/index.html
@@ -79,7 +79,7 @@
           <ul class="links">
             <li><a href="https://groups.google.com/a/opencast.org/forum/#!myforums">Mailing Lists (Google
                 Groups)</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=opencast">IRC-Channel (Webinterface)</a></li>
+            <li><a href="http://webchat.freenode.net/?channels=opencast">IRC-Channel (Webinterfafa face)</a></li>
             <li><a href="https://github.com/opencast/opencast/issues">Issue Tracker</a></li>
           </ul>
 

--- a/modules/runtime-info-ui/src/main/resources/ui/index.html
+++ b/modules/runtime-info-ui/src/main/resources/ui/index.html
@@ -79,7 +79,7 @@
           <ul class="links">
             <li><a href="https://groups.google.com/a/opencast.org/forum/#!myforums">Mailing Lists (Google
                 Groups)</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=opencast">IRC-Channel (Webinterfafa face)</a></li>
+            <li><a href="http://webchat.freenode.net/?channels=opencast">IRC-Channel (Webinterface)</a></li>
             <li><a href="https://github.com/opencast/opencast/issues">Issue Tracker</a></li>
           </ul>
 


### PR DESCRIPTION
Download button dropdown on the LTI series list

Adds a dropdown to each episode in a series. Clicking an entry in the dropdown 
will download the corresponding video file. @wsmirnow 
This pull request is intended as a quick change to r/8.x and will very likely be overwritten in r/9.x.

Expected result:
![DropDownOpen](https://user-images.githubusercontent.com/14070005/78668720-6ff94700-78db-11ea-91dc-e3a3f7e08684.jpg)


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
