### PR TITLE
Studio encoding profile performance improved

### DIFF
--- a/etc/encoding/adaptive-streaming-movies.properties
+++ b/etc/encoding/adaptive-streaming-movies.properties
@@ -108,19 +108,19 @@ profile.studio.adaptive-parallel.http.suffix.360p-quality = -360p-quality.mp4
 profile.studio.adaptive-parallel.http.jobload = 4
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1800 = \
   -filter:v scale=w=3840:h=trunc(3840/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -c:v libx264 -tune film -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 14800k -bufsize 29600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.2160p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1260 = \
   -filter:v scale=w=2560:h=trunc(2560/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -c:v libx264 -tune film -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 9800k -bufsize 19600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1440p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-900 = \
   -filter:v scale=w=1920:h=trunc(1920/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -c:v libx264 -tune film -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 4800k -bufsize 9600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1080p-quality}
@@ -129,12 +129,12 @@ profile.studio.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
   #{if-height-geq-1260} \
   #{if-height-geq-900} \
   -filter:v scale=w=1280:h=trunc(1280/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -c:v libx264 -tune film -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 2400k -bufsize 4800k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.720p-quality} \
   -filter:v scale=w=640:h=trunc(640/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -c:v libx264 -tune film -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 1200k -bufsize 2400k \
     -c:a aac -b:a 64k -ac 1 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.360p-quality}

--- a/etc/encoding/adaptive-streaming-movies.properties
+++ b/etc/encoding/adaptive-streaming-movies.properties
@@ -109,19 +109,19 @@ profile.studio.adaptive-parallel.http.jobload = 4
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1800 = \
   -filter:v scale=w=3840:h=trunc(3840/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 14800k -bufsize 29600k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 14800k -bufsize 14800k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.2160p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1260 = \
   -filter:v scale=w=2560:h=trunc(2560/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 9800k -bufsize 19600k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 9800k -bufsize 9800k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1440p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-900 = \
   -filter:v scale=w=1920:h=trunc(1920/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 4800k -bufsize 9600k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 4800k -bufsize 4800k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1080p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
@@ -130,11 +130,11 @@ profile.studio.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
   #{if-height-geq-900} \
   -filter:v scale=w=1280:h=trunc(1280/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 2400k -bufsize 4800k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 2400k -bufsize 2400k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.720p-quality} \
   -filter:v scale=w=640:h=trunc(640/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 1200k -bufsize 2400k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 1200k -bufsize 1200k \
     -c:a aac -b:a 64k -ac 1 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.360p-quality}

--- a/etc/encoding/adaptive-streaming-movies.properties
+++ b/etc/encoding/adaptive-streaming-movies.properties
@@ -108,7 +108,7 @@ profile.studio.adaptive-parallel.http.suffix.360p-quality = -360p-quality.mp4
 profile.studio.adaptive-parallel.http.jobload = 4
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1800 = \
   -filter:v scale=w=3840:h=trunc(3840/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 preset faster -tune film -pix_fmt yuv420p \
+    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 14800k -bufsize 29600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.2160p-quality}

--- a/etc/encoding/adaptive-streaming-movies.properties
+++ b/etc/encoding/adaptive-streaming-movies.properties
@@ -109,19 +109,19 @@ profile.studio.adaptive-parallel.http.jobload = 4
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1800 = \
   -filter:v scale=w=3840:h=trunc(3840/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 14800k -bufsize 29600k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 14800k -bufsize 29600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.2160p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1260 = \
   -filter:v scale=w=2560:h=trunc(2560/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 9800k -bufsize 19600k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 9800k -bufsize 19600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1440p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-900 = \
   -filter:v scale=w=1920:h=trunc(1920/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 4800k -bufsize 9600k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 4800k -bufsize 9600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1080p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
@@ -130,11 +130,11 @@ profile.studio.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
   #{if-height-geq-900} \
   -filter:v scale=w=1280:h=trunc(1280/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 2400k -bufsize 4800k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 2400k -bufsize 4800k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.720p-quality} \
   -filter:v scale=w=640:h=trunc(640/dar/2)*2,setsar=1,fps=25 \
     -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 1200k -bufsize 2400k \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -maxrate 1200k -bufsize 2400k \
     -c:a aac -b:a 64k -ac 1 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.360p-quality}

--- a/etc/encoding/adaptive-streaming-movies.properties
+++ b/etc/encoding/adaptive-streaming-movies.properties
@@ -108,20 +108,20 @@ profile.studio.adaptive-parallel.http.suffix.360p-quality = -360p-quality.mp4
 profile.studio.adaptive-parallel.http.jobload = 4
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1800 = \
   -filter:v scale=w=3840:h=trunc(3840/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset slower -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 20 -maxrate 14800k -bufsize 18000k \
-    -c:a aac -b:a 196k -ac 2 \
+    -c:v libx264 preset faster -tune film -pix_fmt yuv420p \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 14800k -bufsize 29600k \
+    -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.2160p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-1260 = \
   -filter:v scale=w=2560:h=trunc(2560/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset slower -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 20 -maxrate 9800k -bufsize 14000k \
+    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 9800k -bufsize 19600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1440p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command.if-height-geq-900 = \
   -filter:v scale=w=1920:h=trunc(1920/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset slower -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 20 -maxrate 4800k -bufsize 8000k \
+    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 4800k -bufsize 9600k \
     -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.1080p-quality}
 profile.studio.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
@@ -129,12 +129,12 @@ profile.studio.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
   #{if-height-geq-1260} \
   #{if-height-geq-900} \
   -filter:v scale=w=1280:h=trunc(1280/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset slower -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 20 -maxrate 2400k -bufsize 2400k \
-    -c:a aac -b:a 96k -ac 2 \
+    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 2400k -bufsize 4800k \
+    -c:a aac -b:a 128k -ac 2 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.720p-quality} \
   -filter:v scale=w=640:h=trunc(640/dar/2)*2,setsar=1,fps=25 \
-    -c:v libx264 -preset slower -tune film -pix_fmt yuv420p \
-    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 1200k -bufsize 800k \
+    -c:v libx264 -preset faster -tune film -pix_fmt yuv420p \
+    -x264opts keyint=25:min-keyint=25:no-scenecut -crf 23 -maxrate 1200k -bufsize 2400k \
     -c:a aac -b:a 64k -ac 1 \
     -movflags +faststart #{out.dir}/#{out.name}#{out.suffix.360p-quality}


### PR DESCRIPTION
The studio-upload workflow uses an dynamic encoding profile for generating the delivery version of the videos. This profile is currently really slow. I've changed the x264 encoder preset from slower to faster. On the way the buffer size for each quality was fixed to hold 2 sec. of video.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
