### PR TITLE
Mark Outdated Development Documentation

### DIFF
--- a/docs/guides/developer/docs/javascript/extra.js
+++ b/docs/guides/developer/docs/javascript/extra.js
@@ -26,6 +26,15 @@ $(document).ready(function () {
         ga('send', 'pageview');
     }
     tocPaneFix();
+
+    // Display a hint that the development docs are outdated unless we are on develop.
+    if (window.location.pathname.startsWith('/r/')) {
+        let path = window.location.pathname.replace(/^\/r\/[0-9]+\.*x/, '/develop')
+        let page_content = $('.wm-page-content').prepend(
+            `<div style="padding: 20px; border-left: 3px solid silver;">
+            This is an outdated version of the development documentation for Opencast.
+            The latest version of the docs can be found <a href="${path}">here</a>.</div>`)
+    }
 });
 
 


### PR DESCRIPTION
This patch adds a hint to the development documentation of older
branches marking them as outdated and linking the documentation of the
branch `develop`.

---

![dev-docs hint](https://user-images.githubusercontent.com/1008395/105022257-d81fb080-5a49-11eb-8f41-03f348e22e15.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
