### PR TITLE
Remove automatic handling of HLS bitrate ladder

### DIFF
--- a/docs/guides/admin/docs/releasenotes/hls-bitrate-handling.txt
+++ b/docs/guides/admin/docs/releasenotes/hls-bitrate-handling.txt
@@ -1,0 +1,3 @@
+Opencast 11 removes support for automatically setting up an HLS encoding ladder via the `{video,audio}.bitrates.mink`
+and `{video,audio}.bitrates.maxk` encoding profile options. Instead, users should now explicitly specify the bit rate
+and bit rate control mechanism in the `ffmpeg.command`.

--- a/docs/guides/admin/docs/workflowoperationhandlers/multiencode-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/multiencode-woh.md
@@ -334,11 +334,6 @@ profile.hls-full-res-presentation-mp4.jobload=4.0
 profile.multiencode-hls.name = multiencode-hls
 # adaptive type - only used in a group to supplement encoding only HLS is supported
 profile.multiencode-hls.adaptive.type = HLS
-# Delivery format SHOULD state video and audio bitrates, but the process will try to generate bitrate settings high to low, if bitrates are absent
-profile.multiencode-hls.video.bitrates.maxk = 4000
-profile.multiencode-hls.video.bitrates.mink = 300
-profile.multiencode-hls.audio.bitrates.maxk = 128
-profile.multiencode-hls.audio.bitrates.mink = 32
 profile.multiencode-hls.input = visual
 # manifest type means that it is a supplement
 profile.multiencode-hls.output = manifest
@@ -363,11 +358,6 @@ profile.multiencode-hls.jobload=1.0
 profile.multiencode-hls-4s.name = multiencode-hls-4s
 # adaptive type - only used in a group to supplement encoding only HLS is supported
 profile.multiencode-hls-4s.adaptive.type = HLS
