### PR TITLE
Fix LTI Tool Build

### DIFF
--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -181,7 +181,7 @@ class TranslatedSeries extends React.Component<SeriesProps, SeriesState> {
     }
 
     annotateEpisodeCallback(id: string) {
-        window.top.location.href = "/annotation-tool/index.html?id=" + id
+        window.top!.location.href = "/annotation-tool/index.html?id=" + id
     }
 
     downloadEventCallback(track: Track) {


### PR DESCRIPTION
In TypeScript 4.4.3 the type declarations for `top` has changed to
`WindowProxy | null`. That is why pull request #2956 broke the build
once it was merged into `develop`. `develop` already uses the new
TypeScript version. The result is:

```
Failed to compile.

/home/lars/dev/opencast/modules/lti/src/components/Series.tsx
TypeScript error in /home/lars/dev/opencast/modules/lti/src/components/Series.tsx(184,9):
Object is possibly 'null'.  TS2531

    182 |
    183 |     annotateEpisodeCallback(id: string) {
  > 184 |         window.top.location.href = "/annotation-tool/index.html?id=" + id
        |         ^
    185 |     }
    186 |
    187 |     downloadEventCallback(track: Track) {

```

According to the specification, `window.top` may never be `null` in a
bowser context. That is why it should be safe to just tell TypeScript to
ignore that this type could be `null`.

This fixes the build.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
