### PR TITLE
Closing tags for consecutive select elements

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleValue.html
@@ -36,7 +36,7 @@
             name="hours"
             placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.HOUR' | translate}}'"
             ng-options="h.index as h.value for h in hours"
-            />
+            ></select>
       <select chosen
               ng-if="params.type === 'time' && editMode"
               ng-change="submit()"
@@ -49,5 +49,5 @@
               name="minutes"
               placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.MINUTE' | translate}}'"
               ng-options="m.index as m.value for m in minutes"
-              />
+              ></select>
 </div>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
@@ -85,7 +85,7 @@
                                     ng-options="id as name for (id, name) in acls"
                                     placeholder-text-single="'{{ 'USERS.ACLS.DETAILS.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                     no-results-text="'{{ 'USERS.ACLS.DETAILS.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                    />
+                                    ></select>
                           </div>
                         </td>
                       </tr>
@@ -133,7 +133,7 @@
                                       call-on-search="getMatchingRoles"
                                       placeholder-text-single="'{{ 'USERS.ACLS.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
                                       no-results-text="'{{ 'USERS.ACLS.DETAILS.ACCESS.ROLES.EMPTY' | translate }}'"
-                                      />
+                                      ></select>
                             </td>
                             <td class="fit"><input type="checkbox" ng-model="policy.read"/></td>
                             <td class="fit"><input type="checkbox" ng-model="policy.write"/></td>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/edit-events-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/edit-events-modal.html
@@ -143,7 +143,7 @@
                             ng-change="onTemporalValueChange(wd, 'start')"
                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}'"
                             ng-options="h.index as h.value for h in hours"
-                    />
+                    ></select>
                     <select chosen
                             ng-disabled="checkingConflicts"
                             data-width="'100px'"
@@ -151,7 +151,7 @@
                             ng-change="onTemporalValueChange(wd, 'start');"
                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}'"
                             ng-options="m.index as m.value for m in minutes"
-                    />
+                    ></select>
                   </td>
                 </tr>
                 <tr>
@@ -164,7 +164,7 @@
                             ng-change="onTemporalValueChange(wd, 'end');"
                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}'"
                             ng-options="h.index as h.value for h in hours"
-                    />
+                    ></select>
                     <select chosen
                             ng-disabled="checkingConflicts"
                             data-width="'100px'"
@@ -172,7 +172,7 @@
                             ng-change="onTemporalValueChange(wd, 'end');"
                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}'"
                             ng-options="m.index as m.value for m in minutes"
-                    />
+                    ></select>
                     <span ng-bind="scheduling.end.date"
                           ng-show="scheduling.end.date !== scheduling.start.date"
                     />
@@ -188,7 +188,7 @@
                             ng-model="scheduling[wd].location"
                             ng-options="ca.name for ca in captureAgents | filter:hasAgentAccess track by ca.id"
                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
-                            />
+                            ></select>
                   </td>
                   <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                     {{ source.device.name }}

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -267,7 +267,7 @@
                           ng-change="onTemporalValueChange('start')"
                           placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}'"
                           ng-options="h.index as h.value for h in hours"
-                          />
+                          ></select>
                     <select chosen
                             ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                             data-width="'100px'"
@@ -275,7 +275,7 @@
                             ng-change="onTemporalValueChange('start')"
                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}'"
                             ng-options="m.index as m.value for m in minutes"
-                            />
+                            ></select>
                 </td>
                 <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                   {{ source.start.hour | addLeadingZeros : 2 }} : {{ source.start.minute | addLeadingZeros : 2}}
@@ -291,7 +291,7 @@
                           ng-change="onTemporalValueChange('duration')"
                           placeholder-text-single="'{{ 'WIZARD.DURATION.HOURS' | translate }}'"
                           ng-options="h.index as h.value for h in hours"
-                          />
+                          ></select>
 
                     <select chosen
                             ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
@@ -300,7 +300,7 @@
                             ng-change="onTemporalValueChange('duration')"
                             placeholder-text-single="'{{ 'WIZARD.DURATION.MINUTES' | translate }}'"
                             ng-options="m.index as m.value for m in minutes"
-                            />
+                            ></select>
                 </td>
                 <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                   {{ source.duration.hour | addLeadingZeros : 2 }} : {{ source.duration.minute | addLeadingZeros : 2}}
