### PR TITLE
Fix capture agent dropdown menus

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/edit-events-modal.html
@@ -186,7 +186,7 @@
                             data-width="'200px'"
                             ng-change="roomChanged();"
                             ng-model="scheduling[wd].location"
-                            ng-options="value.name for (id, value) in captureAgents | filter:hasAgentAccess"
+                            ng-options="ca.name for ca in captureAgents | filter:hasAgentAccess track by ca.id"
                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
                             />
                   </td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/event-details.html
@@ -342,7 +342,7 @@
                           data-width="'200px'"
                           ng-change="roomChanged(); saveScheduling()"
                           ng-model="source.device"
-                          ng-options="value.name for (id, value) in captureAgents | filter:currentAgentOrAccess"
+                          ng-options="ca.name for ca in captureAgents | filter:currentAgentOrAccess track by ca.id"
                           placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
                           />
                 </td>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/wizards/new-event.html
@@ -258,7 +258,7 @@
                         ng-disabled="wizard.step.checkingConflicts"
                         ng-change="wizard.step.roomChanged(); wizard.step.checkConflicts()"
                         ng-model="wizard.step.ud.SCHEDULE_SINGLE.device"
-                        ng-options="value.name for (id, value) in wizard.step.captureAgents | filter:wizard.step.hasAgentAccess"
+                        ng-options="ca.name for ca in wizard.step.captureAgents | filter:wizard.step.hasAgentAccess track by ca.id"
                         placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
                         >
                         <option value=""></option>
@@ -405,7 +405,7 @@
                         tabindex="19"
                         ng-change="wizard.step.roomChanged(); wizard.step.checkConflicts()"
                         ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.device"
-                        ng-options="value.name for (id, value) in wizard.step.captureAgents | filter:wizard.step.hasAgentAccess"
+                        ng-options="ca.name for ca in wizard.step.captureAgents | filter:wizard.step.hasAgentAccess track by ca.id"
                         placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
                         >
                         <option value=""></option>


### PR DESCRIPTION
This fixes #1845. Without this fix, the capture agent dropdown menu in the scheduling tab of the New Event dialog is broken: 
If you change your selection, either a different capture agent is picked than the one you actually selected (which is... very bad, because you might not notice this at all until much later) or the selection fails with an error. (For more details on how to reproduce this see the issue description.)

I also edited the ng-options of the capture agent dropdown menus in Event Details and Edit Scheduled Events, even though these weren't affected, to keep things consistent. It doesn't do any harm and is imo easier to understand.