### PR TITLE
Remove Ingest service reference from duplicate event WOH

### DIFF
--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -52,12 +52,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-ingest-service-api</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-working-file-repository-service-api</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>

--- a/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/duplicate-event.xml
+++ b/modules/workflow-workflowoperation/src/main/resources/OSGI-INF/operations/duplicate-event.xml
@@ -20,8 +20,6 @@
              cardinality="1..1" policy="static" bind="setDistributionService"/>
   <reference name="series-service" interface="org.opencastproject.series.api.SeriesService"
              bind="setSeriesService"/>
-  <reference name="ingest-service" interface="org.opencastproject.ingest.api.IngestService"
-             bind="setIngestService"/>
   <reference name="authorization-service" interface="org.opencastproject.security.api.AuthorizationService"
              bind="setAuthorizationService"/>
 </scr:component>


### PR DESCRIPTION
Duplicate event WOH uses ingest service to put a series catalog into Workspace. Why not using Workspace directly and drop the newly added ingest service reference?

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
