### PR TITLE
Prevent search service endpoint from querying series service

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -35,6 +35,7 @@ import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.impl.SearchServiceImpl;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.util.SolrUtils;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
@@ -462,7 +463,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
         SearchQuery seriesSearch = new SearchQuery();
         seriesSearch.includeSeries(true)
             .includeEpisodes(false)
-            .withQuery("*:(dc_title___:" + seriesName + ")");
+            .withQuery("*:(dc_title___:" + SolrUtils.clean(seriesName) + ")");
         result = searchService.getByQuery(seriesSearch);
       } catch (SearchException e) {
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -26,19 +26,14 @@ import org.opencastproject.job.api.Job;
 import org.opencastproject.job.api.JobProducer;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageImpl;
-import org.opencastproject.metadata.dublincore.DublinCore;
-import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
-import org.opencastproject.metadata.dublincore.DublinCoreCatalogList;
-import org.opencastproject.metadata.dublincore.DublinCoreValue;
 import org.opencastproject.rest.AbstractJobProducerEndpoint;
 import org.opencastproject.search.api.SearchException;
 import org.opencastproject.search.api.SearchQuery;
+import org.opencastproject.search.api.SearchResult;
 import org.opencastproject.search.api.SearchResultImpl;
+import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.impl.SearchServiceImpl;
 import org.opencastproject.security.api.UnauthorizedException;
-import org.opencastproject.series.api.SeriesException;
-import org.opencastproject.series.api.SeriesQuery;
-import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
@@ -94,9 +89,6 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
 
   /** The search service */
   protected SearchServiceImpl searchService;
-
-  /** The optional series service; has to be volatile by the OSGi spec */
-  private volatile SeriesService seriesService;
 
   /** The service registry */
   private ServiceRegistry serviceRegistry;
@@ -465,35 +457,33 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
 
     boolean invalidSeries = false;
     if (seriesName != null) {
-      if (seriesService == null) {
-        return Response.status(Response.Status.NOT_IMPLEMENTED).build();
-      }
-      DublinCoreCatalogList result;
+      SearchResult result = new SearchResultImpl();
       try {
-        result = seriesService.getSeries(new SeriesQuery().setSeriesTitle(seriesName));
-      } catch (SeriesException e) {
+        SearchQuery seriesSearch = new SearchQuery();
+        seriesSearch.includeSeries(true)
+                    .includeEpisodes(false)
+                    .withText(seriesName)
+                    .withLimit(1);
+        result = searchService.getByQuery(seriesSearch);
+      } catch (SearchException e) {
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
             .entity("Error while searching for series")
             .build();
       }
       // Specifying a nonexistent series ID is not an error, so a nonexistent
       // series name shouldn't be, either.
-      if (result.getTotalCount() == 0) {
+      if (result.getTotalSize() == 0) {
+        logger.debug("Retrieved 0 series results");
         invalidSeries = true;
       } else {
-        if (result.getTotalCount() > 1) {
+        if (result.getTotalSize() > 1) {
           return Response.status(Response.Status.BAD_REQUEST)
               .entity("more than one series matches given series name")
               .build();
         }
-        DublinCoreCatalog seriesResult = result.getCatalogList().get(0);
-        final List<DublinCoreValue> identifiers = seriesResult.get(DublinCore.PROPERTY_IDENTIFIER);
-        if (identifiers.size() != 1) {
-          return Response.status(Response.Status.BAD_REQUEST)
-              .entity("more than one identifier in dublin core catalog for series")
-              .build();
-        }
-        seriesId = identifiers.get(0).getValue();
+        SearchResultItem seriesResult = result.getItems()[0];
+        seriesId = seriesResult.getId();
+        logger.debug("Using sname parameter, series ID found: {}", seriesId);
       }
     }
 
@@ -705,16 +695,6 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
    */
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
-  }
-
-  /**
-   * Callback from OSGi to set the series service implementation.
-   *
-   * @param seriesService
-   *          the series servie
-   */
-  public void setSeriesService(SeriesService seriesService) {
-    this.seriesService = seriesService;
   }
 
   /**

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -461,9 +461,8 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
       try {
         SearchQuery seriesSearch = new SearchQuery();
         seriesSearch.includeSeries(true)
-                    .includeEpisodes(false)
-                    .withText(seriesName)
-                    .withLimit(1);
+            .includeEpisodes(false)
+            .withQuery("*:(dc_title___:" + seriesName + ")");
         result = searchService.getByQuery(seriesSearch);
       } catch (SearchException e) {
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)

--- a/modules/search-service-impl/src/main/resources/OSGI-INF/search-service-rest.xml
+++ b/modules/search-service-impl/src/main/resources/OSGI-INF/search-service-rest.xml
@@ -15,6 +15,4 @@
              cardinality="1..1" policy="static" bind="setSearchService"/>
   <reference name="serviceregistry" interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
              cardinality="1..1" policy="static" bind="setServiceRegistry"/>
-  <reference name="seriesservice" interface="org.opencastproject.series.api.SeriesService"
-             bind="setSeriesService" cardinality="0..1" policy="dynamic"/>
 </scr:component>


### PR DESCRIPTION
This fixes #2738 , where the search episode endpoint uses the series service when providing the sname parameter. Instead of relying on the series service, we can use the solr search index directly to map the sname parameter to a series id value.