### PR TITLE
Fix Maven Plugin Multithreading Problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,17 +617,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>com.googlecode.maven-download-plugin</groupId>
           <artifactId>download-maven-plugin</artifactId>
-          <version>1.5.0</version>
+          <version>1.6.6</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -701,6 +701,7 @@
             </execution>
           </executions>
           <configuration>
+            <skip>${skipJasmineTests}</skip>
             <version>1.9.8</version>
           </configuration>
         </plugin>


### PR DESCRIPTION
This patch fixes a few issues appearing when building with multiple
threads:

- The download-maven-plugin file locking [was broken](https://github.com/maven-download-plugin/maven-download-plugin/issues/95), causing several modules (e.g. studio, editor) to fail. Updating the plugin fixes the problem.

- The phantomjs-maven-plugin is not thread-safe and causes all Theodul modules to fail. Unfortunately, [it is no longer maintained](https://github.com/klieber/phantomjs-maven-plugin#phantomjs-maven-plugin) and we should consider removing it. Especially, since it is only needed for running the Jasmine tests which are disabled by default and also partly broken and known to be unreliable (that's why they were deactivated back then).

  For now, this patch makes Maven skip the phantomjs-maven-plugin as well if the Jasmine tests are disabled.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
