### PR TITLE
Do not build against Java 8

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/checkstyle/**'
       - 'docs/log4j/**'
       - 'assemblies/**'
+      - '.github/**'
   push:
     paths:
       - 'pom.xml'
@@ -15,14 +16,15 @@ on:
       - 'docs/checkstyle/**'
       - 'docs/log4j/**'
       - 'assemblies/**'
+      - '.github/**'
 
 jobs:
   build:
     strategy:
       matrix:
         java:
-          - 8
           - 11
+          - 13
     name: build (java ${{ matrix.java }})
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
Opencast 10 does not support Java 8 any longer, so we don't need to run
our tests against it. This makes Actions run the tests against Java 13
instead.

The Opencast build fails with newer versions of Java. Mid-term, it would
make sense to build against all LTS versions we support, plus the latest
version of Java.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
