### PR TITLE
Some bug fixes to IBM Watson transcription service

### DIFF
--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
@@ -68,17 +68,23 @@ import org.opencastproject.workspace.api.Workspace;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.FileEntity;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONArray;
@@ -92,6 +98,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -153,6 +160,7 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     String COMPLETED = "completed";
     String FAILED = "failed";
     String PROCESSING = "processing";
+    String WAITING = "waiting";
   }
 
   /** Service dependencies */
@@ -199,8 +207,6 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
   /** Service configuration values */
   private boolean enabled = false; // Disabled by default
   private String watsonServiceUrl = UrlSupport.concat(IBM_WATSON_SERVICE_URL, API_VERSION);
-  private String user; // user name or 'apikey'
-  private String psw; // password or api key
   private String model;
   private String workflowDefinitionId = DEFAULT_WF_DEF;
   private long workflowDispatchInterval = DEFAULT_DISPATCH_INTERVAL;
@@ -217,11 +223,15 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
   private String callbackUrl;
   private boolean callbackAlreadyRegistered = false;
   private ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(2);
+  // For preemptive basic authentication
+  private AuthCache authCache;
+  private CredentialsProvider credentialsProvider;
 
   public IBMWatsonTranscriptionService() {
     super(JOB_TYPE);
   }
 
+  @Override
   public void activate(ComponentContext cc) {
     if (cc != null) {
       // Has this service been enabled?
@@ -236,6 +246,8 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
 
         // Api key is checked first. If not entered, user and password are mandatory (to
         // support older instances of the STT service)
+        String user; // user name or 'apikey'
+        String psw; // user password or api key
         Option<String> keyOpt = OsgiUtil.getOptCfg(cc.getProperties(), IBM_WATSON_API_KEY_CONFIG);
         if (keyOpt.isSome()) {
           user = APIKEY;
@@ -247,6 +259,17 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
           // Password (mandatory if api key is empty)
           psw = OsgiUtil.getComponentContextProperty(cc, IBM_WATSON_PSW_CONFIG);
           logger.info("Using transcription service at {} with username {}", watsonServiceUrl, user);
+        }
+        // We will use preemptive basic auth
+        try {
+          URI uri = new URI(watsonServiceUrl);
+          HttpHost targetHost = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+          credentialsProvider = new BasicCredentialsProvider();
+          credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, psw));
+          authCache = new BasicAuthCache();
+          authCache.put(targetHost, new BasicScheme());
+        } catch (URISyntaxException e) {
+          throw new RuntimeException("Watson STT service url is not valid: " + watsonServiceUrl, e);
         }
 
         // Language model to be used (optional)
@@ -494,10 +517,14 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     CloseableHttpClient httpClient = makeHttpClient();
     HttpPost httpPost = new HttpPost(
             UrlSupport.concat(watsonServiceUrl, REGISTER_CALLBACK) + String.format("?callback_url=%s", callbackUrl));
