### PR TITLE
Fix mime type parsing for publish-oaipmh operation

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/MimeTypes.java
+++ b/modules/common/src/main/java/org/opencastproject/util/MimeTypes.java
@@ -138,7 +138,7 @@ public final class MimeTypes {
     @Override
     public Opt<MimeType> apply(String name) {
       try {
-        return Opt.some(fromString(name));
+        return Opt.some(parseMimeType(name));
       } catch (Exception e) {
         return Opt.none();
       }


### PR DESCRIPTION
The publish-oaipmh allows to set the mime type. This did not work before
as it was parsed as a file extension.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
