### PR TITLE
Limit Incident Text ID Text

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/IncidentTextDto.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/IncidentTextDto.java
@@ -42,7 +42,7 @@ import javax.persistence.Table;
 @NamedQueries({@NamedQuery(name = "IncidentText.findAll", query = "select a from IncidentText a")})
 public class IncidentTextDto {
   @Id
-  @Column(name = "id")
+  @Column(name = "id", length = 128)
   private String id;
 
   @Column(name = "text", nullable = false, length = 2038)


### PR DESCRIPTION
This patch shortens the primary key used for the incident text
identifier from varchar(255) to varchar(128) since some database default
settings seem to cause problems with this and it's used only for shorter
strings.

If the table was already successfully created with a larger key, this
does not do anything.

This fixes #2294

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)