### PR TITLE
Handle multiple creators in Paella player

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.descriptionPlugin/mh_description.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.descriptionPlugin/mh_description.js
@@ -67,7 +67,12 @@ paella.addPlugin(function() {
           : [thisClass._episode.mediapackage.creators.creator])
           .join(', ');
       }
-      if (thisClass._episode.dcContributor) { this.desc.contributor = thisClass._episode.dcContributor; }
+      if (thisClass._episode.mediapackage.contributors) {
+        this.desc.contributor = (Array.isArray(thisClass._episode.mediapackage.contributors.contributor)
+          ? thisClass._episode.mediapackage.contributors.contributor
+          : [thisClass._episode.mediapackage.contributors.contributor])
+          .join(', ');
+      }
       if (thisClass._episode.dcDescription) { this.desc.description = thisClass._episode.dcDescription; }
       if (thisClass._episode.dcLanguage) { this.desc.language = thisClass._episode.dcLanguage; }
       if (thisClass._episode.dcSubject) { this.desc.subject = thisClass._episode.dcSubject; }
@@ -170,4 +175,3 @@ paella.addPlugin(function() {
     }
   };
 });
-

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.descriptionPlugin/mh_description.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.descriptionPlugin/mh_description.js
@@ -61,7 +61,12 @@ paella.addPlugin(function() {
       var thisClass = this;
 
       if (thisClass._episode.dcTitle) { this.desc.title = thisClass._episode.dcTitle; }
-      if (thisClass._episode.dcCreator) { this.desc.presenter = thisClass._episode.dcCreator; }
+      if (thisClass._episode.mediapackage.creators) {
+        this.desc.presenter = (Array.isArray(thisClass._episode.mediapackage.creators.creator)
+          ? thisClass._episode.mediapackage.creators.creator
+          : [thisClass._episode.mediapackage.creators.creator])
+          .join(', ');
+      }
       if (thisClass._episode.dcContributor) { this.desc.contributor = thisClass._episode.dcContributor; }
       if (thisClass._episode.dcDescription) { this.desc.description = thisClass._episode.dcDescription; }
       if (thisClass._episode.dcLanguage) { this.desc.language = thisClass._episode.dcLanguage; }


### PR DESCRIPTION
This patch fixes the problem that the Paella player would just display a
single random creator, even if the event has multiple creators.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
