### PR TITLE
Check ICLA only on pull request

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -1,6 +1,5 @@
 name: Check ICLA
 on:
-  push:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
The ICLA check also runs on push events which causes a workflow failure
since the steps then try to comment on the non-existent pull request.
This patch fixes that problem.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
