### PR TITLE
Stream Security Fix

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -27,14 +27,23 @@ import org.opencastproject.mediapackage.identifier.Id;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -100,6 +109,27 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
    * @see org.opencastproject.mediapackage.MediaPackageBuilder#loadFromXml(java.io.InputStream)
    */
   public MediaPackage loadFromXml(InputStream is) throws MediaPackageException {
+    if (serializer != null) {
+      try {
+        // CHECKSTYLE:OFF
+
+        //Convert InputStream to XML document to rewrite the URLs
+        Document xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+        rewriteUrls(xml, serializer);
+
+        // Reconverting back to inputStream
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        Source xmlSource = new DOMSource(xml);
+        Result outputTarget = new StreamResult(os);
+        //FIXME: Checkstyle Alerts for this line to use xmlSafeParser instead of this line
+        TransformerFactory.newInstance().newTransformer().transform(xmlSource, outputTarget);
+        is = new ByteArrayInputStream(os.toByteArray());
+        // CHECKSTYLE:ON
+
+      } catch (Exception e) {
+        throw new MediaPackageException("Error deserializing paths in media package", e);
+      }
+    }
     return MediaPackageImpl.valueOf(is);
   }
 

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -32,17 +32,11 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.xml.transform.Result;
-import javax.xml.transform.Source;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -108,26 +102,29 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
    * @see org.opencastproject.mediapackage.MediaPackageBuilder#loadFromXml(java.io.InputStream)
    */
   public MediaPackage loadFromXml(InputStream is) throws MediaPackageException {
+    try {
+      Document xml = XmlSafeParser.parse(is);
+      if (serializer != null) {
 
-    if (serializer != null) {
-      try {
 
-        //Convert InputStream to XML document to rewrite the URLs
-        Document xml = XmlSafeParser.parse(is);
+      //Convert InputStream to XML document to rewrite the URLs
+
         rewriteUrls(xml, serializer);
 
-        // Reconverting back to inputStream
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        Source xmlSource = new DOMSource(xml);
-        Result outputTarget = new StreamResult(os);
-        XmlSafeParser.newTransformerFactory().newTransformer().transform(xmlSource, outputTarget);
-        is = new ByteArrayInputStream(os.toByteArray());
+      // Reconverting back to inputStream
+//        ByteArrayOutputStream os = new ByteArrayOutputStream();
+//        Source xmlSource = new DOMSource(xml);
+//        Result outputTarget = new StreamResult(os);
+//        XmlSafeParser.newTransformerFactory().newTransformer().transform(xmlSource, outputTarget);
+//        is = new ByteArrayInputStream(os.toByteArray());
 
-      } catch (Exception e) {
-        throw new MediaPackageException("Error deserializing paths in media package", e);
-      }
+        }
+      return loadFromXml(xml);
+    } catch (Exception e) {
+      throw new MediaPackageException("Error deserializing paths in media package", e);
     }
-    return MediaPackageImpl.valueOf(is);
+//    return MediaPackageImpl.valueOf(is);
+
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -23,6 +23,7 @@
 package org.opencastproject.mediapackage;
 
 import org.opencastproject.mediapackage.identifier.Id;
+import org.opencastproject.util.XmlSafeParser;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -38,10 +39,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
@@ -111,20 +110,17 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
   public MediaPackage loadFromXml(InputStream is) throws MediaPackageException {
     if (serializer != null) {
       try {
-        // CHECKSTYLE:OFF
 
         //Convert InputStream to XML document to rewrite the URLs
-        Document xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+        Document xml = XmlSafeParser.parse(is);
         rewriteUrls(xml, serializer);
 
         // Reconverting back to inputStream
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         Source xmlSource = new DOMSource(xml);
         Result outputTarget = new StreamResult(os);
-        //FIXME: Checkstyle Alerts for this line to use xmlSafeParser instead of this line
-        TransformerFactory.newInstance().newTransformer().transform(xmlSource, outputTarget);
+        XmlSafeParser.newTransformerFactory().newTransformer().transform(xmlSource, outputTarget);
         is = new ByteArrayInputStream(os.toByteArray());
-        // CHECKSTYLE:ON
 
       } catch (Exception e) {
         throw new MediaPackageException("Error deserializing paths in media package", e);

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -108,6 +109,7 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
    * @see org.opencastproject.mediapackage.MediaPackageBuilder#loadFromXml(java.io.InputStream)
    */
   public MediaPackage loadFromXml(InputStream is) throws MediaPackageException {
+
     if (serializer != null) {
       try {
 

--- a/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/search/impl/SearchServiceImplTest.java
@@ -82,6 +82,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
@@ -165,7 +166,7 @@ public class SearchServiceImplTest {
     // workspace
     Workspace workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.read(EasyMock.anyObject(URI.class)))
-        .andAnswer(() -> getClass().getResourceAsStream("/" + EasyMock.getCurrentArguments()[0].toString()))
+        .andAnswer(() -> new FileInputStream(((URI)EasyMock.getCurrentArguments()[0]).getPath()))
         .anyTimes();
     EasyMock.replay(workspace);
 


### PR DESCRIPTION
This PR fixes the non-signing issue that was reported on the issue in #3017 

I need your comments about this line `TransformerFactory.newInstance().newTransformer().transform(xmlSource, outputTarget);` The checkstyle algorithm makes some alarms to use another class instead, but from what I've read, it's a well-known class and method to use for transform back to `inputStream`

How to try it
1. Enable stream security signing.
2. upload an event
3. use the search endpoint and look if the stream links are signed.


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
