### PR TITLE
sort the options alphabeticaly, this makes the languages field etc more readable

### DIFF
--- a/modules/lti/src/components/EditForm.tsx
+++ b/modules/lti/src/components/EditForm.tsx
@@ -66,7 +66,7 @@ function collectionToOptions(collection: EventMetadataCollection, translatable: 
         .map(([k, v]) => [parseMetadataCollectionKey(k).label, v])
         .map(([k, v]) => [translatable ? t(k) : k, v])
         .map(([k, v]) => ({ value: v, label: k}))
-        .sort((a,b) => a.label.localeCompare(b.label));
+        .sort((a,b) => a.label.localeCompare(b.label, i18next.language));
 }
 
 function MetadataFieldReadOnly(props: MetadataFieldProps) {

--- a/modules/lti/src/components/EditForm.tsx
+++ b/modules/lti/src/components/EditForm.tsx
@@ -49,10 +49,24 @@ function parseMetadataCollectionKey(s: string): MetadataCollectionKey {
 }
 
 function collectionToOptions(collection: EventMetadataCollection, translatable: boolean, t: i18next.TFunction): OptionType[] {
-    return collectionToPairs(collection)
+    const pairs = collectionToPairs(collection);
+    //Check if we get a JSON object back, and that this contains the order field
+    //Use the order field in this case to determine to order of the items in the dropdown
+    if(pairs[0][0].startsWith("{") === true) {
+        if(Object.prototype.hasOwnProperty.call(JSON.parse(pairs[0][0]), "order") === true) {
+            return pairs
+                .sort((a,b)  => JSON.parse(a[0]).order - JSON.parse(b[0]).order)
+                .map(([k, v]) => [parseMetadataCollectionKey(k).label, v])
+                .map(([k, v]) => [translatable ? t(k) : k, v])
+                .map(([k, v]) => ({ value: v, label: k}));
+        }
+    }
+    //Otherwise just return an alphabetically sorted list
+    return pairs
         .map(([k, v]) => [parseMetadataCollectionKey(k).label, v])
         .map(([k, v]) => [translatable ? t(k) : k, v])
-        .map(([k, v]) => ({ value: v, label: k })).sort((a,b) => a.label.localeCompare(b.label));
+        .map(([k, v]) => ({ value: v, label: k}))
+        .sort((a,b) => a.label.localeCompare(b.label));
 }
 
 function MetadataFieldReadOnly(props: MetadataFieldProps) {

--- a/modules/lti/src/components/EditForm.tsx
+++ b/modules/lti/src/components/EditForm.tsx
@@ -52,7 +52,7 @@ function collectionToOptions(collection: EventMetadataCollection, translatable: 
     return collectionToPairs(collection)
         .map(([k, v]) => [parseMetadataCollectionKey(k).label, v])
         .map(([k, v]) => [translatable ? t(k) : k, v])
-        .map(([k, v]) => ({ value: v, label: k }));
+        .map(([k, v]) => ({ value: v, label: k })).sort((a,b) => a.label.localeCompare(b.label));
 }
 
 function MetadataFieldReadOnly(props: MetadataFieldProps) {


### PR DESCRIPTION
We had some complaints of our users that the language and license options field with the lti upload were difficult to use because there was no kind of sorting applied and the list seemed random. This applies a simple alphabetical sort to the options for the language field and the licenses field.