### PR TITLE
Fix Possible NullPointerException During Ingest

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -1166,7 +1166,8 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
     final String workflowDefinition = wfConfig.get(WORKFLOW_DEFINITION_ID_PARAM);
 
     // Adding ingest start time to workflow configuration
-    wfConfig.put(IngestService.START_DATE_KEY, DATE_FORMAT.format(startCache.asMap().get(mp.getIdentifier().toString())));
+    final Date ingestDate = startCache.getIfPresent(mp.getIdentifier().toString());
+    wfConfig.put(IngestService.START_DATE_KEY, DATE_FORMAT.format(ingestDate != null ? ingestDate : new Date()));
 
     final X<WorkflowInstance> ingest = new X<WorkflowInstance>() {
       @Override


### PR DESCRIPTION
This patch fixes a possible NullPointerException happening during ingest
when the media package identifier is not cached:

    Caused by: java.lang.NullPointerException
        at java.util.Calendar.setTime(Calendar.java:1800) ~[?:?]
        at java.text.SimpleDateFormat.format(SimpleDateFormat.java:974) ~[?:?]
        at java.text.SimpleDateFormat.format(SimpleDateFormat.java:967) ~[?:?]
        at java.text.DateFormat.format(DateFormat.java:374) ~[?:?]
        at org.opencastproject.ingest.endpoint.IngestRestService.ingest(IngestRestService.java:1169) ~[?:?]
        at org.opencastproject.ingest.endpoint.IngestRestService.ingest(IngestRestService.java:1097) ~[?:?]

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
