### PR TITLE
Allow proper mapping of tenant hostnames to URLs

### DIFF
--- a/docs/guides/admin/docs/configuration/multi.tenancy.md
+++ b/docs/guides/admin/docs/configuration/multi.tenancy.md
@@ -30,7 +30,7 @@ installation that cannot be mapped to any organization.
 ### Limitations
 
 Multi tenancy in Opencast is working, however it is not fully finished. Certain objects are still shared amongst
-organizations, most notably workflow definitions, RSS/Atom feeds and encoding profiles.
+organizations, most notably RSS/Atom feeds and encoding profiles.
 
 
 Adding A Tenant
@@ -48,11 +48,13 @@ installation, on each of the nodes.  As an example, this is what the admin node 
 
     id=tenant1
     name=Tenant 1
-    port=8080
-    prop.org.opencastproject.host.admin.example.org=tenant1-admin.example.org
-    prop.org.opencastproject.host.presentation.example.org=tenant1-presentation.example.org
     admin_role=ROLE_ADMIN
     anonymous_role=ROLE_ANONYMOUS
+
+    # Hostname URL mapping
+    prop.org.opencastproject.host.admin.example.org=https://tenant1-admin.example.org
+    prop.org.opencastproject.host.presentation.example.org=https://tenant1-presentation.example.org
+    prop.org.opencastproject.host.worker.example.org=https://tenant1-worker.example.org:8443
 
     # Admin and Presentation Server Urls
     prop.org.opencastproject.admin.ui.url=https://tenant1-admin.example.org
