### PR TITLE
Fixed limit value returned by search service endpoint

### DIFF
--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -155,10 +155,7 @@ public class SolrRequester {
    * @throws SolrServerException
    *           if the solr server is not working as expected
    */
-  private SearchResult createSearchResult(final SolrQuery query, final SearchQuery sQuery) throws SolrServerException {
-
-    final boolean signed = sQuery.willSignURLs();
-    final long limit = sQuery.getLimit();
+  private SearchResult createSearchResult(final SolrQuery query, final boolean signed) throws SolrServerException {
 
     // Execute the query and try to get hold of a query response
     QueryResponse solrResponse = null;
@@ -172,7 +169,7 @@ public class SolrRequester {
     final SearchResultImpl result = new SearchResultImpl(query.getQuery());
     result.setSearchTime(solrResponse.getQTime());
     result.setOffset(solrResponse.getResults().getStart());
-    result.setLimit(limit);
+    result.setLimit(query.getRows());
     result.setTotal(solrResponse.getResults().getNumFound());
 
     // Walk through response and create new items with title, creator, etc:
@@ -823,7 +820,7 @@ public class SolrRequester {
    */
   public SearchResult getForAdministrativeRead(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, READ.toString(), false);
-    return createSearchResult(query, q);
+    return createSearchResult(query, q.willSignURLs());
   }
 
   /**
@@ -836,7 +833,7 @@ public class SolrRequester {
    */
   public SearchResult getForRead(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, READ.toString(), true);
-    return createSearchResult(query, q);
+    return createSearchResult(query, q.willSignURLs());
   }
 
   /**
@@ -849,7 +846,7 @@ public class SolrRequester {
    */
   public SearchResult getForWrite(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, WRITE.toString(), true);
-    return createSearchResult(query, q);
+    return createSearchResult(query, q.willSignURLs());
   }
 
   /**

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -155,7 +155,10 @@ public class SolrRequester {
    * @throws SolrServerException
    *           if the solr server is not working as expected
    */
-  private SearchResult createSearchResult(final SolrQuery query, final boolean signed) throws SolrServerException {
+  private SearchResult createSearchResult(final SolrQuery query, final SearchQuery sQuery) throws SolrServerException {
+
+    final boolean signed = sQuery.willSignURLs();
+    final long limit = sQuery.getLimit();
 
     // Execute the query and try to get hold of a query response
     QueryResponse solrResponse = null;
@@ -169,7 +172,7 @@ public class SolrRequester {
     final SearchResultImpl result = new SearchResultImpl(query.getQuery());
     result.setSearchTime(solrResponse.getQTime());
     result.setOffset(solrResponse.getResults().getStart());
-    result.setLimit(solrResponse.getResults().size());
+    result.setLimit(limit);
     result.setTotal(solrResponse.getResults().getNumFound());
 
     // Walk through response and create new items with title, creator, etc:
@@ -820,7 +823,7 @@ public class SolrRequester {
    */
   public SearchResult getForAdministrativeRead(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, READ.toString(), false);
-    return createSearchResult(query, q.willSignURLs());
+    return createSearchResult(query, q);
   }
 
   /**
@@ -833,7 +836,7 @@ public class SolrRequester {
    */
   public SearchResult getForRead(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, READ.toString(), true);
-    return createSearchResult(query, q.willSignURLs());
+    return createSearchResult(query, q);
   }
 
   /**
@@ -846,7 +849,7 @@ public class SolrRequester {
    */
   public SearchResult getForWrite(SearchQuery q) throws SolrServerException {
     SolrQuery query = getForAction(q, WRITE.toString(), true);
-    return createSearchResult(query, q.willSignURLs());
+    return createSearchResult(query, q);
   }
 
   /**


### PR DESCRIPTION
Previously, the limit value in the response xml/json was guessed at. This changes the value to actual limit that was being used.

Resolves #1173.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
