### PR TITLE
Fix Log Spamming

### DIFF
--- a/modules/adopter-statistics-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
+++ b/modules/adopter-statistics-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
@@ -83,7 +83,7 @@ public class Controller {
                         responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR) },
                         returnDescription = "GETs the adopter registration data.")
   public String getRegistrationForm() {
-    logger.info("Retrieving adopter registration data.");
+    logger.debug("Retrieving adopter registration data.");
     return gson.toJson(registrationService.retrieveFormData());
   }
 
@@ -99,7 +99,7 @@ public class Controller {
           @RestResponse(responseCode = SC_BAD_REQUEST,
                   description = "Couldn't save adopter registration data.")})
   public Response register(String data) {
-    logger.info("Saving adopter registration data.");
+    logger.debug("Saving adopter registration data.");
     Form form = gson.fromJson(data, Form.class);
     try {
       registrationService.saveFormData(form);
@@ -120,7 +120,7 @@ public class Controller {
                   responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR) },
           returnDescription = "DELETEs the adopter registration data.")
   public Response deleteRegistrationData() {
-    logger.info("Deleting adopter registration data.");
+    logger.debug("Deleting adopter registration data.");
     try {
       registrationService.deleteFormData();
       return ok();


### PR DESCRIPTION
This patch fixes the adopter registration spamming the logs by
effectively logging each and every request made to the service:

```
2020-10-05 21:15:48,313 | INFO  | (Controller:86) - Retrieving adopter registration data.
2020-10-05 21:15:48,992 | INFO  | (Controller:86) - Retrieving adopter registration data.
2020-10-05 21:16:03,709 | INFO  | (Controller:86) - Retrieving adopter registration data.
2020-10-05 21:16:03,923 | INFO  | (Controller:86) - Retrieving adopter registration data.
2020-10-05 21:16:12,046 | INFO  | (Controller:102) - Saving adopter registration data.
2020-10-05 21:16:33,437 | INFO  | (Controller:86) - Retrieving adopter registration data.
2020-10-05 21:16:41,883 | INFO  | (Controller:86) - Retrieving adopter registration data.
2020-10-05 21:16:45,537 | INFO  | (Controller:86) - Retrieving adopter registration data.
2020-10-05 21:16:46,334 | INFO  | (Controller:86) - Retrieving adopter registration data.
2020-10-05 21:16:47,072 | INFO  | (Controller:86) - Retrieving adopter registration data.
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
