### PR TITLE
Enable publish-configure to publish to streaming

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-configure-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-configure-woh.md
@@ -2,26 +2,31 @@
 
 ## Description
 
-The `ConfigurablePublishWorkflowOperationHandler` will distribute the given elements and create a publication element for
-it. By default it will retract all publications before publishing anew.
+The `ConfigurablePublishWorkflowOperationHandler` will distribute the given elements and create a publication element 
+for them. By default it will retract all published download elements before publishing anew.
 
 ## Parameter Table
 
-These are the keys that are configured through the workflow definition. At least one media package element must match
-the supplied `source-flavors` or `source-tags` or else the operation will not know what to publish. The `channel-id` and
-`url-pattern` are also mandatory.
+These are the keys that can be configured for this operation in the workflow definition. At least one media package 
+element must match the supplied `source-flavors` or `source-tags` (either for download or streaming or both) or else 
+the operation will not know what to publish. The `channel-id` and `url-pattern` are also mandatory.
 
-|Key                    |Description                                          |Example    |Default  |
-|-----------------------|-----------------------------------------------------|-----------|---------|
-|channel-id             |Id of the channel to publish to                      |`internal` |         |
-|mimetype               |Mime type of the published element                   |`text/html`|Type of last distributed element|
-|source-flavors         |Flavors of the media package elements to publish     |`*/trimmed`|         |
-|source-tags            |Tags of the media package elements to publish        |`engage`   |         |
-|url-pattern            |Pattern to create the URI for the published from     |`ftp://…/${event_id}`|  |
-|with-published-elements|Use the current contents of the media package instead of publishing elements to a channel|`true`|  |
-|check-availability     |Check if the media is reachable after publication    |`false`    |`false`  |
-|strategy               |Strategy for when there is already published material|`fail`     |`retract`|
-|mode                   |How elements are distributed                         |`mixed`    |`bulk`   |
+|Key                      |Description                                                |Example              |Default  |
+|-------------------------|-----------------------------------------------------------|---------------------|---------|
+|channel-id               |Id of the channel to publish to                            |`internal`           |         |
+|mimetype                 |Mime type of the published element                         |`text/html`          |Type of last distributed element|
+|download-source-flavors  |Flavors of the download media package elements to publish  |`*/trimmed`          |         |
+|download-source-tags     |Tags of the download media package elements to publish     |`engage-download`    |         |
+|streaming-source-flavors |Flavors of the streaming media package elements to publish |`*/trimmed`          |         |
+|streaming-source-tags    |Tags of the streaming media package elements to publish    |`engage-streaming`   |         |
+|url-pattern              |Pattern to create the URI for the published from           |`ftp://…/${event_id}`|         |
+|with-published-elements  |Use the current contents of the media package instead of publishing elements to a channel|`true`|  |
+|check-availability       |Check if the media is reachable after publication          |`false`              |`false`  |
+|strategy                 |Strategy for when there is already published material      |`fail`               |`retract`|
+|mode                     |How elements are distributed                               |`mixed`              |`bulk`   |
+|retract-streaming        |Whether to also retract streaming elements \*              |`true`               |`false`  |
+
+\* Enable if you have published streaming elements to this channel.
 
 ## Mode
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/retract-configure-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/retract-configure-woh.md
@@ -9,7 +9,17 @@ If the elements have been added to the Publication using "with-published-element
 api, they haven't actually been published so it is unnecessary to have a retract-configuration. Adding a retraction
 won't cause any errors, it will just skip those elements.
 
-There is only one configuration key "channel-id". This is the channel to remove the published elements from.
+## Parameters
+
+These are the keys that can be configured for the worklow operation in the workflow definition.  The `channel-id` is
+mandatory.
+
+|Key                    |Description                                          |Example    |Default  |
+|-----------------------|-----------------------------------------------------|-----------|---------|
+|channel-id             |The id of the channel to retract from                |`internal` |         |
+|retract-streaming      |Whether to retract streaming elements as well        |`true`     | `false` |
+
+Setting `retract-streaming` to true only makes sense if you've published streaming elements for this channel before.
 
 ## Operation Examples
 
@@ -32,5 +42,6 @@ There is only one configuration key "channel-id". This is the channel to remove 
       description="Retract from external api publication channel">
       <configurations>
         <configuration key="channel-id">api</configuration>
+        <configuration key="retract-streaming">false</configuration>
       </configurations>
     </operation>

--- a/etc/workflows/cleanup-publish-placeholder.xml
+++ b/etc/workflows/cleanup-publish-placeholder.xml
@@ -145,7 +145,7 @@
       <configurations>
         <configuration key="channel-id">api</configuration>
         <configuration key="mimetype">application/json</configuration>
-        <configuration key="source-tags">engage-download,engage-streaming</configuration>
+        <configuration key="download-source-tags">engage-download,engage-streaming</configuration>
         <configuration key="url-pattern">http://localhost:8080/api/events/${event_id}</configuration>
         <configuration key="with-published-elements">false</configuration>
         <configuration key="check-availability">true</configuration>

