### PR TITLE
Fix error while searching episode by browser

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -270,6 +270,8 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
       }
     }
 
+    seriesName = StringUtils.trimToNull(seriesName);
+    seriesId = StringUtils.trimToNull(seriesId);
     if (seriesName != null && seriesId != null) {
       return Response.status(Response.Status.BAD_REQUEST).entity("invalid request, both 'sid' and 'sname' specified")
               .build();


### PR DESCRIPTION
Description:
While invoking REST API via browser to search episode by series, a 400 error returns.
This patch fix the problem.

Test Plan:

1. Go to https://develop.opencast.org/docs.html?path=/search

2. Open the form for GET /episode.{format:xml|json}
Input **Format** with **json** , **sid** with **foo** and leave **admin** unchecked.

3. Submit the form, and get a response **Status: 400 (error)**

Expected Behavior:
Get a response with status code 200, and an empty search result list.

Interesting Fact:
This API works good in [stable](https://stable.opencast.org/docs.html?path=/search), and the code is almost same as develop branch.



### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
