### PR TITLE
Documentation: OsgiAclServiceRestEndpoint

### DIFF
--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpoint.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpoint.java
@@ -40,7 +40,7 @@ import javax.ws.rs.Path;
 
 /** REST endpoint for ACL manager. */
 @Path("/")
-@RestService(name = "aclmanager", title = "ACL Manager", abstractText = "This service creates, edits and retrieves and helps managing and scheduling ACL's.", notes = {})
+@RestService(name = "aclmanager", title = "ACL Manager", abstractText = "This service creates, edits, retrieves and helps managing access policies (ACL templates).", notes = {})
 public final class OsgiAclServiceRestEndpoint extends AbstractAclServiceRestEndpoint {
   /** Logging utility */
   private static final Logger logger = LoggerFactory.getLogger(OsgiAclServiceRestEndpoint.class);


### PR DESCRIPTION
- ACLs can't be scheduled.
- the UI calls them "access policies" and while they are actual Access Control List they are not tied to an object.
- Wikpedia defines "An access-control list (ACL), with respect to a computer file system, is a list of permissions attached to an object".
- So let's call them templates (that can be applied to episodes or series).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* ~[ ] have appropriate tags applied~
