### PR TITLE
Retry Documentation Deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -99,4 +99,9 @@ jobs:
     - name: push updates
       working-directory: docs.opencast.org/
       run: |
+        set -e
+        if ! git push origin gh-pages; then
+        git fetch origin
+        git rebase origin/gh-pages
         git push origin gh-pages
+        fi


### PR DESCRIPTION
While concurrent build within a branch cancel each other to not run into
problems, deployments can still fail when merges happen in quick
succession on different branches. This patch will mitigate the issue by
rebasing to the updated code in case of conflicts when pushing the
updated docs.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
