### PR TITLE
Handle Ingest with Unavailable Media Package Element

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -1195,6 +1195,10 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
       startCache.asMap().remove(mp.getIdentifier().toString());
       return Response.ok(WorkflowParser.toXml(workflow)).build();
     } catch (Exception e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof NotFoundException) {
+        return badRequest("Could not retrieve all media package elements", e);
+      }
       logger.warn("Unable to ingest mediapackage", e);
       return Response.serverError().status(Status.INTERNAL_SERVER_ERROR).build();
     }


### PR DESCRIPTION
This patch catches ingests of media packages with essential (meaning
they are used during ingest like DC catalogs) media package elements
having invalid links (e.g. linking non existing documents).

This patch makes Opencast return a 400 BAD REQUEST with a sensible
explanation instead of dying with an internal server error.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
