### PR TITLE
Add null checker when publishing to streaming service

### DIFF
--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -378,7 +378,7 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
         mediaPackage.add(publicationElement);
 
         // create publication URI for streaming
-        if (streamingDistributionService.publishToStreaming() && !publishedStreamingFormats.isEmpty()) {
+        if (streamingDistributionService != null && streamingDistributionService.publishToStreaming() && !publishedStreamingFormats.isEmpty()) {
           for (Track track : mediaPackageForSearch.getTracks()) {
             String mimeType = track.getMimeType().toString();
             if (isStreamingFormat(track) && (publishedStreamingFormats.contains(mimeType)


### PR DESCRIPTION
This PR mainly add null checker for StreamingDistributionService in PublishEngageWorkflowOperationHandler.

In `/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-aws.xml`, streaingDistributionService is not binded to PublishEngageWorkflowOperationHandler. So, in such case, 'publish-aws' operation will fail due to a NullPointerException.

By contrast, in `/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-engage.xml`, StreamingDistributionService is binded. So, `publish-engage` operation can run without NPE.


* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