@@ -68,15 +70,16 @@ copy of the already existing `org.opencastproject.organization-mh_default_org.cf
 Note, the default organization file `org.opencastproject.organization-mh_default_org.org` *must* refer to the actual
 server names:
 
-    prop.org.opencastproject.host.admin.example.org=admin.example.org
-    prop.org.opencastproject.host.presentation.example.org=presentation.example.org
+    prop.org.opencastproject.host.admin.example.org=https://admin.example.org
+    prop.org.opencastproject.host.presentation.example.org=https://presentation.example.org
+    prop.org.opencastproject.host.worker.example.org=https://worker.example.org:8443
 
 This file sets the default organization that is selected.  This is currently required because some Opencast components
 do not support multitenancy.
 
-Note that if you are running Apache httpd with mod\_proxy in front of the Opencast installation, the port number will be
--1 in both files.
-
+Hosts can have different schemas (http / https) and port numbers, e.g. when you run behind proxy server. Note, however,
+that hostnames are uniquely mapped to an organization. You cannot use the same hostname but different port numbers for
+two different organizations.
 ### Step 2: Security Configuration
 
 Create a file called tenant1.xml in /etc/security. This file specifies access rules for individual URLs that specify

--- a/docs/guides/admin/docs/configuration/multi.tenancy.md
+++ b/docs/guides/admin/docs/configuration/multi.tenancy.md
@@ -77,9 +77,9 @@ server names:
 This file sets the default organization that is selected.  This is currently required because some Opencast components
 do not support multitenancy.
 
-Hosts can have different schemas (http / https) and port numbers, e.g. when you run behind proxy server. Note, however,
-that hostnames are uniquely mapped to an organization. You cannot use the same hostname but different port numbers for
-two different organizations.
+Hosts can have different schemas (http / https) and port numbers, e.g. when you run behind proxy server. Note, that
+the combination of hostname and port number is uniquely mapped to an organization.
+
 ### Step 2: Security Configuration
 
 Create a file called tenant1.xml in /etc/security. This file specifies access rules for individual URLs that specify

--- a/docs/guides/admin/docs/releasenotes/propper-tenant-url-mapping.txt
+++ b/docs/guides/admin/docs/releasenotes/propper-tenant-url-mapping.txt
@@ -1,0 +1,18 @@
+Opencast 11 changes how hosts are mapped to tenants. If you use a multi-tenant system you therefore need to update your
+`org.opencastproject.organization-*.cfg` configuration files:
+
+Before Opencast 11 the domain names were mapped to tenants and a common port number was assumed for all domains. Now you
+need to configure a URL per instance you want to map to a tenant.
+
+Before:
+```
+port=8080
+prop.org.opencastproject.host.admin.example.org=tenant1-admin.example.org
+prop.org.opencastproject.host.presentation.example.org=tenant1-presentation.example.org
+```
+
+Now:
+```
+prop.org.opencastproject.host.admin.example.org=https://tenant1-admin.example.org
+prop.org.opencastproject.host.presentation.example.org=https://tenant1-presentation.example.org:8443
+```

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -52,26 +52,17 @@ name=Opencast Project
 #
 # Example Configuration:
 #
-# prop.org.opencastproject.host.admin-presentation.opencast.com=tenant1.admin-presentation.opencast.com
-# prop.org.opencastproject.host.ingest.opencast.com=tenant1.ingest.opencast.com
-# prop.org.opencastproject.host.worker.opencast.com=tenant1.worker.opencast.com
+# prop.org.opencastproject.host.admin-presentation.opencast.com=http://tenant1.admin-presentation.opencast.com
+# prop.org.opencastproject.host.ingest.opencast.com=https://tenant1.ingest.opencast.com
+# prop.org.opencastproject.host.worker.opencast.com=https://tenant1.worker.opencast.com:8433
 #
 # Important notices:
 #  - Values read from here are stored in the database (table oc_organization_node) and will not be removed if a node is
 #    removed from this list.
 #  - Do not include schema or port in the URLs.
 #
-# Default: localhost
-# prop.org.opencastproject.host.localhost = localhost
-
-# Port for this tenant.
-#
-# When run behind a proxy server, set this to -1 since most proxies won't forward the
-# original port and set the corresponding field in the request to this value.
-#
-# Value: <integer port number>
-#
-port=8080
+# Default: http://localhost:8080
+# prop.org.opencastproject.host.localhost = http://localhost:8080
 
 # Identifier of the Administrative role.
 #

--- a/modules/common/src/main/java/org/opencastproject/security/util/SecurityUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/security/util/SecurityUtil.java
@@ -164,7 +164,11 @@ public final class SecurityUtil {
 
   /** Extract hostname and port number from a URL. */
   public static Tuple<String, Integer> hostAndPort(URL url) {
-    return tuple(StringUtils.strip(url.getHost(), "/"), url.getPort());
+    int port = url.getPort();
+    if (port < 0) {
+      port = url.getDefaultPort();
+    }
+    return tuple(StringUtils.strip(url.getHost(), "/"), port);
   }
 
   /**

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceImpl.java
@@ -44,6 +44,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Dictionary;
@@ -86,11 +87,11 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
   /** The managed property that specifies the organization server name */
   public static final String ORG_SERVER_PREFIX = "prop.org.opencastproject.host.";
 
-  /** The default in case no server is configured */
-  public static final String DEFAULT_SERVER = "localhost";
+  /** The default host in case no server is configured */
+  public static final String DEFAULT_SERVER_HOST = "localhost";
 
-  /** The managed property that specifies the server port */
-  public static final String ORG_PORT_KEY = "port";
+  /** The default port in case no server is configured */
+  public static final int DEFAULT_SERVER_PORT = 8080;
 
   /** The managed property that specifies the organization administrative role */
   public static final String ORG_ADMIN_ROLE_KEY = "admin_role";
@@ -183,14 +184,12 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
     if (StringUtils.isBlank(id))
       throw new ConfigurationException(ORG_ID_KEY, ORG_ID_KEY + " must be set");
 
-    final String portAsString = StringUtils.trimToNull((String) properties.get(ORG_PORT_KEY));
-    final int port = portAsString != null ? Integer.parseInt(portAsString) : 80;
     final String adminRole = (String) properties.get(ORG_ADMIN_ROLE_KEY);
     final String anonRole = (String) properties.get(ORG_ANONYMOUS_ROLE_KEY);
 
     // Build the properties map
     final Map<String, String> orgProperties = new HashMap<String, String>();
-    ArrayList<String> serverUrls = new ArrayList();
+    HashMap<String, Integer> servers = new HashMap<>();
 
     for (Enumeration<?> e = properties.keys(); e.hasMoreElements();) {
       final String key = (String) e.nextElement();
@@ -201,15 +200,22 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
 
       if (key.startsWith(ORG_SERVER_PREFIX)) {
         String tenantSpecificHost = StringUtils.trimToNull((String) properties.get(key));
-        serverUrls.add(tenantSpecificHost);
+        if (tenantSpecificHost != null) {
+          try {
+            Tuple<String, Integer> hostPort = hostAndPort(new URL(tenantSpecificHost));
+            servers.put(hostPort.getA(), hostPort.getB());
+          } catch (MalformedURLException malformedURLException) {
+            logger.error("{} is not a URL", tenantSpecificHost);
+          }
+        }
       }
 
       orgProperties.put(key.substring(ORG_PROPERTY_PREFIX.length()), (String) properties.get(key));
     }
 
-    if (serverUrls.isEmpty()) {
-      logger.debug("No server URL configured for organization " + name + ", setting default localhost");
-      serverUrls.add(DEFAULT_SERVER);
+    if (servers.isEmpty()) {
+      logger.debug("No server URL configured for organization {}, setting default {}:{}", name, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT);
+      servers.put(DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT);
     }
 
     // Load the existing organization or create a new one
@@ -218,10 +224,9 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
       try {
         org = (JpaOrganization) persistence.getOrganization(id);
         org.setName(name);
-        for (String serverUrl : serverUrls) {
-          if (StringUtils.isNotBlank(serverUrl)) {
-            org.addServer(serverUrl, port);
-          }
+        // TODO: should this really be append only?
+        for (Map.Entry<String, Integer> server : servers.entrySet()) {
+          org.addServer(server.getKey(), server.getValue());
         }
         org.setAdminRole(adminRole);
         org.setAnonymousRole(anonRole);
@@ -230,12 +235,6 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
         persistence.storeOrganization(org);
         fireOrganizationUpdated(org);
       } catch (NotFoundException e) {
-        HashMap<String, Integer> servers = new HashMap<String, Integer>();
-        for (String serverUrl : serverUrls) {
-          if (StringUtils.isNotBlank(serverUrl)) {
-            servers.put(serverUrl, port);
-          }
-        }
         org = new JpaOrganization(id, name, servers, adminRole, anonRole, orgProperties);
         logger.info("Creating organization '{}'", id);
         persistence.storeOrganization(org);

--- a/modules/kernel/src/test/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceTest.java
+++ b/modules/kernel/src/test/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceTest.java
@@ -65,7 +65,7 @@ public class OrganizationDirectoryServiceTest {
           Map<String, Integer> servers = organization.getServers();
           assertEquals(1, servers.size());
           assertTrue(servers.containsKey("localhost"));
-          assertTrue(servers.containsValue(8080));
+          assertEquals(443, servers.get("localhost").intValue());
           assertEquals("true", organization.getProperties().get("org.test"));
         } else if (i == 1) {
           assertNotNull(organization);
@@ -76,10 +76,11 @@ public class OrganizationDirectoryServiceTest {
           Map<String, Integer> servers = organization.getServers();
           assertEquals(3, servers.size());
           assertTrue(servers.containsKey("localhost"));
-          assertTrue(servers.containsValue(8080));
+          assertEquals(443, servers.get("localhost").intValue());
           assertTrue(servers.containsKey("localhost2"));
-          assertTrue(servers.containsValue(8081));
+          assertEquals(80, servers.get("localhost2").intValue());
           assertTrue(servers.containsKey("another"));
+          assertEquals(8888, servers.get("another").intValue());
           assertEquals("false", organization.getProperties().get("org.test"));
         } else {
           fail("Too many storeOrganization calls: " + i);
@@ -140,8 +141,7 @@ public class OrganizationDirectoryServiceTest {
     // Add properties
     properties.put(OrganizationDirectoryServiceImpl.ORG_ID_KEY, "mh_default");
     properties.put(OrganizationDirectoryServiceImpl.ORG_NAME_KEY, "Opencast Test");
-    properties.put(OrganizationDirectoryServiceImpl.ORG_SERVER_PREFIX + "localhost", "localhost");
-    properties.put(OrganizationDirectoryServiceImpl.ORG_PORT_KEY, "8080");
+    properties.put(OrganizationDirectoryServiceImpl.ORG_SERVER_PREFIX + "localhost", "https://localhost");
     properties.put(OrganizationDirectoryServiceImpl.ORG_ADMIN_ROLE_KEY, "ROLE_TEST_ADMIN");
     properties.put(OrganizationDirectoryServiceImpl.ORG_ANONYMOUS_ROLE_KEY, "ROLE_TEST_ANONYMOUS");
     properties.put("prop.org.test", "true");
@@ -156,9 +156,8 @@ public class OrganizationDirectoryServiceTest {
     properties = new Hashtable<String, String>();
     properties.put(OrganizationDirectoryServiceImpl.ORG_ID_KEY, "mh_default");
     properties.put(OrganizationDirectoryServiceImpl.ORG_NAME_KEY, "Opencast Test 2");
-    properties.put(OrganizationDirectoryServiceImpl.ORG_SERVER_PREFIX + "localhost2", "localhost2");
-    properties.put(OrganizationDirectoryServiceImpl.ORG_SERVER_PREFIX + "another", "another");
-    properties.put(OrganizationDirectoryServiceImpl.ORG_PORT_KEY, "8081");
+    properties.put(OrganizationDirectoryServiceImpl.ORG_SERVER_PREFIX + "localhost2", "http://localhost2");
+    properties.put(OrganizationDirectoryServiceImpl.ORG_SERVER_PREFIX + "another", "http://another:8888");
     properties.put(OrganizationDirectoryServiceImpl.ORG_ADMIN_ROLE_KEY, "ROLE_TEST2_ADMIN");
     properties.put(OrganizationDirectoryServiceImpl.ORG_ANONYMOUS_ROLE_KEY, "ROLE_TEST2_ANONYMOUS");
     properties.put("prop.org.test", "false");


### PR DESCRIPTION
Opencast has some assumptions about how hosts are accessed in different
organizations. Especially the schema and port number are assumed to be
equal or in certain cases just the default protocol port number.

This changes the host mapping configuration to explicitly specify a URL.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
