### PR TITLE
Update Editor Profile

### DIFF
--- a/etc/encoding/opencast-movies.properties
+++ b/etc/encoding/opencast-movies.properties
@@ -187,13 +187,13 @@ profile.scale.fhd.framerate.fix.ffmpeg.command = -i #{in.video.path} \
 
 # Editor
 #   This profile is used as a preview and work copy for the video editor.
-#   The gnonlin component in the gstreamer based video editor modules needs
-#   an mp4 codec to work reliable. This could also be used for the web preview
-#   although the file might be quite large for web distribution
-
 profile.editor.work.name = editor
 profile.editor.work.input = audiovisual
 profile.editor.work.output = audiovisual
 profile.editor.work.suffix = -editor.mp4
 profile.editor.work.mimetype = video/mp4
-profile.editor.work.ffmpeg.command = -i #{in.video.path} -filter:v crop=trunc(iw/2)*2:trunc(ih/2)*2,fps=25 -shortest -c:v libx264 -preset superfast -pix_fmt yuv420p -crf 18 -c:a aac -strict -2 -b:a 196k #{out.dir}/#{out.name}#{out.suffix}
+profile.editor.work.ffmpeg.command = -i #{in.video.path} \
+  -filter:v crop=trunc(iw/2)*2:trunc(ih/2)*2,fps=25 -shortest \
+  -c:v libx264 -preset superfast -pix_fmt yuv420p -crf 18 \
+  -c:a aac -b:a 196k \
+  #{out.dir}/#{out.name}#{out.suffix}


### PR DESCRIPTION
This patch updates the `editor.work` encoding profile. It removes the
unnecessary `-strict -2`, make the formatting look a bit nicer and
removes some outdated comments (the editor is not using GStreamer).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
