### PR TITLE
Use original file extension in the asset manger

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
@@ -244,7 +244,7 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
   }
 
   @GET
-  @Path("assets/{mediaPackageID}/{mediaPackageElementID}/{version}/{filenameIgnore}")
+  @Path("assets/{mediaPackageID}/{mediaPackageElementID}/{version}/{filename}")
   @RestQuery(name = "getAsset",
       description = "Get an asset",
       returnDescription = "The file",
@@ -265,8 +265,8 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
               isRequired = true,
               type = STRING),
           @RestParameter(
-              name = "filenameIgnore",
-              description = "a descriptive filename which will be ignored though",
+              name = "filename",
+              description = "a descriptive filename used as the download filename",
               isRequired = false,
               type = STRING)},
       responses = {
@@ -288,6 +288,7 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
   public Response getAsset(@PathParam("mediaPackageID") final String mediaPackageID,
                            @PathParam("mediaPackageElementID") final String mediaPackageElementID,
                            @PathParam("version") final String version,
+                           @PathParam("filename") String fileName,
                            @HeaderParam("If-None-Match") String ifNoneMatch) {
 
     try {
@@ -310,11 +311,12 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
             }
           }
 
-          final String fileName = mediaPackageElementID
-                  .concat(".")
-                  .concat(asset.getMimeType().bind(suffix).getOr("unknown"));
+          if (StringUtils.isEmpty(fileName)) {
+            fileName = mediaPackageElementID
+                .concat(".")
+                .concat(asset.getMimeType().bind(suffix).getOr("unknown"));
+          }
 
-          asset.getMimeType().map(MimeTypeUtil.Fns.toString);
           // Write the file contents back
           Option<Long> length = asset.getSize() > 0 ? Option.some(asset.getSize()) : Option.none();
           return ok(asset.getInputStream(),

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/AbstractAssetManagerRestEndpoint.java
@@ -311,7 +311,7 @@ public abstract class AbstractAssetManagerRestEndpoint extends AbstractJobProduc
             }
           }
 
-          if (StringUtils.isEmpty(fileName)) {
+          if (StringUtils.isBlank(fileName)) {
             fileName = mediaPackageElementID
                 .concat(".")
                 .concat(asset.getMimeType().bind(suffix).getOr("unknown"));

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/OsgiEndpointHttpAssetProvider.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/OsgiEndpointHttpAssetProvider.java
@@ -20,7 +20,6 @@
  */
 package org.opencastproject.assetmanager.impl.endpoint;
 
-import static org.apache.commons.io.FilenameUtils.getBaseName;
 import static org.opencastproject.util.MimeTypeUtil.Fns.suffix;
 import static org.opencastproject.util.OsgiUtil.getComponentContextProperty;
 import static org.opencastproject.util.OsgiUtil.getContextProperty;
@@ -107,7 +106,13 @@ public class OsgiEndpointHttpAssetProvider implements HttpAssetProvider {
   }
 
   private URI createUriFor(MediaPackageElement mpe, Snapshot snapshot) {
-    String baseName = getBaseName(AssetManagerImpl.getFileNameFromUrn(mpe).getOr(mpe.getElementType().toString()));
+    Opt<String> fileNameOpt = AssetManagerImpl.getFileNameFromUrn(mpe);
+    String fileName;
+    if (fileNameOpt.isSome()) {
+      fileName = fileNameOpt.get();
+    } else {
+      fileName = mpe.getElementType().toString() + "." + mimeTypeToSuffix(Opt.nul(mpe.getMimeType()));
+    }
 
     // the returned uri must match the path of the {@link #getAsset} method
     return uri(calcServerUrl(snapshot.getOrganizationId().toString()),
@@ -116,7 +121,7 @@ public class OsgiEndpointHttpAssetProvider implements HttpAssetProvider {
                mpe.getMediaPackage().getIdentifier().toString(),
                mpe.getIdentifier(),
                snapshot.getVersion().toString(),
-               baseName + "." + mimeTypeToSuffix(Opt.nul(mpe.getMimeType())));
+               fileName);
   }
 
   /** Get a file name suffix for the given MIME type. */


### PR DESCRIPTION
Up until now the asset manager might change the file extension based on
the mime type (or `.unknown` if the mime type is not known). This PR uses
the original file extention used during the upload and only relies on
known mime types if there is no file extension.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
