### PR TITLE
Replace “Click Here” Links on Documentation Landing Page

### DIFF
--- a/docs/guides/.infrastructure/index.html.j2
+++ b/docs/guides/.infrastructure/index.html.j2
@@ -89,9 +89,10 @@
       <div class="row">
         <div class="col-md-6">
           <h4>Webinars</h4>
-          <p>Our webinars touch different topics, from how to use basic tools up to highly technical topics. 
-            You can access our webinar playlist <a href="https://video.ethz.ch/events/opencast/webinars.html">
-            here.</a>
+          <p>Our webinars range from how to use basic tools to highly technical topics.
+            Upcoming webinars are announced on the mailing list and on the website.
+            Take a look at <a href="https://video.ethz.ch/events/opencast/webinars.html">
+            the list of previously recorded webinars</a>.
           </p>
         </div>
       </div>
@@ -164,7 +165,7 @@
         <div class="col-md-6">
           <h4>Code</h4>
           <p>You can find the codebase of Opencast in the Git repository hosted at
-          <a href="https://github.com/opencast/opencast">github.com/opencast/opencast</a>. Feel free to fork to project
+          <a href="https://github.com/opencast/opencast">github.com/opencast/opencast</a>. Feel free to fork the project
           and open pull requests. If you need help or more information, please do not hesitate to ask any question on
           the developers list.</p>
         </div>


### PR DESCRIPTION
This patch modifies the documentation landing page and…

- Replaces the „click here“ link, which is generally not a good idea to use. For some details, see for example, [Why Your Links Should Never Say “Click Here”](https://uxmovement.com/content/why-your-links-should-never-say-click-here/)
- Adds where webinars will be announced
- Fixes a typo

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