+    // Add AuthCache to the execution context for preemptive auth
+    HttpClientContext context = HttpClientContext.create();
+    context.setCredentialsProvider(credentialsProvider);
+    context.setAuthCache(authCache);
     CloseableHttpResponse response = null;
 
     try {
-      response = httpClient.execute(httpPost);
+      response = httpClient.execute(httpPost, context);
       int code = response.getStatusLine().getStatusCode();
 
       switch (code) {
@@ -557,24 +584,27 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     CloseableHttpClient httpClient = makeHttpClient();
     String additionalParms = "";
     if (callbackAlreadyRegistered) {
-      additionalParms = String.format("&callback_url=%s&events=%s,%s", callbackUrl, JobEvent.COMPLETED_WITH_RESULTS,
-              JobEvent.FAILED);
+      additionalParms = String.format("&user_token=%s&callback_url=%s&events=%s,%s", mpId, callbackUrl,
+              JobEvent.COMPLETED_WITH_RESULTS, JobEvent.FAILED);
     }
     if (!StringUtils.isEmpty(model)) {
       additionalParms += String.format("&model=%s", model);
     }
+    // Add AuthCache to the execution context for preemptive auth
+    HttpClientContext context = HttpClientContext.create();
+    context.setCredentialsProvider(credentialsProvider);
+    context.setAuthCache(authCache);
     CloseableHttpResponse response = null;
     try {
       HttpPost httpPost = new HttpPost(UrlSupport.concat(watsonServiceUrl, RECOGNITIONS)
               + String.format(
-                      "?user_token=%s&inactivity_timeout=-1&timestamps=true&smart_formatting=true%s",
-                      mpId, additionalParms));
+                      "?inactivity_timeout=-1&timestamps=true&smart_formatting=true%s", additionalParms));
       logger.debug("Url to invoke ibm watson service: {}", httpPost.getURI().toString());
       httpPost.setHeader(HttpHeaders.CONTENT_TYPE, track.getMimeType().toString());
       FileEntity fileEntity = new FileEntity(audioFile);
       fileEntity.setChunked(true);
       httpPost.setEntity(fileEntity);
-      response = httpClient.execute(httpPost);
+      response = httpClient.execute(httpPost, context);
       int code = response.getStatusLine().getStatusCode();
 
       switch (code) {
@@ -638,11 +668,15 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
    */
   String getAndSaveJobResults(String jobId) throws TranscriptionServiceException {
     CloseableHttpClient httpClient = makeHttpClient();
+    // Add AuthCache to the execution context for preemptive auth
+    HttpClientContext context = HttpClientContext.create();
+    context.setCredentialsProvider(credentialsProvider);
+    context.setAuthCache(authCache);
     CloseableHttpResponse response = null;
     String mpId = "unknown";
     try {
       HttpGet httpGet = new HttpGet(UrlSupport.concat(watsonServiceUrl, RECOGNITIONS, jobId));
-      response = httpClient.execute(httpGet);
+      response = httpClient.execute(httpGet, context);
       int code = response.getStatusLine().getStatusCode();
 
       switch (code) {
@@ -740,12 +774,10 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
   }
 
   protected CloseableHttpClient makeHttpClient() {
-    CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-    credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(user, psw));
     RequestConfig reqConfig = RequestConfig.custom().setConnectTimeout(CONNECTION_TIMEOUT)
             .setSocketTimeout(SOCKET_TIMEOUT).setConnectionRequestTimeout(CONNECTION_TIMEOUT).build();
-    return HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).setDefaultRequestConfig(reqConfig)
-            .build();
+    return HttpClients.custom().setDefaultRequestConfig(reqConfig)
+            .setRetryHandler(new DefaultHttpRequestRetryHandler(3, true)).build();
   }
 
   protected void retryOrError(String jobId, String mpId, String errorMsg) throws TranscriptionDatabaseException {
@@ -909,13 +941,14 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
                   retryOrError(jobId, mpId,
                           String.format("Transcription job failed for mpId %s, jobId %s", mpId, jobId));
                   continue;
-                } else if (RecognitionJobStatus.PROCESSING.equals(jobStatus)) {
-                  // Job still running so check if it should have finished more than N seconds ago
+                } else if (RecognitionJobStatus.PROCESSING.equals(jobStatus)
+                        || RecognitionJobStatus.WAITING.equals(jobStatus)) {
+                  // Job still waiting/running so check if it should have finished more than N seconds ago
                   if (j.getDateCreated().getTime() + j.getTrackDuration()
                           + (completionCheckBuffer + maxProcessingSeconds) * 1000 < System.currentTimeMillis()) {
                     // Processing for too long, mark job as error or retry and don't check anymore
                     retryOrError(jobId, mpId, String.format(
-                            "Transcription job was in processing state for too long (media package %s, job id %s)",
+                            "Transcription job was in waiting or processing state for too long (media package %s, job id %s)",
                             mpId, jobId));
                   }
                   // else job still running, not finished

--- a/modules/transcription-service-ibm-watson-impl/src/test/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionServiceTest.java
+++ b/modules/transcription-service-ibm-watson-impl/src/test/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionServiceTest.java
@@ -73,6 +73,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -111,6 +112,7 @@ public class IBMWatsonTranscriptionServiceTest {
   private static final String PUSHED_TRANSCRIPTION_FILE = "pushed_transcription.json";
   private static final String COMPLETE_WITH_ERROR_FILE = "complete_with_error.json";
   private static final String IN_PROGRESS_JOB = "in_progress_job.json";
+  private static final String WAITING_JOB = "waiting_job.json";
   private static final String WATSON_URL = "https://test.stream.watsonplatform.net/speech-to-text/api";
   private static final String API_KEY = "test-api-key";
   private static final String RETRY_WORKFLOW = "retry-workflow";
@@ -231,7 +233,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(response, status);
 
     Capture<HttpPost> capturedPost = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedPost))).andReturn(response);
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedPost), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response);
     EasyMock.replay(httpClient);
 
     service.registerCallback();
