### PR TITLE
Add Learn section and webinars list

### DIFF
--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -83,6 +83,22 @@
       <hr>
 
       <h3>
+        <span class="glyphicon glyphicon-education" aria-hidden="true"></span>
+        Learn
+      </h3>
+      <div class="row">
+        <div class="col-md-6">
+          <h4>Webinars</h4>
+          <p>Our webinars touch diferent topics, from how to use basic tools up to highly technical topics. 
+            You can access to our webinar playlist <a href="https://video.ethz.ch/events/opencast/webinars.html">
+            here.</a>
+          </p>
+        </div>
+      </div>
+
+      <hr>
+
+      <h3>
         <span class="glyphicon glyphicon-bullhorn" aria-hidden="true"></span>
         Communication &amp; Help
       </h3>


### PR DESCRIPTION
This adds the webinars to the documentation, also adds the section "Learn" to add later new parts (For example a cookbook or any other resource that helps new and old people in opencast).


* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
