### PR TITLE
Unify loadFromXml behavior

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -23,12 +23,14 @@
 package org.opencastproject.mediapackage;
 
 import org.opencastproject.mediapackage.identifier.Id;
+import org.opencastproject.util.XmlSafeParser;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -100,7 +102,13 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
    * @see org.opencastproject.mediapackage.MediaPackageBuilder#loadFromXml(java.io.InputStream)
    */
   public MediaPackage loadFromXml(InputStream is) throws MediaPackageException {
-    return MediaPackageImpl.valueOf(is);
+    try {
+      return loadFromXml(XmlSafeParser.parse(is));
+    } catch (IOException | SAXException e) {
+      throw new MediaPackageException(e);
+    } finally {
+      IOUtils.closeQuietly(is);
+    }
   }
 
   /**

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
@@ -82,6 +82,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
@@ -165,7 +166,7 @@ public class SearchServiceImplTest {
     // workspace
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class)))
-        .andAnswer(() -> getClass().getResourceAsStream("/" + EasyMock.getCurrentArguments()[0].toString()))
+        .andAnswer(() -> new FileInputStream(((URI)EasyMock.getCurrentArguments()[0]).getPath()))
         .anyTimes();
     EasyMock.replay(workspace);
 


### PR DESCRIPTION
All loadFromXml function should handled with MediaPackageSerializer.

There are three loadFromXml functions implemented in `MediaPackageBuilderImpl.java`. Two of them (`loadFromXml(String xml)` and `loadFromXml(Node xml)`) will handle media package with registered `MediaPackageSerializer`. Yet, the third one `loadFromXml(InputStream is)` handle media package without registered `MediaPackageSerializer`.

This PR unify the behavior of `loadFromXml` function to make them all handle media packages with registered `MediaPackageSerializer`.

This change make a test case in `SearchServiceImplTest.java` fail. Because it use `loadFromXml(InputStream is)` to get the resource file. When it use `DefaultMediaPackageSerialzerImpl` to handle media packages, the url of the resource is translated to an absolute path which can not be accessed by `getClass().getResourceAsStream()`. So, I modify the test case, use `FileInputStream` to handle the absolute path.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
