### PR TITLE
Put max load config of server into right place

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -231,6 +231,10 @@ org.opencastproject.working.file.repository.cleanup.collections=failed.zips
 # Default: true
 #org.opencastproject.job.load.acceptexceeding=true
 
+# The max load on this server.
+# Default: number of cores
+#org.opencastproject.server.maxload=
+
 ######### Capture and Ingest #########
 
 # Timeout for capture agent status, in minutes.

--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -24,7 +24,3 @@
 # Note that this setting does have a large impact on the performance of service statistics generation.
 # Default: 14
 #org.opencastproject.statistics.services.max_job_age = 14
-
-# The max load on this server.
-# Default: number of cores
-#org.opencastproject.server.maxload=


### PR DESCRIPTION
Currently the max load config for a server doesn't do anything because it's in the wrong place - it was moved into the service registry config (most likely by #272), but the code looks for it in the custom.properties. So I put it back there. ;)

For the future it might be nice for this to be hot-loaded, but that change would rather be something for develop.



