### PR TITLE
Admin UI says current OC version unsupported when it can't reach GitHub

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
@@ -56,7 +56,7 @@ function monitorService($http, $location, $translate, Storage) {
         Monitoring.populateService(LATEST_VERSION_NAME);
 
         if (response_latest_version.status === 200 && response_my_version.status === 200
-        && response_my_version.data.consistent) {
+        && response_my_version.data.consistent && response_latest_version.data != '') {
           var my_version = response_my_version.data.version,
               latest_version = response_latest_version.data;
           services.service[LATEST_VERSION_NAME].docs_url =


### PR DESCRIPTION
The admin UI will now display indeterminable version when the admin node can't reach GH.

Previous behaviour caused the ui to list the current version as unsupported, when in
reality the core just doesn't know what the current version is.

Fixes #2279

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
