### PR TITLE
Fix for issue 1280:  Notification of Newer Opencast Version in Admin UI

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -59,7 +59,12 @@
           <span id="error-count" class="badge" ng-show="services.error">{{ services.numErr }}</span>
           <ul class="dropdown-ul">
             <li ng-repeat="(key, value) in services.service"><!-- service directive -->
-              <a ng-click="toServices($event)" service-name="{{ key }}">
+              <a ng-if="key == 'Latest Version'" href="{{ value.docs_url }}" service-name="{{ key }}">
+                <span>{{ key }}</span>
+                <span class="ng-multi-value ng-multi-value-red" ng-if="value.error">{{ value.status }}</span>
+                <span class="ng-multi-value ng-multi-value-green" ng-if="!value.error">{{ value.status }}</span>
+              </a>
+              <a ng-if="key != 'Latest Version'" ng-click="toServices($event)" service-name="{{ key }}">
                 <span>{{ key }}</span>
                 <span class="ng-multi-value ng-multi-value-red" ng-if="value.error">{{ value.status }}</span>
                 <span class="ng-multi-value ng-multi-value-green" ng-if="!value.error">{{ value.status }}</span>

--- a/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
@@ -61,7 +61,7 @@ angular.module('adminNg.services')
           var my_version = response_my_version.data.version;
           var latest_version = response_latest_version.data;
           services.service[LATEST_VERSION_NAME].docs_url =
-            'https://docs.opencast.org/r/' + latest_version[0] + '.x/admin/';
+            'https://docs.opencast.org/r/' + parseInt(latest_version) + '.x/admin/';
 
           if (parseFloat(my_version) >= parseFloat(latest_version)
              || (my_version[0] == latest_version[0] && my_version.endsWith('SNAPSHOT'))) {

--- a/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
@@ -69,7 +69,7 @@ angular.module('adminNg.services')
           } else if (my_version[0] == latest_version[0]) {
             services.service[LATEST_VERSION_NAME].status = 'There is a minor update available.';
             services.service[LATEST_VERSION_NAME].error = true;
-          } else if (parseInt(latest_version[0]) - parseInt(my_version[0]) <= 2) {
+          } else if (parseInt(latest_version[0]) - parseInt(my_version[0]) < 2) {
             Monitoring.setError(LATEST_VERSION_NAME, 'There is a major update available.');
           } else {
             Monitoring.setError(LATEST_VERSION_NAME,

--- a/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
@@ -63,7 +63,8 @@ angular.module('adminNg.services')
           services.service[LATEST_VERSION_NAME].docs_url =
             'https://docs.opencast.org/r/' + latest_version[0] + '.x/admin/';
 
-          if (parseFloat(my_version) >= parseFloat(latest_version) || my_version.endsWith('SNAPSHOT')) {
+          if (parseFloat(my_version) >= parseFloat(latest_version)
+             || (my_version[0] == latest_version[0] && my_version.endsWith('SNAPSHOT'))) {
             services.service[LATEST_VERSION_NAME].status = OK;
             services.service[LATEST_VERSION_NAME].error = false;
           } else if (my_version[0] == latest_version[0]) {

--- a/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
@@ -29,6 +29,7 @@ angular.module('adminNg.services')
     numErr: 0
   };
 
+  var LATEST_VERSION_NAME = 'Latest Version';
   var AMQ_NAME = 'ActiveMQ';
   var STATES_NAME = 'Service States';
   var BACKEND_NAME = 'Backend Services';
@@ -36,6 +37,8 @@ angular.module('adminNg.services')
   var OK = 'OK';
   var SERVICES_FRAGMENT = '/systems/services';
   var SERVICE_NAME_ATTRIBUTE = 'service-name';
+  var LATEST_VERSION_PATH = 'oc-version/version.json';
+  var MY_VERSION_PATH = '/sysinfo/bundles/version?prefix=opencast';
 
   Monitoring.run = function() {
     //Clear existing data
@@ -45,6 +48,42 @@ angular.module('adminNg.services')
 
     Monitoring.getActiveMQStats();
     Monitoring.getBasicServiceStats();
+    Monitoring.getVersionStats();
+  };
+
+  Monitoring.getVersionStats = function() {
+    $http.get(MY_VERSION_PATH).then(function(response_my_version) {
+      $http.get(LATEST_VERSION_PATH).then(function(response_latest_version) {
+        Monitoring.populateService(LATEST_VERSION_NAME);
+
+        if (response_latest_version.status === 200 && response_my_version.status === 200
+        && response_my_version.data.consistent) {
+          var my_version = response_my_version.data.version;
+          var latest_version = response_latest_version.data;
+          services.service[LATEST_VERSION_NAME].docs_url =
+            'https://docs.opencast.org/r/' + latest_version[0] + '.x/admin/';
+
+          if (parseFloat(my_version) >= parseFloat(latest_version) || my_version.endsWith('SNAPSHOT')) {
+            services.service[LATEST_VERSION_NAME].status = OK;
+            services.service[LATEST_VERSION_NAME].error = false;
+          } else if (my_version[0] == latest_version[0]) {
+            services.service[LATEST_VERSION_NAME].status = 'There is a minor update available.';
+            services.service[LATEST_VERSION_NAME].error = true;
+          } else if (parseInt(latest_version[0]) - parseInt(my_version[0]) <= 2) {
+            Monitoring.setError(LATEST_VERSION_NAME, 'There is a major update available.');
+          } else {
+            Monitoring.setError(LATEST_VERSION_NAME,
+              'Version ' + my_version + ' of Opencast is no longer supported. Please update.');
+          }
+        } else {
+          Monitoring.setError(LATEST_VERSION_NAME, 'Version not found');
+          services.service[LATEST_VERSION_NAME].docs_url = 'https://docs.opencast.org';
+        }
+      });
+    }).catch(function(err) {
+      Monitoring.setError(LATEST_VERSION_NAME, err.statusText);
+      services.service[LATEST_VERSION_NAME].docs_url = 'https://docs.opencast.org';
+    });
   };
 
   Monitoring.getActiveMQStats = function() {
@@ -58,11 +97,7 @@ angular.module('adminNg.services')
         services.service[AMQ_NAME].error = true;
       }
     }).catch(function(err) {
-      Monitoring.populateService(AMQ_NAME);
-      services.service[AMQ_NAME].status = err.statusText;
-      services.service[AMQ_NAME].error = true;
-      services.error = true;
-      services.numErr++;
+      Monitoring.setError(AMQ_NAME, err.statusText);
     });
   };
 
