### PR TITLE
Exclude administrators from artificial limit in `SolrRequester`

### DIFF
--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchQuery.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchQuery.java
@@ -92,6 +92,11 @@ public class SearchQuery {
     return this;
   }
 
+  /**
+   * Sets a limit on the maximum number of returned items. If the query
+   * execution is not performed by an administrator, this is capped at some
+   * absolute limit (e.g. 2000)!
+   */
   public SearchQuery withLimit(int limit) {
     this.limit = limit;
     return this;

--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResult.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResult.java
@@ -22,6 +22,8 @@
 
 package org.opencastproject.search.api;
 
+import java.util.Optional;
+
 /**
  * A single result of searching.
  */
@@ -67,7 +69,7 @@ public interface SearchResult {
    *
    * @return The limit.
    */
-  long getLimit();
+  Optional<Long> getLimit();
 
   /**
    * Get the search time.

--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultImpl.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultImpl.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -46,7 +47,11 @@ import javax.xml.bind.annotation.XmlType;
  * The search result represents a set of result items that has been compiled as a result for a search operation.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "search-results", namespace = "http://search.opencastproject.org", propOrder = { "query", "resultSet" })
+@XmlType(
+    name = "search-results",
+    namespace = "http://search.opencastproject.org",
+    propOrder = { "query", "resultSet", "limit" }
+)
 @XmlRootElement(name = "search-results", namespace = "http://search.opencastproject.org")
 public class SearchResultImpl implements SearchResult {
 
@@ -94,8 +99,8 @@ public class SearchResultImpl implements SearchResult {
   private long offset = 0;
 
   /** The pagination limit. Default is 10. */
-  @XmlAttribute
-  private long limit = 10;
+  @XmlElement
+  private Optional<Long> limit = Optional.of(10L);
 
   /** The number of hits total, regardless of the limit */
   @XmlAttribute
@@ -190,7 +195,7 @@ public class SearchResultImpl implements SearchResult {
    *
    * @see org.opencastproject.search.api.SearchResult#getLimit()
    */
-  public long getLimit() {
+  public Optional<Long> getLimit() {
     return limit;
   }
 
@@ -200,7 +205,7 @@ public class SearchResultImpl implements SearchResult {
    * @param limit
    *          The limit.
    */
-  public void setLimit(long limit) {
+  public void setLimit(Optional<Long> limit) {
     this.limit = limit;
   }
 
@@ -248,8 +253,8 @@ public class SearchResultImpl implements SearchResult {
    * @see org.opencastproject.search.api.SearchResult#getPage()
    */
   public long getPage() {
-    if (limit != 0) {
-      return offset / limit;
+    if (limit.isPresent() && limit.get() != 0) {
+      return offset / limit.get();
     }
     return 0;
   }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/SeriesFeedService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/SeriesFeedService.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -224,7 +225,7 @@ public class SeriesFeedService extends AbstractFeedService implements FeedGenera
         SearchResultImpl artificialResult = new SearchResultImpl();
 
         // Response either finds the one series or nothing at all
-        artificialResult.setLimit(1);
+        artificialResult.setLimit(Optional.of(1L));
         artificialResult.setOffset(0);
         artificialResult.setTotal(1);
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -170,7 +171,7 @@ public class SolrRequester {
     final SearchResultImpl result = new SearchResultImpl(query.getQuery());
     result.setSearchTime(solrResponse.getQTime());
     result.setOffset(solrResponse.getResults().getStart());
-    result.setLimit(query.getRows());
+    result.setLimit(Optional.ofNullable(query.getRows()).map(i -> Long.valueOf(i)));
     result.setTotal(solrResponse.getResults().getNumFound());
 
     // Walk through response and create new items with title, creator, etc:

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -24,6 +24,7 @@ package org.opencastproject.search.impl.solr;
 
 import static org.opencastproject.security.api.Permissions.Action.READ;
 import static org.opencastproject.security.api.Permissions.Action.WRITE;
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
 import static org.opencastproject.util.data.Collections.filter;
 import static org.opencastproject.util.data.Collections.head;
 import static org.opencastproject.util.data.Option.option;
@@ -733,10 +734,10 @@ public class SolrRequester {
       sb.append("*:*");
     }
 
+    User user = securityService.getUser();
     if (applyPermissions) {
       sb.append(" AND ").append(Schema.OC_ORGANIZATION).append(":")
               .append(SolrUtils.clean(securityService.getOrganization().getId()));
-      User user = securityService.getUser();
       Set<Role> roles = user.getRoles();
       boolean userHasAnonymousRole = false;
       if (roles.size() > 0) {
@@ -787,10 +788,18 @@ public class SolrRequester {
 
     SolrQuery query = new SolrQuery(sb.toString());
 
-    if ((q.getLimit() > 0) && (q.getLimit() < QUERY_MAX_ROWS)) {
-      query.setRows(q.getLimit());
+    String orgAdminRole = user.getOrganization().getAdminRole();
+    boolean isAdmin = user.hasRole(GLOBAL_ADMIN_ROLE) || user.hasRole(orgAdminRole);
+    if (isAdmin) {
+      if (q.getLimit() > 0) {
+        query.setRows(q.getLimit());
+      }
     } else {
-      query.setRows(QUERY_MAX_ROWS);
+      if ((q.getLimit() > 0) && (q.getLimit() < QUERY_MAX_ROWS)) {
+        query.setRows(q.getLimit());
+      } else {
+        query.setRows(QUERY_MAX_ROWS);
+      }
     }
 
     if (q.getOffset() > 0) {


### PR DESCRIPTION
This artificial limit of 2000 was added in PR #1092, this commit:
608720f4add3706e7bb2c3f9b67a1589420bca0a

It was added because requesting the search API without limit would try
to retrieve all events, which could exhaust the server's memory.

Given that this limit was completely undocumented, this is a surprising
behavior for the `SearchService`. In my opinion it would be best to
only have such an artificial limit for external APIs that normal users
can use. But unfortunately, the search API is also used internally by
the `SearchServiceRemoteImpl`. So without massively rewriting the
remote impl, I don't see how one could really improve upon it.

This commit only lifts the limit for admins. This still protects against
DOS attacks by non-admin users while still making the SearchService
more useful to some other Opencast modules.

CC @lkiesow 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
