### PR TITLE
Using ConcurrentHashMap for synchronizing LTI user login

### DIFF
--- a/modules/security-lti/pom.xml
+++ b/modules/security-lti/pom.xml
@@ -58,10 +58,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>javax.persistence</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-kernel</artifactId>
       <version>${project.version}</version>

--- a/modules/security-lti/pom.xml
+++ b/modules/security-lti/pom.xml
@@ -58,6 +58,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>javax.persistence</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-kernel</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
This Pull Request is correcting 

https://github.com/opencast/opencast/pull/1532 
and 
https://github.com/opencast/opencast/pull/1622

Now we simple using a ConcurrentHashMap to synchronize the user authenticated by LTI.
We save the username in the map and removing it in the finally block after user is added or updated.
The fix is related to https://github.com/opencast/opencast/pull/1532 and the mentioned exceptions.

The code of the patches above is not needed anymore.