### PR TITLE
Drop existing video chaptermarks on cutting

### DIFF
--- a/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
+++ b/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
@@ -12,7 +12,7 @@ video.codec = libx264
 # This is a temporary file, so it doesn't have to be generic, the default is ffmpeg only - lossless
 # ffmpeg.properties = -strict -2 -preset ultrafast -qp 0 -tune film
 # DO NOT use filters here, it will conflict with -complex-filter in the editor
-ffmpeg.properties = -strict -2 -preset veryfast -crf 18 -tune film
+ffmpeg.properties = -strict -2 -preset veryfast -crf 18 -tune film -map_metadata -1 -map_chapters -1 -sn -dn
 # preset can be: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow. Default is medium
 # faster = larger output file
 


### PR DESCRIPTION
The smil segment list from editor is used to cut the videos accordingly. ffmpeg apply it on audio and video streams but not for chaptermarks. Therefore, the chaptermarks are invalid for the output video. We want to drop chaptermarks as we do not use them in further processing.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
