### PR TITLE
Updating Guava version

### DIFF
--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -117,6 +117,17 @@
       <classifier>opencast</classifier>
       <version>2.2.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+    <!-- If using JDK 8, add the following additional dependency. -->
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>javac</artifactId>
+      <version>9+181-r4173-1</version>
+    </dependency>
     <!-- testing -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -154,7 +165,8 @@
               org.jdom.*,
             </Private-Package>
             <Export-Package>
-              org.opencastproject.publication.youtube.*;version=${project.version}
+              org.opencastproject.publication.youtube.*;version=${project.version},
+              org.checkerframework.*
             </Export-Package>
             <_exportcontents>
               com.google.api.*
@@ -170,6 +182,7 @@
             </Import-Package>
             <Embed-Dependency>
               javax.activation-mail;inline=true,
+              checker-qual,
               org.apache.felix.http.bundle;inline=true
             </Embed-Dependency>
             <Service-Component>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <cxf.version>3.2.6</cxf.version>
     <eclipselink.version>2.7.3</eclipselink.version>
     <functional.version>1.4.2</functional.version>
-    <guava.version>23.0</guava.version>
+    <guava.version>24.1.1-jre</guava.version>
     <httpcomponents-httpclient.version>4.5.7</httpcomponents-httpclient.version>
     <httpcomponents-httpcore.version>4.4.11</httpcomponents-httpcore.version>
     <jackson.version>2.10.0</jackson.version>


### PR DESCRIPTION
This PR updates the Guava version in response to [this advisory](https://github.com/opencast/opencast/network/alert/pom.xml/com.google.guava:guava/closed).  This necessitated adding the checker framework to the youtube bundle, bloating the module from 5.1MB to 5.6MB.
