### PR TITLE
Set modified date to deletion date when an event is deleted

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -192,8 +192,8 @@ function($, bootbox, _, alertify, jsyaml) {
 
     sortMap['DATE_CREATED_DESC'] = tData.recording_date_new;
     sortMap['DATE_CREATED'] = tData.recording_date_old;
-    sortMap['DATE_PUBLISHED_DESC'] = tData.publishing_date_new;
-    sortMap['DATE_PUBLISHED'] = tData.publishing_date_old;
+    sortMap['DATE_MODIFIED_DESC'] = tData.publishing_date_new;
+    sortMap['DATE_MODIFIED'] = tData.publishing_date_old;
     sortMap['TITLE'] = tData.title_a_z;
     sortMap['TITLE_DESC'] = tData.title_z_a;
     sortMap['CREATOR'] = tData.author_a_z;

--- a/modules/engage-ui/src/main/resources/ui/template/desktop.html
+++ b/modules/engage-ui/src/main/resources/ui/template/desktop.html
@@ -71,14 +71,14 @@
               </label>
             </li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_PUBLISHED_DESC" value="DATE_PUBLISHED_DESC">
-              <label for="DATE_PUBLISHED_DESC">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_MODIFIED_DESC" value="DATE_MODIFIED_DESC">
+              <label for="DATE_MODIFIED_DESC">
               <%- publishing_date_new %>
               </label>
             </li>
             <li role="presentation">
-              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_PUBLISHED" value="DATE_PUBLISHED">
-              <label for="DATE_PUBLISHED">
+              <input type="radio" class="oc-sort-dropdown" name="sort" id="DATE_MODIFIED" value="DATE_MODIFIED">
+              <label for="DATE_MODIFIED">
               <%- publishing_date_old %>
               </label>
             </li>

--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchQuery.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchQuery.java
@@ -46,7 +46,7 @@ public class SearchQuery {
 
   public enum Sort {
     DATE_CREATED,
-    DATE_PUBLISHED,
+    DATE_MODIFIED,
     TITLE,
     SERIES_ID,
     MEDIA_PACKAGE_ID,

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -227,7 +227,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               isRequired = false,
               type = RestParameter.Type.STRING,
               description = "The sort order.  May include any of the following: "
-                  + "DATE_CREATED, DATE_PUBLISHED, TITLE, SERIES_ID, MEDIA_PACKAGE_ID, CREATOR, "
+                  + "DATE_CREATED, DATE_MODIFIED, TITLE, SERIES_ID, MEDIA_PACKAGE_ID, CREATOR, "
                   + "CONTRIBUTOR, LANGUAGE, LICENSE, SUBJECT, DESCRIPTION, PUBLISHER. "
                   + "Add '_DESC' to reverse the sort order (e.g. TITLE_DESC)."
           ),
@@ -368,7 +368,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               isRequired = false,
               type = RestParameter.Type.STRING,
               description = "The sort order.  May include any of the following: "
-                  + "DATE_CREATED, DATE_PUBLISHED, TITLE, SERIES_ID, MEDIA_PACKAGE_ID, CREATOR, "
+                  + "DATE_CREATED, DATE_MODIFIED, TITLE, SERIES_ID, MEDIA_PACKAGE_ID, CREATOR, "
                   + "CONTRIBUTOR, LANGUAGE, LICENSE, SUBJECT, DESCRIPTION, PUBLISHER. "
                   + "Add '_DESC' to reverse the sort order (e.g. TITLE_DESC)."
           ),
@@ -543,7 +543,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               isRequired = false,
               type = RestParameter.Type.STRING,
               description = "The sort order.  May include any of the following: "
-                  + "DATE_CREATED, DATE_PUBLISHED, TITLE, SERIES_ID, MEDIA_PACKAGE_ID, CREATOR, "
+                  + "DATE_CREATED, DATE_MODIFIED, TITLE, SERIES_ID, MEDIA_PACKAGE_ID, CREATOR, "
                   + "CONTRIBUTOR, LANGUAGE, LICENSE, SUBJECT, DESCRIPTION, PUBLISHER. "
                   + "Add '_DESC' to reverse the sort order (e.g. TITLE_DESC)."
           ),
