### PR TITLE
userTrackingSaverPlugin wrongly invoke PUT request

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/04_datadelegates.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/04_datadelegates.js
@@ -176,8 +176,7 @@ class MHFootPrintsDataDelegate extends paella.DataDelegate {
 
   write(context,params,value,onSuccess) {
     var episodeId = params.id;
-    paella.ajax.get({url: '/usertracking/', params: {
-      _method: 'PUT',
+    paella.ajax.put({url: '/usertracking/', params: {
       id: episodeId,
       type:'FOOTPRINT',
       in:value.in,

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.userTrackingSaverPlugIn/mh_usertracking_saver.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.userTrackingSaverPlugIn/mh_usertracking_saver.js
@@ -47,7 +47,6 @@ paella.addPlugin(function() {
       })
       .then((paused) => {
         var opencastLog = {
-          _method: 'PUT',
           'id': paella.player.videoIdentifier,
           'type': undefined,
           'in': videoCurrentTime,


### PR DESCRIPTION
# Reproduce the problem

1. Enable `userTrackingSaverPlugin`
2. Open a video and play it
3. Meanwhile, open the inspect view of browser to check the requests

Some requests with `GET` method were sent periodically like following:
`https://${OPENCAST_DOMAIN}/usertracking/?_method=PUT&id=${MEDIAPACKAGE_ID}&type=FOOTPRINT&in=0&out=5&_=${TIMESTAMP}`
and get response like
```json
{"version":"v1.6.0","url":"http:\/\/localhost:8080\/api"}
```

# Expected behavior
Requests should be sent with `PUT` method and get a XML response.

# Find the bug
`userTrackingSaverPlugin` use a param named `_method` to set the request method, yet this is omitted by the method it invokes.
So, in the server side, these requests is treated as `GET` methods.

# Solution
This PR use `ajax.put` instead of using params `_method: 'PUT'.



### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
