### PR TITLE
Fix resolution scaling by removing `force_original_aspect_ratio`

### DIFF
--- a/etc/encoding/adaptive-streaming-movies.properties
+++ b/etc/encoding/adaptive-streaming-movies.properties
@@ -29,7 +29,7 @@ profile.adaptive-2160p.http.suffix = -preview.mp4
 profile.adaptive-2160p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 10000k -bufsize 10000k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
-  -filter:v scale=3840:-2:force_original_aspect_ratio=decrease,fps=25 \
+  -filter:v scale=3840:-2,fps=25 \
   -c:a aac -b:a 96k -ac 1 \
   -f mp4 #{out.dir}/#{out.name}#{out.suffix}
 
@@ -40,7 +40,7 @@ profile.adaptive-1080p.http.suffix = -preview.mp4
 profile.adaptive-1080p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 4000k -bufsize 8000k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
-  -filter:v scale=1920:-2:force_original_aspect_ratio=decrease,fps=25 \
+  -filter:v scale=1920:-2,fps=25 \
   -c:a aac -b:a 96k -ac 1 \
   -f mp4 #{out.dir}/#{out.name}#{out.suffix}
 
@@ -51,7 +51,7 @@ profile.adaptive-720p.http.suffix = -preview.mp4
 profile.adaptive-720p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 1200k -bufsize 2400k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
-  -filter:v scale=1280:-2:force_original_aspect_ratio=decrease,fps=25 \
+  -filter:v scale=1280:-2,fps=25 \
   -c:a aac -b:a 64k -ac 1 \
   -f mp4 #{out.dir}/#{out.name}#{out.suffix}
 
@@ -62,7 +62,7 @@ profile.adaptive-480p.http.suffix = -preview.mp4
 profile.adaptive-480p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 800k -bufsize 800k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
-  -filter:v scale=640:-2:force_original_aspect_ratio=decrease,fps=25 \
+  -filter:v scale=640:-2,fps=25 \
   -c:a aac -b:a 32k -ac 1 \
   -f mp4 #{out.dir}/#{out.name}#{out.suffix}
 
@@ -73,7 +73,7 @@ profile.adaptive-360p.http.suffix = -preview.mp4
 profile.adaptive-360p.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 30 -maxrate 600k -bufsize 600k -profile:v high -level 4.0 -pix_fmt yuv420p \
   -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
-  -filter:v scale=480:-2:force_original_aspect_ratio=decrease:-2,fps=25 \
+  -filter:v scale=480:-2:-2,fps=25 \
   -c:a aac -b:a 32k -ac 1 \
   -f mp4 #{out.dir}/#{out.name}#{out.suffix}
 
@@ -86,15 +86,15 @@ profile.adaptive-parallel.http.suffix.480p-quality = -480p.mp4
 profile.adaptive-parallel.http.ffmpeg.command = -i #{in.video.path} \
   -c:v libx264 -crf 23 -maxrate 4000k -bufsize 8000k -profile:v high -level 4.0 -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
-    -vf scale=1920:-2:force_original_aspect_ratio=decrease,fps=25 \
+    -vf scale=1920:-2,fps=25 \
     -c:a aac -b:a 96k -ac 1 -f mp4 #{out.dir}/#{out.name}#{out.suffix.1080p-quality} \
   -c:v libx264 -crf 23 -maxrate 1200k -bufsize 2400k -profile:v high -level 4.0 -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
-    -vf scale=1280:-2:force_original_aspect_ratio=decrease,fps=25 \
+    -vf scale=1280:-2,fps=25 \
     -c:a aac -b:a 64k -ac 1 -f mp4 #{out.dir}/#{out.name}#{out.suffix.720p-quality} \
   -c:v libx264 -crf 23 -maxrate 800k -bufsize 800k -profile:v high -level 4.0 -pix_fmt yuv420p \
     -x264opts keyint=25:min-keyint=25:no-scenecut -movflags +faststart \
-    -vf scale=640:-2:force_original_aspect_ratio=decrease,fps=25 \
+    -vf scale=640:-2,fps=25 \
     -c:a aac -b:a 32k -ac 1 -f mp4 #{out.dir}/#{out.name}#{out.suffix.480p-quality}
 
 profile.studio.adaptive-parallel.http.name = parallel encoding of studio video in multiple qualities for adaptive streaming


### PR DESCRIPTION
Fixes #2297

Ideally, we would use `force_divisible_by=2`, but that option requires a fairly new ffmpeg version and we don't want to bump the ffmpeg version requirement in a minor Opencast update. For example, Ubuntu 20.04 default repositories contain a version that's too old. 

All the resize operations will still maintain the aspect ratio due to the `-2` as the height term. See the linked issue for why the `force_original_aspect_ratio` is not required.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
