### PR TITLE
Fix Graphs in Documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,7 @@ jobs:
       working-directory: docs/guides/
       run: |
         pip install -q -r requirements.txt
+        pip install -q markdown-inline-graphviz-extension-png
 
     - name: build admin docs
       working-directory: docs/guides/admin/


### PR DESCRIPTION
While r/8.x is fine, the graphs are broken in the 9.x docs due to one
line being removed from the build script. This patch simply
re-introduces that line.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
