### PR TITLE
Clarifies debug options in setenv file

### DIFF
--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -35,7 +35,7 @@
 #
 # Debug options
 # export KARAF_DEBUG       # Enable debug mode
-# export JAVA_DEBUG_PORT   # Set Debug Port (If not set defaults to 5005)
+# export JAVA_DEBUG_PORT   # Set debug port (defaults to 5005)
 
 
 export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"

--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -31,8 +31,12 @@
 # export KARAF_BASE        # Karaf base folder
 # export KARAF_ETC         # Karaf etc  folder
 # export KARAF_OPTS        # Additional Karaf options
-# export KARAF_DEBUG       # Enable debug mode
 # export KARAF_REDIRECT    # Enable/set the std/err redirection when using bin/start
+#
+# Debug options
+# export KARAF_DEBUG       # Enable debug mode
+# export JAVA_DEBUG_PORT   # Set Debug Port (If not set defaults to 5005)
+
 
 export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8"
 export JAVA_MAX_MEM="${JAVA_MAX_MEM:-1G}"


### PR DESCRIPTION
This commit adds comments to the setenv file to make more easy to enable the debug mode and set the port for the debug mode if necessary.

PS: I've made this commit against develop because adds comments to a file that is not the documentation, if its alright, I can change it to go directly to r/8.x


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
