### PR TITLE
Don't ask Dependabot to sign ICLA

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   main:
+    if: github.event.pull_request.user.login != 'dependabot-preview[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v1


### PR DESCRIPTION
This patch excludes Dependabot from the ICLA tests.
We may want to do this for more nots, but this should catch most
complaints.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
