### PR TITLE
Check whether streamingDistributionService is set before invoking it

### DIFF
--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
@@ -119,7 +119,7 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
         jobs.add(retractDownloadDistributionJob);
       }
     }
-    if (streamingDistributionService.publishToStreaming()) {
+    if (streamingDistributionService != null && streamingDistributionService.publishToStreaming()) {
       for (MediaPackageElement element : searchMediaPackage.getElements()) {
         Job retractStreamingJob = streamingDistributionService.retract(CHANNEL_ID, searchMediaPackage,
                 element.getIdentifier());


### PR DESCRIPTION
`streamingDistributionService` is not always set in `RetractEngageWorkflowOperationHandler`.
For example, `modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/publish-aws.xml`, so before invoking it, check it first.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
