### PR TITLE
Fix Video Editor (Start Workflow)

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/subresources/partials/tools.html
@@ -394,20 +394,22 @@
 
           <div class="video-save-panel" ng-if="tab === 'editor' && player.adapter">
             <div class="buttons">
-              <select chosen pre-select-from="video.workflows" class="workflow"
-                                                               ng-disabled="!video.workflows || video.workflows.length === 0 || activeTransaction || activeSubmission"
-                                                               data-width="'175px'"
-                                                               ng-model="video.workflow"
-                                                               ng-options="workflow.id as workflow.name for workflow in video.workflows | orderBy: 'displayOrder':true" />
+              <select pre-select-from="video.workflows"
+                      class="workflow"
+                      ng-disabled="!video.workflows || video.workflows.length === 0 || activeTransaction || activeSubmission"
+                      data-width="'175px'"
+                      ng-model="video.workflow"
+                      ng-options="workflow.id as workflow.name for workflow in video.workflows | orderBy: 'displayOrder':true" >
+              </select>
 
-                <a ng-click="submit()"
-                   ng-class="{disabled: activeTransaction || activeSubmission || sanityCheckFlags()}"
-                   class="save-and-close-button"
-                   translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
-                  <!-- Save and Continue -->
-                </a>
+              <a ng-click="submit()"
+                 ng-class="{disabled: activeTransaction || activeSubmission || sanityCheckFlags()}"
+                 class="save-and-close-button"
+                 translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
+                <!-- Save and Continue -->
+              </a>
 
-                <a class="return-button" ng-click="leave()" translate>VIDEO_TOOL.BUTTONS.CLOSE</a>
+              <a class="return-button" ng-click="leave()" translate>VIDEO_TOOL.BUTTONS.CLOSE</a>
             </div>
           </div>
         </div>

--- a/modules/admin-ui-frontend/app/styles/components/video/_video-controls.scss
+++ b/modules/admin-ui-frontend/app/styles/components/video/_video-controls.scss
@@ -262,6 +262,41 @@ $playback-icon-font-size: 16px;
         text-align: right;
     }
 
+    select.workflow {
+
+      /* styling */
+      background-color: white;
+      border: 1px solid #c3cbce;
+      border-radius: 4px;
+      display: inline-block;
+      font: inherit;
+      line-height: 1.5em;
+      padding: 0.5em 3.5em 0.7em 1em;
+
+      /* reset */
+
+      margin: 0;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+
+      background-image:
+        linear-gradient(45deg, transparent 50%, gray 50%),
+        linear-gradient(135deg, gray 50%, transparent 50%),
+        linear-gradient(to right, #ccc, #ccc);
+      background-position:
+        calc(100% - 20px) calc(1em + 2px),
+        calc(100% - 15px) calc(1em + 2px),
+        calc(100% - 2.5em) 0.5em;
+      background-size:
+        5px 5px,
+        5px 5px,
+        1px 1.5em;
+      background-repeat: no-repeat;
+    }
+
     .save-button {
         @include btn(brightblue);
         margin-right: 10px;


### PR DESCRIPTION
This patch fixes the save and start workflow actions in the admin
interfaces video editor. The buttons for starting these actions were
non-existing in the DOM tree due to broken HTML code.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
