### PR TITLE
Transformer Factory Identification

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/XmlSafeParser.java
+++ b/modules/common/src/main/java/org/opencastproject/util/XmlSafeParser.java
@@ -116,7 +116,7 @@ public final class XmlSafeParser {
    */
   public static TransformerFactory configureTransformerFactory(TransformerFactory f) {
     try {
-      if (f.getClass() == com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl.class) {
+      if (f.getClass().getName().equals("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl")) {
         f.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         f.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         f.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");


### PR DESCRIPTION
This patch updates the identification of the transformer factory used
for XML transformation to use the same method used for the other
implementations. The previous method required the Xalan to be present
which could be annoying problematic for development. This is likely also
the reason why the other libraries use a different mechanism for
identification.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