@@ -252,7 +255,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(response, status);
 
     Capture<HttpPost> capturedPost = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedPost))).andReturn(response);
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedPost), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response);
     EasyMock.replay(httpClient);
 
     service.registerCallback();
@@ -272,7 +276,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.expect(status.getStatusCode()).andReturn(HttpStatus.SC_BAD_REQUEST).anyTimes();
     EasyMock.replay(response, status);
 
-    EasyMock.expect(httpClient.execute(EasyMock.anyObject(HttpPost.class))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.anyObject(HttpPost.class), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     service.registerCallback();
@@ -299,12 +304,13 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(httpEntity, response, status);
 
     Capture<HttpPost> capturedPost = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedPost))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedPost), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     service.createRecognitionsJob(MP_ID, mediaPackage.getTrack("audioTrack1"));
-    Assert.assertEquals(WATSON_URL + "/v1/recognitions?user_token=" + MP_ID
-            + "&inactivity_timeout=-1&timestamps=true&smart_formatting=true"
+    Assert.assertEquals(WATSON_URL + "/v1/recognitions?inactivity_timeout=-1&timestamps=true&smart_formatting=true"
+            + "&user_token=" + MP_ID
             + "&callback_url=http://ADMIN_SERVER/transcripts/watson/results&events=recognitions.completed_with_results,recognitions.failed",
             capturedPost.getValue().getURI().toString());
     TranscriptionJobControl j = database.findByJob(JOB_ID);
@@ -328,7 +334,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(response, status);
 
     Capture<HttpPost> capturedPost = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedPost))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedPost), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     service.createRecognitionsJob(MP_ID, mediaPackage.getTrack("audioTrack1"));
@@ -468,7 +475,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(httpEntity, response, status);
 
     Capture<HttpGet> capturedGet = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     long before = System.currentTimeMillis();
@@ -499,7 +507,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(response, status);
 
     Capture<HttpGet> capturedGet = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     try {
@@ -522,7 +531,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(response, status);
 
     Capture<HttpGet> capturedGet = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     service.getAndSaveJobResults(JOB_ID);
@@ -577,7 +587,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.expect(status.getStatusCode()).andReturn(HttpStatus.SC_OK).anyTimes();
     EasyMock.replay(httpEntity, response, status);
 
-    EasyMock.expect(httpClient.execute(EasyMock.anyObject(HttpGet.class))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.anyObject(HttpGet.class), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     MediaPackageElement mpe = service.getGeneratedTranscription(MP_ID, JOB_ID);
@@ -682,7 +693,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(httpEntity, response, status);
 
     Capture<HttpGet> capturedGet = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet))).andReturn(response);
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response);
     EasyMock.replay(httpClient);
 
     Capture<Set<String>> capturedMpIds = mockAssetManagerAndWorkflow(IBMWatsonTranscriptionService.DEFAULT_WF_DEF,
@@ -722,7 +734,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(httpEntity, response, status);
 
     Capture<HttpGet> capturedGet = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), 0, DATE_EXPECTED, PROVIDER);
