### PR TITLE
Admin UI editor segment list item delete button position fixed

### DIFF
--- a/modules/admin-ui-frontend/app/styles/components/video/_video-editor.scss
+++ b/modules/admin-ui-frontend/app/styles/components/video/_video-editor.scss
@@ -679,7 +679,7 @@ $segment-deleted-selected: saturate(darken($segment-deleted, 25%), 5%);
 
 .editor-segments {
     padding: 4px 12px 4px 12px;
-    min-width: 400px;
+    min-width: 420px;
     display: inline-block;
 
     $segment-list-element-height: 35px;


### PR DESCRIPTION
The delete button position in the Admin UI editor was broken for some locales, like German.

Before:
![image](https://user-images.githubusercontent.com/26736/121082814-f14db180-c7de-11eb-8b8c-68f11a87e947.png)

After:
![image](https://user-images.githubusercontent.com/26736/121082881-0296be00-c7df-11eb-8231-24e301e526e3.png)



* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