@@ -316,7 +316,7 @@
                           ng-change="onTemporalValueChange('end')"
                           placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.HOUR' | translate}}'"
                           ng-options="h.index as h.value for h in hours"
-                          />
+                          ></select>
                     <select chosen
                             ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                             data-width="'100px'"
@@ -324,7 +324,7 @@
                             ng-change="onTemporalValueChange('end')"
                             placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.MINUTE' | translate}}'"
                             ng-options="m.index as m.value for m in minutes"
-                            />
+                            ></select>
                       <span ng-bind="source.end.date"
                             ng-show="source.end.date !== source.start.date"
                             />
@@ -347,7 +347,7 @@
                           ng-model="source.device"
                           ng-options="ca.name for ca in captureAgents | filter:currentAgentOrAccess track by ca.id"
                           placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"
-                          />
+                          ></select>
                 </td>
                 <td ng-if="!$root.userIs('ROLE_UI_EVENTS_DETAILS_SCHEDULING_EDIT')">
                   {{ source.device.name }}
@@ -472,7 +472,7 @@
                                     ng-options="w.id as w.title for w in workflowDefinitions | orderBy: 'displayOrder':true"
                                     placeholder-text-single="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW' | translate }}'"
                                     no-results-text="'{{ 'EVENTS.EVENTS.NEW.PROCESSING.SELECT_WORKFLOW_EMPTY' | translate }}'"
-                                    />
+                                    ></select>
                               <div class="obj-container padded">{{ workflows.workflow.description }}</div>
                           </div>
                         </td>
@@ -560,7 +560,7 @@
                                       ng-options="id as name for (id, name) in acls"
                                       placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                       no-results-text="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                      />
+                                      ></select>
                             </div>
                             <p ng-show="transactions.read_only">{{baseAclId}}</p>
                           </div>
@@ -611,7 +611,7 @@
                                       call-on-search="getMatchingRoles"
                                       placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
                                       no-results-text="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ROLES.EMPTY' | translate }}'"
-                                      />
+                                      ></select>
                             </td>
                             <td ng-show="transactions.read_only">
                               <p>{{policy.role}}</p>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
@@ -161,7 +161,7 @@
                                     ng-options="id as name for (id, name) in acls"
                                     placeholder-text-single="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                     no-results-text="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                    />
+                                    ></select>
                           </div>
                         </td>
                       </tr>
@@ -212,7 +212,7 @@
                                     call-on-search="getMatchingRoles"
                                     placeholder-text-single="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
                                     no-results-text="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ROLES.EMPTY' | translate }}'"
-                                    />
+                                    ></select>
                           </td>
                           <td class="fit text-center">
                             <input type="checkbox"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
@@ -61,7 +61,7 @@
                                          ng-options="id as name for (id, name) in wizard.step.acls"
                                          placeholder-text-single="'{{ 'USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                          no-results-text="'{{ 'USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                         />
+                                         ></select>
                         </div>
                       </td>
                     </tr>
@@ -106,7 +106,7 @@
                                          ng-options="role as role for role in wizard.step.roles"
                                          placeholder-text-single="'{{ 'USERS.ACLS.NEW.ACCESS.ROLES.LABEL' | translate }}'"
                                          no-results-text="'{{ 'USERS.ACLS.NEW.ACCESS.ROLES.EMPTY' | translate }}'"
-                                         />
+                                         ></select>
                         </td>
                         <td class="fit text-center"><input type="checkbox"  ng-model="policy.read"/></td>
                         <td class="fit text-center"><input type="checkbox"  ng-model="policy.write"/></td>
@@ -177,4 +177,3 @@
     </div>
   </div>
 </div>
-

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
@@ -86,7 +86,7 @@
                                   ng-options="id as name for (id, name) in wizard.step.acls"
                                   placeholder-text-single="'{{ 'EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                   no-results-text="'{{ 'EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                  />
+                                  ></select>
                         </div>
                       </td>
                     </tr>


### PR DESCRIPTION
and also for non-consecutive ones (to avoid breakage if they become
consecutive one day)

Angular JS only supports `<void elements/>` from the HTML spec.

See
- https://github.com/angular/angular.js/issues/1237
- https://stackoverflow.com/a/31724215/2683737

Resolves #2025
Contained in/ Base for: #2719

![image](https://user-images.githubusercontent.com/2311611/121775822-14cf7e00-cb8a-11eb-8889-d650df28f572.png)

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
