### PR TITLE
Don't update events in index twice when changing series metadata

### DIFF
--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/series/Series.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/series/Series.java
@@ -140,8 +140,6 @@ public class Series implements IndexObject {
   @XmlElement(name = "theme")
   private Long theme = null;
 
-  private boolean seriesTitleUpdated = false;
-
   /** Context for serializing and deserializing */
   private static JAXBContext context = null;
 
@@ -202,7 +200,6 @@ public class Series implements IndexObject {
     }
 
     this.title = title;
-    seriesTitleUpdated = true;
   }
 
   /**
@@ -507,10 +504,6 @@ public class Series implements IndexObject {
    */
   public Long getTheme() {
     return theme;
-  }
-
-  public boolean isSeriesTitleUpdated() {
-    return seriesTitleUpdated;
   }
 
   /**

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -31,11 +31,7 @@ import org.opencastproject.authorization.xacml.manager.api.AclServiceFactory;
 import org.opencastproject.authorization.xacml.manager.api.ManagedAcl;
 import org.opencastproject.authorization.xacml.manager.util.AccessInformationUtil;
 import org.opencastproject.elasticsearch.api.SearchIndexException;
-import org.opencastproject.elasticsearch.api.SearchResult;
-import org.opencastproject.elasticsearch.api.SearchResultItem;
 import org.opencastproject.elasticsearch.index.AbstractSearchIndex;
-import org.opencastproject.elasticsearch.index.event.Event;
-import org.opencastproject.elasticsearch.index.event.EventSearchQuery;
 import org.opencastproject.elasticsearch.index.series.Series;
 import org.opencastproject.index.rebuild.AbstractIndexProducer;
 import org.opencastproject.index.rebuild.IndexProducer;
@@ -691,45 +687,8 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   private void updateSeriesMetadataInIndex(String seriesId, AbstractSearchIndex index, DublinCoreCatalog dc) {
     String orgId = securityService.getOrganization().getId();
     logger.debug("Updating metadata of series {} in the {} index.", seriesId, index.getIndexName());
-
-    // update series
     Function<Optional<Series>, Optional<Series>> updateFunction = getMetadataUpdateFunction(seriesId, dc, orgId);
-    Optional<Series> updatedSeriesOpt = updateSeriesInIndex(seriesId, index, orgId, updateFunction);
-
-    // update series title for events?
-    if (updatedSeriesOpt.isPresent() && updatedSeriesOpt.get().isSeriesTitleUpdated()) {
-      Series updatedSeries = updatedSeriesOpt.get();
-      User user = securityService.getUser();
-      SearchResult<Event> events;
-      try {
-        events = index.getByQuery(
-                new EventSearchQuery(orgId, user).withoutActions().withSeriesId(updatedSeries.getIdentifier()));
-      } catch (SearchIndexException e) {
-        logger.error("Error requesting the events of the series {} from the {} index.", seriesId, index.getIndexName(),
-                e);
-        return;
-      }
-
-      for (SearchResultItem<Event> searchResultItem : events.getItems()) {
-        String eventId = searchResultItem.getSource().getIdentifier();
-
-        Function<Optional<Event>, Optional<Event>> eventUpdateFunction = (Optional<Event> eventOpt) -> {
-          if (eventOpt.isPresent() && eventOpt.get().getSeriesId().equals(updatedSeries.getIdentifier())) {
-            Event event = eventOpt.get();
-            event.setSeriesName(updatedSeries.getTitle());
-            return Optional.of(event);
-          }
-          return Optional.empty();
-        };
-
-        try {
-          index.addOrUpdateEvent(eventId, eventUpdateFunction, orgId, user);
-          logger.debug("Series title of series {} updated for event {} in the index.", seriesId, eventId);
-        } catch (SearchIndexException e) {
-          logger.error("Error updating the series title for event {} of series {} to the index.", eventId, seriesId, e);
-        }
-      }
-    }
+    updateSeriesInIndex(seriesId, index, orgId, updateFunction);
   }
 
   /**


### PR DESCRIPTION
Right now, the update of events in the index is done twice when triggered by a series metadata change: 
Once directly in the series service after updating the series in the index, and once asynchronously by the AssetManagerUpdatedEventHandler when doing a snapshot. 
The first approach is faster, but will only update the index, not the actual event data. So if something goes wrong during the snapshot, this will lead to inconsistency. It's also a bit of a code smell in my opinion to do this twice. 
So I'd like to remove this, even though it might result in slower performance, because the index should represent the actual state of the data, not the state it will hopefully soon be in. But I'm open to criticism here.
