### PR TITLE
Add track fields `is_master_playlist` and `is_live` to external API

### DIFF
--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -643,6 +643,10 @@ __Response__
     },
     "checksum": "ac0e3138be69927c0fb6ff4ea7465df0 (md5)",
     "description": "",
+    "has_audio": true,
+    "has_video": true,
+    "is_master_playlist": false,
+    "is_live": false,
     "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/ea9a6cd8-85d2-4fb5-8571-29dc8b9c5940\/5\/presenter.mp4",
     "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/ea9a6cd8-85d2-4fb5-8571-29dc8b9c5940\/5\/presenter.mp4",
     "tags": [
@@ -675,6 +679,10 @@ __Response__
     },
     "checksum": "e6a5fad8100fd5b09920e6a6dddc44dc (md5)",
     "description": "",
+    "has_audio": true,
+    "has_video": true,
+    "is_master_playlist": false,
+    "is_live": false,
     "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/28fba154-cdbd-4bd8-b6b7-829ad1ea6746\/5\/84066_segment_0_480p.mp4",
     "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/28fba154-cdbd-4bd8-b6b7-829ad1ea6746\/5\/84066_segment_0_480p.mp4",
     "tags": [
@@ -708,6 +716,10 @@ __Response__
     },
     "checksum": "6f547c80f9cc4166ccea52192ce82045 (md5)",
     "description": "",
+    "has_audio": true,
+    "has_video": true,
+    "is_master_playlist": false,
+    "is_live": false,
     "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/3f359b10-da82-4834-8e65-741bc62dcdaf\/5\/84066_segment_1_720p.mp4",
     "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/3f359b10-da82-4834-8e65-741bc62dcdaf\/5\/84066_segment_1_720p.mp4",
     "tags": [
@@ -757,6 +769,10 @@ __Response__
     },
     "checksum": "053aaad6a0ada363e17c787e78a2b349 (md5)",
     "description": "",
+    "has_audio": true,
+    "has_video": true,
+    "is_master_playlist": true,
+    "is_live": false,
     "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/db9e1496-5044-4451-9070-18399e20791a\/5\/presenter.m3u8",
     "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/db9e1496-5044-4451-9070-18399e20791a\/5\/presenter.m3u8",
     "tags": [
@@ -789,6 +805,10 @@ __Response__
     },
     "checksum": "d7109c109cf955b2d6e9ebdf0ad07f6c (md5)",
     "description": "",
+    "has_audio": true,
+    "has_video": true,
+    "is_master_playlist": false,
+    "is_live": false,
     "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/dfd0a8a6-be37-46fa-993e-997b0aad064f\/5\/84066_variant_0.m3u8",
     "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/dfd0a8a6-be37-46fa-993e-997b0aad064f\/5\/84066_variant_0.m3u8",
     "tags": [
@@ -821,6 +841,10 @@ __Response__
     },
     "checksum": "720c93ec46bba9fa14cf1b5761b0458e (md5)",
     "description": "",
+    "has_audio": true,
+    "has_video": true,
+    "is_master_playlist": false,
+    "is_live": false,
     "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/d94e2fbc-8f65-4b21-b7b9-cf2dcee43eeb\/5\/84066_variant_1.m3u8",
     "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/d94e2fbc-8f65-4b21-b7b9-cf2dcee43eeb\/5\/84066_variant_1.m3u8",
     "tags": [
@@ -1058,6 +1082,8 @@ __Response__
       ],
       "has_audio":true,
       "has_video":true,
+      "is_master_playlist": false,
+      "is_live": false,
       "duration":3648,
       "description":"Video: h264 (Constrained Baseline) (avc1 / 0x31637661), yuv420p, 640x360, 447 kb/s, 25 fps, 25"
     },
@@ -1073,6 +1099,8 @@ __Response__
       ],
       "has_audio":true,
       "has_video":false,
+      "is_master_playlist": false,
+      "is_live": false,
       "duration":3648,
       "description":"aac (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 96 kb/s (default)"
     }

--- a/docs/guides/developer/docs/api/events-api.md
+++ b/docs/guides/developer/docs/api/events-api.md
@@ -481,8 +481,8 @@ In case of a conflict (when updating `scheduling`):
 
 ### DELETE /api/events/{event_id}
 
