### PR TITLE
Set jobLoad to 0 when jobCache is empty for very small jobLoads

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -950,7 +950,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     }
     logger.debug("Current host load: {}, job load cache size: {}", format("%.1f", localSystemLoad), jobCache.size());
 
-    if (jobCache.isEmpty() && Math.abs(localSystemLoad) > 0.01f) {
+    if (jobCache.isEmpty() && localSystemLoad != 0) {
       logger.warn("No jobs in the job load cache, but load is {}: setting job load to 0",
               format("%.2f", localSystemLoad));
       localSystemLoad = 0;


### PR DESCRIPTION
There was an issue with a extremely low jobLoad values at ETH, which Opencast cannot handle very well (I think it was permanently blocking workers).

Logs:
```
mh03-sbox | 2021-09-11T10:54:04,822 | DEBUG | (AbstractJobProducer:175) - 308 Current load on this host: 5.9604645E-7, job's load: 4.0, job's status: DISPATCHING, max load: 4.0
mh03-sbox | 2021-09-11T10:54:04,822 | DEBUG | (AbstractJobProducer:192) - 308 Declining job 216264 of type org.opencastproject.composer with load 4 because load of 4 would exceed this node's limit of 4.
```

I'm not sure how that load came to be, or if this PR actually fixes the issue for ETH, but it seems reasonable to cleanly set the jobLoad to 0 if the jobCache is empty.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
