### PR TITLE
Remove com.springsource.org.cyberneko.html

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1083,11 +1083,6 @@
         <version>3.3.3</version>
       </dependency>
       <dependency>
-        <groupId>net.sourceforge.nekohtml</groupId>
-        <artifactId>com.springsource.org.cyberneko.html</artifactId>
-        <version>1.9.13</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.commons-httpclient</artifactId>
         <version>3.1_7</version>


### PR DESCRIPTION
This patch removes com.springsource.org.cyberneko.html since we don't
need it any longer.

_If only the other Spring related stuff were so easy to deal with._

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
