### PR TITLE
Role Prefix in Moodle User Provider

### DIFF
--- a/etc/org.opencastproject.userdirectory.moodle-default.cfg.template
+++ b/etc/org.opencastproject.userdirectory.moodle-default.cfg.template
@@ -1,6 +1,6 @@
 # Moodle UserDirectoryProvider configuration
 
-# This is an an optional service which is not enabled by default. To enable it,
+# This is an optional service which is not enabled by default. To enable it,
 # edit etc/org.apache.karaf.features.cfg and add opencast-moodle to the featuresBoot option.
 
 # The organization for this provider
@@ -30,3 +30,12 @@ org.opencastproject.userdirectory.moodle.token=mytoken1234abcdef
 # same user in Moodle.
 # Default: false
 #org.opencastproject.userdirectory.moodle.user.lowercase.conversion=false
+
+# Context role and group prefix
+# Defines a prefix to prepend to context roles like “12345_Learner” and the main “ROLE_GROUP_MOODLE”. This can be used
+# to prevent role clashes in case multiple instances of Moodle are connected to Opencast which both could have the exact
+# same course identifier.
+# Effect on context roles: 123_Learner becomes <PREFIX>123_Learner
+# Effect on Moodle group: ROLE_GROUP_MOODLE becomes ROLE_GROUP_<PREFIX>MOODLE
+# Default: No prefix
+#org.opencastproject.userdirectory.moodle.context.role.prefix=

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
@@ -43,6 +43,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Dictionary;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.management.MalformedObjectNameException;
@@ -63,7 +64,7 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
   private static final Logger logger = LoggerFactory.getLogger(MoodleUserProviderFactory.class);
 
   /**
-   * The key to look up the organization identifer in the service configuration properties
+   * The key to look up the organization identifier in the service configuration properties
    */
   private static final String ORGANIZATION_KEY = "org.opencastproject.userdirectory.moodle.org";
 
@@ -111,6 +112,11 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
   private static final String LOWERCASE_USERNAME = "org.opencastproject.userdirectory.moodle.user.lowercase.conversion";
 
   /**
+   * Key for configuring a context role prefix
+   */
+  private static final String CONTEXT_ROLE_PREFIX = "org.opencastproject.userdirectory.moodle.context.role.prefix";
+
+  /**
    * The OSGI bundle context
    */
   protected BundleContext bundleContext = null;
@@ -133,7 +139,7 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
    * @throws NullPointerException
    * @throws MalformedObjectNameException
    */
