### PR TITLE
Don't Store Documentation Redirect in History

### DIFF
--- a/docs/guides/.infrastructure/404.html.j2
+++ b/docs/guides/.infrastructure/404.html.j2
@@ -6,7 +6,7 @@
     <script type="text/javascript">
       // Redirect if URL links to stable
       if (window.location.pathname.startsWith('/stable/')) {
-        window.location.pathname = window.location.pathname.replace(/^\/stable\//, '/{{ stable_branch }}/')
+        window.location.replace(window.location.pathname.replace(/^\/stable\//, '/{{ stable_branch }}/'));
       }
     </script>
   </head>


### PR DESCRIPTION
This patch ensures that the redirect page for stable does no longer stay
in the browser history, making it hard to go back due to the redirect
kicking in over and over again.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
