### PR TITLE
Editor Workflow Description

### DIFF
--- a/etc/workflows/cleanup-publish-placeholder.xml
+++ b/etc/workflows/cleanup-publish-placeholder.xml
@@ -2,14 +2,15 @@
 <definition xmlns="http://workflow.opencastproject.org">
 
   <id>placeholdervideo</id>
-  <title>Cleanup and publish placeholder video</title>
-    <tags>
-      <tag>archive</tag>
-      <tag>editor</tag>
-    </tags>
+  <title>Delete event, publish a placeholder instead</title>
+  <tags>
+    <tag>archive</tag>
+    <tag>editor</tag>
+  </tags>
+  <displayOrder>2000</displayOrder>
   <description>
-    Publish a placeholder video for corrupt videos.
-    Delete and cleanup corrupt videos and old snapshots, but keep the metadata.
+    Delete all media related to this event, keeping the metadata and publishing a placeholder video instead.
+    The original media will be unrecoverable.
   </description>
   <configuration_panel/>
 

--- a/etc/workflows/publish-after-cutting.xml
+++ b/etc/workflows/publish-after-cutting.xml
@@ -6,7 +6,10 @@
   <tags>
     <tag>editor</tag>
   </tags>
-  <description/>
+  <displayOrder>1000</displayOrder>
+  <description>
+    Process and publish media.
+  </description>
   <configuration_panel/>
 
   <operations>


### PR DESCRIPTION
This patch improves the workflow description of the editor workflows,
making it much clearer that `placeholdervideo` will irrevocably delete
the events media and placing `publish-after-cutting` before that
workflow.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
