### PR TITLE
Fix kernel test with running Opencast

### DIFF
--- a/modules/kernel/src/test/java/org/opencastproject/kernel/security/TrustedHttpClientImplTest.java
+++ b/modules/kernel/src/test/java/org/opencastproject/kernel/security/TrustedHttpClientImplTest.java
@@ -137,7 +137,7 @@ public class TrustedHttpClientImplTest {
   @Test
   public void noDefaultHttpConnectionFactoryResultsInException() {
     try {
-      client.execute(new HttpPost("http://localhost:8080/fakeEndpoint"));
+      client.execute(new HttpPost("http://localhost:9/fakeEndpoint"));
       // It should fail without a default http connection factory
       Assert.fail();
     } catch (TrustedHttpClientException e) {


### PR DESCRIPTION
This patch fixes a test which would fail if something on the machine is
actually running on `localhost:8080`. This patch just uses port 9
instead which is reserved for the discard protocol and should never
respond to TCP requests.

This fixes #2313

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
