### PR TITLE
Fix issue with duplicate entries in role list

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/resources/rolesResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/rolesResource.js
@@ -39,7 +39,9 @@ angular.module('adminNg.resources')
 
         var roleNames = [];
         angular.forEach(data, function (role) {
-          roleNames.push(role.name);
+          if (roleNames.indexOf(role.name) === -1) {
+            roleNames.push(role.name);
+          }
         });
 
         return roleNames;


### PR DESCRIPTION
The role list provided in the role selection of the ACL tab may have duplicate entries. For example, at [develop.opencast.org](https://develop.opencast.org) the role `ROLE_ANONYMOUS` appears twice:

![image](https://user-images.githubusercontent.com/6248816/130925209-9ae66593-ef9d-4de2-ad45-32b4c4ac9e9d.png)

When inspecting the response of the [`acl/roles.json`](https://develop.opencast.org/admin-ng/acl/roles.json) endpoint we can see that in this case the returned entries are not strickly identical in all fields:

```json
[
  {"organization":"mh_default_org","name":"ROLE_ANONYMOUS","description":null,"type":"INTERNAL"},
  {"organization":"mh_default_org","name":"ROLE_ANONYMOUS","description":"","type":"SYSTEM"}
]
```

But there is also another case in which duplicate entries may occur. When using AAI for authentication then the AAI role provider implementation will be considered (e.g. [`DynamicLoginHandler.java#L250-L256`](https://github.com/opencast/opencast/blob/develop/modules/security-aai/src/main/java/org/opencastproject/security/aai/DynamicLoginHandler.java#L250-L256)). Here, all roles associated to the authenticated user are returned. If the configured AAI role mapping assigns a role that is also returned by another role provider (e.g. `ROLE_ADMIN` with a configuration like [this](https://github.com/opencast/opencast/blob/develop/etc/security/mh_default_org.xml#L669)) then the `acl/roles.json` endpoint will return two strictly identical entries:

```json
[
  {"organization":"mh_default_org","name":"ROLE_ADMIN","description":null,"type":"INTERNAL"},
  {"organization":"mh_default_org","name":"ROLE_ADMIN","description":null,"type":"INTERNAL"}
]
```

I added a check to the Admin UI frontend code that prevents duplicates when querying for role names only. I did this in the frontend and not in the backend becuase in the backend all fields of the role entries are considered. Hence, when comparing entries the first case where role entries are not stricly identical would still lead to duplications.

Or is there a better way to fix this issue?

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
