### PR TITLE
Default for Access Control Entry Allow

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlParser.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlParser.java
@@ -169,7 +169,7 @@ public final class AccessControlParser {
   private static AccessControlEntry getAce(JSONObject jsonAce) {
     String role = (String) jsonAce.get(ROLE);
     String action = (String) jsonAce.get(ACTION);
-    Boolean allow = (Boolean) jsonAce.get(ALLOW);
+    Boolean allow = (Boolean) jsonAce.getOrDefault(ALLOW, Boolean.TRUE);
     return new AccessControlEntry(role, action, allow);
   }
 


### PR DESCRIPTION
Opencast only allows access control lists with allow rules. Deny rules
are not permitted. Yet, every ACE needs to have `allow: true`
explicitly set.

This patch changes that behavior by introducing a default value for
`allow`, allowing simpler requests but not changing current ones.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
