### PR TITLE
Fix admin interface not displaying the correct role

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -168,6 +168,9 @@ angular.module('adminNg.controllers')
         },
         changePolicies = function (access, loading) {
           var newPolicies = {};
+          if (!Array.isArray(access)) {
+            access = [access];
+          }
           angular.forEach(access, function (acl) {
             var policy = newPolicies[acl.role];
 

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -431,7 +431,7 @@ angular.module('adminNg.controllers')
           //to resolve before we can add the roles that are present in the series but not in the system
           $scope.access.$promise.then(function () {
             $scope.roles.$promise.then(function() {
-              angular.forEach($scope.access.episode_access.privileges, function(newRole) {
+              angular.forEach(Object.keys($scope.access.episode_access.privileges), function(newRole) {
                 if ($scope.roles.indexOf(newRole) == -1) {
                   $scope.roles.push(newRole);
                 }


### PR DESCRIPTION
If a role is not provided by the admin interface's list provider, it will now be displayed in the role selection.

Previously, there was a bug and the UI displayed [object, Object] in the role selection.
Now it shows the name of the role.

This fixes #1969.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
