### PR TITLE
Fix NullPointerException when accessing series details

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/FeedEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/FeedEndpoint.java
@@ -21,7 +21,11 @@
 
 package org.opencastproject.adminui.endpoint;
 
+import static org.apache.http.HttpStatus.SC_OK;
+
 import org.opencastproject.serviceregistry.api.RemoteBase;
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
 import org.apache.commons.io.IOUtils;
@@ -61,6 +65,15 @@ public class FeedEndpoint extends RemoteBase {
   @GET
   @Path("/feeds")
   @Produces(MediaType.APPLICATION_JSON)
+  @RestQuery(
+      name = "feeds",
+      description = "List available series based feeds retrieved from the search service",
+      returnDescription = "Return list of feeds",
+      responses = {
+          @RestResponse(
+              responseCode = SC_OK,
+              description = "List of available feeds returned.")
+      })
   public String listFeedServices() {
 
     HttpGet get = new HttpGet("/feeds");

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/FeedEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/FeedEndpoint.java
@@ -23,22 +23,26 @@ package org.opencastproject.adminui.endpoint;
 
 import static org.apache.http.HttpStatus.SC_OK;
 
+import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.serviceregistry.api.RemoteBase;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("/")
 @RestService(name = "FeedService", title = "Admin UI Feed Service",
@@ -60,7 +64,7 @@ public class FeedEndpoint extends RemoteBase {
   }
 
   /** Logging facility */
-  private static Logger logger = LoggerFactory.getLogger(FeedEndpoint.class);
+  private static final Logger logger = LoggerFactory.getLogger(FeedEndpoint.class);
 
   @GET
   @Path("/feeds")
@@ -74,20 +78,26 @@ public class FeedEndpoint extends RemoteBase {
               responseCode = SC_OK,
               description = "List of available feeds returned.")
       })
-  public String listFeedServices() {
+  public Response listFeedServices() {
 
     HttpGet get = new HttpGet("/feeds");
-    HttpResponse response = null;
-    String result = null;
-
     try {
-      response = getResponse(get);
-      result = IOUtils.toString(response.getEntity().getContent(), "utf-8");
+      InputStream response = getResponse(get).getEntity().getContent();
+      return Response.ok(response).build();
     } catch (Exception e) {
-      logger.error("Could not get /feeds request in FeedEndpoint. " + e.toString());
+      logger.error("Error requesting data from feeds endpoint", e);
+      return Response.serverError().build();
     }
+  }
 
-    return result;
+  @Reference
+  public void setTrustedHttpClient(final TrustedHttpClient client) {
+    this.client = client;
+  }
+
+  @Reference
+  public void setRemoteServiceManager(final ServiceRegistry remoteServiceManager) {
+    this.remoteServiceManager = remoteServiceManager;
   }
 
 }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
@@ -22,6 +22,8 @@
 
 package org.opencastproject.feed.impl;
 
+import static org.apache.http.HttpStatus.SC_OK;
+
 import org.opencastproject.feed.api.Feed;
 import org.opencastproject.feed.api.FeedGenerator;
 import org.opencastproject.security.api.Organization;
@@ -110,6 +112,15 @@ public class FeedServiceImpl {
   @GET
   @Path("/feeds")
   @Produces(MediaType.APPLICATION_JSON)
+  @RestQuery(
+      name = "feeds",
+      description = "List available series based feeds",
+      returnDescription = "Return list of feeds",
+      responses = {
+          @RestResponse(
+              responseCode = SC_OK,
+              description = "List of available feeds returned.")
+      })
   public String listFeedServices() {
 
     List<Map<String, String>> feedServices = new ArrayList<>();
@@ -131,7 +142,7 @@ public class FeedServiceImpl {
     return gson.toJson(feedServices);
   }
 
-  /*
+  /**
    * Note: We're using Regex matching for the path here, instead of normal JAX-RS paths.  Previously this class was a servlet,
    * which was fine except that it had auth issues.  Removing the servlet fixed the auth issues, but then the paths (as written
    * in the RestQuery docs) don't work because  JAX-RS does not support having "/" characters as part of the variable's value.


### PR DESCRIPTION
When accessing the series details in the admin interface with the
default configuration, a NullPointerException was being thrown.
This was caused by incorrect OSGi binding in combination with
inappropriate error handling.

This is based on #2243
This fixes #2218

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
