### PR TITLE
Fix Search Capability in Documentation

### DIFF
--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -6,6 +6,7 @@ markdown_extensions:
   - markdown_inline_graphviz
 
 plugins:
+  - search:
   - mermaid2:
       arguments:
         theme: neutral


### PR DESCRIPTION
This patch fixes the capability of the documentation built with `mkdocs`
to search through the documentation.

---

To see the broken state, go to https://docs.opencast.org/r/9.x/admin/ and try using the search functionality. The result will be:

![Screenshot from 2021-02-18 00-25-29](https://user-images.githubusercontent.com/1008395/108281335-d5ff5d80-717f-11eb-8899-8306053fc7d5.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
