### PR TITLE
Revert "Remove Series Service from Authorization Service"

### DIFF
--- a/modules/authorization-xacml/pom.xml
+++ b/modules/authorization-xacml/pom.xml
@@ -51,10 +51,6 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-    </dependency>
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -118,7 +114,6 @@
             <ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUnusedDeclaredDependency>
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.glassfish.jaxb:jaxb-runtime</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
This reverts commit b664670c59a13db64a7fe5bea1df4c12ff283061 because
that commit:

- Does not do what it claims to be doing
- introduces unwanted runtime dependencies
- Causes maven warnings

```
Warning:
Warning:  Some problems were encountered while building the effective model for org.opencastproject:opencast-authorization-xacml:bundle:10.2
Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.glassfish.jaxb:jaxb-runtime:jar -> duplicate declaration of version (?) @ org.opencastproject:opencast-authorization-xacml:[unknown-version], /__w/opencast-rpmbuild/opencast-rpmbuild/opencast/modules/authorization-xacml/pom.xml, line 98, column 17
Warning:
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
Warning:
```

The patch was part of pull request #2743.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
