### PR TITLE
Let Encode Handle HLS

### DIFF
--- a/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/ComposerServiceTest.java
+++ b/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/ComposerServiceTest.java
@@ -216,8 +216,12 @@ public class ComposerServiceTest {
     // Create and populate the composer service
     composerService = new ComposerServiceImpl() {
       @Override
-      protected Track inspect(Job job, URI workspaceURI) throws EncoderException {
-        return inspectedTrack;
+      protected List<Track> inspect(Job job, List<URI> uris) throws EncoderException {
+        final var result = new ArrayList<Track>(uris.size());
+        for (URI uri: uris) {
+          result.add(inspectedTrack);
+        }
+        return result;
       }
     };
 


### PR DESCRIPTION
The internal code of the encode operation will now pick up HLS playlist
but this is unfortunately not handles later in the code, causing the
inspect operations to fail. This fixes the issue by looking out for HLS
playlists, ensuring the file references in there are correct during
inspection.

This also changes the way inspections are run, switching from a
sequential run on all files to running the inspection in parallel, like
we do with the other operations.

This shouldn't change the default behavior of the encode operations in
any way.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
