### PR TITLE
Properly parse boolean values

### DIFF
--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
@@ -28,6 +28,7 @@ import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.UserProvider;
 import org.opencastproject.util.NotFoundException;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
@@ -189,10 +190,8 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
     if (StringUtils.isBlank(token))
       throw new ConfigurationException(MOODLE_TOKEN_KEY, "is not set");
 
-    boolean groupRoles = false;
-    String groupRolesStr = (String) properties.get(GROUP_ROLES_KEY);
-    if ("true".equals(groupRolesStr))
-      groupRoles = true;
+    final String groupRolesStr = (String) properties.get(GROUP_ROLES_KEY);
+    final boolean groupRoles = BooleanUtils.toBoolean(groupRolesStr);
 
     String coursePattern = (String) properties.get(COURSE_PATTERN_KEY);
     String userPattern = (String) properties.get(USER_PATTERN_KEY);


### PR DESCRIPTION
This patch switches to using BooleanUtils for parsing boolean values
from configuration files instead of doing a string comparison. This
means that a string like `True` will not become the boolean value
`false` which is pretty confusing.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
