### PR TITLE
Engage: Theodul: Audio: Refer to correct items

### DIFF
--- a/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
@@ -1473,8 +1473,9 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
   }
 
   function registerEventsAudioOnly(videoDisplay) {
-    var audioPlayer_id = $('#' + videoDisplay);
-    var audioPlayer = audioPlayer_id[0];
+    var video_display = $('#' + videoDisplay);
+    var audioPlayer_id = video_display.find('audio');
+    var audioPlayer = video_display[0].player;
     var audioLoadTimeout = window.setTimeout(function () {
       Engage.trigger(plugin.events.audioCodecNotSupported.getName());
       $('.' + class_audioDisplay).hide();


### PR DESCRIPTION
- The audioPlayer_id is supposed to be an HTML5 audio elem
- The audioPlayer is supposed to be a player object, not an elem
- After this patch is applied, one can at least press the play button
  and the audio plays if the codec is supported.
  Still no timeline support or seeking though.
  The play button will be still grey.

Resolves: #1588
Does not resolve: Video.js 4.x issues with `<audio>` element (seeking and much
more broken)

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* - include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* - have appropriate tags applied
