### PR TITLE
Harmonize defaults of serviceregistry with config file

### DIFF
--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -1,20 +1,23 @@
 # Configuration for the service registry
 
-# Number of failed jobs on a service before to set it in error state
-max.attempts=10
+# Number of failed jobs on a service before to set it in error state.
+# Default: 10
+#max.attempts=10
 
-# The interval in seconds between two rounds of dispatching in the service registry. The default value is 5s, and
-# a mimimum value of 1s is enforced due to performance reasons. Set to 0 to disable dispatching from this service
-# registry.
-#Service registry dispatching should be set to 0 on everything but admin or allinone
+# The interval in seconds between two rounds of dispatching in the service registry. A mimimum value of 1s is enforced
+# due to performance reasons. Set to 0 to disable dispatching from this service registry.
+# Service registry dispatching should be set to 0 on everything but admin or allinone!
+# Default: 5
 #dispatch.interval=5
 
-# The interval in seconds between checking if the hosts in the service registry hosts are still alive. The default value
-# is 60 seconds. Set to 0 to disable checking if hosts are still alive and able to be dispatched to.
-#heartbeat.interval=0
+# The interval in seconds between checking if the hosts in the service registry hosts are still alive.
+# Set to 0 to disable checking if hosts are still alive and able to be dispatched to.
+# Default: 60
+#heartbeat.interval=60
 
-# Whether to collect detailed job statistics information.  This can cause excessive database load (see MH-10034).
-jobstats.collect=false
+# Whether to collect detailed job statistics information. This can cause excessive database load (see MH-10034)!
+# Default: false
+#jobstats.collect=false
 
 # The maximum age (in days) of jobs that will be considering for the generation of the service statistics.
 # Note that this setting does have a large impact on the performance of service statistics generation.

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -212,13 +212,13 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   static final int DEFAULT_DISPATCH_JOBS_LIMIT = 100;
 
   /** Default setting on job statistics collection */
-  static final boolean DEFAULT_JOB_STATISTICS = true;
+  static final boolean DEFAULT_JOB_STATISTICS = false;
 
   /** Default setting on service statistics retrieval */
   static final int DEFAULT_SERVICE_STATISTICS_MAX_JOB_AGE = 14;
 
   /** Default value for {@link #maxAttemptsBeforeErrorState} */
-  private static final int MAX_FAILURE_BEFORE_ERROR_STATE = 1;
+  private static final int MAX_FAILURE_BEFORE_ERROR_STATE = 10;
 
   /** The configuration key for setting {@link #maxAttemptsBeforeErrorState} */
   private static final String MAX_ATTEMPTS_CONFIG_KEY = "max.attempts";


### PR DESCRIPTION
This is a relatively minor change that is supposed to harmonize the defaults set in the service registry with the values currently set in the config file.