### PR TITLE
Add I18n support for text 'General' in 2 modals

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/edit-events-modal.html
@@ -4,7 +4,7 @@
     <h2 translate="BULK_ACTIONS.EDIT_EVENTS.CAPTION"><!-- Template --></h2>
   </header>
   <wizard edit-mode="false" name="editEventsWz" on-finish="submit()" template="shared/partials/wizardNav.html">
-  <wz-step wz-title="General" canexit="editEventsForm.generalForm.$valid" wz-disabled="!editEventsForm.generalForm.$valid" ng-form="generalForm" novalidate>
+  <wz-step wz-title="{{ 'BULK_ACTIONS.EDIT_EVENTS.GENERAL.CAPTION' | translate }}" canexit="editEventsForm.generalForm.$valid" wz-disabled="!editEventsForm.generalForm.$valid" ng-form="generalForm" novalidate>
     <!-- First Step: General -->
     <div class="modal-content active">
       <div class="modal-body">

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/schedule-task-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/schedule-task-modal.html
@@ -4,7 +4,7 @@
     <h2 translate="BULK_ACTIONS.SCHEDULE_TASK.CAPTION"><!-- Template --></h2>
   </header>
   <wizard edit-mode="false" name="scheduleTaskWz" on-finish="submit()" template="shared/partials/wizardNav.html">
-  <wz-step wz-title="General" canexit="scheduleTaskForm.generalForm.$valid" wz-disabled="!scheduleTaskForm.generalForm.$valid" ng-form="generalForm" novalidate>
+  <wz-step wz-title="{{ 'BULK_ACTIONS.SCHEDULE_TASK.GENERAL.CAPTION' | translate }}" canexit="scheduleTaskForm.generalForm.$valid" wz-disabled="!scheduleTaskForm.generalForm.$valid" ng-form="generalForm" novalidate>
     <!-- First Step: General -->
     <div class="modal-content active">
       <div class="modal-body">


### PR DESCRIPTION
Add I18n support for text 'General' in 2 modals.

The translation key is already in l10n json file, maybe someone forgot to change the html.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
