### PR TITLE
Default is defined now, for the admin interface user filter

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -315,7 +315,7 @@ org.opencastproject.working.file.repository.cleanup.collections=failed.zips
 # A username that matches this regex will be listed in the filter selection
 # The filter is located in the top right corner in the admin ui.
 # Default (allow all users): .*
-org.opencastproject.adminui.filter.user.regex = .*
+#org.opencastproject.adminui.filter.user.regex = .*
 
 
 ######### KARAF CONFIGURATION #########

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
@@ -48,6 +48,7 @@ import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.osgi.framework.BundleContext;
@@ -91,10 +92,13 @@ public class ListProvidersEndpoint {
   /** This regex is used to reduce the users in the filter selectbox.
    * The filter is located in the top right corner in the admin ui. */
   private static final String PROP_KEY_USER_FILTER_REGEX = "org.opencastproject.adminui.filter.user.regex";
+  private static final String PROP_KEY_USER_FILTER_REGEX_DEFAULT = ".*";
 
   protected void activate(BundleContext bundleContext) {
     logger.info("Activate list provider service");
-    JSONUtils.setUserRegex(bundleContext.getProperty(PROP_KEY_USER_FILTER_REGEX));
+    JSONUtils.setUserRegex(StringUtils.defaultIfBlank(
+            bundleContext.getProperty(PROP_KEY_USER_FILTER_REGEX),
+            PROP_KEY_USER_FILTER_REGEX_DEFAULT));
   }
 
   /** OSGi callback for series services. */


### PR DESCRIPTION
fixes #2828 

This fix sets the missing default value for the user filter regex in the admin interface.
