### PR TITLE
Correct Series ACLs when Recreating the Search Service Index

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -327,6 +327,8 @@ public class SolrIndexManager {
    *          the media package to post
    * @param acl
    *          the access control list for this mediapackage
+   * @param seriesAcl
+   *          the access control list for the series
    * @param deletionDate
    *          the deletion date
    * @param modificationDate
@@ -335,12 +337,14 @@ public class SolrIndexManager {
    * @throws SolrServerException
    *           if an errors occurs while talking to solr
    */
-  public boolean add(MediaPackage sourceMediaPackage, AccessControlList acl, Date deletionDate, Date modificationDate)
+  public boolean add(MediaPackage sourceMediaPackage, AccessControlList acl,
+      AccessControlList seriesAcl, Date deletionDate,
+      Date modificationDate)
           throws SolrServerException {
     try {
       SolrInputDocument episodeDocument = createEpisodeInputDocument(sourceMediaPackage, acl);
 
-      SolrInputDocument seriesDocument = createSeriesInputDocument(sourceMediaPackage.getSeries(), acl);
+      SolrInputDocument seriesDocument = createSeriesInputDocument(sourceMediaPackage.getSeries(), seriesAcl);
       if (seriesDocument != null)
         Schema.enrich(episodeDocument, seriesDocument);
 


### PR DESCRIPTION
When re-creating the search service Solr index (used for engage
publication), series may end up with stricter access control than
expected since series will end up with the access control list of the
last event added to this series.

This may lead to hidden series if some events in this series are hidden,
even if the rest of the events are public.

Note that this bug may only cause stricter ACLs then expected and is
thus no security concern.

This is related to GHSA-vpc2-3wcv-qj4w.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
