### PR TITLE
Fixes issue #1642: Drop-down menu does not disappear

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js
@@ -28,9 +28,12 @@ angular.module('adminNg.directives')
     },
     link: function ($scope, element) {
       element.on('click', function (event) {
+        var is_active = angular.element(this).hasClass('active');
         angular.element('[old-admin-ng-dropdown]').removeClass('active');
         event.stopPropagation();
-        angular.element(this).toggleClass('active');
+        if (!is_active) {
+          angular.element(this).toggleClass('active');
+        }
       });
 
       $scope.$on('$destroy', function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js
@@ -28,12 +28,9 @@ angular.module('adminNg.directives')
     },
     link: function ($scope, element) {
       element.on('click', function (event) {
-        var is_active = angular.element(this).hasClass('active');
-        angular.element('[old-admin-ng-dropdown]').removeClass('active');
+        angular.element('[old-admin-ng-dropdown]').not(this).removeClass('active');
         event.stopPropagation();
-        if (!is_active) {
-          angular.element(this).toggleClass('active');
-        }
+        angular.element(this).toggleClass('active');
       });
 
       $scope.$on('$destroy', function () {

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js
@@ -29,7 +29,7 @@ angular.module('adminNg.directives')
     link: function ($scope, element) {
       element.on('click', function (event) {
         var is_active = angular.element(this).hasClass('active');
-        angular.element('[old-admin-ng-dropdown]').removeClass('active');
+        angular.element('[old-admin-ng-dropdown]').not(this).removeClass('active');
         event.stopPropagation();
         if (!is_active) {
           angular.element(this).toggleClass('active');


### PR DESCRIPTION
The drop-down-menu in the adminUI now disappears after launching „Start Task“ dialog. 
This also works for:
- The language menu, 
- if you select ? → Keyboard shortcuts, 
- and the other links in that menu.

Added control for click event in modules/admin-ui/src/main/webapp/scripts/shared/directives/oldDropdownDirective.js 

This fixes #1642