### PR TITLE
Fix `jakarta.mail` Dependency Problem

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -48,6 +48,7 @@
     <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>
     <bundle>mvn:com.google.guava/failureaccess/${failureaccess.version}</bundle>
     <bundle>mvn:com.google.code.gson/gson/${gson.version}</bundle>
+    <bundle>mvn:com.sun.mail/jakarta.mail/${jakarta.mail.version}</bundle>
     <bundle>mvn:commons-fileupload/commons-fileupload/${commons-fileupload.version}</bundle>
     <bundle>mvn:commons-io/commons-io/${commons-io.version}</bundle>
     <!-- FIXME: commons-lang 2.6 only needed for org.springframework.ldap/1.3.1.RELEASE -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <httpcomponents-httpclient.version>4.5.12</httpcomponents-httpclient.version>
     <httpcomponents-httpcore.version>4.4.13</httpcomponents-httpcore.version>
     <jackson.version>2.12.3</jackson.version>
+    <jakarta.mail.version>1.6.7</jakarta.mail.version>
     <jersey.version>2.29.1</jersey.version>
     <jettison.version>1.4.1</jettison.version>
     <jdk.version>1.8</jdk.version>
@@ -982,9 +983,9 @@
         <version>1.2.1</version>
       </dependency>
       <dependency>
-        <groupId>javax.mail</groupId>
-        <artifactId>mail</artifactId>
-        <version>1.4.7</version>
+        <groupId>com.sun.mail</groupId>
+        <artifactId>jakarta.mail</artifactId>
+        <version>${jakarta.mail.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.inject</groupId>


### PR DESCRIPTION
In the new CXF version, `javax.mail` has been replaced by
`jakarta.mail-api` whis was missing in our distributions.
This caused a broken mail system in Opencast and an exception on boot:

```
2021-06-17 19:23:34,228 | ERROR | (Log:186) - [org.osgi.service.cm.ManagedService, org.opencastproject.kernel.mail.SmtpService, id=396, bundle=134/mvn:org.opencastproject/opencast-kernel/10.0]: Unexpected problem updating configuration org.opencastproject.kernel.mail.SmtpService
java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger
	at javax.mail.Session.initLogger(Session.java:260) ~[?:?]
        ...
```

This patch adds the latest 1.6 version of `jakarta.mail-api`.
This fixes #2746.

@geichelberger, can you review this and verify if this fixes the issue?

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
