### PR TITLE
Add Build Date in User Interface

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -114,9 +114,20 @@
 
     <footer id="main-footer" ng-controller="NavCtrl">
       <div class="default-footer">
-        <div ng-if="version.version" class="meta">
+        <div ng-if="version.version"
+             class="meta"
+             title="{{ 'BUILD.VERSION' | translate }}">
           Opencast {{ version.version }}
-          <span with-role="ROLE_ADMIN"> - {{ version.buildNumber || 'undefined' }}</span>
+          <span ng-if="version.buildNumber"
+                with-role="ROLE_ADMIN"
+                title="{{ 'BUILD.COMMIT' | translate }}">
+            - {{ version.buildNumber || 'undefined' }}
+          </span>
+          <span ng-if="version['last-modified']"
+                with-role="ROLE_ADMIN"
+                title="{{ 'BUILD.DATE_DESC' | translate }}">
+            - {{ 'BUILD.BUILT_ON' | translate }} {{ version['last-modified'] }}
+          </span>
         </div>
         <div ng-if="feedbackUrl" class="feedback-btn" id="feedback-btn">
           <a href="javascript:;">Feedback</a>

--- a/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
@@ -102,6 +102,9 @@ angular.module('adminNg.controllers')
 
     if (angular.isUndefined($rootScope.version)) {
       VersionResource.query(function(response) {
+        if (response['last-modified']) {
+          response['last-modified'] = new Date(response['last-modified']).toISOString().substr(0, 10);
+        }
         $rootScope.version = response.version
           ? response
           : (angular.isArray(response.versions) ? response.versions[0] : {});

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2,6 +2,12 @@
    "MATTERHORN":   "Opencast",
    "NAV_HOME":     "Start",
    "NAV_ABOUT":    "About",
+   "BUILD": {
+     "BUILT_ON":   "built on",
+     "DATE_DESC":  "Date this system's kernel module was built on.",
+     "COMMIT":     "Git commit this version was built from.",
+     "VERSION":    "Common bundle version"
+   },
    "NO":           "No",
    "SUBMIT":       "Submit",
    "UPDATE":       "Update",

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpoint.java
@@ -44,6 +44,9 @@ import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+
 import java.util.List;
 import java.util.Set;
 
@@ -66,6 +69,13 @@ public abstract class BundleInfoRestEndpoint {
   private static final String DEFAULT_BUNDLE_PREFIX = "opencast";
 
   protected abstract BundleInfoDb getDb();
+
+  private long lastModified = 0;
+
+  @Activate
+  public void activate(ComponentContext cc) {
+    lastModified = cc.getBundleContext().getBundle().getLastModified();
+  }
 
   @GET
   // path prefix "bundles" is contained here and not in the path annotation of the class
@@ -149,7 +159,9 @@ public abstract class BundleInfoRestEndpoint {
             throw new Error("bug");
           case 1:
             // all versions align
-            return ok(obj(p("consistent", true)).append(fullVersionJson.apply(example.getVersion())));
+            return ok(obj(p("consistent", true))
+                .append(fullVersionJson.apply(example.getVersion()))
+                .append(obj(p("last-modified", lastModified))));
           default:
             // multiple versions found
             return ok(obj(p("consistent", false),


### PR DESCRIPTION
This patch adds the build date to the build information visible to the
system administrator in the admin interface.

This fixes #1215

![Screenshot from 2021-04-16 20-34-18](https://user-images.githubusercontent.com/1008395/115069501-efa8f100-9ef3-11eb-8e57-e45f06dd3e61.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
