### PR TITLE
Resolution based encoding extension: if-width-or-height-geq-

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
@@ -88,11 +88,12 @@ profile.parallel.http.ffmpeg.command = -i #{in.video.path} \
 ### Resolution Based Encoding
 
 The `encode` operation supports encoding based on the input video's resolution. For example, you can encode a certain
-output resolution only for high resolution inputs. For this you can define variables like `if-height-geq-720` which
-retain their value only if the video resolution meets the defined criteria.
+output resolution only for high resolution inputs. For this you can define conditionally set variables like `if-height-geq-720`
+as part of the `ffmpeg.command` property which retain their value only if the video resolution meets the defined criteria.
+This variable can then be used in the `ffmpeg.command` property.
 
 This modification to the encoding profile from above will encode the 720p output only if the input height is at least
-720 pixels:
+720 pixels, note the Reference `#{if-height-geq-720}` to the variable at the end of the `ffmpeg.command` property:
 
 ```properties
 …
@@ -105,3 +106,10 @@ profile.parallel.http.ffmpeg.command = -i #{in.video.path} \
   -c:a aac -ar 44100 -ab 96k #{out.dir}/#{out.name}#{out.suffix.high-quality} \
   #{if-height-geq-720}
 ```
+
+There are currently two resolution based conditionally set variables supported:
+
+| Variable                                 | Example                           | Description                                                                                                                    |
+|------------------------------------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+|`if-height-geq-<height>`                  |`if-height-geq-720`                |The value is set if the height of the video is greater or equal to `<height>` pixels.                                           |
+|`if-width-or-height-geq-<width>-<height>` |`if-width-or-height-geq-1280-720`  |The value is set if the width of the video is greater or equal to `<width>` or if the height is greater or equal to `<height>`. |


### PR DESCRIPTION
This pull request adds a new conditionally set variable to the encoding profiles of the encode-woh to better support Resolution Based Encoding: `if-width-or-height-geq-`.
A similar variable `if-height-geq-` already exists, but only focuses on the height of the video.

The documentation is also adjusted.