### PR TITLE
Remove JDOM From Ingest Service

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -72,10 +72,6 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
     <bundle>mvn:org.codehaus.jettison/jettison/1.4.0</bundle>
     <bundle>mvn:org.codehaus.groovy/groovy/2.4.3</bundle>
-    <!-- At least ingest-service-impl need JDOM in version 1.x -->
-    <!-- JDOM 1.x updates will be bug fixes as new features are gone to 2.x (see http://www.jdom.org/) -->
-    <bundle>mvn:org.jdom/com.springsource.org.jdom/1.1.0</bundle>
-    <!-- At least search-service-impl need JDOM in version 2.x -->
     <bundle>mvn:org.jdom/com.springsource.org.jdom/2.0.1</bundle>
     <bundle>mvn:org.opencastproject/android-mms/1.2</bundle>
     <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/${json-simple.version}</bundle>

--- a/docs/checkstyle/maven-dependency-plugin.exceptions
+++ b/docs/checkstyle/maven-dependency-plugin.exceptions
@@ -8,7 +8,6 @@ modules/db/pom.xml
 modules/distribution-service-aws-s3/pom.xml
 modules/external-api/pom.xml
 modules/index-service/pom.xml
-modules/ingest-service-impl/pom.xml
 modules/oaipmh-persistence/pom.xml
 modules/publication-service-youtube-v3/pom.xml
 modules/scheduler-impl/pom.xml

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -69,10 +69,6 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
@@ -128,6 +124,19 @@
       <artifactId>commons-fileupload</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-working-file-repository-service-impl</artifactId>
       <version>${project.version}</version>
@@ -147,13 +156,20 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>com.springsource.org.jdom</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- provide a logger for tests -->
+            <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>


### PR DESCRIPTION
This patch removes JDOM from the ingest service, making Opencast use one
less XML library. As discussed on list, this breaks compatibility with
zipped Matterhorn ≤ 1.3 media packages.

In case there are still such media around, ingest the media by
extracting the zip archive and adding the files one by one.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
