### PR TITLE
Fix `metrics-exporter` Prometheus dependency

### DIFF
--- a/modules/metrics-exporter/pom.xml
+++ b/modules/metrics-exporter/pom.xml
@@ -95,12 +95,13 @@
             <Import-Package>
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,
+              !io.opentelemetry.*,
               *
             </Import-Package>
             <Embed-Dependency>
-              simpleclient,
-              simpleclient_common
+              *;groupId=io.prometheus,
             </Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
This PR embeds all relevant Prometheus dependencies
(even transitive ones) into the `metrics-exporter` bundle;
some new ones were missing due to the `0.11.0` update.
The update also seems to add some new functionality related
to OpenTelemetry, which we don't use (:crossed_fingers:),
but which we still need to exlude from the generated `Import-Packages`
header.

### Your pull request should…

* [x] have a concise title
* [x] ~~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
