### PR TITLE
Use engage plugin name in URL to prevent random ID changes

### DIFF
--- a/modules/engage-theodul-core/src/main/java/org/opencastproject/engage/theodul/manager/impl/PluginData.java
+++ b/modules/engage-theodul-core/src/main/java/org/opencastproject/engage/theodul/manager/impl/PluginData.java
@@ -80,11 +80,11 @@ public class PluginData {
   }
 
   public String getStaticResourcesPath() {
-    return Integer.toString(id) + "/" + EngagePlugin.STATIC_RESOURCES_PATH;
+    return name + "/" + EngagePlugin.STATIC_RESOURCES_PATH;
   }
 
   public String getRestPath() {
-    return Integer.toString(id) + "/" + EngagePlugin.REST_ENDPOINT_PATH;
+    return name + "/" + EngagePlugin.REST_ENDPOINT_PATH;
   }
 
   public String getName() {


### PR DESCRIPTION
Depending on the plugin registration order the URL to a specific plugin
might change between restarts. Using the static plugin name prevents
this. Note that the name must therefore be unique. A constant URL helps
with caching.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
