### PR TITLE
Check if series catalog exists

### DIFF
--- a/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerBase.java
+++ b/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandlerBase.java
@@ -334,10 +334,13 @@ public abstract class CoverImageWorkflowOperationHandlerBase extends AbstractWor
           appendXml(xml, "creators", getValuesAsString(entry));
           break;
         case "isPartOf":
-          xml.append("<series>");
           //get series catalog
           Catalog[] seriesCatalogs =
                   mp.getCatalogs(new MediaPackageElementFlavor(seriesFlavor.getType(), seriesFlavor.getSubtype()));
+          if (seriesCatalogs.length == 0) {
+            continue;
+          }
+          xml.append("<series>");
           //get Series metadata
           DublinCoreCatalog dcSeries = DublinCoreUtil.loadDublinCore(getWorkspace(), seriesCatalogs[0]);
           Map<EName, List<DublinCoreValue>> seriesMetadata = dcSeries.getValues();


### PR DESCRIPTION
If `isPartOf` is set in the episode catalog there should be a series
catalog. We have some events where this is not the case leading to an
exception when accessing the elemnt in `cover-image`. This adds a check
if the series catalog actually exists.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
