### PR TITLE
Fix lti rest endpoint annotations and ogsi properties

### DIFF
--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
@@ -220,8 +220,9 @@ public class LtiServiceRestEndpoint {
               name = "eventId",
               description = "The event (id) to copy",
               isRequired = true,
-              type = STRING
-          ),
+              type = STRING)
+      },
+      restParameters = {
           @RestParameter(
               name = "seriesId",
               description = "The series (id) to copy into",
@@ -255,6 +256,9 @@ public class LtiServiceRestEndpoint {
       returnDescription = "",
       pathParameters = {
           @RestParameter(name = "eventId", description = "The event id", isRequired = true, type = STRING)
+      },
+      restParameters = {
+          @RestParameter(name = "metadataJson", description = "Event metadata", isRequired = true, type = STRING),
       },
       responses = {
           @RestResponse(

--- a/modules/lti-service-impl/src/main/resources/OSGI-INF/lti-service-impl.xml
+++ b/modules/lti-service-impl/src/main/resources/OSGI-INF/lti-service-impl.xml
@@ -4,7 +4,6 @@
                immediate="true">
   <implementation class="org.opencastproject.lti.service.impl.LtiServiceImpl"/>
   <property name="service.description" value="LTI Service"/>
-  <property name="opencast.service.type" value="org.opencastproject.lti.service"/>
   <service>
     <!-- expose interface for MH REST publisher! -->
     <provide interface="org.opencastproject.lti.service.api.LtiService"/>

--- a/modules/lti/src/main/java/org/opencastproject/lti/LtiServiceGuiEndpoint.java
+++ b/modules/lti/src/main/java/org/opencastproject/lti/LtiServiceGuiEndpoint.java
@@ -66,7 +66,7 @@ import javax.ws.rs.core.Response.Status;
  */
 @Path("/")
 @RestService(
-    name = "ltirestserviceendpoint",
+    name = "ltirestserviceguiendpoint",
     title = "LTI Service",
     notes = {},
     abstractText = "Provides operations to LTI clients"

--- a/modules/lti/src/main/resources/OSGI-INF/opencast-lti-service-gui-endpoint.xml
+++ b/modules/lti/src/main/resources/OSGI-INF/opencast-lti-service-gui-endpoint.xml
@@ -3,7 +3,7 @@
                name="org.opencastproject.lti.LtiServiceGuiEndpoint"
                immediate="true">
   <implementation class="org.opencastproject.lti.LtiServiceGuiEndpoint"/>
-  <property name="service.description" value="LTI Service"/>
+  <property name="service.description" value="LTI Service GUI"/>
   <property name="opencast.service.type" value="org.opencastproject.lti.service.remote"/>
   <property name="opencast.service.path" value="/lti-service-gui"/>
   <service>


### PR DESCRIPTION
Declaring the seriesId as a path parameter caused the IllegalStateException #2180. 
The problem described in #2442 should be caused by two OSGi services having the same `opencast.service.type` property value.

Fixes #2180  and should fix #2442