### PR TITLE
Remove **all** Java 8 packages in the Java upgrade guide

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -29,6 +29,7 @@ Or replace the old Java version like this:
 ```
 % dnf shell
 > remove java-1.8.0-openjdk.x86_64
+> remove java-1.8.0-openjdk-headless.x86_64
 > install java-11-openjdk.x86_64
 > run
 ```

--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -28,8 +28,7 @@ Or replace the old Java version like this:
 
 ```
 % dnf shell
-> remove java-1.8.0-openjdk.x86_64
-> remove java-1.8.0-openjdk-headless.x86_64
+> remove 'java-1.8.0*'
 > install java-11-openjdk.x86_64
 > run
 ```


### PR DESCRIPTION
I'm not 100% sure about this since I'm not a CentOS/RedHat/... person, so I'd like a second pair of eyes instead of just pushing this doc update directly.

I just ran into this while upgrading a system from 9.2 to 10.0. I upgraded Java following the guide, but when I started Opencast it failed very early on due to OSGi wiring errors. `gson` couldn't have it's execution environment requirement (`JavaSE)(version=9.0)`) fulfilled. Checking `java -version` I saw that I was **still** running Java 8, which came from the `java-1.8.0-openjdk-headless` package.

### Your pull request should…

* [x] have a concise title
* [x] ~~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
