### PR TITLE
Solves #2034 (Execute-once subprocess issue)

### DIFF
--- a/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandler.java
+++ b/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandler.java
@@ -26,7 +26,6 @@ import org.opencastproject.execute.api.ExecuteService;
 import org.opencastproject.inspection.api.MediaInspectionException;
 import org.opencastproject.inspection.api.MediaInspectionService;
 import org.opencastproject.job.api.Job;
-import org.opencastproject.job.api.JobBarrier;
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
@@ -191,8 +190,8 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
             // Have the track inspected and return the result
             Job inspectionJob = null;
             inspectionJob = inspectionService.inspect(resultElement.getURI());
-            JobBarrier barrier = new JobBarrier(job, serviceRegistry, inspectionJob);
-            if (!barrier.waitForJobs().isSuccess()) {
+
+            if (!waitForStatus(inspectionJob).isSuccess()) {
               throw new ExecuteException("Media inspection of " + resultElement.getURI() + " failed");
             }
 


### PR DESCRIPTION
Fixes Execute-Once WOH issue (#2034) when is configured for a Track Output: Left an entry to an execute process that is
not running in the Job list.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] have proper commit messages (title and body) [for all commits](https://medium.com/@steveamaza/e028865e5791)
