### PR TITLE
Default Visibility in Admin Interface

### DIFF
--- a/docs/guides/admin/docs/releasenotes/changed-behavior/default-event-visibility-in-admin-interface.txt
+++ b/docs/guides/admin/docs/releasenotes/changed-behavior/default-event-visibility-in-admin-interface.txt
@@ -1,0 +1,3 @@
+- The default visibility of events and series in the admin interface has changed so that users will not only see
+  entities they have write access to. This obviously has no effect on admin users since they have write access to
+  everything anyway.

--- a/etc/org.opencastproject.adminui.endpoint.OsgiEventEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.OsgiEventEndpoint.cfg
@@ -25,10 +25,10 @@ preview.subtype=preview
 
 # If this property is true, we only see the series to which we have write access
 # within the new event wizard or event details.
-# Default: false
-# eventModal.onlySeriesWithWriteAccess=false
+# Default: true
+#eventModal.onlySeriesWithWriteAccess=true
 
 # If this property is true, we only see the events to which we have write access
 # to in the events tab.
-# Default: false
-# eventsTab.onlyEventsWithWriteAccess=false
+# Default: true
+#eventsTab.onlyEventsWithWriteAccess=true

--- a/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.SeriesEndpoint.cfg
@@ -3,14 +3,14 @@
 # Note: Have a look at org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
 #       property.series.required=false if you want to configure if a event has to have a series
 # Default: true
-# series.hasEvents.delete.allow=true
+#series.hasEvents.delete.allow=true
 
 # If this property is true, we only see the series to which we have write access
 # to in the series tab.
-# Default: false
-# seriesTab.onlySeriesWithWriteAccess=false
+# Default: true
+#seriesTab.onlySeriesWithWriteAccess=true
 
 # If this property is true, we only see the series to which we have write access
 # to in the events filter.
-# Default: false
-# eventsFilter.onlySeriesWithWriteAccess=false
+# Default: true
+#eventsFilter.onlySeriesWithWriteAccess=true

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -40,6 +40,7 @@ import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
 
 import java.util.Dictionary;
+import java.util.Objects;
 
 import javax.ws.rs.Path;
 
@@ -211,14 +212,10 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
             this.getClass().getSimpleName());
 
     Object dictionaryValue = properties.get(EVENTMODAL_ONLYSERIESWITHWRITEACCESS_KEY);
-    if (dictionaryValue != null) {
-      onlySeriesWithWriteAccessEventModal = BooleanUtils.toBoolean(dictionaryValue.toString());
-    }
+    onlySeriesWithWriteAccessEventModal = BooleanUtils.toBoolean(Objects.toString(dictionaryValue, "true"));
 
     dictionaryValue = properties.get(EVENTSTAB_ONLYEVENTSWITHWRITEACCESS_KEY);
-    if (dictionaryValue != null) {
-      onlyEventsWithWriteAccessEventsTab = BooleanUtils.toBoolean(dictionaryValue.toString());
-    }
+    onlyEventsWithWriteAccessEventsTab = BooleanUtils.toBoolean(Objects.toString(dictionaryValue, "true"));
   }
 
   @Override

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -124,6 +124,7 @@ import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
@@ -231,14 +232,10 @@ public class SeriesEndpoint implements ManagedService {
     }
 
     dictionaryValue = properties.get(SERIESTAB_ONLYSERIESWITHWRITEACCESS_KEY);
-    if (dictionaryValue != null) {
-      onlySeriesWithWriteAccessSeriesTab = BooleanUtils.toBoolean(dictionaryValue.toString());
-    }
+    onlySeriesWithWriteAccessSeriesTab = BooleanUtils.toBoolean(Objects.toString(dictionaryValue, "true"));
 
     dictionaryValue = properties.get(EVENTSFILTER_ONLYSERIESWITHWRITEACCESS_KEY);
-    if (dictionaryValue != null) {
-      onlySeriesWithWriteAccessEventsFilter = BooleanUtils.toBoolean(dictionaryValue.toString());
-    }
+    onlySeriesWithWriteAccessEventsFilter = BooleanUtils.toBoolean(Objects.toString(dictionaryValue, "true"));
   }
 
   @GET


### PR DESCRIPTION
This patch updates the default visibility in the admin interface so
users will only see events and series they have write access to. This
prevents them trying to modify events they cannot, resulting in errors
for those users.

While I was originally against this, the recent development of having
end users on the interface has shown that this is something everyone
configures anyway and which prevents lots of user errors. Hence, it
probably makes sense to set this as default after all.

This obviously has no effect on admin users since they have write access
to everything anyway.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
