### PR TITLE
Changed PartialImportWOH to ignore smil entries for tracks that don't exist

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -927,7 +927,13 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
       } else {
         SMILMediaElement e = (SMILMediaElement) item;
         if (mediaType.equals(e.getNodeName())) {
-          Track track = getFromOriginal(e.getId(), originalTracks, type);
+          Track track;
+          try {
+            track = getFromOriginal(e.getId(), originalTracks, type);
+          } catch (IllegalStateException exception) {
+            logger.debug("Skipping smil entry, reason: " + exception.getMessage());
+            continue;
+          }
           double beginInSeconds = e.getBegin().item(0).getResolvedOffset();
           long beginInMs = Math.round(beginInSeconds * 1000d);
           // Fill out gaps with first or last frame from video


### PR DESCRIPTION
Currentely, the Partial Import WOH will fail if even a single smil entry contains a track that is not in the entries specified location anymore. This is for example annoying if you want to process some of the tracks in a different way than using Partial Import (e.g. use Partial Import for your tracks in `presentation/source` and Videogrid for your tracks in `presenter/source`). Therefore, I would propose that such smil entries should rather be ignored than cause exceptions.

This should resolve #1918.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
