### PR TITLE
Make media package handle multi-byte Unicode characters

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -27,7 +27,6 @@ import org.opencastproject.mediapackage.identifier.Id;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -36,7 +35,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -102,18 +100,7 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
    * @see org.opencastproject.mediapackage.MediaPackageBuilder#loadFromXml(java.io.InputStream)
    */
   public MediaPackage loadFromXml(InputStream is) throws MediaPackageException {
-    if (serializer != null) {
-      // FIXME This code runs if *any* serializer is present, regardless of the serializer implementation
-      try {
-        Document xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
-        rewriteUrls(xml, serializer);
-        return MediaPackageImpl.valueOf(xml);
-      } catch (Exception e) {
-        throw new MediaPackageException("Error deserializing paths in media package", e);
-      }
-    } else {
-      return MediaPackageImpl.valueOf(is);
-    }
+    return MediaPackageImpl.valueOf(is);
   }
 
   /**

--- a/modules/common/src/test/java/org/opencastproject/mediapackage/MediaPackageMergeTest.java
+++ b/modules/common/src/test/java/org/opencastproject/mediapackage/MediaPackageMergeTest.java
@@ -24,7 +24,6 @@ package org.opencastproject.mediapackage;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.opencastproject.mediapackage.MediaPackageSupport.MergeMode;
@@ -40,7 +39,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
@@ -192,15 +190,11 @@ public class MediaPackageMergeTest {
    * @throws MediaPackageException
    */
   private void testMediaPackageConsistency(MediaPackage mediaPackage) throws MediaPackageException {
-    List<String> ids = new ArrayList<String>();
-    List<URI> files = new ArrayList<URI>();
+    List<String> ids = new ArrayList<>();
     for (MediaPackageElement e : mediaPackage.elements()) {
       if (ids.contains(e.getIdentifier()))
         throw new MediaPackageException("Duplicate id " + e.getIdentifier() + "' found");
       ids.add(e.getIdentifier());
-      if (files.contains(e.getURI()))
-        throw new MediaPackageException("Duplicate filename " + e.getURI() + "' found");
-      files.add(e.getURI());
     }
   }
 
@@ -208,9 +202,9 @@ public class MediaPackageMergeTest {
   public void testMergeByMerging() {
     try {
       MediaPackage mediaPackage = MediaPackageSupport.merge(targetPackage, sourcePackage, MergeMode.Merge);
-      assertTrue(mediaPackage.getTracks().length == 5);
-      assertTrue(mediaPackage.getCatalogs().length == 6);
-      assertTrue(mediaPackage.getAttachments().length == 3);
+      assertEquals(5, mediaPackage.getTracks().length);
+      assertEquals(6, mediaPackage.getCatalogs().length);
+      assertEquals(3, mediaPackage.getAttachments().length);
       testMediaPackageConsistency(mediaPackage);
     } catch (MediaPackageException e) {
       fail(e.getMessage());

--- a/modules/common/src/test/resources/manifest.xml
+++ b/modules/common/src/test/resources/manifest.xml
@@ -1,5 +1,5 @@
 <oc:mediapackage xmlns:oc="http://mediapackage.opencastproject.org" id="597d0b42-5af6-450e-ac0b-c2cb619fc2be" start="2007-12-05T13:40:00" duration="1004400000">
-  <oc:title>t1</oc:title>
+  <oc:title>I &#128420; Opencast</oc:title>
   <oc:seriestitle>s1</oc:seriestitle>
   <oc:creators>
     <oc:creator>p1</oc:creator>

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
@@ -82,7 +82,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
@@ -165,12 +164,9 @@ public class SearchServiceImplTest {
     EntityManager em = emf.createEntityManager();
     // workspace
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.read((URI) EasyMock.anyObject())).andAnswer(new IAnswer<InputStream>() {
-      @Override
-      public InputStream answer() throws Throwable {
-        return new FileInputStream(new File(new URI(EasyMock.getCurrentArguments()[0].toString())));
-      }
-    }).anyTimes();
+    EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class)))
+        .andAnswer(() -> getClass().getResourceAsStream("/" + EasyMock.getCurrentArguments()[0].toString()))
+        .anyTimes();
     EasyMock.replay(workspace);
 
     // User, organization and service registry


### PR DESCRIPTION
Parsing media packages had a strange internal behavior of parsing the
XML, possibly modifying the XML, serializing the XML again to then parse
the XML again. The serializer used in this process could not handle
multi-byte Unicode characters properly which broke the entire process.

This was used as part of the search service which caused the Media
module and player to break on such events.

This patch fixes the problem by directly parsing the XML in most cases
and using a different serializer in the other cases.

Note that this will not fix already broken XML!
It just prevents breaking new XML.

---

Due to the very strange parsing behavior previously present in the code,
I would like to get two separate reviews on this.
If you happen to have further questions, please do not hesitate to ask.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
