### PR TITLE
Fixed double encoding of search-field in engage-ui

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -257,7 +257,7 @@ function($, bootbox, _, alertify, jsyaml) {
     // search query from form
     searchQuery = GetURLParameter('q') == undefined ? '' : 'q=' + GetURLParameter('q') + '&';
     log('Searching for: ' + searchQuery);
-    if (searchQuery != '') $('#searchInput').val(decodeURI(GetURLParameter('q')));
+    if (searchQuery != '') $('#searchInput').val(decodeURIComponent(GetURLParameter('q').replace(/\+/g, ' ')));
 
     // sort
     if (GetURLParameter('sort') == undefined) {


### PR DESCRIPTION
This PR should fix #1613 . The search parameter doesn't change anymore, after clicking the search button multiple times with the same input. This prevents double encoding of the search term. 

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
