### PR TITLE
Added reloading of filters in users page

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
@@ -21,8 +21,8 @@
 'use strict';
 
 angular.module('adminNg.controllers')
-.controller('UserCtrl', ['$rootScope', '$scope', 'Table', 'UserRolesResource', 'UserResource', 'UsersResource', 'JsHelper',
-  'Notifications', 'Modal', 'AuthService', 'underscore',
+.controller('UserCtrl', ['$rootScope', '$scope', 'Table', 'UserRolesResource', 'UserResource', 'UsersResource',
+  'JsHelper', 'Notifications', 'Modal', 'AuthService', 'underscore',
   function ($rootScope, $scope, Table, UserRolesResource, UserResource, UsersResource, JsHelper, Notifications, Modal,
     AuthService, _) {
     $scope.manageable = true;

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/userController.js
@@ -21,9 +21,9 @@
 'use strict';
 
 angular.module('adminNg.controllers')
-.controller('UserCtrl', ['$scope', 'Table', 'UserRolesResource', 'UserResource', 'UsersResource', 'JsHelper',
+.controller('UserCtrl', ['$rootScope', '$scope', 'Table', 'UserRolesResource', 'UserResource', 'UsersResource', 'JsHelper',
   'Notifications', 'Modal', 'AuthService', 'underscore',
-  function ($scope, Table, UserRolesResource, UserResource, UsersResource, JsHelper, Notifications, Modal,
+  function ($rootScope, $scope, Table, UserRolesResource, UserResource, UsersResource, JsHelper, Notifications, Modal,
     AuthService, _) {
     $scope.manageable = true;
     $scope.roleSlice = 100;
@@ -133,6 +133,7 @@ angular.module('adminNg.controllers')
         $scope.user.$update({ username: $scope.user.username }, function () {
           Notifications.add('success', 'USER_UPDATED');
           Modal.$scope.close();
+          $rootScope.$emit('user_changed');
         }, function () {
           Notifications.add('error', 'USER_NOT_SAVED', 'user-form');
         });
@@ -142,6 +143,7 @@ angular.module('adminNg.controllers')
           Modal.$scope.close();
           Notifications.add('success', 'USER_ADDED');
           Modal.$scope.close();
+          $rootScope.$emit('user_changed');
         }, function () {
           Notifications.add('error', 'USER_NOT_SAVED', 'user-form');
         });

--- a/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/usersController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/users/controllers/usersController.js
@@ -21,9 +21,9 @@
 'use strict';
 
 angular.module('adminNg.controllers')
-.controller('UsersCtrl', ['$scope', 'Table', 'UsersResource', 'UserResource', 'ResourcesFilterResource',
+.controller('UsersCtrl', ['$rootScope', '$scope', 'Table', 'UsersResource', 'UserResource', 'ResourcesFilterResource',
   'Notifications', 'Modal',
-  function ($scope, Table, UsersResource, UserResource, ResourcesFilterResource, Notifications, Modal) {
+  function ($rootScope, $scope, Table, UsersResource, UserResource, ResourcesFilterResource, Notifications, Modal) {
 
     $scope.table = Table;
     $scope.table.configure({
@@ -63,10 +63,16 @@ angular.module('adminNg.controllers')
       UserResource.delete({username: row.id}, function () {
         Table.fetch();
         Modal.$scope.close();
+        $scope.filters = ResourcesFilterResource.get({ resource: $scope.table.resource });
         Notifications.add('success', 'USER_DELETED');
       }, function () {
         Notifications.add('error', 'USER_NOT_DELETED');
       });
     };
+
+    $rootScope.$on('user_changed', function() {
+      $scope.filters = ResourcesFilterResource.get({ resource: $scope.table.resource });
+    });
+
   }
 ]);

--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/tableFilterDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/tableFilterDirective.js
@@ -69,6 +69,10 @@ angular.module('adminNg.directives')
         };
 
         scope.restoreFilters = function () {
+          scope.filters.map = {};
+          if (Object.keys(scope.filters.map).length === 0) {
+            scope.initializeMap();
+          }
           angular.forEach(scope.filters.filters, function (filter, name) {
             filter.value = Storage.get('filter', scope.namespace)[name];
 
@@ -80,11 +84,6 @@ angular.module('adminNg.directives')
         };
 
         scope.filters.$promise.then(function () {
-          scope.filters.map = {};
-          if (Object.keys(scope.filters.map).length === 0) {
-            scope.initializeMap();
-          }
-
           scope.restoreFilters();
         }).catch(angular.noop);
 
@@ -121,6 +120,7 @@ angular.module('adminNg.directives')
         };
 
         scope.selectFilterSelectValue = function (filter)  {
+          scope.restoreFilters();
           var filterName = scope.getFilterName();
           scope.showFilterSelector = false;
           scope.selectedFilter = null;


### PR DESCRIPTION
This PR should fix #1139 . The name of newly created/edited/deleted users in the filter menu does now update without having to reload the whole page. Since this is my first time working with angularjs, I am not entirely sure propagating through the rootScope is the best solution here. I guess using a service would work as well(?). 
Otherwise this should work just fine. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
