### PR TITLE
Add cutting to the default Studio workflow

### DIFF
--- a/etc/workflows/partial-transcode-studio-tracks.xml
+++ b/etc/workflows/partial-transcode-studio-tracks.xml
@@ -17,6 +17,20 @@
       </configurations>
     </operation>
 
+    <!-- Cut the videos -->
+
+    <operation id="editor"
+      exception-handler-workflow="partial-error"
+      description="Cut the recording according to the edit decision list">
+      <configurations>
+        <configuration key="source-flavors">*/source+transcoded</configuration>
+        <configuration key="smil-flavors">smil/cutting</configuration>
+        <configuration key="target-smil-flavor">smil/cutting</configuration>
+        <configuration key="target-flavor-subtype">source+trimmed</configuration>
+        <configuration key="skip-if-not-trimmed">true</configuration>
+      </configurations>
+    </operation>
+
     <operation
       id="tag"
       exception-handler-workflow="partial-error"
@@ -31,9 +45,9 @@
     <operation
       id="tag"
       exception-handler-workflow="partial-error"
-      description="Tagging transcoded presenter video as source and for archive">
+      description="Tagging transcoded and trimmed presenter video as source and for archive">
       <configurations>
-        <configuration key="source-flavors">presenter/source+transcoded</configuration>
+        <configuration key="source-flavors">presenter/source+trimmed</configuration>
         <configuration key="target-flavor">presenter/source</configuration>
         <configuration key="target-tags">archive</configuration>
       </configurations>
@@ -53,9 +67,9 @@
     <operation
       id="tag"
       exception-handler-workflow="partial-error"
-      description="Tagging transcoded presentation video as source and for archive">
+      description="Tagging transcoded and trimmed presentation video as source and for archive">
       <configurations>
-        <configuration key="source-flavors">presentation/source+transcoded</configuration>
+        <configuration key="source-flavors">presentation/source+trimmed</configuration>
         <configuration key="target-flavor">presentation/source</configuration>
         <configuration key="target-tags">archive</configuration>
       </configurations>


### PR DESCRIPTION
The next Opencast Studio release, slated to be included in Opencast 8.4, will likely support a very minimal editing interface. See elan-ev/opencast-studio#454. This needs to be supported by the Opencast workflow used to process the Studio uploads, though, since the plan at the moment is to just submit a SMIL file together with the video, as opposed to cutting the video client side.

This PR adapts the standard studio workflow accordingly.