### PR TITLE
Temporarily Ignore Failing Test

### DIFF
--- a/modules/termination-state-aws/src/test/java/org/opencastproject/terminationstate/aws/AutoScalingTerminationStateServiceTest.java
+++ b/modules/termination-state-aws/src/test/java/org/opencastproject/terminationstate/aws/AutoScalingTerminationStateServiceTest.java
@@ -38,6 +38,7 @@ import org.easymock.IAnswer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
@@ -128,6 +129,7 @@ public class AutoScalingTerminationStateServiceTest {
   }
 
   @Test
+  @Ignore // regularly fails. See https://github.com/opencast/opencast/issues/1111
   public void testLifeCyclePolling() throws Exception {
     service.startPollingLifeCycleHook();
     String[] trigger = scheduler.getTriggerNames(AutoScalingTerminationStateService.SCHEDULE_GROUP);


### PR DESCRIPTION
This patch is a temporary fix for #1111, preventing CI failures.
This is identical to #1206 since the issue still shows and was not fixed
by:

  d5f3e19a38 fix #1111, explicitly call scheduled job instead of waiting for scheduler to trigger it. Avoids possible race conditions
  a448b634f9 fix #1111, increase polling in test

This regularly breaks builds and confuses pull request authors.
Let's deactivate this until this gets properly fixed.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
