### PR TITLE
Document and Test i18next in LTI Tools

### DIFF
--- a/docs/guides/admin/docs/modules/ltimodule.md
+++ b/docs/guides/admin/docs/modules/ltimodule.md
@@ -100,11 +100,13 @@ custom parameters to be defined globally.
     - `series_name=SERIESNAME` if you just have the series name (has to be unique)
     - `deletion=true` to show a delete button next to each episode
     - `edit=true` if you want to display an edit button next to each episode
+    - `lng=LANG` to force a language (the browser language is used otherwise)
 - To show an upload dialog, use `ltitools/index.html` as LTI `custom_tool` launch parameter
   and specify the following query parameters:
     - `subtool=upload`
     - `series=SERIESID` if you have the series ID
     - `series_name=SERIESNAME` if you just have the series name (has to be unique)
+    - `lng=LANG` to force a language (the browser language is used otherwise)
 - To show a single video, use `/play/<id>` as LTI `custom_tool` launch parameter
 - To show a debug page before proceeding to the tool, append the parameter `test=true`
 

--- a/modules/lti/selenium-tests
+++ b/modules/lti/selenium-tests
@@ -120,6 +120,18 @@ def check_upload_tool(edit=False, deletion=False):
         pass
 
 
+def check_i18next():
+    header('Testing Internationalization')
+
+    # Probe German translation of the series tool
+    navigate(f'/ltitools/index.html?subtool=series&lng=de')
+    wait_for(driver, (By.TAG_NAME, 'header'))
+
+    # Check for a translated results header
+    elem = driver.find_element(By.TAG_NAME, 'header')
+    assert not elem.text.startswith('Results')
+
+
 def main():
     os.setpgrp()
     try:
@@ -129,6 +141,7 @@ def main():
         check_series_tool()
         check_series_tool(True, True)
         check_upload_tool()
+        check_i18next()
         driver.close()
     finally:
         try:


### PR DESCRIPTION
This patch adds some documentation and a simple test to check i18next
actually works in the LTI tools.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
