### PR TITLE
Document Database Defaults

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -112,6 +112,10 @@ org.opencastproject.download.directory=${org.opencastproject.storage.dir}/downlo
 #org.opencastproject.db.jdbc.driver=org.mariadb.jdbc.Driver
 
 # The jdbc connection url, username, and password
+# Defaults:
+#  .url=jdbc:h2:${org.opencastproject.storage.dir}/db
+#  .user=sa
+#  .pass=sa
 #org.opencastproject.db.jdbc.url=jdbc:mysql://localhost/opencast?useMysqlMetadata=true
 #org.opencastproject.db.jdbc.user=opencast
 #org.opencastproject.db.jdbc.pass=dbpassword


### PR DESCRIPTION
This patch adds documentation for the default values Opencast has for
the database configuration.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
