### PR TITLE
Event status will not change after removing the workflow

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/index/event/Event.java
@@ -876,6 +876,14 @@ public class Event implements IndexObject {
 
     if (getWorkflowId() != null && StringUtils.isNotBlank(getWorkflowState())) {
       eventStatus = workflowStatusMapping.get(getWorkflowState());
+    } else if ("EVENTS.EVENTS.STATUS.PROCESSED".equals(eventStatus)
+            && (RecordingState.CAPTURE_FINISHED.equals(getRecordingStatus())
+            || RecordingState.UPLOAD_FINISHED.equals(getRecordingStatus()))) {
+      eventStatus = "EVENTS.EVENTS.STATUS.PROCESSED";
+    } else if ("EVENTS.EVENTS.STATUS.PROCESSING_FAILURE".equals(eventStatus)
+            && RecordingState.CAPTURE_ERROR.equals(getRecordingStatus())
+            || RecordingState.UPLOAD_ERROR.equals(getRecordingStatus())) {
+      eventStatus = recordingStatusMapping.get(getRecordingStatus());
     } else if (StringUtils.isNotBlank(getRecordingStatus())) {
       eventStatus = recordingStatusMapping.get(getRecordingStatus());
     } else if (isScheduledEvent()) {


### PR DESCRIPTION
closes #1596 

When the status of an event is "Finished" and the workflow is deleted via REST (or the "WorkflowCleanupScanner), the status were updated based on the "recording_status" field. When an event wasn't uploaded and the workflow was deleted, the recording status were (and is)  "capture_finished" and the event status was set back to "recording". When an event was uploaded, the recording status is "uploading_finished" and the event status were set to "ingesting" after deleting the workflow.

This fix simply adds new if statements when the event status gets updated.

To test this, just create a new event (recorded via scheduler) and delete the workflow after the event status is set to "finished". The status should remain the same. It should work when the event was uploaded and when it wasn't. The status should also remain the same, when an error occurred while recording or uploading and the event status was set to "error" (or something similar).