### PR TITLE
LDAP Group Mapping

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -51,6 +51,10 @@ Please make sure to compare your configuration against the current configuration
 - The configuration keys `source-tags` and `source-flavors` of the _publish-configure_ workflow operation were renamed
   to `download-source-tags` and `download-source-flavors` respectively. If you use custom workflows, you may need to
   adjust them accordingly.
+- A new configuration option `org.opencastproject.userdirectory.ldap.groupcheckprefix` with default option
+  was added to the LDAP configuration. The option affects the
+  `org.opencastproject.userdirectory.ldap.roleattributes` and `org.opencastproject.userdirectory.ldap.extra.roles`
+  configuration options and should be adjusted accordingly
 
 
 Install and configure a standalone Elasticsearch node

--- a/etc/org.opencastproject.userdirectory.ldap.cfg.template
+++ b/etc/org.opencastproject.userdirectory.ldap.cfg.template
@@ -31,9 +31,12 @@ org.opencastproject.userdirectory.ldap.searchbase=
 ## Example: (uid={0})
 org.opencastproject.userdirectory.ldap.searchfilter=
 
-## The comma-separated list of attributes that will be translated into roles.
+## The comma-separated list of attributes that will be translated into roles/groups.
 ## Note that the attributes may be converted to uppercase and prefixed depending on the configuration below.
-## Please refer to the documentation of the "roleprefix" property.
+## Please refer to the documentation of the "roleprefix" and "groupcheckprefix" property.
+##   Additionally it is possible to specify a mapping between those attributes and roles/groups.
+##   If wanted the direct translation of attributes to roles can also be disabled.
+##   See the "Mapping configuration properties" below for more information.
 ## Example: berkeleyEduAffiliations,departmentNumber
 org.opencastproject.userdirectory.ldap.roleattributes=
 
@@ -72,13 +75,41 @@ org.opencastproject.userdirectory.ldap.roleattributes=
 ## Default: <empty>
 #org.opencastproject.userdirectory.ldap.exclude.prefixes=
 
+## A prefix which is used to CHECK whether a roleattribute value or extra role should be added as a group to a user
+## Default: ROLE_GROUP_
+#org.opencastproject.userdirectory.ldap.groupcheckprefix=ROLE_GROUP_
+
 ## Whether or not the role names should be converted to uppercase. It defaults to "true".
 ## Please note that this setting affects the prefix defined above.
 ## Default: true
 #org.opencastproject.userdirectory.ldap.uppercase=true
 
 ## A comma-separated list of extra roles to apply to all the users authenticated with this LDAP instance
-## The roles in this list are converted to uppercase if the corresponding parameter is set. However, the 'roleprefix'
-## setting does not affect them -i.e. they will not be further modified even if 'roleprefix' is set.
+## The roles in this list are converted to uppercase if the corresponding parameter is set and are also affected by the
+## groupcheckprefix. However, the 'roleprefix' setting does not affect them
+## -i.e. they will not be further modified even if 'roleprefix' is set.
 ## Defaut: <empty>
 #org.opencastproject.userdirectory.ldap.extra.roles=
+
+
+#########
+## Mapping configuration properties (also optional)
+######
+
+## The following properties can be used to define a mapping (affected by uppercase conversion)
+## of LDAP roleattribute values (defined above) to specific opencast roles/groups.
+##   For example the following lines add two mappings identified by 'examplemap1' and 'examplemap2':
+##     'examplemap1' applies the opencast role 'ROLE_EXAMPLE_1' to any user which has the roleattribute value 'example1'.
+##     'examplemap2' maps the roleattribute value 'example2' to the opencast roles 'ROLE_EXAMPLE_2' and 'ROLE_EXAMPLE_3',
+##       and additionally adds the group 'ROLE_GROUP_EXAMPLE'.
+#org.opencastproject.userdirectory.ldap.map.examplemap1.value=example1
+#org.opencastproject.userdirectory.ldap.map.examplemap1.roles=ROLE_EXAMPLE_1
+#org.opencastproject.userdirectory.ldap.map.examplemap2.value=example2
+#org.opencastproject.userdirectory.ldap.map.examplemap2.roles=ROLE_EXAMPLE_2,ROLE_EXAMPLE_3
+#org.opencastproject.userdirectory.ldap.map.examplemap2.groups=ROLE_GROUP_EXAMPLE
+
+## If the mapping is used there may be no need for the direct translation of roleattributes to roles/groups.
+## The direct translation can be disabled by setting the following properties to false:
+## Default: true
+#org.opencastproject.userdirectory.ldap.roleattributes.applyasroles=true
+#org.opencastproject.userdirectory.ldap.roleattributes.applyasgroups=true

--- a/etc/org.opencastproject.userdirectory.ldap.cfg.template
+++ b/etc/org.opencastproject.userdirectory.ldap.cfg.template
@@ -109,7 +109,8 @@ org.opencastproject.userdirectory.ldap.roleattributes=
 #org.opencastproject.userdirectory.ldap.map.examplemap2.groups=ROLE_GROUP_EXAMPLE
 
 ## If the mapping is used there may be no need for the direct translation of roleattributes to roles/groups.
-## The direct translation can be disabled by setting the following properties to false:
+## The direct translation can be disabled by setting the following properties to false
+## (if applyasroles is disabled applyasgroups can't be set to true):
 ## Default: true
 #org.opencastproject.userdirectory.ldap.roleattributes.applyasroles=true
 #org.opencastproject.userdirectory.ldap.roleattributes.applyasgroups=true

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
@@ -245,6 +245,10 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
             properties.get(APPLY_ROLEATTRIBUTES_AS_ROLES_KEY), "true"));
     boolean applyRoleattributesAsGroups = BooleanUtils.toBoolean(Objects.toString(
             properties.get(APPLY_ROLEATTRIBUTES_AS_GROUPS_KEY), "true"));
+    if (applyRoleattributesAsGroups && !applyRoleattributesAsRoles) {
+      throw new ConfigurationException(APPLY_ROLEATTRIBUTES_AS_GROUPS_KEY,
+              "'" + APPLY_ROLEATTRIBUTES_AS_ROLES_KEY + "' needs to be 'true' to enable this option");
+    }
 
     // extra roles
     String[] extraRoles =  StringUtils.split(Objects.toString(properties.get(EXTRA_ROLES_KEY), ""), ",");
