### PR TITLE
Update Studio to 2020-05-14

### DIFF
--- a/docs/guides/admin/docs/modules/studio.md
+++ b/docs/guides/admin/docs/modules/studio.md
@@ -17,6 +17,23 @@ The preferred way to let your users access Studio is via LTI. Remember to config
 
 ## Configuring Studio
 
-Studio is pre-configured via `etc/ui-config/mh_default_org/studio/settings.json`. You can modify that file to change the configuration, but note that you probably don't want to touch `opencast.serverUrl` and `opencast.loginProvided`. For information on possible configuration values, please see [the Studio repository](https://github.com/elan-ev/opencast-studio).
+Studio is pre-configured via `etc/ui-config/mh_default_org/studio/settings.json`. You can modify that file to change the configuration, but note that you probably don't want to touch `opencast.serverUrl` and `opencast.loginProvided`. For information on possible configuration values, please see [`CONFIGURATION.md` in the Studio repository](https://github.com/elan-ev/opencast-studio/blob/master/CONFIGURATION.md).
 
 If you want to pre-configure the ACL that is sent by studio, place a file `acl.xml` in `etc/ui-config/mh_default_org/studio/` and set `upload.acl` in `settings.json` to `/ui/config/studio/acl.xml`.
+
+## Workflow requirements
+
+The videos produced by the built-in recording capabilities of browsers are often quite exotic, to put it mildly. The Opencast workflow responsible for processing uploads from Studio needs to be able to handle the following things:
+
+- **Variable framerate**. If your workflow produces 1000fps videos, it's probably because it can't handle variable framerate. The standard solution would be to re-encode at a fixed and common framerate.
+- **Missing duration and seeking data**. Videos produced by Chrome and Edge do not store the video duration in the container. Furthermore, they don't contain any seeking cues, so that some operations can't be done quickly.
+- **Variable video dimensions**. This can happen when someone records from a phone and rotates it by 90°, making width and height of the video swap. Another common case is browsers capturing a single window/application on the user's desktop. When that window is resized, the video dimensions change, too.
+- **Very long frames**. If the user's device is very slow and can't keep up with encoding, the frame rate might be *very* low. A more extreme example is the "capture tab" feature of Chrome. In that case, Chrome records all the frames produced by its rendering engine – if the website displayed in the selected tab is static and the user does not scroll, no new frames are created, potentially for minutes!
+
+Additionally, for the video cutting in Studio to work, your workflow needs to respect the SMIL catalog Studio includes in the ingest. The default Studio workflow can handle all those things.
+
+Finally, here are some other oddities and details of videos produced by browsers:
+
+- Most browsers will default to VP8 as video codec, OPUS as audio codec and WEBM (or the superset MKV) as container.
+- Desktop capture seem to happen with 30fps in Chrome and Firefox (tested on a 60hz monitor).
+- In some cases, Firefox encodes all frames as key-frames, which – given the fixed bitrate – oftne results in a fairly low quality video.

--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2020-03-26/oc-studio-2020-03-26-integrated.tar.gz</opencast.studio.url>
-    <opencast.studio.sha256>4ca7c2eb54ec8e6dcbdea7325d21b737098a01fcf37f63a33d29fc03edaa4719</opencast.studio.sha256>
+    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2020-05-14/oc-studio-2020-05-14-integrated.tar.gz</opencast.studio.url>
+    <opencast.studio.sha256>61e16ae44eb6e423e30c621b3a870d0336415fa01dce71863e199ed82ccc576e</opencast.studio.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
This PR updates Studio from `2020-03-26` to `2020-05-14`. The detailed release notes can be seen in the respective releases: 
- https://github.com/elan-ev/opencast-studio/releases/tag/2020-04-20
- https://github.com/elan-ev/opencast-studio/releases/tag/2020-04-27
- https://github.com/elan-ev/opencast-studio/releases/tag/2020-05-06
- https://github.com/elan-ev/opencast-studio/releases/tag/2020-05-14

**A summary of the most important changes:**

- Add minimal video cutting tools to cut the start and end of the recording (only works when uploading to Opencast!)
- Add progress bar for the upload to Opencast
- Add UI to let the user choose the camera device, the audio device, the resolution of video streams and the aspect ratio of the camera stream
- Add complete Spanish, French and Dutch translations (Note: right now, they are not quite complete. I will try to contact some native speakers in the following days to translate the remaining strings for 8.4)
- Obtain LTI course ID from LTI session and not from user roles
- Lots of bug fixes, making Studio more robust against user error and technical faults, quality of life improvements, improve error messages, ...


This PR depends on #1578 for the video cutting to work correctly.

CC @rrolf @lkiesow 

---

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
