### PR TITLE
Update Studio version to 2020-05-20

### DIFF
--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2020-05-14/oc-studio-2020-05-14-integrated.tar.gz</opencast.studio.url>
-    <opencast.studio.sha256>61e16ae44eb6e423e30c621b3a870d0336415fa01dce71863e199ed82ccc576e</opencast.studio.sha256>
+    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2020-05-20/oc-studio-2020-05-20-integrated.tar.gz</opencast.studio.url>
+    <opencast.studio.sha256>cef95075166c4de3733cac01372b036ec86c11e9f98f15df2631db8f7f80641c</opencast.studio.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
This is the final version for the 8.4 release. The main update happened in https://github.com/opencast/opencast/pull/1581, this [version bump mainly completes the translations and fixes minor things](https://github.com/elan-ev/opencast-studio/releases/tag/2020-05-20).

As far as I can tell, this should be the last PR blocking 8.4.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
