### PR TITLE
Organization Fallback for UI Configuration

### DIFF
--- a/etc/ui-config/readme.md
+++ b/etc/ui-config/readme.md
@@ -2,8 +2,10 @@ User Interface Configuration
 ============================
 
 This folder can contain user interface configuration and customization files which are served by Opencast's web server
-and can easily be used for frontend configuration. Please expect all these configurations to be public and unprotected.
-Therefore, so not use them for any kind of secrets (passwords, …).
+and can easily be used for frontend configuration.
 
-Note that the configuration is organization aware. That means that if you use the service, the HTTP path
+All configuration files are public.  Do not use them for any kind of secrets (passwords, …).
+
+The configuration is organization aware. That means that if you use the service, the HTTP path
 `/ui/config/<component>/<filename>` will map to the local file `<organization-id>/<component>/<filename>`.
+A fallback to the default organization (`mh_default_org`) exists.


### PR DESCRIPTION
The user interface configuration is often identical between several
tenants, but right now, each tenant requires its own configuration. That
patch allows configuration to fall back to the default organization,
allowing for a far simpler configuration in many cases.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
