### PR TITLE
Use normal file appender instead of RandomAccessFile for logging

### DIFF
--- a/etc/org.ops4j.pax.logging.cfg
+++ b/etc/org.ops4j.pax.logging.cfg
@@ -47,7 +47,7 @@ log4j2.appender.console.layout.type = PatternLayout
 log4j2.appender.console.layout.pattern = ${log4j2.out.pattern}
 
 # Rolling file appender
-log4j2.appender.out.type = RandomAccessFile
+log4j2.appender.out.type = File
 log4j2.appender.out.name = File
 log4j2.appender.out.fileName = ${karaf.data}/log/opencast.log
 log4j2.appender.out.append = true


### PR DESCRIPTION
The previous behavior leads to problems with external log rotation
tools. Those tools usually truncate the file to 0 length. When using
this RandomAccessFile, the JVM process keeps a file pointer (a position)
into the file and the next write will write at that position. When
an external process truncates the log file, the next log message is
written at the byte position that's equal to the previous length of
the log file. All previous bytes of the file will then be filled with
0s. This very annoying when trying to open the log file with `less`
or similar tools.

The standard file appender does not maintain such a file pointer and
always correctly appends.

Unfortunately, the normal file appender is apparently slower than
the RandomAccessFile. See these links:

- https://logging.apache.org/log4j/2.x/manual/appenders.html
- https://logging.apache.org/log4j/2.x/performance.html#whichAppender

It looks like at worst, we make logging half as fast (in terms of
messages per second). I am not sure if that will be significant for
Opencast in practice. 

**So that's the main question for the reviewer of this PR: is the worse logging performance fine?**

---

If you want to reproduce the bug yourself:
- Compile and start a local opencast
- In `build/.../data/log` run `cp opencast.log old.log && truncate -s 0 opencast.log`
- Produce more log message (e.g. by ingesting something)
- Observe how now `opencast.log` starts with `wc -c old.log` many 0 bytes before containing the new log messages.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
