### PR TITLE
Don't list docs twice

### DIFF
--- a/docs/scripts/service/opencast.service
+++ b/docs/scripts/service/opencast.service
@@ -5,7 +5,6 @@ Documentation=https://docs.opencast.org
 After=local-fs.target
 After=network.target
 After=remote-fs.target
-Documentation=https://docs.opencast.org
 
 [Service]
 ExecStart=/opt/opencast/bin/start-opencast server


### PR DESCRIPTION
The documentation if referenced twice in the Systemd Unit which does not make a lot of sense.
This removes one of them.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
