### PR TITLE
Added config option for disabling the embed-code button 

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -175,6 +175,12 @@ prop.org.opencastproject.admin.mediamodule.url=${prop.org.opencastproject.engage
 # Default: false
 prop.adminui.user.external_role_display=false
 
+# Set a flag to display the embed-code button in the admin UI
+#
+# Value: <boolean>
+# Default: true
+#prop.adminui.embed_button_display=true
+
 # Name of the list to provide a user listing as used in the group editor of the admin ui.
 #
 # Values:

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
@@ -52,10 +52,7 @@ angular.module('adminNg.controllers')
         $scope.editorUrl = '#!/events/events/$id/tools/editor';
       }
       if (angular.isDefined(user.org.properties['adminui.embed_button_display'])) {
-        var embedButtonConfig = user.org.properties['adminui.embed_button_display'];
-        if (embedButtonConfig === 'false') {
-          $scope.showEmbedButtons = embedButtonConfig;
-        }
+        $scope.showEmbedButtons = user.org.properties['adminui.embed_button_display'] !== 'false';
       }
     }).catch(angular.noop);
 

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
@@ -30,6 +30,8 @@ angular.module('adminNg.controllers')
 
     $scope.stats = Stats;
 
+    $scope.showEmbedButtons = true;
+
     var statsConfiguration = ResourcesListResource.queryRecursive({ resource: 'STATS' });
     statsConfiguration.$promise.then(function (configuration) {
 
@@ -48,6 +50,12 @@ angular.module('adminNg.controllers')
       $scope.editorUrl = user.org.properties['admin.editor.url'];
       if (!$scope.editorUrl) {
         $scope.editorUrl = '#!/events/events/$id/tools/editor';
+      }
+      if (angular.isDefined(user.org.properties['adminui.embed_button_display'])) {
+        var embedButtonConfig = user.org.properties['adminui.embed_button_display'];
+        if (embedButtonConfig === 'false') {
+          $scope.showEmbedButtons = embedButtonConfig;
+        }
       }
     }).catch(angular.noop);
 
@@ -132,6 +140,7 @@ angular.module('adminNg.controllers')
         row.comments = CommentResource.query({ resource: 'event', resourceId: row.id, type: 'comments' });
 
         row.editorUrl = $scope.editorUrl.replace('$id', row.id);
+        row.showEmbed = $scope.showEmbedButtons;
       }
     });
 

--- a/modules/admin-ui-frontend/app/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/partials/eventActionsCell.html
@@ -63,6 +63,7 @@
 </a>
 
 <a ng-click="row.embeddingCode()"
+   ng-show="{{ row.showEmbed }}"
    class="fa fa-link"
    title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.EMBEDDING_CODE' | translate }}"
    with-role="ROLE_UI_EVENTS_EMBEDDING_CODE_VIEW">


### PR DESCRIPTION
This PR adds a configuration option for disabling the embed-code button in the admin ui. 

The configuration can be changed by setting a flag on the `prop.adminui.embed_button_display` option in `etc/org.opencastproject.organization-mh_default_org.cfg` . If it's set to any other value than `false` or not set at all, it defaults to `true`.
### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
