### PR TITLE
Update Nginx example regarding proxy_cookie_path

### DIFF
--- a/docs/guides/admin/docs/configuration/https/nginx.md
+++ b/docs/guides/admin/docs/configuration/https/nginx.md
@@ -113,7 +113,10 @@ http {
             proxy_redirect          http://$host https://$host;
 
             # Make sure to serve cookies only via secure connections.
-            proxy_cookie_path / "/; HTTPOnly; Secure";
+            proxy_cookie_flags ~ secure httponly;
+            # When using Nginx <1.19.3 replace the above 'proxy_cookie_flags' line
+            # with the (uncommented) 'proxy_cookie_path' line below.
+            #proxy_cookie_path / "/; HTTPOnly; Secure";
 
             # Depending on your integration, you may also want to allow cookies
             # to be used on other sites. In that case, use this instead:


### PR DESCRIPTION
Recommend proxy_cookie_flags for Nginx >=1.19.3
but mention the proxy_cookie_path workaround for Nginx <1.19.3

This request addresses #2135 