-# Delivery format should state video and audio bitrates, but the process will try to generate bitrate settings high to low, if bitrates are absent
-profile.multiencode-hls-4s.video.bitrates.maxk = 3000
-profile.multiencode-hls-4s.video.bitrates.mink = 300
-profile.multiencode-hls-4s.audio.bitrates.maxk = 128
-profile.multiencode-hls-4s.audio.bitrates.mink = 32
 profile.multiencode-hls-4s.input = visual
 # manifest type means that it is a supplement
 profile.multiencode-hls-4s.output = manifest

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -558,12 +558,8 @@ public class EncoderEngine implements AutoCloseable {
     private String aInputPad = "";
     private String vsplit = "";
     private String asplit = "";
-    // Adaptive only - Each variant must have a bitrate
-    private ArrayList<String> vbitrate = null; // target video bitrate for variant
-    private ArrayList<String> abitrate = null; // target audio bitrate for variant
-    private final ArrayList<String> vstream; // target video bitrate for variant
-    private final ArrayList<String> astream; // target audio bitrate for variant
-    private String streamMap = "";
+    private final ArrayList<String> vstream; // output video name
+    private final ArrayList<String> astream; // output audio name
 
     public OutputAggregate(List<EncodingProfile> profiles,
             Map<String, String> params, String vInputPad, String aInputPad) throws EncoderException {
@@ -593,9 +589,6 @@ public class EncoderEngine implements AutoCloseable {
       // name of output pads to map to files
       apads = new ArrayList<>(Collections.nCopies(size, null));
       vpads = new ArrayList<>(Collections.nCopies(size, null));
-
-      vbitrate = new ArrayList<>(Collections.nCopies(size, null));
-      abitrate = new ArrayList<>(Collections.nCopies(size, null));
 
       vstream = new ArrayList<>(Collections.nCopies(size, null));
       astream = new ArrayList<>(Collections.nCopies(size, null));
@@ -803,8 +796,6 @@ public class EncoderEngine implements AutoCloseable {
         ffmpgCmd = ffmpgCmd.replace("#{space}", " ");
         List<String> cmdToken;
         try {
-          //arguments = CommandLineUtils.translateCommandline(ffmpgCmd);
-          //arguments = StringUtils.splitByWholeSeparator(ffmpgCmd,null);
           cmdToken = commandSplit(ffmpgCmd);
         } catch (Exception e) {
           throw new EncoderException("Could not parse encoding profile command line", e);
@@ -853,25 +844,11 @@ public class EncoderEngine implements AutoCloseable {
               cmd = cmd + " " + adjustABRVMaps("-c:a", indx);
             else
               cmd = cmd + " " + adjustABRVMaps(opt, indx);
-            // opt;
-            // if target bitrate - store it separately for doing adaptive
-          } else if (opt.startsWith("-b:v") || opt.startsWith("-vb") || opt.startsWith("-bitrate")) {
-            vbitrate.set(indx, cmdToken.get(i + 1));
-            i++;
-          } else if (opt.startsWith("-b:a") || opt.startsWith("-ab")) {
-            abitrate.set(indx, cmdToken.get(i + 1));
-            i++;
-          } else if (opt.startsWith("-maxrate")) {
-            cmd = cmd + " " + adjustABRVMaps(opt, indx) + " " + cmdToken.get(i + 1);
-            maxrate = cmdToken.get(i + 1); // keep maxrate as backup
-            i++;
           } else { // keep the rest
             cmd = cmd + " " + adjustABRVMaps(opt, indx);
           }
           i++;
         }
-        if (vbitrate.get(indx) == null) // use maxrate only if no video bitrate
-          vbitrate.set(indx, maxrate); // this may be null too
 
         /* Remove unused commandline parts */
         cmd = cmd.replaceAll("#\\{.*?\\}", "");
@@ -906,131 +883,42 @@ public class EncoderEngine implements AutoCloseable {
       }
       setVideoFilters();
       setAudioFilters();
-      setHLSAdaptive(groupProfile, ffmpgGCmd, vInputPad != null, aInputPad != null); // Only HLS is supported so far
+      setHLSVarStreamMap(ffmpgGCmd, vInputPad != null, aInputPad != null); // Only HLS is supported so far
     }
 
     /**
-     * Geometrically distribute bitrates from max to min. It serves as an estimate if no bitrates are given in encoding
-     * profile
+     * Sets the mapping of outputs to HLS streams.
      *
-     * @param n
-     *          - number of quality to generate
-     * @param min
-     * @param max
-     * @param unit
-     *          - add unit "k" or "m"
-     * @return
-     */
-    private String[] distributeBitrates(int n, int min, int max, String unit) {
-      float ratio = (float) (Math.log(max) / min);
-      String[] bitrates = new String[n];
-      float fac = (float) Math.exp(Math.log(ratio) / n);
-      for (int i = 0; i < n; i++) {
-        bitrates[i] = "" + (int) (max * java.lang.Math.pow(fac, i)) + unit;
-      }
-      return bitrates;
-    }
-
-    /**
-     * Got min and max bitrate from the HLS encoding profile
-     * @param profile - HLS encoding profile
-     * @param minSuffix - suffix to get min bitrate
-     * @param maxSuffix - suffix to get max bitrate
-     * @param n - number of variants required
-     * @param defaultMin - default min
-     * @param defaultMax - default max
-     * @param unit
-     * @return
-     */
-    private String[] getBitrates(EncodingProfile profile, String minSuffix, String maxSuffix, int n, int defaultMin, int defaultMax,
-            String unit) {
-      int min;
-      int max;
-      try {
-        min = Integer.parseInt(profile.getExtension(minSuffix));
-      } catch (Exception e) {
-        min = defaultMin;
-      }
-      try {
-        max = Integer.parseInt(profile.getExtension(maxSuffix));
-      } catch (Exception e) {
-        max = defaultMax;
-      }
-      return distributeBitrates(n, min, max, unit);
-    }
-
-    /**
-     * In HLS, all streams must have a bitrate to determine stream switching Map all the outputs to streams with bit
-     * rates. if they are defined in all targets or put in a default if any of them are missing. If different sizes are
-     * used, the first target is assumed to have the highest resolution and therefore bitrate
-     *
-     * @param prof
-     *          - encoding profile for HLS
      * @param ffmpgCmd
-     *          - ffmpeg command with subsitution from the encoding profile
+     *          - ffmpeg command with substitution from the encoding profile
      * @param hasVideo
      *          - use video stream
      * @param hasAudio
      *          - use audio stream
      */
-    private void setHLSAdaptive(EncodingProfile prof, String ffmpgCmd, boolean hasVideo, boolean hasAudio) {
-      final String videoMinBitrateSuffix = "video.bitrates.mink"; // HLS defaults
-      final String videoMaxBitrateSuffix = "video.bitrates.maxk"; // HLS defaults
-      final String audioMinBitrateSuffix = "audio.bitrates.mink"; // HLS defaults
-      final String audioMaxBitrateSuffix = "audio.bitrates.maxk"; // HLS defaults
-      // https://developer.apple.com/documentation/http_live_streaming/hls_authoring_specification_for_apple_devices
-      final int defaultVideoMinBitrate = 100; // average for 640 x 360 <= 30fps = 160
-      final int defaultVideoMaxBitrate = 4000; // average for 1280x720 <= 30fps = 3850
-      // stereo audio from 160k to 32k
-      final int defaultAudioMinBitrate = 32; // k
-      final int defaultAudioMaxBitrate = 160; // k
-      int np = pf.size();
-      // if any of the targets profiles lack a video bitrate, replace all with default
-      if (hasVideo)
-        for (int i = 0; i < pf.size(); i++) {
-          if (vbitrate.get(i) == null) {
-            String[] vbrs = getBitrates(prof, videoMinBitrateSuffix, videoMaxBitrateSuffix, np, defaultVideoMinBitrate,
-                    defaultVideoMaxBitrate, "k");
-            for (int j = 0; j < np; j++) {
-              vbitrate.set(j, vbrs[j]);
-            }
-            break;
-          }
-        }
-      if (hasAudio)
-        // if any of the targets lack a audio bitrate, replace all with default
-        for (int i = 0; i < np; i++) {
-          if (abitrate.get(i) == null) {
-            String[] abrs = getBitrates(prof, audioMinBitrateSuffix, audioMaxBitrateSuffix, np, defaultAudioMinBitrate,
-                    defaultAudioMaxBitrate, "k");
-            for (int j = 0; j < np; j++) {
-              abitrate.set(j, abrs[j]);
-            }
-            break;
-          }
-        }
-      streamMap = "";
-      String[] vStreamMap = new String[pf.size()];
-      // Sort out bitrates for each mapped output
-      String mapping = ""; // each mapping [av]:[i] is matched with bitrate
+    private void setHLSVarStreamMap(String ffmpgCmd, boolean hasVideo, boolean hasAudio) {
+      StringBuilder varStreamMap = new StringBuilder();
+      varStreamMap.append(" -var_stream_map '");
+
       for (int i = 0; i < pf.size(); i++) {
         int j = 0;
         String[] maps = new String[2];
         if (hasVideo && vstream.get(i) != null) { // Has video
-          mapping += " -b:v:" + i + " " + vbitrate.get(i);
           maps[j] = "v:" + i;
           ++j;
         }
         if (hasAudio && astream.get(i) != null) { // Has audio
-          mapping += " -b:a:" + i + " " + abitrate.get(i);
           maps[j] = "a:" + i;
         }
-        vStreamMap[i] = joinNonNullString(maps, ","); // each target delivery is v:i,a:i
+        // each target delivery is v:i,a:i
+        varStreamMap.append(joinNonNullString(maps, ","));
+        varStreamMap.append(" ");
       }
-      // Put all the streams together
-      String varStreamMap = "-var_stream_map '" + StringUtils.join(vStreamMap, " ") + "' ";
-      streamMap += " " + varStreamMap + " " + ffmpgCmd + " ";
-      outputs.add(mapping + streamMap); // treat as another output
+
+      varStreamMap.append("' ");
+      varStreamMap.append(ffmpgCmd);
+      varStreamMap.append(" ");
+      outputs.add(varStreamMap.toString()); // treat as another output
     }
 
     /**

--- a/modules/composer-ffmpeg/src/test/resources/encodingprofiles.properties
+++ b/modules/composer-ffmpeg/src/test/resources/encodingprofiles.properties
@@ -206,10 +206,6 @@ profile.demux.work.ffmpeg.command = -i #{in.video.path} -strict -2 -acodec copy 
 
 profile.multiencode-hls.name = multiencode-hls
 profile.multiencode-hls.adaptive.type = HLS
-profile.multiencode-hls.video.bitrates.mink = 50
-profile.multiencode-hls.video.bitrates.maxk = 400
-profile.multiencode-hls.audio.bitrates.mink = 32
-profile.multiencode-hls.audio.bitrates.maxk = 128
 profile.multiencode-hls.input = visual
 profile.multiencode-hls.output = manifest
 profile.multiencode-hls.suffix = .m3u8


### PR DESCRIPTION
When using HLS Opencast currently forces the use of `-b:v` and `-b:a`
for each stream. The bitrate is determined either from the same options
in the encoding profile or geometrically distribute between a min and a
max. This limits the rate control mechanism to either Average Bitrate
(ABR) (i.e. only setting `-b`) or Constant Bitrate (CBR) (i.e. setting
`-b`, `-maxrate`, `-minrate`, `-bufsize`). In particular, Constrained
Encoding (VBV) (i.e. setting `-crf`, `-maxrate`, `-minrate`, `-bufsize`)
is not possible.

This removes the bitrate handling in Opencast completely forcing the
user to properly setup the rate control in the used encoding profiles.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
