### PR TITLE
Error Notification Style

### DIFF
--- a/modules/admin-ui-frontend/app/styles/main.scss
+++ b/modules/admin-ui-frontend/app/styles/main.scss
@@ -164,7 +164,7 @@ a.disabled, button.disabled, div.disabled {
 
 .ng-multi-value {
   display: inline-block;
-  padding: 0px 5px;
+  padding: 2px 5px;
   margin: 1px 5px 1px 0;
   font-size: 11px;
   background: $l-blue;


### PR DESCRIPTION
This patch is a tiny style adjustment to the error notifications which
had barely any space at the bottom, potentially cutting into some
characters.

![Screenshot from 2020-11-04 02-06-03](https://user-images.githubusercontent.com/1008395/100523165-9d6a6c00-31ae-11eb-847a-62d73122137e.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
