### PR TITLE
Fix isActive check for workflows

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowUtil.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowUtil.java
@@ -34,10 +34,9 @@ public final class WorkflowUtil {
    *          The workflow state to check.
    * @return True if the workflow is currently active, not stopped or failed.
    */
+  @Deprecated
   public static boolean isActive(WorkflowState workflowState) {
-    return WorkflowState.INSTANTIATED.equals(workflowState)
-            || WorkflowState.RUNNING.equals(workflowState)
-            || WorkflowState.PAUSED.equals(workflowState);
+    return !workflowState.isTerminated();
   }
 
   /**
@@ -48,8 +47,6 @@ public final class WorkflowUtil {
    * @return True if the workflow is currently active, not stopped or failed.
    */
   public static boolean isActive(String workflowState) {
-    return WorkflowState.INSTANTIATED.toString().equalsIgnoreCase(workflowState)
-        || WorkflowState.RUNNING.toString().equalsIgnoreCase(workflowState)
-        || WorkflowState.PAUSED.toString().equalsIgnoreCase(workflowState);
+    return !WorkflowState.valueOf(workflowState).isTerminated();
   }
 }


### PR DESCRIPTION
This patch fixes the `isActive` check for workflows from the workflow
utils which should be the inverse of `isTerminated` but was actually
missing the `failing` state.

This also marks this method as deprecated since with the existence of
`status.isTerminated()`, there is no real benefit in having a separate
utils method for this check.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
