### PR TITLE
Move just the latest snapshot to S3

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/move-storage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/move-storage-woh.md
@@ -8,7 +8,7 @@ The MoveStorageOperationHandler can be used to move files in the Asset Manager f
 |Configuration Key|Example           |Description                                       |
 |:----------------|:----------------:|:-------------------------------------------------|
 |target-storage*  |local-storage     |The ID of the storage to move the files to        |
-|target-version   |0                 |The (optional) snapshot version to move           |
+|target-version   |0                 |The (optional) snapshot version to move. Use the keyword `latest` to move the last snapshot version.           |
 
 \* mandatory configuration key
 

--- a/modules/asset-manager-workflowoperation/pom.xml
+++ b/modules/asset-manager-workflowoperation/pom.xml
@@ -43,6 +43,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.entwinemedia.common</groupId>
+      <artifactId>functional</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/asset-manager-workflowoperation/src/main/resources/OSGI-INF/operations/move-storage.xml
+++ b/modules/asset-manager-workflowoperation/src/main/resources/OSGI-INF/operations/move-storage.xml
@@ -12,6 +12,8 @@
   </service>
   <reference name="asset-manager-job-producer" interface="org.opencastproject.assetmanager.impl.TieredStorageAssetManagerJobProducer"
              cardinality="1..1" policy="static" bind="setJobProducer"/>
+  <reference name="asset-manager" interface="org.opencastproject.assetmanager.api.AssetManager"
+             cardinality="1..1" policy="static" bind="setAssetManager"/>
   <reference name="ServiceRegistry" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
              cardinality="1..1" policy="static" bind="setServiceRegistry"/>
 </scr:component>


### PR DESCRIPTION
We needed to upload just the last archived version of an event to S3. Currently it is only possible to specify an explicit snapshot version or move all snapshots to S3 by the `Move-Storage`-WOH. This PR makes it possible to also specify the string `latest` as `asset-version`, to move just the latest snapshot to S3.     

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
