### PR TITLE
Store modification & deletion dates for series and add range-lookup method to `SeriesService`

### DIFF
--- a/docs/guides/admin/docs/releasenotes/db-migration.txt
+++ b/docs/guides/admin/docs/releasenotes/db-migration.txt
@@ -1,0 +1,3 @@
+Upgrading to Opencast 11 requires a DB migration, as some tables have changed slightly.
+Migration scripts can be found in `doc/upgrade/10_to_11/`.
+There are separate scripts for MariaDB/MySQL (`mysql5.sql`) and PostgreSQL (`postgresql.sql`).

--- a/docs/upgrade/10_to_11/postgresql9.sql
+++ b/docs/upgrade/10_to_11/postgresql9.sql
@@ -1,5 +1,5 @@
 -- Increase mime_type field size
-ALTER TABLE oc_assets_asset MODIFY COLUMN mime_type VARCHAR (255);
+ALTER TABLE oc_assets_asset ALTER COLUMN mime_type TYPE VARCHAR (255);
 
 -- Add modified and deletion date fields to series.
 --
@@ -20,4 +20,4 @@ UPDATE oc_series
 UPDATE oc_series
     SET modified_date = TIMESTAMP '1970-01-01 00:00:01'
     WHERE modified_date IS NULL;
-ALTER TABLE oc_series MODIFY modified_date TIMESTAMP NOT NULL;
+ALTER TABLE oc_series ALTER COLUMN modified_date SET NOT NULL;

--- a/modules/dublincore/pom.xml
+++ b/modules/dublincore/pom.xml
@@ -55,6 +55,10 @@
       <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
     </dependency>

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalog.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalog.java
@@ -35,6 +35,7 @@ import org.opencastproject.util.data.Function2;
 
 import com.entwinemedia.fn.Fns;
 import com.entwinemedia.fn.data.ImmutableSetWrapper;
+import com.google.gson.annotations.JsonAdapter;
 
 import org.apache.commons.collections4.Closure;
 import org.apache.commons.collections4.CollectionUtils;
@@ -64,6 +65,7 @@ import javax.xml.transform.TransformerException;
  * Attention: Encoding schemes are not preserved! See http://opencast.jira.com/browse/MH-8759
  */
 @ParametersAreNonnullByDefault
