### PR TITLE
Make copy-event-to-series workflow id configurable

### DIFF
--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -49,7 +49,7 @@ For more details, take a look at the options in
 
 
 The “delete” key in the series overview tool can be configured by specifying the retraction workflow in
-`etc/org.opencastproject.lti.endpoint.EventsEndpoint.cfg`. The property is called `retract-workflow-id`, and it defaults
+`etc/org.opencastproject.lti.service.impl.LtiServiceImpl.cfg`. The property is called `retract-workflow-id`, and it defaults
 to `retract`.
 
 Configure and test an LTI tool in the LMS

--- a/etc/org.opencastproject.lti.service.impl.LtiServiceImpl.cfg
+++ b/etc/org.opencastproject.lti.service.impl.LtiServiceImpl.cfg
@@ -4,3 +4,4 @@ workflow=schedule-and-upload
 workflow-configuration={"flagForCutting":"false","flagForReview":"false","publishToEngage":"true","publishToHarvesting":"true","straightToPublishing":"true"}
 # After deletion, events are retracted with this workflow
 retract-workflow-id=retract
+copy-workflow-id=copy-event-to-series

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -105,7 +105,6 @@ public class LtiServiceImpl implements LtiService, ManagedService {
   private static final Logger logger = LoggerFactory.getLogger(LtiServiceImpl.class);
 
   private static final Gson gson = new Gson();
-  private static final String COPY_EVENT_TO_SERIES_WORKFLOW = "copy-event-to-series";
   private static final String NEW_MP_ID_KEY = "newMpId";
   private IndexService indexService;
   private IngestService ingestService;
@@ -118,6 +117,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
   private String workflow;
   private String workflowConfiguration;
   private String retractWorkflowId;
+  private String copyWorkflowId;
   private final List<EventCatalogUIAdapter> catalogUIAdapters = new ArrayList<>();
 
   /** OSGi DI */
@@ -174,7 +174,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
     workflowService.addWorkflowListener(new WorkflowListener() {
       @Override
       public void stateChanged(WorkflowInstance workflow) {
-        if (!workflow.getTemplate().equals(COPY_EVENT_TO_SERIES_WORKFLOW)) {
+        if (!workflow.getTemplate().equals(copyWorkflowId)) {
           return;
         }
 
@@ -297,7 +297,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
 
   @Override
   public void copyEventToSeries(final String eventId, final String seriesId) {
-    final String workflowId = COPY_EVENT_TO_SERIES_WORKFLOW;
+    final String workflowId = copyWorkflowId;
     try {
       final WorkflowDefinition wfd = workflowService.getWorkflowDefinitionById(workflowId);
       final Workflows workflows = new Workflows(assetManager, workflowService);
@@ -492,6 +492,12 @@ public class LtiServiceImpl implements LtiService, ManagedService {
         this.retractWorkflowId = "retract";
       } else {
         this.retractWorkflowId = retractWorkflowId;
+      }
+      final String copyWorkflowId = (String) properties.get("copy-workflow-id");
+      if (copyWorkflowId == null) {
+        this.copyWorkflowId = "copy-event-to-series";
+      } else {
+        this.copyWorkflowId = copyWorkflowId;
       }
     } catch (JsonSyntaxException e) {
       throw new IllegalArgumentException("Invalid JSON specified for workflow configuration");

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -95,6 +95,7 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -487,18 +488,8 @@ public class LtiServiceImpl implements LtiService, ManagedService {
       gson.fromJson(workflowConfigurationStr, Map.class);
       workflowConfiguration = workflowConfigurationStr;
       workflow = workflowStr;
-      final String retractWorkflowId = (String) properties.get("retract-workflow-id");
-      if (retractWorkflowId == null) {
-        this.retractWorkflowId = "retract";
-      } else {
-        this.retractWorkflowId = retractWorkflowId;
-      }
-      final String copyWorkflowId = (String) properties.get("copy-workflow-id");
-      if (copyWorkflowId == null) {
-        this.copyWorkflowId = "copy-event-to-series";
-      } else {
-        this.copyWorkflowId = copyWorkflowId;
-      }
+      this.retractWorkflowId = Objects.toString(properties.get("retract-workflow-id"), "retract");
+      this.copyWorkflowId = Objects.toString(properties.get("copy-workflow-id"), "copy-event-to-series");
     } catch (JsonSyntaxException e) {
       throw new IllegalArgumentException("Invalid JSON specified for workflow configuration");
     }


### PR DESCRIPTION
This makes copy-event-to-series workflow id for the new LTI tools configurable. 
This fixes issue #1930 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
