### PR TITLE
Fix 0 comparison

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -950,7 +950,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     }
     logger.debug("Current host load: {}, job load cache size: {}", format("%.1f", localSystemLoad), jobCache.size());
 
-    if (jobCache.isEmpty() && localSystemLoad != 0) {
+    if (jobCache.isEmpty() && Math.signum(localSystemLoad) != 0) {
       logger.warn("No jobs in the job load cache, but load is {}: setting job load to 0",
               format("%.2f", localSystemLoad));
       localSystemLoad = 0;


### PR DESCRIPTION
This patch fixes a condition which would check if a float value is `= 0`
which does not work properly for float values, potentially causing:

    WARN  | (ServiceRegistryJpaImpl:954) -
            No jobs in the job load cache,
            but load is -0.00: setting job load to 0

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
