### PR TITLE
Autoconfigure Job Dispatching

### DIFF
--- a/assemblies/dist-ingest/pom.xml
+++ b/assemblies/dist-ingest/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
+    <disableJobDispatching>true</disableJobDispatching>
   </properties>
   <artifactId>opencast-dist-ingest</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-presentation/pom.xml
+++ b/assemblies/dist-presentation/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
+    <disableJobDispatching>true</disableJobDispatching>
   </properties>
   <artifactId>opencast-dist-presentation</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-worker/pom.xml
+++ b/assemblies/dist-worker/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
+    <disableJobDispatching>true</disableJobDispatching>
   </properties>
   <artifactId>opencast-dist-worker</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -153,6 +153,15 @@
                   <replaceregexp file="target/classes/package.xml" match="tar\.gz" replace="dir" byline="true"/>
                   <replaceregexp file="target/classes/package.xml" match="baseDirectory&gt;.*&lt;/baseDirectory&gt;" replace="includeBaseDirectory&gt;false&lt;/includeBaseDirectory&gt;" byline="true"/>
                 </target>
+
+                <!-- Disable job displatching in non-admin distributions -->
+                <target if="disableJobDispatching">
+                  <replaceregexp
+                    file="target/classes/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg"
+                    match="^#dispatch.interval=5$"
+                    replace="dispatch.interval=0"
+                    byline="true" />
+                </target>
               </configuration>
               <goals>
                 <goal>run</goal>

--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -4,9 +4,10 @@
 # Default: 10
 #max.attempts=10
 
-# The interval in seconds between two rounds of dispatching in the service registry. A mimimum value of 1s is enforced
+# The interval in seconds between two rounds of dispatching in the service registry. A minimum value of 1s is enforced
 # due to performance reasons. Set to 0 to disable dispatching from this service registry.
-# Service registry dispatching should be set to 0 on everything but admin or allinone!
+# Service registry dispatching is automatically set to 0 on everything but admin or allinone nodes and should usually
+# not be activated on these nodes to avoid concurrency problems.
 # Default: 5
 #dispatch.interval=5
 


### PR DESCRIPTION
Our documentation clearly states that job dispatching should be disabled
on all but admin servers to avoid concurrency problems. Nevertheless, we
see problems related to this over and over again because people missed
that.

This patch automatically sets the correct configuration for non-admin
distributions, leading to a safer default configuration.

A code fix removing the job dispatching entirely from non admin modes or
making them work in parallel (e.g. building a failover system) would be
better, but this is an easy solution and should already help a lot.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
