### PR TITLE
Changed preencode encoding profile to handle divBy2 problems

### DIFF
--- a/etc/encoding/opencast-movies.properties
+++ b/etc/encoding/opencast-movies.properties
@@ -196,4 +196,4 @@ profile.editor.work.input = audiovisual
 profile.editor.work.output = audiovisual
 profile.editor.work.suffix = -editor.mp4
 profile.editor.work.mimetype = video/mp4
-profile.editor.work.ffmpeg.command = -i #{in.video.path} -filter:v 'crop=trunc(iw/2)*2:trunc(ih/2)*2,fps=25' -shortest -c:v libx264 -preset superfast -pix_fmt yuv420p -crf 18 -c:a aac -strict -2 -b:a 196k #{out.dir}/#{out.name}#{out.suffix}
+profile.editor.work.ffmpeg.command = -i #{in.video.path} -filter:v crop=trunc(iw/2)*2:trunc(ih/2)*2,fps=25 -shortest -c:v libx264 -preset superfast -pix_fmt yuv420p -crf 18 -c:a aac -strict -2 -b:a 196k #{out.dir}/#{out.name}#{out.suffix}

--- a/etc/encoding/opencast-movies.properties
+++ b/etc/encoding/opencast-movies.properties
@@ -196,4 +196,4 @@ profile.editor.work.input = audiovisual
 profile.editor.work.output = audiovisual
 profile.editor.work.suffix = -editor.mp4
 profile.editor.work.mimetype = video/mp4
-profile.editor.work.ffmpeg.command = -i #{in.video.path} -filter:v fps=25 -shortest -c:v libx264 -preset superfast -pix_fmt yuv420p -crf 18 -c:a aac -strict -2 -b:a 196k #{out.dir}/#{out.name}#{out.suffix}
+profile.editor.work.ffmpeg.command = -i #{in.video.path} -filter:v 'crop=trunc(iw/2)*2:trunc(ih/2)*2,fps=25' -shortest -c:v libx264 -preset superfast -pix_fmt yuv420p -crf 18 -c:a aac -strict -2 -b:a 196k #{out.dir}/#{out.name}#{out.suffix}


### PR DESCRIPTION
The encoding profile that is used per default for preencoding in the partial import operation throws an error for videos with a resolution not divisible by 2. As the purpose of preencoding is to avoid exactly this kind of problem, this PR extends the default encoding profile by a crop filter to ensure an even resolution.

This is potentially superseded by #2669.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
