### PR TITLE
Wowza url signing

### DIFF
--- a/docs/guides/admin/docs/configuration/stream-security.md
+++ b/docs/guides/admin/docs/configuration/stream-security.md
@@ -220,6 +220,25 @@ Example:
     url.regex.archive=.*archive\/archive\/mediapackage\/.*\/.*\/.*
     url.regex.static=.*static.*
 
+Configuration of Wowza URL Signing
+----------------------------------
+
+To configure Wowza URL Signing, you should use the file configuration `org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg`.
+
+You can find three properties to configure:
+
+    # key.wowzatoken.secret=myTokenPrefix:mySharedSecret
+    # key.wowzatoken.url=http://localhost:8080
+    # key.wowzatoken.organization=mh_default_org
+
+Each property has the form: key.*keyId*.*propertyName*
+
+`key.wowzatoken.organization` is optional. By deafult is `*`, that means any organization.
+
+`key.wowzatoken.url` is mandatory. describes the url prefix that urls must have.
+
+`key.wowzatoken.secret=myTokenPrefix:mySharedSecret` is mandatory. It is a pair separated by `:`. First value, `myTokenPrefix`, means defines the prefix that all parameters of signed urls will have. Second value, `mySharedSecret`, defines a secret value, to secure urls.
+
 Testing
 -------
 

--- a/etc/org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg
+++ b/etc/org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg
@@ -10,7 +10,9 @@
 # A URL signing key has the following attributes:
 
     # Key ID: Key Identifier, e.g. ‘demoKeyOne’
-    # Key secret: Key value, e.g. ‘25DA2BA549CB62EF297977845259A’. The key-length is not predefined, but a key length of
+    # Key secret: Key value pair prefix:secret
+        # prefix is the prefix that all the parameters of the url will have.
+        # secret is a key value, e.g. ‘25DA2BA549CB62EF297977845259A’. The key-length is not predefined, but a key length of
         # at least 128 bit is recommended. Any larger value will not increase security of the underlying algorithm.
     # URL prefix: The URL Signing Provider will only sign URLs that start with this value. This allows to support
         # multiple distributions and different key pairs.
@@ -25,3 +27,7 @@
 
 # key.demoKeyTwo.secret=6EDB5EDDCF994B7432C371D7C274F
 # key.demoKeyTwo.url=http://wowza.opencast.org/custom
+
+# key.wowzatoken.secret=myTokenPrefix:mySharedSecret
+# key.wowzatoken.url=http://localhost:8080/
+# key.wowzatoken.organization=mh_default_org

