### PR TITLE
Test only with Firefox or Chrome

### DIFF
--- a/docs/guides/admin/docs/installation/source-macosx.md
+++ b/docs/guides/admin/docs/installation/source-macosx.md
@@ -52,6 +52,7 @@ Required:
     ffmpeg >= 3.2.4
     maven >= 3.1
     python >= 2.6
+    Firefox or Chrome
 
 (If you are using [jEnv](http://www.jenv.be/) to set up your environment, make sure to [enable the maven plugin
 ](https://stackoverflow.com/a/37466252).)

--- a/modules/admin-ui-frontend/test/karma.conf.js
+++ b/modules/admin-ui-frontend/test/karma.conf.js
@@ -59,26 +59,18 @@ module.exports = function (config) {
             enabled: true,
             usePhantomJS: false,
             preferHeadless: true,
-            // post processing of browsers list
-            // here you can edit the list of browsers used by karma
-            postDetection: function(availableBrowsers) {
-                var result = availableBrowsers;
-                /* Leaving this commented out as an example.
-                   If we ever want to disable an installed browser (c.f: IE) we can exclude it like this
-                //Remove PhantomJS if another browser has been detected
-                if (availableBrowsers.length > 1 && availableBrowsers.indexOf('PhantomJS')>-1) {
-                    var i = result.indexOf('PhantomJS');
-                    if (i !== -1) {
-                        result.splice(i, 1);
-                    }
-                }
-		*/
-		if (availableBrowsers.length < 1) {
+            // limit the list of browsers used by karma
+            postDetection: (browsers) => {
+                const allowed = new Set(['ChromeHeadless', 'FirefoxHeadless'])
+                console.info('Detected browsers: ' + browsers);
+                browsers = browsers.filter(browser => allowed.has(browser));
+                console.info('Usable browsers: ' + browsers);
+                if (browsers.length < 1) {
                     console.error("No browsers detected");
                     console.error("Suggest installing Firefox or other FOSS browser");
                     throw "No browsers detected";
-	        }
-                return result;
+                }
+                return browsers;
             }
         },
 


### PR DESCRIPTION
As discussed at today's technical meeting this patch closes #2527 and
replaces it with a patch limiting the tests to Firefox or Chrome so we
know that we actually run in a somewhat known and safe environment.

---

Note that `r/9.x` seems to have the same issue I fixed in #2720 for `r/10.x`.
Make sure to build with something like this if you test this locally:

```
TZ="America/Regina" mvn clean install -Pnone -DtrimStackTrace=false
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
