### PR TITLE
Gracefully handle missing Shibboleth User References

### DIFF
--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -56,6 +56,10 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
+++ b/modules/security-aai/src/main/java/org/opencastproject/security/aai/ConfigurableLoginHandler.java
@@ -43,6 +43,7 @@ import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -382,7 +383,7 @@ public class ConfigurableLoginHandler implements ShibbolethLoginHandler, RolePro
     // Load the user reference
     JpaUserReference userReference = userReferenceProvider.findUserReference(id, organization.getId());
     if (userReference == null) {
-      throw new IllegalStateException("User reference '" + id + "' was not found");
+      throw new UsernameNotFoundException("User reference '" + id + "' was not found");
     }
 
     // Update the reference


### PR DESCRIPTION
Shibboleth will usually check on login if a user is present in the
system, importing the user data as user reference if not or continuing
otherwise.

This behavior fails if a user exists but no user reference, causing the
login process to fail.

This might, for example, be caused if another userprovider is active to
supply the roles which a user has while Shibboleth is used for login.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
