### PR TITLE
Add config for service error states to service registry

### DIFF
--- a/docs/guides/admin/docs/releasenotes/service-registry-config.txt
+++ b/docs/guides/admin/docs/releasenotes/service-registry-config.txt
@@ -4,4 +4,5 @@ Opencast 11 comes with minor changes to the service registry config at `ServiceR
 state completely. Before, this was equivalent to 0, which would have the service go into error state after one attempt,
 though this was undocumented. Check your configuration to be sure you didn't rely on this behavior.
 
-2. `no.error.state.services` was added. With this, you can define service types that should never go into error state.
+2. `no.error.state.service.types` was added. With this, you can define service types that should never go into error
+state.

--- a/docs/guides/admin/docs/releasenotes/service-registry-config.txt
+++ b/docs/guides/admin/docs/releasenotes/service-registry-config.txt
@@ -1,0 +1,7 @@
+Opencast 11 comes with minor changes to the service registry config at `ServiceRegistryJpaImpl.cfg`:
+
+1. The usage of `max.attempts` is modified in the sense that if you set -1, you can disable services going into error
+state completely. Before, this was equivalent to 0, which would have the service go into error state after one attempt,
+though this was undocumented. Check your configuration to be sure you didn't rely on this behavior.
+
+2. `no.error.state.services` was added. With this, you can define service types that should never go into error state.

--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -4,9 +4,9 @@
 # Default: 10
 #max.attempts=10
 
-# Comma-separated list of services that should never go into error state.
+# Comma-separated list of service types that should never go into error state, e.g. org.opencastproject.assetmanager
 # Default: None
-#no.error.state.services=
+#no.error.state.service.types=
 
 # The interval in seconds between two rounds of dispatching in the service registry. A minimum value of 1s is enforced
 # due to performance reasons. Set to 0 to disable dispatching from this service registry.

--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -1,8 +1,12 @@
 # Configuration for the service registry
 
-# Number of failed jobs on a service before to set it in error state.
+# Number of failed jobs on a service before to set it in error state. Set to -1 to disable error states completely.
 # Default: 10
 #max.attempts=10
+
+# Comma-separated list of services that should never go into error state.
+# Default: None
+#no.error.state.services=
 
 # The interval in seconds between two rounds of dispatching in the service registry. A minimum value of 1s is enforced
 # due to performance reasons. Set to 0 to disable dispatching from this service registry.

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -219,14 +219,24 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** Default setting on service statistics retrieval */
   static final int DEFAULT_SERVICE_STATISTICS_MAX_JOB_AGE = 14;
 
-  /** Default value for {@link #maxAttemptsBeforeErrorState} */
-  private static final int MAX_FAILURE_BEFORE_ERROR_STATE = 10;
-
   /** The configuration key for setting {@link #maxAttemptsBeforeErrorState} */
-  private static final String MAX_ATTEMPTS_CONFIG_KEY = "max.attempts";
+  static final String MAX_ATTEMPTS_CONFIG_KEY = "max.attempts";
 
-  /** Number of failed jobs on a service before to set it in error state */
-  protected int maxAttemptsBeforeErrorState = MAX_FAILURE_BEFORE_ERROR_STATE;
+  /** The configuration key for setting {@link #noErrorStateServices} */
+  static final String NO_ERROR_STATE_SERVICES_CONFIG_KEY = "no.error.state.services";
+
+  /** Default value for {@link #maxAttemptsBeforeErrorState} */
+  private static final int DEFAULT_MAX_ATTEMPTS_BEFORE_ERROR_STATE = 10;
+
+  /** Default value for {@link #errorStatesEnabled} */
+  private static final boolean DEFAULT_ERROR_STATES_ENABLED = true;
+
+  /** Number of failed jobs on a service before to set it in error state. -1 will disable error states completely. */
+  protected int maxAttemptsBeforeErrorState = DEFAULT_MAX_ATTEMPTS_BEFORE_ERROR_STATE;
+  private boolean errorStatesEnabled = DEFAULT_ERROR_STATES_ENABLED;
+
+  /** Services for which error state is disabled */
+  private List<String> noErrorStateServices = new ArrayList();
 
   /** Default delay between checking if hosts are still alive in seconds * */
   static final long DEFAULT_HEART_BEAT = 60;
@@ -731,14 +741,31 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
 
     logger.info("Updating service registry properties");
 
+    maxAttemptsBeforeErrorState = DEFAULT_MAX_ATTEMPTS_BEFORE_ERROR_STATE;
+    errorStatesEnabled = DEFAULT_ERROR_STATES_ENABLED;
     String maxAttempts = StringUtils.trimToNull((String) properties.get(MAX_ATTEMPTS_CONFIG_KEY));
     if (maxAttempts != null) {
       try {
         maxAttemptsBeforeErrorState = Integer.parseInt(maxAttempts);
-        logger.info("Set max attempts before error state to {}", maxAttempts);
+        if (maxAttemptsBeforeErrorState < 0) {
+          errorStatesEnabled = false;
+          logger.info("Error states of services disabled");
+        } else {
+          errorStatesEnabled = true;
+          logger.info("Set max attempts before error state to {}", maxAttempts);
+        }
       } catch (NumberFormatException e) {
         logger.warn("Can not set max attempts before error state to {}. {} must be an integer", maxAttempts,
                 MAX_ATTEMPTS_CONFIG_KEY);
+      }
+    }
+
+    noErrorStateServices = new ArrayList();
+    String noErrorStateServicesStr = StringUtils.trimToNull((String) properties.get(NO_ERROR_STATE_SERVICES_CONFIG_KEY));
+    if (noErrorStateServicesStr != null) {
+      noErrorStateServices = Arrays.asList(noErrorStateServicesStr.split("\\s*,\\s*"));
+      if (!noErrorStateServices.isEmpty()) {
+        logger.info("Set services without error state to {}", String.join(", ", noErrorStateServices));
       }
     }
 
@@ -2540,7 +2567,8 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         }
 
         // The current service already is in WARNING state and max attempts is reached
-        else if (getHistorySize(currentService) >= maxAttemptsBeforeErrorState) {
+        else if (errorStatesEnabled && !noErrorStateServices.contains(currentService.getServiceType())
+                && getHistorySize(currentService) >= maxAttemptsBeforeErrorState) {
           logger.info("State set to ERROR for current service {} on host {}", currentService.getServiceType(),
                   currentService.getHost());
           currentService.setServiceState(ERROR, job.toJob().getSignature());

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -222,8 +222,8 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** The configuration key for setting {@link #maxAttemptsBeforeErrorState} */
   static final String MAX_ATTEMPTS_CONFIG_KEY = "max.attempts";
 
-  /** The configuration key for setting {@link #noErrorStateServices} */
-  static final String NO_ERROR_STATE_SERVICES_CONFIG_KEY = "no.error.state.services";
+  /** The configuration key for setting {@link #noErrorStateServiceTypes} */
+  static final String NO_ERROR_STATE_SERVICE_TYPES_CONFIG_KEY = "no.error.state.service.types";
 
   /** Default value for {@link #maxAttemptsBeforeErrorState} */
   private static final int DEFAULT_MAX_ATTEMPTS_BEFORE_ERROR_STATE = 10;
@@ -236,7 +236,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   private boolean errorStatesEnabled = DEFAULT_ERROR_STATES_ENABLED;
 
   /** Services for which error state is disabled */
-  private List<String> noErrorStateServices = new ArrayList();
+  private List<String> noErrorStateServiceTypes = new ArrayList();
 
   /** Default delay between checking if hosts are still alive in seconds * */
   static final long DEFAULT_HEART_BEAT = 60;
@@ -760,12 +760,13 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       }
     }
 
-    noErrorStateServices = new ArrayList();
-    String noErrorStateServicesStr = StringUtils.trimToNull((String) properties.get(NO_ERROR_STATE_SERVICES_CONFIG_KEY));
-    if (noErrorStateServicesStr != null) {
-      noErrorStateServices = Arrays.asList(noErrorStateServicesStr.split("\\s*,\\s*"));
-      if (!noErrorStateServices.isEmpty()) {
-        logger.info("Set services without error state to {}", String.join(", ", noErrorStateServices));
+    noErrorStateServiceTypes = new ArrayList();
+    String noErrorStateServiceTypesStr = StringUtils.trimToNull((String) properties.get(
+            NO_ERROR_STATE_SERVICE_TYPES_CONFIG_KEY));
+    if (noErrorStateServiceTypesStr != null) {
+      noErrorStateServiceTypes = Arrays.asList(noErrorStateServiceTypesStr.split("\\s*,\\s*"));
+      if (!noErrorStateServiceTypes.isEmpty()) {
+        logger.info("Set service types without error state to {}", String.join(", ", noErrorStateServiceTypes));
       }
     }
 
@@ -2567,7 +2568,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         }
 
         // The current service already is in WARNING state and max attempts is reached
-        else if (errorStatesEnabled && !noErrorStateServices.contains(currentService.getServiceType())
+        else if (errorStatesEnabled && !noErrorStateServiceTypes.contains(currentService.getServiceType())
                 && getHistorySize(currentService) >= maxAttemptsBeforeErrorState) {
           logger.info("State set to ERROR for current service {} on host {}", currentService.getServiceType(),
                   currentService.getHost());

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -38,7 +38,9 @@ import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.TrustedHttpClientException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
+import org.opencastproject.serviceregistry.api.ServiceRegistration;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
+import org.opencastproject.serviceregistry.api.ServiceState;
 import org.opencastproject.serviceregistry.api.SystemLoad;
 import org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.JobDispatcher;
 import org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.JobProducerHeartbeat;
@@ -75,8 +77,11 @@ import org.slf4j.LoggerFactory;
 
 import java.beans.PropertyVetoException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -480,6 +485,108 @@ public class ServiceRegistryJpaImplTest {
     Job updatedJob = serviceRegistryJpaImpl.updateJob(job);
     Assert.assertNotNull(updatedJob.getDateCompleted());
     Assert.assertNotNull(updatedJob.getRunTime());
+  }
+
+  @Test
+  public void testErrorState() throws Exception {
+    // set max attempts to 1
+    Dictionary<String, String> properties = new Hashtable<>();
+    properties.put(ServiceRegistryJpaImpl.MAX_ATTEMPTS_CONFIG_KEY, "1");
+    serviceRegistryJpaImpl.updated(properties);
+
+    serviceRegistryJpaImpl.sanitize(TEST_SERVICE, TEST_HOST);
+
+    // first job pushes service into warning state
+    Job job = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE, TEST_PATH, new ArrayList(
+            Arrays.asList("a", "b")), null, true, null, 1.0f);
+    job.setStatus(Job.Status.FAILED);
+    job.setProcessingHost(TEST_HOST);
+    serviceRegistryJpaImpl.updateJob(job);
+    ServiceRegistration service = serviceRegistryJpaImpl.getServiceRegistration(TEST_SERVICE, TEST_HOST);
+    Assert.assertEquals(ServiceState.WARNING, service.getServiceState());
+
+    // second job takes service to error state
+    Job job2 = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE, TEST_PATH, new ArrayList(
+            Arrays.asList("a", "b", "c")), null, true, null, 1.0f);
+    job2.setStatus(Job.Status.FAILED);
+    job2.setProcessingHost(TEST_HOST);
+    serviceRegistryJpaImpl.updateJob(job2);
+    service = serviceRegistryJpaImpl.getServiceRegistration(TEST_SERVICE, TEST_HOST);
+    Assert.assertEquals(ServiceState.ERROR, service.getServiceState());
+  }
+
+  @Test
+  public void testDisablingErrorState() throws Exception {
+    // disable error states
+    Dictionary<String, String> properties = new Hashtable<>();
+    properties.put(ServiceRegistryJpaImpl.MAX_ATTEMPTS_CONFIG_KEY, "-1");
+    serviceRegistryJpaImpl.updated(properties);
+
+    serviceRegistryJpaImpl.sanitize(TEST_SERVICE, TEST_HOST);
+
+    // warning state still works
+    Job job = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE, TEST_PATH, new ArrayList(
+            Arrays.asList("a", "b")), null, true, null, 1.0f);
+    job.setStatus(Job.Status.FAILED);
+    job.setProcessingHost(TEST_HOST);
+    serviceRegistryJpaImpl.updateJob(job);
+    ServiceRegistration service = serviceRegistryJpaImpl.getServiceRegistration(TEST_SERVICE, TEST_HOST);
+    Assert.assertEquals(ServiceState.WARNING, service.getServiceState());
+
+    // error state isn't entered
+    Job job2 = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE, TEST_PATH, new ArrayList(
+            Arrays.asList("a", "b", "c")), null, true, null, 1.0f);
+    job2.setStatus(Job.Status.FAILED);
+    job2.setProcessingHost(TEST_HOST);
+    serviceRegistryJpaImpl.updateJob(job2);
+    service = serviceRegistryJpaImpl.getServiceRegistration(TEST_SERVICE, TEST_HOST);
+    Assert.assertEquals(ServiceState.WARNING, service.getServiceState());
+  }
+
+  @Test
+  public void testDisablingErrorStateForService() throws Exception {
+    // disable error states for one service
+    Dictionary<String, String> properties = new Hashtable<>();
+    properties.put(ServiceRegistryJpaImpl.MAX_ATTEMPTS_CONFIG_KEY, "1");
+    properties.put(ServiceRegistryJpaImpl.NO_ERROR_STATE_SERVICES_CONFIG_KEY, TEST_SERVICE_2 + ", " + TEST_SERVICE_3);
+    serviceRegistryJpaImpl.updated(properties);
+
+    serviceRegistryJpaImpl.sanitize(TEST_SERVICE, TEST_HOST);
+    serviceRegistryJpaImpl.sanitize(TEST_SERVICE_2, TEST_HOST);
+
+    // error states still work for other services
+    Job job = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE, TEST_PATH, new ArrayList(
+            Arrays.asList("a", "b")), null, true, null, 1.0f);
+    job.setStatus(Job.Status.FAILED);
+    job.setProcessingHost(TEST_HOST);
+    serviceRegistryJpaImpl.updateJob(job);
+    ServiceRegistration service = serviceRegistryJpaImpl.getServiceRegistration(TEST_SERVICE, TEST_HOST);
+    Assert.assertEquals(ServiceState.WARNING, service.getServiceState());
+
+    Job job2 = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE, TEST_PATH, new ArrayList(
+            Arrays.asList("a", "b", "c")), null, true, null, 1.0f);
+    job2.setStatus(Job.Status.FAILED);
+    job2.setProcessingHost(TEST_HOST);
+    serviceRegistryJpaImpl.updateJob(job2);
+    service = serviceRegistryJpaImpl.getServiceRegistration(TEST_SERVICE, TEST_HOST);
+    Assert.assertEquals(ServiceState.ERROR, service.getServiceState());
+
+    // but not for the configured service
+    Job job3 = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE_2, TEST_PATH, new ArrayList(
+            Arrays.asList("a", "b")), null, true, null, 1.0f);
+    job3.setStatus(Job.Status.FAILED);
+    job3.setProcessingHost(TEST_HOST);
+    serviceRegistryJpaImpl.updateJob(job3);
+    ServiceRegistration service2 = serviceRegistryJpaImpl.getServiceRegistration(TEST_SERVICE_2, TEST_HOST);
+    Assert.assertEquals(ServiceState.WARNING, service2.getServiceState());
+
+    Job job4 = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE_2, TEST_PATH, new ArrayList(
+            Arrays.asList("a", "b", "c")), null, true, null, 1.0f);
+    job4.setStatus(Job.Status.FAILED);
+    job4.setProcessingHost(TEST_HOST);
+    serviceRegistryJpaImpl.updateJob(job4);
+    service2 = serviceRegistryJpaImpl.getServiceRegistration(TEST_SERVICE_2, TEST_HOST);
+    Assert.assertEquals(ServiceState.WARNING, service2.getServiceState());
   }
 
   @Test

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -548,7 +548,7 @@ public class ServiceRegistryJpaImplTest {
     // disable error states for one service
     Dictionary<String, String> properties = new Hashtable<>();
     properties.put(ServiceRegistryJpaImpl.MAX_ATTEMPTS_CONFIG_KEY, "1");
-    properties.put(ServiceRegistryJpaImpl.NO_ERROR_STATE_SERVICES_CONFIG_KEY, TEST_SERVICE_2 + ", " + TEST_SERVICE_3);
+    properties.put(ServiceRegistryJpaImpl.NO_ERROR_STATE_SERVICE_TYPES_CONFIG_KEY, TEST_SERVICE_2 + ", " + TEST_SERVICE_3);
     serviceRegistryJpaImpl.updated(properties);
 
     serviceRegistryJpaImpl.sanitize(TEST_SERVICE, TEST_HOST);


### PR DESCRIPTION
This modifies the use of one config for the service registry and adds another. With this, you can either disable error states for services completely or only for specific services. The warning state behavior remains unchanged. Default behavior is unchanged. Release Notes were added. Tests were added. :)
