### PR TITLE
Add index changes to release notes of 10.1

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -46,8 +46,14 @@ API changes
 Additional Notes about 10.1
 ---------------------------
 
-This release contains many bugfixes.  In particular, the email libraries are now working properly!
+This release contains many bugfixes.  In particular, the email libraries are now working properly! You might also
+encounter issues with updating the Elasticsearch indices with 10.0, especially when deleting elements, that are fixed
+with this minor release.
 
+From this release onwards there's also no longer the need to run the Elasticsearch index rebuild separately for each
+service to avoid concurrency issues. Instead, you can simply use the /admin-ng/index/recreateIndex or /api/recreateIndex
+endpoints to trigger the complete rebuild and be sure that everything will happen in order, since there is no longer any
+asynchronicity involved.
 
 Release Schedule
 ----------------


### PR DESCRIPTION
Pretty much what it says on the tin. Since #2743 was included in 10.1 to fix some issues with index updates, I thought I'd add that info to the release notes to encourage people to update. It also mentions that there is no longer the possibility for concurrency issues when running a complete index rebuild.
