### PR TITLE
Python < 3.0 requirement deleted

### DIFF
--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -44,7 +44,7 @@ Required:
     java-1.8.0-openjdk-devel.x86_64 / openjdk-8-jdk
     ffmpeg >= 3.2.4
     maven >= 3.1
-    python >= 2.6, < 3.0
+    python >= 2.6
     unzip
     gcc-c++
     tar


### PR DESCRIPTION
It is possible to use Python > 3.0 for Opencast Installation

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
