### PR TITLE
Notes fetch comments in backend

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
@@ -160,8 +160,6 @@ angular.module('adminNg.controllers')
       });
     };
 
-    // Text for events without notes
-    $scope.noCommentTextArea = '';
     // Type of comments in the notes column
     $scope.table.notesCommentReason = 'EVENTS.EVENTS.DETAILS.COMMENTS.REASONS.ADMINUI_NOTES';
 

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
@@ -129,8 +129,6 @@ angular.module('adminNg.controllers')
           ConfirmationModal.show('embedding-code',Table.fullScreenUrl,row);
         };
 
-        row.comments = CommentResource.query({ resource: 'event', resourceId: row.id, type: 'comments' });
-
         row.editorUrl = $scope.editorUrl.replace('$id', row.id);
       }
     });

--- a/modules/admin-ui-frontend/app/scripts/modules/events/partials/eventsNotesCell.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/partials/eventsNotesCell.html
@@ -1,8 +1,9 @@
 <div class="comment-container">
   <textarea type="text" class="textarea"
             ng-if="filtered.length === 0"
-            ng-model="noCommentTextArea"
-            ng-blur="table.createComment(noCommentTextArea, row.id)"> </textarea>
+            ng-model="row.noCommentYet"
+            ng-focus="table.stopRefresh()"
+            ng-blur="table.startRefresh(); table.createComment(row.noCommentYet, row.id)"> </textarea>
 
   <div class="comment" ng-class="{ active : $parent.replyToId === comment.id }"
        ng-repeat="comment in row.comments

--- a/modules/admin-ui-frontend/app/scripts/shared/resources/eventsResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/eventsResource.js
@@ -101,6 +101,7 @@ angular.module('adminNg.resources')
         row.agent_id = r.agent_id;
         row.managed_acl = r.managedAcl;
         row.type = 'EVENT';
+        row.comments = r.comments;
         return row;
       });
 

--- a/modules/admin-ui-frontend/app/scripts/shared/services/tableService.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/tableService.js
@@ -320,12 +320,14 @@ angular.module('adminNg.services')
         query.offset = me.pagination.offset * me.pagination.limit;
 
         // If the notes column is being displayed, fetch comments
