### PR TITLE
Window Selection Style

### DIFF
--- a/modules/admin-ui-frontend/app/styles/views/modals/_embedded-code.scss
+++ b/modules/admin-ui-frontend/app/styles/views/modals/_embedded-code.scss
@@ -22,7 +22,7 @@
 .embedSizeButton {
     display: inline-block;
     background-color: #466DC3;
-    border: 5px solid #313135;
+    border: 1px solid silver;
     border-radius: 10px;
     cursor: pointer;
     margin-right: 5px;


### PR DESCRIPTION
This patch adjust the style of the window size selector for selecting
embed codes in the admin interface.

Before, the selector had a very thick border that looked alien in
comparison to the style commonly used in the admin interface. This patch
switches to thinner, light gray borders which are also used elsewhere in
the ui.

Before:
![Screenshot from 2020-07-17 15-34-46](https://user-images.githubusercontent.com/1008395/87814309-c9bac700-c863-11ea-88a0-adad18b3870d.png)

After:
![Screenshot from 2020-07-17 15-34-33](https://user-images.githubusercontent.com/1008395/87814363-e1924b00-c863-11ea-8c84-f4f92699b6bb.png)


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
