### PR TITLE
Fixed publication pop-overs overlaying each other

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/touchController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/touchController.js
@@ -24,7 +24,7 @@ angular.module('adminNg.controllers')
 .controller('TouchCtrl', ['$scope', '$document',
   function ($scope, $document) {
     $scope.openPopup = function(id) {
-     $scope.clearPopup();
+      $scope.clearPopup();
       var popup = angular.element(document.getElementById(id));
       popup.toggle('is-hidden');
     };

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/touchController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/touchController.js
@@ -24,6 +24,7 @@ angular.module('adminNg.controllers')
 .controller('TouchCtrl', ['$scope', '$document',
   function ($scope, $document) {
     $scope.openPopup = function(id) {
+     $scope.clearPopup();
       var popup = angular.element(document.getElementById(id));
       popup.toggle('is-hidden');
     };


### PR DESCRIPTION
Circumvents the problem by closing all other publication pop-overs when opening a new one. This means the pop-overs can potentially still overlap with other elements (e.g. the filter dropdown), but maybe that's not a bug but a feature.

Resolves #2519

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
