### PR TITLE
Allow empty track duration

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1662,7 +1662,7 @@ public class EventsEndpoint implements ManagedService {
               f("url", v(getSignedUrl(track.getURI(), sign), BLANK)), f("flavor", v(track.getFlavor(), BLANK)),
               f("size", v(track.getSize())), f("checksum", v(track.getChecksum(), BLANK)),
               f("tags", arr(track.getTags())), f("has_audio", v(track.hasAudio())),
-              f("has_video", v(track.hasVideo())), f("duration", v(track.getDuration())),
+              f("has_video", v(track.hasVideo())), f("duration", v(track.getDuration(), BLANK)),
               f("description", v(track.getDescription(), BLANK))).merge(trackInfo));
     }
     return tracks;


### PR DESCRIPTION
The track duration might be empty and in with case the external API request will fail. An empty track duration happens e.g. for subtitle tracks.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
