### PR TITLE
JDK Support proposal (2020-11-11) documentation for 8.x

### DIFF
--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -43,3 +43,8 @@ export KARAF_NOROOT=true
 export OMP_THREAD_LIMIT=1
 
 . "$DIRNAME/check_ports"
+
+if ! java -version 2>&1 | grep -q '1\.8\.'; then
+  echo "ERROR: Opencast 8 requires OpenJDK 8"
+  exit 1
+fi

--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -24,6 +24,12 @@ Currently Supported
 * Ubuntu 18.04 amd64
 
 
+Java version support
+--------------------
+
+The only supported Java version for Opencast 8 is JDK 8.  Newer versions will not work with Opencast 8, nor will older versions.
+
+
 OpenJDK 8 on Debian 10
 ----------------------
 

--- a/docs/guides/admin/docs/installation/rpm-el7.md
+++ b/docs/guides/admin/docs/installation/rpm-el7.md
@@ -26,6 +26,12 @@ Currently Supported
 > *Other architectures like i386, i686, arm, … are not supported!*
 
 
+Java version support
+--------------------
+
+The only supported Java version for Opencast 8 is JDK 8.  Newer versions will not work with Opencast 8, nor will older versions.
+
+
 Activate Repository
 -------------------
 

--- a/docs/guides/admin/docs/installation/rpm-el8.md
+++ b/docs/guides/admin/docs/installation/rpm-el8.md
@@ -25,6 +25,12 @@ Currently Supported
 > *Other architectures like i386, i686, arm, … are not supported!*
 
 
+Java version support
+--------------------
+
+The only supported Java version for Opencast 8 is JDK 8.  Newer versions will not work with Opencast 8, nor will older versions.
+
+
 Activate Repository
 -------------------
 

--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -72,12 +72,6 @@ Required for animate service (optional):
     synfig
 
 
-Java version support
---------------------
-
-The only supported Java version for Opencast 8 is JDK 8.  Newer versions will not work with Opencast 8, nor will older versions.
-
-
 ### Dependency Download
 
 Pre-built versions of most dependencies that are not in the repositories can be downloaded from the respective project

--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -71,6 +71,13 @@ Required for animate service (optional):
 
     synfig
 
+
+Java version support
+--------------------
+
+The only supported Java version for Opencast 8 is JDK 8.  Newer versions will not work with Opencast 8, nor will older versions.
+
+
 ### Dependency Download
 
 Pre-built versions of most dependencies that are not in the repositories can be downloaded from the respective project


### PR DESCRIPTION
This PR adds the relevant JDK support documentation for 8.x.  A further PR will be filed after this has been merged forward.