### PR TITLE
Replacing remaining Freenode references with Matrix

### DIFF
--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -9,8 +9,8 @@ contributed, how they are merged and how releases are done.
 *If this document does not answer all of your questions, here is how you can get further help:*
 
 * *Ask on the [Opencast Development List](https://groups.google.com/a/opencast.org/forum/#!forum/dev)*
-* *Chat with developers on [IRC (#opencast on Freenode)](http://webchat.freenode.net/?channels=opencast)*
-* *Join our weekly technical meeting (see lists or IRC)*
+* *Chat with developers on [Matrix (#opencast-community)](https://app.element.io/#/room/#opencast-community:matrix.org)*
+* *Join our weekly technical meeting (see lists or Matrix)*
 
 
 Contributing Code

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -108,8 +108,8 @@
         </div>
         <div class="col-md-6">
           <h4>IRC channel (Chat)</h4>
-          <p>For occasional quick questions we have an IRC channel on <a
-            href="https://webchat.freenode.net/?channels=opencast">Freenode</a>: <em>#opencast</em>.</p>
+          <p>For occasional quick questions we have a Matrix <a
+            href="https://app.element.io/#/room/#opencast-community:matrix.org">channel</a>: <em>#opencast-community</em>.</p>
         </div>
         <div class="col-md-6">
           <h4>Technical meeting</h4>

--- a/modules/runtime-info-ui/src/main/resources/ui/index.html
+++ b/modules/runtime-info-ui/src/main/resources/ui/index.html
@@ -79,7 +79,7 @@
           <ul class="links">
             <li><a href="https://groups.google.com/a/opencast.org/forum/#!myforums">Mailing Lists (Google
                 Groups)</a></li>
-            <li><a href="http://webchat.freenode.net/?channels=opencast">IRC-Channel (Webinterface)</a></li>
+            <li><a href="https://app.element.io/#/room/#opencast-community:matrix.org">Matrix Channel (Webinterface)</a></li>
             <li><a href="https://github.com/opencast/opencast/issues">Issue Tracker</a></li>
           </ul>
 


### PR DESCRIPTION
We either missed some, or never actually checked, but I've replaced the remaining links to Freenode with Matrix links.