### PR TITLE
Rebuild ExternalIndex while triggering an index recreation

### DIFF
--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -182,6 +182,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-external-api-index</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-list-providers-service</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/IndexEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/IndexEndpoint.java
@@ -22,6 +22,7 @@
 package org.opencastproject.adminui.endpoint;
 
 import org.opencastproject.adminui.index.AdminUISearchIndex;
+import org.opencastproject.external.index.ExternalIndex;
 import org.opencastproject.index.rebuild.IndexRebuildService;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.util.SecurityContext;
@@ -66,6 +67,9 @@ public class IndexEndpoint {
   /** The admin UI index */
   private AdminUISearchIndex adminUISearchIndex;
 
+  /** The External index */
+  private ExternalIndex externalIndex;
+
   /** The security service */
   protected SecurityService securityService = null;
 
@@ -76,6 +80,10 @@ public class IndexEndpoint {
    */
   public void setAdminUISearchIndex(AdminUISearchIndex adminUISearchIndex) {
     this.adminUISearchIndex = adminUISearchIndex;
+  }
+
+  public void setExternalIndex(ExternalIndex externalIndex) {
+    this.externalIndex = externalIndex;
   }
 
   public void setIndexRebuildService(IndexRebuildService indexRebuildService) {
@@ -106,6 +114,7 @@ public class IndexEndpoint {
       try {
         logger.info("Clear the Admin UI index");
         adminUISearchIndex.clear();
+        externalIndex.clear();
         return R.ok();
       } catch (Throwable t) {
         logger.error("Clearing the Admin UI index failed", t);
@@ -132,6 +141,7 @@ public class IndexEndpoint {
       try {
         logger.info("Starting to repopulate the index from service {}", service);
         indexRebuildService.rebuildIndex(adminUISearchIndex, service);
+        indexRebuildService.rebuildIndex(externalIndex, service);
       } catch (Throwable t) {
         logger.error("Repopulating the index failed", t);
       }
@@ -151,6 +161,7 @@ public class IndexEndpoint {
       try {
         logger.info("Starting to repopulate the index");
         indexRebuildService.rebuildIndex(adminUISearchIndex);
+        indexRebuildService.rebuildIndex(externalIndex);
       } catch (Throwable t) {
         logger.error("Repopulating the index failed", t);
       }

--- a/modules/admin-ui/src/main/resources/OSGI-INF/index_endpoint.xml
+++ b/modules/admin-ui/src/main/resources/OSGI-INF/index_endpoint.xml
@@ -15,6 +15,11 @@
              cardinality="1..1"
              policy="static"
              bind="setAdminUISearchIndex"/>
+  <reference name="ExternalIndex"
+             interface="org.opencastproject.external.index.ExternalIndex"
+             cardinality="1..1"
+             policy="static"
+             bind="setExternalIndex"/>
   <reference name="SecurityService"
              interface="org.opencastproject.security.api.SecurityService"
              cardinality="1..1"


### PR DESCRIPTION
While invoke index rebuild API with  `/admin-ng/index/createIndex`, only `adminUISearchIndex` is cleaned and rebuilt.

This PR make `externalIndex` cleaned and rebuilt as the same way as `adminUISearchIndex`.

If `externalInbox` is not processed in index creation process, some search results will be conflict with each other from different endpoint. This will affect some scenes like batch update data or clean up data.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
