### PR TITLE
Estimate number of frames if not declared in file

### DIFF
--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/FFmpegAnalyzer.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/FFmpegAnalyzer.java
@@ -310,6 +310,11 @@ public class FFmpegAnalyzer implements MediaAnalyzer {
             obj = stream.get("nb_frames");
             if (obj != null) {
               vMetadata.setFrames(Long.parseLong((String) obj));
+            } else if (vMetadata.getDuration() != null && vMetadata.getFrameRate() != null) {
+              long framesEstimation = Double.valueOf(vMetadata.getDuration() / 1000.0 * vMetadata.getFrameRate()).longValue();
+              if (framesEstimation >= 1) {
+                vMetadata.setFrames(framesEstimation);
+              }
             }
           }
 


### PR DESCRIPTION
Some video streams do not declare a frame count. This adds an estimate
in case duration and framerate is set, i.e. `frame count = duration * fps`.

**I'm unsure if this negatively affects #1230. How can I produce such a file? Would duration and framerate be set?**

This could (partially) address #2234 and #2235.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
