### PR TITLE
Add a 'defaultValue' to getComponentContextProperty

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/OsgiUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/OsgiUtil.java
@@ -39,6 +39,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.servlet.Servlet;
 
@@ -82,6 +83,14 @@ public final class OsgiUtil {
     if (StringUtils.isBlank(p))
       throw new RuntimeException("Please provide context property " + key);
     return StringUtils.trimToEmpty(p);
+  }
+
+  /**
+   * Get a mandatory, non-blank value from the <em>component</em> context.
+   * In case the propertie is not defined (null), the default value will be returned.
+   */
+  public static String getComponentContextProperty(ComponentContext cc, String key, String defaultValue) {
+    return Objects.toString(cc.getProperties().get(key), defaultValue);
   }
 
   /**


### PR DESCRIPTION
Usually, properties were loaded from cfg files.
Some of them may have default values or allow empty.
Yet, the code to set default value if redundant.

This PR can make it easy to load such properties.

Here's an example, to property 'endpoint' actually is optional for AWS S3 distruibution.
To handle it properly, the code may be
```Java
String endpoint = "";
try {
  endpoint = OsgiUtil.getComponentContextProperty(cc, "endpoint");
} catch (RuntimeException e) {
  endpoint = "";
}
```
With the new method, this can be easily written as
```Java
String endpoint = OsgiUtil.getComponentContextProperty(cc, "endpoint", "");
```


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
