### PR TITLE
Opencast server node name should be optional

### DIFF
--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/HostRegistrationJpaImpl.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/HostRegistrationJpaImpl.java
@@ -58,7 +58,7 @@ public class HostRegistrationJpaImpl implements HostRegistration {
   @Column(name = "address", nullable = false, length = 39)
   private String ipAddress;
 
-  @Column(name = "node_name", nullable = false, length = 39)
+  @Column(name = "node_name", length = 255)
   private String nodeName;
 
   @Column(name = "memory", nullable = false)

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/HostRegistration.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/HostRegistration.java
@@ -115,7 +115,7 @@ public interface HostRegistration {
   void setMaintenanceMode(boolean maintenanceMode);
 
   /**
-   * @return the node id for this host
+   * @return the node name for this host or null, if not set
    */
   String getNodeName();
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServersListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServersListProvider.java
@@ -142,7 +142,8 @@ public class ServersListProvider implements ResourceListProvider {
 
       switch (listName) {
         case LIST_NODE_NAME:
-          list.put(vNodeName, vNodeName);
+          if (vNodeName != null)
+            list.put(vNodeName, vNodeName);
           break;
         case LIST_HOSTNAME:
         default:

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -320,7 +320,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     // Register this host
     try {
       if (cc == null || StringUtils.isBlank(cc.getBundleContext().getProperty(OpencastConstants.NODE_NAME_PROPERTY))) {
-        nodeName = hostName;
+        nodeName = null;
       } else {
         nodeName = cc.getBundleContext().getProperty(OpencastConstants.NODE_NAME_PROPERTY);
       }
@@ -1225,6 +1225,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         hostRegistration.setCores(cores);
         hostRegistration.setMaxLoad(maxLoad);
         hostRegistration.setOnline(true);
+        hostRegistration.setNodeName(nodeName);
         em.merge(hostRegistration);
       }
       logger.info("Registering {} with a maximum load of {}", host, maxLoad);


### PR DESCRIPTION
The code is inconsistent about the node name of hosts. The sql scripts (ddl initialization and upgrade) set the property as nullable with varchar length of 255. But in the code we expect an non nullable value with initialized length of 39. Running opencast on a host without node name set (e.g. not configured the property in custom.properties or upgraded from an earlier opencast version) does not enable the servers, systems and services filters in the Admin UI, cause of null values in the oc_host_registration.node_name. This patch fix issues with null values.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
