### PR TITLE
Perform `check-availibility` WF check with system user

### DIFF
--- a/modules/distribution-service-download/src/test/java/org/opencastproject/distribution/download/DownloadDistributionServiceImplTest.java
+++ b/modules/distribution-service-download/src/test/java/org/opencastproject/distribution/download/DownloadDistributionServiceImplTest.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.distribution.download;
 
+import static org.opencastproject.systems.OpencastConstants.DIGEST_USER_PROPERTY;
+
 import org.opencastproject.distribution.api.DistributionService;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobBarrier;
@@ -162,6 +164,8 @@ public class DownloadDistributionServiceImplTest {
         .andReturn(distributionRoot.toString()).anyTimes();
     EasyMock.expect(bc.getProperty("org.opencastproject.download.url"))
         .andReturn(UrlSupport.DEFAULT_BASE_URL).anyTimes();
+    EasyMock.expect(bc.getProperty(DIGEST_USER_PROPERTY))
+        .andReturn("opencast_system_account").anyTimes();
     ComponentContext cc = EasyMock.createNiceMock(ComponentContext.class);
     Dictionary<String, Object> p = new Hashtable<String, Object>();
     p.put(DistributionService.CONFIG_KEY_STORE_TYPE, "download");


### PR DESCRIPTION
This is to prevent problems when the user starting the workflow is not
authorized to access the distributed assets. This should be rare in
theory, but in practice, the authorization for static files might use
a cache for permissions. This can easily lead to workflows failing
because the the availability check encounters a 403 response due to
permission caching.

Using the system user here doesn't seem like a problem: the availability check was
never supposed to test any authorization-related things, but simply
whether the published file exists at all.

I tested this patch on a multi-node system and it seems to work. And in particular, it solves the problem I encountered where workflows would fail because of that.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
