### PR TITLE
Fix Paella Player assuming track is audio-only when it's actually video and audio

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -205,7 +205,7 @@ class OpencastToPaellaConverter {
           if (currentTrack.video) {
             currentStream.type = 'video';
           }
-          else if (currentTrack.audio) {
+          else if (currentTrack.audio && currentStream.type !== 'video') {
             currentStream.type = 'audio';
           }
         }


### PR DESCRIPTION
As of now, Opencast/Paella assumes the stream's type to be the same type the last track is.
However, the track-order returned by Opencast appears to depend on various things while processing and
publishing/indexing the video so the order (audio or video last) is hard to determine.

This PR makes Paella Player assume the stream is a video stream as soon as one video track is present.

For reference, see https://groups.google.com/a/opencast.org/g/users/c/e7hP9wANC1w/m/RAwjBBF0AAAJ

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
