### PR TITLE
Silence detection should create media duration properties

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/silence-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/silence-woh.md
@@ -12,7 +12,24 @@ The silence operation performs a silence detection on an audio-only input file.
 |------------------------|-----------|-----------|-------------|
 |source-flavors          |`*/audio`  |The input parameter source-flavors takes one flavor/sub-type or multiple input flavors with the \*-operator followed by the sub-type|EMPTY|
 |reference-tracks-flavor|`*/preview`|The input parameter reference-tracks-flavor is the subtype of the media files that should be included in the provided SMIL file. The * should not be modified here. In most cases it is not important which reference-tracks-flavor is selected as long as all relevant flavors are available within this feature. "preview" is not a bad choice as all files available within the video editor UI are also available with this flavor, unlike "source" where not all flavors may be available, as some recorders record all streams to one file and the tracks are separated afterwards. The editor operation afterwards will anyway try to select the best available quality.|  EMPTY|
-|smil-flavor-subtype     |`smil`     |The output parameter is smil-flavor-subtype which provides the modificatory for the flavor subtype after this operation. The main flavor will be consistent and only the subtype will be replaced. |EMPTY|
+|smil-flavor-subtype     |`smil`     |The output parameter is smil-flavor-subtype which provides the modification for the flavor subtype after this operation. The main flavor will be consistent and only the subtype will be replaced. |EMPTY|
+|export-segments-duration |`true`    |Set this value to true and this operation will set two workflow properties for each analyzed track, the sum of duration of each non silent segment and same value in relation to the whole track length (in percent). |`false` |
+
+### Workflow properties generated if export-segments-duration is set to true
+
+For each source track the silence detection will run as expected. As a result we get a list of non-silent segments.
+Each segment has a start and end timestamp, where we can calculate the segment duration.
+The sum of duration of all non-silent segments will be set as workflow property with the name
+`<source_flavor_type>_<source_flavor_subtype>_active_audio_duration` and value in seconds.
+The relation to the whole track length will be set with the workflow property named
+`<source_flavor_type>_<source_flavor_subtype>_active_audio_duration_percent` as percent value (0-100).
+
+
+Example output for an 120 minutes long presenter/source track:
+```
+presenter_source_active_audio_duration = 5400
+presenter_source_active_audio_duration_percent = 75
+```
 
 
 Operation Example
@@ -25,5 +42,6 @@ Operation Example
         <configuration key="source-flavors">*/audio</configuration>
         <configuration key="smil-flavor-subtype">smil</configuration>
         <configuration key="reference-tracks-flavor">*/preview</configuration>
+        <configuration key="export-segments-duration">true</configuration>
       </configurations>
     </operation>

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
@@ -36,6 +36,9 @@ import org.opencastproject.silencedetection.api.SilenceDetectionService;
 import org.opencastproject.smil.api.SmilException;
 import org.opencastproject.smil.api.SmilService;
 import org.opencastproject.smil.entity.api.Smil;
+import org.opencastproject.smil.entity.media.api.SmilMediaObject;
+import org.opencastproject.smil.entity.media.container.api.SmilMediaContainer;
+import org.opencastproject.smil.entity.media.element.api.SmilMediaElement;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -44,6 +47,7 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
@@ -52,6 +56,9 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * workflowoperationhandler for silencedetection executes the silencedetection and adds a SMIL document to the
@@ -76,6 +83,10 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
 
   /** Name of the configuration option for track flavors to reference in generated smil. */
   private static final String REFERENCE_TRACKS_FLAVOR_PROPERTY = "reference-tracks-flavor";
+
+  /** Name of the configuration option whether to set workflow properties with sum of
+   * segments duration in seconds and relation to the whole track length for each track.*/
+  private static final String EXPORT_SEGMENTS_DURATION = "export-segments-duration";
 
   /** Name of the configuration option that provides the smil file name */
   private static final String TARGET_FILE_NAME = "smil.smil";
@@ -104,6 +115,19 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
             SMIL_FLAVOR_SUBTYPE_PROPERTY));
     String smilTargetFlavorString = StringUtils.trimToNull(workflowInstance.getCurrentOperation().getConfiguration(
             SMIL_TARGET_FLAVOR_PROPERTY));
