### PR TITLE
Use series ACL as default ACL for events in LTI upload tool if available

### DIFF
--- a/modules/lti-service-impl/pom.xml
+++ b/modules/lti-service-impl/pom.xml
@@ -60,6 +60,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-series-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.entwinemedia.common</groupId>
       <artifactId>functional</artifactId>
     </dependency>

--- a/modules/lti-service-impl/src/main/resources/OSGI-INF/lti-service-impl.xml
+++ b/modules/lti-service-impl/src/main/resources/OSGI-INF/lti-service-impl.xml
@@ -38,4 +38,6 @@
              bind="setWorkspace"/>
   <reference name="authorization-service" interface="org.opencastproject.security.api.AuthorizationService"
              bind="setAuthorizationService"/>
+  <reference name="series-service" interface="org.opencastproject.series.api.SeriesService"
+             bind="setSeriesService"/>
 </scr:component>


### PR DESCRIPTION
This PR meet the following requirement.
If an LTI tool is set as an upload form with such params 
- `tool=ltitools/index.html`
-  `subtool=upload`
- `series=SERIESID`
Users may hope the upload videos has the same privileges as the corresponding series do.

Yet, current code just add 4 fix ACL:
- ROLE_ADMIN, write
- ROLE_ADMIN, read
- ROLE_OAUTH_USER, write
- ROLE_OAUTH_USER, read

This is suitable for videos without series setting, but may not friendly enough for videos with a series setting.

This PR will give the upload videos ACL as the same as the series ACL if the series is available.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
