### PR TITLE
Removed servicewarnings endpoint

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/ServiceRegistryEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/ServiceRegistryEndpoint.java
@@ -136,13 +136,6 @@ public class ServiceRegistryEndpoint {
     return getStatisticsAsJson();
   }
 
-  @GET
-  @Path("servicewarnings")
-  @RestQuery(name = "servicewarnings", description = "Get the number of services currently in a non-NORMAL state", returnDescription = "The count of abnormal services.", reponses = { @RestResponse(responseCode = SC_OK, description = "A plain text representation of the number of abnormal services") })
-  public long serviceWarnings() throws ServiceRegistryException {
-    return serviceRegistry.countOfAbnormalServices();
-  }
-
   @POST
   @Path("sanitize")
   @RestQuery(name = "sanitize", description = "Sets the given service to NORMAL state", returnDescription = "No content", restParameters = {


### PR DESCRIPTION
This PR fixes #1450 
The unused /services/servicewarnings endpoint is removed. 
Hence no more error message. 

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
