### PR TITLE
Remove Apache Mina

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
     <joda-time.version>2.10.10</joda-time.version>
     <json-simple.version>1.1.1</json-simple.version>
     <karaf.version>4.2.9</karaf.version>
-    <mina.version>2.1.3</mina.version>
     <node.version>v14.17.0</node.version>
     <osgi.compendium.version>5.0.0</osgi.compendium.version>
     <osgi.core.version>5.0.0</osgi.core.version>
@@ -806,26 +805,6 @@
         <groupId>org.apache.geronimo.specs</groupId>
         <artifactId>geronimo-jms_1.1_spec</artifactId>
         <version>1.1.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.mina</groupId>
-        <artifactId>mina-core</artifactId>
-        <version>${mina.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.mina</groupId>
-        <artifactId>mina-integration-beans</artifactId>
-        <version>${mina.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.mina</groupId>
-        <artifactId>mina-integration-jmx</artifactId>
-        <version>${mina.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.mina</groupId>
-        <artifactId>mina-integration-ognl</artifactId>
-        <version>${mina.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
Pull request #3130 updates Apache MINA since a specifically crafted,
malformed HTTP request may cause the HTTP Header decoder to loop
indefinitely when it is used (CVE-2021-41973).

Fortunately, Opencast does not use MINA at all any longer and this patch
thus removes it completely.

This closes #3130

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
