### PR TITLE
Fix Solr Metadata Field

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -38,6 +38,7 @@ import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.mediapackage.MediaPackageReference;
 import org.opencastproject.metadata.api.MetadataValue;
+import org.opencastproject.metadata.api.MetadataValues;
 import org.opencastproject.metadata.api.StaticMetadata;
 import org.opencastproject.metadata.api.StaticMetadataService;
 import org.opencastproject.metadata.api.util.Interval;
@@ -639,13 +640,13 @@ public class SolrIndexManager {
 
   static List<DField<String>> fromMValue(List<MetadataValue<String>> as) {
     return as.stream()
-        .map(v -> new DField<>(v.getValue(), ""))
+        .map(v -> new DField<>(v.getValue(), MetadataValues.LANGUAGE_UNDEFINED))
         .collect(Collectors.toList());
   }
 
   static List<DField<String>> fromDCValue(List<DublinCoreValue> as) {
     return as.stream()
-        .map(v -> new DField<>(v.getValue(), ""))
+        .map(v -> new DField<>(v.getValue(), DublinCore.LANGUAGE_UNDEFINED))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
Pull request #2815 (commit 5520156) fixed an issue with the publication
of metadata with different language tags. Unfortunately, the patch used
the empty string to represent all metadata values. This conflicts with
the most commonly used one for representing data with no language tags
which was `__`.

This results in a conflict if people now republish media which were
previously published using a different language representation.

This patch switches back to `__` to avoid further conflicts.

Unfortunately, these changes make a search service Solr index rebuild
necessary in _some_ cases. Other Solr or Elasticsearch indexes are _not_
effected in any way.

Who is effected and what's the effect
-------------------------------------

__If you have never run Opencast 10.1__:

Don't worry. No action is necessary. Just upgrade from Opencast ≤ 9.x to
Opencast ≥ 10.2 directly.

__If you did run Opencast 10.1 in production__

You may already have seen an error message like this while trying to
republish media originally published with Opencast ≤ Opencast 10.0:

    (SolrException:139) - org.apache.solr.common.SolrException:
       ERROR: multiple values encountered for non multiValued
       copy field dc_title-sort

This happens if old and new data get mixed. The field `dc_title-sort`
will automatically gather multiple values, but can actually only handle a
single value. Hence, (re-)publication will fail.

To fix this, you will need to re-write the Solr entries set in 10.1,
either by removing and resetting specific events or (recommended) by
re-indexing all events.

To re-index, stop Opencast, remove `<karaf-data>/solr-indexes/search`
and restart Opencast. The re-index progress will be logged. Fortunately,
this is a lot faster than with Elasticsearch.

_Sorry for the inconvenience!_

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
