### PR TITLE
Check for Apereo CLA

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -1,0 +1,36 @@
+name: Check ICLA
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v1
+
+      - name: Install Python module
+        run: pip install apereocla
+
+      - name: Check Apereo ICLA for GitHub user
+        run: apereocla -g "${{ github.event.pull_request.user.login }}"
+
+      - name: Comment if no CLA has been filed
+        if: ${{ failure() }}
+        uses: thollander/actions-comment-pull-request@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: >
+            Hi @${{ github.event.pull_request.user.login }}
+
+            Thank you for contributing to Opencast.
+
+            We noticed that you have not yet filed an [Individual Contributor License Agreement](https://www.apereo.org/licensing/agreements/icla).
+            Doing that (once) helps us to ensure that Opencast stays free for all.
+            If you make your contribution on behalf of an institution, you might also want to file a
+            [Corporate Contributor License Agreement](https://www.apereo.org/licensing/agreements/ccla)
+            (giving you as individual contributor a bit more security as well).
+
+            Please let us know if you have any questions regarding the CLA.


### PR DESCRIPTION
This patch adds a bot checking if there exists an individual
contributor license agreement filed with Apereo which has the pull
request author's username attached to it.

If we want this, we should check if the GitHub user names of our regular
contributors are filed correctly since we were on Bitbucket when we
started filing them with Apereo.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
