### PR TITLE
Add S3 presigned URL support

### DIFF
--- a/docs/guides/admin/docs/modules/awss3distribution.md
+++ b/docs/guides/admin/docs/modules/awss3distribution.md
@@ -37,6 +37,33 @@ Amazon CloudFront provides an *optional* way to better handle distributing your 
 configuring CloudFront is outside the scope of this documentation, we wish to note that this does affect one of the keys
 described below.  Please ensure you use the correct distribution base format depending on which service you are using!
 
+Presigned URL
+-------------
+As a typical CDN service, CloudFront can accerate the speed of distributing your media. Yet, anyone can get the media
+files if the URL is leaked. 
+
+S3 provide **Presigned URL** to generate URLs only valid in a certain duration time. That means, even the media's URL
+is leaked, the URL only can be used in a short time.
+
+Set `org.opencastproject.distribution.aws.s3.presigned.url` to `true` to enable this feature.
+
+Note: **CloudFront** and **Presigned URL** can be used together. 
+
+S3 Compatible Service
+----------------------
+The S3 API has become the de facto standard interface for almost all storage providers.
+This module also supports S3 compatible service.
+In this case, `org.opencastproject.distribution.aws.s3.endpoint` should be set to the endpoint of the S3 service.
+Meanwhile, `org.opencastproject.distribution.aws.s3.region` should not be set.
+Note: only one of these two configuration keys may be set.
+
+There are [two access](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html) style for bucket, virtual hosted style (default) and path style.
+- Virtual hosted style sample: `https://bucketname.s3.service.com/`
+- Path style sample: `https://s3.service.com/bucketname`
+
+AWS use virtual hosted style by default, and will deprecate path style. Yet, for self hosted s3 compatible service, path style URL is useful.  
+Set `org.opencastproject.distribution.aws.s3.path.style` to `true` to enable this feature.
+
 Opencast Service Configuration
 ------------------------------
 
@@ -47,10 +74,14 @@ The Opencast AWS S3 Distribution service has five configuration keys, which can 
 |--------|-----|-------|
 |org.opencastproject.distribution.aws.s3.distribution.enable|True to enable S3 distribution, false otherwise|true|
 |org.opencastproject.distribution.aws.s3.region|The AWS region to set|us-west-2|
+|org.opencastproject.distribution.aws.s3.endpoint|The endpoint of AWS S3 service. Only used with S3 compatible service|https://s3.service.com|
+|org.opencastproject.distribution.aws.s3.path.style|True to enable path style access URL for bucket, false otherwise|false|
 |org.opencastproject.distribution.aws.s3.bucket|The S3 bucket name|example-org-dist|
 |org.opencastproject.distribution.aws.s3.distribution.base|Where the S3 files are available from.  This value can be derived from the bucket and region values, or is set by CloudFront.|http://s3-us-west-2.amazonaws.com/example-org-dist, or DOMAIN_NAME.cloudfront.net|
 |org.opencastproject.distribution.aws.s3.access.id|Your access ID|20 alphanumeric characters|
 |org.opencastproject.distribution.aws.s3.secret.key|Your secret key|40 characters|
+|org.opencastproject.distribution.aws.s3.presigned.url|True to enable presigned URL, false otherwise|false|
+|org.opencastproject.distribution.aws.s3.presigned.url.valid.duration|Valid duration for presigned URL in milliseconds|14400000|
 
 If *org.opencastproject.distribution.aws.s3.access.id* and *org.opencastproject.distribution.aws.s3.secret.key* are
  not *explicitly* provided, search for credentials will be performed in the order specified by the

--- a/etc/org.opencastproject.distribution.aws.s3.AwsS3DistributionServiceImpl.cfg
+++ b/etc/org.opencastproject.distribution.aws.s3.AwsS3DistributionServiceImpl.cfg
@@ -44,4 +44,11 @@ org.opencastproject.distribution.aws.s3.distribution.enable=false
 # If you are using another S3 service/provider, please refer to its documentation.
 #org.opencastproject.distribution.aws.s3.path.style=true
 
