### PR TITLE
Partial import muxing fix

### DIFF
--- a/etc/encoding/opencast-movies.properties
+++ b/etc/encoding/opencast-movies.properties
@@ -167,7 +167,7 @@ profile.import.silent.name = Generate silent audio tracks for filling gaps
 profile.import.silent.input = nothing
 profile.import.silent.output = audio
 profile.import.silent.suffix = -silent-audio.mp4
-profile.import.silent.ffmpeg.command = -strict -2 -filter_complex aevalsrc=0::d=#{time} -c:a aac -b:a 8k #{out.dir}/#{out.name}#{out.suffix}
+profile.import.silent.ffmpeg.command = -strict -2 -filter_complex aevalsrc=0:d=#{time} -c:a aac -b:a 8k #{out.dir}/#{out.name}#{out.suffix}
 
 # Transcode videos generated with opencast studio to cover some issues
 # The video resolution should be reduced to maximum of 1080p.
@@ -184,3 +184,16 @@ profile.scale.fhd.framerate.fix.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 21 \
   -movflags +faststart \
   #{out.dir}/#{out.name}#{out.suffix}
+
+# Editor
+#   This profile is used as a preview and work copy for the video editor.
+#   The gnonlin component in the gstreamer based video editor modules needs
+#   an mp4 codec to work reliable. This could also be used for the web preview
+#   although the file might be quite large for web distribution
+
+profile.editor.work.name = editor
+profile.editor.work.input = audiovisual
+profile.editor.work.output = audiovisual
+profile.editor.work.suffix = -editor.mp4
+profile.editor.work.mimetype = video/mp4
+profile.editor.work.ffmpeg.command = -i #{in.video.path} -shortest -c:v libx264 -preset superfast -pix_fmt yuv420p -crf 18 -c:a aac -strict -2 -b:a 196k #{out.dir}/#{out.name}#{out.suffix}

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -407,9 +407,14 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
     queueTime += checkForTrimming(mediaPackage, trimProfile, deriveAudioFlavor(targetPresenterFlavor),
             trackDurationInSeconds, elementsToClean);
 
+    // New: Mux within presentation and presenter
+    queueTime += checkForMuxing(mediaPackage, targetPresenterFlavor, deriveAudioFlavor(targetPresenterFlavor), false, elementsToClean);
+    queueTime += checkForMuxing(mediaPackage, targetPresentationFlavor, deriveAudioFlavor(targetPresentationFlavor), false, elementsToClean);
+
     adjustAudioTrackTargetFlavor(mediaPackage, targetPresenterFlavor);
     adjustAudioTrackTargetFlavor(mediaPackage, targetPresentationFlavor);
 
+    // Mux between presentation and presenter? Why?
     queueTime += checkForMuxing(mediaPackage, targetPresenterFlavor, targetPresentationFlavor, false, elementsToClean);
 
     queueTime += checkForEncodeToStandard(mediaPackage, forceEncoding, forceProfile, requiredExtensions,
@@ -744,7 +749,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
       audioTrack = audioElements.get(0);
     }
 
-    logger.debug("Check for mux between '{}' and '{}' flavors and found video track '{}' and audio track '{}'",
+    logger.info("Check for mux between '{}' and '{}' flavors and found video track '{}' and audio track '{}'",
             targetPresentationFlavor, targetPresenterFlavor, videoTrack, audioTrack);
     if (videoTrack != null && audioTrack != null) {
       queueTime += mux(mediaPackage, videoTrack, audioTrack, elementsToClean);
@@ -907,6 +912,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
                 logger.info("Fill {} track gap from {} to {} with image frame",
                         type.get(), Double.toString(positionInSeconds), Double.toString(beginInSeconds));
                 Track previousTrack = tracks.get(tracks.size() - 1);
+                logger.info("ARNE::Previous Track to Presentation Track: " + previousTrack);
                 Attachment tempLastImageFrame = extractLastImageFrame(previousTrack, elementsToClean);
                 tracks.add(createVideoFromImage(tempLastImageFrame, fillTime, elementsToClean));
               }
@@ -1000,7 +1006,15 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
 
   private Attachment extractLastImageFrame(Track presentationTrack, List<MediaPackageElement> elementsToClean)
           throws EncoderException, MediaPackageException, WorkflowOperationException, NotFoundException {
+    logger.info("ARNE::Get Streams: " + presentationTrack.getStreams());
     VideoStream[] videoStreams = TrackSupport.byType(presentationTrack.getStreams(), VideoStream.class);
+    logger.info("ARNE::Video Streams: " + videoStreams);
+    logger.info("ARNE::Video Streams: " + videoStreams[0]);
+    for (int arneI = 0; arneI < videoStreams.length; arneI++)
+    {
+      logger.info("ARNE::Video Streams Framecount " + arneI + ": " + videoStreams[arneI].getFrameCount());
+    }
+
     Map<String, String> properties = new HashMap<String, String>();
     properties.put("frame", Long.toString(videoStreams[0].getFrameCount() - 1));
 

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -749,7 +749,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
       audioTrack = audioElements.get(0);
     }
 
-    logger.info("Check for mux between '{}' and '{}' flavors and found video track '{}' and audio track '{}'",
+    logger.debug("Check for mux between '{}' and '{}' flavors and found video track '{}' and audio track '{}'",
             targetPresentationFlavor, targetPresenterFlavor, videoTrack, audioTrack);
     if (videoTrack != null && audioTrack != null) {
       queueTime += mux(mediaPackage, videoTrack, audioTrack, elementsToClean);
@@ -912,7 +912,6 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
                 logger.info("Fill {} track gap from {} to {} with image frame",
                         type.get(), Double.toString(positionInSeconds), Double.toString(beginInSeconds));
                 Track previousTrack = tracks.get(tracks.size() - 1);
-                logger.info("ARNE::Previous Track to Presentation Track: " + previousTrack);
                 Attachment tempLastImageFrame = extractLastImageFrame(previousTrack, elementsToClean);
                 tracks.add(createVideoFromImage(tempLastImageFrame, fillTime, elementsToClean));
               }
@@ -1006,14 +1005,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
 
   private Attachment extractLastImageFrame(Track presentationTrack, List<MediaPackageElement> elementsToClean)
           throws EncoderException, MediaPackageException, WorkflowOperationException, NotFoundException {
-    logger.info("ARNE::Get Streams: " + presentationTrack.getStreams());
     VideoStream[] videoStreams = TrackSupport.byType(presentationTrack.getStreams(), VideoStream.class);
-    logger.info("ARNE::Video Streams: " + videoStreams);
-    logger.info("ARNE::Video Streams: " + videoStreams[0]);
-    for (int arneI = 0; arneI < videoStreams.length; arneI++)
-    {
-      logger.info("ARNE::Video Streams Framecount " + arneI + ": " + videoStreams[arneI].getFrameCount());
-    }
 
     Map<String, String> properties = new HashMap<String, String>();
     properties.put("frame", Long.toString(videoStreams[0].getFrameCount() - 1));


### PR DESCRIPTION
Fixed Muxing in flavors in PartialImportWorkflowOperationHandler
    
Pure audio and pure video files in a single flavor should be muxed according to the documentation, but aren't. This is fixed in this commit.
Also adds an editor.work encoding profile, as this is required by PartialImport but was missing.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
