### PR TITLE
Attempt to detect invalid DB credentials

### DIFF
--- a/modules/db/src/main/java/org/opencastproject/db/Activator.java
+++ b/modules/db/src/main/java/org/opencastproject/db/Activator.java
@@ -141,13 +141,13 @@ public class Activator implements BundleActivator {
       pooledDataSource.getMaxPoolSize(), pooledDataSource.getMinPoolSize(), pooledDataSource.getMaxIdleTime());
     Statement statement = pooledDataSource.getConnection().createStatement();
 
-    double random = Math.random() * 1000000;
+    long random = Math.round(Math.random() * 1000000);
     String tableName = "oc_temp_" + random;
     try {
-      runUpdate(statement, "CREATE TABLE " + tableName + " ( id BIGINT NOT NULL, test BIGINT, PRIMARY KEY (id) );");
+      statement.executeUpdate("CREATE TABLE " + tableName + " ( id BIGINT NOT NULL, test BIGINT, PRIMARY KEY (id) );");
       runUpdate(statement, "INSERT INTO " + tableName + " VALUES (" + random + ", 0);");
       runUpdate(statement, "UPDATE " + tableName + " SET test = " + random + ";");
-      ResultSet rs = statement.executeQuery("SELECT FROM " + tableName + ";");
+      ResultSet rs = statement.executeQuery("SELECT * FROM " + tableName + ";");
       while (rs.next()) {
         long id = rs.getLong("id");
         long test = rs.getLong("test");
@@ -156,11 +156,12 @@ public class Activator implements BundleActivator {
         }
       }
       runUpdate(statement, "DELETE FROM " + tableName + " WHERE id = " + random + ";");
+      logger.info("Database credentials passed basic tests!");
     } catch (Exception e) {
-      throw new RuntimeException("Unable to verify SQL credentials have required permissions!");
+      throw new RuntimeException("Unable to verify SQL credentials have required permissions!", e);
     } finally {
       try {
-        runUpdate(statement, "DROP TABLE " + tableName + ";");
+        statement.executeQuery("DROP TABLE " + tableName + ";");
       } catch (Exception e) {
         logger.warn("Unable to delete temp table {}, please remove this yourself!", tableName);
       }

--- a/modules/db/src/main/java/org/opencastproject/db/Activator.java
+++ b/modules/db/src/main/java/org/opencastproject/db/Activator.java
@@ -141,25 +141,29 @@ public class Activator implements BundleActivator {
       pooledDataSource.getMaxPoolSize(), pooledDataSource.getMinPoolSize(), pooledDataSource.getMaxIdleTime());
     Statement statement = pooledDataSource.getConnection().createStatement();
 
-    long time = System.currentTimeMillis();
-    String tableName = "oc-temp" + time;
+    double random = Math.random() * 1000000;
+    String tableName = "oc_temp_" + random;
     try {
       runUpdate(statement, "CREATE TABLE " + tableName + " ( id BIGINT NOT NULL, test BIGINT, PRIMARY KEY (id) );");
-      runUpdate(statement, "INSERT INTO " + tableName + " VALUES (" + time + "," + time + ");");
-      runUpdate(statement, "INSERT INTO " + tableName + " VALUES (" + time + 1 + "," + time + 1 + ");");
-      runUpdate(statement, "UPDATE " + tableName + " SET test = " + time + 2 + " WHERE id = " + time + ";");
-      ResultSet rs = statement.executeQuery("SELECT FROM " + tableName + " WHERE id = " + time + 2 + ";");
+      runUpdate(statement, "INSERT INTO " + tableName + " VALUES (" + random + ", 0);");
+      runUpdate(statement, "UPDATE " + tableName + " SET test = " + random + ";");
+      ResultSet rs = statement.executeQuery("SELECT FROM " + tableName + ";");
       while (rs.next()) {
         long id = rs.getLong("id");
         long test = rs.getLong("test");
-        if (id != time || test != time + 2) {
+        if (id != random || test != random) {
           throw new RuntimeException("Unable to verify updating a table functions correctly");
         }
       }
-      runUpdate(statement, "DELETE FROM " + tableName + " WHERE id = " + time + ";");
-      runUpdate(statement, "DROP TABLE " + tableName + ";");
+      runUpdate(statement, "DELETE FROM " + tableName + " WHERE id = " + random + ";");
     } catch (Exception e) {
       throw new RuntimeException("Unable to verify SQL credentials have required permissions!");
+    } finally {
+      try {
+        runUpdate(statement, "DROP TABLE " + tableName + ";");
+      } catch (Exception e) {
+        logger.warn("Unable to delete temp table {}, please remove this yourself!", tableName);
+      }
     }
 
   }


### PR DESCRIPTION
Adding an attempt to check if the database user permissions are correct.  This is by no means comprehensive, but will catch a bunch of easily missed situations.  The exception looks like the following, and stops Opencast from booting:

```
2020-11-27T16:28:35,989 | ERROR | (BootFeaturesInstaller:113) - Error installing boot features
org.apache.karaf.features.internal.util.MultiException: Error restarting bundles:
        Activator start error in bundle opencast-db [80].
        at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:1044) ~[?:?]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.doProvision(FeaturesServiceImpl.java:1062) ~[?:?]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.lambda$doProvisionInThread$13(FeaturesServiceImpl.java:998) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:834) [?:?]
        Suppressed: org.osgi.framework.BundleException: Activator start error in bundle opencast-db [80].
                at org.apache.felix.framework.Felix.activateBundle(Felix.java:2290) ~[?:?]
                at org.apache.felix.framework.Felix.startBundle(Felix.java:2146) ~[?:?]
                at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:998) ~[?:?]
                at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:984) ~[?:?]
                at org.apache.karaf.features.internal.service.BundleInstallSupportImpl.startBundle(BundleInstallSupportImpl.java:165) ~[?:?]
                at org.apache.karaf.features.internal.service.FeaturesServiceImpl.startBundle(FeaturesServiceImpl.java:1153) ~[?:?]
                at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:1036) ~[?:?]
                at org.apache.karaf.features.internal.service.FeaturesServiceImpl.doProvision(FeaturesServiceImpl.java:1062) ~[?:?]
                at org.apache.karaf.features.internal.service.FeaturesServiceImpl.lambda$doProvisionInThread$13(FeaturesServiceImpl.java:998) ~[?:?]
                at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
                at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
                at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
                at java.lang.Thread.run(Thread.java:834) [?:?]
        Caused by: java.lang.RuntimeException: Unable to verify SQL credentials have required permissions!
                at org.opencastproject.db.Activator.start(Activator.java:161) ~[?:?]
                at org.apache.felix.framework.util.SecureAction.startActivator(SecureAction.java:697) ~[?:?]
                at org.apache.felix.framework.Felix.activateBundle(Felix.java:2240) ~[?:?]
                ... 12 more
```

Note: I've tested against MariaDB 10 so this will probably work against MySQL as well. We should double check that it works against PostgreSQL though... 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
