### PR TITLE
Fix Version Check

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -59,10 +59,9 @@
           <span id="error-count" class="badge" ng-show="services.error">{{ services.numErr }}</span>
           <ul class="dropdown-ul">
             <li ng-repeat="(key, value) in services.service"><!-- service directive -->
-              <a ng-if="key == 'Latest Version'" href="{{ value.docs_url }}" service-name="{{ key }}">
-                <span>{{ key }}</span>
-                <span class="ng-multi-value ng-multi-value-red" ng-if="value.error">{{ value.status }}</span>
-                <span class="ng-multi-value ng-multi-value-green" ng-if="!value.error">{{ value.status }}</span>
+              <a ng-if="key == 'Latest Version' && value.error" href="{{ value.docs_url }}" service-name="{{ key }}">
+                <span>Opencast</span>
+                <span class="ng-multi-value ng-multi-value-red">{{ value.status }}</span>
               </a>
               <a ng-if="key != 'Latest Version'" ng-click="toServices($event)" service-name="{{ key }}">
                 <span>{{ key }}</span>

--- a/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
@@ -20,8 +20,7 @@
  */
 'use strict';
 
-angular.module('adminNg.services')
-.factory('RestServiceMonitor', ['$http', '$location', 'Storage', function($http, $location, Storage) {
+function monitorService($http, $location, $translate, Storage) {
   var Monitoring = {};
   var services = {
     service: {},
@@ -58,26 +57,33 @@ angular.module('adminNg.services')
 
         if (response_latest_version.status === 200 && response_my_version.status === 200
         && response_my_version.data.consistent) {
-          var my_version = response_my_version.data.version;
-          var latest_version = response_latest_version.data;
+          var my_version = response_my_version.data.version,
+              latest_version = response_latest_version.data;
           services.service[LATEST_VERSION_NAME].docs_url =
             'https://docs.opencast.org/r/' + parseInt(latest_version) + '.x/admin/';
 
           if (parseFloat(my_version) >= parseFloat(latest_version)
-             || (my_version[0] == latest_version[0] && my_version.endsWith('SNAPSHOT'))) {
+             || (parseInt(my_version) == parseInt(latest_version) && my_version.endsWith('SNAPSHOT'))) {
             services.service[LATEST_VERSION_NAME].status = OK;
             services.service[LATEST_VERSION_NAME].error = false;
-          } else if (my_version[0] == latest_version[0]) {
-            services.service[LATEST_VERSION_NAME].status = 'There is a minor update available.';
+          } else if (parseInt(my_version) == parseInt(latest_version)) {
+            $translate('UPDATE.MINOR').then(function(translation) {
+              services.service[LATEST_VERSION_NAME].status = translation;
+            }).catch(angular.noop);
             services.service[LATEST_VERSION_NAME].error = true;
-          } else if (parseInt(latest_version[0]) - parseInt(my_version[0]) < 2) {
-            Monitoring.setError(LATEST_VERSION_NAME, 'There is a major update available.');
+          } else if (parseInt(latest_version) - parseInt(my_version) < 2) {
+            $translate('UPDATE.MAJOR').then(function(translation) {
+              Monitoring.setError(LATEST_VERSION_NAME, translation);
+            }).catch(angular.noop);
           } else {
-            Monitoring.setError(LATEST_VERSION_NAME,
-              'Version ' + my_version + ' of Opencast is no longer supported. Please update.');
+            $translate('UPDATE.UNSUPPORTED', {'version': my_version}).then(function(translation) {
+              Monitoring.setError(LATEST_VERSION_NAME, translation);
+            }).catch(angular.noop);
           }
         } else {
-          Monitoring.setError(LATEST_VERSION_NAME, 'Version not found');
+          $translate('UPDATE.UNDETERMINED').then(function(translation) {
+            Monitoring.setError(LATEST_VERSION_NAME, translation);
+          }).catch(angular.noop);
           services.service[LATEST_VERSION_NAME].docs_url = 'https://docs.opencast.org';
         }
       });
@@ -173,4 +179,7 @@ angular.module('adminNg.services')
   };
 
   return Monitoring;
-}]);
+}
+
+angular.module('adminNg.services')
+.factory('RestServiceMonitor', ['$http', '$location', '$translate', 'Storage', monitorService]);

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -16,6 +16,12 @@
    "SELECT_NO_OPTIONS_AVAILABLE": "No options available",
    "YES":          "Yes",
    "COPY":         "Copy to clipboard",
+   "UPDATE": {
+     "MINOR": "Minor update available",
+     "MAJOR": "Major update available",
+     "UNSUPPORTED": "Version {{ version }} no longer supported",
+     "UNDETERMINED": "Indeterminable version"
+   },
    "LTI": {
      "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",
      "SERIES_TITLE": "Edit series",


### PR DESCRIPTION
This patch fixes the check for new updates of Opencast:

- It prevents the code from printing `Latest version` as service name in
  the list of notifications when Opencast is up-to-date
- It fixes the handling of versions numbers greater version 9
- It introduces translations for the warnings

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
