### PR TITLE
#1541 adding write access parameter to events and series endpoint

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -789,7 +789,7 @@ public class EventsEndpoint implements ManagedService {
     if (optOffset.isSome())
       query.withOffset(offset);
 
-    if (onlyWithWriteAccess) {
+    if (onlyWithWriteAccess != null && onlyWithWriteAccess) {
       query.withoutActions();
       query.withAction(Permissions.Action.WRITE);
     }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -287,7 +287,7 @@ public class SeriesEndpoint {
         }
       }
 
-      if (onlyWithWriteAccess) {
+      if (onlyWithWriteAccess != null && onlyWithWriteAccess) {
         query.withoutActions();
         query.withAction(Permissions.Action.WRITE);
       }


### PR DESCRIPTION
## Pull Request for adding wrtite access paramater to Series and Events endpoint in the external api.

Issue : https://github.com/opencast/opencast/issues/1541

We are adding the **write access** params in the Method : 

`getEvents(...)`

and 

` getSeriesList(...)`

if parameter is not set the response will include all events/series, even these with no write access.