### PR TITLE
Be more lenient towards service failures

### DIFF
--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -1,7 +1,7 @@
 # Configuration for the service registry
 
 # Number of failed jobs on a service before to set it in error state
-max.attempts=1
+max.attempts=10
 
 # The interval in milliseconds between two rounds of dispatching in the service registry. The default value is 5s, and
 # a mimimum value of 1s is enforced due to performance reasons. Set to 0 to disable dispatching from this service


### PR DESCRIPTION
With much more user content like we see right now, it's much more likely
that a failed operation does not mean a broken service or a broken
service configuration.

That is why this pull request increases the number of times a job may
fail on a service before that service is sent into an error state.

Note that services in a warning state will be sanitized automatically
when operations succeed on the same service. Hence, if a service fails
three times but then succeeds, the service will be in a normal state.

The amount of allowed failures chosen is just a guess. A single
operation failing can cause multiple jobs fail simultaneously. That's
why 10 did not seem too high.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
