### PR TITLE
Force same sample rate for audio files in PartialImport WOH encoding profiles

### DIFF
--- a/etc/encoding/opencast-movies.properties
+++ b/etc/encoding/opencast-movies.properties
@@ -167,7 +167,7 @@ profile.import.silent.name = Generate silent audio tracks for filling gaps
 profile.import.silent.input = nothing
 profile.import.silent.output = audio
 profile.import.silent.suffix = -silent-audio.mp4
-profile.import.silent.ffmpeg.command = -strict -2 -filter_complex aevalsrc=0:d=#{time} -c:a aac -b:a 8k #{out.dir}/#{out.name}#{out.suffix}
+profile.import.silent.ffmpeg.command = -strict -2 -filter_complex aevalsrc=0:d=#{time} -c:a aac -b:a 8k -ar 44100 #{out.dir}/#{out.name}#{out.suffix}
 
 # Transcode videos generated with opencast studio to cover some issues
 # The video resolution should be reduced to maximum of 1080p.
@@ -212,5 +212,5 @@ profile.partial-import-preencode.ffmpeg.command = -i #{in.video.path} \
   -filter:v scale=1920:-2,fps=30 \
   -shortest -c:v libx264 -pix_fmt yuv420p \
   -c:a aac -b:a 196k \
-  -ar 48000 \
+  -ar 44100 \
   #{out.dir}/#{out.name}#{out.suffix}


### PR DESCRIPTION
The PartialImport WOH does not only concatenate input files, but also self-generated ones, one of which are silent audio files. During concatenation of input audio files and generated silent audio files, "Non-monotonous DTS" warnings could appear and the output file would be distorted. For example, the output file could have a different length from the sum of its parts or the quality would be significantly lowered. Forcing the same sample rate alleviates the problem (thanks Lars!).

To test this PR, you want to test the PartialImport WOH with at least one video file, and one audio file which is shorter than the video files, so the operation is forced to generate some silent audio tracks.

Should this PR be approved, #3106 should be updated accordingly.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
