### PR TITLE
No Decoration on Section Links

### DIFF
--- a/docs/guides/admin/docs/css/extra.css
+++ b/docs/guides/admin/docs/css/extra.css
@@ -153,6 +153,7 @@ a.header-link {
     margin-left: 10px;
     font-size: 80%;
     opacity: 0.3;
+    text-decoration: none;
 }
 
 a.header-link:hover {

--- a/docs/guides/developer/docs/css/extra.css
+++ b/docs/guides/developer/docs/css/extra.css
@@ -153,6 +153,7 @@ a.header-link {
     margin-left: 10px;
     font-size: 80%;
     opacity: 0.3;
+    text-decoration: none;
 }
 
 a.header-link:hover {


### PR DESCRIPTION
This patch removes the text decoration from the section link which looks
kind of odd when hovering over it.

![docs-section-link](https://user-images.githubusercontent.com/1008395/103443303-0e91b900-4c5e-11eb-99fe-9eb2c693ad2b.jpg)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
