### PR TITLE
Reverting part of #1291 because this code is actually needed

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageImpl.java
@@ -31,6 +31,7 @@ import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.util.DateTimeSupport;
 import org.opencastproject.util.IoSupport;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +39,7 @@ import org.w3c.dom.Node;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
@@ -1108,6 +1110,26 @@ public final class MediaPackageImpl implements MediaPackage {
       e.verify();
     }
   }
+
+  /* NOTE: DO NOT REMOVE THIS METHOD IT WILL BREAK THINGS,
+    * SEE https://github.com/opencast/opencast/issues/1860 for an example
+    */
+  /**
+   * Unmarshals XML representation of a MediaPackage via JAXB.
+   *
+   * @param xml
+   *          the serialized xml string
+   * @return the deserialized media package
+   * @throws MediaPackageException
+   */
+  public static MediaPackageImpl valueOf(String xml) throws MediaPackageException {
+    try {
+      return MediaPackageImpl.valueOf(IOUtils.toInputStream(xml, "UTF-8"));
+    } catch (IOException e) {
+      throw new MediaPackageException(e);
+    }
+  }
+
 
   /**
    * @see java.lang.Object#hashCode()


### PR DESCRIPTION
The MediaPackageImpl class does not demarshall from XML without this method, and it was accidentally cleaned up
during a cleanup purge.  This commit reverts that change, resolving #1860

Fixes #1860

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
