### PR TITLE
Fix LTI Without Persistence

### DIFF
--- a/modules/security-lti/pom.xml
+++ b/modules/security-lti/pom.xml
@@ -36,7 +36,6 @@
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
-      <version>5.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -57,6 +56,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>javax.persistence</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/security-lti/pom.xml
+++ b/modules/security-lti/pom.xml
@@ -59,10 +59,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-kernel</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
This patch fixes LTI which was completely broken if persisting user
references were not enabled and partly broken if it was enabled but the
user was not yet persisted.

This problem was caused by pull request #1532 which this pull request
complete reverts.

In addition, this pull request fixes the problem #1532 was originally
supposed to fix: On concurrent LTI requests it could happen that
Opencast would try to create the same user multiple times in parallel.
This patch fixes the problem by using an optimistic approach,
deliberately allowing an insert to fail, if an entry already exists.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
