### PR TITLE
Add search form input field epFrom on sort if url parameter is set

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -541,6 +541,12 @@ function($, bootbox, _, alertify, jsyaml) {
     });
 
     $($oc_sort_dropdown).on('change', function() {
+      let epFrom = GetURLParameter('epFrom');
+      if (epFrom) {
+        $('#oc-search-form .form-group').append(
+          '<input type=\'hidden\' name=\'epFrom\' value=\'' + _.escape(epFrom) + '\' />'
+        );
+      }
       $($oc_search_form).submit();
     });
 


### PR DESCRIPTION
With this pull request, the media module remembers whether episodes of a certain series have been filtered and takes this into account when sorting.

Before this fix, applying the sort criterion removed the epFrom filter parameter.

Fixes #2919 