### PR TITLE
Point out memory limits

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -49,6 +49,9 @@ Please make sure to compare your configuration against the current configuration
 - The configuration keys `source-tags` and `source-flavors` of the _publish-configure_ workflow operation were renamed
   to `download-source-tags` and `download-source-flavors` respectively. If you use custom workflows, you may need to
   adjust them accordingly.
+- In large installations, consider raising the Java memory limits…
+    - of Opencast in `/usr/share/opencast/bin/setenv` or `etc/setenv`
+    - of Elasticsearch in `/etc/elasticsearch/jvm.options`
 
 
 ### Wowza streaming configuration changes


### PR DESCRIPTION
This patch adds a note about memory limits to the 9.x upgrade guide, since it is the first version with external Elasticsearch.
This closes #3016 which could not be merged.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
