### PR TITLE
Improve Email Workflow Operation

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -33,6 +33,8 @@ Parameter Table
 |cc|The field `cc` of the email<br>i.e. the comma separated list of email accounts that will receive a carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |bcc|The field `bcc` of the email<br>i.e. the comma separated list of email accounts that will receive a blind carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |use-html|Flag to indicate that the email content should be displayed as 'text/html'|false|true/false|
+|address-separator|Separator to use for splitting a string into separate email addresses|`, <tab>`|`,`|
+|skip-invalid-address|If the operation should skip invalid addresses instead of failing|false|true/false|
 
 **Some other email parameters can be customized in the SMTP Service configuration**
 

--- a/modules/email-template-service-api/src/main/java/org/opencastproject/email/template/api/EmailTemplateService.java
+++ b/modules/email-template-service-api/src/main/java/org/opencastproject/email/template/api/EmailTemplateService.java
@@ -36,4 +36,20 @@ public interface EmailTemplateService {
    */
   String applyTemplate(String templateName, String templateContent, WorkflowInstance workflowInstance);
 
+  /**
+   * Apply the template to the workflow instance.
+   *
+   * @param templateName
+   *          template name
+   * @param templateContent
+   *          template content
+   * @param workflowInstance
+   *          workflow
+   * @param multiValueDelimiter
+   *          How to separate multi-value metadata fields
+   * @return text with applied template
+   */
+  String applyTemplate(String templateName, String templateContent, WorkflowInstance workflowInstance,
+      String multiValueDelimiter);
+
 }

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class EmailTemplateServiceImpl implements EmailTemplateService {
   private static final Logger logger = LoggerFactory.getLogger(EmailTemplateServiceImpl.class);
 
-  public static final String DEFAULT_DELIMITER_FOR_MULTIPLE = ",";
+  public static final String DEFAULT_DELIMITER_FOR_MULTIPLE = ", ";
 
   /** The workspace (needed to read the catalogs when processing templates) **/
   private Workspace workspace;

--- a/modules/email-template-service-impl/src/test/java/org/opencastproject/email/template/impl/EmailTemplateServiceImplTest.java
+++ b/modules/email-template-service-impl/src/test/java/org/opencastproject/email/template/impl/EmailTemplateServiceImplTest.java
@@ -41,6 +41,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -68,8 +69,10 @@ public class EmailTemplateServiceImplTest {
     URI episodeURI = EmailTemplateServiceImplTest.class.getResource("/episode_dublincore.xml").toURI();
     URI seriesURI = EmailTemplateServiceImplTest.class.getResource("/series_dublincore.xml").toURI();
     Workspace workspace = EasyMock.createMock(Workspace.class);
-    EasyMock.expect(workspace.get(new URI("episode_dublincore.xml"))).andReturn(new File(episodeURI));
-    EasyMock.expect(workspace.get(new URI("series_dublincore.xml"))).andReturn(new File(seriesURI));
+    EasyMock.expect(workspace.read(new URI("episode_dublincore.xml")))
+        .andReturn(new FileInputStream(new File(episodeURI)));
+    EasyMock.expect(workspace.read(new URI("series_dublincore.xml")))
+        .andReturn(new FileInputStream(new File(seriesURI)));
     EasyMock.replay(workspace);
     service.setWorkspace(workspace);
 

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
@@ -292,7 +292,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String[] to, String[] cc, String[] bcc, String subject, String body, Boolean isHTML) throws MessagingException {
+  public void send(String[] to, String[] cc, String[] bcc, String subject, String body, boolean isHTML) throws MessagingException {
     MimeMessage message = createMessage();
     addRecipients(message, RecipientType.TO, to);
     addRecipients(message, RecipientType.CC, cc);

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -109,7 +109,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
       return createResult(srcPackage, Action.SKIP);
     }
 
-    String subject = applyTemplateIfNecessary(workflowInstance, operation, SUBJECT_PROPERTY, ", ");
+    String subject = applyTemplateIfNecessary(workflowInstance, operation, SUBJECT_PROPERTY);
     String bodyText;
     String body = operation.getConfiguration(BODY_PROPERTY);
     boolean isHTML = BooleanUtils.toBoolean(operation.getConfiguration(IS_HTML));
@@ -120,9 +120,9 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
       // Set the body of the message to be the ID of the media package
       bodyText = String.format("%s (%s)", srcPackage.getTitle(), srcPackage.getIdentifier());
     } else if (body != null) {
-      bodyText = applyTemplateIfNecessary(workflowInstance, operation, BODY_PROPERTY, ", ");
+      bodyText = applyTemplateIfNecessary(workflowInstance, operation, BODY_PROPERTY);
     } else {
-      bodyText = applyTemplateIfNecessary(workflowInstance, operation, BODY_TEMPLATE_FILE_PROPERTY, ", ");
+      bodyText = applyTemplateIfNecessary(workflowInstance, operation, BODY_TEMPLATE_FILE_PROPERTY);
     }
 
     try {
@@ -180,6 +180,11 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
   }
 
   private String applyTemplateIfNecessary(WorkflowInstance workflowInstance, WorkflowOperationInstance operation,
+      String configName) {
+    return applyTemplateIfNecessary(workflowInstance, operation, configName, null);
+  }
+
+  private String applyTemplateIfNecessary(WorkflowInstance workflowInstance, WorkflowOperationInstance operation,
           String configName, String separator) {
     String configValue = operation.getConfiguration(configName);
 
@@ -203,7 +208,11 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
       // template and thus return the value as it is
       return configValue;
     }
+
     // Apply the template
+    if (separator == null) {
+      return emailTemplateService.applyTemplate(templateName, templateContent, workflowInstance);
+    }
     return emailTemplateService.applyTemplate(templateName, templateContent, workflowInstance, separator);
   }
 

