### PR TITLE
Fixed display error for the start date filter in the Admin UI

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/directives/tableFilterDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/tableFilterDirective.js
@@ -156,9 +156,10 @@ angular.module('adminNg.directives')
             // "filter.period.to" and "filter.period.from" are local Date formated into string "YY-MM-DD"
             // Parse back into local Date obj by adding timezone offset
             // -- Get the current local timezone offset in MS --
-            var localTimeZoneOffSetInMs = new Date().getTimezoneOffset() * 60 * 1000;
-            var localOffsetFrom = new Date(Date.parse(filter.period.from) + localTimeZoneOffSetInMs);
-            var localOffsetTo = new Date(Date.parse(filter.period.to) + localTimeZoneOffSetInMs);
+            var localFromTimeZoneOffSetInMs = new Date(Date.parse(filter.period.from)).getTimezoneOffset() * 60 * 1000;
+            var localToTimeZoneOffSetInMs = new Date(Date.parse(filter.period.to)).getTimezoneOffset() * 60 * 1000;
+            var localOffsetFrom = new Date(Date.parse(filter.period.from) + localFromTimeZoneOffSetInMs);
+            var localOffsetTo = new Date(Date.parse(filter.period.to) + localToTimeZoneOffSetInMs);
             // -- Set "From" date to start of day (00:01) and "To" date to end of day (23:59) --
             var from = new Date(localOffsetFrom.setHours(0, 0, 0, 1));
             var to = new Date(localOffsetTo.setHours(23, 59, 59, 999));


### PR DESCRIPTION
The start date filter would sometimes display dates that were off by one day due to daylight savings offsets. This should get the correct offsets for the selected dates.

To test this, go to the start date filter in the Admin UI and select dates that are in a different daylight savings time (e.g. if you are in Germany and now is the 6th of May, try selecting the 1st of March).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
