### PR TITLE
Exclude user provider configuration for contributors list provider

### DIFF
--- a/etc/org.opencastproject.index.service.resources.list.provider.ContributorsListProvider.cfg
+++ b/etc/org.opencastproject.index.service.resources.list.provider.ContributorsListProvider.cfg
@@ -1,0 +1,14 @@
+# A comma separated list of user provider names to exclude the users from the result set.
+# The available user provider names depends on your system configuration.
+# Common user providers are:
+#   - opencast: Opencast managed users
+#   - system: Opencast internal users e.g. digest user
+#   - matterhorn-reference: referenced users e.g. LTI user references
+#   - ldap: LDAP user directory
+#   - canvas: Canvas user provider
+#   - moodle: Moodle referenced users
+#   - sakai: Sakai referenced users
+# A special value to match all available providers is: `*`.
+# This can improve the performance quite a bit if you do not need the users.
+# Default value: <empty>
+# exclude.user.provider =

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
@@ -34,7 +34,6 @@ import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.util.data.Option;
 
 import org.apache.commons.lang3.StringUtils;
-import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,11 +66,12 @@ public class ContributorsListProvider implements ResourceListProvider {
 
   private static final Logger logger = LoggerFactory.getLogger(ContributorsListProvider.class);
 
-  private Set<String> excludeUserProvider = new HashSet<>();
+  private final Set<String> excludeUserProvider = new HashSet<>();
   private UserDirectoryService userDirectoryService;
   private AbstractSearchIndex searchIndex;
 
-  protected void activate(BundleContext bundleContext) {
+  protected void activate(Map<String, Object> properties) {
+    modified(properties);
     logger.info("Contributors list provider activated!");
   }
 
@@ -85,6 +85,7 @@ public class ContributorsListProvider implements ResourceListProvider {
         }
       }
     }
+    logger.debug("Excluded user providers: {}", excludeUserProvider);
   }
 
   /** OSGi callback for users services. */

--- a/modules/index-service/src/main/resources/OSGI-INF/list-providers/contributors.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/list-providers/contributors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
                name="org.opencastproject.index.service.resources.list.provider.ContributorsListProvider"
-               immediate="true" activate="activate">
+               immediate="true" activate="activate" modified="modified">
   <implementation class="org.opencastproject.index.service.resources.list.provider.ContributorsListProvider"/>
   <property name="service.description" value="Contributors list provider"/>
   <property name="opencast.service.type"

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProviderTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProviderTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -152,6 +153,28 @@ public class ContributorsListProviderTest {
   }
 
   @Test
+  public void testUsernamesListWithExcludeUserProvider() {
+    Map<String, Object> configuration = new HashMap<>();
+    configuration.put("exclude.user.provider", "provider1");
+    contributorsListProvider.modified(configuration);
+
+    Map<String, String> list = contributorsListProvider.getList(ContributorsListProvider.NAMES_TO_USERNAMES, null);
+
+    Assert.assertFalse(list.containsKey(user1.getUsername()));
+    Assert.assertFalse(list.containsKey(user2.getUsername()));
+    Assert.assertFalse(list.containsKey(user3.getUsername()));
+
+    Assert.assertTrue(list.containsValue(user1.getName()));
+    Assert.assertFalse(list.containsValue(user2.getName()));
+    Assert.assertFalse(list.containsValue(user3.getUsername()));
+
+    Assert.assertTrue(list.containsKey("User 5"));
+    Assert.assertTrue(list.containsValue("User 5"));
+
+    Assert.assertEquals(2, list.size());
+  }
+
+  @Test
   public void testListSimple() throws ListProviderException {
     Map<String, String> list = contributorsListProvider.getList(ContributorsListProvider.DEFAULT, null);
 
@@ -165,6 +188,25 @@ public class ContributorsListProviderTest {
     Assert.assertTrue(list.containsValue("User 5"));
 
     Assert.assertEquals(3, list.size());
+  }
+
+  @Test
+  public void testListSimpleWithExcludeUserProvider() {
+    Map<String, Object> configuration = new HashMap<>();
+    configuration.put("exclude.user.provider", "provider1");
+    contributorsListProvider.modified(configuration);
+
+    Map<String, String> list = contributorsListProvider.getList(ContributorsListProvider.DEFAULT, null);
+
+    Assert.assertTrue(list.containsKey(user1.getName()));
+    Assert.assertTrue(list.containsValue("User 1"));
+    Assert.assertFalse(list.containsKey(user2.getName()));
+    Assert.assertFalse(list.containsKey(user3.getName()));
+
+    Assert.assertTrue(list.containsKey("User 5"));
+    Assert.assertTrue(list.containsValue("User 5"));
+
+    Assert.assertEquals(2, list.size());
   }
 
   @Test


### PR DESCRIPTION
On Opencast systems with enabled LTI reference users, the performance of filters.json and metadata.json admin UI request is drastically decreased. Per default the result contains all known users names as option for contributors and presenters metadata fields. With this patch you have an option to deactivate user listings from some or all user providers.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
