### PR TITLE
Document Committers

### DIFF
--- a/docs/guides/developer/.generate-list-of-committers.sh
+++ b/docs/guides/developer/.generate-list-of-committers.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+USER=<username>
+TOKEN=<personal-github-access-token>
+
+echo 'List of Committers'
+echo '------------------'
+echo
+echo '<ul>'
+
+LINK='<a href=" + .html_url + ">'
+IMG='<img style=\"width: 40px; margin: 0\" src=" + .avatar_url + " /> "'
+curl -s -u "$USER:$TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/orgs/opencast/teams/committers/members \
+    | jq -r '.[] | "<li>'"${LINK}${IMG}"' + .login + "</a></li>"' \
+    | sort -f \
+    | grep -v oc-bot
+
+echo '</ul>'

--- a/docs/guides/developer/docs/committer.md
+++ b/docs/guides/developer/docs/committer.md
@@ -71,3 +71,59 @@ Committer status can be lost through any of the methods below:
 * *Revocation of Commit Privileges*: A committer may make a proposal to remove an individual from the committer body.
   Discussion and voting happen on the confidential committers mailing list, and the committer in question is not
   entitled to a vote (though they do get to participate in the discussion).
+
+List of Committers
+------------------
+
+The current list of committers in aplhabetical order:
+
+<ul>
+<li><a href=https://github.com/Arnei><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/14070005?u=6e73d565059359edfca6ec780d0263e9c2a01668&v=4
+ /> Arnei</a></li>
+<li><a href=https://github.com/CGreweling><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/3499600?u=27138059f4750ec5ce6ea6f4e80d08443b75367a&v=4
+ /> CGreweling</a></li>
+<li><a href=https://github.com/gregorydlogan><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/5639561?u=3980a41f51a9b4fcaa988a80e561de14913d062d&v=4
+ /> gregorydlogan</a></li>
+<li><a href=https://github.com/JamesUoM><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/2952979?u=b192e1a3272c7a1264365cc591d893829b186dcf&v=4
+ /> JamesUoM</a></li>
+<li><a href=https://github.com/JulianKniephoff><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/123272?v=4
+ /> JulianKniephoff</a></li>
+<li><a href=https://github.com/karendolan><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/1331728?u=636e1f73f13acf3faf48c5127d1c72dbaef6c71f&v=4
+ /> karendolan</a></li>
+<li><a href=https://github.com/KatrinIhler><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/11960278?u=9faf9a88d3097c7864dc80f799b9845bc09d7026&v=4
+ /> KatrinIhler</a></li>
+<li><a href=https://github.com/lkiesow><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/1008395?u=9f82bb48d2d8f88f6c41ef382e41aae132d894e6&v=4
+ /> lkiesow</a></li>
+<li><a href=https://github.com/mliradelc><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/8040628?u=d5028c1e9214b6cee0374a6651f8947e55bc546f&v=4
+ /> mliradelc</a></li>
+<li><a href=https://github.com/mtneug><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/3051721?u=2c323b5e247fc422dd4d97976f1d513c401dd512&v=4
+ /> mtneug</a></li>
+<li><a href=https://github.com/rrolf><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/1894165?u=b854d241d81a504b9f692b8086ff15097c6c333e&v=4
+ /> rrolf</a></li>
+<li><a href=https://github.com/rute-santos><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/9451622?u=a240189b32811b984d04939ee82e456aaa68eb59&v=4
+ /> rute-santos</a></li>
+<li><a href=https://github.com/smarquard><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/5888197?u=71bbc5d122a4175f8954502c280afc0a3c575e59&v=4
+ /> smarquard</a></li>
+<li><a href=https://github.com/ts23><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/3940856?v=4
+ /> ts23</a></li>
+<li><a href=https://github.com/turro><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/3541284?u=c9b1c8c7d2d674a3bc633c3f026a3b09e9131ae6&v=4
+ /> turro</a></li>
+<li><a href=https://github.com/wsmirnow><img style="width: 40px; margin: 0"
+ src=https://avatars.githubusercontent.com/u/26736?u=ac49366f1834d1b32c6e0c0f330cc2ec4b640e04&v=4
+ /> wsmirnow</a></li>
+</ul>


### PR DESCRIPTION
This patch adds a list of current committers to the developers
documentation and provides a handy script to re-generate the list.

This is based on the committers team in GitHub but as Olaf pointed out,
that list is invisible to most people.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