+@JsonAdapter(DublinCoreGsonAdapter.class)
 public class DublinCoreCatalog extends XMLCatalogImpl implements DublinCore, MetadataCatalog, Cloneable {
   private static final long serialVersionUID = -4568663918115847488L;
 

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreGsonAdapter.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreGsonAdapter.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.metadata.dublincore;
+
+
+import com.google.gson.JsonParser;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import org.json.simple.parser.ParseException;
+
+import java.io.IOException;
+
+
+/** Gson adapter to provide proper (de)serialization for {@code DublinCoreCatalog} */
+public class DublinCoreGsonAdapter extends TypeAdapter<DublinCoreCatalog> {
+  @Override
+  public void write(JsonWriter out, DublinCoreCatalog catalog) throws IOException {
+    out.jsonValue(catalog.toJson());
+  }
+
+  @Override
+  public DublinCoreCatalog read(JsonReader in) throws IOException {
+    try {
+      // TODO: this is a bit stupid. To avoid duplicating logic of
+      // `DublinCoreJsonFormat.read(JSONObject json)`, we convert given reader
+      // into a string and then parse it again with `DublinCoreJsonFormat.read`.
+      // At some point we should either parse into a `JSONObject` (from json.simple)
+      // directly or avoid parsing twice some other way.
+      String raw = JsonParser.parseReader(in).toString();
+      return DublinCoreJsonFormat.read(raw);
+    } catch (ParseException e) {
+      // Gson throws parse errors as `IllegalStateException`. For example, see `beginObject` of
+      // `JsonReader`.
+      throw new IllegalStateException("could not parse JSON when deserializing DublinCoreCatalog: ", e);
+    }
+  }
+}

--- a/modules/series-service-api/src/main/java/org/opencastproject/series/api/Series.java
+++ b/modules/series-service-api/src/main/java/org/opencastproject/series/api/Series.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.series.api;
+
+import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
+
+import java.util.Date;
+
+
+/**
+ * An Opencast series.
+ */
+public class Series {
+  /** The ID of this series */
+  private String id;
+
+  /** The organization this series belongs to */
+  private String organization;
+
+  /** Serialized dublin core metadata catalogue */
+  private DublinCoreCatalog dublinCore;
+
+  /** Serialized access control lists */
+  private String accessControl;
+
+  /** Date of the last time anything about this series was modified */
+  private Date modifiedDate;
+
+  /**
+   * Date of the last time this series was deleted, or {@code null} if it is not currently deleted.
+   */
+  private Date deletionDate;
+
+
+  public String getId() {
+    return this.id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getOrganization() {
+    return this.organization;
+  }
+
+  public void setOrganization(String organization) {
+    this.organization = organization;
+  }
+
+  public DublinCoreCatalog getDublinCore() {
+    return this.dublinCore;
+  }
+
+  public void setDublinCore(DublinCoreCatalog dublinCore) {
+    this.dublinCore = dublinCore;
+  }
+
+  public String getAccessControl() {
+    return this.accessControl;
+  }
+
+  public void setAccessControl(String accessControl) {
+    this.accessControl = accessControl;
+  }
+
+  public Date getModifiedDate() {
+    return this.modifiedDate;
+  }
+
+  public void setModifiedDate(Date modifiedDate) {
+    this.modifiedDate = modifiedDate;
+  }
+
+  public Date getDeletionDate() {
+    return this.deletionDate;
+  }
+
+  public void setDeletionDate(Date deletionDate) {
+    this.deletionDate = deletionDate;
+  }
+
+
+  /** Returns whether or not this series is currently deleted. */
+  public boolean isDeleted() {
+    return deletionDate != null;
+  }
+}

--- a/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
+++ b/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
@@ -29,7 +29,10 @@ import org.opencastproject.util.NotFoundException;
 
 import com.entwinemedia.fn.data.Opt;
 
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Series service API for creating, removing and searching over series.
@@ -150,6 +153,16 @@ public interface SeriesService {
    *           if query could not be performed
    */
   DublinCoreCatalogList getSeries(SeriesQuery query) throws SeriesException, UnauthorizedException;
+
+
+  /**
+   * Returns all series (including deleted ones!) that have been modified in the
+   * given date range {@code from} (inclusive) -- {@code to} (exclusive). At
+   * most {@code limit} many series are returned. ACLs/permissions are NOT
+   * checked as this is only intended to be used in an administrative context.
+   */
+  List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
+          throws SeriesException;
 
   /**
    * Returns a map of series Id to title of all series the user can access

--- a/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
+++ b/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
@@ -162,7 +162,7 @@ public interface SeriesService {
    * checked as this is only intended to be used in an administrative context.
    */
   List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
-          throws SeriesException;
+          throws SeriesException, UnauthorizedException;
 
   /**
    * Returns a map of series Id to title of all series the user can access

--- a/modules/series-service-impl/pom.xml
+++ b/modules/series-service-impl/pom.xml
@@ -65,6 +65,10 @@
       <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
@@ -49,6 +49,7 @@ import org.opencastproject.rest.RestConstants;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.series.api.Series;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesQuery;
 import org.opencastproject.series.api.SeriesService;
@@ -68,6 +69,7 @@ import com.entwinemedia.fn.data.Opt;
 import com.entwinemedia.fn.data.json.JValue;
 import com.entwinemedia.fn.data.json.Jsons;
 import com.entwinemedia.fn.data.json.SimpleSerializer;
+import com.google.gson.Gson;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -84,7 +86,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
@@ -124,6 +129,8 @@ import javax.ws.rs.core.Response;
 public class SeriesRestService {
 
   private static final String SERIES_ELEMENT_CONTENT_TYPE_PREFIX = "series/";
+
+  private static final Gson gson = new Gson();
 
   /** Logging utility */
   private static final Logger logger = LoggerFactory.getLogger(SeriesRestService.class);
@@ -343,6 +350,90 @@ public class SeriesRestService {
   )
   public Response getSeriesAccessControlListJson(@PathParam("seriesID") String seriesID) {
     return getSeriesAccessControlList(seriesID);
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/allInRangeAdministrative.json")
+  @RestQuery(
+      name = "allInRangeAdministrative",
+      description = "Internal API! Returns all series (included deleted ones!) in the given "
+          + "range 'from' (inclusive) .. 'to' (exclusive). Returns at most 'limit' many series. "
+          + "Can only be used as administrator!",
+      returnDescription = "Series in the range",
+      restParameters = {
+          @RestParameter(
+              name = "from",
+              isRequired = true,
+              description = "Start of date range (inclusive) in milliseconds "
+                  + "since 1970-01-01T00:00:00Z. Has to be >=0.",
+              type = Type.INTEGER
+          ),
+          @RestParameter(
+              name = "to",
+              isRequired = false,
+              // TODO: this shows the default value as 0 despite us not setting this value!
+              description = "End of date range (exclusive) in milliseconds "
+                  + "since 1970-01-01T00:00:00Z. Has to be > 'from'.",
+              type = Type.INTEGER
+          ),
+          @RestParameter(
+              name = "limit",
+              isRequired = true,
+              description = "Maximum number of series to be returned. Has to be >0.",
+              type = Type.INTEGER
+          ),
+      },
+      responses = {
+          @RestResponse(responseCode = SC_OK, description = "All series in the range"),
+          @RestResponse(responseCode = SC_BAD_REQUEST, description = "if the given parameters are invalid"),
+          @RestResponse(responseCode = SC_UNAUTHORIZED, description = "If the user is not an administrator"),
+      }
+  )
+  public Response getAllInRangeAdministrative(
+      @FormParam("from") Long from,
+      @FormParam("to") Long to,
+      @FormParam("limit") Integer limit
+  ) throws UnauthorizedException {
+    // Parameter error handling
+    if (from == null) {
+      return badRequestAllInRange("Required parameter 'from' not specified");
+    }
+    if (limit == null) {
+      return badRequestAllInRange("Required parameter 'limit' not specified");
+    }
+    if (from < 0) {
+      return badRequestAllInRange("Parameter 'from' < 0, but it has to be >= 0");
+    }
+    if (to != null && to <= from) {
+      return badRequestAllInRange("Parameter 'to' <= 'from', but that is not allowed");
+    }
+    if (limit <= 0) {
+      return badRequestAllInRange("Parameter 'limit' <= 0, but it has to be > 0");
+    }
+
+    try {
+      final List<Series> series = seriesService.getAllForAdministrativeRead(
+          new Date(from),
+          Optional.ofNullable(to).map(millis -> new Date(millis)),
+          limit);
+
+      return Response.ok(gson.toJson(series)).build();
+    } catch (SeriesException e) {
+      logger.error("Unexpected exception in getAllInRangeAdministrative", e);
+      return Response.status(INTERNAL_SERVER_ERROR)
+          .entity("internal server error")
+          .build();
+    }
+  }
+
+  /**
+   * Returns a {@code Response} object representing a BAD_REQUEST to `allInRangeAdministrative`
+   * with the given message as body. Also logs the message.
+   */
+  private static Response badRequestAllInRange(String msg) {
+    logger.debug("Bad request to /series/allInRangeAdministrative: {}", msg);
+    return Response.status(BAD_REQUEST).entity(msg).build();
   }
 
   /**

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
@@ -24,14 +24,17 @@ package org.opencastproject.series.impl;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.series.api.Series;
 import org.opencastproject.series.impl.persistence.SeriesEntity;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Tuple;
 
 import com.entwinemedia.fn.data.Opt;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * API that defines persistent storage of series.
@@ -104,6 +107,15 @@ public interface SeriesServiceDatabase {
    *           if exception occurs
    */
   List<SeriesEntity> getAllSeries() throws SeriesServiceDatabaseException;
+
+  /**
+   * Returns all series (including deleted ones!) that have been modified in the
+   * given date range {@code from} (inclusive) -- {@code to} (exclusive). At
+   * most {@code limit} many series are returned. ACLs/permissions are NOT
+   * checked as this is only intended to be used in an administrative context.
+   */
+  List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
+          throws SeriesServiceDatabaseException;
 
   /**
    * Retrieves ACL for series with given ID.

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceDatabase.java
@@ -115,7 +115,7 @@ public interface SeriesServiceDatabase {
    * checked as this is only intended to be used in an administrative context.
    */
   List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
-          throws SeriesServiceDatabaseException;
+          throws SeriesServiceDatabaseException, UnauthorizedException;
 
   /**
    * Retrieves ACL for series with given ID.

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -85,6 +85,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
@@ -401,6 +402,25 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       throw new SeriesException(e);
     }
   }
+
+  @Override
+  public List<org.opencastproject.series.api.Series> getAllForAdministrativeRead(
+      Date from,
+      Optional<Date> to,
+      int limit
+  ) throws SeriesException {
+    try {
+      return persistence.getAllForAdministrativeRead(from, to, limit);
+    } catch (SeriesServiceDatabaseException e) {
+      String msg = String.format(
+          "Exception while reading all series in range %s to %s from persistence storage",
+          from,
+          to
+      );
+      throw new SeriesException(msg, e);
+    }
+  }
+
 
   @Override
   public Map<String, String> getIdTitleMapOfAllSeries() throws SeriesException, UnauthorizedException {

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -408,7 +408,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       Date from,
       Optional<Date> to,
       int limit
-  ) throws SeriesException {
+  ) throws SeriesException, UnauthorizedException {
     try {
       return persistence.getAllForAdministrativeRead(from, to, limit);
     } catch (SeriesServiceDatabaseException e) {

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
@@ -36,6 +36,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.MapKeyColumn;
@@ -55,7 +56,11 @@ import javax.persistence.UniqueConstraint;
 @Entity(name = "SeriesEntity")
 @IdClass(SeriesEntityId.class)
 @Access(AccessType.FIELD)
-@Table(name = "oc_series")
+@Table(name = "oc_series",
+    indexes = {
+        @Index(name = "IX_oc_series_modified_date", columnList = ("modified_date")),
+    }
+)
 @NamedQueries({
     @NamedQuery(
         name = "Series.findAll",

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
@@ -52,7 +52,8 @@ import javax.persistence.UniqueConstraint;
  * rules.
  *
  */
-@Entity(name = "SeriesEntity") @IdClass(SeriesEntityId.class)
+@Entity(name = "SeriesEntity")
+@IdClass(SeriesEntityId.class)
 @Access(AccessType.FIELD)
 @Table(name = "oc_series")
 @NamedQueries({
@@ -67,6 +68,18 @@ import javax.persistence.UniqueConstraint;
     @NamedQuery(
         name = "seriesById",
         query = "select s from SeriesEntity as s where s.seriesId=:seriesId and s.organization=:organization"
+    ),
+    @NamedQuery(
+        name = "Series.getAllModifiedSince",
+        query = "select s from SeriesEntity as s "
+            + "where s.modifiedDate >= :since "
+            + "order by s.modifiedDate asc"
+    ),
+    @NamedQuery(
+        name = "Series.getAllModifiedInRange",
+        query = "select s from SeriesEntity as s "
+            + "where s.modifiedDate >= :from and s.modifiedDate < :to "
+            + "order by s.modifiedDate asc"
     ),
 })
 public class SeriesEntity {

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
@@ -77,13 +77,13 @@ import javax.persistence.UniqueConstraint;
     @NamedQuery(
         name = "Series.getAllModifiedSince",
         query = "select s from SeriesEntity as s "
-            + "where s.modifiedDate >= :since "
+            + "where s.modifiedDate >= :since and s.organization=:organization "
             + "order by s.modifiedDate asc"
     ),
     @NamedQuery(
         name = "Series.getAllModifiedInRange",
         query = "select s from SeriesEntity as s "
-            + "where s.modifiedDate >= :from and s.modifiedDate < :to "
+            + "where s.modifiedDate >= :from and s.modifiedDate < :to and s.organization=:organization "
             + "order by s.modifiedDate asc"
     ),
 })

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesEntity.java
@@ -22,6 +22,7 @@
 package org.opencastproject.series.impl.persistence;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -41,6 +42,8 @@ import javax.persistence.MapKeyColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
 /**
@@ -53,13 +56,18 @@ import javax.persistence.UniqueConstraint;
 @Access(AccessType.FIELD)
 @Table(name = "oc_series")
 @NamedQueries({
-    @NamedQuery(name = "Series.findAll", query = "select s from SeriesEntity s"),
-    @NamedQuery(name = "Series.getCount", query = "select COUNT(s) from SeriesEntity s"),
+    @NamedQuery(
+        name = "Series.findAll",
+        query = "select s from SeriesEntity s where s.deletionDate is null"
+    ),
+    @NamedQuery(
+        name = "Series.getCount",
+        query = "select COUNT(s) from SeriesEntity s where s.deletionDate is null"
+    ),
     @NamedQuery(
         name = "seriesById",
         query = "select s from SeriesEntity as s where s.seriesId=:seriesId and s.organization=:organization"
     ),
-    @NamedQuery(name = "allSeriesInOrg", query = "select s from SeriesEntity as s where s.organization=:organization")
 })
 public class SeriesEntity {
 
@@ -83,6 +91,14 @@ public class SeriesEntity {
   @Lob
   @Column(name = "access_control", length = 65535)
   protected String accessControl;
+
+  @Column(name = "modified_date", nullable = false)
+  @Temporal(TemporalType.TIMESTAMP)
+  protected Date modifiedDate = new Date();
+
+  @Column(name = "deletion_date")
+  @Temporal(TemporalType.TIMESTAMP)
+  protected Date deletionDate = null;
 
   @Lob
   @ElementCollection(targetClass = String.class)
@@ -186,6 +202,26 @@ public class SeriesEntity {
    */
   public void setOrganization(String organization) {
     this.organization = organization;
+  }
+
+  public Date getModifiedDate() {
+    return this.modifiedDate;
+  }
+
+  public void setModifiedDate(Date date) {
+    this.modifiedDate = date;
+  }
+
+  public Date getDeletionDate() {
+    return this.deletionDate;
+  }
+
+  public void setDeletionDate(Date date) {
+    this.deletionDate = date;
+  }
+
+  public boolean isDeleted() {
+    return this.deletionDate != null;
   }
 
   public Map<String, String> getProperties() {

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -174,7 +174,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not delete series: {}", e.getMessage());
+      logger.error("Could not delete series", e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -219,7 +219,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not delete series: {}", e.getMessage());
+      logger.error("Could not delete property for series '{}'", seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -242,7 +242,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     try {
       return query.getResultList();
     } catch (Exception e) {
-      logger.error("Could not retrieve all series: {}", e.getMessage());
+      logger.error("Could not retrieve all series", e);
       throw new SeriesServiceDatabaseException(e);
     } finally {
       em.close();
@@ -271,7 +271,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not retrieve ACL for series '{}': {}", seriesId, e.getMessage());
+      logger.error("Could not retrieve ACL for series '{}'", seriesId, e);
       throw new SeriesServiceDatabaseException(e);
     } finally {
       em.close();
@@ -329,7 +329,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
       tx.commit();
       return newSeries;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not update series", e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -373,7 +373,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not retrieve series", e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -407,7 +407,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not retrieve properties of series '{}'", seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -445,7 +445,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not retrieve property '{}' of series '{}'", propertyName, seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }
@@ -508,7 +508,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     try {
       serializedAC = AccessControlParser.toXml(accessControl);
     } catch (Exception e) {
-      logger.error("Could not serialize access control parameter: {}", e.getMessage());
+      logger.error("Could not serialize access control parameter", e);
       throw new SeriesServiceDatabaseException(e);
     }
     EntityManager em = emf.createEntityManager();
@@ -540,7 +540,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
-      logger.error("Could not update series: {}", e.getMessage());
+      logger.error("Could not store ACL for series '{}'", seriesId, e);
       if (tx.isActive()) {
         tx.rollback();
       }

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -430,10 +430,12 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
         q = em.createNamedQuery("Series.getAllModifiedInRange", SeriesEntity.class)
             .setParameter("from", from)
             .setParameter("to", to.get())
+            .setParameter("organization", user.getOrganization().getId())
             .setMaxResults(limit);
       } else {
         q = em.createNamedQuery("Series.getAllModifiedSince", SeriesEntity.class)
             .setParameter("since", from)
+            .setParameter("organization", user.getOrganization().getId())
             .setMaxResults(limit);
       }
 

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -406,7 +406,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
 
   @Override
   public List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
-          throws SeriesServiceDatabaseException {
+          throws SeriesServiceDatabaseException, UnauthorizedException {
     // Validate parameters
     if (limit <= 0) {
       throw new IllegalArgumentException("limit has to be > 0");
@@ -415,9 +415,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
     // Make sure the user is actually an administrator of sorts
     User user = securityService.getUser();
     if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(user.getOrganization().getAdminRole())) {
-      throw new SeriesServiceDatabaseException(
-          new UnauthorizedException(user, getClass().getName() + ".getModifiedInRangeForAdministrativeRead")
-      );
+      throw new UnauthorizedException(user, getClass().getName() + ".getModifiedInRangeForAdministrativeRead");
     }
 
     // Load series from DB.

--- a/modules/series-service-remote/pom.xml
+++ b/modules/series-service-remote/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>json-simple</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -42,6 +42,7 @@ import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AccessControlParser;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.series.api.Series;
 import org.opencastproject.series.api.SeriesException;
 import org.opencastproject.series.api.SeriesQuery;
 import org.opencastproject.series.api.SeriesService;
@@ -83,9 +84,11 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import javax.ws.rs.GET;
@@ -320,6 +323,13 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
       closeConnection(response);
     }
     throw new SeriesException("Unable to get series from remote series index");
+  }
+
+  @Override
+  public List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
+          throws SeriesException {
+    // TODO: decide what to do about this.
+    throw new SeriesException("NOT IMPLEMENTED");
   }
 
   @Override

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -26,6 +26,7 @@ import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_NOT_FOUND;
@@ -57,6 +58,8 @@ import org.opencastproject.util.doc.rest.RestService;
 
 
 import com.entwinemedia.fn.data.Opt;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -80,7 +83,11 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.StringWriter;
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -120,10 +127,10 @@ import javax.ws.rs.core.Response;
 )
 @Component(
     property = {
-    "service.description=Series Remote Service Proxy",
-    "opencast.service.type=org.opencastproject.series",
-    "opencast.service.path=/series",
-    "opencast.service.publish=false"
+        "service.description=Series Remote Service Proxy",
+        "opencast.service.type=org.opencastproject.series",
+        "opencast.service.path=/series",
+        "opencast.service.publish=false"
     },
     immediate = true,
     service = { SeriesService.class, SeriesServiceRemoteImpl.class }
@@ -131,6 +138,10 @@ import javax.ws.rs.core.Response;
 public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService {
 
   private static final Logger logger = LoggerFactory.getLogger(SeriesServiceRemoteImpl.class);
+
+
+  private static final Gson gson = new Gson();
+  private static final Type seriesListType = new TypeToken<ArrayList<Series>>() { }.getType();
 
   public SeriesServiceRemoteImpl() {
     super(JOB_TYPE);
@@ -327,9 +338,41 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
 
   @Override
   public List<Series> getAllForAdministrativeRead(Date from, Optional<Date> to, int limit)
-          throws SeriesException {
-    // TODO: decide what to do about this.
-    throw new SeriesException("NOT IMPLEMENTED");
+          throws SeriesException, UnauthorizedException {
+    // Assemble URL
+    StringBuilder url = new StringBuilder();
+    url.append("/allInRangeAdministrative.json?");
+
+    List<NameValuePair> queryParams = new ArrayList<>();
+    queryParams.add(new BasicNameValuePair("from", Long.toString(from.getTime())));
+    queryParams.add(new BasicNameValuePair("limit", Integer.toString(limit)));
+    if (to.isPresent()) {
+      queryParams.add(new BasicNameValuePair("to", Long.toString(to.get().getTime())));
+    }
+    url.append(URLEncodedUtils.format(queryParams, StandardCharsets.UTF_8));
+    HttpGet get = new HttpGet(url.toString());
+
+    // Send HTTP request
+    HttpResponse response = getResponse(get, SC_OK, SC_BAD_REQUEST, SC_UNAUTHORIZED);
+    try {
+      if (response == null) {
+        throw new SeriesException("Unable to get series from remote series index");
+      }
+
+      if (response.getStatusLine().getStatusCode() == SC_BAD_REQUEST) {
+        throw new SeriesException("internal server error when fetching /allInRangeAdministrative.json");
+      } else if (response.getStatusLine().getStatusCode() == SC_UNAUTHORIZED) {
+        throw new UnauthorizedException("got UNAUTHORIZED when fetching /allInRangeAdministrative.json");
+      } else {
+        // Retrieve and deserialize data
+        Reader reader = new InputStreamReader(response.getEntity().getContent(), "UTF-8");
+        return gson.fromJson(reader, seriesListType);
+      }
+    } catch (IOException e) {
+      throw new SeriesException("failed to reader response body of /allInRangeAdministrative.json", e);
+    } finally {
+      closeConnection(response);
+    }
   }
 
   @Override


### PR DESCRIPTION
Like other PRs before, these changes are required by the upcoming Tobira module. The module will enable the new video portal Tobira to synchronize with Opencast somewhat efficiently. It's still in development in https://github.com/elan-ev/opencast-tobira/. We want to push all tobira-unrelated improvements to the community as early as possible though. Hence this PR.

---

To synchronized with Opencast efficiently, Opencast needs to know when a "thing" last changed. That was already true for events (at least in the search service), but Opencast did not know this information for series. This PR changes that by adding a modified date field to series. 

To notify other applications, like Tobira, about a deleted series, we now store a deletion date instead of actually deleting the series.

To use this new information, a new method is added to the `SeriesService` that allows modification date range lookup and returns series sorted by modification date. Unfortunately, to implement the remote impl, we needed to add a new JSON API as well. This is described as internal and is not expected to be used outside of Opencast itself. 

Also see commit message for more details. This PR can probably be reviewed commit-by-commit fairly well.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
