### PR TITLE
Added the access_policy field to elasticsearch and made it searchable

### DIFF
--- a/modules/elasticsearch-impl/src/main/resources/elasticsearch/event-mapping.json
+++ b/modules/elasticsearch-impl/src/main/resources/elasticsearch/event-mapping.json
@@ -55,7 +55,7 @@
 
         "rights": { "type" : "keyword" },
 
-        "access_policy": { "type" : "text", "index" : false, "store" : false },
+        "access_policy": { "type" : "text" },
 
         "managed_acl": { "type" : "keyword" },
 

--- a/modules/elasticsearch-impl/src/main/resources/elasticsearch/series-mapping.json
+++ b/modules/elasticsearch-impl/src/main/resources/elasticsearch/series-mapping.json
@@ -23,7 +23,7 @@
 
           "license": { "type" : "keyword" },
 
-          "access_policy": { "type" : "text", "index" : false, "store" : false },
+          "access_policy": { "type" : "text" },
 
           "managed_acl": { "type" : "keyword" },
 

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/event/EventIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/event/EventIndexUtils.java
@@ -206,7 +206,7 @@ public final class EventIndexUtils {
     }
 
     if (StringUtils.isNotBlank(event.getAccessPolicy())) {
-      metadata.addField(EventIndexSchema.ACCESS_POLICY, event.getAccessPolicy(), false);
+      metadata.addField(EventIndexSchema.ACCESS_POLICY, event.getAccessPolicy(), true);
       addAuthorization(metadata, event.getAccessPolicy());
     }
 


### PR DESCRIPTION
closes #2104 

The events table in the admin ui should be searchable by the access_policy again, so someone can find events by the read and write rights.