### PR TITLE
Fix file permissions of start-opencast

### DIFF
--- a/assemblies/package.xml
+++ b/assemblies/package.xml
@@ -73,7 +73,7 @@
       <source>target/assembly/bin/karaf</source>
       <outputDirectory>bin</outputDirectory>
       <destName>start-opencast</destName>
-      <fileMode>0744</fileMode>
+      <fileMode>0755</fileMode>
     </file>
     <file>
       <source>target/assembly/bin/inc</source>


### PR DESCRIPTION
The patch fixes the file permissions of Opencast's start script which
should be executable not only for the file owner.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