@@ -126,7 +161,6 @@ angular.module('adminNg.services')
       serviceName = event.target.getAttribute(SERVICE_NAME_ATTRIBUTE);
     else
       serviceName = event.target.parentNode.getAttribute(SERVICE_NAME_ATTRIBUTE);
-
     if (serviceName != AMQ_NAME) {
       Storage.put('filter', 'services', 'actions', 'true');
       $location.path(SERVICES_FRAGMENT).replace();

--- a/modules/admin-ui-frontend/test/test/unit/shared/controllers/applicationControllerSpec.js
+++ b/modules/admin-ui-frontend/test/test/unit/shared/controllers/applicationControllerSpec.js
@@ -24,6 +24,7 @@ describe('Application controller', function () {
         $httpBackend.whenGET('/sysinfo/bundles/version?prefix=opencast').respond(
             {'buildNumber': '01b60ff', 'consistent': true, 'version': '1.6.0.SNAPSHOT'}
         );
+        $httpBackend.whenGET('oc-version/version.json').respond({'data': '1.6.0SNAPSHOT'});
         $httpBackend.whenGET('/broker/status').respond('{}');
         $httpBackend.whenGET('/services/services.json').respond(
                    {"services":

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/VersionEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/VersionEndpoint.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.adminui.endpoint;
+
+import static org.apache.http.HttpStatus.SC_OK;
+
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
+import org.opencastproject.util.doc.rest.RestService;
+
+import com.google.gson.Gson;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/")
+@RestService(name = "VersionService", title = "Version service",
+  abstractText = "Provides latest opencast version",
+  notes = { "This service offers the GET method to retrieve the latest opencast version from https://api.github.com ."})
+@Component(
+  immediate = true,
+  service = VersionEndpoint.class,
+  property = {
+    "service.description=Admin UI - Latest Version Endpoint",
+    "opencast.service.type=org.opencastproject.adminui.endpoint.VersionEndpoint",
+    "opencast.service.path=/admin-ng/oc-version"
+  }
+)
+public class VersionEndpoint {
+
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory.getLogger(VersionEndpoint.class);
+
+  /** The version */
+  private String version = "";
+
+  /** GitHub URL */
+  private String url = "https://api.github.com/repos/opencast/opencast/releases/latest";
+
+  /** The date */
+  private long lastUpdated = 0;
+
+  private static final Gson gson = new Gson();
+
+  /** OSGi callback. */
+  @Activate
+  protected void activate() {
+    logger.info("Activate the Admin ui - Latest version endpoint");
+  }
+
+  @GET
+  @Path("version.json")
+  @Produces(MediaType.APPLICATION_JSON)
+  @RestQuery(name = "latestversion", description = "Returns the latest Opencast version",
+          returnDescription = "Returns the latest Opencast version retrieved from GitHub",
+          reponses = { @RestResponse(responseCode = SC_OK, description = "The latest Opencast version.") })
+  public String getVersion() {
+    if (System.currentTimeMillis() / 1000L - lastUpdated >= 3600) {
+      updateVersion();
+    }
+    return gson.toJson(version);
+  }
+
+  private synchronized void updateVersion() {
+    if (System.currentTimeMillis() / 1000L - lastUpdated < 3600) {
+      return;
+    }
+    try {
+      HttpClient client = HttpClientBuilder.create().build();
+      HttpGet request = new HttpGet(url);
+      HttpResponse response = client.execute(request);
+      String responseString = IOUtils.toString(response.getEntity().getContent(), "utf-8");
+      Map data = gson.fromJson(responseString, Map.class);
+      version = (String) data.get("tag_name");
+      lastUpdated = System.currentTimeMillis() / 1000L;
+    } catch (Exception e) {
+      logger.error("Error while parsing the version: " + e.toString());
+    }
+  }
+}

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/VersionEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/VersionEndpoint.java
@@ -86,7 +86,7 @@ public class VersionEndpoint {
   @Produces(MediaType.APPLICATION_JSON)
   @RestQuery(name = "latestversion", description = "Returns the latest Opencast version",
           returnDescription = "Returns the latest Opencast version retrieved from GitHub",
-          reponses = { @RestResponse(responseCode = SC_OK, description = "The latest Opencast version.") })
+          responses = { @RestResponse(responseCode = SC_OK, description = "The latest Opencast version.") })
   public String getVersion() {
     if (System.currentTimeMillis() / 1000L - lastUpdated >= 3600) {
       updateVersion();

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/VersionEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/VersionEndpoint.java
@@ -107,7 +107,7 @@ public class VersionEndpoint {
       version = (String) data.get("tag_name");
       lastUpdated = System.currentTimeMillis() / 1000L;
     } catch (Exception e) {
-      logger.error("Error while parsing the version: " + e.toString());
+      logger.warn("Error while parsing the Opencast version from GitHub", e);
     }
   }
 }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/VersionEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/VersionEndpoint.java
@@ -68,7 +68,7 @@ public class VersionEndpoint {
   private String version = "";
 
   /** GitHub URL */
-  private String url = "https://api.github.com/repos/opencast/opencast/releases/latest";
+  private String url = "https://api.github.com/repos/opencast/opencast/releases";
 
   /** The date */
   private long lastUpdated = 0;
@@ -103,8 +103,14 @@ public class VersionEndpoint {
       HttpGet request = new HttpGet(url);
       HttpResponse response = client.execute(request);
       String responseString = IOUtils.toString(response.getEntity().getContent(), "utf-8");
-      Map data = gson.fromJson(responseString, Map.class);
-      version = (String) data.get("tag_name");
+      Map[] data = gson.fromJson(responseString, Map[].class);
+      double latestVersion = 0;
+      for (Map<String,Object> release : data) {
+        if (Double.parseDouble((String) release.get("tag_name")) > latestVersion) {
+          latestVersion = Double.parseDouble((String) release.get("tag_name"));
+          version = (String) release.get("tag_name");
+        }
+      }
       lastUpdated = System.currentTimeMillis() / 1000L;
     } catch (Exception e) {
       logger.warn("Error while parsing the Opencast version from GitHub", e);


### PR DESCRIPTION
This patch adds a notification in the admin UI (behind the bell) if there is a newer version of Opencast available.
The notification shows:
- if there is a new minor release (e.g. 8.4 -> 8.5)
- if there is a new major release (e.g. 7.4 -> 8.1)
- if your version is no longer supported (older than two major releases)

Added service in restServiceMonitor.js :
- compares your version to the latest version and adds notification accordingly.
- adds link in the notification to https://docs.opencast.org/r/<LATEST VERSION>/admin/ to enable the user to update if neccesary.

Added new endpoint at VersionEndpoint.java :
- retrieves latest version from https://api.github.com/repos/opencast/opencast/releases/latest .
- updates every hour.
- provides version via /admin-ng/oc-version/version.json .

This fixes #1280

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
