### PR TITLE
8.x specific fixes for the markdown generation code

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,7 @@ jobs:
       working-directory: docs/guides/
       run: |
         pip install -q -r requirements.txt
+        pip install -q markdown-inline-graphviz-extension-png
 
     - name: build admin docs
       working-directory: docs/guides/admin/

--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -20,8 +20,13 @@ jobs:
 
     - name: install dependencies
       run: |
-        pip install -q mkdocs markdown_inline_graphviz_extension mkdocs-windmill
+        sudo apt update -q
+        sudo apt install -y -q \
+          graphviz
         cd docs/guides
+        pip install -q -r requirements.txt
+        #Unclear why this needs to be a separate step, but it 100% does
+        pip install -q markdown-inline-graphviz-extension-png
         npm ci
 
     - name: check documentation

--- a/docs/guides/requirements.txt
+++ b/docs/guides/requirements.txt
@@ -1,4 +1,3 @@
 mkdocs
 mkdocs-windmill
 markdown_inline_graphviz_extension
-markdown-inline-graphviz-extension-png


### PR DESCRIPTION
For some reason markdown-inline-graphviz-extension-png needs to be
installed separately, after the rest of the markdown modules.  It's
unclear why exactly this is happening, but it's also not happening in
9.x so it's not worth the time to debug why.

Closes #2386 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
