### PR TITLE
Update some documentation URLs from latest to develop

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -349,7 +349,7 @@ karaf.pid.file=${karaf.data}/pid
 # distributed artifacts on the downloads and streaming servers, all of which are protected by verification components.
 # Default is 60 seconds as it shouldn't take longer than that to make a request to a server. This will have no impact on
 # a system where url signing is not configured. For more information please see:
-# http://docs.opencast.org/latest/admin/configuration/stream-security/#configuration-of-url-signing-timeout-values
+# http://docs.opencast.org/develop/admin/configuration/stream-security/#configuration-of-url-signing-timeout-values
 #org.opencastproject.security.internal.url.signing.duration=60
 
 

--- a/etc/org.opencastproject.adminui.endpoint.OsgiEventEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.OsgiEventEndpoint.cfg
@@ -1,7 +1,7 @@
 # Stream Security Configuration:
 
 # For further information please see:
-# http://docs.opencast.org/latest/admin/configuration/stream-security/
+# http://docs.opencast.org/develop/admin/configuration/stream-security/
 
 # This property changes the number of seconds from when a link in the admin ui is signed until is expires. Default is
 # 7200 seconds (2 hours) which should give the user more than enough time to access the content. Content that is being

--- a/etc/org.opencastproject.adminui.endpoint.ToolsEndpoint.cfg
+++ b/etc/org.opencastproject.adminui.endpoint.ToolsEndpoint.cfg
@@ -1,7 +1,7 @@
 # Stream Security Configuration:
 
 # For further information please see:
-# http://docs.opencast.org/latest/admin/configuration/stream-security/
+# http://docs.opencast.org/develop/admin/configuration/stream-security/
 
 # This property changes the number of seconds from when a request is made for a resource from the preview / editor until
 # its signed URL will expire. For example this would control the expiry duration for signed URLs for video files

--- a/etc/org.opencastproject.editor.EditorServiceImpl.cfg
+++ b/etc/org.opencastproject.editor.EditorServiceImpl.cfg
@@ -33,7 +33,7 @@
 # Stream Security Configuration:
 
 # For further information please see:
-# http://docs.opencast.org/latest/admin/configuration/stream-security/
+# http://docs.opencast.org/develop/admin/configuration/stream-security/
 
 # This property changes the number of seconds from when a request is made for a resource from the preview / editor until
 # its signed URL will expire. For example this would control the expiry duration for signed URLs for video files

--- a/etc/org.opencastproject.security.urlsigning.SigningMediaPackageSerializer.cfg
+++ b/etc/org.opencastproject.security.urlsigning.SigningMediaPackageSerializer.cfg
@@ -1,7 +1,7 @@
 # Stream Security Configuration:
 
 # For further information please see:
-# http://docs.opencast.org/latest/admin/configuration/stream-security/
+# http://docs.opencast.org/develop/admin/configuration/stream-security/
 
 # This property changes the number of seconds from when a request is made for a resource from the search service until
 # its signed URL will expire. For example this would control the expiry duration for signed URLs for video files

--- a/etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg
+++ b/etc/org.opencastproject.security.urlsigning.provider.impl.GenericUrlSigningProvider.cfg
@@ -18,7 +18,7 @@
 # Important: For all URL prefixes, no URL prefix may be a prefix of any other URL prefix
 
 # For further information please see:
-# http://docs.opencast.org/latest/admin/configuration/stream-security/
+# http://docs.opencast.org/develop/admin/configuration/stream-security/
 
 # A typical configuration looks like this:
 

--- a/etc/org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg
+++ b/etc/org.opencastproject.security.urlsigning.provider.impl.WowzaUrlSigningProvider.cfg
@@ -16,7 +16,7 @@
         # multiple distributions and different key pairs.
 
 # For further information please see:
-# http://docs.opencast.org/latest/admin/configuration/stream-security/
+# http://docs.opencast.org/develop/admin/configuration/stream-security/
 
 # A typical configuration looks like this:
 

--- a/etc/org.opencastproject.security.urlsigning.verifier.impl.UrlSigningVerifierImpl.cfg
+++ b/etc/org.opencastproject.security.urlsigning.verifier.impl.UrlSigningVerifierImpl.cfg
@@ -16,4 +16,4 @@
 # etc/org.opencastproject.security.urlsigning.filter.UrlSigningFilter.cfg
 
 # For further information please see:
-# http://docs.opencast.org/latest/admin/configuration/stream-security/
+# http://docs.opencast.org/develop/admin/configuration/stream-security/


### PR DESCRIPTION
Somewhere in the past, the "latest" route was replaced with "develop" when referring to the documentation in the develop branch.

However, some document link references haven't been updated in configuration files. This is now done.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
