### PR TITLE
Fix for issue 1616: User keep write permission on ACL template selection

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -186,6 +186,19 @@ angular.module('adminNg.controllers')
             }
           });
 
+          // add policy to allow ROLE_USER_* to read and write
+          var userRole = Object.keys($scope.roles).filter(function(role){
+            return role.startsWith('ROLE_USER_') && role != 'ROLE_USER_ADMIN';
+          });
+          if (angular.isDefined(userRole) && userRole.length == 1){
+            userRole = userRole[0];
+            if (angular.isUndefined(newPolicies[userRole])){
+              newPolicies[userRole] = createPolicy(userRole);
+            }
+            newPolicies[userRole]['read'] = true;
+            newPolicies[userRole]['write'] = true;
+          }
+
           $scope.policies = [];
           angular.forEach(newPolicies, function (policy) {
             $scope.policies.push(policy);


### PR DESCRIPTION
This patch fixes the issue that non-admin user loose writing access to events on selecting an ACL template.
Changed function changePolicies() in eventController.js .
Added additional policy to allow ROLE_USER_<USERNAME> to read and write.

this fixes #1616
### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