-Retracts possible publications and deletes an event. Since version 1.6.0 published events will be retracted by this 
-endpoint, if you use a version previous to 1.6.0 don't call this endpoint before retracting published events.  
+Retracts possible publications and deletes an event. Since version 1.6.0 published events will be retracted by this
+endpoint, if you use a version previous to 1.6.0 don't call this endpoint before retracting published events.
 
 __Response__
 
@@ -603,6 +603,234 @@ __Response__
 `204 (NO CONTENT)`: The permission has been revoked from the access control list of the specified event.<br/>
 `404 (NOT FOUND)`: The specified event does not exist.
 
+# Media
+
+### GET /api/events/{event_id}/media
+
+Returns the complete set of media tracks.
+
+__Response__
+
+`200 (OK)`: The list of media tracks is returned.<br/>
+`404 (NOT FOUND)`: The specified event does not exist.
+
+```
+[
+  {
+    "duration": 184669,
+    "flavor": "presenter\/source",
+    "identifier": "ea9a6cd8-85d2-4fb5-8571-29dc8b9c5940",
+    "mimetype": "video\/mp4",
+    "size": 65072115,
+    "streams": {
+      "video-1": {
+        "identifier": "video-1",
+        "framecount": 4430,
+        "framewidth": 2048,
+        "framerate": 24.0,
+        "format": "H.264 \/ AVC \/ MPEG-4 AVC \/ MPEG-4 part 10",
+        "bitrate": 2685332.0,
+        "frameheight": 858
+      },
+      "audio-1": {
+        "identifier": "audio-1",
+        "channels": 2,
+        "framecount": 7954,
+        "format": "AAC (Advanced Audio Coding)",
+        "bitrate": 128878.0,
+        "samplingrate": 44100
+      }
+    },
+    "checksum": "ac0e3138be69927c0fb6ff4ea7465df0 (md5)",
+    "description": "",
+    "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/ea9a6cd8-85d2-4fb5-8571-29dc8b9c5940\/5\/presenter.mp4",
+    "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/ea9a6cd8-85d2-4fb5-8571-29dc8b9c5940\/5\/presenter.mp4",
+    "tags": [
+      "archive"
+    ]
+  },
+  {
+    "duration": 184606,
+    "flavor": "presenter\/delivery",
+    "identifier": "28fba154-cdbd-4bd8-b6b7-829ad1ea6746",
+    "mimetype": "video\/mp4",
+    "size": 16513961,
+    "streams": {
+      "video-1": {
+        "identifier": "video-1",
+        "framecount": 4429,
+        "framewidth": 854,
+        "framerate": 24.0,
+        "format": "H.264 \/ AVC \/ MPEG-4 AVC \/ MPEG-4 part 10",
+        "bitrate": 582517.0,
+        "frameheight": 358
+      },
+      "audio-1": {
+        "identifier": "audio-1",
+        "channels": 2,
+        "format": "AAC (Advanced Audio Coding)",
+        "bitrate": 128965.0,
+        "samplingrate": 44100
+      }
+    },
+    "checksum": "e6a5fad8100fd5b09920e6a6dddc44dc (md5)",
+    "description": "",
+    "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/28fba154-cdbd-4bd8-b6b7-829ad1ea6746\/5\/84066_segment_0_480p.mp4",
+    "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/28fba154-cdbd-4bd8-b6b7-829ad1ea6746\/5\/84066_segment_0_480p.mp4",
+    "tags": [
+      "480p-quality",
+      "archive"
+    ]
+  },
+  {
+    "duration": 184606,
+    "flavor": "presenter\/delivery",
+    "identifier": "3f359b10-da82-4834-8e65-741bc62dcdaf",
+    "mimetype": "video\/mp4",
+    "size": 27365772,
+    "streams": {
+      "video-1": {
+        "identifier": "video-1",
+        "framecount": 4429,
+        "framewidth": 1280,
+        "framerate": 24.0,
+        "format": "H.264 \/ AVC \/ MPEG-4 AVC \/ MPEG-4 part 10",
+        "bitrate": 1052783.0,
+        "frameheight": 536
+      },
+      "audio-1": {
+        "identifier": "audio-1",
+        "channels": 2,
+        "format": "AAC (Advanced Audio Coding)",
+        "bitrate": 128965.0,
+        "samplingrate": 44100
+      }
+    },
+    "checksum": "6f547c80f9cc4166ccea52192ce82045 (md5)",
+    "description": "",
+    "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/3f359b10-da82-4834-8e65-741bc62dcdaf\/5\/84066_segment_1_720p.mp4",
+    "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/3f359b10-da82-4834-8e65-741bc62dcdaf\/5\/84066_segment_1_720p.mp4",
+    "tags": [
+      "720p-quality",
+      "archive"
+    ]
+  },
+  {
+    "duration": 185000,
+    "flavor": "presenter\/delivery",
+    "identifier": "db9e1496-5044-4451-9070-18399e20791a",
+    "mimetype": "application\/x-mpegURL",
+    "size": 462,
+    "streams": {
+      "video-1": {
+        "identifier": "video-1",
+        "framecount": 4440,
+        "framewidth": 854,
+        "framerate": 24.0,
+        "format": "H.264 \/ AVC \/ MPEG-4 AVC \/ MPEG-4 part 10",
+        "bitrate": 201482.0,
+        "frameheight": 358
+      },
+      "audio-1": {
+        "identifier": "audio-1",
+        "channels": 2,
+        "format": "AAC (Advanced Audio Coding)",
+        "bitrate": 130322.0,
+        "samplingrate": 44100
+      },
+      "video-2": {
+        "identifier": "video-2",
+        "framecount": 4440,
+        "framewidth": 1280,
+        "framerate": 24.0,
+        "format": "H.264 \/ AVC \/ MPEG-4 AVC \/ MPEG-4 part 10",
+        "bitrate": 386268.0,
+        "frameheight": 536
+      },
+      "audio-2": {
+        "identifier": "audio-2",
+        "channels": 2,
+        "format": "AAC (Advanced Audio Coding)",
+        "bitrate": 130322.0,
+        "samplingrate": 44100
+      }
+    },
+    "checksum": "053aaad6a0ada363e17c787e78a2b349 (md5)",
+    "description": "",
+    "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/db9e1496-5044-4451-9070-18399e20791a\/5\/presenter.m3u8",
+    "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/db9e1496-5044-4451-9070-18399e20791a\/5\/presenter.m3u8",
+    "tags": [
+      "archive"
+    ]
+  },
+  {
+    "duration": 185000,
+    "flavor": "presenter\/delivery",
+    "identifier": "dfd0a8a6-be37-46fa-993e-997b0aad064f",
+    "mimetype": "application\/x-mpegURL",
+    "size": 3991,
+    "streams": {
+      "video-1": {
+        "identifier": "video-1",
+        "framecount": 4440,
+        "framewidth": 854,
+        "framerate": 24.0,
+        "format": "H.264 \/ AVC \/ MPEG-4 AVC \/ MPEG-4 part 10",
+        "bitrate": 201482.0,
+        "frameheight": 358
+      },
+      "audio-1": {
+        "identifier": "audio-1",
+        "channels": 2,
+        "format": "AAC (Advanced Audio Coding)",
+        "bitrate": 130322.0,
+        "samplingrate": 44100
+      }
+    },
+    "checksum": "d7109c109cf955b2d6e9ebdf0ad07f6c (md5)",
+    "description": "",
+    "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/dfd0a8a6-be37-46fa-993e-997b0aad064f\/5\/84066_variant_0.m3u8",
+    "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/dfd0a8a6-be37-46fa-993e-997b0aad064f\/5\/84066_variant_0.m3u8",
+    "tags": [
+      "archive"
+    ]
+  },
+  {
+    "duration": 185000,
+    "flavor": "presenter\/delivery",
+    "identifier": "d94e2fbc-8f65-4b21-b7b9-cf2dcee43eeb",
+    "mimetype": "application\/x-mpegURL",
+    "size": 4009,
+    "streams": {
+      "video-1": {
+        "identifier": "video-1",
+        "framecount": 4440,
+        "framewidth": 1280,
+        "framerate": 24.0,
+        "format": "H.264 \/ AVC \/ MPEG-4 AVC \/ MPEG-4 part 10",
+        "bitrate": 386268.0,
+        "frameheight": 536
+      },
+      "audio-1": {
+        "identifier": "audio-1",
+        "channels": 2,
+        "format": "AAC (Advanced Audio Coding)",
+        "bitrate": 130322.0,
+        "samplingrate": 44100
+      }
+    },
+    "checksum": "720c93ec46bba9fa14cf1b5761b0458e (md5)",
+    "description": "",
+    "element-description": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/d94e2fbc-8f65-4b21-b7b9-cf2dcee43eeb\/5\/84066_variant_1.m3u8",
+    "uri": "https:\/\/admin.opencast.org\/assets\/assets\/3627bd37-7681-4e4b-bff1-a7d299be38cd\/d94e2fbc-8f65-4b21-b7b9-cf2dcee43eeb\/5\/84066_variant_1.m3u8",
+    "tags": [
+      "archive"
+    ]
+  }
+]
+```
+
+
 # Metadata
 
 This section describes how to use the External API to work with metadata catalogs associated to events.
