### PR TITLE
Document Version Warning Conditions

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/restServiceMonitor.js
@@ -61,23 +61,32 @@ function monitorService($http, $location, $translate, Storage) {
           services.service[LATEST_VERSION_NAME].docs_url =
             'https://docs.opencast.org/r/' + parseInt(latest_version) + '.x/admin/';
 
+          // Check if this is the latest major.minor version available
           if (parseFloat(my_version) >= parseFloat(latest_version)
              || (parseInt(my_version) == parseInt(latest_version) && my_version.endsWith('SNAPSHOT'))) {
             services.service[LATEST_VERSION_NAME].status = OK;
             services.service[LATEST_VERSION_NAME].error = false;
+
+          // Check if this is the latest major but not the latest minor version
           } else if (parseInt(my_version) == parseInt(latest_version)) {
             $translate('UPDATE.MINOR').then(function(translation) {
               Monitoring.setWarning(LATEST_VERSION_NAME, translation);
             }).catch(angular.noop);
+
+          // Check if this is still supported even though it is not the latest major version
           } else if (parseInt(latest_version) - parseInt(my_version) < 2) {
             $translate('UPDATE.MAJOR').then(function(translation) {
               Monitoring.setWarning(LATEST_VERSION_NAME, translation);
             }).catch(angular.noop);
+
+          // This version is no longer supported
           } else {
             $translate('UPDATE.UNSUPPORTED', {'version': my_version}).then(function(translation) {
               Monitoring.setError(LATEST_VERSION_NAME, translation);
             }).catch(angular.noop);
           }
+
+        // Couldn't determine this Opencast's version or what the latest version is
         } else {
           $translate('UPDATE.UNDETERMINED').then(function(translation) {
             Monitoring.setWarning(LATEST_VERSION_NAME, translation);


### PR DESCRIPTION
This patch adds a few lines of documentation to the conditions
determining the different version-related warnings and errors in the
admin interface so that you don't have to work though all the conditions
one by one.

This is related to #2929

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
