### PR TITLE
Remove unused `org.opencastproject.export.distribution.ExportUi.cfg`

### DIFF
--- a/etc/org.opencastproject.export.distribution.ExportUi.cfg
+++ b/etc/org.opencastproject.export.distribution.ExportUi.cfg
@@ -1,4 +1,0 @@
-This file controls the export UI servlet
-
-#The URL, relative to org.opencastproject.server.url, to serve from.  Defaults to ${org.opencastproject.server.url}/export
-alias=/export


### PR DESCRIPTION
`org.opencastproject.export.distribution.ExportUi.cfg` does not seem to
be used anymore and can therefore be removed.