### PR TITLE
Add workflow state for standalone editor

### DIFF
--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
@@ -26,6 +26,7 @@ import org.opencastproject.util.data.Tuple;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +35,7 @@ import java.util.List;
  * Provides access to the parsed editing information
  */
 public final class EditingData {
+  public static final String WORKFLOW_ACTIVE = "workflow_active";
   private final List<SegmentData> segments;
   private final List<WorkflowData> workflows;
   private final List<TrackData> tracks;
@@ -41,10 +43,11 @@ public final class EditingData {
   private final String date;
   private final Long duration;
   private final SeriesData series;
+  @SerializedName(WORKFLOW_ACTIVE)
+  private final Boolean workflowActive;
 
-  public EditingData(List<SegmentData> segments, List<TrackData> tracks,
-          List<WorkflowData> workflows, Long duration, String title, String recordingStartDate, String seriesId,
-          String seriesName) {
+  public EditingData(List<SegmentData> segments, List<TrackData> tracks, List<WorkflowData> workflows, Long duration,
+          String title, String recordingStartDate, String seriesId, String seriesName, Boolean workflowActive) {
     this.segments = segments;
     this.tracks = tracks;
     this.workflows = workflows;
@@ -52,6 +55,7 @@ public final class EditingData {
     this.title = title;
     this.date = recordingStartDate;
     this.series = new SeriesData(seriesId, seriesName);
+    this.workflowActive = workflowActive;
   }
 
   public static EditingData parse(String json) {

--- a/modules/editor-service-api/src/test/resources/edit.json
+++ b/modules/editor-service-api/src/test/resources/edit.json
@@ -1,6 +1,7 @@
 {
   "date": "2021-01-13T12:34:35Z",
   "duration": 30000,
+  "workflow_active": true,
   "series": {
     "id": "c60d6a65-2948-489d-95a4-894422b4f59d",
     "title": "Test-Series"

--- a/modules/editor-service-endpoint/src/main/docs/editor-service-swagger.yaml
+++ b/modules/editor-service-endpoint/src/main/docs/editor-service-swagger.yaml
@@ -41,6 +41,10 @@ paths:
                     description: Title of the video 
                     type: string
                     example: "Video title"
+                  workflow_active:
+                    description: Is a workflow runing
+                    type: boolean
+                    example: false
                   date:
                     description: Creation date 
                     type: string

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -610,9 +610,11 @@ public class EditorServiceImpl implements EditorService {
 
   @Override
   public EditingData getEditData(final String mediaPackageId) throws EditorServiceException {
-    // Select tracks
+
     Event event = getEvent(mediaPackageId);
     MediaPackage mp = getMediaPackage(event);
+
+    boolean workflowActive = WorkflowUtil.isActive(event.getWorkflowState());
 
     final Opt<Publication> internalPubOpt = getInternalPublication(mp);
     if (internalPubOpt.isNone() || internalPubOpt.isEmpty()) {
@@ -676,7 +678,7 @@ public class EditorServiceImpl implements EditorService {
     }).collect(Collectors.toList());
 
     return new EditingData(segments, tracks, workflows, mp.getDuration(), mp.getTitle(), event.getRecordingStartDate(),
-            event.getSeriesId(), event.getSeriesName());
+            event.getSeriesId(), event.getSeriesName(), workflowActive);
   }
 
   private MediaPackage getMediaPackage(Event event) throws EditorServiceException {


### PR DESCRIPTION
Currently users of the new standalone editor are not aware if a workflow is running on an event and thus they are not aware if they are able to store their changes on an edited event. This PR adds a boolean field called `workflow_active` to the editor endpoint that shows if a workflow is currently running on a given event.

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
