### PR TITLE
Show language of LTI tool depend on LTI param

### DIFF
--- a/modules/lti/src/main/java/org/opencastproject/lti/LtiServlet.java
+++ b/modules/lti/src/main/java/org/opencastproject/lti/LtiServlet.java
@@ -239,6 +239,13 @@ public class LtiServlet extends HttpServlet {
       }
     }
 
+    // Add locale param from LMS
+    String localeParamValue = req.getParameter(LOCALE);
+    if (StringUtils.isNotBlank(localeParamValue)) {
+      // 'lng' is query param for i18next-browser-languagedetector
+      builder.queryParam("lng", localeParamValue);
+    }
+
     // Build the final URL (as a string)
     String redirectUrl = builder.build().toString();
 


### PR DESCRIPTION
LTI tool show translation by browser settings, with the abilty of `i18next-browser-languagedetector`.

Yet, LTI tool is usually embedded in an LMS system which has its own language preference, and may different from the browser settings.

This PR will check the standard parameter `launch_presentation_locale` of LTI request, and use its value to decide which language to be displayed. Or, fallback to English.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated testing
* [ ] have a clean commit history
* [ ] have proper commit messages (title and body) for all commits
* [ ] have appropriate tags applied
