### PR TITLE
Fix series endpoint update series method by skipping the ACL update if the parameter is empty

### DIFF
--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
@@ -665,18 +665,21 @@ public class SeriesRestService {
     } else {
       return Response.status(BAD_REQUEST).entity("Required series metadata not provided").build();
     }
-    try {
-      AccessControlList acl = null;
-      if (StringUtils.isNotBlank(accessControl)) {
-        try {
-          acl = AccessControlParser.parseAcl(accessControl);
-        } catch (Exception e) {
-          logger.debug("Could not parse ACL", e);
-          return Response.status(BAD_REQUEST).entity("Could not parse ACL").build();
-        }
+    AccessControlList acl = null;
+    if (StringUtils.isNotBlank(accessControl)) {
+      try {
+        acl = AccessControlParser.parseAcl(accessControl);
+      } catch (Exception e) {
+        logger.debug("Could not parse ACL", e);
+        return Response.status(BAD_REQUEST).entity("Could not parse ACL").build();
       }
+    }
+
+    try {
       DublinCoreCatalog newSeries = seriesService.updateSeries(dc);
-      seriesService.updateAccessControl(dc.getFirst(PROPERTY_IDENTIFIER), acl, override);
+      if (acl != null) {
+        seriesService.updateAccessControl(dc.getFirst(PROPERTY_IDENTIFIER), acl, override);
+      }
       if (newSeries == null) {
         logger.debug("Updated series {} ", dc.getFirst(PROPERTY_IDENTIFIER));
         return Response.status(NO_CONTENT).build();


### PR DESCRIPTION
This pull request again allows the ACL parameter to be optional.
The commit https://github.com/opencast/opencast/commit/d260846aa1269c422d464eb1b14d5c6ce1aad04c changed that behavior and required the ACL parameter, which leads to a broken SeriesServiceRemote update series function.

Endpoint POST /
https://develop.opencast.org/docs.html?path=/series#updateSeries-5