### PR TITLE
Add organization ID to the S3 distribution object path

### DIFF
--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -720,7 +720,8 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
           String fileName) throws DistributionException {
     String objectName = null;
     if (StringUtils.isNotBlank(fileName)) {
-      objectName = buildObjectName(channelId, mediaPackage.getIdentifier().toString(), elementId, fileName);
+      final String orgId = securityService.getOrganization().getId();
+      objectName = buildObjectName(orgId, channelId, mediaPackage.getIdentifier().toString(), elementId, fileName);
     } else {
       objectName = buildObjectName(channelId, mediaPackage.getIdentifier().toString(),
               mediaPackage.getElementById(elementId));
@@ -771,23 +772,25 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
    * @return
    */
   protected String buildObjectName(String channelId, String mpId, MediaPackageElement element) {
-    // Something like CHANNEL_ID/MP_ID/ELEMENT_ID/FILE_NAME.EXTENSION
+    // Something like ORG_ID/CHANNEL_ID/MP_ID/ELEMENT_ID/FILE_NAME.EXTENSION
+    final String orgId = securityService.getOrganization().getId();
     String uriString = element.getURI().toString();
     String fileName = FilenameUtils.getName(uriString);
-    return buildObjectName(channelId, mpId, element.getIdentifier(), fileName);
+    return buildObjectName(orgId, channelId, mpId, element.getIdentifier(), fileName);
   }
 
   /**
    * Builds the aws s3 object name using the raw elementID and filename
    *
+   * @param orgId
    * @param channelId
    * @param mpId
    * @param elementId
    * @param fileName
    * @return
    */
-  protected String buildObjectName(String channelId, String mpId, String elementId, String fileName) {
-    return StringUtils.join(new String[] { channelId, mpId, elementId, fileName }, "/");
+  protected String buildObjectName(String orgId, String channelId, String mpId, String elementId, String fileName) {
+    return StringUtils.join(new String[] { orgId, channelId, mpId, elementId, fileName }, "/");
   }
 
   /**
@@ -798,7 +801,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
    *           if the concrete implementation tries to create a malformed uri
    */
   protected URI getDistributionUri(String objectName) throws URISyntaxException {
-    // Something like https://OPENCAST_DOWNLOAD_URL/CHANNEL_ID/MP_ID/ELEMENT_ID/FILE_NAME.EXTENSION
+    // Something like https://OPENCAST_DOWNLOAD_URL/ORG_ID/CHANNEL_ID/MP_ID/ELEMENT_ID/FILE_NAME.EXTENSION
     return new URI(opencastDistributionUrl + objectName);
   }
 
@@ -808,7 +811,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
    * @return The distributed object name
    */
   protected String getDistributedObjectName(MediaPackageElement element) {
-    // Something like https://OPENCAST_DOWNLOAD_URL/CHANNEL_ID/MP_ID/ORIGINAL_ELEMENT_ID/FILE_NAME.EXTENSION
+    // Something like https://OPENCAST_DOWNLOAD_URL/ORG_ID/CHANNEL_ID/MP_ID/ORIGINAL_ELEMENT_ID/FILE_NAME.EXTENSION
     String uriString = element.getURI().toString();
 
     // String directoryName = distributionDirectory.getAbsolutePath();
@@ -818,7 +821,7 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
       // Cannot retract
       logger.warn(
           "Cannot retract {}. Uri must be in the format "
-              + "https://host/bucketName/channelId/mpId/originalElementId/fileName.extension",
+              + "https://host/bucketName/orgId/channelId/mpId/originalElementId/fileName.extension",
           uriString);
       return null;
     }

--- a/modules/distribution-service-aws-s3/src/test/resources/distributed_hls_mediapackage.xml
+++ b/modules/distribution-service-aws-s3/src/test/resources/distributed_hls_mediapackage.xml
@@ -11,7 +11,7 @@
 	<media>
 		<track type="presenter/delivery" id="presenter-mp4">
 			<mimetype>video/mp4</mimetype>
-			<url>http://XYZ.cloudfront.net/channelId/efd6e4df-63b6-49af-be5f-15f598778877/presenter-mp4/video-presenter-delivery.mp4</url>
+			<url>http://XYZ.cloudfront.net/mh_default_org/channelId/efd6e4df-63b6-49af-be5f-15f598778877/presenter-mp4/video-presenter-delivery.mp4</url>
 			<duration>14226</duration>
 			<audio id="audio-1">
 				<device />
@@ -31,7 +31,7 @@
 		</track>
 		<track type="presenter/delivery" id="presenter-m3u8">
 			<mimetype>application/x-mpegURL</mimetype>
-			<url>http://XYZ.cloudfront.net/channelId/efd6e4df-63b6-49af-be5f-15f598778877/presenter-m3u8/video-presenter-delivery.m3u8</url>
+			<url>http://XYZ.cloudfront.net/mh_default_org/channelId/efd6e4df-63b6-49af-be5f-15f598778877/presenter-m3u8/video-presenter-delivery.m3u8</url>
 			<duration>14226</duration>
 			<audio id="audio-1">
 				<device />
@@ -53,11 +53,11 @@
 	<metadata>
 		<catalog type="dublincore/episode" id="episode-dc-distributed">
 			<mimetype>text/xml</mimetype>
-			<url>http://XYZ.cloudfront.net/channelId/efd6e4df-63b6-49af-be5f-15f598778877/episode-dce/episode-dublincore.xml</url>
+			<url>http://XYZ.cloudfront.net/mh_default_org/channelId/efd6e4df-63b6-49af-be5f-15f598778877/episode-dce/episode-dublincore.xml</url>
 		</catalog>
 		<catalog type="dublincore/series" id="series-dc-distributed">
 			<mimetype>text/xml</mimetype>
-			<url>http://XYZ.cloudfront.net/channelId/efd6e4df-63b6-49af-be5f-15f598778877/series-dc/series-dublincore.xml</url>
+			<url>http://XYZ.cloudfront.net/mh_default_org/channelId/efd6e4df-63b6-49af-be5f-15f598778877/series-dc/series-dublincore.xml</url>
 		</catalog>
 	</metadata>
 	<attachments />

--- a/modules/distribution-service-aws-s3/src/test/resources/mediapackage_distributed.xml
+++ b/modules/distribution-service-aws-s3/src/test/resources/mediapackage_distributed.xml
@@ -11,7 +11,7 @@
 	<media>
 		<track type="presenter/delivery" id="presenter-delivery-distributed">
 			<mimetype>video/mp4</mimetype>
-			<url>http://XYZ.cloudfront.net/channelId/efd6e4df-63b6-49af-be5f-15f598778877/presenter-delivery/video-presenter-delivery.mp4</url>
+			<url>http://XYZ.cloudfront.net/mh_default_org/channelId/efd6e4df-63b6-49af-be5f-15f598778877/presenter-delivery/video-presenter-delivery.mp4</url>
 			<duration>14226</duration>
 			<audio id="audio-1">
 				<device />
@@ -33,11 +33,11 @@
 	<metadata>
 		<catalog type="dublincore/episode" id="episode-dc-distributed">
 			<mimetype>text/xml</mimetype>
-			<url>http://XYZ.cloudfront.net/channelId/efd6e4df-63b6-49af-be5f-15f598778877/episode-dce/episode-dublincore.xml</url>
+			<url>http://XYZ.cloudfront.net/mh_default_org/channelId/efd6e4df-63b6-49af-be5f-15f598778877/episode-dce/episode-dublincore.xml</url>
 		</catalog>
 		<catalog type="dublincore/series" id="series-dc-distributed">
 			<mimetype>text/xml</mimetype>
-			<url>http://XYZ.cloudfront.net/channelId/efd6e4df-63b6-49af-be5f-15f598778877/series-dc/series-dublincore.xml</url>
+			<url>http://XYZ.cloudfront.net/mh_default_org/channelId/efd6e4df-63b6-49af-be5f-15f598778877/series-dc/series-dublincore.xml</url>
 		</catalog>
 	</metadata>
 	<attachments />


### PR DESCRIPTION
When distributing files with S3 the organization ID is curretly not part
of the S3 object path. Adding it brings it on par with the download
distribution.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
