### PR TITLE
Synchronize merge conflict check

### DIFF
--- a/.github/workflows/check-merge-conflict.yml
+++ b/.github/workflows/check-merge-conflict.yml
@@ -1,20 +1,21 @@
-name: Merge Conflict Check
+name: Merge conflict check
 on:
-  # So that PRs touching the same files as the push are updated
   push:
-  # So that the `dirtyLabel` is removed if conflicts are resolve
-  # We recommend `pull_request_target` so that github secrets are available.
-  # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:
-    types: [synchronize]
+    types:
+      - opened
+      - synchronize
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - name: check if prs are dirty
+      - name: Check for dirty pull requests
         uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: has-conflicts
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
+          commentOnDirty: |
+              This pull request has conflicts ☹
+              Please resolve those so we can review the pull request.
+              Thanks.


### PR DESCRIPTION
Mostly adapt this to what Opencast Studio and Zobira uses as well. The
minor differences are:

- Immediately inform contributors opening a pull request if they missed
  that there is a conflict.
- Adjust the comment
- Rename some tasks

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
