### PR TITLE
Fix Wowza Streaming Misconfiguration

### DIFF
--- a/etc/org.opencastproject.distribution.streaming.wowza.WowzaStreamingDistributionService.cfg
+++ b/etc/org.opencastproject.distribution.streaming.wowza.WowzaStreamingDistributionService.cfg
@@ -1,7 +1,7 @@
 # Configures the streaming directory path for Wowza streaming service.
 # If this configuration is not set default path will be set
 # Default: streams folder in Opencast storage folder(org.opencastproject.storage.dir in custom.properties file)
-org.opencastproject.streaming.directory=~/opencast/streams
+#org.opencastproject.streaming.directory=${org.opencastproject.storage.dir}/streams
 
 # Configures the formats that are distributed to the Wowza streaming service.
 # Possible options are: hls, hds, smooth, dash

--- a/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
+++ b/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
@@ -232,7 +232,8 @@ public class WowzaStreamingDistributionService extends AbstractDistributionServi
         try {
           Files.createDirectories(distributionDirectory.toPath());
         } catch (IOException e) {
-          throw new ComponentException("Distribution directory does not exist and can't be created", e);
+          throw new ComponentException("Distribution directory " + distributionDirectory
+              + " does not exist and can't be created", e);
         }
       }
 


### PR DESCRIPTION
This patch removes a hard-coded configuration path to the storage
directory used by Wowza which is configured to be relative to the
current working directory and overwrites the (actually sane) default.

This causes Opencast to not properly boot on RPM (possibly other)
installations with an exception like:

```
1Caused by: java.nio.file.AccessDeniedException: /usr/share/opencast/~
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
