### PR TITLE
Workflow Configuration Margin

### DIFF
--- a/modules/admin-ui-frontend/app/styles/views/modals/_new-event-series.scss
+++ b/modules/admin-ui-frontend/app/styles/views/modals/_new-event-series.scss
@@ -62,10 +62,14 @@
                 display: block;
             }
         }
-        
+
         .scheduling-conflict {
           @include alert-variant($state-danger-bg, $state-danger-border, $state-danger-text);
           margin-bottom: 15px;
+        }
+
+        #new-event-workflow-configuration {
+          margin-top: 10px;
         }
     }
 }

--- a/modules/admin-ui-frontend/test/app/GET/admin-ng/event/new/processing
+++ b/modules/admin-ui-frontend/test/app/GET/admin-ng/event/new/processing
@@ -4,7 +4,7 @@
     {
       "configuration_panel": "\n    \n      <div id=\"workflow-configuration\">\n        <fieldset>\n          <input\n            id=\"numberOfEvents\"\n            name=\"numberOfEvents\"\n            type=\"number\"\n            class=\"configField\"\n            onkeypress=\"return event.charCode > 47\"\n            oninput=\"checkValueInBounds()\"\n            min=\"1\"\n            value=\"1\"\n            max=\"25\"\n            />\n          <label for=\"numberOfEvents\">Number of Events</label>\n        </fieldset>\n      </div>\n\n      <script type=\"text/javascript\">\n        function checkValueInBounds() {\n          var value = $('#numberOfEvents').val();\n          var max = $('#numberOfEvents').attr('max');\n          var min = $('#numberOfEvents').attr('min');\n          if (parseInt(value) < parseInt(min)) $('#numberOfEvents').val(min);\n          if (parseInt(value) > parseInt(max)) $('#numberOfEvents').val(max);\n        }\n      </script>\n    \n  ",
       "displayOrder": 10,
-      "description": "",
+      "description": "This is a test workflow defined in the frontend mockup.\n It is not loaded from the system, nor does it represent one of the actual default workflows",
       "id": "duplicate-event",
       "title": "Duplicate Event"
     },


### PR DESCRIPTION
This patch slightly increases the margin between workflow configuration
panel and workflow description in the admin interface's add event
dialog which is too small unless the workflow styles it itself.

![Screenshot from 2021-10-22 18-25-43](https://user-images.githubusercontent.com/1008395/138491485-4af12ec2-d5ae-402b-bc32-66e3a5198436.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
