### PR TITLE
Test admin frontend only once on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,8 @@ jobs:
     - stage: build
       env: name=build
       script:
+        # Don't run the admin interface frontend tests. We run them in parallel anyway:
+        - sed -i 's/build --skipTests=${skipTests}/build --skipTests=true/' modules/admin-ui-frontend/pom.xml
         - mvn clean install -Pnone
 
     # Run JS tests in Chrome


### PR DESCRIPTION
This patch deactivates the admin interface frontend tests in the full
build on Travis CI since they run in parallel anyway. This should
hopefully make the build 2-3 minutes faster.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
