### PR TITLE
Long Labels in Segment List

### DIFF
--- a/modules/admin-ui-frontend/app/styles/components/video/_video-editor.scss
+++ b/modules/admin-ui-frontend/app/styles/components/video/_video-editor.scss
@@ -679,8 +679,8 @@ $segment-deleted-selected: saturate(darken($segment-deleted, 25%), 5%);
 
 .editor-segments {
     padding: 4px 12px 4px 12px;
-    width: 25%;
     min-width: 400px;
+    display: inline-block;
 
     $segment-list-element-height: 35px;
 


### PR DESCRIPTION
This patch fixes the issue that long labels in the segment list break
the admin interface. It is admittedly not perfect since it will still
break eventually, but it should now works with reasonable long texts and
is a really simple fix.

This fixes #1978

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated testing
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits
* [x] have appropriate tags applied
