### PR TITLE
Use HTTPS in Documentation Landing Page

### DIFF
--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -41,7 +41,7 @@
                 <li role="presentation">
                   <a role="menuitem"
                      tabindex="-1"
-                     href="http://docs.opencast.org/{{ version['branch'] }}/admin"
+                     href="//docs.opencast.org/{{ version['branch'] }}/admin"
                      style="display: flex; justify-content: space-between;">
                     <span>{{ version['name'] }}</span>
                     {%- if version['attribute'] -%}
@@ -66,7 +66,7 @@
                 <li role="presentation">
                   <a role="menuitem"
                      tabindex="-1"
-                     href="http://docs.opencast.org/{{ version['branch'] }}/developer"
+                     href="//docs.opencast.org/{{ version['branch'] }}/developer"
                      style="display: flex; justify-content: space-between;">
                     <span>{{ version['name'] }}</span>
                     {%- if version['attribute'] -%}
@@ -124,7 +124,7 @@
           <p>Our weekly open meeting of developers and dev-ops takes place on
           <a href="https://opencast.blindsidenetworks.net">meet.opencast.video</a> (room 1, p: welcome) on every
           Tuesday at
-          <a href="http://arewemeetingyet.com/UTC/2019-02-26/15:00/w/Opencast's%20Technical%20Meeting#eyJ1cmwiOiJodHRwczovL29wZW5jYXN0LmJsaW5kc2lkZW5ldHdvcmtzLm5ldCJ9">
+          <a href="https://arewemeetingyet.com/UTC/2019-02-26/15:00/w/Opencast's%20Technical%20Meeting#eyJ1cmwiOiJodHRwczovL29wZW5jYXN0LmJsaW5kc2lkZW5ldHdvcmtzLm5ldCJ9">
             3pm UTC</a>.</p>
         </div>
         <div class="col-md-6">


### PR DESCRIPTION
This patch switches to HTTPS for documentation links if possible instead
of using HTTP and relying on redirects.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
