### PR TITLE
Capture Agent Authentication Method

### DIFF
--- a/docs/guides/developer/docs/modules/capture-agent/capture-agent.md
+++ b/docs/guides/developer/docs/modules/capture-agent/capture-agent.md
@@ -51,6 +51,37 @@ to be stable for a long time. The same is not true for other parts of the API an
 hardware with other parts of Opencast's API
 
 
+Authentication
+--------------
+
+Opencast supports two types of authentication which can be used by capture agents:
+
+- (Backend) HTTP Digest authentication which is historically used for machine-to-machine communication.
+- (General) HTTP Basic (or session-based) authentication used for both front-end users and integrations.
+
+HTTP Digest authentication is the legacy option for capture agents. It is still widely used today and will continue to
+be supported. HTTP Digest is more complicated and has the disadvantage that users need to be specified separately in the
+backend. There is a global HTTP Digest user with admin privileges but specific capture agent users with limited
+privileges can be defined as well.
+
+When using HTTP Digest authentication, you need to send the additional header `X-Requested-Auth: Digest`:
+
+    curl --digest -u opencast_system_account:CHANGE_ME -H "X-Requested-Auth: Digest" \
+      https://develop.opencast.org/info/me.json
+
+HTTP Basic authentication can be used with users defined via web-interface or via any regular user provider. A request
+using HTTP Basic does not need to specify any additional headers:
+
+    curl -u admin:opencast https://develop.opencast.org/info/me.json
+
+Generally, we recommend using HTTP Basic authentication since it's easier for adopters to manage capture agent users via
+the admin interface and does not rely on hidden users while being less complicated at the same time.
+
+Whatever authentication method you choose to implement – maybe even both, allowing users to choose for themselves –
+please clearly specify what authentication you expect since users have to provide different types of users which can
+easily lead to usability problems if not clearly marked.
+
+
 Action Details
 --------------
 


### PR DESCRIPTION
This patch documents and defines two authentication methods capture
agents can use. Historically, HTTP Digest was used by capture agents
while by now, HTTP Basic makes more sense in a lot of cases.

Technically, the method to use was never specified and this does not
change at all how the capture agent API works. Still, there was always
the implicit assumption that capture agents would use HTTP Digest. This
assumption was mainly for historical reasons.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
