### PR TITLE
Speed up preview encoding

### DIFF
--- a/etc/encoding/engage-movies.properties
+++ b/etc/encoding/engage-movies.properties
@@ -26,13 +26,20 @@ profile.mp4-preview.http.name = preview video
 profile.mp4-preview.http.input = visual
 profile.mp4-preview.http.output = visual
 profile.mp4-preview.http.suffix = -preview.mp4
-profile.mp4-preview.http.ffmpeg.command = -i #{in.video.path} -c:v libx264 -filter:v yadif,scale=-2:360 -preset veryfast -crf 23 -profile:v baseline -pix_fmt yuv420p -tune film  -movflags faststart -c:a aac -strict -2 -ar 22050 -ab 64k #{out.dir}/#{out.name}#{out.suffix}
+profile.mp4-preview.http.ffmpeg.command = -i #{in.video.path} \
+  -filter:v scale=-2:360 \
+  -c:v libx264 -preset veryfast -crf 23 -profile:v baseline -pix_fmt yuv420p -tune film -movflags faststart \
+  -c:a aac -ar 22050 -ab 64k \
+  #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-preview.dual.http.name = preview video (picture-by-picture)
 profile.mp4-preview.dual.http.input = visual
 profile.mp4-preview.dual.http.output = visual
 profile.mp4-preview.dual.http.suffix = -preview-composite.mp4
-profile.mp4-preview.dual.http.ffmpeg.command = -i #{in.video.path} #{compositeCommand} -c:v libx264 -preset veryfast -crf 23 -profile:v baseline -pix_fmt yuv420p -tune film -movflags faststart -c:a aac -strict -2 -ar 22050 -ab 64k #{out.dir}/#{out.name}#{out.suffix}
+profile.mp4-preview.dual.http.ffmpeg.command = -i #{in.video.path} #{compositeCommand} \
+  -c:v libx264 -preset veryfast -crf 23 -profile:v baseline -pix_fmt yuv420p -tune film -movflags faststart \
+  -c:a aac -ar 22050 -ab 64k \
+  #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-low.http.name = low quality video
 profile.mp4-low.http.input = visual


### PR DESCRIPTION
This patch changes the FFmpeg command used in single-stream preview
encodings to achieve about 2× faster encoding rates by dropping the
nowadays unnecessary deinterlace filter.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
