### PR TITLE
Use millisecond precision in Solr date range queries (instead of secs)

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/SolrUtils.java
+++ b/modules/common/src/main/java/org/opencastproject/util/SolrUtils.java
@@ -107,11 +107,11 @@ public final class SolrUtils {
   }
 
   /**
-   * Return a date format suitable for solr. Format a date as UTC with a granularity of seconds.
-   * <code>yyyy-MM-dd'T'HH:mm:ss'Z'</code>
+   * Return a date format suitable for solr. Format a date as UTC with a granularity of
+   * milliseconds. <code>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</code>
    */
   public static DateFormat newSolrDateFormat() {
-    SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    SimpleDateFormat f = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     f.setTimeZone(TimeZone.getTimeZone("UTC"));
     return f;
   }

--- a/modules/common/src/test/java/org/opencastproject/util/SolrUtilsTest.java
+++ b/modules/common/src/test/java/org/opencastproject/util/SolrUtilsTest.java
@@ -40,7 +40,7 @@ import java.util.TimeZone;
 public class SolrUtilsTest {
 
   private static DateFormat dateFormatUTC() {
-    DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
     df.setTimeZone(TimeZone.getTimeZone("UTC"));
     return df;
   }


### PR DESCRIPTION
We store the dates in millisecond precision anyway, so our queries might as well use it. This is very useful for upcoming work on the Tobira (video portal) API. And I don't see a reason why we would want to keep the current behavior.

Now: is this a breaking change? Technically, yes, we think. If some application uses the search API, and it assumes the precision of date filters is in seconds, then that application might use some "time + 1s" logic to obtain the next date range. In that case, the application could suddenly lose some data with dates in between "time" and "time + 1s".

But we think this use case is rather fabricated. Additionally, I don't think second precision is guaranteed anywhere *and* the end of a date range is exclusive. Thus, applications should request the ranges "a to b" followed by "b to c"; and not "b + 1 to c"!

So yes, I think we can certainly merge this as non-breaking.

CC @lkiesow @JulianKniephoff 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
