### PR TITLE
Enable Elasticsearch in docs

### DIFF
--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -124,11 +124,13 @@ is required, neither Opencast nor ActiveMQ are configured to start automatically
 [Basic Configuration guide](../configuration/basic.md).  Once you are ready, enable Opencast and ActiveMQ to start on boot with:
 
         systemctl enable activemq.service
+        systemctl enable elasticsearch.service
         systemctl enable opencast.service
 
 then start them with:
 
         systemctl start activemq.service
+        systemctl start elasticsearch.service
         systemctl start opencast.service
 
 


### PR DESCRIPTION
Enabling ES in the deb install docs, since the package itself does not do so.

Fixes: #2358 