### PR TITLE
Expose ACLs in search service (via `SearchResultItem`)

### DIFF
--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultItem.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultItem.java
@@ -23,6 +23,7 @@
 package org.opencastproject.search.api;
 
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.security.api.AccessControlList;
 
 import java.util.Date;
 
@@ -58,6 +59,11 @@ public interface SearchResultItem {
    * @return the organization identifier
    */
   String getOrganization();
+
+  /**
+   * Returns the access control list of this event that is stored in the index.
+   */
+  AccessControlList getAccessControlList();
 
   /**
    * @return the dcExtent

--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultItemImpl.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultItemImpl.java
@@ -23,6 +23,7 @@
 package org.opencastproject.search.api;
 
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.security.api.AccessControlList;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -62,6 +63,9 @@ public class SearchResultItemImpl implements SearchResultItem {
   /** The media package */
   @XmlElement(name = "mediapackage", namespace = "http://mediapackage.opencastproject.org")
   private MediaPackage mediaPackage = null;
+
+  @XmlElement(name = "acl")
+  private AccessControlList acl = null;
 
   /** Dublin core field 'dc:extent' */
   @XmlElement
@@ -595,6 +599,14 @@ public class SearchResultItemImpl implements SearchResultItem {
     return mediaPackage;
   }
 
+  public void setAccessControlList(AccessControlList acl) {
+    this.acl = acl;
+  }
+
+  public AccessControlList getAccessControlList() {
+    return acl;
+  }
+
   /**
    * {@inheritDoc}
    *
@@ -708,6 +720,7 @@ public class SearchResultItemImpl implements SearchResultItem {
     item.setId(from.getId());
     item.setOrganization(from.getOrganization());
     item.setMediaPackage(from.getMediaPackage());
+    item.setAccessControlList(from.getAccessControlList());
     item.setDcExtent(from.getDcExtent());
     item.setDcTitle(from.getDcTitle());
     item.setDcSubject(from.getDcSubject());

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/SeriesFeedService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/SeriesFeedService.java
@@ -35,6 +35,7 @@ import org.opencastproject.search.api.SearchResult;
 import org.opencastproject.search.api.SearchResultImpl;
 import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.api.SearchResultItemImpl;
+import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.util.data.Function;
 
 import com.google.common.cache.CacheBuilder;
@@ -242,6 +243,11 @@ public class SeriesFeedService extends AbstractFeedService implements FeedGenera
 
           @Override
           public MediaPackage getMediaPackage() {
+            return null;
+          }
+
+          @Override
+          public AccessControlList getAccessControlList() {
             return null;
           }
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -725,8 +725,9 @@ public class SolrIndexManager {
         actionPermissions = new ArrayList<String>();
         permissions.put(entry.getAction(), actionPermissions);
       }
-      actionPermissions.add(entry.getRole());
-
+      if (adminRole != null && !entry.getRole().equals(adminRole)) {
+        actionPermissions.add(entry.getRole());
+      }
     }
 
     // Write the permissions to the solr document

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrIndexManager.java
@@ -721,10 +721,6 @@ public class SolrIndexManager {
         logger.debug("Search service doesn't know how to handle action: {}", entry.getAction());
         continue;
       }
-      if (acl == null) {
-        actionPermissions = new ArrayList<String>();
-        permissions.put(entry.getAction(), actionPermissions);
-      }
       if (adminRole != null && !entry.getRole().equals(adminRole)) {
         actionPermissions.add(entry.getRole());
       }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -40,6 +40,8 @@ import org.opencastproject.search.api.SearchResultImpl;
 import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.api.SearchResultItem.SearchResultItemType;
 import org.opencastproject.search.api.SearchResultItemImpl;
+import org.opencastproject.security.api.AccessControlEntry;
+import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
@@ -62,6 +64,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
@@ -69,6 +72,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Class implementing <code>LookupRequester</code> to provide connection to solr indexing facility.
@@ -207,6 +211,18 @@ public class SolrRequester {
             }
           }
           return null;
+        }
+
+        @Override
+        public AccessControlList getAccessControlList() {
+          final List<AccessControlEntry> entries = Schema.getOcAcl(doc)
+              .stream()
+              .flatMap(field -> {
+                return Arrays.stream(field.getValue().strip().split("\\s+"))
+                    .map(role -> new AccessControlEntry(role, field.getSuffix(), true));
+              })
+              .collect(Collectors.toCollection(ArrayList::new));
+          return new AccessControlList(entries);
         }
 
         @Override


### PR DESCRIPTION
Like other PRs before, these changes are required by the upcoming Tobira module. The module will enable the new video portal Tobira to synchronize with Opencast somewhat efficiently. It's still in development in https://github.com/elan-ev/opencast-tobira/. We want to push all tobira-unrelated improvements to the community as early as possible though. Hence this PR.

---

The ACL information is available in the search index in non-XML form. Code using the search service might be interested in those ACLs without needing to load an attachment and parse XML. So it makes sense to provide this information as part of `SearchResultItem`.

Unfortunately, to make the `SearchService` remote impl work (which uses the search API), the access control list has to be serialized and exposed in that API. Offering more information in the de-facto public and often-used search REST API was not the goal of this PR. But I don't really see a good alternative.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
