### PR TITLE
Recognize more input types in WF configuration

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/processing.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/processing.js
@@ -148,9 +148,11 @@ angular.module('adminNg.services')
 
     // Most of the stuff we do here with input elements doesn't distinguish between
     // input type="text" and input type="number", so we need this getter a few times.
-    function elementIsTextual(angularElement) {
-      return angularElement.is('[type=text]') || angularElement.is('[type=number]') ||
-             angularElement.is('[type=hidden]');
+    function elementWhoseValueMatters(angularElement) {
+      const matters = ['color', 'date', 'datetime-local', 'email', 'hidden',
+        'month', 'number', 'password', 'range', 'tel', 'text', 'time', 'url',
+        'week'];
+      return matters.indexOf(angularElement.prop('type')) !== -1;
     }
 
     // Gather all input elements used in the workflow configuration HTML into a dictionary:
@@ -158,7 +160,7 @@ angular.module('adminNg.services')
     function gatherHtmlFormElements(htmlElement) {
       var result = {};
       forEachHtmlFormElement(htmlElement, function(id, angularElement) {
-        if (elementIsTextual(angularElement)) {
+        if (elementWhoseValueMatters(angularElement)) {
           if (angularElement.val() === '') {
             result[id] = null;
           } else {
@@ -211,7 +213,7 @@ angular.module('adminNg.services')
     // Set a HTML form value (abstracts over "set checked" or "set
     // value" for checkboxes and text fields, respectively)
     function setHtmlFormValue(angularElement, value) {
-      if (elementIsTextual(angularElement)) {
+      if (elementWhoseValueMatters(angularElement)) {
         angularElement.val(value);
       } else if (angularElement.is('[type=checkbox]') || angularElement.is('[type=radio]')) {
         if (value === 'true') {
@@ -225,7 +227,7 @@ angular.module('adminNg.services')
     // Set an indeterminate HTML form value (depends on the type
     // of the form element)
     function setIndeterminateHtmlFormValue(angularElement) {
-      if (elementIsTextual(angularElement)) {
+      if (elementWhoseValueMatters(angularElement)) {
         angularElement.val('');
       } else if (angularElement.is('[type=checkbox]')) {
         angularElement.prop('indeterminate', true);

--- a/modules/admin-ui-frontend/test/test/unit/shared/services/wizards/new-event/proccessingSpec.js
+++ b/modules/admin-ui-frontend/test/test/unit/shared/services/wizards/new-event/proccessingSpec.js
@@ -117,6 +117,30 @@ describe('Processing Step in New Event Wizard', function () {
                     .toEqual({ testID: 'testvalueA' });
             });
         });
+
+        describe('with an email field', function () {
+            beforeEach(function () {
+                $('#new-event-workflow-configuration')
+                    .append('<input type="email" class="configField" id="testID" value="support@opencast.org">');
+            });
+
+            it('returns the field value', function () {
+                expect(NewEventProcessing.getWorkflowConfig())
+                    .toEqual({ testID: 'support@opencast.org' });
+            });
+        });
+
+        describe('with a range field', function () {
+            beforeEach(function () {
+                $('#new-event-workflow-configuration')
+                    .append('<input type="range" min="0" max="1" step="0.1" class="configField" id="testID" value="0.5">');
+            });
+
+            it('returns the field value', function () {
+                expect(NewEventProcessing.getWorkflowConfig())
+                    .toEqual({ testID: '0.5' });
+            });
+        });
     });
 
     describe('#getUserEntries', function () {


### PR DESCRIPTION
Opencast Workflows can contain configuration panels. Fields
classified as *configField* should be evaluated and used for
initilization of workflow variables.
However, only hidden, number and textual inputs were considered.

This patch will allow using inputs of the following types:
'color', 'date', 'datetime-local', 'email', 'hidden', 'month',
'number', 'password', 'range', 'tel', 'text', 'time', 'url',
'week'.

It also adds uni tests and renames the method's name that checked
for the input type as some of them are not really "textual" but
their value can be used directly (in contrast to inputs where
the checked state matters: radio and checkbox).

Resolves #2703

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
