### PR TITLE
Ensure User Roles

### DIFF
--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
@@ -41,10 +41,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
 
 import java.lang.management.ManagementFactory;
+import java.util.Arrays;
 import java.util.Dictionary;
+import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.management.MalformedObjectNameException;
@@ -207,10 +210,15 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
     // optional with default values
     String rolePrefix = Objects.toString(properties.get(ROLE_PREFIX_KEY), "ROLE_");
     String[] excludePrefixes = StringUtils.split((String) properties.get(EXCLUDE_PREFIXES_KEY), ",");
-    String[] extraRoles =  StringUtils.split(Objects.toString(properties.get(EXTRA_ROLES_KEY), ""), ",");
     boolean convertToUppercase = BooleanUtils.toBoolean(Objects.toString(properties.get(UPPERCASE_KEY), "true"));
     int cacheSize = NumberUtils.toInt((String) properties.get(CACHE_SIZE), 1000);
     int cacheExpiration = NumberUtils.toInt((String) properties.get(CACHE_EXPIRATION), 5);
+
+    // extra roles
+    String[] extraRoles =  StringUtils.split(Objects.toString(properties.get(EXTRA_ROLES_KEY), ""), ",");
+    Set<String> extraRoleSet = new HashSet<>(Arrays.asList(extraRoles));
+    extraRoleSet.addAll(Arrays.asList("ROLE_ANONYMOUS", "ROLE_USER"));
+    extraRoles = extraRoleSet.toArray(new String[extraRoles.length]);
 
     // Now that we have everything we need, go ahead and activate a new provider, removing an old one if necessary
     ServiceRegistration existingRegistration = providerRegistrations.remove(pid);


### PR DESCRIPTION
All users accessing Opencast regardless of being logged in or not should
get ROLE_ANONYMOUS to allow for anonymous access to certain public parts
of Opencast. All users logged in to Opencast should have ROLE_USER
regardless of the login method.

This is currently not true for LDAP which instead relies on the
configuration fixing the problem which can have weird side-effects like
a user not being able to watch public content after logging in.

This patch fixes the problem by always providing logged in users with
ROLE_USER and ROLE_ANONYMOUS as users would expect.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
