### PR TITLE
Attachment is not a function LTI error fixed

### DIFF
--- a/modules/lti/src/OpencastRest.ts
+++ b/modules/lti/src/OpencastRest.ts
@@ -210,10 +210,14 @@ export async function searchEpisode(
             licenseKey: result.dcLicense,
             mediapackage: {
                 creators: result.mediapackage.creators !== undefined ? result.mediapackage.creators.creator : [],
-                attachments: result.mediapackage.attachments.attachment.map((attachment: any) => ({
-                    type: attachment.type,
-                    url: attachment.url
-                })),
+                attachments: Array.from(
+                    Array.isArray(result.mediapackage.attachments.attachment) ?
+                        result.mediapackage.attachments.attachment :
+                        Array.of(result.mediapackage.attachments.attachment),
+                    (attachment: any) => ({
+                        type: attachment.type,
+                        url: attachment.url
+                    })),
                 tracks: parseTracksFromResult(result)
             }
         })),


### PR DESCRIPTION
In some cases the LTI series tool fails to render the page for a specific series. Instead of the list of episodes you will see an error Message `Error:  e.mediapackage.attachments.attachment.map is not a function`. I've tracked it down to one episode where the `mediapackage.attachments.attachment` is not an array as expected but an attachment object. This PR fixes the bug.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
