### PR TITLE
Missing ACL after asset upload

### DIFF
--- a/etc/workflows/publish-uploaded-assets.xml
+++ b/etc/workflows/publish-uploaded-assets.xml
@@ -35,7 +35,9 @@
       exception-handler-workflow="partial-error"
       description="Update recording in Opencast Media Module">
       <configurations>
-        <configuration key="download-source-flavors">${download-source-flavors}</configuration>
+        <configuration key="download-source-flavors">${download-source-flavors},dublincore/*,security/*</configuration>
+        <configuration key="download-source-tags">engage-download</configuration>
+        <configuration key="streaming-source-tags">engage-streaming</configuration>
         <configuration key="strategy">merge</configuration>
         <configuration key="check-availability">false</configuration>
       </configurations>


### PR DESCRIPTION
This patch fixes a bug in the asset upload workflow which would cause
additional assets including access control lists to be removed from the
published media, causing the published media to become accessible by
admins only.

Thus broken events could be fixed by running the re-pusblish metadata
workflow which would already ensure that all necessary assets are
published again.

This patch now includes access control lists, Dublin Core catalogs and
assets marked for publication in the first place, making the workaround
unnecessary.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
