### PR TITLE
Fix Job Dispatching Test

### DIFF
--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -22,6 +22,7 @@
 package org.opencastproject.serviceregistry.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.Job.Status;
@@ -461,17 +462,7 @@ public class ServiceRegistryJpaImplTest {
             10.0f);
     JobBarrier barrier = new JobBarrier(null, serviceRegistryJpaImpl, testJob);
     launchDispatcherOnce(false);
-    try {
-      barrier.waitForJobs(JOB_BARRIER_TIMEOUT);
-      // We should never successfully complete the job, so if we get here then something is wrong
-      Assert.fail("Did not receive a timeout exception");
-    } catch (Exception e) {
-      testJob = serviceRegistryJpaImpl.getJob(testJob.getId());
-      // Some explanation here: If the load exceeds the global maximum node load (ie, jobLoad > all individual node max
-      // loads), then we dispatch to the biggest, even if it's not going to normally accept the job.  That node may still
-      // reject the job, but that's AbstractJobProducer's job, not the service registry's
-      Assert.assertEquals(TEST_HOST_THIRD, testJob.getProcessingHost());
-    }
+    assertThrows(IllegalStateException.class, () -> barrier.waitForJobs(JOB_BARRIER_TIMEOUT));
   }
 
   @Test


### PR DESCRIPTION
For a long time parts of the ServiceRegistryJpaImplTest have been
failing occasionally, but on a regular basis:

    [ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 5.336 s <<< FAILURE! - in org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImplTest
    [ERROR] testDispatchingJobsHigherMaxLoad(org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImplTest)  Time elapsed: 1.45 s  <<< FAILURE!
    java.lang.AssertionError: expected:<http://thirdhost:8080> but was:<null>
	at org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImplTest.testDispatchingJobsHigherMaxLoad(ServiceRegistryJpaImplTest.java:473)

The issue seems to be more likely to pop up on slower machines or if
there is a high load on the machine when running the particular test.

The problem with the assumption that test makes is that it creates a job
and then assumes it is dispatched to a host in a particular amount of
time.  Unfortunately, there is no guarantee for the dispatching to
happen in a given time. This means that from time to time the test will
fail.

One kind of solution would be to slow the test down, making failures
less likely. Still, this does not really fix the underlying false
assumption that it's guaranteed to happen and would also overall slow
down builds which is not nice.

That is why this fix removes the final check instead. That means that
the part where it will test that it jumps out of the job barrier
remains, but checking that it is on a certain host went away.

If that's something we need, we should build a proper test for that
eventually. But for now, not having the test will cause less harm.
That's good.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
