### PR TITLE
Fix Ingest by Non-privileged User

### DIFF
--- a/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/WorkflowPropertiesUtil.java
+++ b/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/WorkflowPropertiesUtil.java
@@ -21,6 +21,8 @@
 package org.opencastproject.assetmanager.util;
 
 import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
+import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_EPISODE;
+import static org.opencastproject.mediapackage.MediaPackageElements.XACML_POLICY_SERIES;
 import static org.opencastproject.systems.OpencastConstants.WORKFLOW_PROPERTIES_NAMESPACE;
 
 import org.opencastproject.assetmanager.api.AssetManager;
@@ -30,6 +32,8 @@ import org.opencastproject.assetmanager.api.Value;
 import org.opencastproject.assetmanager.api.query.AQueryBuilder;
 import org.opencastproject.assetmanager.api.query.ARecord;
 import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.mediapackage.Attachment;
+import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilderImpl;
 
@@ -99,7 +103,17 @@ public final class WorkflowPropertiesUtil {
     // Properties can only be created if a snapshot exists. Hence, we create a snapshot if there is none right now.
     // Although, to avoid lots of potentially slow IO operations, we archive an empty media package.
     if (!assetManager.snapshotExists(mediaPackage.getIdentifier().toString())) {
-      assetManager.takeSnapshot(DEFAULT_OWNER, new MediaPackageBuilderImpl().createNew(mediaPackage.getIdentifier()));
+      MediaPackage simplifiedMediaPackage = new MediaPackageBuilderImpl().createNew(mediaPackage.getIdentifier());
+      for (Catalog catalog: mediaPackage.getCatalogs()) {
+        simplifiedMediaPackage.add(catalog);
+      }
+      for (Attachment attachment: mediaPackage.getAttachments(XACML_POLICY_EPISODE)) {
+        simplifiedMediaPackage.add(attachment);
+      }
+      for (Attachment attachment: mediaPackage.getAttachments(XACML_POLICY_SERIES)) {
+        simplifiedMediaPackage.add(attachment);
+      }
+      assetManager.takeSnapshot(DEFAULT_OWNER, simplifiedMediaPackage);
     }
 
     // Store all properties


### PR DESCRIPTION
This patch fixes non-scheduled ingests by non-privileged users which can
currently run into the problem that they don't get the necessary access
rights.

What probably happed was:

- Opencast would create a first version in the asset manager not storing the access control list
- Opencast would then try storing workflow parameters in the asset manager but the asset manager would block access since there are no rules allowing that
- Since no metadata were stored, the event would appear to be empty in the admin interface

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
