### PR TITLE
Add I18n support for presenter name label in episodeFromSeries plugin

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.episodesFromSeries/localization/en-US.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.episodesFromSeries/localization/en-US.json
@@ -5,5 +5,6 @@
   "Previous": "Previous",
   "Related Videos": "Related Videos",
   "Searching...": "Searching...",
-  "Videos in this series:": "Videos in this series:"
+  "Videos in this series:": "Videos in this series:",
+  "by:": "by:"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.episodesFromSeries/mh_episodes_from_serie.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.episodesFromSeries/mh_episodes_from_serie.js
@@ -440,7 +440,7 @@ var SearchEpisode = Class.create({
     var author = '&nbsp;';
     var author_search = '';
     if(recording.dcCreator) {
-      author = 'by ' + recording.dcCreator;
+      author = paella.dictionary.translate('by:') + recording.dcCreator;
       author_search = recording.dcCreator;
     }
     var divResultAuthorText = document.createElement('div');


### PR DESCRIPTION
Just as the title, add I18n support for the word `by` in episodeFromSeries plugin.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