+    String exportSegmentsDurationString = StringUtils.trimToNull(
+        workflowInstance.getCurrentOperation().getConfiguration(EXPORT_SEGMENTS_DURATION));
+    boolean exportSegmentsDuration = false;
+
+    if (StringUtils.isNotBlank(exportSegmentsDurationString)) {
+      try {
+        exportSegmentsDuration = BooleanUtils.toBoolean(exportSegmentsDurationString);
+      } catch (IllegalArgumentException e) {
+        exportSegmentsDuration = false;
+        logger.warn("Unable to parse %s option value %s. Deactivating export of workflow properties.",
+                EXPORT_SEGMENTS_DURATION, exportSegmentsDurationString);
+      }
+    }
 
     MediaPackageElementFlavor smilTargetFlavor = null;
     if (smilTargetFlavorString != null) {
@@ -157,7 +181,7 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
               referenceTracksFlavor));
     }
     MediaPackageElementBuilder mpeBuilder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
-
+    Map<String, String> exportWorkflowProperties = new HashMap<>();
     for (Track sourceTrack : sourceTracks) {
       // Skip over track with no audio stream
       if (!sourceTrack.hasAudio()) {
@@ -190,7 +214,29 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
         } finally {
           IOUtils.closeQuietly(is);
         }
-
+        if (exportSegmentsDuration) {
+          long durationMS = 0;
+          for (SmilMediaObject smilElement : smil.getBody().getMediaElements()) {
+            durationMS += getSegmentDurationMS(smilElement);
+          }
+          String durationWfPropertyName = String.format("%s_%s_active_audio_duration",
+                  sourceTrack.getFlavor().getType(),
+                  sourceTrack.getFlavor().getSubtype());
+          exportWorkflowProperties.put(durationWfPropertyName,
+                  Long.toString(TimeUnit.MILLISECONDS.toSeconds(durationMS)));
+          String relationWfPropertyName = String.format("%s_%s_active_audio_duration_percent",
+                  sourceTrack.getFlavor().getType(),
+                  sourceTrack.getFlavor().getSubtype());
+          double durationTrackLengthRelation = 0;
+          if (sourceTrack.getDuration() > 0) {
+            durationTrackLengthRelation = (double)durationMS / (double)sourceTrack.getDuration();
+            durationTrackLengthRelation *= 100;
+          }
+          durationTrackLengthRelation = Math.floor(durationTrackLengthRelation);
+          durationTrackLengthRelation = Math.min(100, durationTrackLengthRelation);
+          durationTrackLengthRelation = Math.max(0, durationTrackLengthRelation);
+          exportWorkflowProperties.put(relationWfPropertyName, String.format("%.0f", durationTrackLengthRelation));
+        }
         logger.info("Finished silence detection on track {}", sourceTrack.getIdentifier());
       } catch (SilenceDetectionFailedException ex) {
         throw new WorkflowOperationException(String.format("Failed to create silence detection job for track %s",
@@ -201,7 +247,24 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
       }
     }
     logger.debug("Finished silence detection workflow operation for mediapackage {}", mp.getIdentifier().toString());
-    return createResult(mp, Action.CONTINUE);
+    return createResult(mp, exportWorkflowProperties, Action.CONTINUE, 0);
+  }
+
+  /**
+   * Return first media segment length in milliseconds. If smilElement is a container, look for sub elements and
+   * return duration from the first matching element.
+   * @param smilElement smil media or container element to query duration
+   * @return media duration in milliseconds
+   * @throws SmilException on smil parsing error
+   */
+  protected long getSegmentDurationMS(SmilMediaObject smilElement) throws SmilException {
+    if (smilElement.isContainer()) {
+      for (SmilMediaObject element : ((SmilMediaContainer) smilElement).getElements()) {
+        return getSegmentDurationMS(element);
+      }
+    }
+    SmilMediaElement smilMediaElement = (SmilMediaElement) smilElement;
+    return smilMediaElement.getClipEndMS() - smilMediaElement.getClipBeginMS();
   }
 
   @Override


### PR DESCRIPTION
Silence detection should optionally create workflow properties with the sum of non-silent media segment duration and relation to the whole track length.

Example:
Your sample media package contains `presenter/source` and `presentation/source` tracks. Each track is 120 minutes long but the non-silent part in the video is 90 minutes (75%) long. Setting `export-segments-duration` configuration of `silence` operation to `true` will create these workflow properties for you:

```
presentation_source_duration = 5400
presentation_source_duration_percent = 75
presenter_source_duration = 5400
presenter_source_duration_percent = 75
```

You can use this properties to decide the next processing steps in the workflow. You maybe want to skip distribution on well defined threshold or do other stuff.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
