### PR TITLE
Only persist users with specific LTI role

### DIFF
--- a/etc/org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.cfg
+++ b/etc/org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.cfg
@@ -49,11 +49,25 @@
 #lti.blacklist.user.1=
 
 # Determines whether a JpaUserReference should be created on LTI User Login.
-#
 # This persists the LTI Users in the database, giving them the ability to create long running tasks like ingesting a video.
-#
 # Default: true
-#lti.create_jpa_user_reference=true
+# lti.create_jpa_user_reference = true
+
+# Determines which LTI roles should be persisted in the database on LTI user logins.
+# The "lti.create_jpa_user_reference" config key has to be "true", otherwise this config key will be ignored.
+# The value can be a list of LTI roles identifying users to be persisted or the special value * causing all users to be persisted.
+# The value is not case sensitive.
+#
+# Examples:
+#  - Persist only instructors:
+#    lti.create_jpa_user_reference.roles = instructor
+#  - Persist only instructors and administrators:
+#    lti.create_jpa_user_reference.roles = instructor, administrator
+#  - Persist all users:
+#    lti.create_jpa_user_reference.roles = *
+#    Default value is *, so if nothing is defined, all users will be persisted
+#
+# lti.create_jpa_user_reference.roles = *
 
 # Add Custom Roles to users who has the role with custom_role_name
 # Default: empty no custom roles


### PR DESCRIPTION
fixes #1690 

With this change, only users with specific LTI roles will be persisted. The roles can be configured in `etc/org.opencastproject.security.lti.LtiLaunchAuthenticationHandler.cfg`.