### PR TITLE
Fix usage of "organizers" instead of "creators" for series in Admin UI

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -602,7 +602,7 @@ public class SeriesEndpoint implements ManagedService {
             case SeriesIndexSchema.CONTRIBUTORS:
               query.sortByContributors(criterion.getOrder());
               break;
-            case SeriesIndexSchema.CREATOR:
+            case SeriesIndexSchema.ORGANIZERS:
               query.sortByOrganizers(criterion.getOrder());
               break;
             case SeriesIndexSchema.CREATED_DATE_TIME:

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/seriesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/seriesController.js
@@ -33,8 +33,8 @@ angular.module('adminNg.controllers')
         label: 'EVENTS.SERIES.TABLE.TITLE',
         sortable: true
       }, {
-        template: 'modules/events/partials/seriesCreatorsCell.html',
-        name:  'creators',
+        template: 'modules/events/partials/seriesOrganizersCell.html',
+        name:  'organizers',
         label: 'EVENTS.SERIES.TABLE.ORGANIZERS',
         sortable: true
       }, {

--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesOrganizersCell.html
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/partials/seriesOrganizersCell.html
@@ -1,4 +1,4 @@
-<span ng-repeat="creator in row.creators"
+<span ng-repeat="creator in row.organizers"
       class=metadata-entry>
   {{creator}}
 </span>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-series-modal.html
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/partials/modals/delete-series-modal.html
@@ -46,7 +46,7 @@
                   </td>
                   <td>{{ row.title }}</td>
                   <td>
-                    <span class="metadata-entry" ng-repeat="creator in row.creators">{{ creator }}</span>
+                    <span class="metadata-entry" ng-repeat="organizer in row.organizers">{{ organizer }}</span>
                   </td>
                   <td ng-class="row.hasEvents == true ? 'fa fa-check' : ''"></td>
                 </tr>

--- a/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesResource.js
+++ b/modules/admin-ui/src/main/webapp/scripts/shared/resources/seriesResource.js
@@ -34,7 +34,7 @@ angular.module('adminNg.resources')
           var row = {};
           row.id = r.id;
           row.title = r.title;
-          row.creators = r.organizers;
+          row.organizers = r.organizers;
           row.contributors = r.contributors;
           row.createdDateTime = Language.formatDate('short', r.creation_date);
           row.managed_acl = r.managedAcl;

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/SeriesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/SeriesEndpointTest.java
@@ -103,7 +103,7 @@ public class SeriesEndpointTest {
     reader = new InputStreamReader(stream);
     expected = (JSONObject) new JSONParser().parse(reader);
 
-    actual = (JSONObject) parser.parse(given().queryParam("sort", "creator:DESC").expect().statusCode(HttpStatus.SC_OK)
+    actual = (JSONObject) parser.parse(given().queryParam("sort", "organizers:DESC").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).when().get(rt.host("/series.json")).asString());
     Assert.assertEquals(expected, actual);
 
@@ -111,7 +111,7 @@ public class SeriesEndpointTest {
     reader = new InputStreamReader(stream);
     expected = (JSONObject) new JSONParser().parse(reader);
 
-    actual = (JSONObject) parser.parse(given().queryParam("sort", "creator:ASC").expect().statusCode(HttpStatus.SC_OK)
+    actual = (JSONObject) parser.parse(given().queryParam("sort", "organizers:ASC").expect().statusCode(HttpStatus.SC_OK)
             .contentType(ContentType.JSON).when().get(rt.host("/series.json")).asString());
     Assert.assertEquals(expected, actual);
     // Test Sort by Title

--- a/modules/admin-ui/src/test/resources/test/unit/shared/resources/seriesResourceSpec.js
+++ b/modules/admin-ui/src/test/resources/test/unit/shared/resources/seriesResourceSpec.js
@@ -35,7 +35,7 @@ describe('Series API Resource', function () {
             $httpBackend.flush();
             expect(data.rows.length).toBe(2);
             expect(data.rows[0].title).toEqual('Mock Series');
-            expect(data.rows[0].creators).toEqual(['Ophelia Organizer']);
+            expect(data.rows[0].organizers).toEqual(['Ophelia Organizer']);
             expect(data.rows[0].contributors).toEqual(['Carl Contributor', 'Carmen Contributor']);
             expect(data.rows[0].createdDateTime).toEqual('2018-08-13T07:20:41Z');
         });


### PR DESCRIPTION
At some point, some of the instances of "creator" were renamed to
"organizer", but apparently a couple instances were forgotten. As a
consequence, it was not possible to sort the series table by
organizers -- a bug which is fixed by this commit.

CC @KatrinIhler as you know stuff about the admin UI and probably touched this code once.

Where I'm still unsure is the two remaining uses of `SeriesIndexSchema.CREATOR`:

https://github.com/opencast/opencast/blob/1a221000150f6474c42beae79494c3ab30c59136/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesQueryBuilder.java#L102-L104

https://github.com/opencast/opencast/blob/1a221000150f6474c42beae79494c3ab30c59136/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesIndexUtils.java#L109-L111

I *think* both of those can be removed, but I am not sure, so I need another opinion on that. Is there still a "creator" metadata field for series that is used? Because if not: below both of these snippets, there is code handling organizers already, so it seems like the if-branches for the "creators" are never entered.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
