### PR TITLE
Remove Deprecated Methods

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/EncoderEngine.java
@@ -28,8 +28,6 @@ import org.opencastproject.composer.api.VideoClip;
 import org.opencastproject.mediapackage.AdaptivePlaylist;
 import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.util.IoSupport;
-import org.opencastproject.util.data.Collections;
-import org.opencastproject.util.data.Tuple;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -45,6 +43,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -107,7 +106,7 @@ public class EncoderEngine implements AutoCloseable {
    */
   File encode(File mediaSource, EncodingProfile format, Map<String, String> properties)
           throws EncoderException {
-    List<File> output = process(Collections.map(Tuple.tuple("video", mediaSource)), format, properties);
+    List<File> output = process(Collections.singletonMap("video", mediaSource), format, properties);
     if (output.size() != 1) {
       throw new EncoderException(String.format("Encode expects one output file (%s found)", output.size()));
     }
@@ -589,17 +588,17 @@ public class EncoderEngine implements AutoCloseable {
       if (vInputPad == null && aInputPad == null)
         throw new EncoderException("At least one of video or audio input must be specified");
       // Init
-      vfilter = new ArrayList<>(java.util.Collections.nCopies(size, null));
-      afilter = new ArrayList<>(java.util.Collections.nCopies(size, null));
+      vfilter = new ArrayList<>(Collections.nCopies(size, null));
+      afilter = new ArrayList<>(Collections.nCopies(size, null));
       // name of output pads to map to files
-      apads = new ArrayList<>(java.util.Collections.nCopies(size, null));
-      vpads = new ArrayList<>(java.util.Collections.nCopies(size, null));
+      apads = new ArrayList<>(Collections.nCopies(size, null));
+      vpads = new ArrayList<>(Collections.nCopies(size, null));
 
-      vbitrate = new ArrayList<>(java.util.Collections.nCopies(size, null));
-      abitrate = new ArrayList<>(java.util.Collections.nCopies(size, null));
+      vbitrate = new ArrayList<>(Collections.nCopies(size, null));
+      abitrate = new ArrayList<>(Collections.nCopies(size, null));
 
-      vstream = new ArrayList<>(java.util.Collections.nCopies(size, null));
-      astream = new ArrayList<>(java.util.Collections.nCopies(size, null));
+      vstream = new ArrayList<>(Collections.nCopies(size, null));
+      astream = new ArrayList<>(Collections.nCopies(size, null));
 
       vsplit = (size > 1) ? (vInputPad + "split=" + size) : null; // number of splits
       asplit = (size > 1) ? (aInputPad + "asplit=" + size) : null;
@@ -1190,7 +1189,7 @@ public class EncoderEngine implements AutoCloseable {
         return edits;
       }
     }
-    java.util.Collections.sort(edits); // Sort clips if all clips are from the same src
+    Collections.sort(edits); // Sort clips if all clips are from the same src
     List<VideoClip> clips = new ArrayList<VideoClip>();
     it = edits.iterator();
     while (it.hasNext()) { // Check for legal durations


### PR DESCRIPTION
This patch removes a deprecated utility method from the encoder engine
and replaces it with the Java standard library.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
