### PR TITLE
Extract image from source

### DIFF
--- a/etc/workflows/fast.xml
+++ b/etc/workflows/fast.xml
@@ -79,7 +79,7 @@
       exception-handler-workflow="partial-error"
       description="Creating Engage search result thumbnails">
       <configurations>
-        <configuration key="source-flavor">*/preview</configuration>
+        <configuration key="source-flavor">*/source</configuration>
         <configuration key="target-flavor">*/search+preview</configuration>
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="encoding-profile">search-cover.http</configuration>
@@ -96,7 +96,7 @@
       exception-handler-workflow="partial-error"
       description="Creating Engage player preview image">
       <configurations>
-        <configuration key="source-flavor">*/preview</configuration>
+        <configuration key="source-flavor">*/source</configuration>
         <configuration key="target-flavor">*/player+preview</configuration>
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="encoding-profile">player-preview.http</configuration>
@@ -113,7 +113,7 @@
       exception-handler-workflow="partial-error"
       description="Detecting slide transitions in presentation track">
       <configurations>
-        <configuration key="source-flavor">presentation/preview</configuration>
+        <configuration key="source-flavor">presentation/source</configuration>
         <configuration key="target-tags">engage-download</configuration>
       </configurations>
     </operation>
@@ -127,9 +127,8 @@
       exception-handler-workflow="partial-error"
       description="Creating presentation segments preview image">
       <configurations>
-        <configuration key="source-flavor">presentation/preview</configuration>
+        <configuration key="source-flavor">presentation/source</configuration>
         <configuration key="target-flavor">presentation/segment+preview</configuration>
-        <configuration key="reference-flavor">presentation/preview</configuration>
         <configuration key="reference-tags">engage-download</configuration>
         <configuration key="target-tags">engage-download</configuration>
         <configuration key="encoding-profile">player-slides.http</configuration>


### PR DESCRIPTION
Instead of extracting images from already processed files which should
have lost quality and could potentially be playlists, this patch make
Opencast extract the preview images from the source material instead.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
