### PR TITLE
Target Java 11

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
@@ -275,12 +275,12 @@ public class UsersEndpoint {
       usersJSON.add(generateJsonUser(user));
     }
 
-    Map<String, Object> response = new HashMap<>();
-    response.put("results", usersJSON);
-    response.put("count", usersJSON.size());
-    response.put("offset", offset);
-    response.put("limit", limit);
-    response.put("total", total);
+    Map<String, Object> response = Map.of(
+        "results", usersJSON,
+        "count", usersJSON.size(),
+        "offset", offset,
+        "limit", limit,
+        "total", total);
     return Response.ok(gson.toJson(response)).build();
   }
 

--- a/modules/asset-manager-static-file-authorization/pom.xml
+++ b/modules/asset-manager-static-file-authorization/pom.xml
@@ -51,9 +51,6 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Export-Package>
-              org.opencastproject.fsresources;version=${project.version}
-            </Export-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -214,6 +214,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              !org.apache.fop.*,
               com.sun.image.codec.jpeg,
               org.w3c.dom,
               javax.ws.rs;version=2.0.1,

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -83,12 +83,13 @@
             <Build-Number>${buildNumber}</Build-Number>
             <Bundle-Activator>org.opencastproject.db.Activator</Bundle-Activator>
             <Import-Package>
+              !com.ibm.*,
+              !com.sun.*,
               !com.vividsolutions.jts.*,
               !org.apache.lucene.*,
-              !org.jboss.resource.adapter.jdbc.*,
               !org.hibernate.*,
+              !org.jboss.resource.adapter.jdbc.*,
               !waffle.*,
-              !com.sun.jna.platform.win32,
               org.w3c.dom;version=0,
               *
             </Import-Package>

--- a/modules/elasticsearch-impl/pom.xml
+++ b/modules/elasticsearch-impl/pom.xml
@@ -180,19 +180,23 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              !com.carrotsearch.randomizedtesting,
               !com.conversantmedia.util.*,
               !com.fasterxml.jackson.dataformat.smile,
               !com.fasterxml.jackson.dataformat.xml.*,
               !com.fasterxml.jackson.dataformat.yaml.*,
               !com.lmax.disruptor.*,
               !com.sun.jna.*,
+              !com.sun.management*,
               !com.tdunning.*,
               !joptsimple.*,
               !org.HdrHistogram.*,
               !org.apache.kafka.clients.producer.*,
+              !org.apache.logging.log4j.util.internal,
               !org.apache.lucene.*,
               !javax.activation.*,
               !javax.annotation,
+              !jdk.net,
               !org.elasticsearch.geometry.*,
               !org.elasticsearch.secure_sm.*,
               !org.jctools.queues.*,

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -167,6 +167,8 @@
               com.google.api.*
             </_exportcontents>
             <Import-Package>
+              !com.google.appengine*,
+              !com.google.apphosting*,
               !javax.annotation,
               !oracle.xml.parser.*,
               !org.jaxen.*,

--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
+    <java.release>8</java.release>
   </properties>
   <dependencies>
     <dependency>

--- a/modules/statistics-provider-influx/pom.xml
+++ b/modules/statistics-provider-influx/pom.xml
@@ -91,11 +91,14 @@
             <Import-Package>
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,
-              !org.msgpack.*,
               !android.*,
-              !kotlin.*,
+              !com.android.org.*,
+              !dalvik.*,
               !javax.annotation.meta,
+              !kotlin.*,
               !org.conscrypt,
+              !org.msgpack.*,
+              !sun.*,
               *
             </Import-Package>
             <Private-Package>

--- a/modules/textanalyzer-impl/pom.xml
+++ b/modules/textanalyzer-impl/pom.xml
@@ -86,7 +86,7 @@
               *
             </Import-Package>
             <Export-Package>
-              org.opencastproject.textanalyzer.impl;version=${project.version}
+              org.opencastproject.textanalyzer.impl;version=${project.version},
               org.opencastproject.textanalyzer.impl.endpoint;version=${project.version}
             </Export-Package>
             <Service-Component>

--- a/modules/workflow-condition-parser/pom.xml
+++ b/modules/workflow-condition-parser/pom.xml
@@ -58,6 +58,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              !org.antlr.v4.gui,
               *
             </Import-Package>
             <Private-Package>

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
     <httpcomponents-httpcore.version>4.4.13</httpcomponents-httpcore.version>
     <jackson.version>2.12.3</jackson.version>
     <jakarta.mail.version>1.6.7</jakarta.mail.version>
+    <java.release>11</java.release>
     <jersey.version>2.29.1</jersey.version>
     <jettison.version>1.4.1</jettison.version>
-    <jdk.version>1.8</jdk.version>
     <joda-time.version>2.10.10</joda-time.version>
     <json-simple.version>1.1.1</json-simple.version>
     <karaf.version>4.2.9</karaf.version>
@@ -318,8 +318,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>${jdk.version}</source>
-          <target>${jdk.version}</target>
+          <release>${java.release}</release>
           <encoding>UTF-8</encoding>
           <compilerArgument>${compilerArgument}</compilerArgument>
         </configuration>
@@ -546,7 +545,6 @@
           <version>2.10.4</version>
           <configuration>
             <detectJavaApiLink>true</detectJavaApiLink>
-            <javadocVersion>${jdk.version}</javadocVersion>
             <maxmemory>512m</maxmemory>
             <quiet>true</quiet>
           </configuration>
@@ -653,7 +651,7 @@
           <configuration>
             <!--<includeTests>true</includeTests> -->
             <typeResolution>true</typeResolution>
-            <targetJdk>${jdk.version}</targetJdk>
+            <targetJdk>${java.release}</targetJdk>
           </configuration>
           <executions>
             <execution>
@@ -1884,7 +1882,6 @@
           <!-- <detectLinks>true</detectLinks> -->
           <!-- http://jira.codehaus.org/browse/MJAVADOC-273 -->
           <detectJavaApiLink>true</detectJavaApiLink>
-          <javadocVersion>${jdk.version}</javadocVersion>
           <maxmemory>512m</maxmemory>
           <quiet>true</quiet>
         </configuration>
@@ -1937,7 +1934,7 @@
           <aggregate>true</aggregate>
           <!--<includeTests>true</includeTests>-->
           <typeResolution>true</typeResolution>
-          <targetJdk>${jdk.version}</targetJdk>
+          <targetJdk>${java.release}</targetJdk>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>5.1.2</version>
           <inherited>true</inherited>
           <configuration>
             <instructions>


### PR DESCRIPTION
This patch sets the target Java version for most modules to 11 which is the
effective minimum requirement for Opencast 10 anyway. This allows the usage of
newer Java syntax and features (Example incuded).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
