### PR TITLE
Display version updates only as warning in the admin interface

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
@@ -67,12 +67,11 @@ function monitorService($http, $location, $translate, Storage) {
             services.service[LATEST_VERSION_NAME].error = false;
           } else if (parseInt(my_version) == parseInt(latest_version)) {
             $translate('UPDATE.MINOR').then(function(translation) {
-              services.service[LATEST_VERSION_NAME].status = translation;
+              Monitoring.setWarning(LATEST_VERSION_NAME, translation);
             }).catch(angular.noop);
-            services.service[LATEST_VERSION_NAME].error = true;
           } else if (parseInt(latest_version) - parseInt(my_version) < 2) {
             $translate('UPDATE.MAJOR').then(function(translation) {
-              Monitoring.setError(LATEST_VERSION_NAME, translation);
+              Monitoring.setWarning(LATEST_VERSION_NAME, translation);
             }).catch(angular.noop);
           } else {
             $translate('UPDATE.UNSUPPORTED', {'version': my_version}).then(function(translation) {


### PR DESCRIPTION
The Latest Version service now reports Minor and Major opencast updates as a warning. 
They are now displayed in orange in the admin UI (and not as red errors as it was formerly the case). 

![Screenshot 2021-08-13 at 23-25-45 Opencast](https://user-images.githubusercontent.com/23011761/129420558-3114bf80-83a2-47b7-a181-38eb8a490763.png)

This is related to #2279 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
