### PR TITLE
Securing Static Files by Default

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -14,6 +14,8 @@ versions of Opencast, please refer to [older release notes](https://docs.opencas
 8. Start Opencast
 9. [Rebuild the Elasticsearch indexes](#rebuild-the-elasticsearch-indexes)
 10. [Check passwords](#check-passwords)
+11. Static file delivery
+
 
 Configuration Changes
 ---------------------
@@ -89,3 +91,16 @@ but to benefit from this mechanism, users have to reset their password.
 
 You can use the endpoint `/user-utils/users/md5.json` to find out which users are still using MD5-hashed passwords and
 suggest to them that they update their passwords.
+
+
+Static File Delivery
+--------------------
+
+Opencast 9.2 came with a [completely new system for securing static file content](configuration/serving-static-files.md)
+which is now active by default in Opencast 10. If you are deferring the file access authorization to another system
+using Opencast's [security token mechanism](configuration/stream-security.md), you need to deactivate this protection
+in:
+
+```
+etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
+```

--- a/etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
+++ b/etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
@@ -1,8 +1,7 @@
 # Shall the static file server check authorization?
 # You might want to disable this if you use other means of checking authentication like authentication tokens.
-# Default: false
-# Future: Default will change in Opencast 10
-#authentication.required = false
+# Default: true
+#authentication.required = true
 
 # Makes the static file service check authentication and availability but return an X-Accel-Redirect header using the
 # following path prefix instead of serving the actual file.

--- a/modules/static/src/main/java/org/opencastproject/fsresources/StaticResourceServlet.java
+++ b/modules/static/src/main/java/org/opencastproject/fsresources/StaticResourceServlet.java
@@ -142,10 +142,10 @@ public class StaticResourceServlet extends HttpServlet {
   public void activate(ComponentContext cc) {
     if (cc == null) {
       // set defaults
-      authRequired = false;
+      authRequired = true;
       xAccelRedirect = null;
     } else {
-      authRequired = BooleanUtils.toBoolean(Objects.toString(cc.getProperties().get(PROP_AUTH_REQUIRED), "false"));
+      authRequired = BooleanUtils.toBoolean(Objects.toString(cc.getProperties().get(PROP_AUTH_REQUIRED), "true"));
 
       xAccelRedirect = Objects.toString(cc.getProperties().get(PROP_X_ACCEL_REDIRECT), null);
 


### PR DESCRIPTION
This patch enables the static file authorization system introduced with
Opencast 9.2 by default. For more details, take a look at the
documentation and the original pull request:

- https://docs.opencast.org/r/9.x/admin/configuration/serving-static-files
- https://github.com/opencast/opencast/pull/1017

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
