### PR TITLE
Users in the admin ui filter can be reduced via regex now.

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -289,6 +289,12 @@ org.opencastproject.workspace.cleanup.max.age=2592000
 # Default: 1 minute
 #org.opencastproject.userdirectory.cache.expiry=1
 
+# This regex is used to reduce the users in the filter selectbox.
+# A username that matches this regex will be listed in the filter selection
+# The filter is located in the top right corner in the admin ui.
+# Default (allow all users): .*
+org.opencastproject.adminui.filter.user.regex = .*
+
 
 ######### KARAF CONFIGURATION #########
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
@@ -88,8 +88,13 @@ public class ListProvidersEndpoint {
   private ListProvidersService listProvidersService;
   private SeriesEndpoint seriesEndpoint;
 
+  /** This regex is used to reduce the users in the filter selectbox.
+   * The filter is located in the top right corner in the admin ui. */
+  private static final String PROP_KEY_USER_FILTER_REGEX = "org.opencastproject.adminui.filter.user.regex";
+
   protected void activate(BundleContext bundleContext) {
     logger.info("Activate list provider service");
+    JSONUtils.setUserRegex(bundleContext.getProperty(PROP_KEY_USER_FILTER_REGEX));
   }
 
   /** OSGi callback for series services. */

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestListProvidersEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestListProvidersEndpoint.java
@@ -23,6 +23,7 @@ package org.opencastproject.adminui.endpoint;
 
 import org.opencastproject.adminui.util.TestServiceRegistryFactory;
 import org.opencastproject.index.service.resources.list.provider.ServersListProvider;
+import org.opencastproject.index.service.util.JSONUtils;
 import org.opencastproject.list.api.ResourceListProvider;
 import org.opencastproject.list.api.ResourceListQuery;
 import org.opencastproject.list.impl.ListProvidersServiceImpl;
@@ -32,6 +33,9 @@ import org.opencastproject.security.api.SecurityService;
 
 import org.easymock.EasyMock;
 import org.junit.Ignore;
+import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,6 +46,8 @@ import javax.ws.rs.Path;
 @Ignore
 public class TestListProvidersEndpoint extends ListProvidersEndpoint {
 
+  private static final Logger logger = LoggerFactory.getLogger(ListProvidersEndpoint.class);
+
   public static final String PROVIDER_NAME = "test";
   public static final String[] PROVIDER_VALUES = { "x", "a", "c", "z", "t", "h" };
   private final Map<String, String> baseMap = new HashMap<String, String>();
@@ -49,6 +55,11 @@ public class TestListProvidersEndpoint extends ListProvidersEndpoint {
   private ListProvidersServiceImpl listProvidersService = new ListProvidersServiceImpl();
   private SecurityService securityService;
   private Organization organization;
+
+  protected void activate(BundleContext bundleContext) {
+    logger.info("Activate list provider service");
+    JSONUtils.setUserRegex(".*");
+  }
 
   public TestListProvidersEndpoint() {
     this.securityService = EasyMock.createNiceMock(SecurityService.class);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/JSONUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/JSONUtils.java
@@ -42,6 +42,7 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -54,6 +55,12 @@ import java.util.Set;
  * Utility class providing helpers for all operation related to JSON.
  */
 public final class JSONUtils {
+
+  /** This regex is used to reduce the users in the filter selectbox.
+   * The filter is located in the top right corner in the admin ui. */
+  private static String userFilterRegex;
+  private static final String[] userListsToReduce = {"CONTRIBUTORS", "PUBLISHER",
+          "ORGANIZERS", "CONTRIBUTORS.USERNAMES", "EVENTS.PUBLISHER", "USERS.NAME"};
 
   private JSONUtils() {
 
@@ -133,6 +140,10 @@ public final class JSONUtils {
           values = new HashMap<String, String>();
         } else {
           values = listProvidersService.getList(listProviderName.get(), query, false);
+          if (Arrays.asList(userListsToReduce).contains(listProviderName.get())) {
+            // reduces the user list ('values' map) by the configured userFilterRegex
+            values.keySet().removeIf(u -> !u.matches(userFilterRegex));
+          }
           translatable = listProvidersService.isTranslatable(listProviderName.get());
         }
 
@@ -247,6 +258,10 @@ public final class JSONUtils {
     }
 
     return map;
+  }
+
+  public static void setUserRegex(String regex) {
+    userFilterRegex = regex;
   }
 
 }

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/util/JSONUtilsTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/util/JSONUtilsTest.java
@@ -121,6 +121,7 @@ public class JSONUtilsTest {
   @Test
   public void testFiltersToJSON() throws Exception {
     String expectedJSON = IOUtils.toString(getClass().getResource("/filters.json"));
+    String expectedJSONreduced = IOUtils.toString(getClass().getResource("/filters_reduced.json"));
 
     SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
     Organization organization = EasyMock.createNiceMock(Organization.class);
@@ -175,6 +176,7 @@ public class JSONUtilsTest {
     EasyMock.expect(query.getOffset()).andReturn(Option.<Integer> none()).anyTimes();
     EasyMock.replay(query);
 
+    JSONUtils.setUserRegex(".*"); //allow all users
     JValue result = JSONUtils.filtersToJSON(query, listProvidersService, organization);
 
     StreamingOutput stream = RestUtils.stream(serializer.fn.toJson(result));
@@ -182,6 +184,18 @@ public class JSONUtilsTest {
     try {
       stream.write(resultStream);
       assertThat(expectedJSON, SameJSONAs.sameJSONAs(resultStream.toString()));
+    } finally {
+      IOUtils.closeQuietly(resultStream);
+    }
+
+    JSONUtils.setUserRegex("contributor2"); //allow just one user
+    result = JSONUtils.filtersToJSON(query, listProvidersService, organization);
+
+    stream = RestUtils.stream(serializer.fn.toJson(result));
+    resultStream = new ByteArrayOutputStream();
+    try {
+      stream.write(resultStream);
+      assertThat(expectedJSONreduced, SameJSONAs.sameJSONAs(resultStream.toString()));
     } finally {
       IOUtils.closeQuietly(resultStream);
     }

--- a/modules/index-service/src/test/resources/filters_reduced.json
+++ b/modules/index-service/src/test/resources/filters_reduced.json
@@ -1,0 +1,14 @@
+{
+    "contributors": {
+        "label": "FILTERS.SERIES.CONTRIBUTORS.LABEL",
+        "options": {
+            "contributor2": "My second contributor"
+        },
+        "translatable": false,
+        "type": "select"
+    },
+    "textFilter": {
+        "label": "FREETEXT.LABEL",
+        "type": "freetext"
+    }
+}


### PR DESCRIPTION
With a regex configured in the 'custom.properties' file, the users listed in the filter selectbox can be reduced now. The filter is in the top right corner in the admin ui.

closes #1965 