### PR TITLE
Improved ffmpeg profile for extracting the last image of a video in P…

### DIFF
--- a/etc/encoding/opencast-images.properties
+++ b/etc/encoding/opencast-images.properties
@@ -59,12 +59,12 @@ profile.import.preview.output = image
 profile.import.preview.suffix = -image.jpg
 profile.import.preview.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
 
-# Extract image by video frame number for partial import operation
-profile.import.image-frame.name = Extract image by video frame number
+# Extract last image for partial import operation
+profile.import.image-frame.name = Extract last image
 profile.import.image-frame.input = visual
 profile.import.image-frame.output = image
 profile.import.image-frame.suffix = -image.jpg
-profile.import.image-frame.ffmpeg.command = -i #{in.video.path} -filter:v select=eq(n\\,#{frame}) -r 1 -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
+profile.import.image-frame.ffmpeg.command = -sseof -3 -i #{in.video.path} -update 1 -q:v 1 #{out.dir}/#{out.name}#{out.suffix}
 
 # Downscale thumbnail preview image for video editor
 profile.editor.thumbnail.preview.downscale.name = Downscale thumbnail preview image for video editor

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -1005,10 +1005,8 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
 
   private Attachment extractLastImageFrame(Track presentationTrack, List<MediaPackageElement> elementsToClean)
           throws EncoderException, MediaPackageException, WorkflowOperationException, NotFoundException {
-    VideoStream[] videoStreams = TrackSupport.byType(presentationTrack.getStreams(), VideoStream.class);
-
+    // Pass empty properties to the composer service, because the given profile requires none
     Map<String, String> properties = new HashMap<String, String>();
-    properties.put("frame", Long.toString(videoStreams[0].getFrameCount() - 1));
 
     Job extractImageJob = composerService.image(presentationTrack, IMAGE_FRAME_PROFILE, properties);
     if (!waitForStatus(extractImageJob).isSuccess())


### PR DESCRIPTION
…artialImportWorkflowOperation

The previous ffmpeg profile would lead the PartialImportWorkflowOperation to fail,
if the input video container contains multiple videos.
This can for example occur in webcam recordings from web-conferencing systems, if the browser changes
the webcam resolutions due to i.e. changes in cpu load.

The new profile should be more robust in that regard. It will always extract the last frame
instead of 'by video frame number'. The apparent loss in functionality is not a problem,
as the profile was only used for extracting the last frame anyway.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
