### PR TITLE
Fix episodeFromSeries plugin show "&nbsp;" while presenter is empty

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.episodesFromSeries/mh_episodes_from_serie.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.episodesFromSeries/mh_episodes_from_serie.js
@@ -437,7 +437,7 @@ var SearchEpisode = Class.create({
 
 
     // author
-    var author = '&nbsp;';
+    var author = ' ';
     var author_search = '';
     if(recording.dcCreator) {
       author = 'by ' + recording.dcCreator;


### PR DESCRIPTION
`episodeFromSeries` plugin shows `&nbsp;` if presenter is not set.
Here is an example.
![nbsp](https://user-images.githubusercontent.com/1639290/130346694-3e377109-8861-4f5a-9137-217e2260c1da.png)

This PR make it show an whitespace if presenter is not set.
As the following pic.
![whitespace](https://user-images.githubusercontent.com/1639290/130346817-b8bced01-bfb5-4dc3-81e9-4a2386badbb6.png)


* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
