### PR TITLE
Paella player should only list http(s) URLs in the download plugin

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.downloadsPlugin/mh_downloads.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.downloadsPlugin/mh_downloads.js
@@ -64,7 +64,7 @@ paella.addPlugin(function() {
         var download = false;
         if (track.tags != undefined && track.tags.tag != undefined
             && track.mimetype.indexOf('video') >= 0
-            && track.url.indexOf('rtmp://') < 0) {
+            && track.url.startsWith('http')) {
           for (var j = 0; j < track.tags.tag.length; j++) {
             if (track.tags.tag[j] === 'engage-download') {
               download = true;


### PR DESCRIPTION
As the media download should only be available for static (not streamed) content, we can expect the URLs in the Paella player should always begin with http. It implies that rtp, rtmp and rtmps URLs will not be shown.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
