### PR TITLE
Revert "No Matrix Build on Opencast 8"

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -71,6 +71,7 @@ jobs:
         working-directory: assemblies
         if: >
           github.event_name == 'push'
+          && matrix.java == 11
           && github.repository == 'opencast/opencast'
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         run: |
@@ -81,6 +82,7 @@ jobs:
         working-directory: build
         if: >
           github.event_name == 'push'
+          && matrix.java == 11
           && github.repository == 'opencast/opencast'
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         run: |
@@ -89,6 +91,7 @@ jobs:
       - name: configure s3cmd
         if: >
           github.event_name == 'push'
+          && matrix.java == 11
           && github.repository == 'opencast/opencast'
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         env:
@@ -108,6 +111,7 @@ jobs:
         working-directory: build
         if: >
           github.event_name == 'push'
+          && matrix.java == 11
           && github.repository == 'opencast/opencast'
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         run: |


### PR DESCRIPTION
This reverts commit 12872fd8ec681dce706616f9654ee9e7edce02f0.

Commit 12872fd8ec681dce706616f9654ee9e7edce02f0 was a temporary fix for
Opencast 8 and should be reverted when merged into `r/9.x`.  On Opencast
9+, builds are run against both Java 8 and Java 11. Since we dont want
to build and upload the distribution twice, possibly even causing upload
problems, the upload steps are limited to Java 11 only.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
