### PR TITLE
Auto-generate OAI-PMH database

### DIFF
--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java
@@ -81,11 +81,7 @@ public class OaiPmhEntity {
 
   /** The last modification date */
   @Column(
-      name = "modification_date",
-      insertable = false,
-      updatable = false,
-      // this is H2 syntax - Opencast uses a dedicated database dependent schema in production
-      columnDefinition = "TIMESTAMP AS CURRENT_TIMESTAMP()")
+      name = "modification_date")
   @Temporal(TemporalType.TIMESTAMP)
   private Date modificationDate;
 
@@ -107,6 +103,7 @@ public class OaiPmhEntity {
    * Default constructor without any import.
    */
   public OaiPmhEntity() {
+    this.modificationDate = new Date();
   }
 
   /**
@@ -125,6 +122,7 @@ public class OaiPmhEntity {
    */
   public void setMediaPackageId(String mediaPackageId) {
     this.mediaPackageId = mediaPackageId;
+    this.modificationDate = new Date();
   }
 
   /**
@@ -140,6 +138,7 @@ public class OaiPmhEntity {
    */
   public void setOrganization(String organization) {
     this.organization = organization;
+    this.modificationDate = new Date();
   }
 
   /**
@@ -157,6 +156,7 @@ public class OaiPmhEntity {
    */
   public void setDeleted(boolean deleted) {
     this.deleted = deleted;
+    this.modificationDate = new Date();
   }
 
   /**
@@ -174,6 +174,7 @@ public class OaiPmhEntity {
    */
   public void setSeries(String series) {
     this.series = series;
+    this.modificationDate = new Date();
   }
 
   /**
@@ -199,6 +200,7 @@ public class OaiPmhEntity {
    */
   public void setMediaPackageXML(String mediaPackageXML) {
     this.mediaPackageXML = mediaPackageXML;
+    this.modificationDate = new Date();
   }
 
   /**
@@ -215,6 +217,7 @@ public class OaiPmhEntity {
    */
   public void setRepositoryId(String repositoryId) {
     this.repositoryId = repositoryId;
+    this.modificationDate = new Date();
   }
 
   /**
@@ -262,6 +265,7 @@ public class OaiPmhEntity {
   public void addMediaPackageElement(OaiPmhElementEntity mediaPackageElementEntity) {
     mediaPackageElements.add(mediaPackageElementEntity);
     mediaPackageElementEntity.setOaiPmhEntity(this);
+    this.modificationDate = new Date();
   }
 
   /**
@@ -271,6 +275,7 @@ public class OaiPmhEntity {
    */
   public void removeMediaPackageElement(OaiPmhElementEntity mediaPackageElementEntity) {
     mediaPackageElements.remove(mediaPackageElementEntity);
+    this.modificationDate = new Date();
   }
 
   /**

--- a/modules/oaipmh-persistence/src/test/java/org/opencastproject/oaipmh/persistence/impl/OaiPmhPersistenceTest.java
+++ b/modules/oaipmh-persistence/src/test/java/org/opencastproject/oaipmh/persistence/impl/OaiPmhPersistenceTest.java
@@ -135,7 +135,7 @@ public class OaiPmhPersistenceTest {
     Assert.assertEquals(mp1, searchResultItem.getMediaPackage());
     Assert.assertFalse(searchResultItem.isDeleted());
     Assert.assertEquals(DefaultOrganization.DEFAULT_ORGANIZATION_ID, searchResultItem.getOrganization());
-    Assert.assertTrue(searchResultItem.getModificationDate() != null);
+    Assert.assertNotNull(searchResultItem.getModificationDate());
     Date modificationDate = searchResultItem.getModificationDate();
     Assert.assertEquals(2, searchResultItem.getElements().size());
     for (SearchResultElementItem catalogItem : searchResultItem.getElements()) {


### PR DESCRIPTION
This addresses my incorrect assumption that OAI-PMH is no longer in any
workflows by default and setting up the database is thus optional. It is
still in the retract workflow which will currently fail if the database
was not manually prepared in advance.

This patch changes the code so that an SQL code is generated which works
with all databases and ensures modifications update the modification
date property on OAI-PMH entries. This will already generate a valid
OAI-PMH repository on its own but is still compatible to the previous
trigger approach.

If a user sets up database trigger, that will ensure that the
modification date is not set in the code but the moment it is actually
being persistent in the database. This works in favor of some less
resilient harvesters. For details see background below.

This does not modify any exising database structure. It will only effect
new database table creation and does not require a migration.

Background: What are the triggers for?
--------------------------------------

OAI-PMH is a harvesting protocol supporting selective harvesting,
meaning that you can e.g. ask only for records being modified after a
given date or time. This allows harvesters to pick up the harvesting
where they last stopped and not harvesting everything every time.

The problem with setting the modification date in code is that an entry
may be written to the database during an active harvest and the
modification date of this new entry may be before the response date of
the harvest. This would mean that if a harvester assumes all records are
contained in the last response, some may get lost.

The Guidelines for Harvester Implementers addresses this problem and
harvesters should deal with this:

- http://www.openarchives.org/OAI/2.0/guidelines-harvester.htm

> Items in a repository may change or be added during a harvest, or
> after a harvest within the same datestamp (i.e. the same day if the
> datestamp is YYYY-MM-DD). This means that to incrementally harvest
> from a repository, a harvester should overlap successive incremental
> harvests by one datestamp increment (i.e. one day if the granularity
> is YYYY-MM-DD). Furthermore, since it is repository implementation
> dependent whether changes that occur during the harvest will be
> reflected in the response, the from argument of the next incremental
> harvest should be based on the the responseDate returned in the first
> partial-list response of a sequence. When harvesting from repositories
> which use a datestamp granularity of one second, it is advisable to
> overlap by a small additional amount to account for any discrepancy
> between the reported responseDate and the time at the repository when
> any search necessary to answer the request was performed.

But at least VideoLaunge did not and the usage of SQL triggers did
protect that harvester implementation from tripping.

This means, the situation after applying this patch is:

- OAI-PMH works out of the box with no modifications
- If you have a very delicate harvester implementation, you can add
  triggers to improve the situation.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
