### PR TITLE
Deactivate Parallel Builds in CI

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: build opencast
         run: |
           mvn --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-            clean install -Pnone -T 1C
+            clean install -Pnone
 
       - name: build assemblies
         if: matrix.java == 11


### PR DESCRIPTION
This patch deactivates the recently activated parallel builds in the CI
system (GitHub Actions). Speed is not so much a concern there since we
need to wait at least to the next Technical Meeting for approval anyway.
Thus, we do not gain much by activating this.

But parallel Maven builds make identifying reasons for errors
incredibly hard. Especially if they happen in slow building modules
(e.g. in some JavaScript builds). Before you would just look at the end
of the build log. Now you need to scroll through thousands of lines of
logs to identify the root cause for a build failure. That is extremely
annoying as a reviewer.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
