### PR TITLE
Don't force inclusion of referred elements in snapshot

### DIFF
--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerSnapshotWorkflowOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerSnapshotWorkflowOperationHandler.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Workflow operation for taking a snapshot of a media package.
@@ -144,7 +143,6 @@ public class AssetManagerSnapshotWorkflowOperationHandler extends AbstractWorkfl
       // Is the element referencing anything?
       MediaPackageReference reference = element.getReference();
       if (reference != null) {
-        Map<String, String> referenceProperties = reference.getProperties();
         MediaPackageElement referencedElement = mp.getElementByReference(reference);
 
         // if we are distributing the referenced element, everything is fine. Otherwise...
@@ -165,14 +163,8 @@ public class AssetManagerSnapshotWorkflowOperationHandler extends AbstractWorkfl
           // Done. Let's cut the path but keep references to the mediapackage itself
           if (reference != null && reference.getType().equals(MediaPackageReference.TYPE_MEDIAPACKAGE)) {
             element.setReference(reference);
-          } else if (reference != null && (referenceProperties == null || referenceProperties.size() == 0)) {
-            element.clearReference();
           } else {
-            // Ok, there is more to that reference than just pointing at an element. Let's keep the original,
-            // you never know.
-            removals.remove(referencedElement);
-            referencedElement.setURI(null);
-            referencedElement.setChecksum(null);
+            element.clearReference();
           }
         }
       }

--- a/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
+++ b/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
@@ -935,7 +935,6 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
       // Is the element referencing anything?
       MediaPackageReference reference = element.getReference();
       if (reference != null) {
-        Map<String, String> referenceProperties = reference.getProperties();
         MediaPackageElement referencedElement = mediaPackage.getElementByReference(reference);
 
         // if we are distributing the referenced element, everything is fine. Otherwise...
@@ -956,13 +955,8 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
           // Done. Let's cut the path but keep references to the mediapackage itself
           if (reference != null && reference.getType().equals(MediaPackageReference.TYPE_MEDIAPACKAGE)) {
             element.setReference(reference);
-          } else if (reference != null && (referenceProperties == null || referenceProperties.size() == 0)) {
-            element.clearReference();
           } else {
-            // Ok, there is more to that reference than just pointing at an element. Let's keep the original,
-            // you never know.
-            referencedElement.setURI(null);
-            referencedElement.setChecksum(null);
+            element.clearReference();
           }
         }
       }


### PR DESCRIPTION
When a referred element should be excluded, but the reference has
properties Opencast forces the element to stay in the snapshot. This
changes the behaviour to the same as when no properties are set, i.e.
the referred element will not be included in the snapshot when a user
requests this.

Fixes #2627

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
