### PR TITLE
Add a Maven project for the Checkstyle rules to be consumed by external projects

### DIFF
--- a/docs/checkstyle/check-config.sh
+++ b/docs/checkstyle/check-config.sh
@@ -5,11 +5,11 @@ set -ue
 ret=0
 
 echo Checking pom.xml files for tabs or trailing spaces…
-if grep -rn $'\t' modules assemblies pom.xml --include=pom.xml; then
+if grep -rn $'\t' modules assemblies docs/checkstyle pom.xml --include=pom.xml; then
   echo "Tabs found!"
   ret=1
 fi
-if grep -rn ' $' modules assemblies pom.xml --include=pom.xml; then
+if grep -rn ' $' modules assemblies docs/checkstyle pom.xml --include=pom.xml; then
   echo "Trailing spaces found!"
   ret=1
 fi

--- a/docs/checkstyle/opencast-checkstyle.xml
+++ b/docs/checkstyle/opencast-checkstyle.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <module name="Checker">
-  <!-- Define some exceptions for a gradual rollout of new style rules -->
-  <module name="SuppressionFilter">
-    <property name="file" value="${checkstyle.suppressions.file}" />
-  </module>
-
   <!-- Check for license header                                 -->
   <!-- See http://checkstyle.sourceforge.net/config_header.html -->
   <module name="Header">

--- a/docs/checkstyle/pom.xml
+++ b/docs/checkstyle/pom.xml
@@ -27,27 +27,34 @@
         </includes>
       </resource>
     </resources>
-
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
-        <executions>
-          <!-- Generate an empty JavaDoc-jar to comply with Maven Central rules -->
-          <execution>
-            <id>empty-javadoc-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <classifier>javadoc</classifier>
-              <classesDirectory>${basedir}/javadoc</classesDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
+
+  <!-- Generate an empty JavaDoc-jar to comply with Maven Central rules when we are releasing -->
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.2.0</version>
+            <executions>
+              <execution>
+                <id>empty-javadoc-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <classesDirectory>${basedir}/javadoc</classesDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/docs/checkstyle/pom.xml
+++ b/docs/checkstyle/pom.xml
@@ -32,6 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <!-- Generate an empty JavaDoc-jar to comply with Maven Central rules -->
           <execution>

--- a/docs/checkstyle/pom.xml
+++ b/docs/checkstyle/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.opencastproject</groupId>
+  <artifactId>checkstyle</artifactId>
+  <version>9-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Opencast Checkstyle Rules</name>
+  <parent>
+    <groupId>org.opencastproject</groupId>
+    <artifactId>base</artifactId>
+    <version>9-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <checkstyle.skip>true</checkstyle.skip>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>.</directory>
+        <includes>
+          <include>opencast-checkstyle.xml</include>
+          <include>opencast-header.txt</include>
+        </includes>
+      </resource>
+    </resources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <!-- Generate an empty JavaDoc-jar to comply with Maven Central rules -->
+          <execution>
+            <id>empty-javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <classesDirectory>${basedir}/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <spring-security.version>3.1.7.RELEASE</spring-security.version>
   </properties>
   <modules>
+    <module>docs/checkstyle</module>
     <module>modules/admin-ui</module>
     <module>modules/admin-ui-frontend</module>
     <module>modules/admin-ui-index</module>


### PR DESCRIPTION
[The Opencast Annotation Tool](/opencast/annotation-tool) would like to format its Java sources in a style consistent with Opencast. We currently have a redundant copy of the file in the repo which already triggers me slightly, but now that there is actually some movement regarding checkstyle thanks to @LukasKalbertodt it's probably outdated as well.

Now, the Maven checkstyle plugin can look up its configuration in the classpath, so you can load configuration files from Maven dependency artifacts. This PR creates such an artifact for our checkstyle configuration! :tada: 

Putting the POM directly in the `checkstyle` folder feels a bit icky since that folder already contains stuff not directly related to checkstyle (albeit related to style checking ...). However, didn't want to completely rename/restructure that directory only to have people not like the result, so I went down the slightly ugly but very simple route for now, looking for feedback on how the community would like to structure this going forward.

With that in mind I'm interested in any and all reviews, but I'm especially interested in what @gregorydlogan and @LukasKalbertodt have to say; @gregorydlogan because the entire goal here is to get this artifact deployed to Central eventually, and I'm not sure I did everything required for that, and @LukasKalbertodt because I don't want to disrupt the whole "restyling" effort.

### Your pull request should…

* [x] have a concise title
* [x] ~~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~~
* [x] be against the correct branch
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
