### PR TITLE
User interface to sort by number of publications

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
@@ -78,9 +78,10 @@ angular.module('adminNg.controllers')
         label: 'EVENTS.EVENTS.TABLE.LOCATION',
         sortable: true
       }, {
-        name:  'published',
+        name:  'publication',
         label: 'EVENTS.EVENTS.TABLE.PUBLISHED',
-        template: 'modules/events/partials/publishedCell.html'
+        template: 'modules/events/partials/publishedCell.html',
+        sortable: true
       }, {
         template: 'modules/events/partials/eventsStatusCell.html',
         name:  'event_status',


### PR DESCRIPTION
This patch adds the user interface to allow for sorting events by the
number of publications. This allows for example to easily find events
without any publications.

This patch will only work once #1758 is merged to fix the broken
back-end.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
