### PR TITLE
Prevent workflows from running in parallel on the same event

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstanceImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstanceImpl.java
@@ -300,7 +300,7 @@ public class WorkflowInstanceImpl implements WorkflowInstance {
 
   @Override
   public boolean isActive() {
-    return WorkflowUtil.isActive(getState());
+    return !getState().isTerminated();
   }
 
   /**

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowQuery.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowQuery.java
@@ -117,6 +117,20 @@ public class WorkflowQuery {
   }
 
   /**
+   * Limit results to workflow instances with active states.
+   *
+   * @return Reference to itself
+   */
+  public WorkflowQuery isActive() {
+    for (WorkflowState state: WorkflowState.values()) {
+      if (!state.isTerminated()) {
+        stateTerms.add(new QueryTerm(state.toString(), true));
+      }
+    }
+    return this;
+  }
+
+  /**
    * Limit results to workflow instances not in a specific state. This method overrides and will be overridden by future
    * calls to {@link #withState(WorkflowState)}
    *

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -574,16 +574,13 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           throw new IllegalArgumentException("Parent workflow " + parentWorkflowId + " not visible to this user");
         }
       } else {
-        WorkflowQuery wfq = new WorkflowQuery().withMediaPackage(sourceMediaPackage.getIdentifier().toString());
+        WorkflowQuery wfq = new WorkflowQuery().withMediaPackage(mediaPackageId).isActive();
         WorkflowSet mpWorkflowInstances = getWorkflowInstances(wfq);
         if (mpWorkflowInstances.size() > 0) {
-          for (WorkflowInstance wfInstance : mpWorkflowInstances.getItems()) {
-            if (wfInstance.isActive())
-              throw new IllegalStateException(String.format(
-                      "Can't start workflow '%s' for media package '%s' because another workflow is currently active.",
-                      workflowDefinition.getTitle(),
-                      sourceMediaPackage.getIdentifier().toString()));
-          }
+          throw new IllegalStateException(String.format(
+                  "Can't start workflow '%s' for media package '%s' because another workflow is currently active.",
+                  workflowDefinition.getTitle(),
+                  sourceMediaPackage.getIdentifier().toString()));
         }
       }
 


### PR DESCRIPTION
This patch fixes a bug which caused the workflow service to only check
the first 20 workflows with a specific media package identifier for
running workflows before starting a new one. This means if 20 had
already run in the past, you could happily start workflows on the same
media package in parallel and no one would prevent that.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
