### PR TITLE
More efficient retrieval of active jobs

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -116,6 +116,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import javax.management.ObjectInstance;
 import javax.persistence.EntityManager;
@@ -270,7 +271,10 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** A static list of statuses that influence how load balancing is calculated */
   protected static final List<Status> JOB_STATUSES_INFLUENCING_LOAD_BALANCING;
 
-  protected static HashMap<Long, Float> jobCache = new HashMap<Long, Float>();
+  private static final Status[] activeJobStatus =
+      Arrays.stream(Status.values()).filter(Status::isActive).collect(Collectors.toList()).toArray(new Status[0]);
+
+  protected static HashMap<Long, Float> jobCache = new HashMap<>();
 
   static {
     JOB_STATUSES_INFLUENCING_LOAD_BALANCING = new ArrayList<Status>();
@@ -1831,20 +1835,11 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    */
   @Override
   public List<Job> getActiveJobs() throws ServiceRegistryException {
-    List<Status> statuses = new ArrayList<Status>();
-    for (Status status : Status.values()) {
-      if (status.isActive())
-        statuses.add(status);
-    }
     EntityManager em = null;
     try {
       em = emf.createEntityManager();
-      List<JpaJob> jpaJobs = getJobsByStatus(em, statuses.toArray(new Status[statuses.size()]));
-      List<Job> jobs = new ArrayList<Job>(jpaJobs.size());
-      for (JpaJob jpaJob : jpaJobs) {
-        jobs.add(jpaJob.toJob());
-      }
-      return jobs;
+      List<JpaJob> jpaJobs = getJobsByStatus(em, activeJobStatus);
+      return jpaJobs.stream().map(JpaJob::toJob).collect(Collectors.toList());
     } catch (Exception e) {
       throw new ServiceRegistryException(e);
     } finally {


### PR DESCRIPTION
This patch improves the service registries mechanism to get active jobs
by not building a static list of active job states and then always
converting that to an array every time the method is called.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
