### PR TITLE
Fix LTI Tool Documentation

### DIFF
--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -92,20 +92,20 @@ Opencast will redirect an LTI user to the URL specified by the LTI custom `tool`
 custom parameters to be defined separately in each place where an LTI tool is used, whereas other systems only allow
 custom parameters to be defined globally.
 
-- To show the media module, use `tool=engage/ui/`
-- To show all videos for a single series, specify the following parameters
-  - `tool=ltitools/index.html`
-  - `subtool=series`
-  - `series=SERIESID` if you have the series ID
-  - `series_name=SERIESNAME` if you just have the series name (has to be unique)
-  - `deletion=true` if you want to display a deletion button next to each episode
-  - `edit=true` if you want to display an edit button next to each episode
-- To show an upload form, specify the following parameters:
-  - `tool=ltitools/index.html`
-  - `subtool=upload`
-  - `series=SERIESID` if you have the series ID
-  - `series_name=SERIESNAME` if you just have the series name (has to be unique)
-- To show a single video, use `tool=/play/MEDIAPACKAGEID`
+- To show the media module, use `engage/ui/` as LTI `custom_tool` launch parameter
+- To show all videos for a single series, use `ltitools/index.html` as LTI `custom_tool` launch parameter
+  and specify the following query parameters:
+    - `subtool=series`
+    - `series=SERIESID` if you have the series ID
+    - `series_name=SERIESNAME` if you just have the series name (has to be unique)
+    - `deletion=true` to show a delete button next to each episode
+    - `edit=true` if you want to display an edit button next to each episode
+- To show an upload dialog, use `ltitools/index.html` as LTI `custom_tool` launch parameter
+  and specify the following query parameters:
+    - `subtool=upload`
+    - `series=SERIESID` if you have the series ID
+    - `series_name=SERIESNAME` if you just have the series name (has to be unique)
+- To show a single video, use `/play/<id>` as LTI `custom_tool` launch parameter
 - To show a debug page before proceeding to the tool, append the parameter `test=true`
 
 For more information about how to set custom LTI parameters, please check the documentation of your LMS.


### PR DESCRIPTION
The current documentation confuses LTI launch parameters such as
`custom_tool` with query parameters of the tool itself making it hard to
know what to actually send to the tool.

This patch fixes the problem by properly naming and structuring the
tool's parameters.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
