### PR TITLE
Remove Unused Servicewarnings Backend

### DIFF
--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
@@ -78,9 +78,7 @@ import javax.persistence.UniqueConstraint;
         @NamedQuery(name = "ServiceRegistration.relatedservices.warning_error", query = "SELECT rh FROM ServiceRegistration rh "
                 + "WHERE rh.serviceType = :serviceType AND (rh.serviceState = 1 OR rh.serviceState = 2)"),
         @NamedQuery(name = "ServiceRegistration.relatedservices.warning", query = "SELECT rh FROM ServiceRegistration rh "
-                + "WHERE rh.serviceType = :serviceType AND rh.serviceState = 1"),
-        @NamedQuery(name = "ServiceRegistration.countNotNormal", query = "SELECT count(rh) FROM ServiceRegistration rh "
-                + "WHERE rh.serviceState <> 0 AND rh.hostRegistration.active = true") })
+                + "WHERE rh.serviceType = :serviceType AND rh.serviceState = 1") })
 public class ServiceRegistrationJpaImpl implements ServiceRegistration {
 
   /** The logger */

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistry.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistry.java
@@ -542,14 +542,6 @@ public interface ServiceRegistry {
   List<ServiceStatistics> getServiceStatistics() throws ServiceRegistryException;
 
   /**
-   * Gets the count of the number of abnormal services across the whole system.
-   *
-   * @return the count of abnormal services
-   * @throws ServiceRegistryException
-   */
-  long countOfAbnormalServices() throws ServiceRegistryException;
-
-  /**
    * Count the number of jobs that match the specified parameters.
    *
    * @param serviceType

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
@@ -818,16 +818,6 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
   /**
    * {@inheritDoc}
    *
-   * @see org.opencastproject.serviceregistry.api.ServiceRegistry#countOfAbnormalServices()
-   */
-  @Override
-  public long countOfAbnormalServices() throws ServiceRegistryException {
-    throw new UnsupportedOperationException("Operation not yet implemented");
-  }
-
-  /**
-   * {@inheritDoc}
-   *
    * @see org.opencastproject.serviceregistry.api.ServiceRegistry#count(java.lang.String,
    *      org.opencastproject.job.api.Job.Status)
    */

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -2088,27 +2088,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /**
    * {@inheritDoc}
    *
-   * @see org.opencastproject.serviceregistry.api.ServiceRegistry#countOfAbnormalServices()
-   */
-  @Override
-  public long countOfAbnormalServices() throws ServiceRegistryException {
-    EntityManager em = null;
-    try {
-      em = emf.createEntityManager();
-      Query query = em.createNamedQuery("ServiceRegistration.countNotNormal");
-      Number count = (Number) query.getSingleResult();
-      return count.longValue();
-    } catch (Exception e) {
-      throw new ServiceRegistryException(e);
-    } finally {
-      if (em != null)
-        em.close();
-    }
-  }
-
-  /**
-   * {@inheritDoc}
-   *
    * @see org.opencastproject.serviceregistry.api.ServiceRegistry#getServiceStatistics()
    */
   @Override


### PR DESCRIPTION
Pull request #1786 removed the broken and unused servicewarnings
endpoint but missed removing the thereafter unused backend for that
endpoint in the service registry. This patch catches up on that.

This is related to #1450.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
