### PR TITLE
Reduce IO Load When Starting a Workflow

### DIFF
--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
@@ -150,11 +150,7 @@ public class TestRestService extends AbstractAclServiceRestEndpoint {
     AccessControlList acl = new AccessControlList();
     Attachment attachment = new AttachmentImpl();
     MediaPackage mediapackage;
-    try {
-      mediapackage = new MediaPackageBuilderImpl().createNew();
-    } catch (MediaPackageException e) {
-      throw new RuntimeException(e);
-    }
+    mediapackage = new MediaPackageBuilderImpl().createNew();
     AuthorizationService authorizationService = EasyMock.createNiceMock(AuthorizationService.class);
     EasyMock.expect(authorizationService.getActiveAcl((MediaPackage) EasyMock.anyObject()))
             .andReturn(Tuple.tuple(acl, AclScope.Series)).anyTimes();
@@ -174,11 +170,7 @@ public class TestRestService extends AbstractAclServiceRestEndpoint {
 
   private static AssetManager newAssetManager() {
     Snapshot snapshot = EasyMock.createNiceMock(Snapshot.class);
-    try {
-      EasyMock.expect(snapshot.getMediaPackage()).andReturn(new MediaPackageBuilderImpl().createNew()).anyTimes();
-    } catch (MediaPackageException e) {
-      throw new RuntimeException(e);
-    }
+    EasyMock.expect(snapshot.getMediaPackage()).andReturn(new MediaPackageBuilderImpl().createNew()).anyTimes();
     ARecord record = EasyMock.createNiceMock(ARecord.class);
     EasyMock.expect(record.getSnapshot()).andReturn(Opt.some(snapshot)).anyTimes();
 
@@ -201,12 +193,8 @@ public class TestRestService extends AbstractAclServiceRestEndpoint {
     EasyMock.expect(query.select(EasyMock.anyObject(Target.class))).andReturn(select).anyTimes();
 
     AssetManager assetManager = EasyMock.createNiceMock(AssetManager.class);
-    try {
     EasyMock.expect(assetManager.getMediaPackage(EasyMock.anyString())).andReturn(Opt.some(new MediaPackageBuilderImpl()
             .createNew())).anyTimes();
-    } catch (MediaPackageException e) {
-      throw new RuntimeException(e);
-    }
     EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
     EasyMock.replay(assetManager, version, query, predicate, select, result, record, snapshot);
     return assetManager;

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -83,7 +83,7 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
    *
    * @see org.opencastproject.mediapackage.MediaPackageBuilder#createNew()
    */
-  public MediaPackage createNew() throws MediaPackageException {
+  public MediaPackage createNew() {
     return new MediaPackageImpl();
   }
 
@@ -92,7 +92,7 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
    *
    * @see org.opencastproject.mediapackage.MediaPackageBuilder#createNew(org.opencastproject.mediapackage.identifier.Id)
    */
-  public MediaPackage createNew(Id identifier) throws MediaPackageException {
+  public MediaPackage createNew(Id identifier) {
     return new MediaPackageImpl(identifier);
   }
 

--- a/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/WorkflowPropertiesUtil.java
+++ b/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/WorkflowPropertiesUtil.java
@@ -31,6 +31,7 @@ import org.opencastproject.assetmanager.api.query.AQueryBuilder;
 import org.opencastproject.assetmanager.api.query.ARecord;
 import org.opencastproject.assetmanager.api.query.AResult;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilderImpl;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -96,8 +97,9 @@ public final class WorkflowPropertiesUtil {
           final Map<String, String> properties) {
 
     // Properties can only be created if a snapshot exists. Hence, we create a snapshot if there is none right now.
+    // Although, to avoid lots of potentially slow IO operations, we archive an empty media package.
     if (!assetManager.snapshotExists(mediaPackage.getIdentifier().toString())) {
-      assetManager.takeSnapshot(DEFAULT_OWNER, mediaPackage);
+      assetManager.takeSnapshot(DEFAULT_OWNER, new MediaPackageBuilderImpl().createNew(mediaPackage.getIdentifier()));
     }
 
     // Store all properties


### PR DESCRIPTION
Workflow properties are persisted in the asset manager when a new
workflow is started. This requires that a snapshot of the event is
already present in the asset manager. Since this is not true for
unscheduled events, a snapshot is created on-the-fly.

Unfortunately, this can delay ingests if the storage system is under
high load and can even cause ingests to fail completely.

This patch modifies the behavior by creating a snapshot of an empty
media package instead. This significantly reduces the stress put onto
storage systems.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
