### PR TITLE
Don't Ask Developers to Register

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
@@ -115,7 +115,9 @@ angular.module('adminNg.controllers')
     }
 
     AdopterRegistrationResource.get({}, function(adopter) {
-      if(adopter.dateModified == null) {
+      // We exclude localhost to not show this to developers all the time.
+      // We wouldn't get proper data from such instances anyway.
+      if(adopter.dateModified == null && window.location.hostname != 'localhost') {
         ResourceModal.show('registration-modal');
         return;
       }


### PR DESCRIPTION
This patch makes the admin interface not open the registration form if
you enter the interface on `localhost`. This makes devs happy and we
wouldn't gather sensible data in these cases anyway.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
