### PR TITLE
Change Paella Usertracking Default

### DIFF
--- a/docs/guides/admin/docs/releasenotes/changed-behavior/paella-user-tracking.txt
+++ b/docs/guides/admin/docs/releasenotes/changed-behavior/paella-user-tracking.txt
@@ -1,0 +1,2 @@
+- Paellas internal user tracking is now disabled by default since it is seldom used and can put a lot of stress on the
+  database.

--- a/etc/ui-config/mh_default_org/paella/config.json
+++ b/etc/ui-config/mh_default_org/paella/config.json
@@ -396,7 +396,7 @@
         "enabled": true
       },
       "es.upv.paella.opencast.userTrackingSaverPlugIn": {
-        "enabled": true
+        "enabled": false
       },
       "es.upv.paella.defaultKeysPlugin": {
         "enabled": true


### PR DESCRIPTION
Paellas internal user tracking is now disabled by default since it is seldom used and can put a lot of stress on the
database.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
