### PR TITLE
TagWorkflowOperationHandler now allows wildcards in target flavor

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElementFlavor.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageElementFlavor.java
@@ -52,7 +52,7 @@ public class MediaPackageElementFlavor implements Cloneable, Comparable<MediaPac
   /**
    * Character that separates both parts of a flavor
    */
-  private static final String SEPARATOR = "/";
+  public static final String SEPARATOR = "/";
 
   /**
    * String representation of type

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
@@ -127,8 +127,24 @@ public class TagWorkflowOperationHandler extends AbstractWorkflowOperationHandle
         element.setIdentifier(null);
         element.setURI(e.getURI()); // use the same URI as the original
       }
-      if (configuredTargetFlavor != null)
-        element.setFlavor(MediaPackageElementFlavor.parseFlavor(configuredTargetFlavor));
+
+      if (configuredTargetFlavor != null) {
+
+        MediaPackageElementFlavor targetFlavor = MediaPackageElementFlavor.parseFlavor(configuredTargetFlavor);
+        String targetFlavorType = targetFlavor.getType();
+        String targetFlavorSubtype = targetFlavor.getSubtype();
+
+        if (MediaPackageElementFlavor.WILDCARD.equals(targetFlavorType)) {
+          targetFlavorType = element.getFlavor().getType();
+        }
+
+        if (MediaPackageElementFlavor.WILDCARD.equals(targetFlavorSubtype)) {
+          targetFlavorSubtype = element.getFlavor().getSubtype();
+        }
+
+        String targetFlavorStr = targetFlavorType + MediaPackageElementFlavor.SEPARATOR + targetFlavorSubtype;
+        element.setFlavor(MediaPackageElementFlavor.parseFlavor(targetFlavorStr));
+      }
 
       if (overrideTags.size() > 0) {
         element.clearTags();

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandlerTest.java
@@ -98,4 +98,70 @@ public class TagWorkflowOperationHandlerTest {
     Assert.assertEquals("tag3", track.getTags()[1]);
   }
 
+  @Test
+  public void testTargetFlavourWithTypeWildcard() throws Exception {
+    WorkflowInstanceImpl instance = new WorkflowInstanceImpl();
+    List<WorkflowOperationInstance> ops = new ArrayList<WorkflowOperationInstance>();
+    WorkflowOperationInstanceImpl operation = new WorkflowOperationInstanceImpl("test", OperationState.INSTANTIATED);
+    ops.add(operation);
+    instance.setOperations(ops);
+    instance.setMediaPackage(mp);
+
+    operation.setConfiguration(TagWorkflowOperationHandler.SOURCE_FLAVORS_PROPERTY, "*/source");
+    operation.setConfiguration(TagWorkflowOperationHandler.TARGET_FLAVOR_PROPERTY, "*/wildcard_test");
+    operation.setConfiguration(TagWorkflowOperationHandler.TARGET_TAGS_PROPERTY, "tag1, tag2");
+    operation.setConfiguration(TagWorkflowOperationHandler.COPY_PROPERTY, "false");
+
+    WorkflowOperationResult result = operationHandler.start(instance, null);
+    MediaPackage resultingMediapackage = result.getMediaPackage();
+    Track track1 = resultingMediapackage.getTrack("track-1");
+    Track track2 = resultingMediapackage.getTrack("track-2");
+    Assert.assertEquals("presentation/wildcard_test", track1.getFlavor().toString());
+    Assert.assertEquals("presenter/wildcard_test", track2.getFlavor().toString());
+  }
+
+  @Test
+  public void testTargetFlavourWithSubtypeWildcard() throws Exception {
+    WorkflowInstanceImpl instance = new WorkflowInstanceImpl();
+    List<WorkflowOperationInstance> ops = new ArrayList<WorkflowOperationInstance>();
+    WorkflowOperationInstanceImpl operation = new WorkflowOperationInstanceImpl("test", OperationState.INSTANTIATED);
+    ops.add(operation);
+    instance.setOperations(ops);
+    instance.setMediaPackage(mp);
+
+    operation.setConfiguration(TagWorkflowOperationHandler.SOURCE_FLAVORS_PROPERTY, "*/source");
+    operation.setConfiguration(TagWorkflowOperationHandler.TARGET_FLAVOR_PROPERTY, "wildcard_test/*");
+    operation.setConfiguration(TagWorkflowOperationHandler.TARGET_TAGS_PROPERTY, "tag1, tag2");
+    operation.setConfiguration(TagWorkflowOperationHandler.COPY_PROPERTY, "false");
+
+    WorkflowOperationResult result = operationHandler.start(instance, null);
+    MediaPackage resultingMediapackage = result.getMediaPackage();
+    Track track1 = resultingMediapackage.getTrack("track-1");
+    Track track2 = resultingMediapackage.getTrack("track-2");
+    Assert.assertEquals("wildcard_test/source", track1.getFlavor().toString());
+    Assert.assertEquals("wildcard_test/source", track2.getFlavor().toString());
+  }
+
+  @Test
+  public void testTargetFlavourWithTypeAndSubtypeWildcard() throws Exception {
+    WorkflowInstanceImpl instance = new WorkflowInstanceImpl();
+    List<WorkflowOperationInstance> ops = new ArrayList<WorkflowOperationInstance>();
+    WorkflowOperationInstanceImpl operation = new WorkflowOperationInstanceImpl("test", OperationState.INSTANTIATED);
+    ops.add(operation);
+    instance.setOperations(ops);
+    instance.setMediaPackage(mp);
+
+    operation.setConfiguration(TagWorkflowOperationHandler.SOURCE_FLAVORS_PROPERTY, "*/source");
+    operation.setConfiguration(TagWorkflowOperationHandler.TARGET_FLAVOR_PROPERTY, "*/*");
+    operation.setConfiguration(TagWorkflowOperationHandler.TARGET_TAGS_PROPERTY, "tag1, tag2");
+    operation.setConfiguration(TagWorkflowOperationHandler.COPY_PROPERTY, "false");
+
+    WorkflowOperationResult result = operationHandler.start(instance, null);
+    MediaPackage resultingMediapackage = result.getMediaPackage();
+    Track track1 = resultingMediapackage.getTrack("track-1");
+    Track track2 = resultingMediapackage.getTrack("track-2");
+    Assert.assertEquals("presentation/source", track1.getFlavor().toString());
+    Assert.assertEquals("presenter/source", track2.getFlavor().toString());
+  }
+
 }


### PR DESCRIPTION
This pull request should close #1513.

As described in the feature request, the `TagWorkflowOperationHandler` should now allow target flavors starting with `*/...`. When using this wildcard, all MediaPackages passing the operation should keep their flavor type and just change the subtype.

Example:
Defined target flavor: `*/foobar`

Mediapackge 1 flavor: `presentation/source`
after passing the `TagWorkflowOperationHandler`: `presentation/source` -> `presentation/foobar`

Mediapackge 2 flavor: `somethingelse/source`
after passing the `TagWorkflowOperationHandler`: `somethingelse/source` -> `somethingelse/foobar`