### PR TITLE
Distinguish Between Documentation and Configuration Checks

### DIFF
--- a/.github/workflows/test-configuration.yml
+++ b/.github/workflows/test-configuration.yml
@@ -1,0 +1,23 @@
+name: Test configuration
+
+on:
+  pull_request:
+    paths:
+      - 'etc/**'
+      - 'docs/checkstyle/check-config.sh'
+      - '**/pom.xml'
+  push:
+    paths:
+      - 'etc/**'
+      - 'docs/checkstyle/check-config.sh'
+      - '**/pom.xml'
+
+jobs:
+  documentation:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: check configuration
+      run: ./docs/checkstyle/check-config.sh

--- a/.github/workflows/test-documentation-build.yml
+++ b/.github/workflows/test-documentation-build.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     paths:
       - 'docs/guides/**'
+      - 'docs/checkstyle/check-docs.sh'
       - '**.md'
   push:
     paths:
       - 'docs/guides/**'
+      - 'docs/checkstyle/check-docs.sh'
       - '**.md'
 
 jobs:
@@ -32,4 +34,4 @@ jobs:
       run: npm ci
 
     - name: check documentation
-      run: bash ./.style-and-markdown-build.sh
+      run: ./docs/checkstyle/check-docs.sh

--- a/.style-and-markdown-build.sh
+++ b/.style-and-markdown-build.sh
@@ -1,62 +1,9 @@
 #!/bin/bash
 
+# Test file used by buildbot
+
 set -ue
 
-ret=0
-
 cd "$(dirname $(realpath -s $0))"
-
-if grep -rn $'\t' modules assemblies pom.xml --include=pom.xml; then
-  echo "Tabs found!"
-  ret=1
-fi
-if grep -rn ' $' modules assemblies pom.xml --include=pom.xml; then
-  echo "Trailing spaces found!"
-  ret=1
-fi
-if grep -rn $'\t' etc; then
-  echo "Tabs found in config files!"
-  ret=1
-fi
-if grep -rn ' $' etc; then
-  echo "Trailing spaces found in config files!"
-  ret=1
-fi
-
-
-# build number must be present in all modules
-if ! grep -L '<Build-Number>${buildNumber}</Build-Number>' modules/*/pom.xml | wc -l | grep -q '^0$'; then
-  echo "Build number is missing from a module!"
-  ret=1
-fi
-
-# maven-dependency-plugin should be active for all new modules
-grep -L maven-dependency-plugin modules/*/pom.xml > maven-dependency-plugin.list
-if ! diff -q maven-dependency-plugin.list docs/checkstyle/maven-dependency-plugin.exceptions; then
-  ret=1
-fi
-
-cd docs/guides
-
-for docs in admin developer; do
-  cd $docs
-  echo "Markdown doc $docs build log:"
-  mkdocs build 2>&1 | tee mkdocs.log
-  if grep \
-       -e 'WARNING.*Documentation file' \
-       -e 'pages exist in the docs directory' \
-       -e 'is not found in the documentation files' \
-        mkdocs.log;
-    then
-      echo "$docs did not build correctly!"
-      ret=1
-  fi
-  cd ..
-done
-
-if ! npm test; then
-  echo "npm test failed!"
-  ret=1
-fi
-
-exit $ret
+./docs/checkstyle/check-config.sh
+./docs/checkstyle/check-docs.sh

--- a/docs/checkstyle/check-config.sh
+++ b/docs/checkstyle/check-config.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -ue
+
+ret=0
+
+echo Checking pom.xml files for tabs or trailing spaces…
+if grep -rn $'\t' modules assemblies pom.xml --include=pom.xml; then
+  echo "Tabs found!"
+  ret=1
+fi
+if grep -rn ' $' modules assemblies pom.xml --include=pom.xml; then
+  echo "Trailing spaces found!"
+  ret=1
+fi
+
+echo Checking configuration files for tabs or trailing spaces…
+if grep -rn $'\t' etc; then
+  echo "Tabs found in config files!"
+  ret=1
+fi
+if grep -rn ' $' etc; then
+  echo "Trailing spaces found in config files!"
+  ret=1
+fi
+
+echo Checking that all modules include a build number…
+if ! grep -L '<Build-Number>${buildNumber}</Build-Number>' modules/*/pom.xml | wc -l | grep -q '^0$'; then
+  echo "Build number is missing from a module!"
+  ret=1
+fi
+
+echo Checking that modules use the maven-dependency-plugin…
+grep -L maven-dependency-plugin modules/*/pom.xml > maven-dependency-plugin.list
+if ! diff -q maven-dependency-plugin.list docs/checkstyle/maven-dependency-plugin.exceptions; then
+  ret=1
+fi
+
+exit $ret

--- a/docs/checkstyle/check-docs.sh
+++ b/docs/checkstyle/check-docs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -ue
+
+ret=0
+cd docs/guides
+
+for docs in admin developer; do
+  cd $docs
+  echo "Markdown doc $docs build log:"
+  mkdocs build &> mkdocs.log
+  cat mkdocs.log
+  if grep \
+       -e 'WARNING.*Documentation file' \
+       -e 'pages exist in the docs directory' \
+       -e 'is not found in the documentation files' \
+        mkdocs.log;
+    then
+      echo "$docs did not build correctly!"
+      ret=1
+  fi
+  cd ..
+done
+
+if ! npm test; then
+  echo "npm test failed!"
+  ret=1
+fi
+
+exit $ret

--- a/docs/checkstyle/check-docs.sh
+++ b/docs/checkstyle/check-docs.sh
@@ -7,17 +7,21 @@ cd docs/guides
 
 for docs in admin developer; do
   cd $docs
-  echo "Markdown doc $docs build log:"
-  mkdocs build &> mkdocs.log
-  cat mkdocs.log
-  if grep \
-       -e 'WARNING.*Documentation file' \
-       -e 'pages exist in the docs directory' \
-       -e 'is not found in the documentation files' \
-        mkdocs.log;
+  echo "Building $docs documentation…"
+  if mkdocs build &> mkdocs.log; then
+    if grep \
+        -e 'WARNING.*Documentation file' \
+        -e 'pages exist in the docs directory' \
+        -e 'is not found in the documentation files' \
+         mkdocs.log;
     then
       echo "$docs did not build correctly!"
+      cat mkdocs.log
       ret=1
+    fi
+  else
+    echo mkdocs exited abnormally.
+    cat mkdocs.log
   fi
   cd ..
 done

--- a/docs/checkstyle/check-docs.sh
+++ b/docs/checkstyle/check-docs.sh
@@ -22,6 +22,7 @@ for docs in admin developer; do
   else
     echo mkdocs exited abnormally.
     cat mkdocs.log
+    ret=1
   fi
   cd ..
 done


### PR DESCRIPTION
This patch stops calling the configuration tests documentation tests and
puts them in a separate workflow with separate rules. This is hopefully
less confusing.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
