### PR TITLE
Series list provider should use admin UI index

### DIFF
--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -277,12 +277,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-series-service-impl</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-asset-manager-impl</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -250,7 +250,7 @@ public abstract class AbstractEventEndpoint {
 
   public abstract JobEndpoint getJobService();
 
-  public abstract SeriesEndpoint getSeriesService();
+  public abstract SeriesEndpoint getSeriesEndpoint();
 
   public abstract AclService getAclService();
 
@@ -1140,12 +1140,12 @@ public abstract class AbstractEventEndpoint {
     for (EventCatalogUIAdapter catalogUIAdapter : catalogUIAdapters) {
       metadataList.add(catalogUIAdapter, catalogUIAdapter.getFields(mediaPackage));
     }
-
     DublinCoreMetadataCollection metadataCollection = EventUtils.getEventMetadata(event, getIndexService().getCommonEventCatalogUIAdapter());
     if (getOnlySeriesWithWriteAccessEventModal()) {
       MetadataField seriesField = metadataCollection.getOutputFields().get(DublinCore.PROPERTY_IS_PART_OF.getLocalName());
-      Map<String, String> seriesWithWriteAccess = getSeriesService().getUserSeriesByAccess(true);
-      seriesField.setCollection(seriesWithWriteAccess);
+      if (seriesField != null) {
+        seriesField.setCollection(getSeriesEndpoint().getUserSeriesByAccess(true));
+      }
     }
     metadataList.add(getIndexService().getCommonEventCatalogUIAdapter(), metadataCollection);
 
@@ -1197,7 +1197,7 @@ public abstract class AbstractEventEndpoint {
     //get once instead of for each event
     Map<String, String> seriesWithWriteAccess = null;
     if (getOnlySeriesWithWriteAccessEventModal()) {
-      seriesWithWriteAccess = getSeriesService().getUserSeriesByAccess(true);
+      seriesWithWriteAccess = getSeriesEndpoint().getUserSeriesByAccess(true);
     }
 
     // collect the metadata of all events
@@ -2061,8 +2061,12 @@ public abstract class AbstractEventEndpoint {
         publisher.setValue(loggedInUser);
       }
 
-      collection.getOutputFields().get(DublinCore.PROPERTY_IS_PART_OF.getLocalName())
-        .setCollection(getSeriesService().getUserSeriesByAccess(getOnlySeriesWithWriteAccessEventModal()));
+      if (getOnlySeriesWithWriteAccessEventModal()) {
+        MetadataField seriesField = collection.getOutputFields().get(DublinCore.PROPERTY_IS_PART_OF.getLocalName());
+        if (seriesField != null) {
+          seriesField.setCollection(getSeriesEndpoint().getUserSeriesByAccess(true));
+        }
+      }
 
       metadataList.add(getIndexService().getCommonEventCatalogUIAdapter(), collection);
     }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -54,7 +54,7 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   private EventCommentService eventCommentService;
   private IndexService indexService;
   private JobEndpoint jobService;
-  private SeriesEndpoint seriesService;
+  private SeriesEndpoint seriesEndpoint;
   private SchedulerService schedulerService;
   private SecurityService securityService;
   private UrlSigningService urlSigningService;
@@ -95,13 +95,13 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint implements ManagedS
   }
 
   /** OSGi DI. */
-  public void setSeriesService(SeriesEndpoint seriesService) {
-    this.seriesService = seriesService;
+  public void setSeriesEndpoint(SeriesEndpoint seriesEndpoint) {
+    this.seriesEndpoint = seriesEndpoint;
   }
 
   @Override
-  public SeriesEndpoint getSeriesService() {
-    return seriesService;
+  public SeriesEndpoint getSeriesEndpoint() {
+    return seriesEndpoint;
   }
 
   /** OSGi DI. */

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -68,6 +68,8 @@ import org.opencastproject.index.service.impl.index.theme.ThemeSearchQuery;
 import org.opencastproject.index.service.resources.list.query.SeriesListQuery;
 import org.opencastproject.index.service.util.AccessInformationUtil;
 import org.opencastproject.index.service.util.RestUtils;
+import org.opencastproject.list.api.ListProviderException;
+import org.opencastproject.list.api.ListProvidersService;
 import org.opencastproject.matterhorn.search.SearchIndexException;
 import org.opencastproject.matterhorn.search.SearchQuery;
 import org.opencastproject.matterhorn.search.SearchResult;
@@ -121,7 +123,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Dictionary;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -173,6 +174,7 @@ public class SeriesEndpoint implements ManagedService {
   private SecurityService securityService;
   private AclServiceFactory aclServiceFactory;
   private IndexService indexService;
+  private ListProvidersService listProvidersService;
   private AdminUISearchIndex searchIndex;
 
   /** Default server URL */
@@ -191,6 +193,11 @@ public class SeriesEndpoint implements ManagedService {
   /** OSGi DI. */
   public void setIndexService(IndexService indexService) {
     this.indexService = indexService;
+  }
+
+  /** OSGi callback for the list provider service */
+  public void setListProvidersService(ListProvidersService listProvidersService) {
+    this.listProvidersService = listProvidersService;
   }
 
   /** OSGi callback for the security service */
@@ -692,27 +699,26 @@ public class SeriesEndpoint implements ManagedService {
    * @return user series with write or read-only access,
    *         depending on the parameter
    */
-  public HashMap<String, String> getUserSeriesByAccess(boolean writeAccess) {
+  public Map<String, String> getUserSeriesByAccess(boolean writeAccess) {
+    String listProviderName = null;
+    MetadataField seriesMetadataField = indexService.getCommonEventCatalogUIAdapter().getRawFields().getOutputFields()
+        .get(DublinCore.PROPERTY_IS_PART_OF.getLocalName());
+    if (seriesMetadataField != null && StringUtils.isNotEmpty(seriesMetadataField.getListprovider())) {
+      listProviderName = seriesMetadataField.getListprovider();
+    }
+    if (StringUtils.isEmpty(listProviderName)) {
+      listProviderName = "SERIES";
+    }
+    SeriesListQuery query = new SeriesListQuery();
+    if (writeAccess) {
+      query.withoutPermissions();
+      query.withReadPermission(true);
+      query.withWritePermission(true);
+    }
     try {
-      SeriesSearchQuery query = new SeriesSearchQuery(
-      securityService.getOrganization().getId(), securityService.getUser());
-
-      if (writeAccess) {
-        query.withoutActions();
-        query.withAction(Permissions.Action.WRITE);
-        query.withAction(Permissions.Action.READ);
-      }
-
-      SearchResult<Series> result = searchIndex.getByQuery(query);
-      HashMap<String, String> seriesMap = new HashMap<String, String>();
-      for (SearchResultItem<Series> item : result.getItems()) {
-        Series series = item.getSource();
-        seriesMap.put(series.getTitle(), series.getIdentifier());
-      }
-
-      return seriesMap;
-    } catch (SearchIndexException e) {
-      logger.warn("Could not perform search query: {}", e);
+      return listProvidersService.getList(listProviderName, query, true);
+    } catch (ListProviderException e) {
+      logger.warn("Could not perform search query.", e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
     }
   }

--- a/modules/admin-ui/src/main/resources/OSGI-INF/event_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/event_endpoint.xml
@@ -23,7 +23,7 @@
              bind="setJobService"/>
   <reference name="seriesEndpoint"
              interface="org.opencastproject.adminui.endpoint.SeriesEndpoint"
-             bind="setSeriesService"/>
+             bind="setSeriesEndpoint"/>
   <reference name="AclServiceFactory"
              interface="org.opencastproject.authorization.xacml.manager.api.AclServiceFactory"
              bind="setAclServiceFactory"/>

--- a/modules/admin-ui/src/main/resources/OSGI-INF/series_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/series_endpoint.xml
@@ -17,6 +17,8 @@
              cardinality="1..1" policy="static" bind="setIndex"/>
   <reference name="IndexService" interface="org.opencastproject.index.service.api.IndexService"
              cardinality="1..1" policy="static" bind="setIndexService"/>
+  <reference name="ListProvidersService" interface="org.opencastproject.list.api.ListProvidersService"
+             bind="setListProvidersService"/>
   <reference name="SecurityService" interface="org.opencastproject.security.api.SecurityService"
              cardinality="1..1" policy="static" bind="setSecurityService"/>
   <reference name="seriesService" interface="org.opencastproject.series.api.SeriesService"

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -688,7 +688,7 @@ public class AbstractEventEndpointTest {
     private WorkflowService workflowService;
     private AssetManager assetManager;
     private JobEndpoint jobService;
-    private SeriesEndpoint seriesService;
+    private SeriesEndpoint seriesEndpoint;
     private AclService aclService;
     private EventCommentService eventCommentService;
     private SecurityService securityService;
@@ -711,12 +711,12 @@ public class AbstractEventEndpointTest {
       return jobService;
     }
 
-    public void setSeriesService(SeriesEndpoint seriesService) {
-      this.seriesService = seriesService;
+    public void setSeriesEndpoint(SeriesEndpoint seriesEndpoint) {
+      this.seriesEndpoint = seriesEndpoint;
     }
 
-    public SeriesEndpoint getSeriesService() {
-      return seriesService;
+    public SeriesEndpoint getSeriesEndpoint() {
+      return this.seriesEndpoint;
     }
 
     public void setWorkflowService(WorkflowService workflowService) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesQueryBuilder.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/series/SeriesQueryBuilder.java
@@ -23,7 +23,6 @@ package org.opencastproject.index.service.impl.index.series;
 
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 
-import org.opencastproject.index.service.impl.index.event.EventIndexSchema;
 import org.opencastproject.matterhorn.search.SearchTerms;
 import org.opencastproject.matterhorn.search.SearchTerms.Quantifier;
 import org.opencastproject.matterhorn.search.impl.AbstractElasticsearchQueryBuilder;
@@ -81,7 +80,7 @@ public class SeriesQueryBuilder extends AbstractElasticsearchQueryBuilder<Series
       if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
         for (Role role : user.getRoles()) {
           for (String action : query.getActions()) {
-            and(EventIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());
+            and(SeriesIndexSchema.ACL_PERMISSION_PREFIX.concat(action), role.getName());
           }
         }
       }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/SeriesListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/SeriesListQuery.java
@@ -52,6 +52,12 @@ public class SeriesListQuery extends ResourceListQueryImpl {
   public static final String FILTER_ACL_NAME = "managedAcl";
   private static final String FILTER_ACL_LABEL = "FILTERS.SERIES.ACCESS_POLICY.LABEL";
 
+  public static final String FILTER_ACL_PERMISSION_READ_NAME = "acl_permission_read";
+  private static final String FILTER_ACL_PERMISSION_READ_LABEL = "FILTERS.SERIES.ACL_PREMISSION_READ.LABEL";
+
+  public static final String FILTER_ACL_PERMISSION_WRITE_NAME = "acl_permission_write";
+  private static final String FILTER_ACL_PERMISSION_WRITE_LABEL = "FILTERS.SERIES.ACL_PREMISSION_WRITE.LABEL";
+
   public static final String FILTER_CONTRIBUTORS_NAME = "contributors";
   private static final String FILTER_CONTRIBUTORS_LABEL = "FILTERS.SERIES.CONTRIBUTORS.LABEL";
 
@@ -102,6 +108,33 @@ public class SeriesListQuery extends ResourceListQueryImpl {
    */
   public Option<String> getAccessPolicy() {
     return this.getFilterValue(FILTER_ACL_NAME);
+  }
+
+  public void withoutPermissions() {
+    ResourceListFilter filter = this.getFilter(FILTER_ACL_PERMISSION_READ_NAME);
+    if (filter != null) {
+      this.removeFilter(filter);
+    }
+    filter = this.getFilter(FILTER_ACL_PERMISSION_WRITE_NAME);
+    if (filter != null) {
+      this.removeFilter(filter);
+    }
+  }
+
+  public void withReadPermission(boolean value) {
+    this.addFilter(createReadPermissionFilter(Option.option(value)));
+  }
+
+  public void withWritePermission(boolean value) {
+    this.addFilter(createWritePermissionFilter(Option.option(value)));
+  }
+
+  public Option<Boolean> getReadPermission() {
+    return this.getFilterValue(FILTER_ACL_PERMISSION_READ_NAME);
+  }
+
+  public Option<Boolean> getWritePermission() {
+    return this.getFilterValue(FILTER_ACL_PERMISSION_WRITE_NAME);
   }
 
   /**
@@ -266,6 +299,16 @@ public class SeriesListQuery extends ResourceListQueryImpl {
   public static ResourceListFilter<String> createAccessPolicyFilter(Option<String> acl) {
     return FiltersUtils.generateFilter(acl, FILTER_ACL_NAME, FILTER_ACL_LABEL, SourceType.SELECT,
             Option.some(AclListProvider.NAME));
+  }
+
+  public static ResourceListFilter<Boolean> createReadPermissionFilter(Option<Boolean> value) {
+    return FiltersUtils.generateFilter(value, FILTER_ACL_PERMISSION_READ_NAME, FILTER_ACL_PERMISSION_READ_LABEL,
+        SourceType.SELECT, Option.none());
+  }
+
+  public static ResourceListFilter<Boolean> createWritePermissionFilter(Option<Boolean> value) {
+    return FiltersUtils.generateFilter(value, FILTER_ACL_PERMISSION_WRITE_NAME, FILTER_ACL_PERMISSION_WRITE_LABEL,
+        SourceType.SELECT, Option.none());
   }
 
   /**

--- a/modules/index-service/src/main/resources/OSGI-INF/list-providers/series.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/list-providers/series.xml
@@ -7,11 +7,14 @@
   <property name="opencast.service.type"
             value="org.opencastproject.index.service.resources.list.provider.SeriesListProvider"/>
 
-  <reference name="series-service" interface="org.opencastproject.series.api.SeriesService"
-             cardinality="1..1" policy="static" bind="setSeriesService"/>
-
   <service>
     <provide interface="org.opencastproject.list.api.ResourceListProvider"/>
   </service>
 
+  <reference name="AdminUISearchIndex"
+             interface="org.opencastproject.adminui.index.AdminUISearchIndex"
+             bind="setSearchIndex"/>
+  <reference name="SecurityService"
+             interface="org.opencastproject.security.api.SecurityService"
+             bind="setSecurityService"/>
 </scr:component>


### PR DESCRIPTION
The series list provider is designed for use by the admin UI endpoints.
But the series service is used as a data source.
As the admin UI index is created for this purpose, we should make use of it.
This patch replace the data source of the series list provider by the
admin UI search index (aka. Elasticsearch).

I also run some performance measurements. Therefore I've created 5000 series with the [create-series script](https://github.com/opencast/helper-scripts/tree/master/create-series) on my local workstation and run several tests with and without this patch. The results are shown in the table below.

| Resource name/URL | Request timing avg. w/o patch | Request timing avg. w patch|
|------------------------------|------------------------------------------|----------------------------------------|
|[SERIES](http://localhost:8080/admin-ng/resources/SERIES.json) | 350ms | 400ms |
|[SERIES.TITLE_EXTENDED](http://localhost:8080/admin-ng/resources/SERIES.TITLE_EXTENDED.json) | 1000ms | 500ms |

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] be against the correct branch (features can only go into develop)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
