### PR TITLE
change translation for the video file upload from the lti tool

### DIFF
--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -38,6 +38,8 @@
      "CURRENT_JOBS": "Today's jobs",
      "PRESENTER": "Presenter",
      "PRESENTER_DESCRIPTION": "Video file for the presenter track",
+     "VIDEOFILE": "Videofile",
+     "VIDEOFILE_DESCRIPTION": "Video file for upload",
      "CAPTION": "Captions",
      "CAPTION_DESCRIPTION": "Caption file; VTT format is supported",
      "UPLOAD": "Upload",

--- a/modules/lti/src/components/EditForm.tsx
+++ b/modules/lti/src/components/EditForm.tsx
@@ -158,9 +158,9 @@ class TranslatedEditForm extends React.Component<EditFormProps> {
                     valueChange={this.fieldValueChange.bind(this)} />)}
             {this.props.withUpload === true &&
                 <div className="form-group">
-                    <label htmlFor="presenter">{this.props.t("LTI.PRESENTER")}</label>
+                    <label htmlFor="presenter">{this.props.t("LTI.VIDEOFILE")}</label>
                     <input type="file" className="form-control-file" onChange={this.onChangePresenterFile.bind(this)} />
-                    <small className="form-text text-muted">{this.props.t("LTI.PRESENTER_DESCRIPTION")}</small>
+                    <small className="form-text text-muted">{this.props.t("LTI.VIDEOFILE_DESCRIPTION")}</small>
                 </div>
             }
             {this.props.withUpload === true &&


### PR DESCRIPTION
We had some comments from our users regarding the label for the videofile to select during the upload via LTI. Since there is only a single video available for upload the label "Presenter" is unclear for end-users when they have to select their videofile. Does it make sense to change this label to "Videofile" instead of presenter. This is different from every other form in opencast, but when using opencast as a video system for an LMS, using the LTI upload form to enable users to upload user generated content, this label does not seem to make a lot of sense. 