### PR TITLE
Fix “Loading” Message in Engage UI

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
+++ b/modules/engage-ui/src/main/resources/ui/js/app/engage-ui.js
@@ -816,7 +816,7 @@ function($, bootbox, _, alertify, jsyaml) {
           var total = data2['search-results']['limit'];
 
           if (total == 0) {
-            $($main_container).append(msg_html_noseries);
+            $($main_container).html(msg_html_noseries);
             $($next).addClass('disabled');
             return;
           }
@@ -842,7 +842,7 @@ function($, bootbox, _, alertify, jsyaml) {
             createSeriesGrid(val);
           });
         } else {
-          $($main_container).append(msg_html_noseries);
+          $($main_container).html(msg_html_noseries);
         }
       }
     }).then(callback);


### PR DESCRIPTION
This patch fixes the issue that the “Loading” message in the series tab
of the Engage UI never disappears if no series exists, even though the
result (no series message) is added to the page.

![Screenshot from 2021-10-22 17-36-43](https://user-images.githubusercontent.com/1008395/138485593-870ff754-e37f-4e0e-a7a5-de6d3e8bfed9.png)

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
