### PR TITLE
Downgrade to latest xml-apis version from 2.0.2 to 1.4.01

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1128,7 +1128,7 @@
       <dependency>
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis</artifactId>
-        <version>2.0.2</version>
+        <version>1.4.01</version>
       </dependency>
       <!-- logging -->
       <dependency>


### PR DESCRIPTION
The latest release of the xml-apis dependency is not version 2.0.2 but version 1.4.01.
See https://repo1.maven.org/maven2/xml-apis/xml-apis/2.0.2/xml-apis-2.0.2.pom

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
