### PR TITLE
Creating a new series doesn't send user collections anymore

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/eventController.js
@@ -742,6 +742,16 @@ angular.module('adminNg.controllers')
 
     $scope.metadataSave = function (id, callback, catalog) {
       catalog.attributeToSend = id;
+
+      if (Object.prototype.hasOwnProperty.call(catalog, 'fields')) {
+        for (var fieldNo in catalog.fields) {
+          var field = catalog.fields[fieldNo];
+          if (Object.prototype.hasOwnProperty.call(field, 'collection')) {
+            field.collection = [];
+          }
+        }
+      }
+
       EventMetadataResource.save({ id: $scope.resourceId }, catalog,  function () {
         if (angular.isDefined(callback)) {
           callback();

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/newSeriesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/newSeriesController.js
@@ -30,6 +30,12 @@ angular.module('adminNg.controllers')
     function pushAllPropertiesIntoArray(object, array) {
       for (var o in object) {
         if (Object.prototype.hasOwnProperty.call(object, o)) {
+          for (var fieldNo in object[o].fields) {
+            var field = object[o].fields[fieldNo];
+            if (Object.prototype.hasOwnProperty.call(field, 'collection')) {
+              field.collection = [];
+            }
+          }
           array.push(object[o]);
         }
       }

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/serieController.js
@@ -333,6 +333,15 @@ angular.module('adminNg.controllers')
     $scope.metadataSave = function (id, callback, catalog) {
       catalog.attributeToSend = id;
 
+      if (Object.prototype.hasOwnProperty.call(catalog, 'fields')) {
+        for (var fieldNo in catalog.fields) {
+          var field = catalog.fields[fieldNo];
+          if (Object.prototype.hasOwnProperty.call(field, 'collection')) {
+            field.collection = [];
+          }
+        }
+      }
+
       SeriesMetadataResource.save({ id: $scope.resourceId }, catalog,  function () {
         if (angular.isDefined(callback)) {
           callback();


### PR DESCRIPTION
fixes #1754 

When creating a new series, all users that were send to the frontend, were also send back again. This causes problems when there are too many users. The collections are not needed in the backend as it seems, so they wouln't be send back anymore.