### PR TITLE
Add JVM metrics to metrics exporter

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -118,6 +118,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-kernel/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-list-providers-service/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-metadata-api/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-metrics-exporter/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-mpeg7/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-runtime-info/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-scheduler-api/${project.version}</bundle>
@@ -222,7 +223,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-message-broker-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-message-broker-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-metadata/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-metrics-exporter/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-oaipmh/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-oaipmh-api/${project.version}</bundle>
@@ -345,7 +345,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-message-broker-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-message-broker-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-metadata/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-metrics-exporter/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-oaipmh-persistence/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-presets/${project.version}</bundle>
@@ -498,7 +497,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-message-broker-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-message-broker-impl/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-metadata/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-metrics-exporter/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-notification-workflowoperation/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-oaipmh/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-oaipmh-api/${project.version}</bundle>

--- a/docs/guides/admin/docs/modules/metrics.md
+++ b/docs/guides/admin/docs/modules/metrics.md
@@ -8,9 +8,8 @@ tools like [Prometheus](https://prometheus.io). The endpoint is available at `/m
 Available Metrics
 -----------------
 
-Opencast metrics are retrieved directly from the service registry and describe the current work load of the Opencast 
-cluster. There should usually be no need for monitoring Opencast metrics on several servers of a cluster. All will
-produce identical metrics. The standard JVM metrics, however, are specific to each server.
+Opencast related metrics describe the whole cluster and will be identical on all nodes
+while JVM metrics are specific to each node.
 
 These available metrics allow monitoring the current cluster state when it comes to processing
 and should allow for good alerting rules:
@@ -53,9 +52,9 @@ opencast_asset_manager_events{organization="mh_default_org",} 1.0
 ```
 
 Additionally, standard JVM metrics are exported providing information about e.g. memory and CPU usage, threads,
-classloading, etc. The JVM metrics collectors are documented [here](https://prometheus.github.io/client_java/).
-A corresponding monitoring mixin with dashboards and alerting rules can be found
-[here](https://github.com/grafana/jsonnet-libs/tree/master/jvm-mixin).
+classloading, etc. For more information, take a look at the [Java client's JavaDoc](https://prometheus.github.io/client_java/).
+A corresponding monitoring mixin with dashboards and alerting rules can be found at
+[github.com/grafana/jsonnet-libs](https://github.com/grafana/jsonnet-libs/tree/master/jvm-mixin).
 
 Access
 ------

--- a/docs/guides/admin/docs/modules/metrics.md
+++ b/docs/guides/admin/docs/modules/metrics.md
@@ -8,10 +8,11 @@ tools like [Prometheus](https://prometheus.io). The endpoint is available at `/m
 Available Metrics
 -----------------
 
-Metrics are retrieved directly from the service registry and describe the current work load of the Opencast cluster.
-There should usually be no need for monitoring several serves of a cluster. All will produce identical metrics.
+Opencast metrics are retrieved directly from the service registry and describe the current work load of the Opencast 
+cluster. There should usually be no need for monitoring Opencast metrics on several servers of a cluster. All will
+produce identical metrics. The standard JVM metrics, however, are specific to each server.
 
-This available metrics allow monitoring the current cluster state when it comes to processing
+These available metrics allow monitoring the current cluster state when it comes to processing
 and should allow for good alerting rules:
 
 - How many workflows are being processed
@@ -19,7 +20,7 @@ and should allow for good alerting rules:
 - Are there any services in a warning or error state
 - How many events are in the asset manager
 
-Here is a complete list of available metrics:
+Here is a complete list of the available metrics specific to Opencast:
 
 ```
 # HELP opencast_services_total Number of services in a cluster
@@ -51,6 +52,10 @@ requests_total 1.0
 opencast_asset_manager_events{organization="mh_default_org",} 1.0
 ```
 
+Additionally, standard JVM metrics are exported providing information about e.g. memory and CPU usage, threads,
+classloading, etc. The JVM metrics collectors are documented [here](https://prometheus.github.io/client_java/).
+A corresponding monitoring mixin with dashboards and alerting rules can be found
+[here](https://github.com/grafana/jsonnet-libs/tree/master/jvm-mixin).
 
 Access
 ------

--- a/docs/guides/admin/docs/modules/metrics.md
+++ b/docs/guides/admin/docs/modules/metrics.md
@@ -19,7 +19,7 @@ and should allow for good alerting rules:
 - Are there any services in a warning or error state
 - How many events are in the asset manager
 
-Here is a complete list of the available metrics specific to Opencast:
+Here is a complete list of the available Opencast related metrics:
 
 ```
 # HELP opencast_services_total Number of services in a cluster
@@ -52,8 +52,187 @@ opencast_asset_manager_events{organization="mh_default_org",} 1.0
 ```
 
 Additionally, standard JVM metrics are exported providing information about e.g. memory and CPU usage, threads,
-classloading, etc. For more information, take a look at the [Java client's JavaDoc](https://prometheus.github.io/client_java/).
-A corresponding monitoring mixin with dashboards and alerting rules can be found at
+classloading, etc. Here is a complete list of the available JVM metrics with exemplary values:
+
+```
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 117.251697
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.623394602475E9
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 627.0
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 10240.0
+
+# HELP jvm_memory_objects_pending_finalization The number of objects waiting in the finalizer queue.
+# TYPE jvm_memory_objects_pending_finalization gauge
+jvm_memory_objects_pending_finalization 0.0
+# HELP jvm_memory_bytes_used Used bytes of a given JVM memory area.
+# TYPE jvm_memory_bytes_used gauge
+jvm_memory_bytes_used{area="heap",} 2.74153448E8
+jvm_memory_bytes_used{area="nonheap",} 2.04918736E8
+# HELP jvm_memory_bytes_committed Committed (bytes) of a given JVM memory area.
+# TYPE jvm_memory_bytes_committed gauge
+jvm_memory_bytes_committed{area="heap",} 4.37256192E8
+jvm_memory_bytes_committed{area="nonheap",} 2.25353728E8
+# HELP jvm_memory_bytes_max Max (bytes) of a given JVM memory area.
+# TYPE jvm_memory_bytes_max gauge
+jvm_memory_bytes_max{area="heap",} 1.073741824E9
+jvm_memory_bytes_max{area="nonheap",} -1.0
+# HELP jvm_memory_bytes_init Initial bytes of a given JVM memory area.
+# TYPE jvm_memory_bytes_init gauge
+jvm_memory_bytes_init{area="heap",} 1.34217728E8
+jvm_memory_bytes_init{area="nonheap",} 7667712.0
+# HELP jvm_memory_pool_bytes_used Used bytes of a given JVM memory pool.
+# TYPE jvm_memory_pool_bytes_used gauge
+jvm_memory_pool_bytes_used{pool="CodeHeap 'non-nmethods'",} 1361536.0
+jvm_memory_pool_bytes_used{pool="Metaspace",} 1.36619544E8
+jvm_memory_pool_bytes_used{pool="CodeHeap 'profiled nmethods'",} 3.937024E7
+jvm_memory_pool_bytes_used{pool="Compressed Class Space",} 1.5748792E7
+jvm_memory_pool_bytes_used{pool="G1 Eden Space",} 1.24780544E8
+jvm_memory_pool_bytes_used{pool="G1 Old Gen",} 1.31547112E8
+jvm_memory_pool_bytes_used{pool="G1 Survivor Space",} 1.7825792E7
+jvm_memory_pool_bytes_used{pool="CodeHeap 'non-profiled nmethods'",} 1.1818624E7
+# HELP jvm_memory_pool_bytes_committed Committed bytes of a given JVM memory pool.
+# TYPE jvm_memory_pool_bytes_committed gauge
+jvm_memory_pool_bytes_committed{pool="CodeHeap 'non-nmethods'",} 2555904.0
+jvm_memory_pool_bytes_committed{pool="Metaspace",} 1.51691264E8
+jvm_memory_pool_bytes_committed{pool="CodeHeap 'profiled nmethods'",} 3.9452672E7
+jvm_memory_pool_bytes_committed{pool="Compressed Class Space",} 1.9791872E7
+jvm_memory_pool_bytes_committed{pool="G1 Eden Space",} 2.33832448E8
+jvm_memory_pool_bytes_committed{pool="G1 Old Gen",} 1.85597952E8
+jvm_memory_pool_bytes_committed{pool="G1 Survivor Space",} 1.7825792E7
+jvm_memory_pool_bytes_committed{pool="CodeHeap 'non-profiled nmethods'",} 1.1862016E7
+# HELP jvm_memory_pool_bytes_max Max bytes of a given JVM memory pool.
+# TYPE jvm_memory_pool_bytes_max gauge
+jvm_memory_pool_bytes_max{pool="CodeHeap 'non-nmethods'",} 5836800.0
+jvm_memory_pool_bytes_max{pool="Metaspace",} -1.0
+jvm_memory_pool_bytes_max{pool="CodeHeap 'profiled nmethods'",} 1.22908672E8
+jvm_memory_pool_bytes_max{pool="Compressed Class Space",} 1.073741824E9
+jvm_memory_pool_bytes_max{pool="G1 Eden Space",} -1.0
+jvm_memory_pool_bytes_max{pool="G1 Old Gen",} 1.073741824E9
+jvm_memory_pool_bytes_max{pool="G1 Survivor Space",} -1.0
+jvm_memory_pool_bytes_max{pool="CodeHeap 'non-profiled nmethods'",} 1.22912768E8
+# HELP jvm_memory_pool_bytes_init Initial bytes of a given JVM memory pool.
+# TYPE jvm_memory_pool_bytes_init gauge
+jvm_memory_pool_bytes_init{pool="CodeHeap 'non-nmethods'",} 2555904.0
+jvm_memory_pool_bytes_init{pool="Metaspace",} 0.0
+jvm_memory_pool_bytes_init{pool="CodeHeap 'profiled nmethods'",} 2555904.0
+jvm_memory_pool_bytes_init{pool="Compressed Class Space",} 0.0
+jvm_memory_pool_bytes_init{pool="G1 Eden Space",} 2.7262976E7
+jvm_memory_pool_bytes_init{pool="G1 Old Gen",} 1.06954752E8
+jvm_memory_pool_bytes_init{pool="G1 Survivor Space",} 0.0
+jvm_memory_pool_bytes_init{pool="CodeHeap 'non-profiled nmethods'",} 2555904.0
+# HELP jvm_memory_pool_collection_used_bytes Used bytes after last collection of a given JVM memory pool.
+# TYPE jvm_memory_pool_collection_used_bytes gauge
+jvm_memory_pool_collection_used_bytes{pool="G1 Eden Space",} 0.0
+jvm_memory_pool_collection_used_bytes{pool="G1 Old Gen",} 1.29009136E8
+jvm_memory_pool_collection_used_bytes{pool="G1 Survivor Space",} 1.7825792E7
+# HELP jvm_memory_pool_collection_committed_bytes Committed after last collection bytes of a given JVM memory pool.
+# TYPE jvm_memory_pool_collection_committed_bytes gauge
+jvm_memory_pool_collection_committed_bytes{pool="G1 Eden Space",} 2.33832448E8
+jvm_memory_pool_collection_committed_bytes{pool="G1 Old Gen",} 2.21249536E8
+jvm_memory_pool_collection_committed_bytes{pool="G1 Survivor Space",} 1.7825792E7
+# HELP jvm_memory_pool_collection_max_bytes Max bytes after last collection of a given JVM memory pool.
+# TYPE jvm_memory_pool_collection_max_bytes gauge
+jvm_memory_pool_collection_max_bytes{pool="G1 Eden Space",} -1.0
+jvm_memory_pool_collection_max_bytes{pool="G1 Old Gen",} 1.073741824E9
+jvm_memory_pool_collection_max_bytes{pool="G1 Survivor Space",} -1.0
+# HELP jvm_memory_pool_collection_init_bytes Initial after last collection bytes of a given JVM memory pool.
+# TYPE jvm_memory_pool_collection_init_bytes gauge
+jvm_memory_pool_collection_init_bytes{pool="G1 Eden Space",} 2.7262976E7
+jvm_memory_pool_collection_init_bytes{pool="G1 Old Gen",} 1.06954752E8
+jvm_memory_pool_collection_init_bytes{pool="G1 Survivor Space",} 0.0
+
+# HELP jvm_memory_pool_allocated_bytes_created Total bytes allocated in a given JVM memory pool. Only updated after GC, not continuously.
+# TYPE jvm_memory_pool_allocated_bytes_created gauge
+jvm_memory_pool_allocated_bytes_created{pool="CodeHeap 'profiled nmethods'",} 1.623394629741E9
+jvm_memory_pool_allocated_bytes_created{pool="G1 Old Gen",} 1.623394629746E9
+jvm_memory_pool_allocated_bytes_created{pool="G1 Eden Space",} 1.623394629746E9
+jvm_memory_pool_allocated_bytes_created{pool="CodeHeap 'non-profiled nmethods'",} 1.623394629746E9
+jvm_memory_pool_allocated_bytes_created{pool="G1 Survivor Space",} 1.623394629746E9
+jvm_memory_pool_allocated_bytes_created{pool="Compressed Class Space",} 1.623394629746E9
+jvm_memory_pool_allocated_bytes_created{pool="Metaspace",} 1.623394629746E9
+jvm_memory_pool_allocated_bytes_created{pool="CodeHeap 'non-nmethods'",} 1.623394629746E9
+
+# HELP jvm_memory_pool_allocated_bytes_total Total bytes allocated in a given JVM memory pool. Only updated after GC, not continuously.
+# TYPE jvm_memory_pool_allocated_bytes_total counter
+jvm_memory_pool_allocated_bytes_total{pool="CodeHeap 'profiled nmethods'",} 3.7028864E7
+jvm_memory_pool_allocated_bytes_total{pool="G1 Old Gen",} 1.3262048E8
+jvm_memory_pool_allocated_bytes_total{pool="G1 Eden Space",} 8.74512384E8
+jvm_memory_pool_allocated_bytes_total{pool="CodeHeap 'non-profiled nmethods'",} 1.145216E7
+jvm_memory_pool_allocated_bytes_total{pool="G1 Survivor Space",} 1.8874368E7
+jvm_memory_pool_allocated_bytes_total{pool="Compressed Class Space",} 1.4760208E7
+jvm_memory_pool_allocated_bytes_total{pool="Metaspace",} 1.28033584E8
+jvm_memory_pool_allocated_bytes_total{pool="CodeHeap 'non-nmethods'",} 1340416.0
+
+# HELP jvm_buffer_pool_used_bytes Used bytes of a given JVM buffer pool.
+# TYPE jvm_buffer_pool_used_bytes gauge
+jvm_buffer_pool_used_bytes{pool="mapped",} 0.0
+jvm_buffer_pool_used_bytes{pool="direct",} 290150.0
+# HELP jvm_buffer_pool_capacity_bytes Bytes capacity of a given JVM buffer pool.
+# TYPE jvm_buffer_pool_capacity_bytes gauge
+jvm_buffer_pool_capacity_bytes{pool="mapped",} 0.0
+jvm_buffer_pool_capacity_bytes{pool="direct",} 290150.0
+# HELP jvm_buffer_pool_used_buffers Used buffers of a given JVM buffer pool.
+# TYPE jvm_buffer_pool_used_buffers gauge
+jvm_buffer_pool_used_buffers{pool="mapped",} 0.0
+jvm_buffer_pool_used_buffers{pool="direct",} 32.0
+
+# HELP jvm_gc_collection_seconds Time spent in a given JVM garbage collector in seconds.
+# TYPE jvm_gc_collection_seconds summary
+jvm_gc_collection_seconds_count{gc="G1 Young Generation",} 41.0
+jvm_gc_collection_seconds_sum{gc="G1 Young Generation",} 0.447
+jvm_gc_collection_seconds_count{gc="G1 Old Generation",} 0.0
+jvm_gc_collection_seconds_sum{gc="G1 Old Generation",} 0.0
+
+# HELP jvm_threads_current Current thread count of a JVM
+# TYPE jvm_threads_current gauge
+jvm_threads_current 188.0
+# HELP jvm_threads_daemon Daemon thread count of a JVM
+# TYPE jvm_threads_daemon gauge
+jvm_threads_daemon 73.0
+# HELP jvm_threads_peak Peak thread count of a JVM
+# TYPE jvm_threads_peak gauge
+jvm_threads_peak 188.0
+# HELP jvm_threads_started_total Started thread count of a JVM
+# TYPE jvm_threads_started_total counter
+jvm_threads_started_total 211.0
+# HELP jvm_threads_deadlocked Cycles of JVM-threads that are in deadlock waiting to acquire object monitors or ownable synchronizers
+# TYPE jvm_threads_deadlocked gauge
+jvm_threads_deadlocked 0.0
+# HELP jvm_threads_deadlocked_monitor Cycles of JVM-threads that are in deadlock waiting to acquire object monitors
+# TYPE jvm_threads_deadlocked_monitor gauge
+jvm_threads_deadlocked_monitor 0.0
+# HELP jvm_threads_state Current count of threads by state
+# TYPE jvm_threads_state gauge
+jvm_threads_state{state="BLOCKED",} 0.0
+jvm_threads_state{state="TERMINATED",} 0.0
+jvm_threads_state{state="WAITING",} 54.0
+jvm_threads_state{state="TIMED_WAITING",} 78.0
+jvm_threads_state{state="NEW",} 0.0
+jvm_threads_state{state="RUNNABLE",} 56.0
+
+# HELP jvm_classes_loaded The number of classes that are currently loaded in the JVM
+# TYPE jvm_classes_loaded gauge
+jvm_classes_loaded 21570.0
+# HELP jvm_classes_loaded_total The total number of classes that have been loaded since the JVM has started execution
+# TYPE jvm_classes_loaded_total counter
+jvm_classes_loaded_total 21570.0
+# HELP jvm_classes_unloaded_total The total number of classes that have been unloaded since the JVM has started execution
+# TYPE jvm_classes_unloaded_total counter
+jvm_classes_unloaded_total 0.0
+
+# HELP jvm_info VM version info
+# TYPE jvm_info gauge
+jvm_info{runtime="OpenJDK Runtime Environment",vendor="Oracle Corporation",version="11.0.10+9",} 1.0
+```
+
+A corresponding monitoring mixin for JVM metrics with dashboards and alerting rules can be found at
 [github.com/grafana/jsonnet-libs](https://github.com/grafana/jsonnet-libs/tree/master/jvm-mixin).
 
 Access

--- a/modules/metrics-exporter/pom.xml
+++ b/modules/metrics-exporter/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <prometheus.version>0.10.0</prometheus.version>
+    <prometheus.version>0.11.0</prometheus.version>
   </properties>
   <dependencies>
     <!-- Opencast dependencies -->
@@ -52,6 +52,11 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_common</artifactId>
+      <version>${prometheus.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_hotspot</artifactId>
       <version>${prometheus.version}</version>
     </dependency>
     <!-- Testing -->
@@ -95,12 +100,14 @@
             <Import-Package>
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,
+              !io.opentelemetry.*,
+              !com.sun.management.*,
               *
             </Import-Package>
             <Embed-Dependency>
-              simpleclient,
-              simpleclient_common
+              *;groupId=io.prometheus,
             </Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
+++ b/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
@@ -38,6 +38,8 @@ import org.osgi.framework.Version;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,10 +208,12 @@ public class MetricsExporter {
     }
 
     // Get numbers from asset manager
-    for (Organization organization: organizationDirectoryService.getOrganizations()) {
-      eventsInAssetManager
-          .labels(organization.getId())
-          .set(assetManager.countEvents(organization.getId()));
+    if (assetManager != null) {
+      for (Organization organization: organizationDirectoryService.getOrganizations()) {
+        eventsInAssetManager
+            .labels(organization.getId())
+            .set(assetManager.countEvents(organization.getId()));
+      }
     }
 
     // collect metrics
@@ -228,8 +232,17 @@ public class MetricsExporter {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference
+  @Reference(
+      policy = ReferencePolicy.DYNAMIC,
+      cardinality = ReferenceCardinality.OPTIONAL,
+      unbind = "unsetAssetManager"
+  )
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
+
+  public void unsetAssetManager(AssetManager assetManager) {
+    this.assetManager = null;
+  }
+
 }

--- a/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
+++ b/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
@@ -57,6 +57,7 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.exporter.common.TextFormat;
+import io.prometheus.client.hotspot.DefaultExports;
 
 /**
  * Opencast metrics endpoint
@@ -138,6 +139,7 @@ public class MetricsExporter {
     final Version version = bundleContext.getBundle().getVersion();
     this.version.labels("major").set(version.getMajor());
     this.version.labels("minor").set(version.getMinor());
+    DefaultExports.initialize();
   }
 
   @GET

--- a/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
+++ b/modules/metrics-exporter/src/main/java/org/opencastproject/metrics/impl/MetricsExporter.java
@@ -125,11 +125,7 @@ public class MetricsExporter {
       .help("Version of Opencast (based on metrics module)")
       .labelNames("part")
       .register();
-  private final Gauge eventsInAssetManager = Gauge.build()
-      .name("opencast_asset_manager_events")
-      .help("Events in Asset Manager")
-      .labelNames("organization")
-      .register();
+  private Gauge eventsInAssetManager;
 
   /** OSGi services */
   private ServiceRegistry serviceRegistry;
@@ -239,10 +235,16 @@ public class MetricsExporter {
   )
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
+    eventsInAssetManager = Gauge.build()
+        .name("opencast_asset_manager_events")
+        .help("Events in Asset Manager")
+        .labelNames("organization")
+        .register();
   }
 
   public void unsetAssetManager(AssetManager assetManager) {
     this.assetManager = null;
+    registry.unregister(eventsInAssetManager);
   }
 
 }


### PR DESCRIPTION
This PR uses the [`simpleclient_hotspot`](https://github.com/prometheus/client_java) library to add JVM metric collectors (e.g. metrics about memory and CPU usage, threads, classloading, etc.). More details on the included JVM metrics collectors can be found [here](https://prometheus.github.io/client_java/).

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