@@ -355,14 +359,14 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
 
     // Instantiate this LDAP instance and register it as such
     LdapUserProviderInstance provider = new LdapUserProviderInstance(pid, org, searchBase, searchFilter, url, userDn,
-            password, roleAttributes, rolePrefix, extraRoles, excludePrefixes, applyRoleattributesAsRoles,
-            ldapAssignmentRoleMap, convertToUppercase, cacheSize, cacheExpiration, securityService);
+            password, roleAttributes, convertToUppercase, cacheSize, cacheExpiration, securityService);
 
     providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
 
     OpencastLdapAuthoritiesPopulator authoritiesPopulator = new OpencastLdapAuthoritiesPopulator(roleAttributes,
-            rolePrefix, excludePrefixes, groupCheckPrefix, applyRoleattributesAsGroups, ldapAssignmentGroupMap,
-            convertToUppercase, org, securityService, groupRoleProvider, extraRoles);
+            rolePrefix, excludePrefixes, groupCheckPrefix, applyRoleattributesAsRoles, applyRoleattributesAsGroups,
+            ldapAssignmentRoleMap, ldapAssignmentGroupMap, convertToUppercase, org, securityService,
+            groupRoleProvider, extraRoles);
 
     // Also, register this instance as LdapAuthoritiesPopulator so that it can be used within the security.xml file
     authoritiesPopulatorRegistrations.put(pid,

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
@@ -28,6 +28,7 @@ import org.opencastproject.security.api.UserProvider;
 import org.opencastproject.userdirectory.JpaGroupRoleProvider;
 import org.opencastproject.util.NotFoundException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -43,6 +44,8 @@ import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
 import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
@@ -99,6 +102,30 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
    * The "role prefix" defined with the ROLE_PREFIX_KEY will not be prepended to the roles starting with any of these
    */
   private static final String EXCLUDE_PREFIXES_KEY = "org.opencastproject.userdirectory.ldap.exclude.prefixes";
+
+  /**
+   * The key to indicate a prefix,
+   * which is used to check whether a roleattribute value shall be added as a group to the user
+   */
+  private static final String GROUP_CHECK_PREFIX_KEY = "org.opencastproject.userdirectory.ldap.groupcheckprefix";
+
+  /** Specifies, whether the roleattributes should be added as a role */
+  private static final String APPLY_ROLEATTRIBUTES_AS_ROLES_KEY = "org.opencastproject.userdirectory.ldap.roleattributes.applyasroles";
+
+  /** Specifies, whether the roleattributes should be added as a group */
+  private static final String APPLY_ROLEATTRIBUTES_AS_GROUPS_KEY = "org.opencastproject.userdirectory.ldap.roleattributes.applyasgroups";
+
+  /** The prefix of the keys, which map a ldap attribute to opencast roles */
+  private static final String ATTRIBUTE_MAPPING_KEY_PREFIX = "org.opencastproject.userdirectory.ldap.map.";
+
+  /** The postfix of the attribute maps, which specifiy the value to map */
+  private static final String ATTRIBUTE_MAPPING_KEY_POSTFIX_VALUE = "value";
+
+  /** The postfix of the attribute maps, which map a ldap attribute to opencast roles */
+  private static final String ATTRIBUTE_MAPPING_KEY_POSTFIX_ROLES = "roles";
+
+  /** The postfix of the attribute maps, which map a ldap attribute to opencast groups */
+  private static final String ATTRIBUTE_MAPPING_KEY_POSTFIX_GROUPS = "groups";
 
   /** The key to indicate whether or not the roles should be converted to uppercase */
   private static final String UPPERCASE_KEY = "org.opencastproject.userdirectory.ldap.uppercase";
@@ -210,15 +237,96 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
     // optional with default values
     String rolePrefix = Objects.toString(properties.get(ROLE_PREFIX_KEY), "ROLE_");
     String[] excludePrefixes = StringUtils.split((String) properties.get(EXCLUDE_PREFIXES_KEY), ",");
+    String groupCheckPrefix = Objects.toString(properties.get(GROUP_CHECK_PREFIX_KEY), "ROLE_GROUP_");
     boolean convertToUppercase = BooleanUtils.toBoolean(Objects.toString(properties.get(UPPERCASE_KEY), "true"));
     int cacheSize = NumberUtils.toInt((String) properties.get(CACHE_SIZE), 1000);
     int cacheExpiration = NumberUtils.toInt((String) properties.get(CACHE_EXPIRATION), 5);
+    boolean applyRoleattributesAsRoles = BooleanUtils.toBoolean(Objects.toString(
+            properties.get(APPLY_ROLEATTRIBUTES_AS_ROLES_KEY), "true"));
+    boolean applyRoleattributesAsGroups = BooleanUtils.toBoolean(Objects.toString(
+            properties.get(APPLY_ROLEATTRIBUTES_AS_GROUPS_KEY), "true"));
 
     // extra roles
     String[] extraRoles =  StringUtils.split(Objects.toString(properties.get(EXTRA_ROLES_KEY), ""), ",");
     Set<String> extraRoleSet = new HashSet<>(Arrays.asList(extraRoles));
     extraRoleSet.addAll(Arrays.asList("ROLE_ANONYMOUS", "ROLE_USER"));
     extraRoles = extraRoleSet.toArray(new String[extraRoles.length]);
+
+    // maps
+    HashMap<String, HashMap<String, String>> ldapAssignmentMappingsPreparation = new HashMap();
+    for (Enumeration<String> e = properties.keys(); e.hasMoreElements();) {
+      String key = e.nextElement();
+
+      if (key.startsWith(ATTRIBUTE_MAPPING_KEY_PREFIX)) {
+        final String[] postfix = key.substring(ATTRIBUTE_MAPPING_KEY_PREFIX.length()).split("\\.");
+
+        if (postfix.length != 2) {
+          throw new ConfigurationException(key,
+                  "Invalid Configkey format, the following format is needed: "
+                  + ATTRIBUTE_MAPPING_KEY_PREFIX + "<identifier>.<key>");
+        }
+
+        final String mappingIdentifier = postfix[0];
+        final String mappingKey = postfix[1];
+
+        HashMap keyValueMap = ldapAssignmentMappingsPreparation.getOrDefault(mappingIdentifier, new HashMap());
+
+        keyValueMap.put(mappingKey, (String) properties.get(key));
+
+        ldapAssignmentMappingsPreparation.put(mappingIdentifier, keyValueMap);
+      }
+    }
+    HashMap<String, String[]> ldapAssignmentRoleMap = new HashMap();
+    HashMap<String, String[]> ldapAssignmentGroupMap = new HashMap();
+    for (HashMap.Entry<String, HashMap<String, String>> entry : ldapAssignmentMappingsPreparation.entrySet()) {
+      HashMap<String, String> mappingConf = entry.getValue();
+      String value = StringUtils.trimToNull(mappingConf.get(ATTRIBUTE_MAPPING_KEY_POSTFIX_VALUE));
+      String roles = StringUtils.trimToNull(mappingConf.get(ATTRIBUTE_MAPPING_KEY_POSTFIX_ROLES));
+      String groups = StringUtils.trimToNull(mappingConf.get(ATTRIBUTE_MAPPING_KEY_POSTFIX_GROUPS));
+
+      if (value == null) {
+        throw new ConfigurationException(ATTRIBUTE_MAPPING_KEY_PREFIX + entry.getKey() + ".*",
+                "LDAP mapping incomplete, the key 'value' is needed");
+      }
+      if (roles == null && groups == null) {
+        throw new ConfigurationException(ATTRIBUTE_MAPPING_KEY_PREFIX + entry.getKey() + ".*",
+                "LDAP mapping incomplete, one of the keys 'roles' or 'groups' is needed");
+      }
+
+      if (convertToUppercase) {
+        value = value.toUpperCase();
+      }
+
+      if (roles != null) {
+        if (convertToUppercase) {
+          roles = roles.toUpperCase();
+        }
+        ldapAssignmentRoleMap.put(value,
+                ArrayUtils.addAll(
+                        ldapAssignmentRoleMap.getOrDefault(value, new String[0]),
+                        Arrays.stream(roles.split(","))
+                                .map(r -> StringUtils.trimToNull(r))
+                                .filter(r -> r != null)
+                                .toArray(String[]::new)
+                )
+        );
+      }
+
+      if (groups != null) {
+        if (convertToUppercase) {
+          groups = groups.toUpperCase();
+        }
+        ldapAssignmentGroupMap.put(value,
+                ArrayUtils.addAll(
+                        ldapAssignmentGroupMap.getOrDefault(value, new String[0]),
+                        Arrays.stream(groups.split(","))
+                                .map(r -> StringUtils.trimToNull(r))
+                                .filter(r -> r != null)
+                                .toArray(String[]::new)
+                )
+        );
+      }
+    }
 
     // Now that we have everything we need, go ahead and activate a new provider, removing an old one if necessary
     ServiceRegistration existingRegistration = providerRegistrations.remove(pid);
@@ -247,13 +355,14 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
 
     // Instantiate this LDAP instance and register it as such
     LdapUserProviderInstance provider = new LdapUserProviderInstance(pid, org, searchBase, searchFilter, url, userDn,
-            password, roleAttributes, rolePrefix, extraRoles, excludePrefixes, convertToUppercase, cacheSize,
-            cacheExpiration, securityService);
+            password, roleAttributes, rolePrefix, extraRoles, excludePrefixes, applyRoleattributesAsRoles,
+            ldapAssignmentRoleMap, convertToUppercase, cacheSize, cacheExpiration, securityService);
 
     providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
 
     OpencastLdapAuthoritiesPopulator authoritiesPopulator = new OpencastLdapAuthoritiesPopulator(roleAttributes,
-            rolePrefix, excludePrefixes, convertToUppercase, org, securityService, groupRoleProvider, extraRoles);
+            rolePrefix, excludePrefixes, groupCheckPrefix, applyRoleattributesAsGroups, ldapAssignmentGroupMap,
+            convertToUppercase, org, securityService, groupRoleProvider, extraRoles);
 
     // Also, register this instance as LdapAuthoritiesPopulator so that it can be used within the security.xml file
     authoritiesPopulatorRegistrations.put(pid,

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderInstance.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderInstance.java
@@ -23,7 +23,6 @@ package org.opencastproject.userdirectory.ldap;
 
 import org.opencastproject.security.api.CachingUserProviderMXBean;
 import org.opencastproject.security.api.JaxbOrganization;
-import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
@@ -38,8 +37,6 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
@@ -49,18 +46,12 @@ import org.springframework.security.ldap.userdetails.LdapUserDetailsService;
 
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -97,21 +88,6 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
   /** Opencast's security service */
   private SecurityService securityService;
 
-  /** The general role prefix, to be added to all the LDAP roles that do not start by one of the exclude prefixes */
-  private String rolePrefix;
-
-  /** A Set of roles to be added to all the users authenticated using this LDAP instance */
-  private Set<GrantedAuthority> setExtraRoles = new HashSet<>();
-
-  /** A Set of prefixes. When a role starts with any of these, the role prefix defined above will not be prepended */
-  private Set<String> setExcludePrefixes = new HashSet<>();
-
-  /** Specifies, whether the roleattributes should be added as a Opencast role */
-  private boolean applyRoleattributesAsRoles = true;
-
-  /** Mapping of ldap assignments to opencast roles */
-  private Map<String, String[]> ldapAssignmentRoleMap = new HashMap();
-
   /**
    * Constructs an ldap user provider with the needed settings.
    *
@@ -131,17 +107,6 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
    *          the user credentials
    * @param roleAttributesGlob
    *          the comma separate list of ldap attributes to treat as roles or to consider for the ldapAssignmentRoleMap
-   * @param rolePrefix
-   *          a prefix to be prepended to all the roles read from the LDAP server
-   * @param extraRoles
-   *          an array of extra roles to add to all the users
-   * @param excludePrefixes
-   *          an array of role prefixes. The roles starting with any of these will not be prepended with the rolePrefix
-   * @param applyRoleattributesAsRoles
-   *          Specifies, whether the roleattributes should be added as a Opencast role
-   * @param ldapAssignmentRoleMap
-   *          a Map which maps the ldap assignments to additional roles
-   *          Key and value are expected to be uppercase if the bool uppercase is set.
    * @param convertToUppercase
    *          whether or not the role names will be converted to uppercase
    * @param cacheSize
@@ -153,8 +118,7 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
    */
   // CHECKSTYLE:OFF
   LdapUserProviderInstance(String pid, Organization organization, String searchBase, String searchFilter, String url,
-          String userDn, String password, String roleAttributesGlob, String rolePrefix, String[] extraRoles,
-          String[] excludePrefixes, boolean applyRoleattributesAsRoles, Map<String, String[]> ldapAssignmentRoleMap,
+          String userDn, String password, String roleAttributesGlob,
           boolean convertToUppercase, int cacheSize, int cacheExpiration, SecurityService securityService) {
     // CHECKSTYLE:ON
     this.organization = organization;
@@ -189,64 +153,10 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
 
       mapper.setRoleAttributes(roleAttributesGlob.split(","));
 
-      if (convertToUppercase)
-        this.rolePrefix = StringUtils.trimToEmpty(rolePrefix).toUpperCase();
-      else
-        this.rolePrefix = StringUtils.trimToEmpty(rolePrefix);
-
-      logger.debug("Role prefix set to: \"{}\"", this.rolePrefix);
-
       // The default prefix value is "ROLE_", so we must explicitly set it to "" by default
       // Because of the parameters extraRoles and excludePrefixes, we must add the prefix manually
       mapper.setRolePrefix("");
       delegate.setUserDetailsMapper(mapper);
-
-      // Process the excludePrefixes if needed
-      if (!this.rolePrefix.isEmpty()) {
-        if (excludePrefixes != null) {
-          // "Clean" the list of exclude prefixes
-          for (String excludePrefix : excludePrefixes) {
-            String cleanPrefix = excludePrefix.trim();
-            if (!cleanPrefix.isEmpty()) {
-              if (convertToUppercase)
-                setExcludePrefixes.add(cleanPrefix.toUpperCase());
-              else
-                setExcludePrefixes.add(cleanPrefix);
-            }
-          }
-
-          if (logger.isDebugEnabled()) {
-            if (setExcludePrefixes.size() > 0) {
-              logger.debug("Exclude prefixes set to:");
-              for (String prefix : excludePrefixes) {
-                logger.debug("\t* {}", prefix);
-              }
-            } else {
-              logger.debug("No exclude prefixes defined");
-            }
-          }
-        }
-      }
-    }
-
-    this.applyRoleattributesAsRoles = applyRoleattributesAsRoles;
-
-    if (ldapAssignmentRoleMap != null) {
-      this.ldapAssignmentRoleMap = ldapAssignmentRoleMap;
-    }
-
-    // Process extra roles
-    if (extraRoles != null) {
-      for (String extraRole : extraRoles) {
-        String finalRole = StringUtils.trimToEmpty(extraRole);
-        if (!finalRole.isEmpty()) {
-          if (convertToUppercase) {
-            setExtraRoles.add(new SimpleGrantedAuthority(finalRole.toUpperCase()));
-          } else {
-            setExtraRoles.add(new SimpleGrantedAuthority(finalRole));
-          }
-        }
-      }
     }
 
     // Setup the caches
@@ -349,53 +259,7 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
       }
 
       JaxbOrganization jaxbOrganization = JaxbOrganization.fromOrganization(organization);
