### PR TITLE
Adjust title of the select-tracks WOH documentation

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
@@ -1,15 +1,15 @@
-SelectStreamsWorkflowOperationHandler
+SelectTracksWorkflowOperationHandler
 ====================================
 
 
 Description
 -----------
 
-The SelectStreamsWorkflowOperationHandler can be used in case not all source streams should be processed. For example,
+The SelectTracksWorkflowOperationHandler can be used in case not all source tracks should be processed. For example,
 given a recording with a presenter and a presentation track, the final recording to be published should only include the
 video stream of the presenter track and the audio stream of the presentation track.
 
-The workflow operation will use workflow properties set by the Opencast video editor to determine which streams should be
+The workflow operation will use workflow properties set by the Opencast video editor to determine which tracks should be
 selected for further processing and add them to the media package based on `target-flavor` and `target-tags`.
 
 **IMPORTANT:** The input tracks need to be inspected using the workflow operation [inspect](inspect-woh.md) before


### PR DESCRIPTION
This changes the title of the documentation of the `select-tracks` WOH to be consisted with the rest of the documentation. Usually the title of the documentation for a WOH is named the same as WOH. This was not the case and made it harder to find the correct documentation.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
