### PR TITLE
Updated new editor with new frontend-release 2021-03-24

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -113,6 +113,11 @@ API changes
   different types of events in one request
 - The Series API can now return ACLs within its response, if you tell it to
 
+Additional Notes about 9.4
+--------------------------
+- [The standalone video editor](modules/editor.md) received an update, featuring optional metadata editing,
+hotkeys for the cutting controls and internationalization support.
+
 Additional Notes about 9.3
 --------------------------
 

--- a/etc/ui-config/mh_default_org/editor/editor-settings.toml
+++ b/etc/ui-config/mh_default_org/editor/editor-settings.toml
@@ -13,7 +13,7 @@
 ### Settings of the metadata tab
 [metadata]
 # If false, the metadata button is not displayed in the main menu
-show = false
+show = true
 
 ### Settings of the thumbnail tab
 [thumbnail]

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-03-05/oc-editor-2021-03-05-v2.tar.gz</editor.url>
-    <editor.sha256>e1686aefdc611c6b19c56a8c50f27a4713a57f7451bcd69e3b1111f58bd09905</editor.sha256>
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-03-23/oc-editor-2021-03-24-v3.tar.gz</editor.url>
+    <editor.sha256>2858d9ba593f22d762a15bb385168ba839bbd80bdb8a60c43f53eff4f92a0e97</editor.sha256>
   </properties>
   <build>
     <plugins>

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-03-23/oc-editor-2021-03-24-v3.tar.gz</editor.url>
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-03-24/oc-editor-2021-03-24-v3.tar.gz</editor.url>
     <editor.sha256>2858d9ba593f22d762a15bb385168ba839bbd80bdb8a60c43f53eff4f92a0e97</editor.sha256>
   </properties>
   <build>


### PR DESCRIPTION
Updates the new (optional) editor with a new frontend release.

Details on the changes in the frontend can be found here: https://github.com/elan-ev/opencast-editor/releases/tag/2021-03-24

Details on the new editor that was introduced with Opencast 9.3 can be found here: https://docs.opencast.org/r/9.x/admin/#modules/editor/

![Screenshot from 2021-03-24 16-50-16](https://user-images.githubusercontent.com/1008395/112340663-0d9e7f80-8cc1-11eb-90f5-1d6f7a8b2d3f.png)
