### PR TITLE
Document encode WOH's source-flavors config key

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
@@ -28,7 +28,7 @@ Parameter Table
 ¹If source-flavour**s** are specified, media of these flavors are considered, if not, media matching the source-flavour
 configuration option is considered.
 
-As explained in the ["Encoding Profile Example"](#encoding) section, every media file created by an encode operation
+As explained in the ["Encoding Profile Example" section](#encoding-profile-example), every media file created by an encode operation
 has its own named suffix. The suffix name is defined in the encode profile definition. It will be added as a tag to the
 corresponding track in the media package. This is different from the `target-tags` workflow operation parameter, which
 will cause the specified tag list to be added to every media file created by the operation.
@@ -58,8 +58,6 @@ Operation Example
 
 Encoding Profile Example
 ------------------------
-
-<a name="encoding"></a>
 
 Unlike a regular compose operation, this operation can generate more than one output file and, therefore, more than one
 media package track elements. In order to distinguish these tracks, the encoding profile syntax for this operation

--- a/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
@@ -16,18 +16,22 @@ better use of multiple CPU cores.
 Parameter Table
 ---------------
 
-|configuration keys|example           |description                           |
-|------------------|------------------|--------------------------------------|
-|source-flavor     |presenter/work    |Which media should be encoded         |
-|target-flavor     |presenter/delivery|Specifies the flavor of the new media |
-|source-tags       |sometag           |Tags of media to encode               |
-|target-tags       |sometag           |Specifies the tags of the new media   |
-|encoding-profile  |webm-hd           |Specifies the encoding profile to use |
+|configuration keys|example                             |description                                                    |
+|------------------|------------------------------------|---------------------------------------------------------------|
+|source-flavor¹    |presenter/work                      |Single flavor specifying media to be encoded                   |
+|source-flavors¹   |presenter/work,presentation/work    |Comma-separated list of flavors specifying media to be encoded |
+|target-flavor     |presenter/delivery                  |Flavor of the new media                                        |
+|source-tags       |sometag                             |Comma-separated list of tags of media to encode                |
+|target-tags       |sometag                             |Comma-separated list of tags to be assigned to the new media   |
+|encoding-profile  |parallel.http                       |Encoding profile to use                                        |
 
-As explained in the "Encoding Profile" section, every media file created by an encode operation has its own named
-suffix. The suffix name is defined in the encode profile definition. It will be added as a tag to the corresponding
-track in the media package. This is different from the `target-tags` workflow operation parameter, which will cause the
-specified tag list to be added to every media file created by the operation.
+¹If source-flavour**s** are specified, media of these flavors are considered, if not, media matching the source-flavour
+configuration option is considered.
+
+As explained in the ["Encoding Profile Example"](#encoding) section, every media file created by an encode operation
+has its own named suffix. The suffix name is defined in the encode profile definition. It will be added as a tag to the
+corresponding track in the media package. This is different from the `target-tags` workflow operation parameter, which
+will cause the specified tag list to be added to every media file created by the operation.
 
 For instance, let us take the example operation and encoding profile defined in this documentation. After a successful
 run of the operation, the media package will contain four new tracks: the first one containing the new tags
@@ -54,6 +58,8 @@ Operation Example
 
 Encoding Profile Example
 ------------------------
+
+<a name="encoding"></a>
 
 Unlike a regular compose operation, this operation can generate more than one output file and, therefore, more than one
 media package track elements. In order to distinguish these tracks, the encoding profile syntax for this operation


### PR DESCRIPTION
because they are used in the example workflows provided by Opencast.

Leaving out the source-tag and target-tag which are also supported by the
Encode WOH because I see no value in them and if they haven't been
documented yet, they might not be used by anyone.

https://groups.google.com/a/opencast.org/g/users/c/5ktt5SdIzNU
modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java#L391
modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java#L131

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
