### PR TITLE
Fix SQL query in static file authorization by using `true` instead of `1` for bool comparison

### DIFF
--- a/modules/asset-manager-static-file-authorization/src/main/java/org/opencastproject/assetmanager/auth/AssetManagerStaticFileAuthorization.java
+++ b/modules/asset-manager-static-file-authorization/src/main/java/org/opencastproject/assetmanager/auth/AssetManagerStaticFileAuthorization.java
@@ -153,7 +153,7 @@ public class AssetManagerStaticFileAuthorization implements StaticFileAuthorizat
       properties.append(" or property_name = ?");
     }
     String sql = "select count(1) from oc_assets_properties "
-        + "where val_bool = 1 "
+        + "where val_bool = true "
         + "and namespace = ? "
         + "and mediapackage_id = ? "
         + "and (" + properties + ")";


### PR DESCRIPTION
This queries fails in PostgreSQL databases. The literal `true` is, as
far as my searches show, defined in the standard SQL. This works for
the M2 database. I also tested a dummy query with `true` on MySQL and
PostgreSQL databases and everything worked out.

For example, you can try the following script [here](https://www.db-fiddle.com/):

```
create table foo (
  name text,
  bob boolean
);

insert into foo (name, bob) values ('peter', true);
insert into foo (name, bob) values ('anna', false);

select * from foo where bob=true;
```

With `bob=1`, it fails on PostgreSQL. 

CC @lkiesow @wsmirnow 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
