### PR TITLE
Limit OpenMP Threads to Prevent Tesseract Blocking the System

### DIFF
--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -39,5 +39,7 @@ export JAVA_MAX_MEM=1G
 export JAVA_PERM_MEM=256M
 export KARAF_NOROOT=true
 
+# Mitigation for new Tesseract 4.x locking up the system
+export OMP_THREAD_LIMIT=1
 
 . "$DIRNAME/check_ports"


### PR DESCRIPTION
This patch is a mitigation for the new Tesseract 4.x locking up the
system during extract text operations.

We have seen systems under full load for up to half a day when running
Tesseract. This seems to be caused by Tesseract spawning far too many
threads. Limiting the OpenMP threads [1] drops the processing time down
to just a few minutes.

Note that this is not completely free of side-effects since it would
also affect other applications run by Opencast which are using OpenMP.
But none of the default ones do and is basically cannot be worse than
what we see with Tesseract right now.

[1] https://www.openmp.org/spec-html/5.0/openmpse58.html

Default events being processed on develop.opencast.org without limits:

![workflow](https://user-images.githubusercontent.com/1008395/98274317-8e1f4680-1f93-11eb-8f69-65a72bbec4d0.png)

Default events being processed on develop.opencast.org with limits:

![workflow-omp-1](https://user-images.githubusercontent.com/1008395/98274283-819aee00-1f93-11eb-93cb-6ade382f6375.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
