### PR TITLE
Update new editor to release 2021-05-20

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-03-24/oc-editor-2021-03-24-v3.tar.gz</editor.url>
-    <editor.sha256>2858d9ba593f22d762a15bb385168ba839bbd80bdb8a60c43f53eff4f92a0e97</editor.sha256>
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-05-20/oc-editor-2021-05-20.tar.gz</editor.url>
+    <editor.sha256>7a6d901355647bda76986f1ca6f5f0f16d4d94b7d1526eb69a6ad6d2b47d25ab</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Updates the new editor frontend to a new release.

Details on important changes can be found in the release notes at https://github.com/elan-ev/opencast-editor/releases/tag/2021-05-20.

Details on the new editor that was introduced with Opencast 9.3 can be found here: https://docs.opencast.org/r/9.x/admin/#modules/editor/

This fixes #2491