### PR TITLE
Copy to Clipboard Tooltip

### DIFF
--- a/docs/guides/admin/docs/javascript/extra.js
+++ b/docs/guides/admin/docs/javascript/extra.js
@@ -140,6 +140,7 @@ function createButton(id) {
     button.classList.add("glyphicon");
     button.classList.add("glyphicon-copy");
     button.classList.add("click-and-copy-button");
+    button.title = 'Copy to clipboard';
     return button;
 }
 

--- a/docs/guides/developer/docs/javascript/extra.js
+++ b/docs/guides/developer/docs/javascript/extra.js
@@ -140,6 +140,7 @@ function createButton(id) {
     button.classList.add("glyphicon");
     button.classList.add("glyphicon-copy");
     button.classList.add("click-and-copy-button");
+    button.title = 'Copy to clipboard';
     return button;
 }
 


### PR DESCRIPTION
This patch adds a title to the copy to clipboard button in Opencast's
documentation.

---

![docs-copy-to-clipboard](https://user-images.githubusercontent.com/1008395/103443120-3849e080-4c5c-11eb-91d2-2ca5ab79e9c8.png)

---

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
