### PR TITLE
Add Mermaid to Documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,6 +30,7 @@ jobs:
         pip install -q mkdocs mkdocs-windmill requests
         pip install -q markdown_inline_graphviz_extension
         pip install -q markdown_inline_graphviz_extension-png
+        pip install -q mkdocs-mermaid2-plugin
 
     - name: build admin docs
       working-directory: docs/guides/admin/

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: 3.9
 
     - name: install mkdocs
-      run: pip install -q mkdocs markdown_inline_graphviz_extension mkdocs-windmill
+      run: pip install -q mkdocs markdown_inline_graphviz_extension mkdocs-windmill mkdocs-mermaid2-plugin
 
     - name: install javascript dependencies
       working-directory: docs/guides

--- a/docs/guides/admin/docs/version-support.md
+++ b/docs/guides/admin/docs/version-support.md
@@ -1,10 +1,48 @@
 Supported Versions
 ==================
 
-Opencast has a standing policy of supporting the current version, and the previous version.  In general terms, this
-means a roughly 1 year support cycle for any given release due to our half year major releases.  Support, in this
-context, means development time: building fixes, applying them, and releasing those changes.
+Opencast has a standing policy of supporting two major versions.
+This results in a roughly 1 year support cycle for any given major release due to our half year release cycle.
+Support, in this context, means development time: building fixes, applying them, and releasing those changes.
 
-For example, as of the time of writing we currently support versions 6.x, and 5.x. Once version 7.0 releases, version
-5.x will no longer be supported, but 6.x will. Questions for older releases will still be answered on list, but
-developer time will usually not be allocated to fixing issues on those versions any longer.
+For example, as of the time of writing we support versions 6.x, and 5.x.
+Once version 7.0 releases, version 5.x will no longer be supported, but 6.x will.
+
+
+```mermaid
+gantt
+    title Support of Opencast 5 and 6
+    dateFormat  YYYY-MM-DD
+    axisFormat  %Y-%m
+
+    section Opencast 5
+    Opencast 5.0     :2018-06-12, 2018-09-03
+    Opencast 5.1     :2018-11-13
+    Opencast 5.2     :2019-01-11
+    Opencast 5.3     :2019-01-24
+    Opencast 5.4     :2019-04-01
+    Opencast 5.5     :2019-06-13
+
+    section Opencast 6
+    Opencast 6.0     :2018-12-10, 2019-01-12
+    Opencast 6.1     :2019-01-24
+    Opencast 6.2     :2019-03-05
+    Opencast 6.3     :2019-04-01
+    Opencast 6.4     :2019-06-14
+    Opencast 6.5     :2019-08-02
+    Opencast 6.6     :2019-08-12
+    Opencast 6.7     :2019-12-17
+```
+
+The chart above shows the releases of Opencast 5 and 6 which overlap in a period of six month.
+The support of Opencast 5.5 ended with the release of Opencast 7.0 on June 6, 2019.
+
+
+Minor Versions
+--------------
+
+We only support the latest minor version of any given major version.
+For example, once Opencast 7.1 is released, Opencast 7.0 is no longer supported.
+
+We take care to make updates between minor versions as smooth as possible.
+This means upgrades are usually very easy and it is recommended to upgrade on a regular basis.

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -5,6 +5,11 @@ edit_uri: edit/develop/docs/guides/admin/docs/
 markdown_extensions:
   - markdown_inline_graphviz
 
+plugins:
+  - mermaid2:
+      arguments:
+        theme: neutral
+
 # Default theme used is windmill
 theme: windmill
 

--- a/docs/guides/readme.md
+++ b/docs/guides/readme.md
@@ -21,6 +21,7 @@ Requires python virtual environment.
 % pip install mkdocs mkdocs-windmill
 % pip install markdown_inline_graphviz_extension
 % pip install markdown-inline-graphviz-extension-png
+% pip install mkdocs-mermaid2-plugin
 % cd developer
 % python -m mkdocs serve
 ```


### PR DESCRIPTION
This patch adds the mermaid mkdocs plugin to allow for drawing several
different chart types in Markdown.

> https://mermaid-js.github.io/mermaid/

This patch includes a chart depicting the version support and the
releases of Opencast 5 and 6.

![Screenshot from 2021-02-07 21-32-33](https://user-images.githubusercontent.com/1008395/107158825-dd0eba80-698c-11eb-93f7-7c591d7dd260.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)