### PR TITLE
Wording error in release notes regarding Amberscript transcriptions?

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -37,7 +37,7 @@ Features
   and to receive news about the project
 - Configure Opencast to trim the start and end automatically
   to help with issues of synchronizing audio and video streams
-- Automatically generate subscriptions with the new AmberScript integration
+- Automatically generate transcriptions with the new AmberScript integration
 - Do more with LTI: Create new events, edit or delete existing ones,
   or move them between series
 - Export statistics to CSV using a new External API endpoint


### PR DESCRIPTION
It said "subscriptions". I think either "transcriptions" or "subtitles" are meant.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
