### PR TITLE
Multiple Creators in Series LTI Tool

### DIFF
--- a/modules/lti/mock-server-api-data/search/episode.json
+++ b/modules/lti/mock-server-api-data/search/episode.json
@@ -3734,7 +3734,10 @@
           "start": "2019-09-19T05:45:53Z",
           "title": "Opencast Studio",
           "creators": {
-            "creator": "Firefox"
+            "creator": [
+              "Firefox",
+              "Chromium"
+            ]
           },
           "media": {
             "track": {

--- a/modules/lti/src/OpencastRest.ts
+++ b/modules/lti/src/OpencastRest.ts
@@ -23,7 +23,6 @@ export interface MediaPackage {
 }
 
 export interface SearchEpisodeResult {
-    readonly dcCreator: string;
     readonly id: string;
     readonly dcTitle: string;
     readonly dcCreated: string;
@@ -202,18 +201,21 @@ export async function searchEpisode(
     const results = Array.isArray(resultsRaw) ? resultsRaw : resultsRaw !== undefined ? [resultsRaw] : [];
     return {
         results: results.map((result: any) => ({
-            dcCreator: result.dcCreator,
             id: result.id,
             dcTitle: result.dcTitle,
             dcCreated: result.dcCreated,
             languageShortCode: result.dcLanguage,
             licenseKey: result.dcLicense,
             mediapackage: {
-                creators: result.mediapackage.creators !== undefined ? result.mediapackage.creators.creator : [],
+                creators: result.mediapackage.creators !== undefined
+                    ? Array.isArray(result.mediapackage.creators.creator)
+                        ? result.mediapackage.creators.creator
+                        : [result.mediapackage.creators.creator]
+                    : [],
                 attachments: Array.from(
-                    Array.isArray(result.mediapackage.attachments.attachment) ?
-                        result.mediapackage.attachments.attachment :
-                        Array.of(result.mediapackage.attachments.attachment),
+                    Array.isArray(result.mediapackage.attachments.attachment)
+                        ? result.mediapackage.attachments.attachment
+                        : Array.of(result.mediapackage.attachments.attachment),
                     (attachment: any) => ({
                         type: attachment.type,
                         url: attachment.url

--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -64,8 +64,8 @@ const SeriesEpisode: React.StatelessComponent<EpisodeProps> = ({ episode, delete
         </div>
         <div className="ml-3">
             <h4>{episode.dcTitle}</h4>
-            {episode.dcCreator !== undefined && <p className="text-muted">
-                {t("LTI.CREATOR", { creator: episode.dcCreator })}
+            {episode.mediapackage.creators.length > 0 && <p className="text-muted">
+                {t("LTI.CREATOR", { creator: episode.mediapackage.creators.join(', ') })}
             </p>}
             <p className="text-muted">{new Date(episode.dcCreated).toLocaleString()}</p>
         </div>


### PR DESCRIPTION
This patch fixes the display of multiple creators in the series LTI tool
which previously just displayed a single random creator.

Inspired by pull request #2489

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
