### PR TITLE
Opencast 10x docs show "compose" instead of "encode" #3059

### DIFF
--- a/docs/guides/admin/docs/configuration/encoding.md
+++ b/docs/guides/admin/docs/configuration/encoding.md
@@ -98,7 +98,7 @@ Using a Profile
 Once defined, use your encoding profile in your workflow by setting the encoding-profile property to the profiles name:
 
     <operation
-        id="compose"
+        id="encode"
         fail-on-error="true"
         exception-handler-workflow="error"
         description="Encode presenter using my audio/video encoding profile">

--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -155,7 +155,7 @@ The next operations will encode the media to the Mp4 format:
 
         <!-- encode: mp4 -->
         <operation
-          id="compose"
+          id="encode"
           fail-on-error="true"
           exception-handler-workflow="error"
           description="Encode camera to mp4">
@@ -168,7 +168,7 @@ The next operations will encode the media to the Mp4 format:
         </operation>
 
         <operation
-          id="compose"
+          id="encode"
           fail-on-error="true"
           exception-handler-workflow="error"
           description="Encode screen to mp4">

--- a/docs/guides/admin/docs/modules/googlespeechtranscripts.md
+++ b/docs/guides/admin/docs/modules/googlespeechtranscripts.md
@@ -171,7 +171,7 @@ the second workflow can retrieve it from the archive to attach the caption/trans
 ```xml
     <!--  Encode audio to flac -->
     <operation
-      id="compose"
+      id="encode"
       fail-on-error="true"
       exception-handler-workflow="partial-error"
       description="Extract audio for transcript generation">

--- a/docs/guides/admin/docs/modules/videoeditor.architecture.md
+++ b/docs/guides/admin/docs/modules/videoeditor.architecture.md
@@ -193,7 +193,7 @@ ${trimHold} variable like in the current workflow definitions with trimming.
     **Workflow operation to create WebM preview videos**
 
         <operation
-          id="compose"
+          id="encode"
           if="${trimHold}"
           fail-on-error="true"
           exception-handler-workflow="error"
@@ -209,7 +209,7 @@ ${trimHold} variable like in the current workflow definitions with trimming.
    prepare-av operation.  Workflow operation to compose the audio-only file(s)
 
         <operation
-          id="compose"
+          id="encode"
           if="${trimHold}"
           fail-on-error="false"
           description="Extracting audio for waveform generation">

--- a/docs/guides/admin/docs/modules/watsontranscripts.md
+++ b/docs/guides/admin/docs/modules/watsontranscripts.md
@@ -143,7 +143,7 @@ the second workflow can retrieve it from the Asset Manager to attach the caption
 <!-- Extract audio from one of the presenter videos -->
 
 <operation
-  id="compose"
+  id="encode"
   fail-on-error="true"
   exception-handler-workflow="partial-error"
   description="Extract audio for transcript generation">

--- a/docs/guides/admin/docs/workflowoperationhandlers/google-speech-start-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/google-speech-start-transcription-woh.md
@@ -21,7 +21,7 @@ text.
 ```xml
     <!--  Encode audio to flac -->
     <operation
-      id="compose"
+      id="encode"
       fail-on-error="true"
       exception-handler-workflow="partial-error"
       description="Extract audio for transcript generation">

--- a/docs/guides/admin/docs/workflowoperationhandlers/start-watson-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/start-watson-transcription-woh.md
@@ -19,7 +19,7 @@ text.
 <!-- Extract audio from video in ogg/opus format -->
 
 <operation
-  id="compose"
+  id="encode"
   fail-on-error="true"
   exception-handler-workflow="partial-error"
   description="Extract audio for transcript generation">

--- a/modules/admin-ui-frontend/test/app/GET/newEventMultipleDSTFixture.json
+++ b/modules/admin-ui-frontend/test/app/GET/newEventMultipleDSTFixture.json
@@ -345,7 +345,7 @@
             "if": "${videoPreview}",
             "fail-on-error": "true",
             "description": "Encoding presenter (camera) video for preview",
