### PR TITLE
Studio workflow schould archive prepared versiond of videos

### DIFF
--- a/etc/workflows/studio-upload.xml
+++ b/etc/workflows/studio-upload.xml
@@ -172,7 +172,7 @@
       <configurations>
         <configuration key="source-flavor">presenter/source</configuration>
         <configuration key="target-flavor">presenter/prepared</configuration>
-        <configuration key="target-tags">-archive</configuration>
+        <configuration key="target-tags">archive</configuration>
         <configuration key="rewrite">false</configuration>
         <configuration key="audio-muxing-source-flavors">*/?,*/*</configuration>
       </configurations>
@@ -185,7 +185,7 @@
       <configurations>
         <configuration key="source-flavor">presentation/source</configuration>
         <configuration key="target-flavor">presentation/prepared</configuration>
-        <configuration key="target-tags">-archive</configuration>
+        <configuration key="target-tags">archive</configuration>
         <configuration key="rewrite">false</configuration>
         <configuration key="audio-muxing-source-flavors">*/?,*/*</configuration>
       </configurations>


### PR DESCRIPTION
As other publication workflows expects the media tracks with */prepared flavor, we should archive it in studio workflow too like schedule-and-upload workflow does.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
