### PR TITLE
Improve `security-jwt` tests

### DIFF
--- a/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTLoginTest.java
+++ b/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTLoginTest.java
@@ -32,7 +32,6 @@ import static org.easymock.EasyMock.reset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.SecurityService;
@@ -166,9 +165,10 @@ public class JWTLoginTest {
   @Test
   public void testLoginWithCache() {
     Object username;
+    String jwt = generator.generateValidSymmetricJWT();
 
     username = authFilter.getPreAuthenticatedPrincipal(
-        mockRequest(generator.generateValidSymmetricJWT())
+        mockRequest(jwt)
     );
     assertEquals(username, generator.getUsername());
 
@@ -176,7 +176,7 @@ public class JWTLoginTest {
     reset(userReferenceProvider);
 
     username = authFilter.getPreAuthenticatedPrincipal(
-        mockRequest(generator.generateValidSymmetricJWT())
+        mockRequest(jwt)
     );
     assertEquals(username, generator.getUsername());
   }
@@ -270,13 +270,12 @@ public class JWTLoginTest {
   @Test
   public void testLoginWithInvalidRequestHeader() {
     authFilter.setPrincipalRequestHeader("XY");
-    Exception exception = assertThrows(
+    assertThrows(
         PreAuthenticatedCredentialsNotFoundException.class,
         () -> authFilter.getPreAuthenticatedPrincipal(
             mockRequest(generator.generateExpiredSymmetricJWT())
         )
     );
-    assertTrue(exception.getMessage().startsWith("XY header not found in request"));
   }
 
   @Test

--- a/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTVerifierTest.java
+++ b/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTVerifierTest.java
@@ -28,7 +28,6 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import com.auth0.jwk.JwkException;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -78,8 +77,6 @@ public class JWTVerifierTest {
 
   @Test
   public void testVerifySymmetric() {
-    Exception exception;
-
     // Valid JWT + valid claim constraints
     DecodedJWT decodedJWT = JWTVerifier.verify(
         generator.generateValidSymmetricJWT(),
@@ -89,7 +86,7 @@ public class JWTVerifierTest {
     assertEquals(generator.getUsername(), decodedJWT.getClaim("username").asString());
 
     // Valid JWT + invalid claim constraints
-    exception = assertThrows(
+    assertThrows(
         JWTVerificationException.class,
         () -> JWTVerifier.verify(
             generator.generateValidSymmetricJWT(),
@@ -97,10 +94,9 @@ public class JWTVerifierTest {
             generator.generateInvalidClaimConstraints()
         )
     );
-    assertTrue(exception.getMessage().startsWith("The claims did not fulfill constraint"));
 
     // Valid JWT + invalid secret
-    exception = assertThrows(
+    assertThrows(
         JWTVerificationException.class,
         () -> JWTVerifier.verify(
             generator.generateValidSymmetricJWT(),
@@ -108,10 +104,9 @@ public class JWTVerifierTest {
             generator.generateValidClaimConstraints()
         )
     );
-    assertTrue(exception.getMessage().startsWith("The Token's Signature resulted invalid"));
 
     // Invalid JWT
-    exception = assertThrows(
+    assertThrows(
         JWTVerificationException.class,
         () -> JWTVerifier.verify(
             generator.generateExpiredSymmetricJWT(),
@@ -119,12 +114,10 @@ public class JWTVerifierTest {
             generator.generateValidClaimConstraints()
         )
     );
-    assertTrue(exception.getMessage().startsWith("The Token has expired on"));
   }
 
   @Test
   public void testVerifyAsymmetric() throws Exception {
-    Exception exception;
     DecodedJWT decodedJWT;
 
     // Valid JWT + valid claim constraints
@@ -136,7 +129,7 @@ public class JWTVerifierTest {
     assertEquals(generator.getUsername(), decodedJWT.getClaim("username").asString());
 
     // Valid JWT + invalid claim constraints
-    exception = assertThrows(
+    assertThrows(
         JWTVerificationException.class,
         () -> JWTVerifier.verify(
             generator.generateValidAsymmetricJWT(),
@@ -144,10 +137,9 @@ public class JWTVerifierTest {
             generator.generateInvalidClaimConstraints()
         )
     );
-    assertTrue(exception.getMessage().startsWith("The claims did not fulfill constraint"));
 
     // Valid JWT + invalid provider
-    exception = assertThrows(
+    assertThrows(
         JWTVerificationException.class,
         () -> JWTVerifier.verify(
             generator.generateValidAsymmetricJWT(),
@@ -155,10 +147,9 @@ public class JWTVerifierTest {
             generator.generateValidClaimConstraints()
         )
     );
-    assertTrue(exception.getMessage().startsWith("The Token's Signature resulted invalid"));
 
     // Invalid JWT
-    exception = assertThrows(
+    assertThrows(
         JWTVerificationException.class,
         () -> JWTVerifier.verify(
             generator.generateExpiredAsymmetricJWT(),
@@ -166,7 +157,6 @@ public class JWTVerifierTest {
             generator.generateValidClaimConstraints()
         )
     );
-    assertTrue(exception.getMessage().startsWith("The Token has expired on"));
 
     // Simulate key rotation
     decodedJWT = JWTVerifier.verify(


### PR DESCRIPTION
This patch improves the stability of some tests in the
`security-jwt` module. There were timing issues in the
`testLoginWithCache` test. Depending on how long the
duration between two statements in this was it failed
or succeeded. This is fixed now. Additionally, I removed
the assertions about exception messages as they might
change quickly. Now only the type of exceptions thrown
is tested.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