-        let commentsColumn = me.columns.find(obj => {
-        // Fixme: Can we avoid using a string literal here?
-          return obj.label === 'EVENTS.EVENTS.TABLE.ADMINUI_NOTES'
-        })
-        if (commentsColumn && !commentsColumn.deactivated) {
-          query.getComments = true
+        if (me.columns) {
+          let commentsColumn = me.columns.find(obj => {
+          // Fixme: Can we avoid using a string literal here?
+            return obj.label === 'EVENTS.EVENTS.TABLE.ADMINUI_NOTES';
+          });
+          if (commentsColumn && !commentsColumn.deactivated) {
+            query.getComments = true;
+          }
         }
 
         (function(resource){

--- a/modules/admin-ui-frontend/app/scripts/shared/services/tableService.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/tableService.js
@@ -319,6 +319,15 @@ angular.module('adminNg.services')
         query.limit = me.pagination.limit;
         query.offset = me.pagination.offset * me.pagination.limit;
 
+        // If the notes column is being displayed, fetch comments
+        let commentsColumn = me.columns.find(obj => {
+        // Fixme: Can we avoid using a string literal here?
+          return obj.label === 'EVENTS.EVENTS.TABLE.ADMINUI_NOTES'
+        })
+        if (commentsColumn && !commentsColumn.deactivated) {
+          query.getComments = true
+        }
+
         (function(resource){
 
           var startTime = new Date();

--- a/modules/admin-ui/src/test/resources/events.json
+++ b/modules/admin-ui/src/test/resources/events.json
@@ -33,51 +33,7 @@
       "has_comments": false,
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
-      "start_date": "2013-03-20T04:00:00Z",
-      "comments": [
-        {
-          "id": 65,
-          "author": {
-            "username": "sample",
-            "email": "with@permissions.com",
-            "name": "WithPermissions"
-          },
-          "creationDate": "2014-06-05T09:15:56Z",
-          "text": "Comment 1",
-          "reason": "Sick",
-          "replies": [
-
-          ],
-          "modificationDate": "2014-06-05T09:15:56Z",
-          "resolvedStatus": true
-        },
-        {
-          "id": 65,
-          "author": {
-            "username": "sample",
-            "email": "with@permissions.com",
-            "name": "WithPermissions"
-          },
-          "creationDate": "2014-06-05T09:15:56Z",
-          "text": "Comment 2",
-          "reason": "Defect",
-          "replies": [
-            {
-              "id": 78,
-              "creationDate": "2014-06-05T09:15:56Z",
-              "author": {
-                "username": "sample",
-                "email": "without@permissions.com",
-                "name": "WithoutPermissions"
-              },
-              "text": "Cant reproduce",
-              "modificationDate": "2014-06-05T09:15:56Z"
-            }
-          ],
-          "modificationDate": "2014-06-05T09:15:56Z",
-          "resolvedStatus": false
-        }
-      ]
+      "start_date": "2013-03-20T04:00:00Z"
     },
     {
       "technical_end": "2013-03-20T05:00:00Z",
@@ -109,51 +65,7 @@
       "has_comments": false,
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
-      "start_date": "2013-03-20T04:00:00Z",
-      "comments": [
-        {
-          "id": 65,
-          "author": {
-            "username": "sample",
-            "email": "with@permissions.com",
-            "name": "WithPermissions"
-          },
-          "creationDate": "2014-06-05T09:15:56Z",
-          "text": "Comment 1",
-          "reason": "Sick",
-          "replies": [
-
-          ],
-          "modificationDate": "2014-06-05T09:15:56Z",
-          "resolvedStatus": true
-        },
-        {
-          "id": 65,
-          "author": {
-            "username": "sample",
-            "email": "with@permissions.com",
-            "name": "WithPermissions"
-          },
-          "creationDate": "2014-06-05T09:15:56Z",
-          "text": "Comment 2",
-          "reason": "Defect",
-          "replies": [
-            {
-              "id": 78,
-              "creationDate": "2014-06-05T09:15:56Z",
-              "author": {
-                "username": "sample",
-                "email": "without@permissions.com",
-                "name": "WithoutPermissions"
-              },
-              "text": "Cant reproduce",
-              "modificationDate": "2014-06-05T09:15:56Z"
-            }
-          ],
-          "modificationDate": "2014-06-05T09:15:56Z",
-          "resolvedStatus": false
-        }
-      ]
+      "start_date": "2013-03-20T04:00:00Z"
     },
     {
       "technical_end": "2013-03-20T05:00:00Z",
@@ -185,51 +97,7 @@
       "has_comments": false,
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
-      "start_date": "2013-03-20T04:00:00Z",
-      "comments": [
-        {
-          "id": 65,
-          "author": {
-            "username": "sample",
-            "email": "with@permissions.com",
-            "name": "WithPermissions"
-          },
-          "creationDate": "2014-06-05T09:15:56Z",
-          "text": "Comment 1",
-          "reason": "Sick",
-          "replies": [
-
-          ],
-          "modificationDate": "2014-06-05T09:15:56Z",
-          "resolvedStatus": true
-        },
-        {
-          "id": 65,
-          "author": {
-            "username": "sample",
-            "email": "with@permissions.com",
-            "name": "WithPermissions"
-          },
-          "creationDate": "2014-06-05T09:15:56Z",
-          "text": "Comment 2",
-          "reason": "Defect",
-          "replies": [
-            {
-              "id": 78,
-              "creationDate": "2014-06-05T09:15:56Z",
-              "author": {
-                "username": "sample",
-                "email": "without@permissions.com",
-                "name": "WithoutPermissions"
-              },
-              "text": "Cant reproduce",
-              "modificationDate": "2014-06-05T09:15:56Z"
-            }
-          ],
-          "modificationDate": "2014-06-05T09:15:56Z",
-          "resolvedStatus": false
-        }
-      ]
+      "start_date": "2013-03-20T04:00:00Z"
     }
   ],
   "offset": 0

--- a/modules/admin-ui/src/test/resources/events.json
+++ b/modules/admin-ui/src/test/resources/events.json
@@ -34,6 +34,50 @@
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
       "start_date": "2013-03-20T04:00:00Z",
+      "comments": [
+        {
+          "id": 65,
+          "author": {
+            "username": "sample",
+            "email": "with@permissions.com",
+            "name": "WithPermissions"
+          },
+          "creationDate": "2014-06-05T09:15:56Z",
+          "text": "Comment 1",
+          "reason": "Sick",
+          "replies": [
+
+          ],
+          "modificationDate": "2014-06-05T09:15:56Z",
+          "resolvedStatus": true
+        },
+        {
+          "id": 65,
+          "author": {
+            "username": "sample",
+            "email": "with@permissions.com",
+            "name": "WithPermissions"
+          },
+          "creationDate": "2014-06-05T09:15:56Z",
+          "text": "Comment 2",
+          "reason": "Defect",
+          "replies": [
+            {
+              "id": 78,
+              "creationDate": "2014-06-05T09:15:56Z",
+              "author": {
+                "username": "sample",
+                "email": "without@permissions.com",
+                "name": "WithoutPermissions"
+              },
+              "text": "Cant reproduce",
+              "modificationDate": "2014-06-05T09:15:56Z"
+            }
+          ],
+          "modificationDate": "2014-06-05T09:15:56Z",
+          "resolvedStatus": false
+        }
+      ]
     },
     {
       "technical_end": "2013-03-20T05:00:00Z",
@@ -66,6 +110,50 @@
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
       "start_date": "2013-03-20T04:00:00Z",
+      "comments": [
+        {
+          "id": 65,
+          "author": {
+            "username": "sample",
+            "email": "with@permissions.com",
+            "name": "WithPermissions"
+          },
+          "creationDate": "2014-06-05T09:15:56Z",
+          "text": "Comment 1",
+          "reason": "Sick",
+          "replies": [
+
+          ],
+          "modificationDate": "2014-06-05T09:15:56Z",
+          "resolvedStatus": true
+        },
+        {
+          "id": 65,
+          "author": {
+            "username": "sample",
+            "email": "with@permissions.com",
+            "name": "WithPermissions"
+          },
+          "creationDate": "2014-06-05T09:15:56Z",
+          "text": "Comment 2",
+          "reason": "Defect",
+          "replies": [
+            {
+              "id": 78,
+              "creationDate": "2014-06-05T09:15:56Z",
+              "author": {
+                "username": "sample",
+                "email": "without@permissions.com",
+                "name": "WithoutPermissions"
+              },
+              "text": "Cant reproduce",
+              "modificationDate": "2014-06-05T09:15:56Z"
+            }
+          ],
+          "modificationDate": "2014-06-05T09:15:56Z",
+          "resolvedStatus": false
+        }
+      ]
     },
     {
       "technical_end": "2013-03-20T05:00:00Z",
@@ -98,6 +186,50 @@
       "technical_start": "2013-03-20T04:00:00Z",
       "has_preview": false,
       "start_date": "2013-03-20T04:00:00Z",
+      "comments": [
+        {
+          "id": 65,
+          "author": {
+            "username": "sample",
+            "email": "with@permissions.com",
+            "name": "WithPermissions"
+          },
+          "creationDate": "2014-06-05T09:15:56Z",
+          "text": "Comment 1",
+          "reason": "Sick",
+          "replies": [
+
+          ],
+          "modificationDate": "2014-06-05T09:15:56Z",
+          "resolvedStatus": true
+        },
+        {
+          "id": 65,
+          "author": {
+            "username": "sample",
+            "email": "with@permissions.com",
+            "name": "WithPermissions"
+          },
+          "creationDate": "2014-06-05T09:15:56Z",
+          "text": "Comment 2",
+          "reason": "Defect",
+          "replies": [
+            {
+              "id": 78,
+              "creationDate": "2014-06-05T09:15:56Z",
+              "author": {
+                "username": "sample",
+                "email": "without@permissions.com",
+                "name": "WithoutPermissions"
+              },
+              "text": "Cant reproduce",
+              "modificationDate": "2014-06-05T09:15:56Z"
+            }
+          ],
+          "modificationDate": "2014-06-05T09:15:56Z",
+          "resolvedStatus": false
+        }
+      ]
     }
   ],
   "offset": 0


### PR DESCRIPTION
The optional "notes" column causes fetching comments for each event from the backend on each refresh, even when not displayed.   This leads to way too many requests which causes flickering and made the notes column unusable on large systems.

This PR attempts a quick fix, by removing the repeated requests from the frontend and instead modifying the events endpoint in the backend to return comments with each event.

A more optimal long-term solution would probably be to add comments to the index, but that seems to be a larger undertaking.