### PR TITLE
Fixes removing a series from an event

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/directives/editableSingleSelectDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/editableSingleSelectDirective.js
@@ -175,7 +175,7 @@ angular.module('adminNg.directives')
             // Selecting "no option" will wrongly set param to `null` instead of the empty string.
             // The backend will ignore `null` submissions, so we set it to the empty string instead.
             if (scope.params.value === null) {
-              scope.params.value = "";
+              scope.params.value = '';
             }
             scope.save(scope.params.id);
             scope.oldValue = scope.params.value;

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/editableSingleSelectDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/editableSingleSelectDirective.js
@@ -172,6 +172,11 @@ angular.module('adminNg.directives')
         // Wait until the change of the value propagated to the parent's metadata object.
         scope.submitTimer = $timeout(function () {
           if (scope.params.value !== scope.oldValue) {
+            // Selecting "no option" will wrongly set param to `null` instead of the empty string.
+            // The backend will ignore `null` submissions, so we set it to the empty string instead.
+            if (scope.params.value === null) {
+              scope.params.value = "";
+            }
             scope.save(scope.params.id);
             scope.oldValue = scope.params.value;
           }


### PR DESCRIPTION
Resolves #1721.

The frontend attempts to save "no option selected" as `null` to the backend. The backend does not accept `null` values. Instead the frontend should save "no option" as the empty string.

This corrects `null` to the empty string when submitting. A rather crude fix, but I could not figure out why AngularJS fails to set the correct value in this case.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
