### PR TITLE
Document use of self-signed certificates

### DIFF
--- a/docs/guides/admin/docs/configuration/https/index.md
+++ b/docs/guides/admin/docs/configuration/https/index.md
@@ -31,3 +31,5 @@ There are also a couple of great sites to test your final setup:
 
 If you have no easy way of obtaining proper TLS certificates for your organization, please consider using
 [Let’s Encrypt](https://letsencrypt.org).
+
+For testing and developer servers, [properly configured self-signed certificates](self-signed-certificates.md) can be an option.

--- a/docs/guides/admin/docs/configuration/https/self-signed-certificates.md
+++ b/docs/guides/admin/docs/configuration/https/self-signed-certificates.md
@@ -1,0 +1,110 @@
+Self-Signed Certificates
+========================
+
+Since commit [4225bf](https://github.com/opencast/opencast/commit/4225bf90af74557deaf8fb6b80b0705c9621acfc)
+([security advisory GHSA-44cw-p2hm-gpf6](https://github.com/opencast/opencast/security/advisories/GHSA-44cw-p2hm-gpf6))
+Opencast services check the validity of the certificates presented by
+third parties and when connecting to each other remotely.
+
+The validity check by Opencast's HTTPS client is basically performed the same
+way as any other HTTPS client would, for instance:
+
+* validate the host name
+* look up if the certificate is signed by a trusted Certificate Authority (CA)
+
+In case of self-signed certificates, a check whether the certificate is signed
+by a trusted CA, would fail.
+
+You are advised to obtain a valid certificate, issued by a trusted CA like
+[Let's Encrypt](https://letsencrypt.org/).
+
+However, valid certificates are not always an option for testing or developer
+instances of Opencast, especially with Enterprise Firewalls or CAA records in
+place.
+
+Generating Self-Signed Certificates
+-----------------------------------
+
+A self-signed certificate for multiple host names can be created with openSSL
+as follows:
+
+`testing-cert.req.conf`:
+
+```ini
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+C = CH
+ST = Wallis
+L = Matterhorn
+O = Apereo
+OU = Opencast
+CN = opencast
+[v3_req]
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = opencast
+DNS.2 = presentation.local
+DNS.3 = admin.local
+DNS.4 = admin
+DNS.5 = presentation
+DNS.6 = worker
+DNS.7 = worker.local
+```
+
+```bash
+openssl req \
+  -x509 \
+  -nodes \
+  -days 365 \
+  -newkey rsa:2048 \
+  -keyout key.pem \
+  -out testing.pem \
+  -config testing-cert.req.conf \
+  -extensions 'v3_req'
+```
+
+In order to view the just generated cert:
+
+```bash
+openssl x509 -in testing.pem -text -noout
+```
+
+Trusting Self-Signed Certificates
+---------------------------------
+
+In order to use self-signed certificates for testing or developer instances of
+Opencast, import your self-signed certificate(s) into the Java Trust Store
+(bundle of trusted CA certs) and restart Opencast.
+
+1. Store your certificate in a format compatible with `keytool` somewhere:
+
+        cat >/tmp/testing.crt <<EOL
+        -----BEGIN CERTIFICATE-----
+        MIIGJzCCBA+gAw...
+        ...O6g==
+        -----END CERTIFICATE-----
+        EOL
+
+2. Import the certificate with alias `testing_root` into the
+`javax.net.ssl.trustStrore` whose password defaults to `changeit` without asking
+questions:
+
+        keytool \
+           -import \
+           -noprompt \
+           -trustcacerts \
+           -storepass changeit \
+           -alias testing_root \
+           -file /tmp/testing.crt \
+           -keystore $JAVA_HOME/jre/lib/security/cacerts
+
+3. Delete the temporary file:
+
+        rm /tmp/testing.crt
+
+4. Restart Opencast.

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - Using Apache httpd: configuration/https/apache-httpd.md
       - Internal HTTPS: 'configuration/https/opencast.only.md'
       - Migrating old content to HTTPS: 'configuration/https/migration.md'
+      - Self-Signed Certificates: 'configuration/https/self-signed-certificates.md'
    - Firewall: 'configuration/firewall.md'
    - Asset Manager: 'configuration/asset-manager.md'
    - Message Broker: 'configuration/message-broker.md'


### PR DESCRIPTION
After host name and cert validation has been turned on for Opencast's HTTPS
client, the use of self-signed certificates got slightly more involved.

References:
* https://github.com/opencast/opencast/security/advisories/GHSA-44cw-p2hm-gpf6
* https://github.com/opencast/opencast/commit/4225bf90af74557deaf8fb6b80b0705c9621acfc
* https://groups.google.com/a/opencast.org/g/users/c/o1V9Vrt6oNQ/m/XoKUJl7wCQAJ

### Your pull request should…

* [X] have a concise title
* [X] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [X] be against the correct branch (features can only go into develop)
* [X] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [X] have a clean commit history
* [X] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
