### PR TITLE
Automerge ESLint Updates

### DIFF
--- a/.github/workflows/automerge-eslint.yml
+++ b/.github/workflows/automerge-eslint.yml
@@ -1,0 +1,18 @@
+name: automerge linter updates
+on: pull_request
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: tell dependabot to merge eslint updates if ci succeeds
+        uses: actions/github-script@0.3.0
+        if: >
+          github.event_name == 'pull_request'
+          && github.event.pull_request.user.login == 'dependabot-preview[bot]'
+          && startsWith(github.event.pull_request.title, 'Bump eslint ')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            github.issues.createComment({ issue_number, owner, repo, body: "@dependabot merge" });


### PR DESCRIPTION
Dependabot updates our JavaScript dependencies on a regular basis. While
most updates should get reviewed before they are merged, updates to
ESLint should be okay to merge if the linting still passes.

This patch will instruct Dependabot to merge ESLint updates
automatically if the pull request passes our CI checks and thus the
linting process.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
