### PR TITLE
Studio-upload workflow should generate search preview images

### DIFF
--- a/etc/encoding/engage-images.properties
+++ b/etc/encoding/engage-images.properties
@@ -34,7 +34,7 @@ profile.player-preview.http.input = visual
 profile.player-preview.http.output = image
 profile.player-preview.http.suffix = -player.jpg
 profile.player-preview.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
-  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),fps=1,reverse,scale=-2:480 \
+  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),fps=1,reverse,scale=-2:720 \
   #{out.dir}/#{out.name}#{out.suffix}
 
 # Slide preview images as shown in the player

--- a/etc/workflows/studio-upload.xml
+++ b/etc/workflows/studio-upload.xml
@@ -219,9 +219,9 @@
     <!-- Encode to engage search result thumbnails -->
 
     <operation
-      id="image"
-      exception-handler-workflow="partial-error"
-      description="Creating search result default thumbnails">
+        id="image"
+        exception-handler-workflow="partial-error"
+        description="Creating search result default thumbnails">
       <configurations>
         <configuration key="source-flavors">*/prepared</configuration>
         <configuration key="target-flavor">*/search+preview</configuration>
@@ -236,10 +236,10 @@
     <operation
         id="image"
         exception-handler-workflow="partial-error"
-        description="Creating player preview image">
+        description="Creating presentation player preview image">
       <configurations>
-        <configuration key="source-flavors">*/prepared</configuration>
-        <configuration key="target-flavor">*/player+preview</configuration>
+        <configuration key="source-flavor">presentation/prepared</configuration>
+        <configuration key="target-flavor">presentation/player+preview</configuration>
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="encoding-profile">player-preview.http</configuration>
         <configuration key="time">1</configuration>
@@ -247,20 +247,21 @@
     </operation>
 
     <operation
-        id="tag"
+        id="image"
         exception-handler-workflow="partial-error"
-        description="Tagging source material for archival">
+        description="Creating presenter cover image">
       <configurations>
-        <configuration key="source-flavors">presenter/player+preview</configuration>
+        <configuration key="source-flavors">presenter/prepared</configuration>
         <configuration key="target-flavor">presenter/coverbackground</configuration>
-        <configuration key="target-tags">-engage-download</configuration>
+        <configuration key="encoding-profile">player-preview.http</configuration>
+        <configuration key="time">1</configuration>
       </configurations>
     </operation>
 
     <operation
         id="cover-image"
         exception-handler-workflow="partial-error"
-        description="Create a cover image">
+        description="Create presenter player preview image">
       <configurations>
         <configuration key="stylesheet">file://${karaf.etc}/branding/coverimage.xsl</configuration>
         <configuration key="width">1280</configuration>

--- a/etc/workflows/studio-upload.xml
+++ b/etc/workflows/studio-upload.xml
@@ -202,6 +202,8 @@
       </configurations>
     </operation>
 
+    <!-- Encode delivery version of the videos -->
+
     <operation
         id="encode"
         exception-handler-workflow="partial-error"
@@ -214,6 +216,21 @@
       </configurations>
     </operation>
 
+    <!-- Encode to engage search result thumbnails -->
+
+    <operation
+      id="image"
+      exception-handler-workflow="partial-error"
+      description="Creating search result default thumbnails">
+      <configurations>
+        <configuration key="source-flavors">*/prepared</configuration>
+        <configuration key="target-flavor">*/search+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">search-cover.http</configuration>
+        <configuration key="time">1</configuration>
+      </configurations>
+    </operation>
+
     <!-- Encode to engage player preview images -->
 
     <operation
@@ -221,11 +238,36 @@
         exception-handler-workflow="partial-error"
         description="Creating player preview image">
       <configurations>
-        <configuration key="source-flavor">*/prepared</configuration>
+        <configuration key="source-flavors">*/prepared</configuration>
         <configuration key="target-flavor">*/player+preview</configuration>
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="encoding-profile">player-preview.http</configuration>
         <configuration key="time">1</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+        id="tag"
+        exception-handler-workflow="partial-error"
+        description="Tagging source material for archival">
+      <configurations>
+        <configuration key="source-flavors">presenter/player+preview</configuration>
+        <configuration key="target-flavor">presenter/coverbackground</configuration>
+        <configuration key="target-tags">-engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+        id="cover-image"
+        exception-handler-workflow="partial-error"
+        description="Create a cover image">
+      <configurations>
+        <configuration key="stylesheet">file://${karaf.etc}/branding/coverimage.xsl</configuration>
+        <configuration key="width">1280</configuration>
+        <configuration key="height">720</configuration>
+        <configuration key="posterimage-flavor">presenter/coverbackground</configuration>
+        <configuration key="target-flavor">presenter/player+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
       </configurations>
     </operation>
 
@@ -236,50 +278,12 @@
         exception-handler-workflow="partial-error"
         description="Creating feed cover image">
       <configurations>
-        <configuration key="source-flavor">*/prepared</configuration>
+        <configuration key="source-flavors">*/prepared</configuration>
         <configuration key="source-tags"></configuration>
         <configuration key="target-flavor">*/feed+preview</configuration>
         <configuration key="target-tags">atom,rss</configuration>
         <configuration key="encoding-profile">feed-cover.http</configuration>
         <configuration key="time">1</configuration>
-      </configurations>
-    </operation>
-
-    <!-- Create a cover image with the default template -->
-
-    <operation
-        id="tag"
-        description="Removing unneeded presenter-cover from download publication">
-      <configurations>
-        <configuration key="source-flavors">presenter/player+preview</configuration>
-        <configuration key="target-tags">-engage-download</configuration>
-      </configurations>
-    </operation>
-
-    <operation
-        id="image"
-        exception-handler-workflow="partial-error"
-        description="Creating player preview image">
-      <configurations>
-        <configuration key="source-flavor">presenter/prepared</configuration>
-        <configuration key="source-tags"></configuration>
-        <configuration key="target-flavor">presenter/coverbackground</configuration>
-        <configuration key="encoding-profile">player-preview.http</configuration>
-        <configuration key="time">1</configuration>
-      </configurations>
-    </operation>
-
-    <operation
-        id="cover-image"
-        exception-handler-workflow="partial-error"
-        description="Create a cover image">
-      <configurations>
-        <configuration key="stylesheet">file://${karaf.etc}/branding/coverimage.xsl</configuration>
-        <configuration key="width">1920</configuration>
-        <configuration key="height">1080</configuration>
-        <configuration key="posterimage-flavor">presenter/coverbackground</configuration>
-        <configuration key="target-flavor">presenter/player+preview</configuration>
-        <configuration key="target-tags">archive, engage-download</configuration>
       </configurations>
     </operation>
 


### PR DESCRIPTION
The search preview image generation tasks are missing in the studio-upload workflow. These images are used by media module and especially the LTI series tool.
Also the player preview images should be generated in higher resolution in general.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
