### PR TITLE
Fix content-type header of ingest endpoint

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -1108,7 +1108,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
   }
 
   @POST
-  @Produces(MediaType.TEXT_HTML)
+  @Produces(MediaType.TEXT_XML)
   @Path("ingest/{wdID}")
   @RestQuery(name = "ingest",
              description = "<p>Ingest the completed media package into the system and start a specified workflow.</p>"
@@ -1130,7 +1130,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
   }
 
   @POST
-  @Produces(MediaType.TEXT_HTML)
+  @Produces(MediaType.TEXT_XML)
   @Path("ingest")
   @RestQuery(name = "ingest",
              description = "<p>Ingest the completed media package into the system</p>"


### PR DESCRIPTION
Both ingest methods returned the content type text/html instead of text/xml. The change can potentially break implementations that rely on the ingest endpoint.

Fixes #3146

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
