### PR TITLE
Documentation Deployment Conflicts

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,10 @@ on:
       - 'r/*'
       - 'develop'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-documentation:
     if: github.repository_owner == 'opencast'


### PR DESCRIPTION
Since the documentation is deployed via git, concurrent deployment can
cause conflicts and failures. This is not that bad since the system will
automatically heal itself eventually, but reducing the chances for
failures is good.

Most of the time, the problem occurs if multiple patches are merged in
quick succession. In that case, we don't need any but the last one to
succeed anyway, and we can just cancel earlier Deployments of one branch.

This patch does exactly that: Put all workflows run on one branch in a
[concurrency group](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency), letting new ones cancel older running ones.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
