### PR TITLE
Fix pagination for LTI series page

### DIFF
--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -60,6 +60,8 @@ const SeriesEpisode: React.StatelessComponent<EpisodeProps> = ({ episode, delete
     </div>;
 }
 
+const EPISONDES_PER_PAGE:number = 15;
+
 class TranslatedSeries extends React.Component<SeriesProps, SeriesState> {
     constructor(props: SeriesProps) {
         super(props);
@@ -75,15 +77,15 @@ class TranslatedSeries extends React.Component<SeriesProps, SeriesState> {
             ...this.state,
             currentPage: pageNumber
         });
-        this.loadCurrentPage();
+        this.loadCurrentPage(pageNumber);
     }
 
-    loadCurrentPage() {
+    loadCurrentPage(pageNumber: number = 1) {
         const qs = parsedQueryString();
-        const episodesPerPage = 15;
+
         searchEpisode(
-            episodesPerPage,
-            this.state.currentPage - 1,
+            EPISONDES_PER_PAGE,
+            (pageNumber - 1) * EPISONDES_PER_PAGE,
             undefined,
             typeof qs.series === "string" ? qs.series : undefined,
             typeof qs.series_name === "string" ? qs.series_name : undefined
@@ -190,7 +192,7 @@ class TranslatedSeries extends React.Component<SeriesProps, SeriesState> {
                 <footer className="mt-3">
                     <Pagination
                         activePage={this.state.currentPage}
-                        itemsCountPerPage={sr.limit}
+                        itemsCountPerPage={EPISONDES_PER_PAGE}
                         totalItemsCount={sr.total}
                         pageRangeDisplayed={5}
                         itemClass="page-item"


### PR DESCRIPTION
### Test plan
1. Have a series with 16 episodes. The ACL of the series and episode should be properly set to allow LMS user to access it.
2. Embed Opencast to an LMS as LTI tools with the following settings
`tool=ltitools/index.html`
`subtool=series`
`series=SERIESID`
`SERIESID` should match the id in step 1
3. Open the LTI tool in LMS, and click the 2nd page link.

### Expected behaviors
The LTI tool should list only the 16th episode in page 2.

### Actual Behaviors
2nd - 16th episodes are shown in page 2.

### Cause
The param `offset` (2nd param) of `searchEpisode` is the number of records as offset, yet `current_page` (page_number) is used.
So, for the test plan, when click the 2nd page, `searchEpisode` return 15 results since the 2nd record. And 2nd to 16th episodes are returned.

This PR fix this problem.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
