### PR TITLE
Fix create new event in admin UI when multiple extended catalogs are used

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/metadataExtended.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/metadataExtended.js
@@ -112,7 +112,10 @@ angular.module('adminNg.services')
         me.updateRequiredMetadata(field.id, field.value);
       }
 
-      me.ud[target].fields[field.tabindex - 1] = field;
+      var i = me.ud[target].fields.findIndex(function(f) {
+        return f.id === field.id;
+      });
+      me.ud[target].fields[i] = field;
     };
 
     this.reset = function () {


### PR DESCRIPTION
The admin UI incorrectly assumes that the catalog fields are indexed
continuously which is only the case when only one extended catalog
exists. This searches for the correct field by its ID.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
