### PR TITLE
Prevent workflow from failing if we have no logs

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -108,8 +108,7 @@ jobs:
 
       - name: show logs on failure
         if: ${{ failure() }}
-        working-directory: build/opencast-dist-allinone/data/log
-        run: cat opencast.log || true
+        run: cat build/opencast-dist-allinone/data/log/opencast.log || true
 
       - name: save version
         working-directory: build


### PR DESCRIPTION
When the tests fail before the integration tests are run, the step which
is executed on failures will also fail since it tries to switch into a
non-existing directory.

This is annoying since GitHub Actions will then highlight that error
instead of the one which actually caused the failure.

This patch should fix the problem.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
