### PR TITLE
Fix Sorting Series by Creators

### DIFF
--- a/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/seriesController.js
+++ b/modules/admin-ui/src/main/webapp/scripts/modules/events/controllers/seriesController.js
@@ -34,7 +34,7 @@ angular.module('adminNg.controllers')
         sortable: true
       }, {
         template: 'modules/events/partials/seriesCreatorsCell.html',
-        name:  'creators',
+        name:  'creator',
         label: 'EVENTS.SERIES.TABLE.ORGANIZERS',
         sortable: true
       }, {


### PR DESCRIPTION
This patch fixes the sorting of series by its creators in the admin
interface which was broken due to an incorrect sort term being used.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
