### PR TITLE
Handle image extraction from very short videos

### DIFF
--- a/etc/encoding/engage-images.properties
+++ b/etc/encoding/engage-images.properties
@@ -34,7 +34,7 @@ profile.player-preview.http.input = visual
 profile.player-preview.http.output = image
 profile.player-preview.http.suffix = -player.jpg
 profile.player-preview.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
-  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),fps=1,reverse,scale=-2:720 \
+  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),scale=-2:720,fps=25,reverse \
   #{out.dir}/#{out.name}#{out.suffix}
 
 # Slide preview images as shown in the player
@@ -50,7 +50,7 @@ profile.search-cover.http.input = visual
 profile.search-cover.http.output = image
 profile.search-cover.http.suffix = -search.jpg
 profile.search-cover.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
-  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),fps=1,reverse,scale=160:-2 \
+  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),scale=160:-2,fps=25,reverse \
   #{out.dir}/#{out.name}#{out.suffix}
 
 profile.search-cover.http.downscale.name = Downscale to cover image for engage

--- a/etc/encoding/feed-images.properties
+++ b/etc/encoding/feed-images.properties
@@ -32,4 +32,6 @@ profile.feed-cover.http.name = cover image for feeds
 profile.feed-cover.http.input = visual
 profile.feed-cover.http.output = image
 profile.feed-cover.http.suffix = -feed.jpg
-profile.feed-cover.http.ffmpeg.command = -ss #{time} -i #{in.video.path} -r 1 -frames:v 1 -filter:v yadif,scale=-1:54 #{out.dir}/#{out.name}#{out.suffix}
+profile.feed-cover.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
+  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),scale=-1:54,fps=25,reverse \
+  #{out.dir}/#{out.name}#{out.suffix}


### PR DESCRIPTION
For very short videos (a fraction of a second), the current image
extraction of the studio workflow will fail due to the `fps` filter
dropping all frames.

This patch changes this by going to a higher frame count since this is
just a safe-guard against videos with extremely high frame rates.

This fixes #2360

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
