### PR TITLE
Ignore not found exception when automatically archiving to another storage

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/TimedMediaArchiver.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/TimedMediaArchiver.java
@@ -149,8 +149,8 @@ public class TimedMediaArchiver extends AbstractScanner implements ManagedServic
     try {
       // Hardcoded date of zero.  Assumption: there is nothing with a date older than 0 which needs to be auto moved.
       assetManager.moveSnapshotsByDate(new Date(0), maxAge, storeId);
-    } catch (NotFoundException e) {
-      throw new RuntimeException("Unable to offload asset manager data", e);
+    } catch (NotFoundException ignore) {
+      logger.debug("No snapshots found that need to be moved");
     }
   }
 


### PR DESCRIPTION
Opencast logs an error message when no snapshots are found to be moved
to another storage. This ignores the exception and logs a debug message
instead.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