--- a/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
+++ b/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
@@ -62,9 +62,9 @@ public class EmailWorkflowOperationHandlerTest {
   private static final String USER_NAME_EMAIL = "username@testemail.com";
   private static final String USER_NAME_NO_EMAIL = "username_no_email";
 
-  private Capture<String> capturedTo;
-  private Capture<String> capturedCC;
-  private Capture<String> capturedBCC;
+  private Capture<String[]> capturedTo;
+  private Capture<String[]> capturedCC;
+  private Capture<String[]> capturedBCC;
   private Capture<String> capturedSubject;
   private Capture<String> capturedBody;
 
@@ -79,11 +79,11 @@ public class EmailWorkflowOperationHandlerTest {
 
     EmailTemplateService emailTemplateService = EasyMock.createMock(EmailTemplateService.class);
     EasyMock.expect(emailTemplateService.applyTemplate("DCE_workflow_2_body",
-            "This is the media package: ${mediaPackage.identifier}", workflowInstance))
+            "This is the media package: ${mediaPackage.identifier}", workflowInstance, ", "))
             .andReturn("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557");
-    EasyMock.expect(emailTemplateService.applyTemplate("template1", null, workflowInstance))
+    EasyMock.expect(emailTemplateService.applyTemplate("template1", null, workflowInstance, ", "))
             .andReturn("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557");
-    EasyMock.expect(emailTemplateService.applyTemplate("templateNotFound", null, workflowInstance))
+    EasyMock.expect(emailTemplateService.applyTemplate("templateNotFound", null, workflowInstance, ", "))
             .andReturn("TEMPLATE NOT FOUND!");
     EasyMock.replay(emailTemplateService);
     operationHandler.setEmailTemplateService(emailTemplateService);
