### PR TITLE
Fix variable always resolving to the default value even when set

### DIFF
--- a/modules/workflow-condition-parser/src/main/java/org/opencastproject/workflow/conditionparser/WorkflowConditionInterpreter.java
+++ b/modules/workflow-condition-parser/src/main/java/org/opencastproject/workflow/conditionparser/WorkflowConditionInterpreter.java
@@ -68,7 +68,7 @@ public final class WorkflowConditionInterpreter {
       int matchStart = matcher.start();
       int matchEnd = matcher.end();
       result.append(source, cursor, matchStart); // add the content before the match
-      String key = source.substring(matchStart + 2, matchEnd - 1);
+      String key = matcher.group("varname");
       String systemProperty = systemPropertyGetter.apply(key);
       String providedProperty = null;
       if (properties != null) {


### PR DESCRIPTION
Workflow variables such as `${my-var:my-default}` would always be
resolved to `my-default` even when `my-var` is set. This is because
the variable lookup incorrectly uses `my-var:my-default` instead
of simply `my-var`.

Related #2561

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
