### PR TITLE
Removes Safari from Karma admin-ui-frontend tests.

### DIFF
--- a/docs/guides/admin/docs/installation/source-macosx.md
+++ b/docs/guides/admin/docs/installation/source-macosx.md
@@ -52,6 +52,7 @@ Required:
     ffmpeg >= 3.2.4
     maven >= 3.1
     python >= 2.6
+    Firefox or Chrome 
 
 (If you are using [jEnv](http://www.jenv.be/) to set up your environment, make sure to [enable the maven plugin
 ](https://stackoverflow.com/a/37466252).)

--- a/modules/admin-ui-frontend/test/karma.conf.js
+++ b/modules/admin-ui-frontend/test/karma.conf.js
@@ -78,6 +78,9 @@ module.exports = function (config) {
                     console.error("Suggest installing Firefox or other FOSS browser");
                     throw "No browsers detected";
 	        }
+        if (availableBrowsers.includes('Safari')){
+                result = availableBrowsers.filter(item => item !== 'Safari')
+        }
                 return result;
             }
         },


### PR DESCRIPTION
This commit removes safari to be use in the admin-ui Karma tests.
 Solves the issue when Opencast is build in macOS fails the admin-ui-frontend tests

This change adds the requirement to have Firefox or Chrome installed when Opencast is
build from source in macOS

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
