### PR TITLE
Remove dom4j

### DIFF
--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -162,10 +162,6 @@
       <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.xalan</artifactId>
     </dependency>
-    <dependency>
-      <groupId>dom4j</groupId>
-      <artifactId>dom4j</artifactId>
-    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>

--- a/modules/cover-image-impl/src/test/java/org/opencastproject/coverimage/impl/CoverImageServiceTest.java
+++ b/modules/cover-image-impl/src/test/java/org/opencastproject/coverimage/impl/CoverImageServiceTest.java
@@ -29,7 +29,6 @@ import static org.xmlmatchers.transform.XmlConverters.the;
 import org.opencastproject.coverimage.CoverImageException;
 
 import org.apache.commons.io.IOUtils;
-import org.dom4j.dom.DOMDocument;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.xmlmatchers.namespace.SimpleNamespaceContext;
@@ -97,7 +96,8 @@ public class CoverImageServiceTest {
    */
   @Test(expected = IllegalArgumentException.class)
   public void testTransformSvgNullSvg() throws Exception {
-    AbstractCoverImageService.transformSvg(null, new StreamSource(), new DOMDocument(), 0, 0, null);
+    Document doc = AbstractCoverImageService.parseXsl("");
+    AbstractCoverImageService.transformSvg(null, new StreamSource(), doc, 0, 0, null);
   }
 
   /**
@@ -105,7 +105,8 @@ public class CoverImageServiceTest {
    */
   @Test(expected = IllegalArgumentException.class)
   public void testTransformSvgNullXmlSource() throws Exception {
-    AbstractCoverImageService.transformSvg(new StreamResult(), null, new DOMDocument(), 0, 0, null);
+    Document doc = AbstractCoverImageService.parseXsl("");
+    AbstractCoverImageService.transformSvg(new StreamResult(), null, doc, 0, 0, null);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -1182,11 +1182,6 @@
         <artifactId>xml-apis</artifactId>
         <version>2.0.2</version>
       </dependency>
-      <dependency>
-        <groupId>dom4j</groupId>
-        <artifactId>dom4j</artifactId>
-        <version>1.6.1</version>
-      </dependency>
       <!-- logging -->
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This patch removes the dom4j dependency which was used solely to provide
an empty XML file for testing but was marked as non-test runtime
dependency. The included version of dem4j has some severe security
vulnerabilities and we should never use this.

Since this only included but never actually used, there is no security
risk.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
