### PR TITLE
Exclude Dependabot from ICLA Check

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   main:
-    if: github.event.pull_request.user.login != 'dependabot'
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v1


### PR DESCRIPTION
This patch excludes `dependabot[bot]` from ICLA checks.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
