### PR TITLE
Fix Calculation of Aspect Ratio

### DIFF
--- a/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-video-videojs/src/main/resources/static/main.js
@@ -969,7 +969,7 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bowser', 'engag
   }
 
   Engage.on(plugin.events.aspectRatioSet.getName(), function (param) {
-    if (param === undefined) {
+    if (param === undefined && aspectRatio) {
       Engage.trigger(plugin.events.aspectRatioSet.getName(), [aspectRatio[1], aspectRatio[2], (aspectRatio[1] / aspectRatio[2]) * 100]);
     }
   })


### PR DESCRIPTION
This patch fixes the calculation of the non-existent aspect ratio of
audio files in the Theodul player.

To test this, you can use the following workflow to directly publish an audio file:

- https://data.lkiesow.io/opencast/publish-audio.xml

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
