### PR TITLE
Fixing unchecked directory list() call

### DIFF
--- a/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
+++ b/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
@@ -946,7 +946,7 @@ public class WowzaStreamingDistributionService extends AbstractDistributionServi
 
     // Try to remove the parent folders, if possible
     File elementDir = elementFile.getParentFile();
-    if (elementDir != null && elementDir.exists()) {
+    if (elementDir != null && elementDir.exists() && elementDir.list() != null) {
       if (elementDir.list().length == 0) {
         if (!elementDir.delete()) {
           logger.warn("Could not properly delete element directory: {}", elementDir);


### PR DESCRIPTION
This change resolves an issue report on the users list where retracting would sometimes cause NPEs when the list().length check was done.  Reading the docs closely, .list() returns null in the case where the File is *not* a directory, or if an IO error occurs.  Since an IO error will likely show up as a *ton* of other errors, we're going to check if the .list() call returns null, and assume that a null here is because the File isn't pointing at a directory.  This probably shouldn't be happening, but we'll try and delete whatever it's pointing at anyway.

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] be against the correct branch (features can only go into develop)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
