### PR TITLE
Admin interface event API logs on user error

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -2189,7 +2189,9 @@ public abstract class AbstractEventEndpoint {
             query.sortByEventStatus(criterion.getOrder());
             break;
           default:
-            throw new WebApplicationException(Status.BAD_REQUEST);
+            final String msg = String.format("Unknown sort criteria field %s", criterion.getFieldName());
+            logger.debug(msg);
+            return RestUtil.R.badRequest(msg);
         }
       }
     }


### PR DESCRIPTION
Requesting an invalid sort criteria from the admin interface like
`/admin-ng/event/events.json?limit=100&offset=0&sort=xy:ASC` causes
Opencast to log long stack traces. This allows users to clutter the
Opencast logs. Since this is a problem with the user request, Opencast
did not do anything wrong.

Therefore, this patch returns the error to the frontend instead and logs
this merely as a debug log.

This fixes  #1751

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
