### PR TITLE
Improved Development Runtime Dependency Containers

### DIFF
--- a/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
@@ -15,6 +15,15 @@ services:
       - 127.0.0.1:61616:61616
     volumes:
       - ../activemq/activemq.xml:/activemq-opencast.tpl.xml:ro
+  postgresql:
+    container_name: opencast-postgresql
+    image: docker.io/library/postgres:12.3
+    ports:
+      - 127.0.0.1:5432:5432
+    environment:
+      POSTGRES_USER: opencast
+      POSTGRES_PASSWORD: opencast
+      POSTGRES_DB: dbpassword
   mariadb:
     container_name: opencast-mariadb
     image: docker.io/library/mariadb:10.5.5

--- a/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
@@ -22,5 +22,5 @@ services:
       - 127.0.0.1:5432:5432
     environment:
       POSTGRES_USER: opencast
-      POSTGRES_PASSWORD: opencast
+      POSTGRES_PASSWORD: dbpassword
       POSTGRES_DB: opencast


### PR DESCRIPTION
This patch changes the database password set in the container
configuration to the default password set in Opencast's
`custom.properties`. This means less configuration for developers when
they test database patches.

Additionally, this adds a docker compose file which will spin up all
supported databases, making tests on several systems easier since you
don't have to spin up a new environment between tests.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
