### PR TITLE
Fix a `NullPointerException` in the new "Servers"-table code

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServerEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ServerEndpoint.java
@@ -213,7 +213,7 @@ public class ServerEndpoint {
         continue;
       }
 
-      if (!filters.getOrDefault(KEY_NODE_NAME, server.nodeName).equalsIgnoreCase(server.nodeName)) {
+      if (!StringUtils.equalsIgnoreCase(filters.getOrDefault(KEY_NODE_NAME, server.nodeName), server.nodeName)) {
         continue;
       }
 


### PR DESCRIPTION
The `node_name` field of a host registration can be `NULL`.
This patch catches that case by using a "symmetric" function
to compare it, instead of calling a method on it.

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