--- a/etc/workflows/fast.xml
+++ b/etc/workflows/fast.xml
@@ -187,7 +187,7 @@
       exception-handler-workflow="partial-error"
       description="Publish to preview publication channel">
       <configurations>
-        <configuration key="source-flavors">*/preview</configuration>
+        <configuration key="download-source-flavors">*/preview</configuration>
         <configuration key="channel-id">internal</configuration>
         <configuration key="url-pattern">http://localhost:8080/admin-ng/index.html#/events/events/${event_id}/tools/playback</configuration>
         <configuration key="check-availability">true</configuration>

--- a/etc/workflows/import.xml
+++ b/etc/workflows/import.xml
@@ -53,7 +53,7 @@
       exception-handler-workflow="partial-error"
       description="Publish to preview publication channel">
       <configurations>
-        <configuration key="source-tags">engage-download</configuration>
+        <configuration key="download-source-tags">engage-download</configuration>
         <configuration key="channel-id">internal</configuration>
         <configuration key="url-pattern">http://localhost:8080/admin-ng/index.html#/events/events/${event_id}/tools/playback</configuration>
         <configuration key="check-availability">true</configuration>

--- a/etc/workflows/partial-preview.xml
+++ b/etc/workflows/partial-preview.xml
@@ -230,7 +230,7 @@
       exception-handler-workflow="partial-error"
       description="Publish to preview publication channel">
       <configurations>
-        <configuration key="source-tags">preview</configuration>
+        <configuration key="download-source-tags">preview</configuration>
         <configuration key="channel-id">internal</configuration>
         <configuration key="url-pattern">http://localhost:8080/admin-ng/index.html#/events/events/${event_id}/tools/playback</configuration>
         <configuration key="check-availability">true</configuration>

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -540,7 +540,7 @@
       <configurations>
         <configuration key="channel-id">api</configuration>
         <configuration key="mimetype">application/json</configuration>
-        <configuration key="source-tags">engage-download,engage-streaming</configuration>
+        <configuration key="download-source-tags">engage-download,engage-streaming</configuration>
         <configuration key="url-pattern">http://localhost:8080/api/events/${event_id}</configuration>
         <configuration key="with-published-elements">false</configuration>
         <configuration key="check-availability">true</configuration>

--- a/etc/workflows/studio-upload.xml
+++ b/etc/workflows/studio-upload.xml
@@ -396,7 +396,7 @@
       <configurations>
         <configuration key="channel-id">api</configuration>
         <configuration key="mimetype">application/json</configuration>
-        <configuration key="source-tags">engage-download,engage-streaming</configuration>
+        <configuration key="download-source-tags">engage-download,engage-streaming</configuration>
         <configuration key="url-pattern">http://localhost:8080/api/events/${event_id}</configuration>
         <configuration key="with-published-elements">false</configuration>
         <configuration key="check-availability">true</configuration>

--- a/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-configurable.xml
+++ b/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-configurable.xml
@@ -14,6 +14,9 @@
   <reference cardinality="1..1" interface="org.opencastproject.distribution.api.DownloadDistributionService"
              name="DownloadDistributionService" policy="static" target="(distribution.channel=download)"
              bind="setDownloadDistributionService"/>
+  <reference interface="org.opencastproject.distribution.api.StreamingDistributionService"
+             name="StreamingDistributionService" target="(distribution.channel=streaming)"
+             bind="setStreamingDistributionService"/>
   <reference cardinality="1..1" interface="org.opencastproject.security.api.SecurityService"
              name="SecurityService" policy="static" bind="setSecurityService"/>
   <reference name="ServiceRegistry" cardinality="1..1"

--- a/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/retract-configurable.xml
+++ b/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/retract-configurable.xml
@@ -15,6 +15,9 @@
   <reference cardinality="1..1" interface="org.opencastproject.distribution.api.DownloadDistributionService"
              name="DownloadDistributionService" policy="static" target="(distribution.channel=download)"
              bind="setDownloadDistributionService"/>
+  <reference interface="org.opencastproject.distribution.api.StreamingDistributionService"
+             name="StreamingDistributionService" target="(distribution.channel=streaming)"
+             bind="setStreamingDistributionService"/>
   <reference name="ServiceRegistry" cardinality="1..1"
              interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
              policy="static" bind="setServiceRegistry"/>


### PR DESCRIPTION
Enable publish-configure and retract-configure workflow operations to be able to publish and retract streaming elements as well. The documentation and the workflows were amended accordingly, but the default behavior is unchanged. Streaming elements will only be published if the operation is configured for it and streaming is enabled in the streaming service. Streaming elements are only retracted if the operation is configured for it. Publish configure will now return "skipped" if no elements (neither download nor streaming) were published.

