### PR TITLE
Fixed LTI Service Rest Docs

### DIFF
--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
@@ -216,18 +216,20 @@ public class LtiServiceRestEndpoint {
       description = "Copy an event to a different series",
       returnDescription = "",
       pathParameters = {
-          @RestParameter(
-              name = "eventId",
-              description = "The event (id) to copy",
-              isRequired = true,
-              type = STRING
-          ),
-          @RestParameter(
-              name = "seriesId",
-              description = "The series (id) to copy into",
-              isRequired = true,
-              type = STRING
-          )
+              @RestParameter(
+                      name = "eventId",
+                      description = "The event (id) to copy",
+                      isRequired = true,
+                      type = STRING
+              ),
+      },
+      restParameters = {
+              @RestParameter(
+                      name = "seriesId",
+                      description = "The series (id) to copy into",
+                      isRequired = true,
+                      type = STRING
+              )
       },
       responses = {
           @RestResponse(


### PR DESCRIPTION
The Rest Docs for the LTI Service would not render because
`HTTP ERROR 500 java.lang.IllegalStateException: Path (/{eventId}/copy) does not match path parameter (seriesId) for endpoint (copyeventtoseries), the path must contain all path parameter names.`
This fixes that.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
