### PR TITLE
MH-13617 Prepare AV fix for fast workflow: add textual warning to docs

### DIFF
--- a/docs/guides/developer/docs/api/workflow-api.md
+++ b/docs/guides/developer/docs/api/workflow-api.md
@@ -5,6 +5,8 @@ The Workflow API is available since API version 1.1.0.
 
 # Workflow instances
 
+**Warning:** these examples reference the `fast` testing workflow. Recordings archived from the `fast` testing workflow can not be used with other Opencast workflows.
+
 ### GET /api/workflows
 
 Returns a list of workflow instances.
@@ -73,6 +75,7 @@ __Sample request__
 ```xml
 https://opencast.example.org/api/workflow-definitions?sort=event_created:DESC&limit=5&offset=1&filter=workflow_definition_identifier:fast
 ```
+Note: The "fast" workflow is for testing only. Recordings created from that workflow are incompatible with other Opencast workflows.
 
 __Response__
 

--- a/etc/workflows/fast.xml
+++ b/etc/workflows/fast.xml
@@ -11,7 +11,8 @@
   <description>
     A minimal workflow that transcodes the media into distribution formats, then
     sends the resulting distribution files, along with their associated metadata,
-    to the distribution channels.
+    to the distribution channels. WARNING: other Opencast workflows are
+    *incompatible* with archived recordings created from this testing workflow.
   </description>
 
   <configuration_panel>
@@ -239,4 +240,3 @@
   </operations>
 
 </definition>
-


### PR DESCRIPTION
This pull clarifies to the user that recordings archived with the "fast" testing workflow are not compatible with other Opencast workflows. 

Closes #2733
Replacement pull for https://github.com/opencast/opencast/pull/1861

