### PR TITLE
Document impact of ROLE_CAPTURE_AGENT

### DIFF
--- a/docs/guides/admin/docs/configuration/admin-ui/role-based-visibility.md
+++ b/docs/guides/admin/docs/configuration/admin-ui/role-based-visibility.md
@@ -17,7 +17,11 @@ There is a set of so-called user interface roles, each of them providing access 
 administrative user interface. Those roles can be easily identified by their name prefix `ROLE_UI`.
 
 __Important__ `ROLE_ADMIN` implicitly provides full access to the user interface. When working with role-based
-visibility, users (and the groups they belong to) may not have `ROLE_ADMIN` therefore.
+visibility, users (and the groups they belong to) may not have `ROLE_ADMIN` therefore. Similarly,
+`ROLE_CAPTURE_AGENT` provides write access to events the user having the role would usually have no write access
+to. This is the role automatically attached to users used by capture agents. They need this special priviledge
+to ingest to events which another user has created. In general, it's not a good idea to re-use this role for
+regular users.
 
 
 ## User Interface Roles


### PR DESCRIPTION
ROLE_CAPTURE_AGENT is treated specially by Opencast.

Lars wrote:
IIRC then ROLE_CAPTURE_AGENT is special and specifically allows users to write to already existing events.
This is the role automatically attached to users used by capture agents. They need this special priviledge to
ingest to events which another user has created. Otherwise, Opencast would prevent that… which would be
weird for capture agents
In general, it's not a good idea to re-use this role for regular users
Something like ROLE_STUDIO (if you want to fall back to default roles) would probably be better suited

One of the impacts is https://github.com/elan-ev/studip-opencast-plugin/issues/538

### Your pull request should…

* [x] have a concise title
* ~close an accompanying issue~ if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
