### PR TITLE
Remove Commented out Imports from `pom.xml`

### DIFF
--- a/modules/admin-ui-frontend/pom.xml
+++ b/modules/admin-ui-frontend/pom.xml
@@ -189,14 +189,6 @@
             <Http-Alias>/admin-ng</Http-Alias>
             <Http-Classpath>/webapp</Http-Classpath>
             <Http-Welcome>index.html</Http-Welcome>
-<!--            <Import-Package>
-              net.fortuna.ical4j.*,
-              org.opencastproject.index.service.message,
-              org.opencastproject.adminui.index,
-              javax.ws.rs;version=2.0.1,
-              javax.ws.rs.core;version=2.0.1,
-              *
-            </Import-Package>-->
             <Private-Package>
               webapp.*
             </Private-Package>


### PR DESCRIPTION
This patch removes unnecessary and already commented out imports from
the admin-ui-frontend's `pom.xml` file.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