@@ -686,6 +686,16 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     } else {
       enumKey = sort;
       ascending = true;
+    }
+
+    // Backwards compatibility check. The enum variant was changed from
+    // `DATE_PUBLISHED` to `DATE_MODIFIED`. To not break existing applications,
+    // we fix an old `sort` value. This will be removed in a future version
+    // of Opencast.
+    if ("DATE_PUBLISHED".equals(enumKey)) {
+      enumKey = "DATE_MODIFIED";
+      logger.warn("Search API was used with deprecated sort parameter 'DATE_PUBLISHED'. "
+          + "Update all applications using this API to switch to 'DATE_MODIFIED'");
     }
 
     try {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -300,26 +300,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     }
 
     query.withSort(SearchQuery.Sort.DATE_CREATED, false);
-    if (StringUtils.isNotBlank(sort)) {
-      // Parse the sort field and direction
-      SearchQuery.Sort sortField = null;
-      if (sort.endsWith(DESCENDING_SUFFIX)) {
-        String enumKey = sort.substring(0, sort.length() - DESCENDING_SUFFIX.length()).toUpperCase();
-        try {
-          sortField = SearchQuery.Sort.valueOf(enumKey);
-          query.withSort(sortField, false);
-        } catch (IllegalArgumentException e) {
-          logger.warn("No sort enum matches '{}'", enumKey);
-        }
-      } else {
-        try {
-          sortField = SearchQuery.Sort.valueOf(sort);
-          query.withSort(sortField);
-        } catch (IllegalArgumentException e) {
-          logger.warn("No sort enum matches '{}'", sort);
-        }
-      }
-    }
+    parseSortParameter(sort, query);
     query.withLimit(limit);
     query.withOffset(offset);
 
@@ -513,26 +494,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     }
 
     search.withSort(SearchQuery.Sort.DATE_CREATED, false);
-    if (StringUtils.isNotBlank(sort)) {
-      // Parse the sort field and direction
-      SearchQuery.Sort sortField = null;
-      if (sort.endsWith(DESCENDING_SUFFIX)) {
-        String enumKey = sort.substring(0, sort.length() - DESCENDING_SUFFIX.length()).toUpperCase();
-        try {
-          sortField = SearchQuery.Sort.valueOf(enumKey);
-          search.withSort(sortField, false);
-        } catch (IllegalArgumentException e) {
-          logger.warn("No sort enum matches '{}'", enumKey);
-        }
-      } else {
-        try {
-          sortField = SearchQuery.Sort.valueOf(sort);
-          search.withSort(sortField);
-        } catch (IllegalArgumentException e) {
-          logger.warn("No sort enum matches '{}'", sort);
-        }
-      }
-    }
+    parseSortParameter(sort, search);
 
     // Build the response
     ResponseBuilder rb = Response.ok();
@@ -638,26 +600,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     }
 
     query.withSort(SearchQuery.Sort.DATE_CREATED, false);
-    if (StringUtils.isNotBlank(sort)) {
-      // Parse the sort field and direction
-      SearchQuery.Sort sortField = null;
-      if (sort.endsWith(DESCENDING_SUFFIX)) {
-        String enumKey = sort.substring(0, sort.length() - DESCENDING_SUFFIX.length()).toUpperCase();
-        try {
-          sortField = SearchQuery.Sort.valueOf(enumKey);
-          query.withSort(sortField, false);
-        } catch (IllegalArgumentException e) {
-          logger.warn("No sort enum matches '{}'", enumKey);
-        }
-      } else {
-        try {
-          sortField = SearchQuery.Sort.valueOf(sort);
-          query.withSort(sortField);
-        } catch (IllegalArgumentException e) {
-          logger.warn("No sort enum matches '{}'", sort);
-        }
-      }
-    }
+    parseSortParameter(sort, query);
     query.withLimit(limit);
     query.withOffset(offset);
 
