### PR TITLE
Prevent Users From Modifying ICLA Workflow

### DIFF
--- a/.github/workflows/check-icla.yml
+++ b/.github/workflows/check-icla.yml
@@ -1,6 +1,6 @@
 name: Check ICLA
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
The workflow for checking a users ICLA should not run in a pull request
context directly since users could otherwise modify the workflow.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
