### PR TITLE
Endtime of segments fixed in the editor

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/shared/directives/segmentsDirective.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/directives/segmentsDirective.js
@@ -172,6 +172,9 @@ angular.module('adminNg.directives')
              */
         scope.setHumanReadableTimes = function () {
           angular.forEach(scope.video.segments, function(segment, key) {
+            if (segment.end > scope.video.duration) {
+              segment.end = scope.video.duration;
+            }
             segment.startTime = scope.formatMilliseconds(segment.start);
             segment.endTime = scope.formatMilliseconds(segment.end);
           });


### PR DESCRIPTION
fixes #2021 

Added a check to the "segment update" function in the editor. If the `endtime` of a segment is larger than the total duration of the video, it will be set to the end of the video.