### PR TITLE
Removed Paella Player Play Button when pausing playback

### DIFF
--- a/etc/ui-config/mh_default_org/paella/config.json
+++ b/etc/ui-config/mh_default_org/paella/config.json
@@ -315,7 +315,8 @@
         "enabled": true
       },
       "es.upv.paella.playButtonOnScreenPlugin": {
-        "enabled": true
+        "enabled": true,
+        "showOnPause": false
       },
       "es.upv.paella.translecture.captionsPlugin": {
         "enabled": true

--- a/modules/engage-paella-player/gulpfile.js
+++ b/modules/engage-paella-player/gulpfile.js
@@ -29,7 +29,7 @@ var source = require('vinyl-source-stream');
 var gunzip = require('gulp-gunzip');
 var untar = require('gulp-untar');
 
-var PAELLA_VERSION = '6.4.3';
+var PAELLA_VERSION = '6.4.4';
 
 var buildPath = 'target/gulp',
     paellaSrc = 'src/main/paella-opencast',


### PR DESCRIPTION
Includes a new Paella Player config option that disables the play button when pausing playback. This requires a minor version bump for the Paella Player. I would like to suggest this as a new default setting, based on the reasoning in #2570.

Resolves #2570.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
