### PR TITLE
fixed publish-configure argument in fast-HLS

### DIFF
--- a/etc/workflows/fast-HLS.xml
+++ b/etc/workflows/fast-HLS.xml
@@ -199,7 +199,7 @@
       exception-handler-workflow="partial-error"
       description="Publish to preview publication channel">
       <configurations>
-        <configuration key="source-flavors">*/delivery</configuration>
+        <configuration key="download-source-flavors">*/delivery</configuration>
         <configuration key="channel-id">internal</configuration>
         <configuration key="url-pattern">http://localhost:8080/admin-ng/index.html#/events/events/${event_id}/tools/playback</configuration>
         <configuration key="check-availability">true</configuration>


### PR DESCRIPTION
I noticed this was the only default workflow that's still using the old "source-flavors" argument for publish-configure.