### PR TITLE
Aditive Filter for Api/events endpoint

### DIFF
--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -5,11 +5,11 @@
 
 Returns a list of events.
 
-The following query string parameters are supported to filter, sort and pagingate the returned list:
+The following query string parameters are supported to filter, sort and paginate the returned list:
 
 Query String Parameter |Type                         | Description
 :----------------------|:----------------------------|:-----------
-`filter`               | [`string`](types.md#basic)  | A comma-separated list of filters to limit the results with (see [Filtering](usage.md#filtering)). See the below table for the list of available filters
+`filter`               | [`string`](types.md#basic)  | A comma-separated list of filters to limit the results with (see [Filtering](usage.md#filtering)). See the below table for the list of available filters. Version 1.5.0 and newer support comma separated use of the `filter` keyword, creating a logical OR.
 `sort`                 | [`string`](types.md#basic)  | A comma-separated list of sort criteria (see [Sorting](usage.md#sorting)).  See the below table for the list of available sort criteria
 `limit`                | [`integer`](types.md#basic) | The maximum number of results to return (see [Pagination](usage.md#pagination))
 `offset`               | [`integer`](types.md#basic) | The index of the first result to return (see [Pagination](usage.md#pagination))
@@ -35,7 +35,7 @@ Filter Name       | Description
 `is_part_of`      | Events based upon which series they are a part of. Use the series identifier here (version 1.1.0 or higher)
 `source`          | Filter events whose source match this value (version 1.1.0 or higher)
 `agent_id`        | Filter events based on the capture agent id (version 1.1.0 or higher)
-`start`           | Filter events based on start date (version 1.1.0 or higer)
+`start`           | Filter events based on start date (version 1.1.0 or higher)
 `technical_start` | Filter events based on the technical start date (version 1.1.0 or higher)
 
 Note:

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
@@ -22,6 +22,7 @@ package org.opencastproject.external.common;
 
 public final class ApiMediaType {
 
+  public static final String VERSION_1_5_0 = "application/v1.5.0+json";
   public static final String VERSION_1_4_0 = "application/v1.4.0+json";
   public static final String VERSION_1_3_0 = "application/v1.3.0+json";
   public static final String VERSION_1_2_0 = "application/v1.2.0+json";
@@ -45,8 +46,10 @@ public final class ApiMediaType {
   public static ApiMediaType parse(String acceptHeader) throws ApiMediaTypeException {
     /* MH-12802: The External API does not support content negotiation */
     ApiMediaType mediaType;
-    if (acceptHeader == null || acceptHeader.contains(VERSION_1_4_0) || acceptHeader.contains(JSON)
+    if (acceptHeader == null || acceptHeader.contains(VERSION_1_5_0) || acceptHeader.contains(JSON)
     || acceptHeader.contains(APPLICATION_ANY) || acceptHeader.contains(ANY)) {
+      mediaType = new ApiMediaType(ApiVersion.VERSION_1_5_0, ApiFormat.JSON, VERSION_1_5_0);
+    } else if (acceptHeader.contains(VERSION_1_4_0)) {
       mediaType = new ApiMediaType(ApiVersion.VERSION_1_4_0, ApiFormat.JSON, VERSION_1_4_0);
     } else if (acceptHeader.contains(VERSION_1_3_0)) {
       mediaType = new ApiMediaType(ApiVersion.VERSION_1_3_0, ApiFormat.JSON, VERSION_1_3_0);

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
@@ -27,10 +27,11 @@ public enum ApiVersion {
   VERSION_1_1_0(1, 1, 0),
   VERSION_1_2_0(1, 2, 0),
   VERSION_1_3_0(1, 3, 0),
-  VERSION_1_4_0(1, 4, 0);
+  VERSION_1_4_0(1, 4, 0),
+  VERSION_1_5_0(1, 5, 0);
 
   /** The most recent version of the External API */
-  public static final ApiVersion CURRENT_VERSION = VERSION_1_4_0;
+  public static final ApiVersion CURRENT_VERSION = VERSION_1_5_0;
 
   private int major;
   private int minor;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
@@ -79,7 +79,7 @@ import javax.ws.rs.core.Response;
  * supported API.
  */
 @Path("/")
-@Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0 })
+@Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0 })
 @RestService(name = "externalapiservice", title = "External API Service", notes = {}, abstractText = "Provides a location for external apis to query the current server of the API.")
 public class BaseEndpoint {
 
@@ -226,6 +226,7 @@ public class BaseEndpoint {
     versions.add(v(ApiVersion.VERSION_1_2_0.toString()));
     versions.add(v(ApiVersion.VERSION_1_3_0.toString()));
     versions.add(v(ApiVersion.VERSION_1_4_0.toString()));
+    versions.add(v(ApiVersion.VERSION_1_5_0.toString()));
     JValue json = obj(f("versions", arr(versions)), f("default", v(ApiVersion.CURRENT_VERSION.toString())));
     return RestUtil.R.ok(MediaType.APPLICATION_JSON_TYPE, serializer.toJson(json));
   }

--- a/modules/external-api/src/test/java/org/opencastproject/external/common/ApiMediaTypeTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/common/ApiMediaTypeTest.java
@@ -29,24 +29,24 @@ public class ApiMediaTypeTest {
   @Test
   public void testDefaultVersionAndFormat() throws Exception {
     ApiMediaType type = ApiMediaType.parse("*/*");
-    assertEquals(ApiVersion.VERSION_1_4_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_5_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.4.0+json", type.toExternalForm());
+    assertEquals("application/v1.5.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse("application/*");
-    assertEquals(ApiVersion.VERSION_1_4_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_5_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.4.0+json", type.toExternalForm());
+    assertEquals("application/v1.5.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse("application/json");
-    assertEquals(ApiVersion.VERSION_1_4_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_5_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.4.0+json", type.toExternalForm());
+    assertEquals("application/v1.5.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse(null);
-    assertEquals(ApiVersion.VERSION_1_4_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_5_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.4.0+json", type.toExternalForm());
+    assertEquals("application/v1.5.0+json", type.toExternalForm());
   }
 
   @Test
@@ -75,6 +75,11 @@ public class ApiMediaTypeTest {
     assertEquals(ApiVersion.VERSION_1_4_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
     assertEquals("application/v1.4.0+json", type.toExternalForm());
+
+    type = ApiMediaType.parse("application/v1.5.0+json");
+    assertEquals(ApiVersion.VERSION_1_5_0, type.getVersion());
+    assertEquals(ApiFormat.JSON, type.getFormat());
+    assertEquals("application/v1.5.0+json", type.toExternalForm());
   }
 
   @Test(expected = ApiMediaTypeException.class)

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
@@ -61,7 +61,7 @@ public class BaseEndpointTest {
 
     JSONObject json = (JSONObject) parser.parse(response);
     assertEquals("https://api.opencast.org", json.get("url"));
-    assertEquals("v1.4.0", json.get("version"));
+    assertEquals("v1.5.0", json.get("version"));
   }
 
   /** Test case for {@link BaseEndpoint#getUserInfo()} */
@@ -122,13 +122,14 @@ public class BaseEndpointTest {
 
     JSONObject json = (JSONObject) parser.parse(response);
     JSONArray version = (JSONArray) json.get("versions");
-    assertEquals("v1.4.0", json.get("default"));
+    assertEquals("v1.5.0", json.get("default"));
     assertTrue(version.contains("v1.0.0"));
     assertTrue(version.contains("v1.1.0"));
     assertTrue(version.contains("v1.2.0"));
     assertTrue(version.contains("v1.3.0"));
     assertTrue(version.contains("v1.4.0"));
-    assertEquals(5, version.size());
+    assertTrue(version.contains("v1.5.0"));
+    assertEquals(6, version.size());
   }
 
   /** Test case for {@link BaseEndpoint#getVersionDefault()} */
@@ -138,7 +139,7 @@ public class BaseEndpointTest {
             .asString();
 
     JSONObject json = (JSONObject) parser.parse(response);
-    assertEquals("v1.4.0", json.get("default"));
+    assertEquals("v1.5.0", json.get("default"));
   }
 
   /** Test case for {@link BaseEndpoint#recreateIndex()} */


### PR DESCRIPTION
This PR modifies the filter to be additive. That means that you can ask for different types of events in the same query that are mutually exclusive

For Example:

/api/events/?=filter=series:\<series-id-1\>&filter=series:\<series-id-2\>


If this is accepted I can make this enhancement for the others endpoints too

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
