### PR TITLE
Add dfxp as subtitle format to LTI upload

### DIFF
--- a/modules/lti-service-api/src/main/java/org/opencastproject/lti/service/api/LtiService.java
+++ b/modules/lti-service-api/src/main/java/org/opencastproject/lti/service/api/LtiService.java
@@ -49,6 +49,8 @@ public interface LtiService {
   void upsertEvent(
           LtiFileUpload file,
           String captions,
+          String captionsFormat,
+          String captionsLanguage,
           String eventId,
           String seriesId,
           String metadataJson) throws UnauthorizedException, NotFoundException;

--- a/modules/lti-service-api/src/main/java/org/opencastproject/lti/service/api/LtiService.java
+++ b/modules/lti-service-api/src/main/java/org/opencastproject/lti/service/api/LtiService.java
@@ -49,8 +49,8 @@ public interface LtiService {
   void upsertEvent(
           LtiFileUpload file,
           String captions,
-          String captionsFormat,
-          String captionsLanguage,
+          String captionFormat,
+          String captionLanguage,
           String eventId,
           String seriesId,
           String metadataJson) throws UnauthorizedException, NotFoundException;

--- a/modules/lti-service-impl/pom.xml
+++ b/modules/lti-service-impl/pom.xml
@@ -112,6 +112,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-scheduler-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workspace-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/lti-service-impl/pom.xml
+++ b/modules/lti-service-impl/pom.xml
@@ -112,11 +112,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-scheduler-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workspace-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
@@ -117,48 +117,48 @@ public class LtiServiceRestEndpoint {
       description = "Creates an event by sending metadata in a multipart request.",
       returnDescription = "",
       restParameters = {
-        @RestParameter(
-            name = "metadata",
-            description = "Event metadata",
-            isRequired = true,
-            type = STRING
-        ),
-        @RestParameter(
-            name = "presenter",
-            description = "Presenter movie track",
-            isRequired = true,
-            type = Type.FILE
-        ),
-        @RestParameter(
-            name = "captions",
-            description = "Caption file",
-            isRequired = false,
-            type = STRING
-        ),
-        @RestParameter(
-            name = "captionsFormat",
+          @RestParameter(
+              name = "metadata",
+              description = "Event metadata",
+              isRequired = true,
+              type = STRING
+          ),
+          @RestParameter(
+              name = "presenter",
+              description = "Presenter movie track",
+              isRequired = true,
+              type = Type.FILE
+          ),
+          @RestParameter(
+              name = "captions",
+              description = "Caption file",
+              isRequired = false,
+              type = STRING
+          ),
+          @RestParameter(
+            name = "captionFormat",
             description = "Caption file format",
             isRequired = false,
             type = STRING
-        ),
-        @RestParameter(
-            name = "captionsLanguage",
+          ),
+          @RestParameter(
+            name = "captionLanguage",
             description = "Caption language",
             isRequired = false,
             type = STRING
-        ),
-        @RestParameter(
-            name = "isPartOf",
-            description = "Series id of the event",
-            isRequired = false,
-            type = STRING
-        ),
-        @RestParameter(
-            name = "eventId",
-            description = "ID of the event to update (if it's an update)",
-            isRequired = false,
-            type = STRING
-        )
+          ),
+          @RestParameter(
+              name = "isPartOf",
+              description = "Series id of the event",
+              isRequired = false,
+              type = STRING
+          ),
+          @RestParameter(
+              name = "eventId",
+              description = "ID of the event to update (if it's an update)",
+              isRequired = false,
+              type = STRING
+          )
       },
       responses = {
         @RestResponse(
@@ -179,8 +179,8 @@ public class LtiServiceRestEndpoint {
     String seriesId = "";
     try {
       String captions = null;
-      String captionsFormat = null;
-      String captionsLanguage = null;
+      String captionFormat = null;
+      String captionLanguage = null;
       String eventId = null;
       String metadataJson = null;
       for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
@@ -195,10 +195,10 @@ public class LtiServiceRestEndpoint {
           metadataJson = Streams.asString(item.openStream());
         } else if ("captions".equals(fieldName)) {
           captions = Streams.asString(item.openStream());
-        } else if ("captionsFormat".equals(fieldName)) {
-          captionsFormat = Streams.asString(item.openStream());
-        } else if ("captionsLanguage".equals(fieldName)) {
-          captionsLanguage = Streams.asString(item.openStream());
+        } else if ("captionFormat".equals(fieldName)) {
+          captionFormat = Streams.asString(item.openStream());
+        } else if ("captionLanguage".equals(fieldName)) {
+          captionLanguage = Streams.asString(item.openStream());
         } else if ("eventId".equals(fieldName)) {
           eventId = Streams.asString(item.openStream());
         } else {
@@ -207,8 +207,8 @@ public class LtiServiceRestEndpoint {
           service.upsertEvent(
                   new LtiFileUpload(stream, streamName),
                   captions,
-                  captionsFormat,
-                  captionsLanguage,
+                  captionFormat,
+                  captionLanguage,
                   eventId,
                   seriesId,
                   metadataJson);
@@ -218,7 +218,7 @@ public class LtiServiceRestEndpoint {
       if (eventId == null) {
         return Response.status(Status.BAD_REQUEST).entity("No file given").build();
       }
-      service.upsertEvent(null, captions, captionsFormat, captionsLanguage, eventId, seriesId, metadataJson);
+      service.upsertEvent(null, captions, captionFormat, captionLanguage, eventId, seriesId, metadataJson);
       return Response.ok().build();
     } catch (FileUploadException | IOException e) {
       return Response.status(Status.INTERNAL_SERVER_ERROR).entity("error while uploading").build();

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
@@ -113,60 +113,74 @@ public class LtiServiceRestEndpoint {
   @Path("/")
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @RestQuery(
-      name = "createevent",
-      description = "Creates an event by sending metadata in a multipart request.",
-      returnDescription = "",
-      restParameters = {
-          @RestParameter(
-              name = "metadata",
-              description = "Event metadata",
-              isRequired = true,
-              type = STRING
-          ),
-          @RestParameter(
-              name = "presenter",
-              description = "Presenter movie track",
-              isRequired = true,
-              type = Type.FILE
-          ),
-          @RestParameter(
-              name = "captions",
-              description = "Caption file",
-              isRequired = false,
-              type = STRING
-          ),
-          @RestParameter(
-              name = "isPartOf",
-              description = "Series id of the event",
-              isRequired = false,
-              type = STRING
-          ),
-          @RestParameter(
-              name = "eventId",
-              description = "ID of the event to update (if it's an update)",
-              isRequired = false,
-              type = STRING
-          )
-      },
-      responses = {
-          @RestResponse(
-              description = "A new event is created or the event is updated",
-              responseCode = HttpServletResponse.SC_OK
-          ),
-          @RestResponse(
-              description = "No authorization to create or update events",
-              responseCode = HttpServletResponse.SC_UNAUTHORIZED
-          ),
-          @RestResponse(
-              description = "The event to be updated wasn't found",
-              responseCode = HttpServletResponse.SC_NOT_FOUND
-          )
-      }
+    name = "createevent",
+    description = "Creates an event by sending metadata in a multipart request.",
+    returnDescription = "",
+    restParameters = {
+        @RestParameter(
+            name = "metadata",
+            description = "Event metadata",
+            isRequired = true,
+            type = STRING
+        ),
+        @RestParameter(
+            name = "presenter",
+            description = "Presenter movie track",
+            isRequired = true,
+            type = Type.FILE
+        ),
+        @RestParameter(
+            name = "captions",
+            description = "Caption file",
+            isRequired = false,
+            type = STRING
+        ),
+        @RestParameter(
+            name = "captionsFormat",
+            description = "Caption file format",
+            isRequired = false,
+            type = STRING
+        ),
+        @RestParameter(
+            name = "captionsLanguage",
+            description = "Caption language",
+            isRequired = false,
+            type = STRING
+        ),
+        @RestParameter(
+            name = "isPartOf",
+            description = "Series id of the event",
+            isRequired = false,
+            type = STRING
+        ),
+        @RestParameter(
+            name = "eventId",
+            description = "ID of the event to update (if it's an update)",
+            isRequired = false,
+            type = STRING
+        )
+    },
+    responses = {
+        @RestResponse(
+            description = "A new event is created or the event is updated",
+            responseCode = HttpServletResponse.SC_OK
+        ),
+        @RestResponse(
+            description = "No authorization to create or update events",
+            responseCode = HttpServletResponse.SC_UNAUTHORIZED
+        ),
+        @RestResponse(
+            description = "The event to be updated wasn't found",
+            responseCode = HttpServletResponse.SC_NOT_FOUND
+        )
+    }
   )
   public Response createNewEvent(@HeaderParam("Accept") String acceptHeader, @Context HttpServletRequest request) {
     String seriesId = "";
     try {
       String captions = null;
+      String captionsFormat = null;
+      String captionsLanguage = null;
       String eventId = null;
       String metadataJson = null;
       for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
@@ -181,6 +195,10 @@ public class LtiServiceRestEndpoint {
           metadataJson = Streams.asString(item.openStream());
         } else if ("captions".equals(fieldName)) {
           captions = Streams.asString(item.openStream());
+        } else if ("captionsFormat".equals(fieldName)) {
+          captionsFormat = Streams.asString(item.openStream());
+        } else if ("captionsLanguage".equals(fieldName)) {
+          captionsLanguage = Streams.asString(item.openStream());
         } else if ("eventId".equals(fieldName)) {
           eventId = Streams.asString(item.openStream());
         } else {
@@ -189,6 +207,8 @@ public class LtiServiceRestEndpoint {
           service.upsertEvent(
                   new LtiFileUpload(stream, streamName),
                   captions,
+                  captionsFormat,
+                  captionsLanguage,
                   eventId,
                   seriesId,
                   metadataJson);
@@ -198,7 +218,7 @@ public class LtiServiceRestEndpoint {
       if (eventId == null) {
         return Response.status(Status.BAD_REQUEST).entity("No file given").build();
       }
-      service.upsertEvent(null, captions, eventId, seriesId, metadataJson);
+      service.upsertEvent(null, captions, captionsFormat, captionsLanguage, eventId, seriesId, metadataJson);
       return Response.ok().build();
     } catch (FileUploadException | IOException e) {
       return Response.status(Status.INTERNAL_SERVER_ERROR).entity("error while uploading").build();

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
@@ -113,10 +113,10 @@ public class LtiServiceRestEndpoint {
   @Path("/")
   @Consumes(MediaType.MULTIPART_FORM_DATA)
   @RestQuery(
-    name = "createevent",
-    description = "Creates an event by sending metadata in a multipart request.",
-    returnDescription = "",
-    restParameters = {
+      name = "createevent",
+      description = "Creates an event by sending metadata in a multipart request.",
+      returnDescription = "",
+      restParameters = {
         @RestParameter(
             name = "metadata",
             description = "Event metadata",
@@ -159,8 +159,8 @@ public class LtiServiceRestEndpoint {
             isRequired = false,
             type = STRING
         )
-    },
-    responses = {
+      },
+      responses = {
         @RestResponse(
             description = "A new event is created or the event is updated",
             responseCode = HttpServletResponse.SC_OK
@@ -173,7 +173,7 @@ public class LtiServiceRestEndpoint {
             description = "The event to be updated wasn't found",
             responseCode = HttpServletResponse.SC_NOT_FOUND
         )
-    }
+      }
   )
   public Response createNewEvent(@HeaderParam("Accept") String acceptHeader, @Context HttpServletRequest request) {
     String seriesId = "";

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -277,8 +277,6 @@ public class LtiServiceImpl implements LtiService, ManagedService {
         captionsMediaPackage.setURI(captionsUri);
       }
 
-      final MetadataList metadataList = new MetadataList();
-      final MediaPackageElementFlavor flavor = new MediaPackageElementFlavor("dublincore", "episode");
       final EventCatalogUIAdapter adapter = getEventCatalogUIAdapter();
 
       final DublinCoreMetadataCollection collection = adapter.getRawFields();

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -314,11 +314,11 @@ public class LtiServiceImpl implements LtiService, ManagedService {
       eventHttpRequest.setAcl(accessControlList);
 
       //Set workflow json object
-      JsonObject workflowConfig = new JSONObject();
+      JSONObject workflowConfig = new JSONObject();
 
-      workflowConfig.put('workflow', workflow);
-      workflowConfig.put('configuration', workflowConfiguration);
-
+      workflowConfig.put("workflow", workflow);
+      workflowConfig.put("configuration", (JSONObject) new JSONParser()
+          .parse(workflowConfiguration));
       eventHttpRequest.setProcessing(workflowConfig);
       eventHttpRequest.setMetadataList(metadataList);
       metadataList.add(adapter, collection);
@@ -326,7 +326,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
       JSONObject source = new JSONObject();
       source.put("type", "UPLOAD");
       eventHttpRequest.setSource(source);
-      indexService.createEvent(r);
+      indexService.createEvent(eventHttpRequest);
     } catch (SchedulerException e) {
       if (e.getCause() instanceof NotFoundException || e.getCause() instanceof IllegalArgumentException) {
         throw new RuntimeException("unable to create event", e.getCause());

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -235,6 +235,8 @@ public class LtiServiceImpl implements LtiService, ManagedService {
   public void upsertEvent(
           final LtiFileUpload file,
           final String captions,
+          final String captionsFormat,
+          final String captionsLanguage,
           final String eventId,
           final String seriesId,
           final String metadataJson) throws UnauthorizedException, NotFoundException {
@@ -251,19 +253,23 @@ public class LtiServiceImpl implements LtiService, ManagedService {
         throw new RuntimeException("Unable to create media package for event");
       }
       if (captions != null) {
-        final MediaPackageElementFlavor captionsFlavor = new MediaPackageElementFlavor("captions", "vtt+en");
+        final MediaPackageElementFlavor captionsFlavor = new MediaPackageElementFlavor(captionsFormat + "+" + captionsLanguage, "captions");
         final MediaPackageElementBuilder elementBuilder
             = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
         final MediaPackageElement captionsMpe = elementBuilder
                 .newElement(MediaPackageElement.Type.Attachment, captionsFlavor);
-        captionsMpe.setMimeType(mimeType("text", "vtt"));
-        captionsMpe.addTag("lang:en");
+        if ("dfxp".equals(captionsFormat)) {
+          captionsMpe.setMimeType(mimeType("application", "xml"));
+        } else {
+          captionsMpe.setMimeType(mimeType("text", captionsFormat));
+        }
+        captionsMpe.addTag("lang:" + captionsLanguage);
         mp.add(captionsMpe);
         final URI captionsUri = workspace
                 .put(
                         mp.getIdentifier().toString(),
                         captionsMpe.getIdentifier(),
-                        "captions.vtt",
+                        "captions." + captionsFormat,
                         new ByteArrayInputStream(captions.getBytes(StandardCharsets.UTF_8)));
         captionsMpe.setURI(captionsUri);
       }

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -354,10 +354,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
     final EventCatalogUIAdapter adapter = catalogUIAdapters.stream()
         .filter(e -> e.getFlavor().equals(flavor))
         .findAny()
-        .orElse(null);
-    if (adapter == null) {
-      throw new RuntimeException("no adapter found");
-    }
+        .orElseThrow(() -> new RuntimeException("no adapter found"));
     return adapter;
   }
 

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -328,8 +328,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
       r.setSource(source);
       indexService.createEvent(r);
     } catch (SchedulerException e) {
-      if (e.getCause() != null && e.getCause() instanceof NotFoundException
-              || e.getCause() instanceof IllegalArgumentException) {
+      if (e.getCause() instanceof NotFoundException || e.getCause() instanceof IllegalArgumentException) {
         throw new RuntimeException("unable to create event", e.getCause());
       } else {
         throw new RuntimeException("unable to create event", e);

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -304,12 +304,18 @@ public class LtiServiceImpl implements LtiService, ManagedService {
 
       AccessControlList accessControlList = null;
 
-      accessControlList = new AccessControlList(
+      // If series is set and it's ACL is not empty, use series' ACL as default
+      if (StringUtils.isNotBlank(seriesId)) {
+        accessControlList = seriesService.getSeriesAccessControl(seriesId);
+      }
+
+      if (accessControlList == null || accessControlList.getEntries().isEmpty()) {
+        accessControlList = new AccessControlList(
           new AccessControlEntry("ROLE_ADMIN", "write", true),
           new AccessControlEntry("ROLE_ADMIN", "read", true),
           new AccessControlEntry("ROLE_OAUTH_USER", "write", true),
           new AccessControlEntry("ROLE_OAUTH_USER", "read", true));
-
+      }
       r.setAcl(accessControlList);
       r.setProcessing(
               (JSONObject) new JSONParser().parse(

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -253,7 +253,8 @@ public class LtiServiceImpl implements LtiService, ManagedService {
         throw new RuntimeException("Unable to create media package for event");
       }
       if (captions != null) {
-        final MediaPackageElementFlavor captionsFlavor = new MediaPackageElementFlavor(captionsFormat + "+" + captionsLanguage, "captions");
+        final MediaPackageElementFlavor captionsFlavor =
+            new MediaPackageElementFlavor(captionsFormat + "+" + captionsLanguage, "captions");
         final MediaPackageElementBuilder elementBuilder
             = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
         final MediaPackageElement captionsMpe = elementBuilder

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -34,7 +34,6 @@ import org.opencastproject.elasticsearch.index.event.Event;
 import org.opencastproject.elasticsearch.index.event.EventSearchQuery;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.exception.IndexServiceException;
-import org.opencastproject.index.service.impl.util.EventHttpServletRequest;
 import org.opencastproject.index.service.impl.util.EventUtils;
 import org.opencastproject.ingest.api.IngestService;
 import org.opencastproject.lti.service.api.LtiFileUpload;
@@ -249,7 +248,6 @@ public class LtiServiceImpl implements LtiService, ManagedService {
       throw new RuntimeException("No workflow configured, cannot upload");
     }
     try {
-      final EventHttpServletRequest eventHttpRequest = new EventHttpServletRequest();
       MediaPackage mediaPackage = ingestService.createMediaPackage();
       if (mediaPackage == null) {
         throw new RuntimeException("Unable to create media package for event");

--- a/modules/lti-service-remote/src/main/java/org/opencastproject/lti/endpoint/LtiServiceRemoteImpl.java
+++ b/modules/lti-service-remote/src/main/java/org/opencastproject/lti/endpoint/LtiServiceRemoteImpl.java
@@ -83,6 +83,8 @@ public class LtiServiceRemoteImpl extends RemoteBase implements LtiService {
   public void upsertEvent(
           final LtiFileUpload file,
           final String captions,
+          final String captionsFormat,
+          final String captionsLanguage,
           final String eventId,
           final String seriesId,
           final String metadataJson) {
@@ -94,6 +96,12 @@ public class LtiServiceRemoteImpl extends RemoteBase implements LtiService {
     }
     if (captions != null) {
       entity.addTextBody("captions", captions);
+    }
+    if (captionsFormat != null) {
+      entity.addTextBody("captionsFormat", captionsFormat);
+    }
+    if (captionsLanguage != null) {
+      entity.addTextBody("captionsLanguage", captionsLanguage);
     }
     if (file != null) {
       entity.addPart(file.getSourceName(), new InputStreamBody(file.getStream(), file.getSourceName()));

--- a/modules/lti-service-remote/src/main/java/org/opencastproject/lti/endpoint/LtiServiceRemoteImpl.java
+++ b/modules/lti-service-remote/src/main/java/org/opencastproject/lti/endpoint/LtiServiceRemoteImpl.java
@@ -83,8 +83,8 @@ public class LtiServiceRemoteImpl extends RemoteBase implements LtiService {
   public void upsertEvent(
           final LtiFileUpload file,
           final String captions,
-          final String captionsFormat,
-          final String captionsLanguage,
+          final String captionFormat,
+          final String captionLanguage,
           final String eventId,
           final String seriesId,
           final String metadataJson) {
@@ -97,11 +97,11 @@ public class LtiServiceRemoteImpl extends RemoteBase implements LtiService {
     if (captions != null) {
       entity.addTextBody("captions", captions);
     }
-    if (captionsFormat != null) {
-      entity.addTextBody("captionsFormat", captionsFormat);
+    if (captionFormat != null) {
+      entity.addTextBody("captionFormat", captionFormat);
     }
-    if (captionsLanguage != null) {
-      entity.addTextBody("captionsLanguage", captionsLanguage);
+    if (captionLanguage != null) {
+      entity.addTextBody("captionLanguage", captionLanguage);
     }
     if (file != null) {
       entity.addPart(file.getSourceName(), new InputStreamBody(file.getStream(), file.getSourceName()));

--- a/modules/lti/src/OpencastRest.ts
+++ b/modules/lti/src/OpencastRest.ts
@@ -253,6 +253,8 @@ export async function uploadFile(
     eventId?: string,
     presenterFile?: Blob,
     captionFile?: Blob,
+    captionFormat?: string,
+    captionLanguage?: string,
     setUploadPogress?: (progress: number) => void): Promise<{}> {
     const percentage = 100;
     const data = new FormData();
@@ -264,6 +266,10 @@ export async function uploadFile(
         data.append("captions", captionFile);
     if (presenterFile !== undefined)
         data.append("presenter", presenterFile);
+    if (captionFormat !== undefined)
+        data.append("captionFormat", captionFormat);
+    if (captionLanguage !== undefined)
+        data.append("captionLanguage", captionLanguage);
     return axios.post(
         hostAndPort() + "/lti-service-gui",
         data,

--- a/modules/lti/src/OpencastRest.ts
+++ b/modules/lti/src/OpencastRest.ts
@@ -262,14 +262,14 @@ export async function uploadFile(
     if (eventId !== undefined)
         data.append("eventId", eventId);
     data.append("seriesId", seriesId);
-    if (captionFile !== undefined)
-        data.append("captions", captionFile);
-    if (presenterFile !== undefined)
-        data.append("presenter", presenterFile);
     if (captionFormat !== undefined)
         data.append("captionFormat", captionFormat);
     if (captionLanguage !== undefined)
         data.append("captionLanguage", captionLanguage);
+    if (captionFile !== undefined)
+        data.append("captions", captionFile);
+    if (presenterFile !== undefined)
+        data.append("presenter", presenterFile);
     return axios.post(
         hostAndPort() + "/lti-service-gui",
         data,

--- a/modules/lti/src/components/EditForm.tsx
+++ b/modules/lti/src/components/EditForm.tsx
@@ -169,17 +169,16 @@ class TranslatedEditForm extends React.Component<EditFormProps> {
             }
             {this.props.withUpload === true &&
                 <>
-                    <div className="form-group my-4">
-                        <label className="px-3" htmlFor="caption">{this.props.t("LTI.CAPTION")}</label>
-                        <input type="file" className="form-control-file px-3" onChange={this.onChangeCaptionFile.bind(this)} />
+                    <div className="form-group">
+                        <label htmlFor="caption">{this.props.t("LTI.CAPTION")}</label>
+                        <input type="file" className="form-control-file" onChange={this.onChangeCaptionFile.bind(this)} />
                         <small className="form-text text-muted">{this.props.t("LTI.CAPTION_DESCRIPTION")}</small>
                     </div>
                     { this.props.captionFormat === "vtt" && languageOptions.length > 0 &&
-                        <div className="form-group my-4">
-                            <label className="px-3" htmlFor="caption_language">{this.props.t("LTI.CAPTION")} {this.props.t("LTI.LANGUAGE")}</label>
+                        <div className="form-group">
+                            <label htmlFor="caption_language">{this.props.t("LTI.CAPTION")} {this.props.t("LTI.LANGUAGE")}</label>
                             <Select
                                 id="caption_language"
-                                className="px-3"
                                 onChange={(value) => this.props.onCaptionLanguageChange((value as OptionType).value)}
                                 options={languageOptions}
                                 placeholder={this.props.t("LTI.SELECT_OPTION")}

--- a/modules/lti/src/components/EditForm.tsx
+++ b/modules/lti/src/components/EditForm.tsx
@@ -169,19 +169,21 @@ class TranslatedEditForm extends React.Component<EditFormProps> {
             }
             {this.props.withUpload === true &&
                 <>
-                    <div className="form-group">
-                        <label htmlFor="caption">{this.props.t("LTI.CAPTION")}</label>
-                        <input type="file" className="form-control-file" onChange={this.onChangeCaptionFile.bind(this)} />
+                    <div className="form-group my-4">
+                        <label className="px-3" htmlFor="caption">{this.props.t("LTI.CAPTION")}</label>
+                        <input type="file" className="form-control-file px-3" onChange={this.onChangeCaptionFile.bind(this)} />
                         <small className="form-text text-muted">{this.props.t("LTI.CAPTION_DESCRIPTION")}</small>
                     </div>
                     { this.props.captionFormat === "vtt" && languageOptions.length > 0 &&
-                        <div className="form-group">
-                            <label htmlFor="caption_language">{this.props.t("LTI.CAPTION")} {this.props.t("LTI.LANGUAGE")}</label>
+                        <div className="form-group my-4">
+                            <label className="px-3" htmlFor="caption_language">{this.props.t("LTI.CAPTION")} {this.props.t("LTI.LANGUAGE")}</label>
                             <Select
                                 id="caption_language"
+                                className="px-3"
                                 onChange={(value) => this.props.onCaptionLanguageChange((value as OptionType).value)}
                                 options={languageOptions}
                                 placeholder={this.props.t("LTI.SELECT_OPTION")}
+                                required
                             />
                         </div>
                     }

--- a/modules/lti/src/components/EditForm.tsx
+++ b/modules/lti/src/components/EditForm.tsx
@@ -23,9 +23,11 @@ interface EditFormProps extends WithTranslation {
     readonly onDataChange: (newData: EventMetadataContainer) => void;
     readonly onPresenterFileChange: (file: Blob) => void;
     readonly onCaptionFileChange: (file: Blob) => void;
+    readonly onCaptionLanguageChange: (language: string) => void;
     readonly onSubmit: () => void;
     readonly pending: boolean;
     readonly hasSubmit: boolean;
+    readonly captionFormat?: string;
 }
 
 interface MetadataFieldProps {
@@ -145,6 +147,11 @@ class TranslatedEditForm extends React.Component<EditFormProps> {
     }
 
     render() {
+        const languageField = this.props.data.fields.filter((field) => field.id === "language")[0];
+        let languageOptions: OptionType[] = [];
+        if(languageField.collection !== undefined){
+            languageOptions = collectionToOptions(languageField.collection, languageField.translatable, this.props.t);
+        }
         return <form>
             {this.props.data.fields
                 .filter((field) => allowedFields.includes(field.id))
@@ -161,11 +168,24 @@ class TranslatedEditForm extends React.Component<EditFormProps> {
                 </div>
             }
             {this.props.withUpload === true &&
-                <div className="form-group">
-                    <label htmlFor="caption">{this.props.t("LTI.CAPTION")}</label>
-                    <input type="file" className="form-control-file" onChange={this.onChangeCaptionFile.bind(this)} />
-                    <small className="form-text text-muted">{this.props.t("LTI.CAPTION_DESCRIPTION")}</small>
-                </div>
+                <>
+                    <div className="form-group">
+                        <label htmlFor="caption">{this.props.t("LTI.CAPTION")}</label>
+                        <input type="file" className="form-control-file" onChange={this.onChangeCaptionFile.bind(this)} />
+                        <small className="form-text text-muted">{this.props.t("LTI.CAPTION_DESCRIPTION")}</small>
+                    </div>
+                    { this.props.captionFormat === "vtt" && languageOptions.length > 0 &&
+                        <div className="form-group">
+                            <label htmlFor="caption_language">{this.props.t("LTI.CAPTION")} {this.props.t("LTI.LANGUAGE")}</label>
+                            <Select
+                                id="caption_language"
+                                onChange={(value) => this.props.onCaptionLanguageChange((value as OptionType).value)}
+                                options={languageOptions}
+                                placeholder={this.props.t("LTI.SELECT_OPTION")}
+                            />
+                        </div>
+                    }
+                </>
             }
             {this.props.hasSubmit === true &&
                 <button

--- a/modules/lti/src/components/Upload.tsx
+++ b/modules/lti/src/components/Upload.tsx
@@ -191,7 +191,7 @@ class TranslatedUpload extends React.Component<UploadProps, UploadState> {
             captionFormat = 'vtt';
         } else {
             if(newFile instanceof File){
-                captionFormat = newFile.name !== undefined ? newFile.name.substring(newFile.name.lastIndexOf('.') + 1) : undefined;
+                captionFormat = newFile.name !== '' ? newFile.name.substring(newFile.name.lastIndexOf('.') + 1) : undefined;
                 if(captionFormat === 'dfxp') {
                     const fileReader = new FileReader();
                     fileReader.onloadend = (e) =>

--- a/modules/lti/src/components/Upload.tsx
+++ b/modules/lti/src/components/Upload.tsx
@@ -35,6 +35,8 @@ interface UploadState {
     readonly metadata: MetadataResult | "error" | undefined;
     readonly presenterFile?: Blob;
     readonly captionFile?: Blob;
+    readonly captionFormat?: string;
+    readonly captionLanguage?: string;
     readonly copyState: "success" | "error" | "pending" | "none";
     readonly copySeries?: OptionType;
     readonly uploadProgress: number;
@@ -156,6 +158,8 @@ class TranslatedUpload extends React.Component<UploadProps, UploadState> {
             this.state.eventId,
             this.state.presenterFile,
             this.state.captionFile,
+            this.state.captionFormat,
+            this.state.captionLanguage,
             this.setUploadProgress = this.setUploadProgress.bind(this)
         ).then((_) => {
             if (!isMetadata(this.state.metadata))
@@ -181,10 +185,41 @@ class TranslatedUpload extends React.Component<UploadProps, UploadState> {
         });
     }
 
-    onCaptionFileChange(newFile: Blob) {
+    onCaptionFileChange(newFile: Blob | File) {
+        let captionFormat: string | undefined = undefined
+        if(newFile.type === 'text/vtt') {
+            captionFormat = 'vtt';
+        } else {
+            if(newFile instanceof File){
+                captionFormat = newFile.name !== undefined ? newFile.name.substring(newFile.name.lastIndexOf('.') + 1) : undefined;
+                if(captionFormat === 'dfxp') {
+                    const fileReader = new FileReader();
+                    fileReader.onloadend = (e) =>
+                    {
+                        if(e.target?.result !== null && typeof e.target?.result === 'string'){
+                            const parser = new DOMParser();
+                            const xml = parser.parseFromString(e.target.result, 'text/xml');
+                            const lang = xml.querySelector('tt')?.getAttribute('xml:lang');
+                            if(lang !== null && lang !== undefined) {
+                                this.onCaptionLanguageChange(lang);
+                            }
+                        }
+                    }
+                    fileReader.readAsText(newFile);
+                }
+            }
+        }
         this.setState({
             ...this.state,
-            captionFile: newFile
+            captionFile: newFile,
+            captionFormat: captionFormat
+        });
+    }
+
+    onCaptionLanguageChange(language: string){
+        this.setState({
+            ...this.state,
+            captionLanguage: language
         });
     }
 
@@ -279,6 +314,8 @@ class TranslatedUpload extends React.Component<UploadProps, UploadState> {
                 onDataChange={this.onDataChange.bind(this)}
                 onPresenterFileChange={this.onPresenterFileChange.bind(this)}
                 onCaptionFileChange={this.onCaptionFileChange.bind(this)}
+                onCaptionLanguageChange={this.onCaptionLanguageChange.bind(this)}
+                captionFormat={this.state.captionFormat}
                 onSubmit={this.onSubmit.bind(this)}
                 hasSubmit={this.state.metadata.edited.locked === undefined}
                 pending={this.state.uploadState === "pending"} />

--- a/modules/lti/src/main/java/org/opencastproject/lti/LtiServiceGuiEndpoint.java
+++ b/modules/lti/src/main/java/org/opencastproject/lti/LtiServiceGuiEndpoint.java
@@ -199,6 +199,8 @@ public class LtiServiceGuiEndpoint {
     String seriesId = "";
     try {
       String captions = null;
+      String captionsFormat = null;
+      String captionsLanguage = null;
       String metadata = null;
       String eventId = null;
       for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
@@ -210,6 +212,10 @@ public class LtiServiceGuiEndpoint {
           metadata = Streams.asString(item.openStream());
         } else if ("captions".equals(fieldName)) {
           captions = Streams.asString(item.openStream());
+        } else if ("captionsFormat".equals(fieldName)) {
+          captionsFormat = Streams.asString(item.openStream());
+        } else if ("captionsLanguage".equals(fieldName)) {
+          captionsLanguage = Streams.asString(item.openStream());
         } else if ("seriesId".equals(fieldName)) {
           final String fieldValue = Streams.asString(item.openStream());
           if (!fieldValue.isEmpty()) {
@@ -219,6 +225,8 @@ public class LtiServiceGuiEndpoint {
           service.upsertEvent(
                   new LtiFileUpload(item.openStream(), item.getName()),
                   captions,
+                  captionsFormat,
+                  captionsLanguage,
                   eventId,
                   seriesId,
                   metadata);
@@ -228,6 +236,8 @@ public class LtiServiceGuiEndpoint {
       service.upsertEvent(
               null,
               captions,
+              captionsFormat,
+              captionsLanguage,
               eventId,
               seriesId,
               metadata);

--- a/modules/lti/src/main/java/org/opencastproject/lti/LtiServiceGuiEndpoint.java
+++ b/modules/lti/src/main/java/org/opencastproject/lti/LtiServiceGuiEndpoint.java
@@ -199,8 +199,8 @@ public class LtiServiceGuiEndpoint {
     String seriesId = "";
     try {
       String captions = null;
-      String captionsFormat = null;
-      String captionsLanguage = null;
+      String captionFormat = null;
+      String captionLanguage = null;
       String metadata = null;
       String eventId = null;
       for (FileItemIterator iter = new ServletFileUpload().getItemIterator(request); iter.hasNext();) {
@@ -212,10 +212,10 @@ public class LtiServiceGuiEndpoint {
           metadata = Streams.asString(item.openStream());
         } else if ("captions".equals(fieldName)) {
           captions = Streams.asString(item.openStream());
-        } else if ("captionsFormat".equals(fieldName)) {
-          captionsFormat = Streams.asString(item.openStream());
-        } else if ("captionsLanguage".equals(fieldName)) {
-          captionsLanguage = Streams.asString(item.openStream());
+        } else if ("captionFormat".equals(fieldName)) {
+          captionFormat = Streams.asString(item.openStream());
+        } else if ("captionLanguage".equals(fieldName)) {
+          captionLanguage = Streams.asString(item.openStream());
         } else if ("seriesId".equals(fieldName)) {
           final String fieldValue = Streams.asString(item.openStream());
           if (!fieldValue.isEmpty()) {
@@ -225,8 +225,8 @@ public class LtiServiceGuiEndpoint {
           service.upsertEvent(
                   new LtiFileUpload(item.openStream(), item.getName()),
                   captions,
-                  captionsFormat,
-                  captionsLanguage,
+                  captionFormat,
+                  captionLanguage,
                   eventId,
                   seriesId,
                   metadata);
@@ -236,8 +236,8 @@ public class LtiServiceGuiEndpoint {
       service.upsertEvent(
               null,
               captions,
-              captionsFormat,
-              captionsLanguage,
+              captionFormat,
+              captionLanguage,
               eventId,
               seriesId,
               metadata);


### PR DESCRIPTION
This adds the possibility to upload dfxp subtitles via the LTI upload module.
When using webvtt you will be prompted to set the language of the subtitles, when using dfxp the language will be parsed from the subtitle file itself, so there is no need to manually set this.