### PR TITLE
Fix Landing Page

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -94,7 +94,7 @@ jobs:
         mv -v docs/guides/developer/site docs.opencast.org/"${GITHUB_REF#refs/heads/}/developer"
         mv -v docs/guides/.infrastructure/*.html docs.opencast.org/ || :
         mv -v docs/guides/.infrastructure/*.js docs.opencast.org/ || :
-        mv -rv docs/guides/.infrastructure/js/ docs.opencast.org/ || :
+        mv -v docs/guides/.infrastructure/js/ docs.opencast.org/ || :
         git log -n1 > docs.opencast.org/"${GITHUB_REF#refs/heads/}/commit"
 
     - name: commit new version


### PR DESCRIPTION
This fixes the broken `mv` command causing some JavaScript dependencies
for the documentation landing page not to be deployed.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
