### PR TITLE
Sanitize xml input in admin frontend

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -298,6 +298,7 @@
     <script src="scripts/shared/directives/selectBoxDirective.js"></script>
     <script src="scripts/shared/directives/navDirective.js"></script>
     <script src="scripts/shared/directives/tableDirective.js"></script>
+    <script src="scripts/shared/directives/sanitizeXMLDirective.js"></script>
     <script src="scripts/shared/directives/statsDirective.js"></script>
     <script src="scripts/shared/directives/collapsibleBoxDirective.js"></script>
     <script src="scripts/shared/directives/confirmationModalDirective.js"></script>

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -724,6 +724,7 @@ angular.module('adminNg.controllers')
       if (Object.prototype.hasOwnProperty.call(catalog, 'fields')) {
         for (var fieldNo in catalog.fields) {
           var field = catalog.fields[fieldNo];
+
           if (Object.prototype.hasOwnProperty.call(field, 'collection')) {
             field.collection = [];
           }

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -312,6 +312,7 @@ angular.module('adminNg.controllers')
       if (Object.prototype.hasOwnProperty.call(catalog, 'fields')) {
         for (var fieldNo in catalog.fields) {
           var field = catalog.fields[fieldNo];
+
           if (Object.prototype.hasOwnProperty.call(field, 'collection')) {
             field.collection = [];
           }

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/sanitizeXMLDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/sanitizeXMLDirective.js
@@ -1,0 +1,67 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name adminNg.modal.sanitizeXml
+ * @description
+ * Removes illegal XML characters from the input string.
+ *
+ * Illegal characters are all characters not in the following list:
+ * x09: Character Tabulation
+ * x0A: Line Feed
+ * x0D: Carriage Return
+ * x20-xD7FF
+ * uE000-uFFFD
+ * x10000-x10FFFF
+ *
+ * Usage: Set this directive in the input element that needs to be sanitized.
+ *
+ * @example
+ * <input sanitize-xml="user.username"/>
+ */
+angular.module('adminNg.directives')
+.directive('sanitizeXml', function () {
+  return {
+    require: 'ngModel',
+    link: function (scope, elem, attrs, ctrl) {
+      scope.unregisterWatch = scope.$watch(attrs.sanitizeXml, function (input) {
+        // Regexp matches illegal characters.
+        // Unfortunately javascript does not play nice with the higher planes of unicode (x10000-x10FFFF).
+        // With ES6 we might be able to switch to a nicer expression like
+        // /([^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFC\u{10000}-\u{10FFFF}])/ug
+        // eslint-disable-next-line no-control-regex
+        var NOT_SAFE_IN_XML_1_0 = new RegExp('((?:[\0-\x08\x0B\f\x0E-\x1F\uFFFD\uFFFE\uFFFF]|'
+          + '[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]))', 'g');
+
+        if (typeof input === 'string') {
+          ctrl.$setViewValue(input.replace(NOT_SAFE_IN_XML_1_0, ''));
+          ctrl.$render();
+        }
+      });
+
+      scope.$on('$destroy', function () {
+        scope.unregisterWatch();
+      });
+    }
+  };
+});

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
@@ -39,7 +39,8 @@
                         ng-model="metadata.name"
                         ng-model-options="{ debounce: {'default': 500} }"
                         ng-required="true"
-                        placeholder="{{ 'USERS.ACLS.DETAILS.METADATA.NAME.PLACEHOLDER' | translate }}">
+                        placeholder="{{ 'USERS.ACLS.DETAILS.METADATA.NAME.PLACEHOLDER' | translate }}"
+                        sanitize-xml="metadata.name">
                     </td>
                   </tr>
                 </table>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -100,7 +100,8 @@
                 </td>
                 <td admin-ng-editable
                     required-role="ROLE_UI_EVENTS_DETAILS_METADATA_EDIT"
-                    params="row" save="getSaveFunction(episodeCatalog.flavor)">
+                    params="row" save="getSaveFunction(episodeCatalog.flavor)"
+                    sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
             </table>
@@ -126,7 +127,8 @@
                 </td>
                 <td admin-ng-editable
                     required-role="ROLE_UI_EVENTS_DETAILS_METADATA_EDIT"
-                    params="row" save="getSaveFunction(catalog.flavor)">
+                    params="row" save="getSaveFunction(catalog.flavor)"
+                    sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
             </table>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/group-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/group-modal.html
@@ -32,11 +32,17 @@
                    placeholder="{{ 'USERS.GROUPS.DETAILS.FORM.NAME' | translate }}..."
                    name="name"
                    ng-class="blurred.name == true && !groupForm.name.$valid ? 'error' : ''"
-                   ng-blur="blurred.name=true">
+                   ng-blur="blurred.name=true"
+                   sanitize-xml="group.name">
           </div>
           <div class="row">
             <label translate="USERS.GROUPS.DETAILS.FORM.DESCRIPTION"><!-- Description --></label>
-            <textarea ng-model="group.description" placeholder="Description..." rows="4" name="description"></textarea>
+            <textarea ng-model="group.description"
+                      placeholder="Description..."
+                      rows="4"
+                      name="description"
+                      sanitize-xml="group.description">
+            </textarea>
           </div>
         </div>
       </div>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
@@ -86,7 +86,8 @@
                 </td>
                 <td admin-ng-editable
                     required-role="ROLE_UI_SERIES_DETAILS_METADATA_EDIT"
-                    params="row" save="getSaveFunction(seriesCatalog.flavor)">
+                    params="row" save="getSaveFunction(seriesCatalog.flavor)"
+                    sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
             </table>
@@ -112,7 +113,8 @@
                 </td>
                 <td admin-ng-editable
                     required-role="ROLE_UI_SERIES_DETAILS_METADATA_EDIT"
-                    params="row" save="getSaveFunction(catalog.flavor)">
+                    params="row" save="getSaveFunction(catalog.flavor)"
+                    sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
             </table>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/user-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/user-modal.html
@@ -51,6 +51,7 @@
                    name="username"
                    required
                    placeholder="{{ 'USERS.USERS.DETAILS.FORM.USERNAME' | translate }}..."
+                   sanitize-xml="user.username"
                    ng-disabled="action == 'edit'"
                    ng-init="blurred.username = false"
                    ng-model="user.username"
@@ -64,6 +65,7 @@
                    name="name"
                    required
                    placeholder="{{ 'USERS.USERS.DETAILS.FORM.NAME' | translate }}..."
+                   sanitize-xml="user.name"
                    ng-disabled="!manageable"
                    ng-init="blurred.name = false"
                    ng-model="user.name"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
@@ -14,6 +14,7 @@
                       class="hidden-input"
                       tabindex="1"
                       focushere
+                      sanitize-xml="wizard.step.metadata.name"
                       ng-model="wizard.step.metadata.name"
                       placeholder="{{ 'USERS.ACLS.NEW.METADATA.NAME.PLACEHOLDER' | translate }}">
                   </td>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
@@ -16,7 +16,8 @@
                 <td admin-ng-editable
                     class="editable" name="row.id"
                                      target="dublincore/episode"
-                                     params="row" save="$parent.wizard.save">
+                                     params="row" save="$parent.wizard.save"
+                                     sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
             </table>
@@ -40,7 +41,8 @@
                 <td>{{ row.label | translate }} <i ng-show="row.required" class="required">*</i></td>
                 <td admin-ng-editable
                     class="editable" name="row.id" target="{{name}}"
-                                                   params="row" save="$parent.wizard.save">
+                                                   params="row" save="$parent.wizard.save"
+                                                   sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
             </table>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-group.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-group.html
@@ -5,14 +5,14 @@
       <div class="form-container">
         <div class="row">
           <label translate="USERS.GROUPS.DETAILS.FORM.NAME" class="required"><!-- Group Name --></label>
-          <input ng-init="blurred.name = false" ng-model="wizard.step.metadata.name" type="text" ng-required="true"
+          <input ng-init="blurred.name = false" ng-model="wizard.step.metadata.name" type="text" ng-required="true" sanitize-xml="wizard.step.metadata.name"
                                                                                                  placeholder="{{ 'USERS.GROUPS.DETAILS.FORM.NAME' | translate }}..." name="name"
                                                                                                                                                                      ng-class="blurred.name == true && !groupForm.name.$valid ? 'error' : ''" ng-blur="blurred.name=true"
                                                                                                                                                                                                                                               tabindex="1" focushere>
         </div>
         <div class="row">
           <label translate="USERS.GROUPS.DETAILS.FORM.DESCRIPTION"><!-- Group Description --></label>
-          <textarea ng-model="wizard.step.metadata.description"
+          <textarea ng-model="wizard.step.metadata.description" sanitize-xml="wizard.step.metadata.description"
                     placeholder="{{ 'USERS.GROUPS.DETAILS.FORM.DESCRIPTION' | translate }}..." rows="4"
                                                                                                name="description" tabindex="2"></textarea>
         </div>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
@@ -11,7 +11,8 @@
                 <td admin-ng-editable
                     class="editable"
                     name="row.id"
-                    params="row" save="$parent.wizard.save">
+                    params="row" save="$parent.wizard.save"
+                    sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
             </table>
@@ -36,7 +37,8 @@
                     class="editable"
                     name="row.id"
                     target="{{name}}"
-                    params="row" save="$parent.wizard.save">
+                    params="row" save="$parent.wizard.save"
+                    sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
             </table>

--- a/modules/admin-ui-frontend/app/scripts/shared/services/jsHelperService.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/jsHelperService.js
@@ -398,7 +398,8 @@ angular.module('adminNg.services')
             }
           });
         });