@@ -141,11 +141,11 @@ public class EmailWorkflowOperationHandlerTest {
     WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
 
     Assert.assertEquals(Action.CONTINUE, result.getAction());
-    Assert.assertEquals(DEFAULT_TO, capturedTo.getValue());
-    Assert.assertEquals(DEFAULT_CC, capturedCC.getValue());
-    Assert.assertEquals(DEFAULT_BCC, capturedBCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedTo.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_CC}, capturedCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_BCC}, capturedBCC.getValue());
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
-    Assert.assertEquals("Test Media Package(3e7bb56d-2fcc-4efe-9f0e-d6e56422f557)", capturedBody.getValue());
+    Assert.assertEquals("Test Media Package (3e7bb56d-2fcc-4efe-9f0e-d6e56422f557)", capturedBody.getValue());
   }
 
   @Test
@@ -160,9 +160,9 @@ public class EmailWorkflowOperationHandlerTest {
     WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
 
     Assert.assertEquals(Action.CONTINUE, result.getAction());
-    Assert.assertEquals(DEFAULT_TO, capturedTo.getValue());
-    Assert.assertEquals(DEFAULT_CC, capturedCC.getValue());
-    Assert.assertEquals(DEFAULT_BCC, capturedBCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedTo.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_CC}, capturedCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_BCC}, capturedBCC.getValue());
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
     Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
   }
@@ -178,9 +178,9 @@ public class EmailWorkflowOperationHandlerTest {
     WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
 
     Assert.assertEquals(Action.CONTINUE, result.getAction());
-    Assert.assertEquals(DEFAULT_TO, capturedTo.getValue());
-    Assert.assertEquals(DEFAULT_CC, capturedCC.getValue());
-    Assert.assertEquals(DEFAULT_BCC, capturedBCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedTo.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_CC}, capturedCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_BCC}, capturedBCC.getValue());
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
     Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
   }
@@ -195,9 +195,9 @@ public class EmailWorkflowOperationHandlerTest {
 
     operationHandler.start(workflowInstance, null);
 
-    Assert.assertEquals(DEFAULT_TO, capturedTo.getValue());
-    Assert.assertEquals(DEFAULT_CC, capturedCC.getValue());
-    Assert.assertEquals(DEFAULT_BCC, capturedBCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedTo.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_CC}, capturedCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_BCC}, capturedBCC.getValue());
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
     Assert.assertEquals("TEMPLATE NOT FOUND!", capturedBody.getValue());
   }
@@ -214,9 +214,9 @@ public class EmailWorkflowOperationHandlerTest {
     WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
 
     Assert.assertEquals(Action.CONTINUE, result.getAction());
-    Assert.assertEquals(DEFAULT_TO, capturedTo.getValue());
-    Assert.assertEquals(DEFAULT_TO, capturedCC.getValue());
-    Assert.assertEquals(DEFAULT_TO, capturedBCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedTo.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedBCC.getValue());
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
     Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
   }
@@ -234,9 +234,9 @@ public class EmailWorkflowOperationHandlerTest {
     WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
 
     Assert.assertEquals(Action.CONTINUE, result.getAction());
-    Assert.assertEquals(DEFAULT_TO + "," + DEFAULT_BCC + "," + DEFAULT_CC, capturedTo.getValue());
-    Assert.assertNull(capturedCC.getValue());
-    Assert.assertNull(capturedBCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO, DEFAULT_BCC, DEFAULT_CC}, capturedTo.getValue());
+    Assert.assertEquals(0, capturedCC.getValue().length);
+    Assert.assertEquals(0, capturedBCC.getValue().length);
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
     Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
   }
@@ -253,9 +253,9 @@ public class EmailWorkflowOperationHandlerTest {
     WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
 
     Assert.assertEquals(Action.CONTINUE, result.getAction());
-    Assert.assertEquals(DEFAULT_TO, capturedTo.getValue());
-    Assert.assertEquals(DEFAULT_TO, capturedCC.getValue());
-    Assert.assertEquals(DEFAULT_TO, capturedBCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedTo.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedCC.getValue());
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO}, capturedBCC.getValue());
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
     Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
   }