+# Enable presigned URL
+# Leave this commented out to use presigned URL fow AWS S3
+#org.opencastproject.distribution.aws.s3.presigned.url=true
 
+# Valid duration for presigned URL in milliseconds, default is 21600000 (6 hours)
+# For detailed information about valid duration of presigned URL,
+# see https://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html
+#org.opencastproject.distribution.aws.s3.presigned.url.valid.duration=21600000

--- a/modules/distribution-service-aws-s3/pom.xml
+++ b/modules/distribution-service-aws-s3/pom.xml
@@ -112,7 +112,8 @@
               *;resolution:=optional
             </Import-Package>
             <Service-Component>
-              OSGI-INF/distribution-service-aws-s3.xml
+              OSGI-INF/distribution-service-aws-s3.xml,
+              OSGI-INF/mediapackage-serializer.xml
             </Service-Component>
           </instructions>
         </configuration>

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -45,6 +45,7 @@ import org.opencastproject.util.data.Option;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.HttpMethod;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -68,6 +69,7 @@ import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -86,6 +88,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -118,6 +121,8 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
   public static final String AWS_S3_BUCKET_CONFIG = "org.opencastproject.distribution.aws.s3.bucket";
   public static final String AWS_S3_ENDPOINT_CONFIG = "org.opencastproject.distribution.aws.s3.endpoint";
   public static final String AWS_S3_PATH_STYLE_CONFIG = "org.opencastproject.distribution.aws.s3.path.style";
+  public static final String AWS_S3_PRESIGNED_URL_CONFIG = "org.opencastproject.distribution.aws.s3.presigned.url";
+  public static final String AWS_S3_PRESIGNED_URL_VALID_DURATION_CONFIG = "org.opencastproject.distribution.aws.s3.presigned.url.valid.duration";
   // config.properties
   public static final String OPENCAST_DOWNLOAD_URL = "org.opencastproject.download.url";
   public static final String OPENCAST_STORAGE_DIR = "org.opencastproject.storage.dir";
@@ -132,6 +137,12 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
 
   /** The load on the system introduced by creating a restore job */
   public static final float DEFAULT_RESTORE_JOB_LOAD = 0.1f;
+
+  /** Default expiration time for presigned URL in millis, 6 hours */
+  public static final int DEFAULT_PRESIGNED_URL_EXPIRE_MILLIS = 6 * 60 * 60 * 1000;
+
+  /** Max expiration time for presigned URL in millis, 7 days */
+  private static final int MAXIMUM_PRESIGNED_URL_EXPIRE_MILLIS = 7 * 24 * 60 * 60 * 1000;
 
   /** The keys to look for in the service configuration file to override the defaults */
   public static final String DISTRIBUTE_JOB_LOAD_KEY = "job.load.aws.s3.distribute";
@@ -166,6 +177,12 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
 
   /** path style enabled */
   private boolean pathStyle = false;
+
+  /** whether use presigned URL */
+  private boolean presignedUrl = false;
+
+  /** valid duration for presigned URL in milliseconds */
+  private int presignedUrlValidDuration = DEFAULT_PRESIGNED_URL_EXPIRE_MILLIS;
 
   /** The opencast download distribution url */
   private String opencastDistributionUrl = null;
@@ -226,6 +243,20 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
       // AWS path style
       pathStyle = Boolean.valueOf(getAWSConfigKey(cc, AWS_S3_PATH_STYLE_CONFIG));
       logger.info("AWS path style is {}", pathStyle);
