### PR TITLE
Allow Admin UI Users to Access /

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -21,6 +21,7 @@
     <!-- ################ -->
 
     <!-- Allow anonymous access to the login form -->
+    <sec:intercept-url pattern="/" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/admin-ng/login.html" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/sysinfo/bundles/version" method="GET" access="ROLE_ANONYMOUS" />
 


### PR DESCRIPTION
Users with limited access rights but ROLE_ADMIN_UI can log in and
access the admin interface but will get an error when they get back to
the main domain since they have no access while already being logged in.

This patch allows anonymous access to / which will then redirect users
to the admin interface where they get access if they have the

This fixes #1345

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
