### PR TITLE
Properly configure AWS S3 distribution on startup by default

### DIFF
--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -54,9 +54,11 @@ import com.amazonaws.auth.policy.actions.S3Actions;
 import com.amazonaws.auth.policy.resources.S3ObjectResource;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.BucketWebsiteConfiguration;
 import com.amazonaws.services.s3.model.DeleteVersionRequest;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ListVersionsRequest;
+import com.amazonaws.services.s3.model.SetBucketWebsiteConfigurationRequest;
 import com.amazonaws.services.s3.model.VersionListing;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
@@ -756,6 +758,13 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
                   .withActions(S3Actions.GetObject).withResources(new S3ObjectResource(bucketName, "*"));
           Policy policy = new Policy().withStatements(allowPublicReadStatement);
           s3.setBucketPolicy(bucketName, policy.toJson());
+
+          //Set the website configuration.  This needs to be static-site-enabled currently.
+          BucketWebsiteConfiguration defaultWebsite = new BucketWebsiteConfiguration();
+          //These files don't actually exist, but that doesn't matter since no one should be looking around in the bucket anyway.
+          defaultWebsite.setIndexDocumentSuffix("index.html");
+          defaultWebsite.setErrorDocument("error.html");
+          s3.setBucketWebsiteConfiguration(new SetBucketWebsiteConfigurationRequest(bucketName, defaultWebsite));
           logger.info("AWS S3 bucket {} created", bucketName);
         } catch (Exception e2) {
           throw new ConfigurationException("Bucket " + bucketName + " cannot be created: " + e2.getMessage(), e2);


### PR DESCRIPTION
Properly configuring S3 distribution on startup.  This leaves your bucket wide open for read access, which is required for S3 dist to work as the current code stands.  See #2044 for a more secure way.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
