### PR TITLE
Fixes the lti captions upload together with the default ingest workflow #2167

### DIFF
--- a/etc/workflows/partial-ingest.xml
+++ b/etc/workflows/partial-ingest.xml
@@ -98,7 +98,7 @@
       id="tag"
       description="Tagging captions for publication">
       <configurations>
-        <configuration key="source-flavors">*/captions</configuration>
+        <configuration key="source-flavors">captions/*</configuration>
         <configuration key="target-tags">+engage-download</configuration>
       </configurations>
     </operation>

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -251,7 +251,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
         throw new RuntimeException("Unable to create media package for event");
       }
       if (captions != null) {
-        final MediaPackageElementFlavor captionsFlavor = new MediaPackageElementFlavor("vtt+en", "captions");
+        final MediaPackageElementFlavor captionsFlavor = new MediaPackageElementFlavor("captions", "vtt+en");
         final MediaPackageElementBuilder elementBuilder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
         final MediaPackageElement captionsMpe = elementBuilder
                 .newElement(MediaPackageElement.Type.Attachment, captionsFlavor);


### PR DESCRIPTION
The LTI upload used the incorrect flavor for the captions, resulting in paella player not able to find the captions. This aims to fix that.