### PR TITLE
Fix: Multiple identical workflow IDs prevent Opencast form starting properly

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
@@ -122,6 +122,7 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
       if (fileWithIdentifier.getValue().equals(workflowIdentifier) && !fileWithIdentifier.getKey().equals(artifact)) {
         logger.warn("Workflow with identifier '{}' already registered in file '{}', ignoring", workflowIdentifier,
                 fileWithIdentifier.getKey());
+        artifactsWithError.add(artifact);
         return;
       }
     }


### PR DESCRIPTION
Fixed an error where multiple workflows with the same id would prevent the WorkflowDefinitionScanner from registering as ready, because the duplicate workflows were not counted towards the erroneous artifacts. Now, workflows with an ID identical to an already registered workflow will be ignored without putting Opencast into an error state.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