+
+      // AWS presigned URL
+      String presignedUrlConfigValue = OsgiUtil.getComponentContextProperty(cc, AWS_S3_PRESIGNED_URL_CONFIG, "false");
+      presignedUrl = StringUtils.equalsIgnoreCase("true", presignedUrlConfigValue);
+      logger.info("AWS use presigned URL: {}", presignedUrl);
+
+      // AWS presigned URL expiration time in millis
+      String presignedUrlExpTimeMillisConfigValue = OsgiUtil.getComponentContextProperty(cc,
+              AWS_S3_PRESIGNED_URL_VALID_DURATION_CONFIG, null);
+      presignedUrlValidDuration = NumberUtils.toInt(presignedUrlExpTimeMillisConfigValue, DEFAULT_PRESIGNED_URL_EXPIRE_MILLIS);
+      if (presignedUrlValidDuration > MAXIMUM_PRESIGNED_URL_EXPIRE_MILLIS) {
+        logger.warn("Valid duration of presigned URL is too large, MAXIMUM_PRESIGNED_URL_EXPIRE_MILLIS(7 days) is used");
+        presignedUrlValidDuration = MAXIMUM_PRESIGNED_URL_EXPIRE_MILLIS;
+      }
 
       opencastDistributionUrl = getAWSConfigKey(cc, AWS_S3_DISTRIBUTION_BASE_CONFIG);
       if (!opencastDistributionUrl.endsWith("/")) {
@@ -451,11 +482,17 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
 
       if (checkAvailability) {
         URI uri = distributedElement.getURI();
+        String distributedElementUriStr = uri.toString();
         int tries = 0;
         CloseableHttpResponse response = null;
         boolean success = false;
         while (tries < MAX_TRIES) {
           try {
+            if (presignedUrl) {
+              // 5 minutes should be enough for check availability for presigned URL.
+              Date fiveMinutesLater = new Date(System.currentTimeMillis() + 5 * 60 * 1000);
+              uri = s3.generatePresignedUrl(bucketName, objectName, fiveMinutesLater, HttpMethod.HEAD).toURI();
+            }
             CloseableHttpClient httpClient = HttpClients.createDefault();
             logger.trace("Trying to access {}", uri);
             response = httpClient.execute(new HttpHead(uri));
@@ -932,6 +969,22 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
         throw new ConfigurationException("Bucket " + bucketName + " exists, but we can't access it: " + e.getMessage(),
                 e);
       }
+    }
+  }
+
+  public URI presignedURI(URI uri) throws URISyntaxException {
+    if (!presignedUrl) {
+      return uri;
+    }
+    String s3UrlPrefix = s3.getUrl(bucketName, "").toString();
+
+    // Only handle URIs match s3 domain and bucket
+    if (uri.toString().startsWith(s3UrlPrefix)) {
+      String objectName = uri.toString().substring(s3UrlPrefix.length());
+      Date validUntil = new Date(System.currentTimeMillis() + presignedUrlValidDuration);
+      return s3.generatePresignedUrl(bucketName, objectName, validUntil).toURI();
+    } else {
+      return uri;
     }
   }
 

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/PresignedUrlMediaPackageSerializer.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/PresignedUrlMediaPackageSerializer.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.distribution.aws.s3;
+
+import org.opencastproject.distribution.aws.s3.api.AwsS3DistributionService;
+import org.opencastproject.mediapackage.MediaPackageSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Implementation of a {@link MediaPackageSerializer} that will support presigned URL feature for a Mediapackage
+ */
+public class PresignedUrlMediaPackageSerializer implements MediaPackageSerializer {
+
+    private static final Logger logger = LoggerFactory.getLogger(PresignedUrlMediaPackageSerializer.class);
+
+    public static final int RANKING = 10;
+
+    /** S3 distribution service used for generate presigned URL */
+    private AwsS3DistributionService service;
+
+    public PresignedUrlMediaPackageSerializer() {
+        logger.info("Init PresignedUrlMediaPackageSerializer");
+    }
+
+    public void setService(AwsS3DistributionService service) {
+        this.service = service;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Generate a presigned URI for the given URI if AwsS3DistributionService is enabled.
+     */
+    @Override
+    public URI decodeURI(URI uri) throws URISyntaxException {
+        URI presignedURI = null;
+        if (service instanceof AwsS3DistributionServiceImpl) {
+            presignedURI = ((AwsS3DistributionServiceImpl)service).presignedURI(uri);
+        }
+        logger.debug("Decode in presigned URL serializer: {} -> {}", uri, presignedURI);
+        return presignedURI;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URI encodeURI(URI uri) throws URISyntaxException {
+        URI encodedUri = null;
+        logger.debug("Encode in presigned URL serializer: {} -> {}", uri, encodedUri);
+        return uri;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getRanking() {
+        return RANKING;
+    }
+}

--- a/modules/distribution-service-aws-s3/src/main/resources/OSGI-INF/mediapackage-serializer.xml
+++ b/modules/distribution-service-aws-s3/src/main/resources/OSGI-INF/mediapackage-serializer.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+               name="org.opencastproject.distribution.aws.s3.PresignedUrlMediaPackageSerializer"
+               immediate="true">
+  <service>
+    <provide interface="org.opencastproject.mediapackage.MediaPackageSerializer"/>
+  </service>
+  <implementation class="org.opencastproject.distribution.aws.s3.PresignedUrlMediaPackageSerializer"/>
+  <property name="service.pid" value="org.opencastproject.distribution.aws.s3.PresignedUrlMediaPackageSerializer"/>
+  <reference name="distributionService"
+             interface="org.opencastproject.distribution.aws.s3.api.AwsS3DistributionService"
+             cardinality="1..1" policy="static" bind="setService"/>
+</scr:component>

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImpl.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImpl.java
@@ -50,6 +50,7 @@ import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElements;
+import org.opencastproject.mediapackage.MediaPackageSerializer;
 import org.opencastproject.metadata.api.MetadataValue;
 import org.opencastproject.metadata.api.StaticMetadata;
 import org.opencastproject.metadata.api.StaticMetadataService;
@@ -66,6 +67,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -90,8 +92,14 @@ public class StaticMetadataServiceDublinCoreImpl implements StaticMetadataServic
 
   protected Workspace workspace = null;
 
+  protected MediaPackageSerializer serializer = null;
+
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
+  }
+
+  public void setMediaPackageSerializer(MediaPackageSerializer serializer) {
+    this.serializer = serializer;
   }
 
   public void activate(@SuppressWarnings("rawtypes") Map properties) {
@@ -386,7 +394,9 @@ public class StaticMetadataServiceDublinCoreImpl implements StaticMetadataServic
   private Option<DublinCoreCatalog> load(Catalog catalog) {
     InputStream in = null;
     try {
-      in = workspace.read(catalog.getURI());
+      URI uri = catalog.getURI();
+      if (serializer != null) uri = serializer.decodeURI(uri);
+      in = workspace.read(uri);
       return some((DublinCoreCatalog) DublinCores.read(in));
     } catch (Exception e) {
       logger.warn("Unable to load metadata from catalog '{}'", catalog);

--- a/modules/dublincore/src/main/resources/OSGI-INF/static-metadata-service.xml
+++ b/modules/dublincore/src/main/resources/OSGI-INF/static-metadata-service.xml
@@ -36,4 +36,7 @@
   </service>
   <reference name="workspace" interface="org.opencastproject.workspace.api.Workspace"
              cardinality="1..1" policy="static" bind="setWorkspace"/>
+  <reference name="serailizer"
+             interface="org.opencastproject.mediapackage.MediaPackageSerializer"
+             cardinality="0..1" policy="dynamic" bind="setMediaPackageSerializer"/>
 </scr:component>


### PR DESCRIPTION
This PR add S3 presigned URL support for Opencast.

Currently, when use s3 distribution to store files, anyone can download the media files from S3 or CDN if he/she can obtain the URL of these files.

By taking advantage of presigned URL, authorized users will get S3 file with a 'temporal' link with a valid duration. This will protect the media files in case its URLs are leaked.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
