### PR TITLE
No Manual Job Sorting

### DIFF
--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
@@ -30,8 +30,6 @@ import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.User;
 import org.opencastproject.serviceregistry.impl.jpa.ServiceRegistrationJpaImpl;
 
-import com.entwinemedia.fn.Fn;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -301,15 +299,6 @@ public class JpaJob {
     return new JobImpl(id, creator, organization, version, jobType, operation, arguments, Status.values()[status],
             createdHost, processingHost, dateCreated, dateStarted, dateCompleted, queueTime, runTime, payload,
             parentJobId, rootJobId, dispatchable, uri, jobLoad);
-  }
-
-  public static Fn<JpaJob, Job> fnToJob() {
-    return new Fn<JpaJob, Job>() {
-      @Override
-      public Job apply(JpaJob jobJpa) {
-        return jobJpa.toJob();
-      }
-    };
   }
 
   @PostLoad


### PR DESCRIPTION
This patch simplifies the service registry code, replaces internal
functionality with Java streams and removes the unnecessary manual
sorting of jobs since they are sorted by the database already.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
