### PR TITLE
Allow the use of organization properties in workflows

### DIFF
--- a/docs/guides/admin/docs/configuration/workflow.md
+++ b/docs/guides/admin/docs/configuration/workflow.md
@@ -299,6 +299,13 @@ This input can also be sent by capture agents, using the ingest endpoints. Pleas
 not load the configuration panel. Hence defaults set in the user interface will not apply to ingests. To circumvent
 this, the [defaults operation](../workflowoperationhandlers/defaults-woh.md) can be used.
 
+## Organisation Properties
+
+Workflows can access organisation properties stored as `prop.*` in the organisation configuration
+(`etc/org.opencastproject.organization-mh_default_org.cfg` for the default organisation `mh_default_org`). This allows
+for organisation specific configuration of your workflow. To access the property use the `org_` prefix, e.g.
+`prop.my.var` can be access using `${org_my.var}`.
+
 ## Conditional Execution
 
 The attribute `if` of the `operation` element can be used to specify a condition to control whether the workflow

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -654,9 +654,18 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
       for (String key : instance.getConfigurationKeys()) {
         wfProperties.put(key, instance.getConfiguration(key));
       }
-      final Function<String, String> systemVariableGetter = key -> componentContext == null
-              ? null
-              : componentContext.getBundleContext().getProperty(key);
+      final Organization currentOrg = securityService.getOrganization();
+      final Function<String, String> systemVariableGetter = key -> {
+        if (key.startsWith("org_")) {
+          String value = currentOrg.getProperties().get(key.substring(4));
+          if (value != null) {
+            return value;
+          }
+        }
+        return componentContext == null
+            ? null
+            : componentContext.getBundleContext().getProperty(key);
+      };
       if (instance.getOperations().stream().anyMatch(op -> op.getExecutionCondition() != null)) {
         instance = WorkflowParser.parseWorkflowInstance(WorkflowParser.toXml(instance));
         instance.getOperations().stream().filter(op -> op.getExecutionCondition() != null).forEach(


### PR DESCRIPTION
Organization workflow properties are exposed to workflows using the
`org_` prefix.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
