### PR TITLE
Node and npm installation

### DIFF
--- a/modules/admin-ui-frontend/pom.xml
+++ b/modules/admin-ui-frontend/pom.xml
@@ -102,7 +102,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
               <execution>

--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -103,7 +103,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/modules/engage-theodul-core/pom.xml
+++ b/modules/engage-theodul-core/pom.xml
@@ -134,7 +134,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/modules/engage-theodul-plugin-controls/pom.xml
+++ b/modules/engage-theodul-plugin-controls/pom.xml
@@ -98,7 +98,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/modules/engage-theodul-plugin-custom-mhConnection/pom.xml
+++ b/modules/engage-theodul-plugin-custom-mhConnection/pom.xml
@@ -98,7 +98,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/modules/engage-theodul-plugin-tab-downloads/pom.xml
+++ b/modules/engage-theodul-plugin-tab-downloads/pom.xml
@@ -98,7 +98,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/modules/engage-ui/pom.xml
+++ b/modules/engage-ui/pom.xml
@@ -124,7 +124,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/modules/lti/pom.xml
+++ b/modules/lti/pom.xml
@@ -151,7 +151,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/modules/runtime-info-ui-ng/pom.xml
+++ b/modules/runtime-info-ui-ng/pom.xml
@@ -93,7 +93,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/modules/runtime-info-ui/pom.xml
+++ b/modules/runtime-info-ui/pom.xml
@@ -93,7 +93,6 @@
                 </goals>
                 <configuration>
                   <nodeVersion>${node.version}</nodeVersion>
-                  <npmVersion>${npm.version}</npmVersion>
                 </configuration>
               </execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,7 @@
     <json-simple.version>1.1.1</json-simple.version>
     <karaf.version>4.2.9</karaf.version>
     <mina.version>2.1.3</mina.version>
-    <node.version>v12.18.4</node.version>
-    <npm.version>6.14.6</npm.version>
+    <node.version>v12.19.0</node.version>
     <osgi.compendium.version>5.0.0</osgi.compendium.version>
     <osgi.core.version>5.0.0</osgi.core.version>
     <querydsl.version>3.7.4</querydsl.version>
@@ -711,7 +710,7 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>1.7.6</version>
+          <version>1.10.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This patch updates the frontend-maven-plugin and node and removes the
instructions for installing a specific version of npm. This will cause
the plugin to select the version which comes with the specified version
of node instead.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
