### PR TITLE
Fix docs of matomo

### DIFF
--- a/docs/guides/admin/docs/modules/player.matomo.tracking.md
+++ b/docs/guides/admin/docs/modules/player.matomo.tracking.md
@@ -68,12 +68,12 @@ Tracked Data
 Additional to the event data that can be turned on for each event (see above), this Opencast specific data is tracked
 if tracking is allowed:
 
-* Page name as "<title of the event> - <lecturer name>"
+* Page name as `<title of the event> - <lecturer name>`
 * Custom Matomo variables:
-    * "event" as "<title of the event> (<event id>)"
-    * "series" as "<title of the series> (<series id>)"
+    * "event" as `<title of the event> (<event id>)`
+    * "series" as `<title of the series> (<series id>)`
     * "presenter"
-    * "view_mode" which can be "desktop", "mobile" or "embed"
+    * "view_mode" which can be `desktop`, `mobile` or `embed`
 
 Heartbeat data does not show how long a video has been played but how long a viewer remained on the page, while the page
 was in the foreground.


### PR DESCRIPTION
Due to some improper usage of markdown. At the bottom of [player.matomo.tracking.md](https://github.com/opencast/opencast/blob/develop/docs/guides/admin/docs/modules/player.matomo.tracking.md), some messages cannot be properly displayed.
And even more messages are missing in the [official guide](https://docs.opencast.org/r/8.x/admin/#modules/player.matomo.tracking/).

Angle brackets are usually used as URLs or Email addresses.

This PR fix the problem.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
