### PR TITLE
Remove check for tracks for OAI-PMH

### DIFF
--- a/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
+++ b/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
@@ -751,10 +751,6 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
     }
     MediaPackage publishedMp = merge(filteredMp, removeMatchingNonExistantElements(filteredMp,
             (MediaPackage) result.getItems().get(0).getMediaPackage().clone(), parsedFlavors, tags));
-    // Does the media package have a title and track?
-    if (!MediaPackageSupport.isPublishable(publishedMp)) {
-      throw new PublicationException("Media package does not meet criteria for publication");
-    }
     // Publish the media package to OAI-PMH
     try {
       logger.debug("Updating metadata of media package {} in {}",


### PR DESCRIPTION
OAI-PMH can be used to only publish metadata so there shouldn't be a
track check as in the other publication types. The check is only done
during the republish anyway so the initial publish already allows for
track-less publications.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
