### PR TITLE
LTI Context Role Prefix

### DIFF
--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -73,10 +73,13 @@ because of the Opencast roles which they have. The Opencast LTI module grants an
 from the LTI parameters `context_id` and `roles`.
 
 The LTI context is typically the LMS course ID, and the default LTI role for a student in a course is `Learner`.
-The Opencast role granted would therefore be `SITEID_Learner`.
+The Opencast role granted would therefore be `<context-id>_Learner`.
 
 To make a series or video visible to students who access Opencast through LTI in an LMS course,
-add the role `SITEID_Learner` to the Series or Event Access Control List (ACL).
+add the role `<context-id>_Learner` to the series or event access control list (ACL).
+
+An additional prefix for these generated roles may be defined in Opencast's LTI configuration file based on the used
+OAuth consumer. That way, you can distinguish between users from multiple different consumers.
 
 LTI users may also have additional roles if the LTI user is created as an Opencast user in the Admin UI and
 given additional roles, or if one or more Opencast User Providers or Role Providers are configured.

--- a/etc/org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.cfg
+++ b/etc/org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.cfg
@@ -61,3 +61,17 @@
 #lti.custom_role_name=Instructor
 #This Role set is an example for a user which can open the editor for an event and upload videos via opencast studio.
 #lti.custom_roles=ROLE_ADMIN_UI,ROLE_API_EVENTS_METADATA_DELETE,ROLE_API_EVENTS_METADATA_EDIT,ROLE_API_EVENTS_METADATA_VIEW,ROLE_UI_EVENTS_DETAILS_COMMENTS_CREATE,ROLE_UI_EVENTS_DETAILS_COMMENTS_DELETE,ROLE_UI_EVENTS_DETAILS_COMMENTS_EDIT,ROLE_UI_EVENTS_DETAILS_COMMENTS_REPLY,ROLE_UI_EVENTS_DETAILS_COMMENTS_RESOLVE,ROLE_UI_EVENTS_DETAILS_COMMENTS_VIEW,ROLE_UI_EVENTS_EDITOR_EDIT,ROLE_UI_EVENTS_EDITOR_VIEW,ROLE_STUDIO
+
+# Prefix for LTI context based roles based on OAuth consumer keys.
+# The LTI context (e.g. the course identifier) is used to generate context roles like “12345_Learner”.
+# If multiple LTI consumers are used, this can clash, causing users from one consumer to get access to content from
+# another consumer. The prefix can be used to prevent this by generating context roles like “PREFIX1_123_Learner” and
+# “PREFIX2_123_Learner” instead.
+#
+# Context roles may not start with “ROLE_”. Avoid using that as a prefix.
+#
+# Default: No prefix
+#
+#lti.consumer_role_prefix.CONSUMERKEY0 = STUDIP_
+#lti.consumer_role_prefix.CONSUMERKEY1 = MOODLE_
+#lti.consumer_role_prefix.CONSUMERKEY2 = ILIAS_

--- a/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
+++ b/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
@@ -52,6 +52,7 @@ import org.springframework.security.oauth.provider.token.OAuthAccessProviderToke
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashSet;
@@ -134,6 +135,12 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
   /** A List of Roles to add to the user if he has the custom role name **/
   private static final String CUSTOM_ROLES = "lti.custom_roles";
 
+  /** Key prefix for configuring consumer role prefixes */
+  private static final String ROLE_PREFIX_KEY = "lti.consumer_role_prefix.";
+
+  /** Consumer role prefix store */
+  private final ConcurrentHashMap<String, String> rolePrefixes = new ConcurrentHashMap<>();
+
   private String customRoleName = "";
 
   private String[] customRoles;
@@ -187,7 +194,7 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
   protected void activate(ComponentContext cc) {
     logger.info("Activating LtiLaunchAuthenticationHandler");
     componentContext = cc;
-    Dictionary properties = cc.getProperties();
+    Dictionary<String, Object> properties = cc.getProperties();
 
     logger.debug("Updating LtiLaunchAuthenticationHandler");
 
@@ -240,6 +247,16 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
       customRoles = custumRolesString.split(",");
     }
 
