### PR TITLE
Add exception for extron smp351 technical catalog

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -936,8 +936,9 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       final boolean isJSON;
       try (InputStream inputStream = workingFileRepository.get(mediaPackageId, elementId)) {
         try (BufferedReader reader  = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-          // Exception for current BBB integration which is ingesting a JSON array as catalog
-          isJSON = reader.read() == '[';
+          // Exception for current BBB integration and Extron SMP351 which is ingesting a JSON array/object as catalog
+          int firstChar = reader.read();
+          isJSON = firstChar == '[' || firstChar == '{';
         }
       }
 


### PR DESCRIPTION
Like the BBB integration the Extron SMP351 ingests a JSON structure as an xml catalog. Without that fix the SMP fails to ingest to Opencast caused by the bad request.

Tested with Extron firmware 2.14

