### PR TITLE
Editor on admin node

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -313,6 +313,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-download-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-streaming-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-workflowoperation/${project.version}</bundle>
+    <bundle start-level="83">mvn:org.opencastproject/opencast-editor/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-email-template-service-api/${project.version}</bundle>


### PR DESCRIPTION
This patch adds the new editor to the admin distribution to prevent
users from jumping to presentation if the editor is used from within the
admin interface.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
