### PR TITLE
Add opencast_major_version to docs

### DIFF
--- a/docs/guides/admin/docs/configuration/security.md
+++ b/docs/guides/admin/docs/configuration/security.md
@@ -16,9 +16,9 @@ with the basic concepts and vocabulary described in the Spring Security document
 
 ## Configure Access
 
-To configure access roles and URL patterns for a tenant, modify `/etc/security/{{tenant_identifier.xml}}`.  If you are
-not hosting multiple tenants on your Opencast server or cluster, all configuration should be done in
-`mh_default_org.xml`.
+To configure access roles and URL patterns for a tenant, modify `etc/security/<tenant_identifier.xml>`.
+If you are not hosting multiple tenants on your Opencast server or cluster,
+all configuration should be done in `mh_default_org.xml`.
 
 Some examples:
 

--- a/docs/guides/admin/docs/index.md
+++ b/docs/guides/admin/docs/index.md
@@ -1,5 +1,5 @@
-Opencast Administration Guide
-=============================
+Opencast {{ opencast_major_version() }} Administration Guide
+============================================================
 
 Welcome to the Opencast Universe! Opencast is an open-source enterprise level lecture recording system. The core of the
 system delivers functionality for scheduling, media encoding, editing and content delivery. For lecture capture,

--- a/docs/guides/admin/docs/workflowoperationhandlers/animate-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/animate-woh.md
@@ -37,13 +37,13 @@ files usually have the file extension `.sif` and *not* `.sifz`.
 You can use all metadata fields present in the episode and series DublinCore catalogs of an event. In SynfigStudio, just
 use placeholders of the following form:
 
-    '{{' ['series' | 'episode'] '.' DC-FIELD '}}'
+    {{ '{{' }} ['series' | 'episode'] '.' DC-FIELD {{ '}}' }}
 
 Here are some common examples:
 
-- `{{episode.title}}`
-- `{{episode.creator}}`
-- `{{series.title}}`
+- {{ '`{{episode.title}}`' }}
+- {{ '`{{episode.creator}}`' }}
+- {{ '`{{series.title}}`' }}
 
 
 Operation Examples

--- a/docs/guides/admin/docs/workflowoperationhandlers/animate-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/animate-woh.md
@@ -37,7 +37,7 @@ files usually have the file extension `.sif` and *not* `.sifz`.
 You can use all metadata fields present in the episode and series DublinCore catalogs of an event. In SynfigStudio, just
 use placeholders of the following form:
 
-    {{ '{{' }} ['series' | 'episode'] '.' DC-FIELD {{ '}}' }}
+    {{ "'{{' ['series' | 'episode'] '.' DC-FIELD '}}'" }}
 
 Here are some common examples:
 

--- a/docs/guides/admin/main.py
+++ b/docs/guides/admin/main.py
@@ -1,0 +1,15 @@
+import pathlib
+
+def define_env(env):
+    'Hook function'
+
+    @env.macro
+    def opencast_major_version():
+        '''Get Opencast version from main pom.xml
+        '''
+        pom_file = str(pathlib.Path(__file__).parent.resolve()) + '/../../../pom.xml'
+        line = ''
+        with open(pom_file, 'r') as pom:
+            while not line.startswith('  <version>'):
+                line = pom.readline()
+        return line.split('>')[1].split('<')[0].split('.')[0].split('-')[0]

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -7,6 +7,7 @@ markdown_extensions:
 
 plugins:
   - search:
+  - macros:
   - mermaid2:
       arguments:
         theme: neutral

--- a/docs/guides/requirements.txt
+++ b/docs/guides/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-windmill
 markdown_inline_graphviz_extension
 markdown-inline-graphviz-extension-png
 mkdocs-mermaid2-plugin
+mkdocs-macros-plugin


### PR DESCRIPTION
This is showing off how we could add an opencast_major_version macro to
the Opencast documentation. This might be helpful for things like the
installation guides.

Comments are welcome. Integration in deployments is still missing. But
it should be obvious how that would look like.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
