### PR TITLE
ActiveMQ configuration needs an update

### DIFF
--- a/docs/scripts/activemq/activemq.xml
+++ b/docs/scripts/activemq/activemq.xml
@@ -64,20 +64,8 @@
         <destinationInterceptors>
           <virtualDestinationInterceptor>
             <virtualDestinations>
-              <compositeQueue name="ACL.QUEUE">
-                <forwardTo>
-                  <queue physicalName="ACL.Adminui" />
-                  <queue physicalName="ACL.Externalapi" />
-                </forwardTo>
-              </compositeQueue>
-            </virtualDestinations>
-          </virtualDestinationInterceptor>
-          <virtualDestinationInterceptor>
-            <virtualDestinations>
               <compositeQueue name="ASSETMANAGER.QUEUE">
                 <forwardTo>
-                  <queue physicalName="ASSETMANAGER.Adminui" />
-                  <queue physicalName="ASSETMANAGER.Externalapi" />
                   <queue physicalName="ASSETMANAGER.Conductor" />
                   <queue physicalName="ASSETMANAGER.Liveschedule" />
                 </forwardTo>
@@ -86,30 +74,8 @@
           </virtualDestinationInterceptor>
           <virtualDestinationInterceptor>
             <virtualDestinations>
-              <compositeQueue name="COMMENT.QUEUE">
-                <forwardTo>
-                  <queue physicalName="COMMENT.Adminui" />
-                  <queue physicalName="COMMENT.Externalapi" />
-                </forwardTo>
-              </compositeQueue>
-            </virtualDestinations>
-          </virtualDestinationInterceptor>
-          <virtualDestinationInterceptor>
-            <virtualDestinations>
-              <compositeQueue name="GROUP.QUEUE">
-                <forwardTo>
-                  <queue physicalName="GROUP.Adminui" />
-                  <queue physicalName="GROUP.Externalapi" />
-                </forwardTo>
-              </compositeQueue>
-            </virtualDestinations>
-          </virtualDestinationInterceptor>
-          <virtualDestinationInterceptor>
-            <virtualDestinations>
               <compositeQueue name="SCHEDULER.QUEUE">
                 <forwardTo>
-                  <queue physicalName="SCHEDULER.Adminui" />
-                  <queue physicalName="SCHEDULER.Externalapi" />
                   <queue physicalName="SCHEDULER.Liveschedule" />
                 </forwardTo>
               </compositeQueue>
@@ -119,29 +85,7 @@
             <virtualDestinations>
               <compositeQueue name="SERIES.QUEUE">
                 <forwardTo>
-                  <queue physicalName="SERIES.Adminui" />
                   <queue physicalName="SERIES.Conductor" />
-                  <queue physicalName="SERIES.Externalapi" />
-                </forwardTo>
-              </compositeQueue>
-            </virtualDestinations>
-          </virtualDestinationInterceptor>
-          <virtualDestinationInterceptor>
-            <virtualDestinations>
-              <compositeQueue name="THEME.QUEUE">
-                <forwardTo>
-                  <queue physicalName="THEME.Adminui" />
-                  <queue physicalName="THEME.Externalapi" />
-                </forwardTo>
-              </compositeQueue>
-            </virtualDestinations>
-          </virtualDestinationInterceptor>
-          <virtualDestinationInterceptor>
-            <virtualDestinations>
-              <compositeQueue name="WORKFLOW.QUEUE">
-                <forwardTo>
-                  <queue physicalName="WORKFLOW.Adminui" />
-                  <queue physicalName="WORKFLOW.Externalapi" />
                 </forwardTo>
               </compositeQueue>
             </virtualDestinations>


### PR DESCRIPTION
We had an incident with Opencast where it was stuck because ActiveMQ did block any incoming message. ActiveMQ did so because it had a memory problem and its log contained messages like:

`2021-08-16 11:24:19,891 | INFO  | Usage(default:memory:queue://ASSETMANAGER.Externalapi:memory) percentUsage=24%, usage=366732408, limit=1503238554, percentUsageMinDelta=1%;Parent:Usage(default:memory) percentUsage=100%, usage=1503321772, limit=1503238554, percentUsageMinDelta=1%: Usage Manager Memory Limit reached. Producer stopped to prevent flooding queue://ASSETMANAGER.Externalapi...`

To solve this issue I had to change the ActiveMQ configuration. Queues with the extension .Externapi and .Adminui are just filled and no more consumed because the update of elasticsearch indices is not using ActiveMQ anymore.

To monitor ActiveMQ memory consumption and queues you may want to activate the ActiveMQ Console Web-UI. This is done by editing the file `activemq.xml` and uncommenting the line `<import resource="jetty.xml"/>`. The file can usually be found in the directory: `/etc/activemq`. Depending on your installation you also have to make the directory `/usr/share/activemq/tmp/` writable for the user that starts ActiveMQ. Afterwards you can access your local ActiveMQ Web-UI at `http://localhost:8161/admin/index.jsp`, standard username and password are (admin/admin). 

If you want to reproduce the problem you just have to ingest events to opencast and monitor the ActiveMQ-WebUI. To speed up the process use a workflow with a lot of "snapshot"-operations and change the line: `<memoryUsage percentOfJvmHeap="70" />` in the file `activemq.xml` from 70 to lets say 5. 

By exchanging the `activemq.xml` file with the one from this PR and restarting ActiveMQ the problem should be fixed.
 
### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
