### PR TITLE
Handle multiple creators in Media Module

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -657,8 +657,12 @@ function($, bootbox, _, alertify, jsyaml) {
         }
         tile = tile + '<div class="infos">';
 
-        if (data.dcCreator) {
-          creator = _.escape(data.dcCreator);
+        if (data.mediapackage.creators) {
+          creator = (Array.isArray(data.mediapackage.creators.creator)
+            ? data.mediapackage.creators.creator
+            : [data.mediapackage.creators.creator])
+            .map(_.escape)
+            .join(', ');
         }
         tile = tile + '<div class="creator">' + creator + '</div>';
 


### PR DESCRIPTION
This patch fixes the problem that the media module would just display a
single random creator, even if the event has multiple creators.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
