### PR TITLE
Use version variable in poms

### DIFF
--- a/modules/elasticsearch-api/pom.xml
+++ b/modules/elasticsearch-api/pom.xml
@@ -3,14 +3,6 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>opencast-elasticsearch-api</artifactId>
   <name>Opencast :: elasticsearch-api</name>
-  <dependencies>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-common</artifactId>
-      <version>10-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
   <packaging>bundle</packaging>
   <parent>
     <groupId>org.opencastproject</groupId>
@@ -22,6 +14,13 @@
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/modules/engage-theodul-plugin-archetype/pom.xml
+++ b/modules/engage-theodul-plugin-archetype/pom.xml
@@ -2,9 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <!-- <Build-Number>${buildNumber}</Build-Number> not necessary since this is no OSGi bundle -->
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.opencastproject</groupId>
   <artifactId>opencast-theodul-plugin</artifactId>
-  <version>10-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
   <name>Opencast :: engage-theodul-plugin-archetype</name>
   <description>An archetype that generates a plugin for the Opencast Theodul Player</description>

--- a/modules/transcription-service-workflowoperation/pom.xml
+++ b/modules/transcription-service-workflowoperation/pom.xml
@@ -41,6 +41,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-transcription-service-amberscript</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -74,12 +79,6 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-transcription-service-amberscript</artifactId>
-      <version>10-SNAPSHOT</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Don't set version in poms explicitly where not required, instead remove it or use version variable where necessary. Split apart from #2649 (and slightly amended) on Pascal's request.