### PR TITLE
Deactivate security-jwt by default

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -126,7 +126,6 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-aai/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-lti/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-shibboleth/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-security-jwt/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-series-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-serviceregistry/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-static/${project.version}</bundle>
@@ -710,6 +709,11 @@
     <bundle start-level="82">mvn:org.springframework.security/spring-security-web/3.1.7.RELEASE</bundle>
     <bundle start-level="82">mvn:org.springframework.security/spring-security-cas/3.1.7.RELEASE</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-cas/${project.version}</bundle>
+  </feature>
+
+  <feature name="opencast-security-jwt" version="${project.version}">
+    <feature start-level="80">opencast-core</feature>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-security-jwt/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-moodle" version="${project.version}">


### PR DESCRIPTION
As discussed at the technical meeting, due to potential problems causing
Opencast to not start up properly, this patch disables the module
`security-jwt` by default, allowing users to activate them using the
`opencast-security-jwt` Karaf feature.

We hope to have this enabled by default again in Opencast 11.

@gregorydlogan will include a note about the deactivation in the 10.4 release notes.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
