### PR TITLE
Inspect Media Size

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/attachment/AttachmentImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/attachment/AttachmentImpl.java
@@ -82,7 +82,7 @@ public class AttachmentImpl extends AbstractMediaPackageElement implements Attac
    * @param mimeType
    *          the attachments mime type
    */
-  protected AttachmentImpl(String identifier, MediaPackageElementFlavor flavor, URI uri, long size, Checksum checksum,
+  protected AttachmentImpl(String identifier, MediaPackageElementFlavor flavor, URI uri, Long size, Checksum checksum,
           MimeType mimeType) {
     super(identifier, Type.Attachment, flavor, uri, size, checksum, mimeType);
     if (uri != null)
@@ -98,7 +98,7 @@ public class AttachmentImpl extends AbstractMediaPackageElement implements Attac
    *          the attachments location
    */
   protected AttachmentImpl(URI uri) {
-    this(null, null, uri, 0, null, null);
+    this(null, null, uri, null, null, null);
   }
 
   /**

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -1196,9 +1196,14 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     cleanup(videoFile);
 
     MediaPackageElementBuilder builder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
-    List<Attachment> imageAttachments = new LinkedList<Attachment>();
+    List<Attachment> imageAttachments = new LinkedList<>();
     for (URI url : workspaceURIs) {
       Attachment attachment = (Attachment) builder.elementFromURI(url, Attachment.TYPE, null);
+      try {
+        attachment.setSize(workspace.get(url).length());
+      } catch (NotFoundException | IOException e) {
+        logger.warn("Could not get file size of {}", url);
+      }
       imageAttachments.add(attachment);
     }
 
@@ -1340,6 +1345,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
 
         MediaPackageElementBuilder builder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
         Attachment convertedImage = (Attachment) builder.elementFromURI(workspaceURI, Attachment.TYPE, null);
+        convertedImage.setSize(output.length());
         convertedImage.setIdentifier(IdImpl.fromUUID().toString());
         try {
           convertedImage.setMimeType(MimeTypes.fromURI(convertedImage.getURI()));

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspector.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspector.java
@@ -146,12 +146,15 @@ public class MediaInspector {
           throw new MediaInspectionException("Unable to extract audio metadata from " + file, e);
         }
 
-        // Videometadata
+        // Video metadata
         try {
           addVideoStreamMetadata(track, metadata);
         } catch (Exception e) {
           throw new MediaInspectionException("Unable to extract video metadata from " + file, e);
         }
+
+        // File size
+        track.setSize(file.length());
 
         return track;
       }


### PR DESCRIPTION
This patch makes the media inspection service add the media file size to
inspected media package elements.

This fixes #1169
This fixes #1177

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
