### PR TITLE
Shorten Adopter Registration Primary Key

### DIFF
--- a/modules/adopter-statistics-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-statistics-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -55,7 +55,7 @@ public class Form implements IForm {
   //================================================================================
 
   @Id
-  @Column(name = "adopter_key")
+  @Column(name = "adopter_key", length = 64)
   private String adopterKey;
 
   @Column(name = "statistic_key")


### PR DESCRIPTION
This patch shortens the primary key used for the adopter registration
from `varchar(255)` to `varchar(64)` since some database default
settings seem to cause problems with this and it's used only for short
UUIDs anyway.

If the table was already successfully created with a larger key, this
does not do anything.

This fixes #2282

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)