### PR TITLE
Remove Unused Dependency on Series Service

### DIFF
--- a/modules/authorization-xacml/pom.xml
+++ b/modules/authorization-xacml/pom.xml
@@ -28,12 +28,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-series-service-api</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.security</groupId>
       <artifactId>jboss-xacml</artifactId>
       <version>2.0.5.final</version>
@@ -98,6 +92,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.compendium</artifactId>
       <scope>compile</scope>
@@ -112,6 +111,7 @@
           <ignoredUnusedDeclaredDependencies>
             <!-- Required for tests -->
             <ignoredUnusedDeclaredDependency>net.sf.saxon:Saxon-HE</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUnusedDeclaredDependency>
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -38,7 +38,6 @@ import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
-import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.MimeTypes;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple;
@@ -89,9 +88,6 @@ public class XACMLAuthorizationService implements AuthorizationService, ManagedS
 
   /** The security service */
   protected SecurityService securityService;
-
-  /** The series service */
-  protected SeriesService seriesService;
 
   /** The serializer for media pacakge */
   private MediaPackageSerializer serializer;
@@ -353,17 +349,6 @@ public class XACMLAuthorizationService implements AuthorizationService, ManagedS
   @Reference(name = "security")
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
-  }
-
-  /**
-   * Declarative services callback to set the series service.
-   *
-   * @param seriesService
-   *          the series service
-   */
-  @Reference(name = "series")
-  protected void setSeriesService(SeriesService seriesService) {
-    this.seriesService = seriesService;
   }
 
 }


### PR DESCRIPTION
This patch removes a superfluous dependency of the authorization-xacml
module to the series service.

g On branch rm-series-service-dependency

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
