### PR TITLE
fix URL to the development process documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 * [ ] have a concise title
 * [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
-* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process/#acceptance-criteria-for-patches-in-different-versions)
+* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process#acceptance-criteria-for-patches-in-different-versions)
 * [ ] include migration scripts and documentation, if appropriate
 * [ ] pass automated tests
 * [ ] have a clean commit history

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Contributing to Opencast
 
 This is a short outline of what to pay attention to when contributing to Opencast. If you are interested in a long
 document defining rules and recommendations as well as a detailed explanation of Opencast's branching model, take a look
-at [the development process documentation](https://docs.opencast.org/develop/developer/development-process/). But this
+at [the development process documentation](https://docs.opencast.org/develop/developer/#development-process). But this
 guide should suffice for most contributions.
 
 


### PR DESCRIPTION
This PR fixes two links in:
- CONTRIBUTING.md
- .github/PULL_REQUEST_TEMPLATE.md

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
