### PR TITLE
Fix a spacing issue in the series LTI tool

### DIFF
--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -62,7 +62,7 @@ const SeriesEpisode: React.StatelessComponent<EpisodeProps> = ({ episode, delete
         <div>
             <img alt="Preview" className="img-fluid" src={image} />
         </div>
-        <div className="ml-3">
+        <div className="ms-3">
             <h4>{episode.dcTitle}</h4>
             {episode.mediapackage.creators.length > 0 && <p className="text-muted">
                 {t("LTI.CREATOR", { creator: episode.mediapackage.creators.join(', ') })}
@@ -70,7 +70,7 @@ const SeriesEpisode: React.StatelessComponent<EpisodeProps> = ({ episode, delete
             <p className="text-muted">{new Date(episode.dcCreated).toLocaleString()}</p>
         </div>
         {(deleteCallback !== undefined || editCallback !== undefined || downloadCallback !== undefined) &&
-            <div className="ml-auto">
+            <div className="ms-auto">
                 {deleteCallback !== undefined &&
                     <button onClick={(e) => { deleteCallback(episode.id); e.stopPropagation(); }}>
                         <FontAwesomeIcon icon={faTrash} />


### PR DESCRIPTION
In 1ce267805f59636e7179e4f605c59fae3a1e2316 we updated
the LTI tools to Bootstrap 5. However, no steps were taken
to actually adapt to this major update. This results in
a somewhat ugly layout problem in the series LTI tool.
(And potentially other things, but I don't know.)

This PR implements one specific adaptation to one of the
breaking changes in that release, specifically the 5th point
in [this list](https://getbootstrap.com/docs/5.0/migration/#utilities).

At some point, we should probably go through that guide
and look at all the other breaking changes listed there.
See also #3007.

Here's a screenshot highlighting the issue:

![Selection_095](https://user-images.githubusercontent.com/123272/133790081-d64a72e3-9aed-457e-b6d6-5435a2447f4e.png)

It's not the best illustration because my test video is mostly white on the right, but there should probably be some space between the video and the text, right?

### Your pull request should…

* [x] have a concise title
* [x] ~~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
