### PR TITLE
Update to Elasticsearch 7.10.2

### DIFF
--- a/modules/elasticsearch-impl/pom.xml
+++ b/modules/elasticsearch-impl/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <lucene.version>8.6.2</lucene.version>
-    <elasticsearch.version>7.9.2</elasticsearch.version>
+    <lucene.version>8.7.0</lucene.version>
+    <elasticsearch.version>7.10.2</elasticsearch.version>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/elasticsearch-index/pom.xml
+++ b/modules/elasticsearch-index/pom.xml
@@ -12,7 +12,7 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <elasticsearch.version>7.9.2</elasticsearch.version>
+    <elasticsearch.version>7.10.2</elasticsearch.version>
     <checkstyle.skip>false</checkstyle.skip>
   </properties>
   <dependencies>


### PR DESCRIPTION
This patch updates Elasticsearch to fix CVE-2020-7021 and
CVE-2021-22132. Both issues should not effect Opencast and should not
need any special security attention.

Since this is a minor update, there is no need to run any other server
version than before and hence no need for any re-indexing.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
