### PR TITLE
Fixed admin interface tests in certain timezones

### DIFF
--- a/modules/admin-ui-frontend/test/test/unit/shared/directives/tableFilterDirectiveSpec.js
+++ b/modules/admin-ui-frontend/test/test/unit/shared/directives/tableFilterDirectiveSpec.js
@@ -194,7 +194,7 @@ describe('adminNg.directives.adminNgTableFilter', function () {
 
             it('sets the time period filter value (accounting for localized day)', function () {
                 // Get local time zone offset to verify user requested day range
-                var timeOffset = new Date().getTimezoneOffset();
+                var timeOffset = toDate.getTimezoneOffset();
                 var expectedFromDate = new Date(fromDateIsoStr);
                 // Adjust to local day
                 expectedFromDate = new Date(expectedFromDate.getTime() + timeOffset * 60 * 1000);


### PR DESCRIPTION
This patch fixes an admin interface unit test which fails in certain timezones
with active daylight saving time (e.g. CEST).

The error is:

```
       Chrome Headless 93.0.4535.3 (Linux x86_64) adminNg.directives.adminNgTableFilter #selectFilterPeriodValue with both from- and to dates sets the time period filter value (accounting for localized day) FAILED
[INFO]  Expected spy put to have been called with:
[INFO]    [ 'filter', 'furniture', undefined, '2014-12-30T23:00:00.001Z/2015-01-02T22:59:59.999Z' ]
[INFO]  but actual calls were:
[INFO]    [ 'filter', 'furniture', undefined, '2014-12-31T23:00:00.001Z/2015-01-02T22:59:59.999Z' ].
[INFO]
[INFO]  Call 0:
[INFO]    Expected $[3] = '2014-12-31T23:00:00.001Z/2015-01-02T22:59:59.999Z' to equal '2014-12-30T23:00:00.001Z/2015-01-02T22:59:59.999Z'.
[INFO]  Error: Expected spy put to have been called with:
[INFO]    [ 'filter', 'furniture', undefined, '2014-12-30T23:00:00.001Z/2015-01-02T22:59:59.999Z' ]
[INFO]  but actual calls were:
[INFO]    [ 'filter', 'furniture', undefined, '2014-12-31T23:00:00.001Z/2015-01-02T22:59:59.999Z' ].
[INFO]  Call 0:
[INFO]    Expected $[3] = '2014-12-31T23:00:00.001Z/2015-01-02T22:59:59.999Z' to equal '2014-12-30T23:00:00.001Z/2015-01-02T22:59:59.999Z'.
[INFO]      at <Jasmine>
[INFO]      at UserContext.<anonymous> (test/unit/shared/directives/tableFilterDirectiveSpec.js:206:37)
[INFO]      at <Jasmine>
       Firefox 89.0 (Fedora 0.0.0) adminNg.directives.adminNgTableFilter #selectFilterPeriodValue with both from- and to dates sets the time period filter value (accounting for localized day) FAILED
[INFO]  Expected spy put to have been called with:
[INFO]    [ 'filter', 'furniture', undefined, '2014-12-30T23:00:00.001Z/2015-01-02T22:59:59.999Z' ]
[INFO]  but actual calls were:
[INFO]    [ 'filter', 'furniture', undefined, '2014-12-31T23:00:00.001Z/2015-01-02T22:59:59.999Z' ].
[INFO]
[INFO]  Call 0:
[INFO]    Expected $[3] = '2014-12-31T23:00:00.001Z/2015-01-02T22:59:59.999Z' to equal '2014-12-30T23:00:00.001Z/2015-01-02T22:59:59.999Z'.
[INFO]  <Jasmine>
[INFO]  @test/unit/shared/directives/tableFilterDirectiveSpec.js:206:37
[INFO]  <Jasmine>
       Chrome Headless 93.0.4535.3 (Linux x86_64): Executed 739 of 761 (1 FAILED) (skipped 22) (8.758 secs / 7.689 secs)
[INFO] Firefox 89.0 (Fedora 0.0.0): Executed 739 of 761 (1 FAILED) (skipped 22) (11.939 secs / 10.721 secs)
[INFO] TOTAL: 2 FAILED, 1476 SUCCESS
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/#development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
