### PR TITLE
Fix race condition when creating or updating user references from LTI

### DIFF
--- a/modules/security-lti/pom.xml
+++ b/modules/security-lti/pom.xml
@@ -59,6 +59,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-kernel</artifactId>
       <version>${project.version}</version>

--- a/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
+++ b/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
@@ -21,10 +21,6 @@
 
 package org.opencastproject.security.lti;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
@@ -33,6 +29,11 @@ import org.opencastproject.security.impl.jpa.JpaRole;
 import org.opencastproject.security.impl.jpa.JpaUserReference;
 import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.userdirectory.api.UserReferenceProvider;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -303,7 +304,7 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
         }
       });
 
-      try{
+      try {
         // use #getUnchecked since the loader does not throw any checked exceptions
         userDetails = (UserDetails)userDetailsCache.getUnchecked(username);
         if (userDetails != nullToken) {


### PR DESCRIPTION
When a LTI client submits very fast calls to Opencast for the same user it sometimes comes to bad race conditions:

Example for two concurrent requests:

```
-04-19T15:17:02,756 | DEBUG | (LtiLaunchAuthenticationHandler:254) - xcampus is a trusted key
2020-04-19T15:17:02,756 | DEBUG | (LtiLaunchAuthenticationHandler:254) - xcampus is a trusted key
2020-04-19T15:17:02,756 | DEBUG | (LtiLaunchAuthenticationHandler:278) - LTI user id is : s324216@uni-xxxx.de
2020-04-19T15:17:02,756 | DEBUG | (LtiLaunchAuthenticationHandler:278) - LTI user id is : s324216@uni-xxxx.de
2020-04-19T15:17:02,758 | DEBUG | (LtiLaunchAuthenticationHandler:384) - Adding group: ROLE_GROUP_LEARNER
2020-04-19T15:17:02,758 | DEBUG | (LtiLaunchAuthenticationHandler:384) - Adding group: ROLE_GROUP_LEARNER
2020-04-19T15:17:02,758 | DEBUG | (LtiLaunchAuthenticationHandler:394) - Adding role: 13671_Lear
```

Inserts and updates run simultanously resulting in conflicts:

```
2020-04-19T15:17:02,936 | DEBUG | (LtiProcessingFilter:49) - Skip resetting the authentication
2020-04-19T15:17:02,937 | WARN  | (HttpChannel:585) - /lti
javax.persistence.RollbackException: Exception [EclipseLink-4002] (Eclipse Persistence Services - 2.7.3.v20180807-4
be1041): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException: Duplicate entry '13
671_Learner-mh_default_org' for key 'UNQ_oc_role'
Error Code: 1062
Call: INSERT INTO oc_role (id, description, name, organization) VALUES (?, ?, ?, ?)
        bind => [4 parameters bound]
Query: InsertObjectQuery(13671_Learner:mh_default_org)
        at org.eclipse.persistence.internal.jpa.transaction.EntityTransactionImpl.commit(EntityTransactionImpl.java:161) ~[?:?]
        at org.opencastproject.userdirectory.UserDirectoryPersistenceUtil.saveRoles(UserDirectoryPersistenceUtil.java:81) ~[?:?]
        at org.opencastproject.userdirectory.JpaUserReferenceProvider.addUserReference(JpaUserReferenceProvider.java:278) ~[?:?]
        at org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.createAuthentication(LtiLaunchAuthenticationHandler.java:335) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:?]
        at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:319) ~[?:?]
        at org.springframework.osgi.service.importer.support.internal.aop.ServiceInvoker.doInvoke(ServiceInvoker.java:58) ~[?:?]
        at org.springframework.osgi.service.importer.support.internal.aop.ServiceInvoker.invoke(ServiceInvoker.java:62) ~[?:?]
```

Finally this results in a 500, and the LTI client fails

`10.109.5.115 - "" [19/Apr/2020:15:17:02 +0200] "POST /lti HTTP/1.1" 500 43880`

This patch locks the relevant database operations for concurrent access **from the same user**. Thus, no performance impact, but safe.

