### PR TITLE
Fix managed acl filter in api

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -210,7 +210,7 @@ public class SeriesEndpoint {
           }
 
           if ("managedAcl".equals(name)) {
-            query.withAccessPolicy(value);
+            query.withManagedAcl(value);
           } else if ("contributors".equals(name)) {
             query.withContributor(value);
           } else if ("CreationDate".equals(name)) {


### PR DESCRIPTION
When using the managed acl filter for getting series from the external api, the access policy gets queried by mistake, and that doesn't even work, because the series acls aren't indexed for fulltext search, resulting in a server error. Now we correctly query for the managed acl. 

Since this is a bug fix and it now works like you would expect it to from the documentation, this imo doesn't need a new api version. But you might disagree with that.

PS: The UI is currently buggy concerning the display of the chosen managed acl (= acl template), but you can still test this.