### PR TITLE
Add 'if-height-lt-' variable to resolution based encoding

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
@@ -113,3 +113,4 @@ There are currently two resolution based conditionally set variables supported:
 |------------------------------------------|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 |`if-height-geq-<height>`                  |`if-height-geq-720`                |The value is set if the height of the video is greater or equal to `<height>` pixels.                                           |
 |`if-width-or-height-geq-<width>-<height>` |`if-width-or-height-geq-1280-720`  |The value is set if the width of the video is greater or equal to `<width>` or if the height is greater or equal to `<height>`. |
+|`if-height-lt-<height>`                   |`if-height-lt-480`                 |The value is set if the height of the video is less than `<height>` pixels.                                                     |

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -471,6 +471,11 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
         if (heightCondition <= height) {
           properties.put(key, profile.getExtension(key));
         }
+      } else if (key.startsWith(CMD_SUFFIX + ".if-height-lt-")) {
+        final int heightCondition = Integer.parseInt(key.substring((CMD_SUFFIX + ".if-height-lt-").length()));
+        if (heightCondition > height) {
+          properties.put(key, profile.getExtension(key));
+        }
       } else if (key.startsWith(CMD_SUFFIX + ".if-width-or-height-geq-")) {
         final String[] resCondition = key.substring((CMD_SUFFIX + ".if-width-or-height-geq-").length()).split("-");
         final int widthCondition = Integer.parseInt(resCondition[0]);


### PR DESCRIPTION
This PR add the `if-height-lt-<height>` variable to resolution based encoding, which will be triggered if height resolution is less than certain pixels.

Since there are two `geq` variable, to make the config easy to understand, here us `lt`(less than) instead of `leq`(less than or equal to).

Due to Opencast cannot restrict the resolution of the media files uploaded by users, it's very useful to define a `if-height-lt-` variable to handle some low resolution files. For example, just keep the origin resolution for these media files.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
