### PR TITLE
Gracefully Handle Missing Timeline Preview

### DIFF
--- a/modules/engage-theodul-plugin-controls/src/main/resources/static/main.js
+++ b/modules/engage-theodul-plugin-controls/src/main/resources/static/main.js
@@ -448,21 +448,26 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bootbox', 'enga
 
         segments = Utils.repairSegmentLength(segments, duration, min_segment_duration);
 
-       try {
-        // find timeline preview images in media package
-        var attachments = Engage.model.get('mediaPackage').get('attachments');
+        try {
+          // find timeline preview images in media package
+          var attachments = Engage.model.get('mediaPackage').get('attachments');
 
-        var timelinePreviewsRegex = /(timeline)+\S*(preview)+/i;
-        timelinePreview = $(attachments).filter(function(index) {
-          return $(attachments[index]).attr('type').search(timelinePreviewsRegex) !== -1;
-        });
+          var timelinePreviewsRegex = /(timeline)+\S*(preview)+/i;
+          timelinePreview = $(attachments).filter(function(index) {
+            return $(attachments[index]).attr('type').search(timelinePreviewsRegex) !== -1;
+          });
 
-        console.log("timelinePreviews loaded: ", timelinePreview);
+          if (!timelinePreview.length) {
+            console.log("No timelinePreviews detected");
+            timelinePreviewsError = true;
 
-        var timelinePreviewsProperties = timelinePreview.get(0).additionalProperties;
+          } else {
+            console.log("timelinePreviews loaded: ", timelinePreview);
 
-        timelinePreviewsProperties.property.forEach(function(property) {
-            switch (property.key) {
+            var timelinePreviewsProperties = timelinePreview.get(0).additionalProperties;
+
+            timelinePreviewsProperties.property.forEach(function(property) {
+              switch (property.key) {
                 case "imageCount":
                     timelinePreviewsImageCount = property.$;
                     break;
@@ -478,15 +483,16 @@ define(['require', 'jquery', 'underscore', 'backbone', 'basil', 'bootbox', 'enga
                 case "resolutionY":
                     timelinePreviewsTileResolution[1] = property.$;
                     break;
-            }
-        });
+              }
+            });
 
-        timelinePreviewsError = false;
+            timelinePreviewsError = false;
+          }
 
-    } catch (e) {
-        timelinePreviewsError = true;
-        console.error("No valid timelinepreviews image was found.", e);
-    }
+        } catch (e) {
+          timelinePreviewsError = true;
+          console.error("No valid timelinepreviews image was found.", e);
+        }
 
         if (Engage.model.get('meInfo')) {
           if (Engage.model.get('meInfo').get('logo_player')) {

--- a/modules/engage-theodul-plugin-controls/src/main/resources/static/utils.js
+++ b/modules/engage-theodul-plugin-controls/src/main/resources/static/utils.js
@@ -144,7 +144,7 @@ define(["jquery"], function($) {
 
     Utils.prototype.removeParentIfElementExists = function(elemenId) {
         if ($("#" + elemenId) && $("#" + elemenId).parent()) {
-+                $("#" + elemenId).parent().remove();
+            $("#" + elemenId).parent().remove();
         }
     }
 


### PR DESCRIPTION
This patch ensures that if no timeline preview exists, e.g. because it's
an audio-only track, loading the timeline will not result in an ugly
exception.

To test this, you can use the following workflow to directly publish an audio file:

- https://data.lkiesow.io/opencast/publish-audio.xml

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
