### PR TITLE
Fix Capture Agent API REST Docs

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -1064,7 +1064,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
     restParameters = {
       @RestParameter(description = "The media package", isRequired = true, name = "mediaPackage", type = RestParameter.Type.TEXT),
       @RestParameter(description = "Workflow definition id", isRequired = false, name = WORKFLOW_DEFINITION_ID_PARAM, type = RestParameter.Type.STRING),
-      @RestParameter(description = "The workflow instance ID to associate with this zipped mediapackage. (This parameter is deprecated.)", isRequired = false, name = WORKFLOW_INSTANCE_ID_PARAM, type = RestParameter.Type.STRING) },
+      @RestParameter(description = "The workflow instance ID to associate this ingest with scheduled events.", isRequired = false, name = WORKFLOW_INSTANCE_ID_PARAM, type = RestParameter.Type.STRING) },
     reponses = {
       @RestResponse(description = "Returns the media package", responseCode = HttpServletResponse.SC_OK),
       @RestResponse(description = "Media package not valid", responseCode = HttpServletResponse.SC_BAD_REQUEST) },


### PR DESCRIPTION
Pull request #1530 accidentally marked a part of the capture agent aAPI
as deprecated which it certainly is not even though the documentation
was misleading.

The parameter `workflowInstanceId` of the `/ingest/ingest` endpoints is
used by capture agents to identify that an ingest in related to a
specific scheduled event from which later then meta data and attachments
can be retrieved.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
