### PR TITLE
Remove Unnecessary Error Logging

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AbstractAssetManager.java
@@ -383,7 +383,6 @@ public abstract class AbstractAssetManager implements AssetManager {
     try {
       return p.get1();
     } catch (Exception e) {
-      logger.error("An error occurred", e);
       throw unwrapExceptionUntil(AssetManagerException.class, e).getOr(new AssetManagerException(e));
     }
   }


### PR DESCRIPTION
This patch removes an error log statement from the asset manager.
The statement itself is meaningless and the exception is thrown again.
This results in:

- either the error ending up as an actual error somewhere else and the
  user seing two separate error logs for the same issue with the same
  data
- or the error being properly caught and handled not resulting in an
  actual error for adopters but being logged as such anyway.

tl;dr: This makes no sense and should go.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
