### PR TITLE
Only allow access with write permissions

### DIFF
--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorRestEndpointBase.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorRestEndpointBase.java
@@ -24,6 +24,7 @@ package org.opencastproject.editor.api;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
+import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.util.RestUtil;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
@@ -81,6 +82,8 @@ public abstract class EditorRestEndpointBase {
       }
     } catch (EditorServiceException e) {
       return checkErrorState(mediaPackageId, e);
+    } catch (UnauthorizedException e) {
+      return Response.status(Response.Status.FORBIDDEN).entity("No write access to this event.").build();
     }
   }
 

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorService.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditorService.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.editor.api;
 
+import org.opencastproject.security.api.UnauthorizedException;
+
 /**
  * Api for the Editor Service
  */
@@ -34,7 +36,7 @@ public interface EditorService {
   /**
    * Provide information to edit video and audio data relevant to the given mediaPackageId
    */
-  EditingData getEditData(String mediaPackageId) throws EditorServiceException;
+  EditingData getEditData(String mediaPackageId) throws EditorServiceException, UnauthorizedException;
 
   /**
    * Store information about edited data relevant to the given mediaPackageId


### PR DESCRIPTION
This patch makes the editor backend check if a user accessing the
standalone video editor has write permissions on the event to be
edited. This avoids all kind of confusion and several errors resulting
in errors when users try to save things they have edited but are not
actually allowed to change. Better to be upfront about the missing
permissions.

This means that users cannot misuse the editor as preview player any
longer but… we have better players for that.

#### Some errors we avoid with this:

![Screenshot from 2021-08-26 17-35-25](https://user-images.githubusercontent.com/1008395/131150513-26d8919e-9314-4c05-ab32-6eacb095f4d7.png)

![Screenshot from 2021-08-26 17-36-13](https://user-images.githubusercontent.com/1008395/131150536-6554653d-9e5e-42a7-a443-17d6a0a46a42.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
