### PR TITLE
Fix conflict checking for scheduled events in multitenant systems

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1066,7 +1066,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   public List<MediaPackage> findConflictingEvents(String captureDeviceID, Date startDate, Date endDate)
       throws SchedulerException {
     try {
-      final Organization organization = new DefaultOrganization();
+      final Organization organization = securityService.getOrganization();
       final User user = SecurityUtil.createSystemUser(systemUserName, organization);
       List<MediaPackage> conflictingEvents = new ArrayList();
 


### PR DESCRIPTION
A small change in #1248 broke conflict checking for scheduled events in multitenant systems: 
The default organization is set for the security context, so that organization is used to look for conflicting events in the database, which can't be found that way.

This PR reverts the responsible commit and closes #1850.