-            "id": "compose",
+            "id": "encode",
             "configurations": {
               "configuration": [
                 {
@@ -517,7 +517,7 @@
             "exception-handler-workflow": "error",
             "fail-on-error": "true",
             "description": "Encoding presenter (camera) to Flash video",
-            "id": "compose",
+            "id": "encode",
             "configurations": {
               "configuration": [
                 {
@@ -545,7 +545,7 @@
             "exception-handler-workflow": "error",
             "fail-on-error": "true",
             "description": "Encoding presentation (screen) to Flash video",
-            "id": "compose",
+            "id": "encode",
             "configurations": {
               "configuration": [
                 {
@@ -573,7 +573,7 @@
             "exception-handler-workflow": "error",
             "fail-on-error": "false",
             "description": "Encoding presenter (camera) to Flash audio",
-            "id": "compose",
+            "id": "encode",
             "configurations": {
               "configuration": [
                 {

--- a/modules/admin-ui-frontend/test/app/GET/newEventMultipleFixture.json
+++ b/modules/admin-ui-frontend/test/app/GET/newEventMultipleFixture.json
@@ -345,7 +345,7 @@
             "if": "${videoPreview}",
             "fail-on-error": "true",
             "description": "Encoding presenter (camera) video for preview",
-            "id": "compose",
+            "id": "encode",
             "configurations": {
               "configuration": [
                 {
@@ -517,7 +517,7 @@
             "exception-handler-workflow": "error",
             "fail-on-error": "true",
             "description": "Encoding presenter (camera) to Flash video",
-            "id": "compose",
+            "id": "encode",
             "configurations": {
               "configuration": [
                 {
@@ -545,7 +545,7 @@
             "exception-handler-workflow": "error",
             "fail-on-error": "true",
             "description": "Encoding presentation (screen) to Flash video",
-            "id": "compose",
+            "id": "encode",
             "configurations": {
               "configuration": [
                 {
@@ -573,7 +573,7 @@
             "exception-handler-workflow": "error",
             "fail-on-error": "false",
             "description": "Encoding presenter (camera) to Flash audio",
-            "id": "compose",
+            "id": "encode",
             "configurations": {
               "configuration": [
                 {

--- a/modules/admin-ui-frontend/test/app/GET/workflow/definitions.json
+++ b/modules/admin-ui-frontend/test/app/GET/workflow/definitions.json
@@ -352,7 +352,7 @@
               }
             },
             {
-              "id": "compose",
+              "id": "encode",
               "description": "Encoding video",
               "fail-on-error": "true",
               "exception-handler-workflow": "partial-error",
@@ -1015,7 +1015,7 @@
               }
             },
             {
-              "id": "compose",
+              "id": "encode",
               "description": "Create single-stream video preview",
               "fail-on-error": "true",
               "if": "NOT (${presenter_work_video} AND ${presentation_work_video})",
@@ -2472,7 +2472,7 @@
               }
             },
             {
-              "id": "compose",
+              "id": "encode",
               "description": "Encoding 360p video to MP4 download",
               "fail-on-error": "true",
               "if": "${flagQuality360p}",
@@ -2501,7 +2501,7 @@
               }
             },
             {
-              "id": "compose",
+              "id": "encode",
               "description": "Encoding 480p video to MP4 download",
               "fail-on-error": "true",
               "if": "${flagQuality480p}",
@@ -2530,7 +2530,7 @@
               }
             },
             {
-              "id": "compose",
+              "id": "encode",
               "description": "Encoding 720p video to MP4 download",
               "fail-on-error": "true",
               "if": "${flagQuality720p}",
@@ -2559,7 +2559,7 @@
               }
             },
             {
-              "id": "compose",
+              "id": "encode",
               "description": "Encoding 1080p video to MP4 download",
               "fail-on-error": "true",
               "if": "${flagQuality1080p}",
@@ -2588,7 +2588,7 @@
               }
             },
             {
-              "id": "compose",
+              "id": "encode",
               "description": "Encoding 2160p video to MP4 download",
               "fail-on-error": "true",
               "if": "${flagQuality2160p}",


### PR DESCRIPTION
### Your pull request should…

* [x ] have a concise title
* [x ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [?] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)

This pull closes Issue #3059

This pull is a companion to pull  #1421 that changed the "compose" WOH name with new name "encode".

This pull replaces the old "compose" WOH name with the new "encode" WOH name in Opencast 10.x documents and tests to avoid confusion for new adopters and for adopters that upgrade to 10.x.