@@ -725,4 +668,31 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
     return serviceRegistry;
   }
 
+  /**
+   * Parses the given sort parameter and calls {@code query.sortWith} with the
+   * parsed value. If the {@code sort} parameter is the empty string, nothing
+   * happens.
+   */
+  private void parseSortParameter(String sort, SearchQuery query) {
+    if (StringUtils.isBlank(sort)) {
+      return;
+    }
+
+    boolean ascending;
+    String enumKey;
+    if (sort.endsWith(DESCENDING_SUFFIX)) {
+      enumKey = sort.substring(0, sort.length() - DESCENDING_SUFFIX.length()).toUpperCase();
+      ascending = false;
+    } else {
+      enumKey = sort;
+      ascending = true;
+    }
+
+    try {
+      SearchQuery.Sort sortField = SearchQuery.Sort.valueOf(enumKey);
+      query.withSort(sortField, ascending);
+    } catch (IllegalArgumentException e) {
+      logger.warn("No sort enum matches '{}'", enumKey);
+    }
+  }
 }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -165,6 +165,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
         }
 
         searchEntity.setDeletionDate(deletionDate);
+        searchEntity.setModificationDate(deletionDate);
         em.merge(searchEntity);
       }
       tx.commit();

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -248,8 +248,9 @@ public class SolrIndexManager {
         inputDocument.setField(field, doc.get(field));
       }
 
-      // Set the oc_deleted field to the current date, then update
+      // Set the oc_deleted and oc_modified field to the given date, then update
       Schema.setOcDeleted(inputDocument, deletionDate);
+      Schema.setOcModified(inputDocument, deletionDate);
       solrServer.add(inputDocument);
       solrServer.commit();
       return true;

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -870,7 +870,7 @@ public class SolrRequester {
         return Schema.DC_CONTRIBUTOR_SORT;
       case DATE_CREATED:
         return Schema.DC_CREATED;
-      case DATE_PUBLISHED:
+      case DATE_MODIFIED:
         return Schema.OC_MODIFIED;
       case CREATOR:
         return Schema.DC_CREATOR_SORT;

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
@@ -422,10 +422,10 @@ public class SearchServiceImplTest {
     assertEquals(olderTitle, service.getByQuery(query).getItems()[0].getDcTitle());
     query.withSort(SearchQuery.Sort.DATE_CREATED, false);
     assertEquals(newerTitle, service.getByQuery(query).getItems()[0].getDcTitle());
-    // FYI: DATE_PUBLISHED is the time of Search update, not DC modified (MH-10573)
-    query.withSort(SearchQuery.Sort.DATE_PUBLISHED);
+    // FYI: DATE_MODIFIED is the time of Search update, not DC modified (MH-10573)
+    query.withSort(SearchQuery.Sort.DATE_MODIFIED);
     assertEquals(newerTitle, service.getByQuery(query).getItems()[0].getDcTitle());
-    query.withSort(SearchQuery.Sort.DATE_PUBLISHED, false);
+    query.withSort(SearchQuery.Sort.DATE_MODIFIED, false);
     assertEquals(olderTitle, service.getByQuery(query).getItems()[0].getDcTitle());
     SearchQuery q = new SearchQuery();
     q.withSort(SearchQuery.Sort.TITLE);


### PR DESCRIPTION
For the new, in-development video portal Tobira, we need to add an API to Opencast that allows received incremental updates about events and series. To implement this, it is very helpful if the modification date of events is set to the deletion date whenever an event is deleted. We think it also makes intuitive sense that "deleting" is some kind of modification. We also believe this is not a breaking change.

Please see the commit messages for more information! This PR can be reviewed commit by commit.

CC @lkiesow @JulianKniephoff 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