@@ -277,6 +277,24 @@ public class EmailWorkflowOperationHandlerTest {
     Assert.assertEquals(DEFAULT_TO, capturedBCC.getValue());
     Assert.assertEquals(DEFAULT_SUBJECT, capturedSubject.getValue());
     Assert.assertEquals("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557", capturedBody.getValue());
+  }
+
+  @Test
+  public void testSeparators() throws Exception {
+    final String separator = "~|~";
+    operation.setConfiguration(EmailWorkflowOperationHandler.TO_PROPERTY, USER_NAME_EMAIL + separator + USER_NAME_EMAIL);
+    operation.setConfiguration(EmailWorkflowOperationHandler.ADDRESS_SEPARATOR_PROPERTY, separator);
+
+    operationHandler.start(workflowInstance, null);
+    Assert.assertArrayEquals(new String[] {DEFAULT_TO, DEFAULT_TO}, capturedTo.getValue());
+  }
+
+  @Test
+  public void testNoRecipient() throws Exception {
+    operation.setConfiguration(EmailWorkflowOperationHandler.SKIP_INVALID_ADDRESS_PROPERTY, "true");
+
+    WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
+    Assert.assertEquals(Action.SKIP, result.getAction());
   }
 
 }

--- a/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
+++ b/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
@@ -79,11 +79,11 @@ public class EmailWorkflowOperationHandlerTest {
 
     EmailTemplateService emailTemplateService = EasyMock.createMock(EmailTemplateService.class);
     EasyMock.expect(emailTemplateService.applyTemplate("DCE_workflow_2_body",
-            "This is the media package: ${mediaPackage.identifier}", workflowInstance, ", "))
+            "This is the media package: ${mediaPackage.identifier}", workflowInstance))
             .andReturn("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557");
-    EasyMock.expect(emailTemplateService.applyTemplate("template1", null, workflowInstance, ", "))
+    EasyMock.expect(emailTemplateService.applyTemplate("template1", null, workflowInstance))
             .andReturn("This is the media package: 3e7bb56d-2fcc-4efe-9f0e-d6e56422f557");
-    EasyMock.expect(emailTemplateService.applyTemplate("templateNotFound", null, workflowInstance, ", "))
+    EasyMock.expect(emailTemplateService.applyTemplate("templateNotFound", null, workflowInstance))
             .andReturn("TEMPLATE NOT FOUND!");
     EasyMock.replay(emailTemplateService);
     operationHandler.setEmailTemplateService(emailTemplateService);


### PR DESCRIPTION
This patch fixes several minor issues with the email workflow operation.
The patch is backwards compatible to not break old integrations.

- Until now, an `TO` header like `J. Doe <jdoe@example.com>` would cause
  the operation to fail due to it trying to use e.g. `J.` as a separate
  address. While the default stays the same, a new operation option
  `address-separator` has been introduced to work around it. Using `,`
  usually makes the most sense.

- Inclusion of one invalid mail address can now be skipped by using
  `skip-invalid-address`. This makes sense, especially is a field like
  _contributor_ is used which can easily contain an invalid field. This
  means, mails are semd only to what can be identified as valid
  addresses.

- Internal representation of arrays as strings with separators has been
  minimized, catching a few edge cases.

- Instead of causing a NullPointerException, the operation will be
  skipped if no recipients are defined.

---

For testing, use a workflow like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<definition xmlns="http://workflow.opencastproject.org">
  <id>send-email</id>
  <title>Send Email</title>
  <tags><tag>upload</tag></tags>
  <operations>
    <operation id="send-email">
      <configurations>
        <configuration key="to">${(catalogs['episode']['contributor'])}</configuration>
        <configuration key="subject">test</configuration>
        <configuration key="address-separator">,</configuration>
        <configuration key="skip-invalid-address">true</configuration>
      </configurations>
    </operation>
  </operations>
</definition>
```

Ingest an event like this:

```
curl -f -i -u admin:opencast http://localhost:8080/ingest/addMediaPackage/send-email \
  -F 'flavor=presentation/source' -F 'BODY=@some-file.txt' \
  -F title=test -F creator=test \
  -F contributor=username1 \
  -F contributor=username2 \
  -F contributor='J. Doe <jdoe@example.com>' \
  -F contributor=non-existing-user
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