@@ -753,7 +766,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(response, status);
 
     Capture<HttpGet> capturedGet = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), 0, DATE_EXPECTED, PROVIDER);
@@ -791,7 +805,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(httpEntity, response, status);
 
     Capture<HttpGet> capturedGet = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), 0, DATE_EXPECTED, PROVIDER);
@@ -831,7 +846,8 @@ public class IBMWatsonTranscriptionServiceTest {
     EasyMock.replay(httpEntity, response, status);
 
     Capture<HttpGet> capturedGet = Capture.newInstance();
-    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet))).andReturn(response).anyTimes();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
     EasyMock.replay(httpClient);
 
     database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), 0, DATE_EXPECTED, PROVIDER);
@@ -849,6 +865,45 @@ public class IBMWatsonTranscriptionServiceTest {
     TranscriptionJobControl j = database.findByJob(JOB_ID);
     Assert.assertNotNull(j);
     Assert.assertEquals(TranscriptionJobControl.Status.Error.toString(), j.getStatus());
+  }
+
+  @Test
+  public void testWorkflowDispatcherJobWaitingTooLong() throws Exception {
+    service.activate(cc);
+
+    InputStream stream = IBMWatsonTranscriptionServiceTest.class.getResourceAsStream("/" + WAITING_JOB);
+
+    HttpEntity httpEntity = EasyMock.createNiceMock(HttpEntity.class);
+    EasyMock.expect(httpEntity.getContent()).andReturn(stream);
+
+    CloseableHttpResponse response = EasyMock.createNiceMock(CloseableHttpResponse.class);
+    StatusLine status = EasyMock.createNiceMock(StatusLine.class);
+    EasyMock.expect(response.getStatusLine()).andReturn(status).anyTimes();
+    EasyMock.expect(response.getEntity()).andReturn(httpEntity).anyTimes();
+    EasyMock.expect(status.getStatusCode()).andReturn(HttpStatus.SC_OK).anyTimes();
+    EasyMock.replay(httpEntity, response, status);
+
+    Capture<HttpGet> capturedGet = Capture.newInstance();
+    EasyMock.expect(httpClient.execute(EasyMock.capture(capturedGet), EasyMock.anyObject(HttpClientContext.class)))
+            .andReturn(response).anyTimes();
+    EasyMock.replay(httpClient);
+
+    database.storeJobControl(MP_ID, TRACK_ID, JOB_ID, TranscriptionJobControl.Status.InProgress.name(), 0,
+            DATE_EXPECTED, PROVIDER);
+
+    EasyMock.replay(workspace);
+
+    WorkflowDispatcher dispatcher = service.new WorkflowDispatcher();
+    dispatcher.run();
+
+    // Check if it called the external service to get the results
+    Assert.assertEquals(WATSON_URL + "/v1/recognitions/" + JOB_ID, capturedGet.getValue().getURI().toString());
+
+    // Check if the job status was updated and email was sent
+    TranscriptionJobControl j = database.findByJob(JOB_ID);
+    Assert.assertNotNull(j);
+    Assert.assertEquals(TranscriptionJobControl.Status.Error.toString(), j.getStatus());
+    EasyMock.verify(smtpService);
   }
 
   @Test

--- a/modules/transcription-service-ibm-watson-impl/src/test/resources/waiting_job.json
+++ b/modules/transcription-service-ibm-watson-impl/src/test/resources/waiting_job.json
@@ -1,0 +1,6 @@
+{
+   "created": "2021-02-23T19:53:15.685Z",
+   "id": "jobId1",
+   "url": "https://api.us-south.speech-to-text.watson.cloud.ibm.com/instances/instanceId/v1/recognitions/jobId1",
+   "status": "waiting"
+}


### PR DESCRIPTION
- Do not pass user_token if not registered to get callback notifications (to avoid warning).
- Use preemptive http basic auth (Watson returns a 503 in some cases when too much load instead of prompting for auth credentials).
- Check for jobs in endless waiting state.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
