### PR TITLE
Remove Spring's Patched JDOM

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -1282,7 +1282,6 @@ ingest-service-impl
   org.apache.commons                     commons-lang3                                    Apache License, Version 2.0
   org.apache.cxf                         cxf-rt-frontend-jaxrs                            Apache License, Version 2.0
   org.apache.felix                       org.apache.felix.fileinstall                     Apache License, Version 2.0
-  org.jdom                               com.springsource.org.jdom                        -
   org.slf4j                              slf4j-api                                        MIT License
 
 
@@ -1530,7 +1529,6 @@ publication-service-youtube-v3
   javax.servlet                          javax.servlet-api                                CDDL + GPLv2 with classpath exception
   org.apache.felix                       org.apache.felix.http.bundle                     -
   org.codehaus.jackson                   jackson-mapper-asl                               The Apache Software License, Version 2.0
-  org.jdom                               com.springsource.org.jdom                        -
   org.sakaiproject.nakamura              javax.activation-mail                            -
   org.slf4j                              slf4j-api                                        MIT License
 
@@ -1631,7 +1629,7 @@ search-service-impl
   org.apache.solr                        solr-solrj                                       Apache 2
   org.eclipse.persistence                jakarta.persistence                              Eclipse Public License v. 2.0-Eclipse Distribution License v. 1.0
   org.eclipse.persistence                org.eclipse.persistence.core                     Eclipse Public License v. 2.0-Eclipse Distribution License v. 1.0
-  org.jdom                               com.springsource.org.jdom                        -
+  org.jdom                               jdom2                                            -
   org.slf4j                              slf4j-api                                        MIT License
 
 

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -72,7 +72,6 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlschema/1.4.3_1</bundle>
     <bundle>mvn:org.codehaus.jettison/jettison/1.4.0</bundle>
     <bundle>mvn:org.codehaus.groovy/groovy/2.4.3</bundle>
-    <bundle>mvn:org.jdom/com.springsource.org.jdom/2.0.1</bundle>
     <bundle>mvn:org.opencastproject/android-mms/1.2</bundle>
     <bundle>wrap:mvn:com.googlecode.json-simple/json-simple/${json-simple.version}</bundle>
 

--- a/docs/checkstyle/maven-dependency-plugin.exceptions
+++ b/docs/checkstyle/maven-dependency-plugin.exceptions
@@ -12,6 +12,5 @@ modules/oaipmh-persistence/pom.xml
 modules/publication-service-youtube-v3/pom.xml
 modules/scheduler-impl/pom.xml
 modules/search/pom.xml
-modules/search-service-impl/pom.xml
 modules/security-shibboleth/pom.xml
 modules/solr/pom.xml

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -31,11 +31,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-workflow-service-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-dublincore</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -103,10 +98,6 @@
       <version>${project.oauth.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>com.springsource.org.jdom</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.sakaiproject.nakamura</groupId>
       <artifactId>javax.activation-mail</artifactId>
       <version>1.1.1.1.4.2-1.4.2</version>
@@ -157,7 +148,6 @@
             <Build-Number>${buildNumber}</Build-Number>
             <Private-Package>
               com.google.*;-split-package:=merge-first,
-              org.jdom.*,
             </Private-Package>
             <Export-Package>
               org.opencastproject.publication.youtube.*;version=${project.version},

--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -41,6 +41,21 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workspace-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-metadata-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-mpeg7</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -48,11 +63,18 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common-jpa-impl</artifactId>
       <version>${project.version}</version>
-      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -61,20 +83,6 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.solr</groupId>
-      <artifactId>solr-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>woodstox</groupId>
-          <artifactId>wstx-asl</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.solr</groupId>
-      <artifactId>solr-solrj</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
@@ -105,8 +113,8 @@
     </dependency>
     <dependency>
       <groupId>org.jdom</groupId>
-      <artifactId>com.springsource.org.jdom</artifactId>
-      <version>2.0.1</version>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -138,23 +146,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.asm</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>org.eclipse.persistence.antlr</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.mchange</groupId>
-      <artifactId>c3p0</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -164,6 +157,21 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- Feed generation runtime dependencies; JDOM is a ROME dependency -->
+            <ignoredUnusedDeclaredDependency>com.rometools:rome-utils</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.jdom:jdom2</ignoredUnusedDeclaredDependency>
+            <!-- provide logger and database for testing -->
+            <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>com.h2database:h2</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>de.empulse.eclipselink</groupId>
         <artifactId>staticweave-maven-plugin</artifactId>
@@ -177,6 +185,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              !org.jaxen*,
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,
               *
@@ -190,6 +199,7 @@
               rome;inline=true,
               rome-modules;inline=true,
               rome-utils;inline=true,
+              jdom2;inline=true,
               itunes;inline=true
             </Embed-Dependency>
             <Service-Component>

--- a/pom.xml
+++ b/pom.xml
@@ -1169,11 +1169,6 @@
         <version>1.6</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>org.jdom</groupId>
-        <artifactId>com.springsource.org.jdom</artifactId>
-        <version>1.1.0</version>
-      </dependency>
       <!-- logging -->
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This patch removes the JDOM implementation taken from Spring and
replaces it – where necessary – with the default implementation
available from Maven Central.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
