### PR TITLE
Fix apache-httpd doc

### DIFF
--- a/docs/guides/admin/docs/configuration/https/apache-httpd.md
+++ b/docs/guides/admin/docs/configuration/https/apache-httpd.md
@@ -65,7 +65,7 @@ The main goals of this set-up are:
   RequestHeader set X-Forwarded-Proto "https"
 
   # Make sure to serve cookies only via secure connections.
-  Header edit Set-Cookie ^(.*)$ $1; HttpOnly; Secure
+  Header edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure
 
   # Depending on your integration, you may also want to allow cookies
   # to be used on other sites. In that case, use this instead:


### PR DESCRIPTION
According to Apache HTTPD Server [mod_headers doc](http://httpd.apache.org/docs/current/mod/mod_headers.html#header)
The grammar should be `Header [condition] add|append|echo|edit|edit*|merge|set|setifempty|unset|note header [[expr=]value [replacement] [early|env=[!]varname|expr=expression]]`

For Opencast, the setting is `Header edit Set-Cookie ^(.*)$ $1; HttpOnly; Secure`, and the part `$1; HttpOnly; Secure` is corresponding to `[replacement]`, which should not contain space, or should be surrounded with quotes.

Current config would not be passed by `apachectl configtest`, and get a warning message `Header has too many arguments`

This PR remove the space in `[replacement]` field, and pass the configtest.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
