### PR TITLE
Fix processing of `fast` events

### DIFF
--- a/docs/guides/developer/docs/api/workflow-api.md
+++ b/docs/guides/developer/docs/api/workflow-api.md
@@ -5,8 +5,6 @@ The Workflow API is available since API version 1.1.0.
 
 # Workflow instances
 
-**Warning:** these examples reference the `fast` testing workflow. Recordings archived from the `fast` testing workflow can not be used with other Opencast workflows.
-
 ### GET /api/workflows
 
 Returns a list of workflow instances.
@@ -75,7 +73,6 @@ __Sample request__
 ```xml
 https://opencast.example.org/api/workflow-definitions?sort=event_created:DESC&limit=5&offset=1&filter=workflow_definition_identifier:fast
 ```
-Note: The "fast" workflow is for testing only. Recordings created from that workflow are incompatible with other Opencast workflows.
 
 __Response__
 

--- a/etc/workflows/fast.xml
+++ b/etc/workflows/fast.xml
@@ -11,8 +11,7 @@
   <description>
     A minimal workflow that transcodes the media into distribution formats, then
     sends the resulting distribution files, along with their associated metadata,
-    to the distribution channels. WARNING: other Opencast workflows are
-    *incompatible* with archived recordings created from this testing workflow.
+    to the distribution channels.
   </description>
 
   <configuration_panel>
@@ -240,3 +239,4 @@
   </operations>
 
 </definition>
+

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -10,6 +10,33 @@
 
   <operations>
 
+    <!-- Fall back to */source if */prepared does not exist -->
+
+    <operation
+        id="analyze-tracks"
+        fail-on-error="true"
+        exception-handler-workflow="partial-error"
+        description="Analyze tracks in media package and set control variables">
+      <configurations>
+        <configuration key="source-flavor">*/prepared</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+        if="NOT (${presentation_prepared_media} OR ${presenter_prepared_media})"
+        id="clone"
+        fail-on-error="true"
+        exception-handler-workflow="partial-error"
+        description="Preparing media">
+      <configurations>
+        <configuration key="source-flavor">*/source</configuration>
+        <configuration key="target-flavor">*/prepared</configuration>
+        <configuration key="target-tags">editor</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Continue processing -->
+
     <operation
         id="select-tracks"
         exception-handler-workflow="partial-error"

--- a/etc/workflows/publish-after-cutting.xml
+++ b/etc/workflows/publish-after-cutting.xml
@@ -25,6 +25,7 @@
         <configuration key="publishToYouTube">false</configuration>
         <configuration key="thumbnailType">0</configuration>
         <configuration key="thumbnailPosition">1</configuration>
+        <configuration key="flagQuality720p">true</configuration>
       </configurations>
     </operation>
 


### PR DESCRIPTION
This patch ensures that users can process events ingested using the
`fast` workflow using either “Start Task” → “Publish” or selecting
“Publish” in the video editor.

This is a continuation of the idea of pull request #1861 with a
different approach being used:

- This adds no unnecessary additional steps and no additional processing
  to the fast testing workflow
- This stores no duplicates of any media
- This only copies the tracks if necessary
- This works with already processed data (fixes the problem for all
  events stored in the asset manager)

It also fixes a problem of #1861 which would fail in the editor due to
no encoding quality being selected.

---

@karendolan, @gregorydlogan, this essentially implements the idea I outlines before in my comment. What do you think about this approach? Would this work for you as well?

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
