### PR TITLE
Fix search episode endpoint with series name

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -488,7 +488,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
         SearchQuery seriesSearch = new SearchQuery();
         seriesSearch.includeSeries(true)
             .includeEpisodes(false)
-            .withQuery("dc_title___:" + SolrUtils.clean(seriesName));
+            .withQuery("dc_title_:" + SolrUtils.clean(seriesName));
         result = searchService.getByQuery(seriesSearch);
       } catch (SearchException e) {
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
This PR fix a problem in search endpoint. The search endpoint cannot handle `sname` (series name) properly in `develop` branch.

### Test plan:
* Create a series with title `foo`
* Add an event `bar` and add the event to the `foo` series
* Search episode in search endpoint ( `https://opencast.domain/docs.html?path=/search`) , `GET /episode.{format:xml|json}` with following parameters
  * format: json
  * sname: foo

### Expected behavior
`bar` should be included in the search result.

### Actual behavior
`bar` is not included in the search result. The search result is empty.

### Explain
The following code is used to set the series name condition
```Java
.withQuery("dc_title___:" + SolrUtils.clean(seriesName));
```
I'm not familiar with Solr. But after I changed the code to
```Java
.withQuery("dc_title_:" + SolrUtils.clean(seriesName));
```
The problem is solved. 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
