### PR TITLE
Fix Karma Safari test in mac OS 

### DIFF
--- a/modules/admin-ui/package.json
+++ b/modules/admin-ui/package.json
@@ -40,7 +40,7 @@
     "karma-firefox-launcher": "^1.1.0",
     "karma-jasmine": "^1.1.2",
     "karma-ng-html2js-preprocessor": "^1.0.0",
-    "karma-safari-launcher": "^1.0.0",
+    "karma-safari-applescript-launcher": "^0.1.0",
     "request": "^2.88.0",
     "request-digest": "^1.0.13",
     "selenium-server-standalone-jar": "3.141.5",


### PR DESCRIPTION
Follow up of #1426, This fix changes the karma plugin to make the tests in safari. The issue with the former plugin was because of the security policies safari asks to open the file `redirect.html`, if you don't make this action the build fails.

![Screenshot 2020-04-23 at 08 43 27](https://user-images.githubusercontent.com/8040628/80082613-e68d7a00-8554-11ea-82c0-21d684425196.png)


Using the `karma-safari-applescript-launcher` allows to comunicate with safari directly. The first time it will only ask in OSX if allows the terminal to run it. later builds it will not ask again.


### Your pull request should…

* [x] have a concise title

* [x] be against the correct branch (features can only go into develop)
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
