### PR TITLE
Only run Github database test for sql scripts

### DIFF
--- a/.github/workflows/test-database-upgrade.yml
+++ b/.github/workflows/test-database-upgrade.yml
@@ -3,10 +3,10 @@ name: Test database upgrade
 on:
   pull_request:
     paths:
-      - 'docs/upgrade/**'
+      - 'docs/upgrade/*/mysql5.sql'
   push:
     paths:
-      - 'docs/upgrade/**'
+      - 'docs/upgrade/*/mysql5.sql'
 
 jobs:
   # Test database upgrade path.

--- a/docs/upgrade/.test.sh
+++ b/docs/upgrade/.test.sh
@@ -37,6 +37,11 @@ echo "# Running upgrade scripts"
 
 echo "$versions" | while read -r line; do
   dir="$(echo "$line" | cut -d' ' -f2)"
-  echo "mysql -u root $remote octest < $dir/mysql5.sql"
-  mysql -u root $remote octest < "$dir/mysql5.sql"
+  script="$dir/mysql5.sql"
+  if [ -f "$script" ]; then
+    echo "mysql -u root $remote octest < $script"
+    mysql -u root $remote octest < "$script"
+  else
+    echo "$script doesn't exist."
+  fi
 done


### PR DESCRIPTION
This way, the test script won't fail if we put any other scripts into our upgrade folders, as currently happening for #2857.

I tested this by creating a small test PR. When you put an sql script into an upgrade folder, that causes this test run, but a simple text file now won't trigger the test script, while it did before.
