### PR TITLE
Provide a minimal "No Op" workflow for debugging and maintenance

### DIFF
--- a/etc/workflows/noop.xml
+++ b/etc/workflows/noop.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition xmlns="http://workflow.opencastproject.org">
+  <id>noop</id>
+  <title>Do nothing (mostly for debugging and maintenance purposes)</title>
+  <operations>
+    <!-- We need at least one operation for this to be considered a valid workflow definition -->
+    <operation id="defaults" />
+  </operations>
+</definition>


### PR DESCRIPTION
This can be useful sometimes, for example when parts of our indices
concerning workflows get out of sync with the database, and you see
inconsistent information about the state of a workflow in the events
table vs. the event details. In a case like that, you can just run
some workflow using the `/workflow/start` API to force Opencast
to go through all the proper channels to update the database
and the indices in a (hopefully) consistent manner.

Having a workflow for that purpose handy is thus often useful,
so admins don't have to have it floating around somewhere external,
or come up with the definition from scratch every time. You can just
specify `noop` as a parameter to the `/workflow/start` endpoint.
Also, this workflow intentionally has no `tags` so that it doesn't
show up anywhere in the UI to confuse people.

### Your pull request should…

* [x] have a concise title
* [x] ~~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
