### PR TITLE
Fix Episode Display in Engage UI

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -574,9 +574,11 @@ function($, bootbox, _, alertify, jsyaml) {
         if (data && data['search-results'] && data['search-results']['total']) {
           // number of total search results
           totalEntries = data['search-results']['total'];
-          var total = data['search-results']['limit'];
 
-          if (data['search-results'] == undefined || total == undefined) {
+          var result = (data['search-results'] || {})['result'];
+          var total = Array.isArray(result) ? result.length : 1;
+
+          if (total === undefined) {
             log('Error: Search results (total) undefined');
             $($main_container).append(msg_html_sthWentWrong);
             return;
@@ -587,8 +589,6 @@ function($, bootbox, _, alertify, jsyaml) {
             $($next).addClass('disabled');
             return;
           }
-
-          var result = data['search-results']['result'];
 
           if (page == 1) {
             $($previous).addClass('disabled');
@@ -813,15 +813,15 @@ function($, bootbox, _, alertify, jsyaml) {
           }
 
           totalEntries = data2['search-results']['total'];
-          var total = data2['search-results']['limit'];
+
+          var result = (data2['search-results'] || {})['result'];
+          var total = Array.isArray(result) ? result.length : 1;
 
           if (total == 0) {
             $($main_container).append(msg_html_noseries);
             $($next).addClass('disabled');
             return;
           }
-
-          var result = data2['search-results']['result'];
 
           if (page == 1) {
             $($previous).addClass('disabled');


### PR DESCRIPTION
Fixing the limit value in pull request #3050 caused the Engage UI to
break since it depended on the invalid data being returned (because… of
course it did…)

This patch fixes the issue by looking at the returned data instead.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
