### PR TITLE
REST Docs: Ingest: WF parameters, WFIID deprecated

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -1036,7 +1036,9 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
   @POST
   @Produces(MediaType.TEXT_HTML)
   @Path("ingest/{wdID}")
-  @RestQuery(name = "ingest", description = "Ingest the completed media package into the system, retrieving all URL-referenced files, and starting a specified workflow",
+  @RestQuery(name = "ingest",
+             description = "<p>Ingest the completed media package into the system and start a specified workflow.</p>"
+             + "<p>In addition to the documented form parameters, workflow parameters are accepted as well.</p>",
     pathParameters = {
       @RestParameter(description = "Workflow definition id", isRequired = true, name = "wdID", type = RestParameter.Type.STRING) },
     restParameters = {
@@ -1056,11 +1058,13 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
   @POST
   @Produces(MediaType.TEXT_HTML)
   @Path("ingest")
-  @RestQuery(name = "ingest", description = "Ingest the completed media package into the system, retrieving all URL-referenced files",
+  @RestQuery(name = "ingest",
+             description = "<p>Ingest the completed media package into the system</p>"
+             + "<p>In addition to the documented form parameters, workflow parameters are accepted as well.</p>",
     restParameters = {
       @RestParameter(description = "The media package", isRequired = true, name = "mediaPackage", type = RestParameter.Type.TEXT),
       @RestParameter(description = "Workflow definition id", isRequired = false, name = WORKFLOW_DEFINITION_ID_PARAM, type = RestParameter.Type.STRING),
-      @RestParameter(description = "The workflow instance ID to associate with this zipped mediapackage", isRequired = false, name = WORKFLOW_INSTANCE_ID_PARAM, type = RestParameter.Type.STRING) },
+      @RestParameter(description = "The workflow instance ID to associate with this zipped mediapackage. (This parameter is deprecated.)", isRequired = false, name = WORKFLOW_INSTANCE_ID_PARAM, type = RestParameter.Type.STRING) },
     reponses = {
       @RestResponse(description = "Returns the media package", responseCode = HttpServletResponse.SC_OK),
       @RestResponse(description = "Media package not valid", responseCode = HttpServletResponse.SC_BAD_REQUEST) },


### PR DESCRIPTION
- This is about the ingest REST endpoint
- Workflow parameters are supported. See IngestServiceImpl::ingest() where they are passed as properties
- In docs.opencast they are referenced to as "Workflow instance configuration"
- C.f. discussion on https://groups.google.com/a/opencast.org/d/msg/anwender/PgJQHlpAGUg/3OFx2LLKCwAJ
- workflow instance ID is deprecated: IngestServiceImpl::ingest():
  "Resuming workflow {} with ingested mediapackage {} is deprecated, skip resuming and start new workflow"

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* ~[ ] have appropriate tags applied~
