### PR TITLE
Fix Hardcoded Dependency Version

### DIFF
--- a/modules/editor-service-api/pom.xml
+++ b/modules/editor-service-api/pom.xml
@@ -4,11 +4,21 @@
   <artifactId>opencast-editor-service-api</artifactId>
   <packaging>bundle</packaging>
   <name>Opencast :: editor-service-api</name>
+  <parent>
+    <groupId>org.opencastproject</groupId>
+    <artifactId>base</artifactId>
+    <version>9-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <properties>
+    <opencast.basedir>${project.basedir}/../..</opencast.basedir>
+    <checkstyle.skip>false</checkstyle.skip>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
-      <version>9-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -31,16 +41,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <parent>
-    <groupId>org.opencastproject</groupId>
-    <artifactId>base</artifactId>
-    <version>9-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
-  </parent>
-  <properties>
-    <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <checkstyle.skip>false</checkstyle.skip>
-  </properties>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
This patch fixes the version of an Opencast dependency which was
accidentally hardcoded to 9-SNAPSHOT instead of using
`${project.version}` as usual.

This could easily cause a broken release otherwise.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
