### PR TITLE
Fix Job Load Warning

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -950,10 +950,11 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     }
     logger.debug("Current host load: {}, job load cache size: {}", format("%.1f", localSystemLoad), jobCache.size());
 
-    if (jobCache.isEmpty() && localSystemLoad != 0) {
-      logger.warn("No jobs in the job load cache, but load is {}: setting job load to 0",
-              format("%.2f", localSystemLoad));
-      localSystemLoad = 0;
+    if (jobCache.isEmpty()) {
+      if (Math.abs(localSystemLoad) > 0.0000001F) {
+        logger.warn("No jobs in the job load cache, but load is {}: setting job load to 0", localSystemLoad);
+      }
+      localSystemLoad = 0.0F;
     }
   }
 


### PR DESCRIPTION
This patch prevents the job dispatcher from printing our warnings on
rounding errors.

Previously, you would see errors like this:

    WARN  | (ServiceRegistryJpaImpl:954) -
            No jobs in the job load cache,
            but load is -0.00: setting job load to 0

Which were probably caused by the float value being not exactly zero.
This patch prevents the warning if it is more or less zero and we can
assume that this was a rounding error.

This will also always set `localSystemLoad` to zero if the cache is
empty, resulting in the same behavior for that as before. Assuming that
was correct, this should still be correct, just without any annoying
warnings for rounding problems.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
