### PR TITLE
Introduce Allinone Profile

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -75,8 +75,12 @@ jobs:
           && github.repository == 'opencast/opencast'
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         run: |
-          mvn --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-            clean install
+          mvn clean install -Pallinone  \
+            --batch-mode \
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+            -Dhttp.keepAlive=false \
+            -Dmaven.wagon.http.pool=false \
+            -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
       - name: save version
         working-directory: build

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -33,6 +33,13 @@
       </modules>
     </profile>
     <profile>
+      <id>allinone</id>
+      <modules>
+        <module>karaf-features</module>
+        <module>dist-allinone</module>
+      </modules>
+    </profile>
+    <profile>
       <id>dev</id>
       <modules>
         <module>karaf-features</module>


### PR DESCRIPTION
We now build all our assemblies all the time for provisioning the test
servers and for the integration tests, even though we would only need
the `allinone` distribution.

This patch adds a separate allinone distribution for this case and makes
our tests and deployment use that one.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
