### PR TITLE
Drop Unused Logger Configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,6 @@
             <M2_REPO>${settings.localRepository}</M2_REPO>
             <java.awt.headless>true</java.awt.headless>
             <eclipselink.logging.level>CONFIG</eclipselink.logging.level>
-            <java.util.logging.config.file>${basedir}/conf/services/java.util.logging.properties</java.util.logging.config.file>
             <logj4.configuration>${basedir}/docs/log4j/log4j.properties</logj4.configuration>
             <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
             <java.locale.providers>COMPAT</java.locale.providers> <!-- Date formats changed with java 9 -->


### PR DESCRIPTION
As @JulianKniephoff  pointed out in Matrix, we don't actually use the logger
configuration this patch removes and since the actual configuration
files do not exist anywhere, it will just fail silently anyway.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