+    // Allow configuring prefixes for certain consumer
+    for (String key: Collections.list(properties.keys())) {
+      if (key.startsWith(ROLE_PREFIX_KEY)) {
+        final String consumerKey = key.substring(ROLE_PREFIX_KEY.length());
+        final String prefix = Objects.toString(properties.get(key), "");
+        logger.debug("Adding role prefix '{}' for consumer using OAuth key '{}'", prefix, consumerKey);
+        rolePrefixes.put(consumerKey, prefix);
+      }
+    }
+
   }
 
   /**
@@ -270,8 +287,11 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
     // We need to construct a complex ID to avoid confusion
     String username = LTI_USER_ID_PREFIX + LTI_ID_DELIMITER + consumerGUID + LTI_ID_DELIMITER + userIdFromConsumer;
 
+    final String oaAuthKey = request.getParameter("oauth_consumer_key");
+
+    final String rolePrefix = rolePrefixes.getOrDefault(oaAuthKey, "");
+
     // if this is a trusted consumer we trust their details
-    String oaAuthKey = request.getParameter("oauth_consumer_key");
     if (highlyTrustedConsumerKeys.contains(oaAuthKey)) {
       logger.debug("{} is a trusted key", oaAuthKey);
 
@@ -315,7 +335,7 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
       // we still need to enrich this user with the LTI Roles
       String roles = request.getParameter(ROLES);
       String context = request.getParameter(CONTEXT_ID);
-      enrichRoleGrants(roles, context, userAuthorities);
+      enrichRoleGrants(roles, context, rolePrefix, userAuthorities);
     } catch (UsernameNotFoundException e) {
       logger.trace("This user is known to the tool consumer only. Creating an Opencast user on the fly.", e);
 
@@ -323,7 +343,7 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
       // We should add the authorities passed in from the tool consumer?
       String roles = request.getParameter(ROLES);
       String context = request.getParameter(CONTEXT_ID);
-      enrichRoleGrants(roles, context, userAuthorities);
+      enrichRoleGrants(roles, context, rolePrefix, userAuthorities);
 
       logger.info("Returning user with {} authorities", userAuthorities.size());
 
@@ -405,31 +425,25 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
    * @param userAuthorities
    *          Collection to append to.
    */
-  private void enrichRoleGrants(String roles, String context, Collection<GrantedAuthority> userAuthorities) {
-    // Roles could be a list
+  private void enrichRoleGrants(String roles, String context, final String rolePrefix,
+      Collection<GrantedAuthority> userAuthorities) {
     if (roles != null) {
+      // Roles could be a list
       String[] roleList = roles.split(",");
 
       // Use a generic context and learner if none is given:
       context = StringUtils.isBlank(context) ? DEFAULT_CONTEXT : context;
 
-      for (String learner : roleList) {
+      for (final String ltiRole : roleList) {
         // Build the role
-        String role;
-        String group;
-        if (learner.equals(customRoleName)) {
-          for (String rolename : customRoles) {
-            userAuthorities.add(new SimpleGrantedAuthority(rolename));
+        if (ltiRole.equals(customRoleName)) {
+          for (String roleName : customRoles) {
+            userAuthorities.add(new SimpleGrantedAuthority(roleName));
           }
         }
 
-        if (StringUtils.isBlank(learner)) {
-          role = context + "_" + DEFAULT_LEARNER;
-        } else {
-          role = context + "_" + learner;
-          group = "ROLE_GROUP_" + learner.toUpperCase();
-          logger.debug("Adding group: {}", group);
-        }
+        final String normalizedLtiRole = StringUtils.defaultIfBlank(ltiRole, DEFAULT_LEARNER);
+        final String role = rolePrefix + context + "_" + normalizedLtiRole;
 
         // Make sure to not accept ROLE_…
         if (role.trim().toUpperCase().startsWith("ROLE_")) {


### PR DESCRIPTION
This patch allows defining a prefix for LTI context based roles based on
OAuth consumer keys.

The LTI context (e.g. the course identifier) is used to generate context
roles like “12345_Learner”.  If multiple LTI consumers are used, this
can clash, causing users from one consumer to get access to content from
another consumer. The prefix can be used to prevent this by generating
context roles like “PREFIX1_123_Learner” and “PREFIX2_123_Learner”
instead.

The default is to use no prefix, making LTI in Opencast behave exactly
the way it used to.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
