### PR TITLE
Change markdown CI checks to bash

### DIFF
--- a/.style-and-markdown-build.sh
+++ b/.style-and-markdown-build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -ue
+
+ret=0
+
+cd "$(dirname $(realpath -s $0))"
+
+if grep -rn $'\t' modules assemblies pom.xml --include=pom.xml; then
+  echo "Tabs found!"
+  ret=1
+fi
+if grep -rn ' $' modules assemblies pom.xml --include=pom.xml; then
+  echo "Trailing spaces found!"
+  ret=1
+fi
+if grep -rn $'\t' etc; then
+  echo "Tabs found in config files!"
+  ret=1
+fi
+if grep -rn ' $' etc; then
+  echo "Trailing spaces found in config files!"
+  ret=1
+fi
+
+
+# build number must be present in all modules
+if ! grep -L '<Build-Number>${buildNumber}</Build-Number>' modules/*/pom.xml | wc -l | grep -q '^0$'; then
+  echo "Build number is missing from a module!"
+  ret=1
+fi
+
+# maven-dependency-plugin should be active for all new modules
+grep -L maven-dependency-plugin modules/*/pom.xml > maven-dependency-plugin.list
+if ! diff -q maven-dependency-plugin.list docs/checkstyle/maven-dependency-plugin.exceptions; then
+  ret=1
+fi
+
+cd docs/guides
+
+for docs in admin developer; do
+  cd $docs
+  echo "Markdown doc $docs build log:"
+  mkdocs build 2>&1 | tee mkdocs.log
+  if grep \
+       -e 'WARNING.*Documentation file' \
+       -e 'pages exist in the docs directory' \
+       -e 'is not found in the documentation files' \
+        mkdocs.log;
+    then
+      echo "$docs did not build correctly!"
+      ret=1
+  fi
+  cd ..
+done
+
+if ! npm test; then
+  echo "npm test failed!"
+  ret=1
+fi
+
+exit $ret

--- a/.style-and-markdown-build.sh
+++ b/.style-and-markdown-build.sh
@@ -31,14 +31,14 @@ if ! grep -L '<Build-Number>${buildNumber}</Build-Number>' modules/*/pom.xml | w
 fi
 
 # maven-dependency-plugin should be active for all new modules
-grep -L maven-dependency-plugin modules/*/pom.xml > maven-dependency-plugin.list
-if ! diff -q maven-dependency-plugin.list docs/checkstyle/maven-dependency-plugin.exceptions; then
-  ret=1
-fi
+#grep -L maven-dependency-plugin modules/*/pom.xml > maven-dependency-plugin.list
+#if ! diff -q maven-dependency-plugin.list docs/checkstyle/maven-dependency-plugin.exceptions; then
+#  ret=1
+#fi
 
 cd docs/guides
 
-for docs in admin developer; do
+for docs in admin developer user; do
   cd $docs
   echo "Markdown doc $docs build log:"
   mkdocs build 2>&1 | tee mkdocs.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,31 +68,7 @@ jobs:
         - pip install mkdocs markdown_inline_graphviz_extension mkdocs-windmill
         - (cd docs/guides && npm install)
       script:
-        - (! grep -rn '	' modules assemblies pom.xml --include=pom.xml)
-        - (! grep -rn ' $' modules assemblies pom.xml --include=pom.xml)
-        - (! grep -rn '	' etc)
-        - (! grep -rn ' $' etc)
-        # build number must be present in all modules
-        - grep -L '<Build-Number>${buildNumber}</Build-Number>' modules/*/pom.xml | wc -l | grep -q '^0$'
-        - >
-          ( cd docs/guides/admin &&
-            mkdocs build > mkdocs.log 2>&1 &&
-            ! grep 'WARNING.*Documentation file' mkdocs.log &&
-            ! grep 'pages exist in the docs directory' mkdocs.log &&
-            cat mkdocs.log )
-        - >
-          ( cd docs/guides/user &&
-            mkdocs build > mkdocs.log 2>&1 &&
-            ! grep 'WARNING.*Documentation file' mkdocs.log &&
-            ! grep 'pages exist in the docs directory' mkdocs.log &&
-            cat mkdocs.log )
-        - >
-          ( cd docs/guides/developer &&
-            mkdocs build > mkdocs.log 2>&1 &&
-            ! grep 'WARNING.*Documentation file' mkdocs.log &&
-            ! grep 'pages exist in the docs directory' mkdocs.log &&
-            cat mkdocs.log )
-        - (cd docs/guides && npm test)
+        - bash ./.style-and-markdown-build.sh
 
     # Test database scripts with MariaDB 10.x
     - stage: quick tests


### PR DESCRIPTION
This PR moves the markdown CI checks to a bash script rather than doing it with Travis.  This means that the script can be reused with Buildbot while also not breaking existing Travis compatibility.

This branch was developed on develop (9.x) which has a few additional checks, so I've added a commit to the tip here that should be reverted upon forward merge of 8.x.