### PR TITLE
Fix Memory Leak

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/HttpUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/HttpUtil.java
@@ -115,8 +115,15 @@ public final class HttpUtil {
     long now = 0L;
     while (true) {
       final HttpHead head = new HttpHead(resourceUri);
+      HttpResponse response = null;
+      final int status;
       try {
-        final int status = http.execute(head).getStatusLine().getStatusCode();
+        try {
+          response = http.execute(head);
+          status = response.getStatusLine().getStatusCode();
+        } finally {
+          http.close(response);
+        }
         if (status == expectedStatus || now >= timeout) {
           return right(status);
         } else {

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -495,8 +495,16 @@ public final class WorkspaceImpl implements Workspace {
     while (true) {
       // run the http request and handle its response
       try {
-        final Either<String, Option<File>> result = handleDownloadResponse(
-            trustedHttpClient.execute(get), src, dst);
+        HttpResponse response = null;
+        final Either<String, Option<File>> result;
+        try {
+          response = trustedHttpClient.execute(get);
+          result = handleDownloadResponse(response, src, dst);
+        } finally {
+          if (response != null) {
+            trustedHttpClient.close(response);
+          }
+        }
         for (Option<File> ff : result.right()) {
           for (File f : ff) {
             return f;


### PR DESCRIPTION
We noticed that Opencast 9 presenter nodes would leak memory, causing an
eventual Java heap out of memory error and a complete failure of the
node.

The reason behind this seems to be the TrustedHttpClient which tracks
requests and thus needs an explicit closing of each request, else it
will keep those in its internal `responseMap` indefinitely.

This patch does not necessarily fix all occurrences but seems to fix at
least the most prominent ones. A default processing of a single video
caused 39 open (leaked) requests with 37 one in the availability check.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