-  public static final ObjectName getObjectName(String pid) throws MalformedObjectNameException, NullPointerException {
+  public static ObjectName getObjectName(String pid) throws MalformedObjectNameException, NullPointerException {
     return new ObjectName(pid + ":type=MoodleRequests");
   }
 
@@ -201,6 +207,8 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
     String groupPattern = (String) properties.get(GROUP_PATTERN_KEY);
     final boolean lowercaseUsername = BooleanUtils.toBoolean((String) properties.get(LOWERCASE_USERNAME));
 
+    final String contextRolePrefix = Objects.toString(properties.get(CONTEXT_ROLE_PREFIX), "");
+
     int cacheSize = 1000;
     try {
       if (properties.get(CACHE_SIZE) != null)
@@ -232,7 +240,8 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
 
     logger.debug("creating new MoodleUserProviderInstance for pid=" + pid);
     MoodleUserProviderInstance provider = new MoodleUserProviderInstance(pid, new MoodleWebServiceImpl(url, token), org,
-            coursePattern, userPattern, groupPattern, groupRoles, cacheSize, cacheExpiration, adminUserName, lowercaseUsername);
+        coursePattern, userPattern, groupPattern, groupRoles, cacheSize, cacheExpiration, adminUserName,
+        lowercaseUsername, contextRolePrefix);
 
     providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
     providerRegistrations.put(pid, bundleContext.registerService(RoleProvider.class.getName(), provider, null));

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderInstance.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderInstance.java
@@ -125,6 +125,11 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
   private String groupPattern;
 
   /**
+   * String to prepend to context roles like “1234_Learner”
+   */
+  private final String contextRolePrefix;
+
+  /**
    * A cache of users, which lightens the load on Moodle.
    */
   private LoadingCache<String, Object> cache;
@@ -162,10 +167,11 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
    * @param cacheSize       The number of users to cache.
    * @param cacheExpiration The number of minutes to cache users.
    * @param adminUserName   Name of the global admin user.
+   * @param contextRolePrefix Prefix to prepend to context roles like 1234_Learner
    */
   public MoodleUserProviderInstance(String pid, MoodleWebService client, Organization organization,
           String coursePattern, String userPattern, String groupPattern, boolean groupRoles, int cacheSize,
-          int cacheExpiration, String adminUserName, final boolean lowercaseUsername) {
+          int cacheExpiration, String adminUserName, final boolean lowercaseUsername, final String contextRolePrefix) {
     this.client = client;
     this.organization = organization;
     this.groupRoles = groupRoles;
@@ -173,6 +179,7 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
     this.userPattern = userPattern;
     this.groupPattern = groupPattern;
     this.lowercaseUsername = lowercaseUsername;
+    this.contextRolePrefix = contextRolePrefix;
 
     // initialize user filter
     this.ignoredUsernames = new ArrayList<>();
@@ -407,6 +414,11 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
     if (query.isEmpty())
       return Collections.emptyIterator();
 
+    // Verify query starts with prefix configured for this user provider instance
+    if (!query.startsWith(contextRolePrefix)) {
+      return Collections.emptyIterator();
+    }
+
     // Verify that role name ends with LEARNER_ROLE_SUFFIX or INSTRUCTOR_ROLE_SUFFIX
     if (exact
             && !query.endsWith("_" + LEARNER_ROLE_SUFFIX)
@@ -414,18 +426,19 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
             && !query.endsWith("_" + GROUP_ROLE_SUFFIX))
       return Collections.emptyIterator();
 
-    boolean findGroupRole = groupRoles && query.startsWith(GROUP_ROLE_PREFIX);
+    final String groupRolePrefix = contextRolePrefix + GROUP_ROLE_PREFIX;
+    final boolean findGroupRole = groupRoles && query.startsWith(groupRolePrefix);
 
     // Extract Moodle id
-    String moodleId = findGroupRole ? query.substring(GROUP_ROLE_PREFIX.length()) : query;
+    String moodleId = findGroupRole ? query.substring(groupRolePrefix.length()) : query;
     if (query.endsWith("_" + LEARNER_ROLE_SUFFIX)) {
-      moodleId = query.substring(0, query.lastIndexOf("_" + LEARNER_ROLE_SUFFIX));
+      moodleId = query.substring(contextRolePrefix.length(), query.lastIndexOf("_" + LEARNER_ROLE_SUFFIX));
       ltirole = true;
     } else if (query.endsWith("_" + INSTRUCTOR_ROLE_SUFFIX)) {
-      moodleId = query.substring(0, query.lastIndexOf("_" + INSTRUCTOR_ROLE_SUFFIX));
+      moodleId = query.substring(contextRolePrefix.length(), query.lastIndexOf("_" + INSTRUCTOR_ROLE_SUFFIX));
       ltirole = true;
     } else if (query.endsWith("_" + GROUP_ROLE_SUFFIX)) {
-      moodleId = query.substring(0, query.lastIndexOf("_" + GROUP_ROLE_SUFFIX));
+      moodleId = query.substring(contextRolePrefix.length(), query.lastIndexOf("_" + GROUP_ROLE_SUFFIX));
       ltirole = true;
     }
 
@@ -453,8 +466,8 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
       roles.add(new JaxbRole(query, jaxbOrganization, "Moodle Site Role", Role.Type.EXTERNAL));
     } else if (findGroupRole) {
       // Group ID
-      roles.add(new JaxbRole(GROUP_ROLE_PREFIX + moodleId + "_" + GROUP_ROLE_SUFFIX, jaxbOrganization,
-              "Moodle Group Learner Role", Role.Type.EXTERNAL));
+      roles.add(new JaxbRole(contextRolePrefix + GROUP_ROLE_PREFIX + moodleId + "_" + GROUP_ROLE_SUFFIX,
+          jaxbOrganization, "Moodle Group Learner Role", Role.Type.EXTERNAL));
     } else {
       // Course ID - return both roles
       roles.add(new JaxbRole(moodleId + "_" + INSTRUCTOR_ROLE_SUFFIX, jaxbOrganization,
@@ -517,28 +530,40 @@ public class MoodleUserProviderInstance implements UserProvider, RoleProvider, C
 
       // Create Opencast Objects
       Set<JaxbRole> roles = new HashSet<>();
-      roles.add(new JaxbRole(Group.ROLE_PREFIX + "MOODLE", jaxbOrganization, "Moodle Users", Role.Type.EXTERNAL_GROUP));
-      for (String courseId : courseIdsInstructor) {
-        roles.add(new JaxbRole(courseId + "_" + INSTRUCTOR_ROLE_SUFFIX, jaxbOrganization, "Moodle Course Instructor Role",
-                Role.Type.EXTERNAL));
+      roles.add(new JaxbRole(Group.ROLE_PREFIX + contextRolePrefix + "MOODLE", jaxbOrganization, "Moodle Users",
+          Role.Type.EXTERNAL_GROUP));
+      for (final String courseId : courseIdsInstructor) {
+        roles.add(contextRole(courseId, INSTRUCTOR_ROLE_SUFFIX, jaxbOrganization));
       }
-      for (String courseId : courseIdsLearner) {
-        roles.add(new JaxbRole(courseId + "_" + LEARNER_ROLE_SUFFIX, jaxbOrganization, "Moodle Course Learner Role",
-                Role.Type.EXTERNAL));
+      for (final String courseId : courseIdsLearner) {
+        roles.add(contextRole(courseId, LEARNER_ROLE_SUFFIX, jaxbOrganization));
       }
-      for (String groupId : groupIdsLearner) {
-        roles.add(new JaxbRole(GROUP_ROLE_PREFIX + groupId + "_" + GROUP_ROLE_SUFFIX, jaxbOrganization,
-                "Moodle Group Learner Role", Role.Type.EXTERNAL));
+      for (final String groupId : groupIdsLearner) {
+        roles.add(contextRole(GROUP_ROLE_PREFIX + groupId, GROUP_ROLE_SUFFIX, jaxbOrganization));
       }
 
       return new JaxbUser(moodleUser.getUsername(), null, moodleUser.getFullname(), moodleUser.getEmail(),
               this.getName(), jaxbOrganization, roles);
     } catch (Exception e) {
-      logger.warn("Exception loading Moodle user {} at {}: {}", username, client.getURL(), e.getMessage());
+      logger.warn("Exception loading Moodle user {} at {}", username, client.getURL());
     } finally {
       currentThread.setContextClassLoader(originalClassloader);
     }
 
     return null;
+  }
+
+  /**
+   * Create an Opencast JaxbRole based on a Moodle user's context.
+   *
+   * @param context Moodle user's context like course identifier
+   * @param contextRole Moodle user's context role like Instructor
+   * @param organization Opencast organization to create user for
+   * @return JaxbRole
+   */
+  private JaxbRole contextRole(final String context, final String contextRole, final JaxbOrganization organization) {
+    final String name = contextRolePrefix + context + "_" + contextRole;
+    final String description = "Moodle Course " + contextRole + " Role";
+    return new JaxbRole(name, organization, description, Role.Type.EXTERNAL);
   }
 }


### PR DESCRIPTION
This patch allows setting a role prefix in the Moodle user provider,
making it possible to distinguish between users from multiple Moodle
instances which are in courses with identical course identifiers (course
identifiers are not unique in Moodle).

For example, this user got roles from three different Moodle instances.
In all of which he belongs to course 3. Still, all the roles and groups
are now different:

```json
{
  "user": {
    "username": "b",
    "name": "b b",
    "email": "b@b.b",
    "provider": "moodle,moodle,moodle",
    "manageable": false,
    "roles": {
      "role": [
        {
          "name": "MOODLE_B_3_Learner",
          "description": "Moodle Course Learner Role",
          "organization-id": "mh_default_org",
          "type": "EXTERNAL"
        },
        {
          "name": "ROLE_ADMIN_UI",
          "organization-id": "mh_default_org",
          "type": "DERIVED"
        },
        {
          "name": "ROLE_GROUP_MOODLE_C_MOODLE",
          "description": "Moodle Users",
          "organization-id": "mh_default_org",
          "type": "EXTERNAL_GROUP"
        },
        {
          "name": "MOODLE_C_3_Learner",
          "description": "Moodle Course Learner Role",
          "organization-id": "mh_default_org",
          "type": "EXTERNAL"
        },
        {
          "name": "ROLE_USER_B",
          "description": "The user id role",
          "organization-id": "mh_default_org",
          "type": "SYSTEM"
        },
        {
          "name": "ROLE_USER",
          "description": "The authenticated user role",
          "organization-id": "mh_default_org",
          "type": "SYSTEM"
        },
        {
          "name": "ROLE_GROUP_MOODLE",
          "description": "Moodle Users",
          "organization-id": "mh_default_org",
          "type": "EXTERNAL_GROUP"
        },
        {
          "name": "3_Learner",
          "description": "Moodle Course Learner Role",
          "organization-id": "mh_default_org",
          "type": "EXTERNAL"
        },
        {
          "name": "ROLE_GROUP_MOODLE_B_MOODLE",
          "description": "Moodle Users",
          "organization-id": "mh_default_org",
          "type": "EXTERNAL_GROUP"
        }
      ]
    },
    "organization": { … }
  }
}
```
This is related to pull request #1764 which adds a similar functionality
for multiple LTI consumers.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
