### PR TITLE
Cut Marks Attachments

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/cut-marks-to-smil-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/cut-marks-to-smil-woh.md
@@ -12,16 +12,19 @@ It does this by attributing the given times to the specified tracks.
 Tracks are assumed to start at 0.
 Likewise, cut marks are assumed to be specified relative to the beginning of the tracks.
 
+The cut marks must be a media package attachment.
+For compatibility to early versions, the code falls back to looking for catalogs if no attachment was found.
+
 
 Parameter Table
 ---------------
 
 |Configuration Keys    |Example              |Description                                                    |
 |----------------------|---------------------|---------------------------------------------------------------|
-|source-media-flavors  |`presenter/prepared` |The flavors containing the video tracks.                       |
-|source-json-flavor    |`cut-marks/json`     |The flavor of the JSON. Must contain exactly one file.         |
+|source-media-flavors  |`presenter/prepared` |The flavors identifying the video tracks.                      |
+|source-json-flavor    |`cut-marks/json`     |The flavor of the JSON. Must identify exactly one element.     |
 |target-smil-flavor    |`smil/cutmarks`      |The flavor of the resulting SMIL.                              |
-|target-tags           |`archive`            |(Optional) Tags to add to the resulting SMIL. Default is `null`|
+|target-tags           |`archive`            |Tags to add to the resulting SMIL. (Default: `null`)           |
 
 
 JSON Format


### PR DESCRIPTION
As discussed at the technical meeting, we don't want JSON files as media
package catalogs. This patch modifies the `cut-marks-to-smil` operation
to look for attachments instead, falling back to catalogs to not break
compatibility though.

This is the first part of enforcing XML catalogs.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
