### PR TITLE
Encode username before useing it in CanvasUserRoleProvider

### DIFF
--- a/modules/userdirectory-canvas/src/main/java/org/opencastproject/userdirectory/canvas/CanvasUserRoleProvider.java
+++ b/modules/userdirectory-canvas/src/main/java/org/opencastproject/userdirectory/canvas/CanvasUserRoleProvider.java
@@ -54,6 +54,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -340,6 +342,11 @@ public class CanvasUserRoleProvider implements UserProvider, RoleProvider {
   }
 
   private String[] getCanvasUserInfo(String userName) {
+    try {
+      userName = URLEncoder.encode(userName, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // Should never be happen, UTF-8 is always supported
+    }
     String urlString = String.format("%s/api/v1/users/sis_login_id:%s", url, userName);
     try {
       JsonNode node = getRequestJson(urlString);
@@ -355,7 +362,12 @@ public class CanvasUserRoleProvider implements UserProvider, RoleProvider {
 
   private List<String> getRolesFromCanvas(String userName) {
     logger.debug("getRolesFromCanvas({})", userName);
-        // Only list 'active' enrollments. That means, only courses in active terms will be used.
+    try {
+      userName = URLEncoder.encode(userName, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // Should never be happen, UTF-8 is always supported
+    }
+    // Only list 'active' enrollments. That means, only courses in active terms will be used.
     String urlString = String.format(
         "%s/api/v1/users/sis_login_id:%s/courses.json?per_page=500&enrollment_state=active&"
             + "state[]=unpublished&state[]=available",
@@ -392,6 +404,11 @@ public class CanvasUserRoleProvider implements UserProvider, RoleProvider {
 
   private boolean verifyCanvasUser(String userName) {
     logger.debug("verifyCanvasUser({})", userName);
+    try {
+      userName = URLEncoder.encode(userName, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // Should never be happen, UTF-8 is always supported
+    }
     String urlString = String.format("%s/api/v1/users/sis_login_id:%s", url, userName);
     try {
       getRequestJson(urlString);


### PR DESCRIPTION
In `CanvasUserRoleProvider`, opencast get users' info via Rest endpoint API. Currently, invoking this API will direct pass the parameters. So, if some special character is in the parameters (blank space for example). The API cannot be invoked successfully due to invalid URI.

This PR encode all parameters with `URLEncoder` before using it.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
