### PR TITLE
Add support for basic authentication with Elasticsearch

### DIFF
--- a/docs/guides/admin/docs/configuration/elasticsearch.md
+++ b/docs/guides/admin/docs/configuration/elasticsearch.md
@@ -16,7 +16,12 @@ Relevant configuration keys are:
 * `org.opencastproject.elasticsearch.username`
 * `org.opencastproject.elasticsearch.password`
 
-Threfore only `admin`, `adminpresentation`, and `allinone` need to connect to Elasticsearch.
+Therefore only `admin`, `adminpresentation`, and `allinone` need to connect to Elasticsearch.
+
+`username` and `password` are optional. If configured, requests to Elasticsearch are secured by
+HTTP basic authentication (which is unsecure without TLS encryption). Refer to [the Elasticsearch
+documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-stack-security.html)
+to properly secure Elasticsearch.
 
 Version
 -------

--- a/docs/guides/admin/docs/configuration/elasticsearch.md
+++ b/docs/guides/admin/docs/configuration/elasticsearch.md
@@ -13,6 +13,8 @@ Relevant configuration keys are:
 * `org.opencastproject.elasticsearch.server.hostname`
 * `org.opencastproject.elasticsearch.server.scheme`
 * `org.opencastproject.elasticsearch.server.port`
+* `org.opencastproject.elasticsearch.username`
+* `org.opencastproject.elasticsearch.password`
 
 Threfore only `admin`, `adminpresentation`, and `allinone` need to connect to Elasticsearch.
 

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -169,6 +169,13 @@ org.opencastproject.workspace.cleanup.max.age=2592000
 # Default: 9200
 #org.opencastproject.elasticsearch.server.port=9200
 
+# The username of Elasticsearch for Opencast to use.
+# Default: None
+#org.opencastproject.elasticsearch.username=
+
+# The password of Elasticsearch for Opencast to use.
+# Default: None
+#org.opencastproject.elasticsearch.password=
 
 ######### SOLR #########
 

--- a/modules/search/pom.xml
+++ b/modules/search/pom.xml
@@ -88,6 +88,15 @@
       <artifactId>httpcore-osgi</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpcomponents-httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
       <version>${lucene.version}</version>
@@ -160,6 +169,8 @@
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpcore</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpcore-osgi</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpclient</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpclient-osgi</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/search/pom.xml
+++ b/modules/search/pom.xml
@@ -89,11 +89,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>${httpcomponents-httpclient.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
     </dependency>
     <dependency>
@@ -169,9 +164,11 @@
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpcore</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpcore-osgi</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpclient</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpclient-osgi</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+          <ignoredUsedUndeclaredDependencies>
+            <ignoredUsedUndeclaredDependency>org.apache.httpcomponents:httpclient</ignoredUsedUndeclaredDependency>
+          </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Elasticsearch allows for basic authentication. This adds two optional
settings for specifying a username and password. By default these are
null which will deactivate the use of basic authentication (as is the
current behavior).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
