### PR TITLE
Set the RFC 822 "Date" header field when sending an email (r/8.x)

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/BaseSmtpService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/BaseSmtpService.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
 import java.util.Properties;
 
 import javax.mail.MessagingException;
@@ -243,6 +244,7 @@ public class BaseSmtpService {
    *           if sending the message failed
    */
   public void send(MimeMessage message) throws MessagingException {
+    message.setSentDate(new Date());
     if (!productionMode) {
       logger.debug("Skipping sending of message {} due to test mode", message);
       return;


### PR DESCRIPTION
Should fix #2010 for r/8.x