### PR TITLE
OAI-PMH Primary Key Length

### DIFF
--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/OaiPmhEntity.java
@@ -58,17 +58,17 @@ public class OaiPmhEntity {
 
   /** media package id, primary key */
   @Id
-  @Column(name = "mp_id", length = 128)
+  @Column(name = "mp_id", length = 64)
   private String mediaPackageId;
 
   /** Organization id */
   @Id
-  @Column(name = "organization", length = 128)
+  @Column(name = "organization", length = 96)
   protected String organization;
 
   /** Repository id */
   @Id
-  @Column(name = "repo_id")
+  @Column(name = "repo_id", length = 12)
   private String repositoryId;
 
   /** Series id */


### PR DESCRIPTION
This patch fixes the same issue we have had with other database tables
in combination with specific MariaDB configurations of Ubuntu 18.04 and
utf8mb4 encoding. This means that we essentially have to decide between
key length and emoji support. This, obviously, is no choice at all.
Hence, we need to reduce the key size. This is what this patch does.

The key length for `repo_id` can be reduced quite a bit. That works
since the key is hard coded and can have just one value anyway<F3>.

This fixes #2352

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
