### PR TITLE
Automatically closing resources on the getAsset AM rest endpoint

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
@@ -71,6 +71,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -318,10 +319,13 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
           asset.getMimeType().map(MimeTypeUtil.Fns.toString);
           // Write the file contents back
           Option<Long> length = asset.getSize() > 0 ? Option.some(asset.getSize()) : Option.none();
-          return ok(asset.getInputStream(),
-                  Option.fromOpt(asset.getMimeType().map(MimeTypeUtil.Fns.toString)),
-                  length,
-                  Option.some(fileName));
+          try (InputStream is = asset.getInputStream()) {
+            return ok(is,
+                    Option.fromOpt(asset.getMimeType().map(MimeTypeUtil.Fns.toString)),
+                    length,
+                    Option.some(fileName));
+          }
+
         }
         // none
         return notFound();


### PR DESCRIPTION
Using autoclose to close input stream for fetched resources.  This was causing filehandle leaks in Osnabruck testing on S3.

### Your pull request should…

* [x] have a concise title
* [ ] ~close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] be against the correct branch (features can only go into develop)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
