### PR TITLE
Fix Total Search Results

### DIFF
--- a/modules/search/src/main/java/org/opencastproject/matterhorn/search/impl/AbstractElasticsearchIndex.java
+++ b/modules/search/src/main/java/org/opencastproject/matterhorn/search/impl/AbstractElasticsearchIndex.java
@@ -404,7 +404,9 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
    */
   protected SearchRequest getSearchRequest(SearchQuery query, QueryBuilder queryBuilder) {
 
-    final SearchSourceBuilder searchSource = new SearchSourceBuilder().query(queryBuilder);
+    final SearchSourceBuilder searchSource = new SearchSourceBuilder()
+        .query(queryBuilder)
+        .trackTotalHits(true);
 
     // Create the actual search query
     logger.debug("Searching for {}", searchSource.toString());


### PR DESCRIPTION
This patch fixes the problem that newer Elasticsearch nodes no longer
include the total amount of search hits in the search result. This lead
to stats in the admin interface being capped at 10000 events.

This fixes #2280

Note that this is currently untested.
Nevertheless, I'm pretty sure it works.
@flyapen, since you have this problem, could you possibly test this patch?

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
