### PR TITLE
LTI User Data

### DIFF
--- a/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
+++ b/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
@@ -352,14 +352,28 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
 
           Date loginDate = new Date();
 
+          // Get some user details
+          String name = request.getParameter("lis_person_name_full");
+          if (name == null) {
+            final String familyName = Objects.toString(request.getParameter("lis_person_name_family"), "");
+            final String givenName = Objects.toString(request.getParameter("lis_person_name_given"), "");
+            name = String.format("%s %s", givenName, familyName).trim();
+            if (name.isEmpty()) {
+              name = username;
+            }
+          }
+          final String email = request.getParameter("lis_person_contact_email_primary");
+
           // Create new JpaUserReference if none exists or update existing
           if (jpaUserReference == null) {
             final String jpaContext = Objects.toString(request.getParameter(CONTEXT_ID), DEFAULT_CONTEXT);
-            JpaUserReference userReference = new JpaUserReference(username, username, null, jpaContext, loginDate,
-                    organization, jpaRoles);
+            JpaUserReference userReference = new JpaUserReference(username, name, email, jpaContext, loginDate,
+                organization, jpaRoles);
             userReferenceProvider.addUserReference(userReference, jpaContext);
           } else {
             jpaUserReference.setLastLogin(loginDate);
+            jpaUserReference.setName(name);
+            jpaUserReference.setEmail(email);
             jpaUserReference.setRoles(jpaRoles);
             userReferenceProvider.updateUserReference(jpaUserReference);
           }


### PR DESCRIPTION
LTI allows the consumer to pass some user data like the name or email
address [1]. When persistence is enabled, it makes sense for Opencast to
respect this data instead of ignoring it or using unrelated data to just
populate the fields.

[1] https://developer.itslearning.com/LTI_standard_parameters.html

---

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
