### PR TITLE
Set external API version v1.7.0 as default

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
@@ -33,7 +33,7 @@ public enum ApiVersion {
   VERSION_1_7_0(1, 7, 0);
 
   /** The most recent version of the External API */
-  public static final ApiVersion CURRENT_VERSION = VERSION_1_6_0;
+  public static final ApiVersion CURRENT_VERSION = VERSION_1_7_0;
 
   private int major;
   private int minor;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
@@ -236,6 +236,7 @@ public class BaseEndpoint {
     versions.add(v(ApiVersion.VERSION_1_4_0.toString()));
     versions.add(v(ApiVersion.VERSION_1_5_0.toString()));
     versions.add(v(ApiVersion.VERSION_1_6_0.toString()));
+    versions.add(v(ApiVersion.VERSION_1_7_0.toString()));
     JValue json = obj(f("versions", arr(versions)), f("default", v(ApiVersion.CURRENT_VERSION.toString())));
     return RestUtil.R.ok(MediaType.APPLICATION_JSON_TYPE, serializer.toJson(json));
   }

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
@@ -61,7 +61,7 @@ public class BaseEndpointTest {
 
     JSONObject json = (JSONObject) parser.parse(response);
     assertEquals("https://api.opencast.org", json.get("url"));
-    assertEquals("v1.6.0", json.get("version"));
+    assertEquals("v1.7.0", json.get("version"));
   }
 
   /** Test case for {@link BaseEndpoint#getUserInfo()} */
@@ -122,7 +122,7 @@ public class BaseEndpointTest {
 
     JSONObject json = (JSONObject) parser.parse(response);
     JSONArray version = (JSONArray) json.get("versions");
-    assertEquals("v1.6.0", json.get("default"));
+    assertEquals("v1.7.0", json.get("default"));
     assertTrue(version.contains("v1.0.0"));
     assertTrue(version.contains("v1.1.0"));
     assertTrue(version.contains("v1.2.0"));
@@ -130,7 +130,8 @@ public class BaseEndpointTest {
     assertTrue(version.contains("v1.4.0"));
     assertTrue(version.contains("v1.5.0"));
     assertTrue(version.contains("v1.6.0"));
-    assertEquals(7, version.size());
+    assertTrue(version.contains("v1.7.0"));
+    assertEquals(8, version.size());
   }
 
   /** Test case for {@link BaseEndpoint#getVersionDefault()} */
@@ -140,7 +141,7 @@ public class BaseEndpointTest {
             .asString();
 
     JSONObject json = (JSONObject) parser.parse(response);
-    assertEquals("v1.6.0", json.get("default"));
+    assertEquals("v1.7.0", json.get("default"));
   }
 
   /** Test case for {@link BaseEndpoint#recreateIndex()} */


### PR DESCRIPTION
API versioning is hard.

I forgot to set v1.7.0 as default version and to include it in the
versions request.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
