### PR TITLE
Fix Prepare-AV Target Tag Handling

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * The <tt>prepare media</tt> operation will make sure that media where audio and video track come in separate files
@@ -145,7 +146,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
 
     // Read the configuration properties
     MediaPackageElementFlavor sourceFlavor = tagsAndFlavors.getSingleSrcFlavor();
-    String targetTrackTags = tagsAndFlavors.getTargetTags().toString();
+    List<String> targetTrackTags = tagsAndFlavors.getTargetTags();
     MediaPackageElementFlavor targetFlavor = tagsAndFlavors.getSingleTargetFlavor();
     String muxEncodingProfileName = StringUtils.trimToNull(operation.getConfiguration("mux-encoding-profile"));
     String audioVideoEncodingProfileName = StringUtils.trimToNull(operation.getConfiguration("audio-video-encoding-profile"));

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -224,10 +224,11 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
     final MediaPackage mediaPackage = workflowInstance.getMediaPackage();
 
     ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance,
-        Configuration.none, Configuration.one, Configuration.none, Configuration.one);
+        Configuration.none, Configuration.one, Configuration.many, Configuration.one);
 
     final MediaPackageElementFlavor sourceFlavor = tagsAndFlavors.getSingleSrcFlavor();
     final MediaPackageElementFlavor targetTrackFlavor = tagsAndFlavors.getSingleTargetFlavor();
+    final List<String> targetTrackTags = tagsAndFlavors.getTargetTags();
 
     final Track[] tracks = mediaPackage.getTracks(sourceFlavor);
 
@@ -341,10 +342,8 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
     });
 
     // Update Tags here
-    getConfiguration(workflowInstance, "target-tags").ifPresent(tags -> {
-      final WorkflowOperationTagUtil.TagDiff tagDiff = WorkflowOperationTagUtil.createTagDiff(tags);
-      result.forEachTrack(t -> WorkflowOperationTagUtil.applyTagDiff(tagDiff, t));
-    });
+    final WorkflowOperationTagUtil.TagDiff tagDiff = WorkflowOperationTagUtil.createTagDiff(targetTrackTags);
+    result.forEachTrack(t -> WorkflowOperationTagUtil.applyTagDiff(tagDiff, t));
 
     return createResult(mediaPackage, WorkflowOperationResult.Action.CONTINUE, result.queueTime);
   }

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationTagUtil.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationTagUtil.java
@@ -23,7 +23,6 @@ package org.opencastproject.workflow.api;
 
 import org.opencastproject.mediapackage.Track;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,16 +51,15 @@ public final class WorkflowOperationTagUtil {
 
   private static final String PLUS = "+";
   private static final String MINUS = "-";
-  private static final String SEPARATOR = ",";
 
-  public static TagDiff createTagDiff(final String tagList) {
+  public static TagDiff createTagDiff(final List<String> tagList) {
 
     final List<String> removeTags = new ArrayList<>();
     final List<String> addTags = new ArrayList<>();
     final List<String> overrideTags = new ArrayList<>();
 
     if (tagList != null) {
-      for (final String tag : StringUtils.split(tagList, SEPARATOR)) {
+      for (final String tag : tagList) {
         if (tag.startsWith(MINUS)) {
           removeTags.add(tag);
         } else if (tag.startsWith(PLUS)) {


### PR DESCRIPTION
Target tag parsing of prepare-av was broken by #2125: list.toString() outputs ["tag1", "tag2"], but the tag diff handler expects "tag1, tag2". The fix also touches select-streams WOH, but should not change its behavior.

This means that the community workflows schedule-and-upload and studio-upload are somewhat broken right now because the /prepared media files that are created by prepare-av are no longer archived since the tag is incorrect. But since the publish workflow falls back to /source when /prepared doesn't exist, this is not so bad. (But since we then kind of skip prepare-av, this might still be a problem for unusual formats.)

Either way, it would be nice to get this into 10.1.