### PR TITLE
Fix Feeds REST Docs

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/FeedEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/FeedEndpoint.java
@@ -21,7 +21,11 @@
 
 package org.opencastproject.adminui.endpoint;
 
+import static org.apache.http.HttpStatus.SC_OK;
+
 import org.opencastproject.serviceregistry.api.RemoteBase;
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
 import org.apache.commons.io.IOUtils;
@@ -61,6 +65,15 @@ public class FeedEndpoint extends RemoteBase {
   @GET
   @Path("/feeds")
   @Produces(MediaType.APPLICATION_JSON)
+  @RestQuery(
+      name = "feeds",
+      description = "List available series based feeds retrieved from the search service",
+      returnDescription = "Return list of feeds",
+      responses = {
+          @RestResponse(
+              responseCode = SC_OK,
+              description = "List of available feeds returned.")
+      })
   public String listFeedServices() {
 
     HttpGet get = new HttpGet("/feeds");

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
@@ -22,6 +22,8 @@
 
 package org.opencastproject.feed.impl;
 
+import static org.apache.http.HttpStatus.SC_OK;
+
 import org.opencastproject.feed.api.Feed;
 import org.opencastproject.feed.api.FeedGenerator;
 import org.opencastproject.security.api.Organization;
@@ -110,6 +112,15 @@ public class FeedServiceImpl {
   @GET
   @Path("/feeds")
   @Produces(MediaType.APPLICATION_JSON)
+  @RestQuery(
+      name = "feeds",
+      description = "List available series based feeds",
+      returnDescription = "Return list of feeds",
+      responses = {
+          @RestResponse(
+              responseCode = SC_OK,
+              description = "List of available feeds returned.")
+      })
   public String listFeedServices() {
 
     List<Map<String, String>> feedServices = new ArrayList<>();
@@ -131,7 +142,7 @@ public class FeedServiceImpl {
     return gson.toJson(feedServices);
   }
 
-  /*
+  /**
    * Note: We're using Regex matching for the path here, instead of normal JAX-RS paths.  Previously this class was a servlet,
    * which was fine except that it had auth issues.  Removing the servlet fixed the auth issues, but then the paths (as written
    * in the RestQuery docs) don't work because  JAX-RS does not support having "/" characters as part of the variable's value.


### PR DESCRIPTION
This patch fixes the problem that the feeds endpoints were missing
several annotations, causing them to not show up in Opencast REST docs.

---

![Screenshot from 2021-01-21 22-10-23](https://user-images.githubusercontent.com/1008395/105413133-f77b3100-5c35-11eb-96dc-88350f3d7ee8.png)

---

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