--- a/modules/urlsigning-service-impl/pom.xml
+++ b/modules/urlsigning-service-impl/pom.xml
@@ -17,6 +17,10 @@
   <dependencies>
     <!-- Third Party -->
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/WowzaResourceStrategyImpl.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/WowzaResourceStrategyImpl.java
@@ -39,15 +39,29 @@ public class WowzaResourceStrategyImpl implements ResourceStrategy {
   private static final String FIND_STREAM_FORMAT = ".{3}[:].*$";
   /** The URI scheme that an RTMP address uses. */
   private static final String RTMP_SCHEME = "rtmp";
+  /** The URI scheme that an http address uses. */
+  private static final String ADAPTIVESTREAMING_HTTP_SCHEME = "http";
+  /** The URI scheme that an https address uses. */
+  private static final String ADAPTIVESTREAMING_HTTPS_SCHEME = "https";
   /** The possible delimiter between the server & application and the stream path and file. */
   private static final String WOWZA_STREAM_DELIMITER = "_definst_";
 
+  /**
+   * Transform a base URI into a proper stream location without the host and application name.
+   *
+   * @param baseUri
+   *          The full URI to the resource including the host and application.
+   * @return A safe standard RTMP or HTTP resource location.
+   */
   @Override
   public String getResource(String baseUri) {
     try {
       URI uri = new URI(baseUri);
       String scheme = uri.getScheme();
-      if (RTMP_SCHEME.equals(scheme)) {
+      if (ADAPTIVESTREAMING_HTTP_SCHEME.equals(scheme)
+              || ADAPTIVESTREAMING_HTTPS_SCHEME.equals(scheme)) {
+            return getHTTPResource(uri);
+      } else if (RTMP_SCHEME.equals(scheme)) {
         return getRTMPResource(uri);
       } else {
         throw new IllegalArgumentException(WowzaResourceStrategyImpl.class.getSimpleName()
@@ -88,4 +102,15 @@ public class WowzaResourceStrategyImpl implements ResourceStrategy {
             + (StringUtils.isNotBlank(baseUri.getQuery()) ? "?" + baseUri.getQuery() : "");
   }
 
+  /**
+   * Transform a base URI into a proper stream location without the host.
+   *
+   * @param baseUri
+   *          The full URI to the resource including the host and application.
+   * @return A safe standard HTTP resource location.
+   */
+  protected static String getHTTPResource(URI baseUri) {
+    // There are no special delimiters so assume the first value between two forward slashes (/.../) is the application.
+    return baseUri.getPath().substring(baseUri.getPath().indexOf("/") + 1, baseUri.getPath().lastIndexOf("/"));
+  }
 }

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProvider.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProvider.java
@@ -21,13 +21,25 @@
 package org.opencastproject.security.urlsigning.provider.impl;
 
 import org.opencastproject.security.urlsigning.WowzaResourceStrategyImpl;
+import org.opencastproject.security.urlsigning.exception.UrlSigningException;
+import org.opencastproject.urlsigning.common.Policy;
 import org.opencastproject.urlsigning.common.ResourceStrategy;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
 public class WowzaUrlSigningProvider extends AbstractUrlSigningProvider {
+
   private static final Logger logger = LoggerFactory.getLogger(WowzaUrlSigningProvider.class);
+
   /** The Wowza resource strategy to use to convert from the base url to a resource url. */
   private ResourceStrategy resourceStrategy = new WowzaResourceStrategyImpl();
 
@@ -46,4 +58,170 @@ public class WowzaUrlSigningProvider extends AbstractUrlSigningProvider {
     return "Wowza URL Signing Provider";
   }
 
+  /**
+   * @param policy
+   *             the policy
+   * @return the signed url
+   */
+  @Override
+  public String sign(Policy policy) throws UrlSigningException {
+    if (!accepts(policy.getBaseUrl())) {
+      throw UrlSigningException.urlNotSupported();
+    }
+
+    try {
+      URI uri = new URI(policy.getBaseUrl());
+
+      /*
+        For backward compatibility, but i can not see how this could work.
+        According to the documentation "https://www.wowza.com/docs/how-to-protect-streaming-using-securetoken-in-wowza-streaming-engine"
+        if you using token v1 we need a TEA implementation.
+      */
+      if ("rtmp".equals((uri.getScheme()))) {
+          return super.sign(policy);
+      }
+
+      Key key = getKey(policy.getBaseUrl());
+      policy.setResourceStrategy(getResourceStrategy());
+
+      if (!key.getSecret().contains(":")) {
+          getLogger().error("Given key not valid. (prefix:secret)");
+          throw new Exception("Given key not valid. (prefix:secret)");
+      }
+      String[] wowzaKeyPair = key.getSecret().split(":");
+      String wowzaPrefix = wowzaKeyPair[0];
+      String wowzaSecret = wowzaKeyPair[1];
+
+      String newUri = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(),
+              addSignutureToRequest(policy, wowzaPrefix, wowzaSecret), null).toString();
+      return newUri;
+    } catch (Exception e) {
+      getLogger().error("Unable to create signed URL because {}", ExceptionUtils.getStackTrace(e));
+      throw new UrlSigningException(e);
+    }
+  }
+
+  /**
+   * @param policy
+   *             the policy
+   * @param encryptionKeyId
+   *             the encription key id
+   * @param encryptionKey
+   *             the encription key
+   * @return true
+   *             if the url is excluded, false otherwise
+   * @exception Exception
+   *             if something goes bad
+   */
+  private String addSignutureToRequest(Policy policy, String encryptionKeyId, String encryptionKey) throws Exception  {
+    final String startTime;
+    final String endTime = Long.toString(policy.getValidUntil().getMillis());
+    final String ip;
+
+    String baseUrl = policy.getBaseUrl();
+    URI url = new URI(policy.getBaseUrl());
+    String resource = policy.getResource();
+    if (policy.getClientIpAddress().isPresent()) {
+      // The ip comes with a slash: /192.168.1.2
+      String ipAux = policy.getClientIpAddress().get().toString();
+      ipAux = ipAux.substring(1, ipAux.length());
+      ip = ipAux;
+    } else {
+      ip = "";
+    }
+
+    if (policy.getValidFrom().isPresent()) {
+      startTime = Long.toString(policy.getValidFrom().get().getMillis());
+    } else {
+      startTime = "";
+    }
+
+    String queryStringParameters = new String();
+
+    queryStringParameters += encryptionKeyId + "endtime=" + endTime;
+
+    if (!"".equals(startTime)) {
+      queryStringParameters += "&" + encryptionKeyId + "starttime=" + startTime;
+    }
+
+    if (url.getQuery() != null) {
+      String query = url.getQuery();
+      String[] params = query.split("&");
+      for (String param : params) {
+        if (param.contains("=")) {
+          String[] keyValue = param.split("=");
+          queryStringParameters += "&" + encryptionKeyId + keyValue[0] + "=" + keyValue[1];
+        }
+      }
+    }
+
+    queryStringParameters += "&" + encryptionKeyId + "hash=" + generateHash(baseUrl, resource, ip, encryptionKeyId, encryptionKey, startTime, endTime);
+
+    return queryStringParameters;
+  }
+
+  /**
+   * @param baseUrl
+   *             the base url
+   * @param resource
+   *             the resource
+   * @param ip
+   *             the ip
+   * @param encryptionKeyId
+   *             the encription key id
+   * @param encryptionKey
+   *             the encription key
+   * @param startTime
+   *             start time
+   * @param endtime
+   *             end time
+   * @return the generated hashed
+   * @exception Exception
+   *             if something goes bad
+   */
+  private String generateHash(String baseUrl, String resource, String ip, String encryptionKeyId, String encryptionKey, String startTime, String endTime) throws Exception {
+    String urlToHash = resource + "?";
+
+    if (!"".equals(ip)) {
+      urlToHash += ip + "&" + encryptionKey;
+    } else {
+      urlToHash += encryptionKey;
+    }
+
+    SortedMap<String, String> arguments = new TreeMap<>();
+
+    arguments.put(encryptionKeyId + "endtime", endTime);
+
+    if (!"".equals(startTime)) {
+        arguments.put(encryptionKeyId + "starttime", startTime);
+    }
+
+    String query = new URI(baseUrl).getQuery();
+    if (null == query) {
+        query = "";
+    }
+
+    String[] params = query.split("&");
+    for (String param : params) {
+      if (param.contains("=")) {
+        String[] keyValue = param.split("=");
+        arguments.put(encryptionKeyId + keyValue[0], keyValue[1]);
+      }
+    }
+
+    for (Map.Entry<String,String> entry : arguments.entrySet()) {
+        String value = entry.getValue();
+        String key = entry.getKey();
+        urlToHash += "&" + key + "=" + value;
+    }
+
+    MessageDigest md = MessageDigest.getInstance("SHA-256");
+    byte[] messageDigest = md.digest(urlToHash.getBytes());
+    String base64Hash = Base64.getEncoder().encodeToString(messageDigest);
+
+    base64Hash = base64Hash.replaceAll("\\+", "-");
+    base64Hash = base64Hash.replaceAll("/", "_");
+
+    return base64Hash;
+  }
 }

--- a/modules/urlsigning-service-impl/src/test/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProviderTest.java
+++ b/modules/urlsigning-service-impl/src/test/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProviderTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.security.urlsigning.provider.impl;
+
+import static org.junit.Assert.assertTrue;
+
+import org.opencastproject.security.api.JaxbOrganization;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.urlsigning.WowzaResourceStrategyImpl;
+import org.opencastproject.security.urlsigning.exception.UrlSigningException;
+import org.opencastproject.urlsigning.common.Policy;
+
+import org.easymock.EasyMock;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.osgi.service.cm.ConfigurationException;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+public class WowzaUrlSigningProviderTest {
+  private static final String KEY_ID = "wowza";
+  private static final String URL_VALUE = "http://192.168.1.1:1935";
+  private static final String SECRET_VALUE = "myTokenPrefix:mySharedSecret";
+  private static final String ORGANIZATION_ID = "mh_default_org";
+
+  private static WowzaUrlSigningProvider signer;
+  private static Dictionary<String, String> properties;
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    JaxbOrganization organization = EasyMock.createNiceMock(JaxbOrganization.class);
+    EasyMock.expect(organization.getId()).andReturn(ORGANIZATION_ID).anyTimes();
+    EasyMock.replay(organization);
+
+    SecurityService securityService = EasyMock.createNiceMock(SecurityService.class);
+    EasyMock.expect(securityService.getOrganization()).andReturn(organization).anyTimes();
+    EasyMock.replay(securityService);
+    signer = new WowzaUrlSigningProvider();
+    signer.setSecurityService(securityService);
+
+    properties = new Hashtable<>();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    properties = new Hashtable<>();
+    signer.updated(properties);
+  }
+
+  @Test
+  public void testSign() throws UrlSigningException, ConfigurationException {
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, AbstractUrlSigningProvider.SECRET), SECRET_VALUE);
+    properties.put(String.join(".", AbstractUrlSigningProvider.KEY_PROPERTY_PREFIX, KEY_ID, AbstractUrlSigningProvider.URL), URL_VALUE);
+
+    signer.updated(properties);
+
+    String ip = "192.168.1.2";
+    String encryptionKeyId = "myTokenPrefix";
+    String encryptionKey = "mySharedSecret";
+    String startTime = "1395230400";
+    String endTime = "1500000000";
+    String predefinedHash = "TgJft5hsjKyC5Rem_EoUNP7xZvxbqVPhhd0GxIcA2oo=";
+    String predefinedUri = "http://192.168.1.1:1935/vod/sample.mp4/playlist.m3u8?"
+            + encryptionKeyId + "endtime=" + endTime
+            + "&" + encryptionKeyId + "starttime=" + startTime
+            + "&" + encryptionKeyId + "CustomParameter=abcdef"
+            + "&" + encryptionKeyId + "hash=" + predefinedHash;
+
+    Policy policy = Policy.mkPolicyValidFromWithIP(
+            "http://192.168.1.1:1935/vod/sample.mp4/playlist.m3u8?CustomParameter=abcdef",
+            new DateTime(Long.parseLong(endTime)), new DateTime(Long.parseLong(startTime)), ip);
+    policy.setResourceStrategy(new WowzaResourceStrategyImpl());
+
+    String uri = signer.sign(policy);
+
+    assertTrue(uri.equals(predefinedUri));
+  }
+}


### PR DESCRIPTION
This is a feature to sign urls with Wowza.
To configure this, use the file configuration **org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg**

Each property has the form: key._keyId_._propertyName_

**key.wowzatoken.organization** is optional. By default is *, that means any organization.
**key.wowzatoken.url** is mandatory. describes the url prefix that urls must have.
**key.wowzatoken.secret=myTokenPrefix:mySharedSecret** is mandatory. It is a pair separated by **:**. First value, _myTokenPrefix_, means the prefix that all parameters of signed urls will have. Second value, _mySharedSecret_, defines a secret value, to secure urls.