### PR TITLE
Disabling Static Files Authorization for external software

### DIFF
--- a/docs/guides/admin/docs/configuration/serving-static-files.md
+++ b/docs/guides/admin/docs/configuration/serving-static-files.md
@@ -32,6 +32,9 @@ The configuration options for requiring authentication can be found in the servi
 An alternative method to this is Opencast's [token based authorization system](stream-security.md) which allows (and
 requires) to defer all security checks to external systems.
 
+With Opencast 10, a new default configuration for static files authorization was introduced.
+For some external software, like Ilias, it is required that all of your media is accessable to every user. If that is not the case, the static files authorization must be disabled by setting the `authentication.required` option in `etc/org.opencastproject.fsresources.StaticResourceServlet.cfg` to `false`.  
+
 
 Available Static File Authorization Plug-ins
 --------------------------------------------

--- a/docs/guides/admin/docs/configuration/serving-static-files.md
+++ b/docs/guides/admin/docs/configuration/serving-static-files.md
@@ -29,11 +29,10 @@ access control lists published to Engage before allowing access.
 The configuration options for requiring authentication can be found in the service's configuration file at
 `etc/org.opencastproject.fsresources.StaticResourceServlet.cfg`.
 
+For some external software, like the ILIAS plugin, it is required to set `authentication.required` to `false` as static files authorization is active by default.
+
 An alternative method to this is Opencast's [token based authorization system](stream-security.md) which allows (and
 requires) to defer all security checks to external systems.
-
-With Opencast 10, a new default configuration for static files authorization was introduced.
-For some external software, like Ilias, it is required that all of your media is accessable to every user. If that is not the case, the static files authorization must be disabled by setting the `authentication.required` option in `etc/org.opencastproject.fsresources.StaticResourceServlet.cfg` to `false`.  
 
 
 Available Static File Authorization Plug-ins

--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -68,4 +68,6 @@ in:
 ```
 etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
 
-The [ILIAS plugin](https://github.com/fluxapps/OpenCast), for example, does not authenticate users against Opencast. If you are using that plugin, this is why you probably want to disable this feature and make your media publically accessable.
+The [ILIAS plugin](https://github.com/fluxapps/OpenCast), for example, does not authenticate users against Opencast.     
+If you are using that plugin, this is why you probably want to disable this feature and make your media publically       
+accessable.

--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -68,3 +68,5 @@ in:
 ```
 etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
 ```
+
+If you are using external software, like Ilias for example, it is required that all of your media is accessable to every user. If that is not the case, the static files authorization must be disabled by setting the `authentication.required` option in the file above to `false`.

--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -67,6 +67,5 @@ in:
 
 ```
 etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
-```
 
-If you are using external software, like Ilias for example, it is required that all of your media is accessable to every user. If that is not the case, the static files authorization must be disabled by setting the `authentication.required` option in the file above to `false`.
+The [ILIAS plugin](https://github.com/fluxapps/OpenCast), for example, does not authenticate users against Opencast. If you are using that plugin, this is why you probably want to disable this feature and make your media publically accessable.


### PR DESCRIPTION
We discovered that after an Update, the ILIAS authentication doesn't work if the static files authorization is enabled. To help other users with the same problem, we want to give an explanation on the cause and how to solve it.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