-      }
+      },
+
     };
   }
 ]);

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/metadataExtended.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/metadataExtended.js
@@ -21,123 +21,125 @@
 'use strict';
 
 angular.module('adminNg.services')
-.factory('NewSeriesMetadataExtended', ['NewSeriesMetadataResource', function (NewSeriesMetadataResource) {
-  var MetadataExtended = function () {
-    var me = this, i;
+.factory('NewSeriesMetadataExtended', ['NewSeriesMetadataResource',
+  function (NewSeriesMetadataResource) {
+    var MetadataExtended = function () {
+      var me = this, i;
 
-    this.updateRequiredMetadata = function(fieldId, value) {
-      if (angular.isDefined(value) && value.length > 0) {
-        me.requiredMetadata[fieldId] = true;
-      } else {
-        me.requiredMetadata[fieldId] = false;
-      }
-    };
-
-    // As soon as the required metadata fields arrive from the backend,
-    // we check which are mandatory.
-    // This information will be needed in order to tell if we can move
-    // on to the next page of the wizard.
-    this.postProcessMetadata = function (data) {
-      var fields = [], chunk;
-      for (chunk in data) {
-        if (Object.prototype.hasOwnProperty.call(data, chunk)) {
-          // extended metadata is every object in the returned data which
-          // does not start with a dollar sign and which isn't dublincore/episode
-          if (chunk !== 'dublincore/series' && chunk.charAt(0) !== '$') {
-            me.ud[chunk] = {fields: data[chunk].fields};
-            me.ud[chunk].flavor = data[chunk].flavor;
-            me.ud[chunk].title = data[chunk].title;
-            fields = fields.concat(data[chunk].fields);
-          }
+      this.updateRequiredMetadata = function(fieldId, value) {
+        if (angular.isDefined(value) && value.length > 0) {
+          me.requiredMetadata[fieldId] = true;
+        } else {
+          me.requiredMetadata[fieldId] = false;
         }
-      }
-      // we go for the extended metadata here
-      if (fields.length > 0) {
-        for (i = 0; i < fields.length; i++) {
-          // just hooking the tab index up here, as this is already running through all elements
-          fields[i].tabindex = i + 1;
-          if (fields[i].required) {
-            me.updateRequiredMetadata(fields[i].id, fields[i].value);
-            if (fields[i].type === 'boolean') {
-              // set all boolean fields to false by default
-              fields[i].value = false;
+      };
+
+      // As soon as the required metadata fields arrive from the backend,
+      // we check which are mandatory.
+      // This information will be needed in order to tell if we can move
+      // on to the next page of the wizard.
+      this.postProcessMetadata = function (data) {
+        var fields = [], chunk;
+        for (chunk in data) {
+          if (Object.prototype.hasOwnProperty.call(data, chunk)) {
+            // extended metadata is every object in the returned data which
+            // does not start with a dollar sign and which isn't dublincore/episode
+            if (chunk !== 'dublincore/series' && chunk.charAt(0) !== '$') {
+              me.ud[chunk] = {fields: data[chunk].fields};
+              me.ud[chunk].flavor = data[chunk].flavor;
+              me.ud[chunk].title = data[chunk].title;
+              fields = fields.concat(data[chunk].fields);
             }
           }
         }
-        me.visible = true;
-      }
-      else {
-        me.visible = false;
-      }
-    };
-
-    // Checks if the current state of this wizard is valid and we are
-    // ready to move on.
-    this.isValid = function () {
-      var result = true;
-      //FIXME: The angular validation should rather be used,
-      // unfortunately it didn't work in this context.
-      angular.forEach(me.requiredMetadata, function (item) {
-        if (item === false) {
-          result = false;
+        // we go for the extended metadata here
+        if (fields.length > 0) {
+          for (i = 0; i < fields.length; i++) {
+            // just hooking the tab index up here, as this is already running through all elements
+            fields[i].tabindex = i + 1;
+            if (fields[i].required) {
+              me.updateRequiredMetadata(fields[i].id, fields[i].value);
+              if (fields[i].type === 'boolean') {
+                // set all boolean fields to false by default
+                fields[i].value = false;
+              }
+            }
+          }
+          me.visible = true;
         }
-      });
-      return result;
-    };
+        else {
+          me.visible = false;
+        }
+      };
 
-    this.save = function (scope) {
-      //FIXME: This should be nicer, rather propagate the id and values instead of looking for them in the parent scope.
-      var field = scope.$parent.params,
-          target = scope.$parent.target;
+      // Checks if the current state of this wizard is valid and we are
+      // ready to move on.
+      this.isValid = function () {
+        var result = true;
+        //FIXME: The angular validation should rather be used,
+        // unfortunately it didn't work in this context.
+        angular.forEach(me.requiredMetadata, function (item) {
+          if (item === false) {
+            result = false;
+          }
+        });
+        return result;
+      };
 
-      if (field.collection) {
-        if (angular.isArray(field.value)) {
-          field.presentableValue = field.value;
+      this.save = function (scope) {
+        //FIXME: This should be nicer,
+        //rather propagate the id and values instead of looking for them in the parent scope.
+        var field = scope.$parent.params,
+            target = scope.$parent.target;
+
+        if (field.collection) {
+          if (angular.isArray(field.value)) {
+            field.presentableValue = field.value;
+          } else {
+            field.presentableValue = field.collection[field.value];
+          }
         } else {
-          field.presentableValue = field.collection[field.value];
+          field.presentableValue = field.value;
         }
-      } else {
-        field.presentableValue = field.value;
-      }
 
-      if (angular.isDefined(me.requiredMetadata[field.id])) {
-        me.updateRequiredMetadata(field.id, field.value);
-      }
+        if (angular.isDefined(me.requiredMetadata[field.id])) {
+          me.updateRequiredMetadata(field.id, field.value);
+        }
 
-      me.ud[target].fields[field.tabindex - 1] = field;
-    };
+        me.ud[target].fields[field.tabindex - 1] = field;
+      };
 
-    this.getFiledCatalogs = function () {
-      var catalogs = [];
+      this.getFiledCatalogs = function () {
+        var catalogs = [];
 
-      angular.forEach(me.ud, function(catalog) {
-        var empty = true;
-        angular.forEach(catalog.fields, function (field) {
-          if (angular.isDefined(field.presentableValue) && field.presentableValue !== '') {
-            empty = false;
+        angular.forEach(me.ud, function(catalog) {
+          var empty = true;
+          angular.forEach(catalog.fields, function (field) {
+            if (angular.isDefined(field.presentableValue) && field.presentableValue !== '') {
+              empty = false;
+            }
+          });
+
+          if (!empty) {
+            catalogs.push(catalog);
           }
         });
 
-        if (!empty) {
-          catalogs.push(catalog);
-        }
-      });
+        return catalogs;
+      };
 
-      return catalogs;
+      this.reset = function () {
+        me.ud = {};
+        me.requiredMetadata = {};
+        me.metadata = NewSeriesMetadataResource.get(me.postProcessMetadata);
+      };
+
+      this.getUserEntries = function () {
+        return me.ud;
+      };
+
+      this.reset();
     };
 
-    this.reset = function () {
-      me.ud = {};
-      me.requiredMetadata = {};
-      me.metadata = NewSeriesMetadataResource.get(me.postProcessMetadata);
-    };
-
-    this.getUserEntries = function () {
-      return me.ud;
-    };
-
-    this.reset();
-  };
-
-  return new MetadataExtended();
-}]);
+    return new MetadataExtended();
+  }]);


### PR DESCRIPTION
Attempts to resolve #2187 by introducing a sanitize function to the frontend and applying it everywhere that seemed relevant. Any feedback on the approach would be appreciated.
<del>
Still a draft because the UI does not give proper feedback on the removal of illegal characters. The illegal characters are only shown as removed during a subsequent edit view, or after an actual subsequent edit. Unsure on how to properly cause the UI to correctly rerender.
</del><del>
Also still a draft because this may sanitize characters we actually want to keep (like emojis!) and I am not sure where to find an up-to-date list of actually illegal XML characters.
</del>
Rewrote the approach into a directive. Illegal characters should now be removed as they are typed. Also updated the regex based on lkiesows feedback.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
