### PR TITLE
Add I18n translation sample file to Paella episodesFromSeries plugin

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.episodesFromSeries/localization/en-US.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.episodesFromSeries/localization/en-US.json
@@ -1,0 +1,9 @@
+{
+  "Available videos:": "Available videos:",
+  "Next": "Next",
+  "Page:": "Page:",
+  "Previous": "Previous",
+  "Related Videos": "Related Videos",
+  "Searching...": "Searching...",
+  "Videos in this series:": "Videos in this series:"
+}


### PR DESCRIPTION
Paella plugin `es.upv.paella.opencast.episodesFromSeries` does not include any translation file.

This PR add an English translation file and it can be added to crowdin to make it be translated.

Related issue #2047 

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