-
-      Collection<GrantedAuthority> springAuthorities = (Collection<GrantedAuthority>) userDetails.getAuthorities();
-
-      // Add mapped roles
-      Set<JaxbRole> roles = springAuthorities.stream()
-              .map(auth -> auth.getAuthority())
-              .map(strAuth -> ldapAssignmentRoleMap.get(strAuth))
-              .filter(arrRole -> arrRole != null)
-              .flatMap(arrRole -> Arrays.stream(arrRole))
-              .map(role -> new JaxbRole(role, jaxbOrganization))
-              .collect(Collectors.toCollection(HashSet::new));
-
-      // Get the roles and add the extra roles
-      Collection<GrantedAuthority> authorities = new HashSet<>();
-      if (applyRoleattributesAsRoles) {
-        authorities.addAll(springAuthorities);
-      }
-      authorities.addAll(setExtraRoles);
-
-      /*
-       * Add roles
-       * Please note the prefix logic for roles:
-       *
-       * - Roles that start with any of the "exclude prefixes" are left intact
-       * - In any other case, the "role prefix" is prepended to the roles read from LDAP
-       *
-       * This only applies to the prefix addition. The conversion to uppercase is independent from these
-       * considerations
-       */
-      for (GrantedAuthority authority : authorities) {
-        String strAuthority = authority.getAuthority();
-
-        boolean hasExcludePrefix = false;
-        for (String excludePrefix : setExcludePrefixes) {
-          if (strAuthority.startsWith(excludePrefix)) {
-            hasExcludePrefix = true;
-            break;
-          }
-        }
-        if (!hasExcludePrefix) {
-          strAuthority = rolePrefix + strAuthority;
-        }
-
-        // Finally, add the role itself
-        roles.add(new JaxbRole(strAuthority, jaxbOrganization));
-      }
-      User user = new JaxbUser(userDetails.getUsername(), PROVIDER_NAME, jaxbOrganization, roles);
+      User user = new JaxbUser(userDetails.getUsername(), PROVIDER_NAME, jaxbOrganization, new HashSet());
       cache.put(userName, user);
       return user;
     } finally {

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulator.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulator.java
@@ -56,7 +56,9 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
   private String prefix = "";
   private Set<String> excludedPrefixes = new HashSet<>();
   private String groupCheckPrefix = null;
+  private boolean applyAttributesAsRoles = true;
   private boolean applyAttributesAsGroups = true;
+  private Map<String, String[]> ldapAssignmentRoleMap = new HashMap();
   private Map<String, String[]> ldapAssignmentGroupMap = new HashMap();
   private boolean uppercase = true;
   private Organization organization;
@@ -67,16 +69,23 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
   /**
    * Activate component
    *
+   * @param applyAttributesAsRoles
+   *          Specifies, whether the ldap attributes should be added as a role.
    * @param applyAttributesAsGroups
    *          Specifies, whether the ldap attributes should be added as a group.
+   *          applyAttributesAsRoles needs to be enabled.
+   * @param ldapAssignmentRoleMap
+   *          Maps the ldap assignments to additional roles.
+   *          Key and value are expected to be uppercase if the bool uppercase is set.
    * @param ldapAssignmentGroupMap
    *          Maps the ldap assignments to additional groups.
    *          Key and value are expected to be uppercase if the bool uppercase is set.
    */
   public OpencastLdapAuthoritiesPopulator(String attributeNames, String prefix, String[] aExcludedPrefixes,
-          String groupCheckPrefix, boolean applyAttributesAsGroups, Map<String, String[]> ldapAssignmentGroupMap,
-          boolean uppercase, Organization organization, SecurityService securityService,
-          JpaGroupRoleProvider groupRoleProvider, String... additionalAuthorities) {
+          String groupCheckPrefix, boolean applyAttributesAsRoles, boolean applyAttributesAsGroups,
+          Map<String, String[]> ldapAssignmentRoleMap, Map<String, String[]> ldapAssignmentGroupMap, boolean uppercase,
+          Organization organization, SecurityService securityService,JpaGroupRoleProvider groupRoleProvider,
+          String... additionalAuthorities) {
 
     logger.debug("Creating new instance");
 
@@ -122,10 +131,7 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
     else
       logger.debug("Roles will NOT be converted to uppercase");
 
-    if (uppercase)
-      this.prefix = StringUtils.trimToEmpty(prefix).replaceAll(ROLE_CLEAN_REGEXP, ROLE_CLEAN_REPLACEMENT).toUpperCase();
-    else
-      this.prefix = StringUtils.trimToEmpty(prefix).replaceAll(ROLE_CLEAN_REGEXP, ROLE_CLEAN_REPLACEMENT);
+    this.prefix = roleCleanUpperCase(prefix, uppercase);
     logger.debug("Role prefix set to: {}", this.prefix);
 
     if (aExcludedPrefixes != null)
@@ -144,8 +150,16 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
       throw new IllegalArgumentException("The parameter groupCheckPrefix cannot be null");
     }
     this.groupCheckPrefix = groupCheckPrefix;
+    if (uppercase) {
+      this.groupCheckPrefix = this.groupCheckPrefix.toUpperCase();
+    }
 
+    this.applyAttributesAsRoles = applyAttributesAsRoles;
     this.applyAttributesAsGroups = applyAttributesAsGroups;
+
+    if (ldapAssignmentRoleMap != null) {
+      this.ldapAssignmentRoleMap = ldapAssignmentRoleMap;
+    }
 
     if (ldapAssignmentGroupMap != null) {
       this.ldapAssignmentGroupMap = ldapAssignmentGroupMap;
@@ -155,7 +169,7 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
       this.additionalAuthorities = new String[0];
     else
       this.additionalAuthorities = Arrays.stream(additionalAuthorities)
-              .filter(x -> roleCleanUpperCase(x, this.uppercase).startsWith(this.groupCheckPrefix))
+              .map(x -> roleCleanUpperCase(x, uppercase))
               .toArray(String[]::new);
 
     if (logger.isDebugEnabled()) {
@@ -182,17 +196,29 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
           for (String attributeValue : attributeValues) {
             // The attribute value may be a single authority (a single role) or a list of roles
             String[] splitValue =  attributeValue.split(",");
-            if (applyAttributesAsGroups) {
-              // ignore attributes which aren't groups according to groupCheckPrefix
-              String[] groups = Arrays.stream(splitValue)
-                      .filter(x -> {
-                        String filter = roleCleanUpperCase(x, uppercase);
-                        return filter.startsWith(groupCheckPrefix);
-                      })
-                      .toArray(String[]::new);
-              addAuthorities(authorities, groups);
+            if (applyAttributesAsRoles) {
+              String[] roles = splitValue;
+              addAuthorities(authorities, roles, false, true);
+              if (applyAttributesAsGroups) {
+                // ignore attributes which aren't groups according to groupCheckPrefix
+                String[] groups = Arrays.stream(splitValue)
+                        .filter(x -> {
+                          String filter = roleCleanUpperCase(x, uppercase);
+                          return filter.startsWith(groupCheckPrefix);
+                        })
+                        .toArray(String[]::new);
+                addAuthorities(authorities, groups, true, true);
+              }
             }
 
+            // map attribute values to roles
+            String[] mappedRoles = Arrays.stream(splitValue)
+                     .map(x -> roleCleanUpperCase(x, uppercase))
+                     .map(x -> ldapAssignmentRoleMap.get(x))
+                     .filter(x -> x != null)
+                     .flatMap(x -> Arrays.stream(x))
+                     .toArray(String[]::new);
+            addAuthorities(authorities, mappedRoles, false, false);
             // map attribute values to groups
             String[] mappedGroups = Arrays.stream(splitValue)
                     .map(x -> roleCleanUpperCase(x, uppercase))
@@ -200,7 +226,7 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
                     .filter(x -> x != null)
                     .flatMap(x -> Arrays.stream(x))
                     .toArray(String[]::new);
-            addAuthorities(authorities, mappedGroups);
+            addAuthorities(authorities, mappedGroups, true, false);
           }
         } else {
           logger.debug("Could not find any attribute named '{}' in user '{}'", attributeName, userData.getDn());
@@ -211,7 +237,12 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
     }
 
     // Add the list of additional roles
-    addAuthorities(authorities, additionalAuthorities);
+    addAuthorities(authorities, additionalAuthorities, false, false);
+    addAuthorities(authorities, Arrays.stream(additionalAuthorities)
+        .filter(x -> x.startsWith(groupCheckPrefix))
+        .toArray(String[]::new),
+        true, false
+    );
 
     if (logger.isDebugEnabled()) {
       StringBuilder authorityListAsString = new StringBuilder();
@@ -230,8 +261,9 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
         authorities.add(new SimpleGrantedAuthority(existingRole.getName()));
       }
       // Convert GrantedAuthority's into JaxbRole's
-      for (GrantedAuthority authority : authorities)
+      for (GrantedAuthority authority : authorities) {
         roles.add(new JaxbRole(authority.getAuthority(), JaxbOrganization.fromOrganization(organization)));
+      }
       JaxbUser user = new JaxbUser(username, LdapUserProviderInstance.PROVIDER_NAME,
               JaxbOrganization.fromOrganization(organization), roles.toArray(new JaxbRole[0]));
 
@@ -311,8 +343,13 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
    *          a set containing the authorities
    * @param values
    *          the values to add to the set
+   * @param addAsGroup
+   *          if enabled, roles and groups are added to the authorities
+   * @param addPrefix
+   *          if enabled, the set prefix is added to the authority, if no excludePrefix applies
    */
-  private void addAuthorities(Set<GrantedAuthority> authorities, String[] values) {
+  private void addAuthorities(Set<GrantedAuthority> authorities, final String[] values,
+                  final boolean addAsGroup, final boolean addPrefix) {
 
     if (values != null) {
       Organization org = securityService.getOrganization();
@@ -337,7 +374,7 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
         if (!authority.isEmpty()) {
           // Check if this role is a group role and assign the groups appropriately
           List<Role> groupRoles;
-          if (groupRoleProvider != null)
+          if (groupRoleProvider != null && addAsGroup)
             groupRoles = groupRoleProvider.getRolesForGroup(authority);
           else
             groupRoles = Collections.emptyList();
@@ -345,16 +382,21 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
           // Try to add the prefix if appropriate
           String prefix = this.prefix;
 
-          if (!prefix.isEmpty()) {
-            boolean hasExcludePrefix = false;
-            for (String excludePrefix : excludedPrefixes) {
-              if (authority.startsWith(excludePrefix)) {
-                hasExcludePrefix = true;
-                break;
+          if (addPrefix) {
+            if (!prefix.isEmpty()) {
+              boolean hasExcludePrefix = false;
+              for (String excludePrefix : excludedPrefixes) {
+                if (authority.startsWith(excludePrefix)) {
+                  hasExcludePrefix = true;
+                  break;
+                }
               }
+              if (hasExcludePrefix)
+                prefix = "";
             }
-            if (hasExcludePrefix)
-              prefix = "";
+          }
+          else {
+            prefix = "";
           }
 
           authority = (prefix + authority).replaceAll(ROLE_CLEAN_REGEXP, ROLE_CLEAN_REPLACEMENT);

--- a/modules/userdirectory-ldap/src/test/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulatorTest.java
+++ b/modules/userdirectory-ldap/src/test/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulatorTest.java
@@ -66,10 +66,12 @@ public class OpencastLdapAuthoritiesPopulatorTest {
 
   private static final String DEFAULT_GROUP_CHECK_PREFIX = "";
 
+  private static final HashMap<String, String[]> DEFAULT_ASSIGNMENT_ROLE_MAP = new HashMap();
   private static final HashMap<String, String[]> DEFAULT_ASSIGNMENT_GROUP_MAP = new HashMap();
 
   private static final String USERNAME = "username";
   private static final String ORG_NAME = "my_organization_id";
+  private static final String MAPPED_ROLE_ATTR = "THIS_ROLE_WILL_BE_MAPPED";
   private static final String GROUP_ROLE = "THIS_IS_THE_GROUP_ROLE";
   private static final String GROUP_ROLE_PREFIX = "THIS_";
   private static final int N_GROUP_ROLES = 3;
@@ -97,42 +99,100 @@ public class OpencastLdapAuthoritiesPopulatorTest {
     for (int i = 0; i < N_EXTRA_ROLES; i++)
       DEFAULT_EXTRA_ROLES[i] = format("extra_role_%d", i);
 
-    ArrayList<Map<String, String[]>> tempGroupMapTests = new ArrayList();
-    tempGroupMapTests.add(null);
-    tempGroupMapTests.add(Collections.unmodifiableMap(DEFAULT_ASSIGNMENT_GROUP_MAP));
+    {
+      ArrayList<Map<String, String[]>> tempGroupMapTests = new ArrayList();
+      tempGroupMapTests.add(null);
+      tempGroupMapTests.add(Collections.unmodifiableMap(DEFAULT_ASSIGNMENT_GROUP_MAP));
 
-    HashMap<String, String[]> tempGroupMap = new HashMap();
-    tempGroupMap.put("NOT_MAPPED_GROUP", new String[] { "NOT_MAPPED_GROUP" });
-    tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+      HashMap<String, String[]> tempGroupMap = new HashMap();
+      tempGroupMap.put("NOT_MAPPED_GROUP", new String[] { "NOT_MAPPED_GROUP" });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
 
-    tempGroupMap = new HashMap();
-    tempGroupMap.put(GROUP_ROLE, null);
-    tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+      tempGroupMap = new HashMap();
+      tempGroupMap.put("NOT_MAPPED_GROUP", new String[] { GROUP_ROLE });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
 
-    tempGroupMap = new HashMap();
-    tempGroupMap.put(GROUP_ROLE, new String[] {});
-    tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+      tempGroupMap = new HashMap();
+      tempGroupMap.put(GROUP_ROLE, null);
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
 
-    tempGroupMap = new HashMap();
-    tempGroupMap.put(GROUP_ROLE, new String[] { "MAPPED_GROUP1" });
-    tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+      tempGroupMap = new HashMap();
+      tempGroupMap.put(GROUP_ROLE, new String[] {});
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
 
-    tempGroupMap = new HashMap();
-    tempGroupMap.put("NOT_MAPPED_GROUP", new String[] { "NOT_MAPPED_GROUP" });
-    tempGroupMap.put(GROUP_ROLE, new String[] { "MAPPED_GROUP1" });
-    tempGroupMap.put("VALUE1", new String[] { "MAPPED_GROUP2" });
-    tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+      tempGroupMap = new HashMap();
+      tempGroupMap.put(GROUP_ROLE, new String[] { "MAPPED_GROUP1" });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
 
-    tempGroupMap = new HashMap();
-    tempGroupMap.put(GROUP_ROLE, new String[] { "MAPPED_GROUP1", "MAPPED_GROUP2" });
-    tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+      tempGroupMap = new HashMap();
+      tempGroupMap.put(GROUP_ROLE, new String[] { GROUP_ROLE });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
 
-    tempGroupMap = new HashMap();
-    tempGroupMap.put(GROUP_ROLE, new String[] { "MAPPED_GROUP1", "MAPPED_GROUP2" });
-    tempGroupMap.put("VALUE1", new String[] { "MAPPED_GROUP3" });
-    tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+      tempGroupMap = new HashMap();
+      tempGroupMap.put("VALUE1", new String[] { GROUP_ROLE });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
 
-    ASSIGNMENT_GROUP_MAP_TESTS = Collections.unmodifiableList(tempGroupMapTests);
+      tempGroupMap = new HashMap();
+      tempGroupMap.put("VALUE2", new String[] { GROUP_ROLE });
+      tempGroupMap.put("VALUE1", new String[] { "MAPPED_GROUP2" });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+
+      tempGroupMap = new HashMap();
+      tempGroupMap.put("NOT_MAPPED_GROUP", new String[] { "NOT_MAPPED_GROUP" });
+      tempGroupMap.put(GROUP_ROLE, new String[] { "MAPPED_GROUP1" });
+      tempGroupMap.put("VALUE1", new String[] { "MAPPED_GROUP2" });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+
+      tempGroupMap = new HashMap();
+      tempGroupMap.put(GROUP_ROLE, new String[] { "MAPPED_GROUP1", "MAPPED_GROUP2" });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+
+      tempGroupMap = new HashMap();
+      tempGroupMap.put(GROUP_ROLE, new String[] { "MAPPED_GROUP1", "MAPPED_GROUP2" });
+      tempGroupMap.put("VALUE1", new String[] { "MAPPED_GROUP3" });
+      tempGroupMapTests.add(Collections.unmodifiableMap(tempGroupMap));
+
+      ASSIGNMENT_GROUP_MAP_TESTS = Collections.unmodifiableList(tempGroupMapTests);
+    }
+
+    {
+      ArrayList<Map<String, String[]>> tempRoleMapTests = new ArrayList();
+      tempRoleMapTests.add(null);
+      tempRoleMapTests.add(Collections.unmodifiableMap(DEFAULT_ASSIGNMENT_ROLE_MAP));
+
+      HashMap<String, String[]> tempRoleMap = new HashMap();
+      tempRoleMap.put("NOT_MAPPED_ROLE", new String[] { "NOT_MAPPED_ROLE" });
+      tempRoleMapTests.add(Collections.unmodifiableMap(tempRoleMap));
+
+      tempRoleMap = new HashMap();
+      tempRoleMap.put(MAPPED_ROLE_ATTR, null);
+      tempRoleMapTests.add(Collections.unmodifiableMap(tempRoleMap));
+
+      tempRoleMap = new HashMap();
+      tempRoleMap.put(MAPPED_ROLE_ATTR, new String[] {});
+      tempRoleMapTests.add(Collections.unmodifiableMap(tempRoleMap));
+
+      tempRoleMap = new HashMap();
+      tempRoleMap.put(MAPPED_ROLE_ATTR, new String[] { "MAPPED_ROLE1" });
+      tempRoleMapTests.add(Collections.unmodifiableMap(tempRoleMap));
+
+      tempRoleMap = new HashMap();
+      tempRoleMap.put("NOT_MAPPED_ROLE", new String[] { "NOT_MAPPED_ROLE" });
+      tempRoleMap.put(MAPPED_ROLE_ATTR, new String[] { "MAPPED_ROLE1" });
+      tempRoleMap.put("VALUE1", new String[] { "MAPPED_ROLE2" });
+      tempRoleMapTests.add(Collections.unmodifiableMap(tempRoleMap));
+
+      tempRoleMap = new HashMap();
+      tempRoleMap.put(MAPPED_ROLE_ATTR, new String[] { "MAPPED_ROLE1", "MAPPED_ROLE2" });
+      tempRoleMapTests.add(Collections.unmodifiableMap(tempRoleMap));
+
+      tempRoleMap = new HashMap();
+      tempRoleMap.put(MAPPED_ROLE_ATTR, new String[] { "MAPPED_ROLE1", "MAPPED_ROLE2" });
+      tempRoleMap.put("VALUE1", new String[] { "MAPPED_ROLE3" });
+      tempRoleMapTests.add(Collections.unmodifiableMap(tempRoleMap));
+
+      ASSIGNMENT_ROLE_MAP_TESTS = Collections.unmodifiableList(tempRoleMapTests);
+    }
   }
 
   /** A map containing the set of LDAP arguments and their values (they keys can be multivalued) */
@@ -144,7 +204,9 @@ public class OpencastLdapAuthoritiesPopulatorTest {
 
   private static final String[] PREFIX_TESTS = new String[] { null, "", DEFAULT_PREFIX, "PREFIX_WHICH_DOES_NOT_EXIST", "extra_role_" };
   private static final String[] GROUP_CHECK_PREFIX_TESTS = new String[] { DEFAULT_GROUP_CHECK_PREFIX, "val", GROUP_ROLE_PREFIX };
+  private static final boolean[] APPLY_ATTRIBUTES_AS_ROLES_TESTS = { true, false };
   private static final boolean[] APPLY_ATTRIBUTES_AS_GROUPS_TESTS = { true, false };
+  private static final List<Map<String, String[]>> ASSIGNMENT_ROLE_MAP_TESTS;
   private static final List<Map<String, String[]>> ASSIGNMENT_GROUP_MAP_TESTS;
   private static final boolean[] UPPERCASE_TESTS = new boolean[] { true, false };
   private static final String[][] EXTRA_ROLES_TESTS = new String[][] { null, new String[] {}, DEFAULT_EXTRA_ROLES };
@@ -192,7 +254,8 @@ public class OpencastLdapAuthoritiesPopulatorTest {
   public void testNullAttributeNames() {
     try {
       new OpencastLdapAuthoritiesPopulator(null, DEFAULT_PREFIX, DEFAULT_EXCLUDE_PREFIXES, DEFAULT_GROUP_CHECK_PREFIX,
-              true, DEFAULT_ASSIGNMENT_GROUP_MAP, false, org, securityService, groupRoleProvider, DEFAULT_EXTRA_ROLES);
+              true, true, DEFAULT_ASSIGNMENT_ROLE_MAP, DEFAULT_ASSIGNMENT_GROUP_MAP, false, org, securityService,
+              groupRoleProvider, DEFAULT_EXTRA_ROLES);
     } catch (IllegalArgumentException e) {
       // OK
       return;
@@ -200,12 +263,12 @@ public class OpencastLdapAuthoritiesPopulatorTest {
     fail(format("A null \"attributeNames\" constructor argument for %s did not raise an exception",
             OpencastLdapAuthoritiesPopulator.class.getName()));
   }
-
   @Test
   public void testEmptyAttributeNames() {
     try {
       new OpencastLdapAuthoritiesPopulator("", DEFAULT_PREFIX, DEFAULT_EXCLUDE_PREFIXES, DEFAULT_GROUP_CHECK_PREFIX,
-              true, DEFAULT_ASSIGNMENT_GROUP_MAP, false, org, securityService, groupRoleProvider, DEFAULT_EXTRA_ROLES);
+              true, true, DEFAULT_ASSIGNMENT_ROLE_MAP, DEFAULT_ASSIGNMENT_GROUP_MAP, false, org, securityService,
+              groupRoleProvider, DEFAULT_EXTRA_ROLES);
     } catch (IllegalArgumentException e) {
       // OK
       return;
@@ -218,7 +281,8 @@ public class OpencastLdapAuthoritiesPopulatorTest {
   public void testNullGroupCheckPrefix() {
     try {
       new OpencastLdapAuthoritiesPopulator(DEFAULT_STR_ATTRIBUTE_NAMES, DEFAULT_PREFIX, DEFAULT_EXCLUDE_PREFIXES, null,
-              true, DEFAULT_ASSIGNMENT_GROUP_MAP, false, org, securityService, groupRoleProvider, DEFAULT_EXTRA_ROLES);
+              true, true, DEFAULT_ASSIGNMENT_ROLE_MAP, DEFAULT_ASSIGNMENT_GROUP_MAP, false, org, securityService,
+              groupRoleProvider, DEFAULT_EXTRA_ROLES);
     } catch (IllegalArgumentException e) {
       // OK
       return;
@@ -231,8 +295,8 @@ public class OpencastLdapAuthoritiesPopulatorTest {
   public void testNullOrganization() {
     try {
       new OpencastLdapAuthoritiesPopulator(DEFAULT_STR_ATTRIBUTE_NAMES, DEFAULT_PREFIX, DEFAULT_EXCLUDE_PREFIXES,
-              DEFAULT_GROUP_CHECK_PREFIX, true, DEFAULT_ASSIGNMENT_GROUP_MAP, false, null, securityService,
-              groupRoleProvider, DEFAULT_EXTRA_ROLES);
+              DEFAULT_GROUP_CHECK_PREFIX, true, true, DEFAULT_ASSIGNMENT_ROLE_MAP, DEFAULT_ASSIGNMENT_GROUP_MAP, false,
+              null, securityService, groupRoleProvider, DEFAULT_EXTRA_ROLES);
     } catch (IllegalArgumentException e) {
       // OK
       return;
@@ -245,8 +309,8 @@ public class OpencastLdapAuthoritiesPopulatorTest {
   public void testNullSecurityService() {
     try {
       new OpencastLdapAuthoritiesPopulator(DEFAULT_STR_ATTRIBUTE_NAMES, DEFAULT_PREFIX, DEFAULT_EXCLUDE_PREFIXES,
-              DEFAULT_GROUP_CHECK_PREFIX, true, DEFAULT_ASSIGNMENT_GROUP_MAP, false, org, null, groupRoleProvider,
-              DEFAULT_EXTRA_ROLES);
+              DEFAULT_GROUP_CHECK_PREFIX, true, true, DEFAULT_ASSIGNMENT_ROLE_MAP, DEFAULT_ASSIGNMENT_GROUP_MAP, false,
+              org, null, groupRoleProvider, DEFAULT_EXTRA_ROLES);
     } catch (IllegalArgumentException e) {
       // OK
       return;
@@ -257,170 +321,53 @@ public class OpencastLdapAuthoritiesPopulatorTest {
 
   @Test
   public void testAttributeNotFound() {
-    OpencastLdapAuthoritiesPopulator populator;
-
     // Prepare the mappings
     // The attribute returns "null", i.e. does not exist in the LDAP user
     mappings.put("myAttribute", null);
     String attributes = StringUtils.join(mappings.keySet(), ", ");
 
-    // Test several argument combinations
-    for (String prefix : PREFIX_TESTS) {
-      for (String[] excludePrefixes : EXCLUDE_PREFIXES_TESTS) {
-        for (String groupCheckPrefix : GROUP_CHECK_PREFIX_TESTS) {
-          for (boolean attrAsGroups : APPLY_ATTRIBUTES_AS_GROUPS_TESTS) {
-            for (Map<String, String[]> ldapAssignmentGroupMap : ASSIGNMENT_GROUP_MAP_TESTS) {
-              for (boolean upper : UPPERCASE_TESTS) {
-                for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
-                  for (String[] extraRoles : EXTRA_ROLES_TESTS) {
-                    populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
-                            groupCheckPrefix, attrAsGroups, ldapAssignmentGroupMap, upper, org, securityService,
-                            groupRoleProvider, extraRoles);
-                    doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
-                            attrAsGroups, ldapAssignmentGroupMap, upper, extraRoles, groupRoleProvider);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    testCombinations(attributes);
   }
 
   @Test
   public void testEmptyAttributeArray() {
-    OpencastLdapAuthoritiesPopulator populator;
-
     // Prepare the mappings
     // The attribute returns an empty array
     mappings.put("myAttribute", new String[] {});
     String attributes = StringUtils.join(mappings.keySet(), ", ");
 
-    // Test several argument combinations
-    for (String prefix : PREFIX_TESTS) {
-      for (String[] excludePrefixes : EXCLUDE_PREFIXES_TESTS) {
-        for (String groupCheckPrefix : GROUP_CHECK_PREFIX_TESTS) {
-          for (boolean attrAsGroups : APPLY_ATTRIBUTES_AS_GROUPS_TESTS) {
-            for (Map<String, String[]> ldapAssignmentGroupMap : ASSIGNMENT_GROUP_MAP_TESTS) {
-              for (boolean upper : UPPERCASE_TESTS) {
-                for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
-                  for (String[] extraRoles : EXTRA_ROLES_TESTS) {
-                    populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
-                            groupCheckPrefix, attrAsGroups, ldapAssignmentGroupMap, upper, org, securityService,
-                            groupRoleProvider, extraRoles);
-                    doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
-                            attrAsGroups, ldapAssignmentGroupMap, upper, extraRoles, groupRoleProvider);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    testCombinations(attributes);
   }
 
   @Test
   public void testEmptySingleAttribute() {
-    OpencastLdapAuthoritiesPopulator populator;
-
     // Prepare the mappings
     mappings.put("myAttribute", new String[] { "" });
     String attributes = StringUtils.join(mappings.keySet(), ", ");
 
-    // Test several argument combinations
-    for (String prefix : PREFIX_TESTS) {
-      for (String[] excludePrefixes : EXCLUDE_PREFIXES_TESTS) {
-        for (String groupCheckPrefix : GROUP_CHECK_PREFIX_TESTS) {
-          for (boolean attrAsGroups : APPLY_ATTRIBUTES_AS_GROUPS_TESTS) {
-            for (Map<String, String[]> ldapAssignmentGroupMap : ASSIGNMENT_GROUP_MAP_TESTS) {
-              for (boolean upper : UPPERCASE_TESTS) {
-                for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
-                  for (String[] extraRoles : EXTRA_ROLES_TESTS) {
-                    populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
-                            groupCheckPrefix, attrAsGroups, ldapAssignmentGroupMap, upper, org, securityService,
-                            groupRoleProvider, extraRoles);
-                    doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
-                            attrAsGroups, ldapAssignmentGroupMap, upper, extraRoles, groupRoleProvider);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    testCombinations(attributes);
   }
 
   @Test
   public void testMultivaluedAttributeSimpleRoles() {
-    OpencastLdapAuthoritiesPopulator populator;
-
     // Prepare the mappings
-    mappings.put("myAttribute", new String[] { " value1 ", " value2 ", " value3 ", " value4 ", GROUP_ROLE });
+    mappings.put("myAttribute", new String[] { " value1 ", " value2 ", " value3 ", " value4 ", GROUP_ROLE, MAPPED_ROLE_ATTR });
     String attributes = StringUtils.join(mappings.keySet(), ", ");
 
-    // Test several argument combinations
-    for (String prefix : PREFIX_TESTS) {
-      for (String[] excludePrefixes : EXCLUDE_PREFIXES_TESTS) {
-        for (String groupCheckPrefix : GROUP_CHECK_PREFIX_TESTS) {
-          for (boolean attrAsGroups : APPLY_ATTRIBUTES_AS_GROUPS_TESTS) {
-            for (Map<String, String[]> ldapAssignmentGroupMap : ASSIGNMENT_GROUP_MAP_TESTS) {
-              for (boolean upper : UPPERCASE_TESTS) {
-                for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
-                  for (String[] extraRoles : EXTRA_ROLES_TESTS) {
-                    populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
-                            groupCheckPrefix, attrAsGroups, ldapAssignmentGroupMap, upper, org, securityService,
-                            groupRoleProvider, extraRoles);
-                    doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
-                            attrAsGroups, ldapAssignmentGroupMap, upper, extraRoles, groupRoleProvider);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    testCombinations(attributes);
   }
 
   @Test
   public void testSingleAttributeMultipleRoles() {
-    OpencastLdapAuthoritiesPopulator populator;
-
     // Prepare the mappings
     mappings.put("myAttribute", new String[] { format(" value1, value2, value3 , value4 , %s ", GROUP_ROLE) });
     String attributes = StringUtils.join(mappings.keySet(), ", ");
 
-    // Test several argument combinations
-    for (String prefix : PREFIX_TESTS) {
-      for (String[] excludePrefixes : EXCLUDE_PREFIXES_TESTS) {
-        for (String groupCheckPrefix : GROUP_CHECK_PREFIX_TESTS) {
-          for (boolean attrAsGroups : APPLY_ATTRIBUTES_AS_GROUPS_TESTS) {
-            for (Map<String, String[]> ldapAssignmentGroupMap : ASSIGNMENT_GROUP_MAP_TESTS) {
-              for (boolean upper : UPPERCASE_TESTS) {
-                for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
-                  for (String[] extraRoles : EXTRA_ROLES_TESTS) {
-                    populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
-                            groupCheckPrefix, attrAsGroups, ldapAssignmentGroupMap, upper, org, securityService,
-                            groupRoleProvider, extraRoles);
-                    doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
-                            attrAsGroups, ldapAssignmentGroupMap, upper, extraRoles, groupRoleProvider);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    testCombinations(attributes);
   }
 
   @Test
   public void testAttributesWithWhitespaces() {
-    OpencastLdapAuthoritiesPopulator populator;
-
     // Prepare the mappings
     mappings.put("attribute1", new String[] { " ", "\n", "\t", "\r", " \n \t", " \nthis\tis an attribute" });
     mappings.put("attribute2",
@@ -429,34 +376,11 @@ public class OpencastLdapAuthoritiesPopulatorTest {
                             "normal_value , normalvalue2, %s", GROUP_ROLE) });
     String attributes = StringUtils.join(mappings.keySet(), ", ");
 
-    // Test several argument combinations
-    for (String prefix : PREFIX_TESTS) {
-      for (String[] excludePrefixes : EXCLUDE_PREFIXES_TESTS) {
-        for (String groupCheckPrefix : GROUP_CHECK_PREFIX_TESTS) {
-          for (boolean attrAsGroups : APPLY_ATTRIBUTES_AS_GROUPS_TESTS) {
-            for (Map<String, String[]> ldapAssignmentGroupMap : ASSIGNMENT_GROUP_MAP_TESTS) {
-              for (boolean upper : UPPERCASE_TESTS) {
-                for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
-                  for (String[] extraRoles : EXTRA_ROLES_TESTS) {
-                    populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
-                            groupCheckPrefix, attrAsGroups, ldapAssignmentGroupMap, upper, org, securityService,
-                            groupRoleProvider, extraRoles);
-                    doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
-                            attrAsGroups, ldapAssignmentGroupMap, upper, extraRoles, groupRoleProvider);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    testCombinations(attributes);
   }
 
   @Test
   public void testRolePrefix() {
-    OpencastLdapAuthoritiesPopulator populator;
-
     // Prepare the mappings
     mappings.put("attribute1", new String[] { " ", "\n", "\t", "\r", " \n \t", " \nthis\tis an attribute" });
     mappings.put("attribute2", new String[] { format("value_1 , exclude_value_1, value_2, exclude_value_2",
@@ -468,28 +392,7 @@ public class OpencastLdapAuthoritiesPopulatorTest {
 
     String[][] excludePrefixesTest = new String[][] { null, new String[0], new String[] { "exclude" } };
 
-    // Test several argument combinations
-    for (String prefix : prefixes) {
-      for (String[] excludePrefixes : excludePrefixesTest) {
-        for (String groupCheckPrefix : GROUP_CHECK_PREFIX_TESTS) {
-          for (boolean attrAsGroups : APPLY_ATTRIBUTES_AS_GROUPS_TESTS) {
-            for (Map<String, String[]> ldapAssignmentGroupMap : ASSIGNMENT_GROUP_MAP_TESTS) {
-              for (boolean upper : UPPERCASE_TESTS) {
-                for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
-                  for (String[] extraRoles : EXTRA_ROLES_TESTS) {
-                    populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
-                            groupCheckPrefix, attrAsGroups, ldapAssignmentGroupMap, upper, org, securityService,
-                            groupRoleProvider, extraRoles);
-                    doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
-                            attrAsGroups, ldapAssignmentGroupMap, upper, extraRoles, groupRoleProvider);
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    testCombinationsPrefixes(attributes, prefixes, excludePrefixesTest);
   }
 
   @Test
@@ -508,23 +411,107 @@ public class OpencastLdapAuthoritiesPopulatorTest {
     // Test several argument combinations
     for (String prefix : PREFIX_TESTS) {
       for (String[] excludePrefixes : EXCLUDE_PREFIXES_TESTS) {
-        for (String groupCheckPrefix : GROUP_CHECK_PREFIX_TESTS) {
-          for (boolean attrAsGroups : APPLY_ATTRIBUTES_AS_GROUPS_TESTS) {
-            for (Map<String, String[]> ldapAssignmentGroupMap : ASSIGNMENT_GROUP_MAP_TESTS) {
-              for (boolean upper : UPPERCASE_TESTS) {
-                for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
-                  for (String[] extraRoles : EXTRA_ROLES_TESTS) {
-                    try {
-                      populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
-                              groupCheckPrefix, attrAsGroups, ldapAssignmentGroupMap, upper, otherOrg, securityService,
-                              groupRoleProvider, extraRoles);
-                      doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
-                              attrAsGroups, ldapAssignmentGroupMap, upper, extraRoles, groupRoleProvider);
-                      fail(format(
-                              "Request came from a different organization (\"%s\") as the expected (\"%s\") but no exception was thrown",
-                              otherOrg, org));
-                    } catch (SecurityException e) {
-                      // OK
+        for (Map<String, String[]> ldapAssignmentRoleMap : ASSIGNMENT_ROLE_MAP_TESTS) {
+          for (boolean upper : UPPERCASE_TESTS) {
+            for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
+              for (String[] extraRoles : EXTRA_ROLES_TESTS) {
+                try {
+                  populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
+                          DEFAULT_GROUP_CHECK_PREFIX, true, true, ldapAssignmentRoleMap, DEFAULT_ASSIGNMENT_GROUP_MAP,
+                          upper, otherOrg, securityService,
+                          groupRoleProvider, extraRoles);
+                  doTest(populator, mappings, prefix, excludePrefixes, DEFAULT_GROUP_CHECK_PREFIX,
+                          true, true, ldapAssignmentRoleMap, DEFAULT_ASSIGNMENT_GROUP_MAP, upper, extraRoles, groupRoleProvider);
+                  fail(format(
+                          "Request came from a different organization (\"%s\") as the expected (\"%s\") but no exception was thrown",
+                          otherOrg, org));
+                } catch (SecurityException e) {
+                  // OK
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private void testCombinations(final String attributes) {
+    /* testing all Combinations takes quite long
+    testCombinationsAdv(attributes, PREFIX_TESTS, EXCLUDE_PREFIXES_TESTS, GROUP_CHECK_PREFIX_TESTS,
+                    APPLY_ATTRIBUTES_AS_ROLES_TESTS, APPLY_ATTRIBUTES_AS_GROUPS_TESTS,
+                    ASSIGNMENT_ROLE_MAP_TESTS, ASSIGNMENT_GROUP_MAP_TESTS, UPPERCASE_TESTS,
+                    groupRoleProviderTests, EXTRA_ROLES_TESTS,
+                    org);
+    */
+    // therefore we only test subsets
+    List<Map<String, String[]>> defaultAssignmentRoleMapList = new ArrayList();
+    defaultAssignmentRoleMapList.add(DEFAULT_ASSIGNMENT_ROLE_MAP);
+    List<Map<String, String[]>> defaultAssignmentGroupMapList = new ArrayList();
+    defaultAssignmentGroupMapList.add(DEFAULT_ASSIGNMENT_GROUP_MAP);
+    testCombinationsAdv(attributes, PREFIX_TESTS, new String[][] { DEFAULT_EXCLUDE_PREFIXES },
+                    GROUP_CHECK_PREFIX_TESTS,
+                    APPLY_ATTRIBUTES_AS_ROLES_TESTS, APPLY_ATTRIBUTES_AS_GROUPS_TESTS,
+                    defaultAssignmentRoleMapList,
+                    defaultAssignmentGroupMapList,
+                    UPPERCASE_TESTS,
+                    groupRoleProviderTests, EXTRA_ROLES_TESTS,
+                    org);
+    testCombinationsAdv(attributes, PREFIX_TESTS, new String[][] { DEFAULT_EXCLUDE_PREFIXES },
+                    new String[] { DEFAULT_GROUP_CHECK_PREFIX },
+                    new boolean[] { true }, new boolean[] { true },
+                    ASSIGNMENT_ROLE_MAP_TESTS,
+                    ASSIGNMENT_GROUP_MAP_TESTS,
+                    UPPERCASE_TESTS,
+                    groupRoleProviderTests, EXTRA_ROLES_TESTS,
+                    org);
+    testCombinationsAdv(attributes, PREFIX_TESTS, EXCLUDE_PREFIXES_TESTS,
+                    new String[] { DEFAULT_GROUP_CHECK_PREFIX },
+                    new boolean[] { true }, new boolean[] { true },
+                    defaultAssignmentRoleMapList,
+                    defaultAssignmentGroupMapList,
+                    UPPERCASE_TESTS,
+                    groupRoleProviderTests, EXTRA_ROLES_TESTS,
+                    org);
+  }
+
+  private void testCombinationsPrefixes(final String attributes, final String[] prefixTests, final String[][] excludePrefixesTests) {
+    testCombinationsAdv(attributes, prefixTests, excludePrefixesTests, GROUP_CHECK_PREFIX_TESTS,
+                    new boolean[] { true }, new boolean[] { true },
+                    ASSIGNMENT_ROLE_MAP_TESTS, ASSIGNMENT_GROUP_MAP_TESTS, UPPERCASE_TESTS,
+                    groupRoleProviderTests, EXTRA_ROLES_TESTS,
+                    org);
+  }
+
+  private void testCombinationsAdv(final String attributes, final String[] prefixTests,
+                  final String[][] excludePrefixesTests, final String[] groupCheckPrefixTests,
+                  final boolean[] applyAttributesAsRolesTests, final boolean[] applyAttributesAsGroupsTests,
+                  final List<Map<String, String[]>> assignmentRoleMapTests,
+                  final List<Map<String, String[]>> assignmentGroupMapTests,
+                  final boolean[] uppercaseTests, final JpaGroupRoleProvider[] groupRoleProviderTests,
+                  final String[][] extraRolesTests,
+                  final Organization pOrg) {
+    OpencastLdapAuthoritiesPopulator populator;
+
+    // Test several argument combinations
+    for (String prefix : prefixTests) {
+      for (String[] excludePrefixes : excludePrefixesTests) {
+        for (String groupCheckPrefix : groupCheckPrefixTests) {
+          for (boolean attrAsRoles : applyAttributesAsRolesTests) {
+            for (boolean attrAsGroups : applyAttributesAsGroupsTests) {
+              for (Map<String, String[]> ldapAssignmentRoleMap : assignmentRoleMapTests) {
+                for (Map<String, String[]> ldapAssignmentGroupMap : assignmentGroupMapTests) {
+                  for (boolean upper : uppercaseTests) {
+                    for (JpaGroupRoleProvider groupRoleProvider : groupRoleProviderTests) {
+                      for (String[] extraRoles : extraRolesTests) {
+                        populator = new OpencastLdapAuthoritiesPopulator(attributes, prefix, excludePrefixes,
+                                groupCheckPrefix, attrAsRoles, attrAsGroups, ldapAssignmentRoleMap,
+                                ldapAssignmentGroupMap, upper, pOrg, securityService,
+                                groupRoleProvider, extraRoles);
+                        doTest(populator, mappings, prefix, excludePrefixes, groupCheckPrefix,
+                                attrAsRoles, attrAsGroups, ldapAssignmentRoleMap, ldapAssignmentGroupMap,
+                                upper, extraRoles, groupRoleProvider);
+                      }
                     }
                   }
                 }
@@ -546,7 +533,8 @@ public class OpencastLdapAuthoritiesPopulatorTest {
    *          value an array of {@code String}s, possibly {@code null} or empty.
    */
   private void doTest(OpencastLdapAuthoritiesPopulator populator, Map<String, String[]> mappings, String rolePrefix,
-          String[] excludePrefixes, String groupCheckPrefix, boolean attrAsGroups, Map<String, String[]> ldapAssignmentGroupMap,
+          String[] excludePrefixes, String groupCheckPrefix, boolean attrAsRoles, boolean attrAsGroups,
+          Map<String, String[]> ldapAssignmentRoleMap, Map<String, String[]> ldapAssignmentGroupMap,
           boolean toUppercase, String[] additionalAuthorities, JpaGroupRoleProvider groupRoleProvider) {
     DirContextOperations dirContextMock = EasyMock.createNiceMock(DirContextOperations.class);
 
@@ -563,24 +551,40 @@ public class OpencastLdapAuthoritiesPopulatorTest {
         for (String attrValues : mappings.get(attrName)) {
           String[] attrValuesSplitted = attrValues.split(",");
 
-          if (attrAsGroups) {
-            String[] attrValuesFiltered = Arrays.stream(attrValuesSplitted)
-                    .filter(x -> {
-                      String filter = roleCleanUpperCase(x, toUppercase);
-                      return filter.startsWith(groupCheckPrefix);
-                    })
-                    .toArray(String[]::new);
-            addRoles(expectedResult, rolePrefix, excludePrefixes, toUppercase, groupRoleProvider, org,
-                    attrValuesFiltered);
+          if (attrAsRoles) {
+            // no group resolve for roles added this way (groupRoleProvider = null)
+            addRoles(expectedResult, rolePrefix, excludePrefixes, toUppercase, null, org,
+                    attrValuesSplitted);
+            if (attrAsGroups) {
+              String[] attrValuesFiltered = Arrays.stream(attrValuesSplitted)
+                      .filter(x -> {
+                        String filter = roleCleanUpperCase(x, toUppercase);
+                        return filter.startsWith(groupCheckPrefix);
+                      })
+                      .toArray(String[]::new);
+              addRoles(expectedResult, rolePrefix, excludePrefixes, toUppercase, groupRoleProvider, org,
+                      attrValuesFiltered);
+            }
           }
 
+          String[] mappedRoles = Arrays.stream(attrValuesSplitted)
+                  .map(x -> roleCleanUpperCase(x, toUppercase))
+                  .map(x -> ldapAssignmentRoleMap != null ? ldapAssignmentRoleMap.get(x) : null)
+                  .filter(x -> x != null)
+                  .flatMap(x-> Arrays.stream(x))
+                  .toArray(String[]::new);
+          // no prefix for roles added this way (prefix = "")
+          // no group resolve for roles added this way (groupRoleProvider = null)
+          addRoles(expectedResult, "", excludePrefixes, toUppercase, null, org,
+                  mappedRoles);
           String[] mappedGroups = Arrays.stream(attrValuesSplitted)
                   .map(x -> roleCleanUpperCase(x, toUppercase))
                   .map(x -> ldapAssignmentGroupMap != null ? ldapAssignmentGroupMap.get(x) : null)
                   .filter(x -> x != null)
                   .flatMap(x -> Arrays.stream(x))
                   .toArray(String[]::new);
-          addRoles(expectedResult, rolePrefix, excludePrefixes, toUppercase, groupRoleProvider, org,
+          // no prefix for roles added this way (prefix = "")
+          addRoles(expectedResult, "", excludePrefixes, toUppercase, groupRoleProvider, org,
                   mappedGroups);
         }
       }
@@ -592,13 +596,17 @@ public class OpencastLdapAuthoritiesPopulatorTest {
     }
 
     // Add the additional authorities
+    // no prefix for roles added this way (prefix = "")
+    // no group resolve for roles added this way (groupRoleProvider = null)
+    addRoles(expectedResult, "", excludePrefixes, toUppercase, null, org, additionalAuthorities);
     String[] filteredAddiAuthorities = null;
     if (additionalAuthorities != null) {
       filteredAddiAuthorities = Arrays.stream(additionalAuthorities)
               .filter(x -> roleCleanUpperCase(x, toUppercase).startsWith(groupCheckPrefix))
               .toArray(String[]::new);
     }
-    addRoles(expectedResult, rolePrefix, excludePrefixes, toUppercase, groupRoleProvider, org, filteredAddiAuthorities);
+    // no prefix for roles added this way (prefix = "")
+    addRoles(expectedResult, "", excludePrefixes, toUppercase, groupRoleProvider, org, filteredAddiAuthorities);
 
     // Check the response is correct
     checkResponse(populator.getGrantedAuthorities(dirContextMock, USERNAME), expectedResult);


### PR DESCRIPTION
Assume the following LDAP configuration:
```ini
org.opencastproject.userdirectory.ldap.roleattributes=memberOf
org.opencastproject.userdirectory.ldap.roleprefix=ROLE_
```
and the following LDAP User:
```ini
memberOf=student, staff, whatever
```

This pull request implements 3 features related to LDAP.

1. Currently, Opencast would try to add all `memberOf` attributes as a group, this leads to warnings if the group doesn't exist.
A new configuration key is added, which checks whether a attribute has a specific prefix, if the prefix is present the attribute is added as a group, otherwise it is only added as a role.
Default config:
```ini
org.opencastproject.userdirectory.ldap.groupprefix=ROLE_GROUP_
```

2. A Map from LDAP attributes to roles, e.g.:
```ini
org.opencastproject.userdirectory.ldap.roles.staff=ROLE_ADMIN
```
This would add the `ROLE_ADMIN`  to the user, because the user has the `staff` attribute.

3. An additional Map, but for groups.
