### PR TITLE
Default to server localhost also for multi tenancy

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceImpl.java
@@ -207,6 +207,11 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
       orgProperties.put(key.substring(ORG_PROPERTY_PREFIX.length()), (String) properties.get(key));
     }
 
+    if (serverUrls.isEmpty()) {
+      logger.debug("No server URL configured for organization " + name + ", setting default localhost");
+      serverUrls.add(DEFAULT_SERVER);
+    }
+
     // Load the existing organization or create a new one
     try {
       JpaOrganization org;


### PR DESCRIPTION
For single tenant setups the default organization is automatically picked anyway, but if we have more than one organization, we should actually default to localhost if the server isn't configured as it says in the config, instead of failing with 'no organization is mapped to handle'.

This is probably only relevant for local testing, but it's one more hurdle for local multi tenancy, and I broke this behavior with #1254, so now I'm fixing it. :)