@@ -625,7 +853,7 @@ Returns the complete set of metadata.
 __Response__
 
 `200 (OK)`: The metadata collection is returned as [`catalogs`](types.md#catalogs).<br/>
-`404 (OK)`: The specified event does not exist.
+`404 (NOT FOUND)`: The specified event does not exist.
 
 ```
 [

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
@@ -22,6 +22,7 @@ package org.opencastproject.external.common;
 
 public final class ApiMediaType {
 
+  public static final String VERSION_1_7_0 = "application/v1.7.0+json";
   public static final String VERSION_1_6_0 = "application/v1.6.0+json";
   public static final String VERSION_1_5_0 = "application/v1.5.0+json";
   public static final String VERSION_1_4_0 = "application/v1.4.0+json";
@@ -47,8 +48,10 @@ public final class ApiMediaType {
   public static ApiMediaType parse(String acceptHeader) throws ApiMediaTypeException {
     /* MH-12802: The External API does not support content negotiation */
     ApiMediaType mediaType;
-    if (acceptHeader == null || acceptHeader.contains(VERSION_1_6_0) || acceptHeader.contains(JSON)
+    if (acceptHeader == null || acceptHeader.contains(VERSION_1_7_0) || acceptHeader.contains(JSON)
     || acceptHeader.contains(APPLICATION_ANY) || acceptHeader.contains(ANY)) {
+      mediaType = new ApiMediaType(ApiVersion.VERSION_1_7_0, ApiFormat.JSON, VERSION_1_7_0);
+    } else if (acceptHeader.contains(VERSION_1_6_0)) {
       mediaType = new ApiMediaType(ApiVersion.VERSION_1_6_0, ApiFormat.JSON, VERSION_1_6_0);
     } else if (acceptHeader.contains(VERSION_1_5_0)) {
       mediaType = new ApiMediaType(ApiVersion.VERSION_1_5_0, ApiFormat.JSON, VERSION_1_5_0);

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
@@ -29,7 +29,8 @@ public enum ApiVersion {
   VERSION_1_3_0(1, 3, 0),
   VERSION_1_4_0(1, 4, 0),
   VERSION_1_5_0(1, 5, 0),
-  VERSION_1_6_0(1, 6, 0);
+  VERSION_1_6_0(1, 6, 0),
+  VERSION_1_7_0(1, 7, 0);
 
   /** The most recent version of the External API */
   public static final ApiVersion CURRENT_VERSION = VERSION_1_6_0;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
@@ -80,7 +80,7 @@ import javax.ws.rs.core.Response;
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
-            ApiMediaType.VERSION_1_6_0 })
+            ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0 })
 @RestService(name = "externalapiservice", title = "External API Service", notes = {},
              abstractText = "Provides a location for external apis to query the current server of the API.")
 public class BaseEndpoint {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
@@ -55,7 +55,8 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
-            ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0 })
+            ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
+            ApiMediaType.VERSION_1_7_0 })
 @RestService(
     name = "externalapicaptureagents",
     title = "External API Capture Agents Service",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -376,6 +376,10 @@ public class EventsEndpoint implements ManagedService {
 
   @GET
   @Path("{eventId}/media")
+  @RestQuery(name = "geteventmedia", description = "Returns media tracks of specific single event.", returnDescription = "", pathParameters = {
+      @RestParameter(name = "eventId", description = "The event id", isRequired = true, type = STRING) }, responses = {
+      @RestResponse(description = "The event's media is returned.", responseCode = HttpServletResponse.SC_OK),
+      @RestResponse(description = "The specified event does not exist.", responseCode = HttpServletResponse.SC_NOT_FOUND) })
   public Response getEventMedia(@HeaderParam("Accept") String acceptHeader, @PathParam("eventId") String id)
           throws Exception {
     ArrayList<TrackImpl> tracks = new ArrayList<>();

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -404,7 +404,7 @@ public class EventsEndpoint implements ManagedService {
         if (track.getIdentifier() != null)
           fields.add(f("identifier", v(track.getIdentifier())));
         if (track.getMimeType() != null)
-          fields.add(f("identifier", v(track.getMimeType().toString())));
+          fields.add(f("mimetype", v(track.getMimeType().toString())));
         fields.add(f("size", v(track.getSize())));
         if (track.getStreams() != null) {
           List<Field> streams = new ArrayList<>();

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -90,7 +90,7 @@ import javax.ws.rs.core.Response;
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
-            ApiMediaType.VERSION_1_6_0 })
+            ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0 })
 @RestService(name = "externalapigroups", title = "External API Groups Service", notes = {}, abstractText = "Provides resources and operations related to the groups")
 public class GroupsEndpoint {
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
@@ -64,7 +64,7 @@ import javax.ws.rs.core.Response;
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
-            ApiMediaType.VERSION_1_6_0 })
+            ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0 })
 @RestService(name = "externalapisecurity", title = "External API Security Service", notes = {}, abstractText = "Provides security operations related to the external API")
 public class SecurityEndpoint implements ManagedService {
 

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -126,7 +126,7 @@ import javax.ws.rs.core.Response.Status;
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
-            ApiMediaType.VERSION_1_6_0 })
+            ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0 })
 @RestService(name = "externalapiseries", title = "External API Series Service", notes = {},
              abstractText = "Provides resources and operations related to the series")
 public class SeriesEndpoint {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
@@ -80,7 +80,7 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
-            ApiMediaType.VERSION_1_6_0 })
+            ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0 })
 @RestService(
   name = "externalapistatistics", title = "External API Statistics Endpoint",
   notes = {}, abstractText = "Provides statistics")
@@ -262,7 +262,8 @@ public class StatisticsEndpoint {
   }
 
   @POST
-  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0 })
+  @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
+              ApiMediaType.VERSION_1_7_0 })
   @Path("data/export.csv")
   @RestQuery(
           name = "getexportcsv",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
@@ -77,7 +77,8 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
-            ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0 })
+            ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
+            ApiMediaType.VERSION_1_7_0 })
 @RestService(name = "externalapiworkflowdefinitions", title = "External API Workflow Definitions Service", notes = {},
              abstractText = "Provides resources and operations related to the workflow definitions")
 public class WorkflowDefinitionsEndpoint {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
@@ -102,7 +102,8 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
-            ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0 })
+            ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
+            ApiMediaType.VERSION_1_7_0 })
 @RestService(name = "externalapiworkflowinstances", title = "External API Workflow Instances Service", notes = {},
              abstractText = "Provides resources and operations related to the workflow instances")
 public class WorkflowsEndpoint {

--- a/modules/external-api/src/test/java/org/opencastproject/external/common/ApiMediaTypeTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/common/ApiMediaTypeTest.java
@@ -29,24 +29,24 @@ public class ApiMediaTypeTest {
   @Test
   public void testDefaultVersionAndFormat() throws Exception {
     ApiMediaType type = ApiMediaType.parse("*/*");
-    assertEquals(ApiVersion.VERSION_1_6_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_7_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.6.0+json", type.toExternalForm());
+    assertEquals("application/v1.7.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse("application/*");
-    assertEquals(ApiVersion.VERSION_1_6_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_7_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.6.0+json", type.toExternalForm());
+    assertEquals("application/v1.7.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse("application/json");
-    assertEquals(ApiVersion.VERSION_1_6_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_7_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.6.0+json", type.toExternalForm());
+    assertEquals("application/v1.7.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse(null);
-    assertEquals(ApiVersion.VERSION_1_6_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_7_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.6.0+json", type.toExternalForm());
+    assertEquals("application/v1.7.0+json", type.toExternalForm());
   }
 
   @Test
@@ -85,6 +85,11 @@ public class ApiMediaTypeTest {
     assertEquals(ApiVersion.VERSION_1_6_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
     assertEquals("application/v1.6.0+json", type.toExternalForm());
+
+    type = ApiMediaType.parse("application/v1.7.0+json");
+    assertEquals(ApiVersion.VERSION_1_7_0, type.getVersion());
+    assertEquals(ApiFormat.JSON, type.getFormat());
+    assertEquals("application/v1.7.0+json", type.toExternalForm());
   }
 
   @Test(expected = ApiMediaTypeException.class)


### PR DESCRIPTION
This PR adds the two fields `is_master_playlist` and `is_live` to the external API when returning data about tracks. This includes the previously undocumented endpoint `/api/events/{event_id}/media`. This endpoint is now documented as well and additionally returns the `has_audio` and `has_video` fields analogously to the publication endpoints.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
