### PR TITLE
Allow anonymous access to static Studio files

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -261,7 +261,13 @@
     <sec:intercept-url pattern="/static/**" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/export/**" method="GET" access="ROLE_ANONYMOUS" />
 
-    <!-- Enable admin access to Opencast Studio -->
+    <!-- Enable access to Opencast Studio -->
+    <!-- Admins can access it, as can users with 'ROLE_STUDIO'. A few static -->
+    <!-- files are also accessible to everyone: 'manifest.json' and source maps -->
+    <!-- are requested without cookies by most browsers. To prevent random -->
+    <!-- errors, we make those files public. They do not contain any secrets. -->
+    <sec:intercept-url pattern="/studio/manifest.json" access="ROLE_ANONYMOUS" />
+    <sec:intercept-url pattern="/studio/static/js/**" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/studio/**" access="ROLE_ADMIN, ROLE_STUDIO" />
 
     <!-- Enable anonymous access to the annotation and the series endpoints -->


### PR DESCRIPTION
Fixes #1495
Fixes elan-ev/opencast-studio#513

Browsers request some special files without sending cookies. This includes
the `manifest.json` and source map files. Currently, this just leads to
errors in the web console, but Studio still works. Preventing those errors
and warnings is a good idea anyway.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
