### PR TITLE
Improve Admin UI Performance

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -86,8 +86,10 @@ import org.opencastproject.index.service.exception.UnsupportedAssetException;
 import org.opencastproject.index.service.impl.util.EventUtils;
 import org.opencastproject.index.service.resources.list.provider.EventsListProvider.Comments;
 import org.opencastproject.index.service.resources.list.query.EventListQuery;
+import org.opencastproject.index.service.resources.list.query.SeriesListQuery;
 import org.opencastproject.index.service.util.JSONUtils;
 import org.opencastproject.index.service.util.RestUtils;
+import org.opencastproject.list.api.ResourceListQuery;
 import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.AudioStream;
 import org.opencastproject.mediapackage.Catalog;
@@ -1189,39 +1191,58 @@ public abstract class AbstractEventEndpoint {
     if (optEvent.isNone())
       return notFound("Cannot find an event with id '%s'.", eventId);
     Event event = optEvent.get();
-
     MetadataList metadataList = new MetadataList();
-    List<EventCatalogUIAdapter> catalogUIAdapters = getIndexService().getEventCatalogUIAdapters();
-    catalogUIAdapters.remove(getIndexService().getCommonEventCatalogUIAdapter());
-    MediaPackage mediaPackage;
-    try {
-      mediaPackage = getIndexService().getEventMediapackage(event);
-    } catch (IndexServiceException e) {
-      if (e.getCause() instanceof NotFoundException) {
-        return notFound("Cannot find data for event %s", eventId);
-      } else if (e.getCause() instanceof UnauthorizedException) {
-        return Response.status(Status.FORBIDDEN).entity("Not authorized to access " + eventId).build();
-      }
-      logger.error("Internal error when trying to access metadata for " + eventId, e);
-      return serverError();
-    }
-    for (EventCatalogUIAdapter catalogUIAdapter : catalogUIAdapters) {
-      metadataList.add(catalogUIAdapter, catalogUIAdapter.getFields(mediaPackage));
-    }
-    DublinCoreMetadataCollection metadataCollection = EventUtils.getEventMetadata(event, getIndexService().getCommonEventCatalogUIAdapter());
-    if (getOnlySeriesWithWriteAccessEventModal()) {
-      MetadataField seriesField = metadataCollection.getOutputFields().get(DublinCore.PROPERTY_IS_PART_OF.getLocalName());
-      if (seriesField != null) {
-        seriesField.setCollection(getSeriesEndpoint().getUserSeriesByAccess(true));
-      }
-    }
+
+    // Load common metadata
+    EventCatalogUIAdapter eventCatalogUiAdapter = getIndexService().getCommonEventCatalogUIAdapter();
+    DublinCoreMetadataCollection metadataCollection = eventCatalogUiAdapter.getRawFields(getCollectionQueryOverrides());
+    EventUtils.setEventMetadataValues(event, metadataCollection);
     metadataList.add(getIndexService().getCommonEventCatalogUIAdapter(), metadataCollection);
 
+    // Load extended metadata
+    List<EventCatalogUIAdapter> extendedCatalogUIAdapters = getIndexService().getExtendedEventCatalogUIAdapters();
+    if (!extendedCatalogUIAdapters.isEmpty()) {
+      MediaPackage mediaPackage;
+      try {
+        mediaPackage = getIndexService().getEventMediapackage(event);
+      } catch (IndexServiceException e) {
+        if (e.getCause() instanceof NotFoundException) {
+          return notFound("Cannot find data for event %s", eventId);
+        } else if (e.getCause() instanceof UnauthorizedException) {
+          return Response.status(Status.FORBIDDEN).entity("Not authorized to access " + eventId).build();
+        }
+        logger.error("Internal error when trying to access metadata for " + eventId, e);
+        return serverError();
+      }
+
+      for (EventCatalogUIAdapter extendedCatalogUIAdapter : extendedCatalogUIAdapters) {
+        metadataList.add(extendedCatalogUIAdapter, extendedCatalogUIAdapter.getFields(mediaPackage));
+      }
+    }
+
+    // lock metadata?
     final String wfState = event.getWorkflowState();
     if (wfState != null && WorkflowUtil.isActive(WorkflowInstance.WorkflowState.valueOf(wfState)))
       metadataList.setLocked(Locked.WORKFLOW_RUNNING);
 
     return okJson(MetadataJson.listToJson(metadataList, true));
+  }
+
+  /**
+   * If we only want to show series with write access, create a special query to fill the collection of the series
+   * metadata field
+   *
+   * @return a map with resource list queries belonging to metadata fields
+   */
+  private Map getCollectionQueryOverrides() {
+    HashMap<String, ResourceListQuery> collectionQueryOverrides = new HashMap();
+    if (getOnlySeriesWithWriteAccessEventModal()) {
+      SeriesListQuery seriesListQuery = new SeriesListQuery();
+      seriesListQuery.withReadPermission(true);
+      seriesListQuery.withWritePermission(true);
+      collectionQueryOverrides.put(DublinCore.PROPERTY_IS_PART_OF.getLocalName(), seriesListQuery);
+    }
+    return collectionQueryOverrides;
   }
 
   @POST  // use POST instead of GET because of a possibly long list of ids
@@ -1241,7 +1262,6 @@ public abstract class AbstractEventEndpoint {
                              responseCode = HttpServletResponse.SC_NOT_FOUND)
              })
   public Response getEventsMetadata(@FormParam("eventIds") String eventIds) throws Exception {
-
     if (StringUtils.isBlank(eventIds)) {
       return badRequest("Event ids can't be empty");
     }
@@ -1261,12 +1281,6 @@ public abstract class AbstractEventEndpoint {
     Set<String> eventsNotFound = new HashSet();
     Set<String> eventsWithRunningWorkflow = new HashSet();
     Set<String> eventsMerged = new HashSet();
-
-    //get once instead of for each event
-    Map<String, String> seriesWithWriteAccess = null;
-    if (getOnlySeriesWithWriteAccessEventModal()) {
-      seriesWithWriteAccess = getSeriesEndpoint().getUserSeriesByAccess(true);
-    }
 
     // collect the metadata of all events
     List<DublinCoreMetadataCollection> collectedMetadata = new ArrayList();
@@ -1288,16 +1302,11 @@ public abstract class AbstractEventEndpoint {
       }
 
       // collect metadata
-      DublinCoreMetadataCollection metadataCollection =
-        EventUtils.getEventMetadata(event, getIndexService().getCommonEventCatalogUIAdapter());
+      EventCatalogUIAdapter eventCatalogUiAdapter = getIndexService().getCommonEventCatalogUIAdapter();
+      DublinCoreMetadataCollection metadataCollection = eventCatalogUiAdapter.getRawFields(
+              getCollectionQueryOverrides());
+      EventUtils.setEventMetadataValues(event, metadataCollection);
       collectedMetadata.add(metadataCollection);
-
-      // in case we want only series with write access
-      if (getOnlySeriesWithWriteAccessEventModal()) {
-        MetadataField seriesField =
-          metadataCollection.getOutputFields().get(DublinCore.PROPERTY_IS_PART_OF.getLocalName());
-        seriesField.setCollection(seriesWithWriteAccess);
-      }
 
       eventsMerged.add(eventId);
     }
@@ -2097,47 +2106,49 @@ public abstract class AbstractEventEndpoint {
   @RestQuery(name = "getNewMetadata", description = "Returns all the data related to the metadata tab in the new event modal as JSON", returnDescription = "All the data related to the event metadata tab as JSON", responses = {
           @RestResponse(responseCode = SC_OK, description = "Returns all the data related to the event metadata tab as JSON") })
   public Response getNewMetadata() {
-    MetadataList metadataList = getIndexService().getMetadataListWithAllEventCatalogUIAdapters();
-    DublinCoreMetadataCollection collection = metadataList
-            .getMetadataByAdapter(getIndexService().getCommonEventCatalogUIAdapter());
-    if (collection != null) {
-      if (collection.getOutputFields().containsKey(DublinCore.PROPERTY_CREATED.getLocalName()))
-        collection.removeField(collection.getOutputFields().get(DublinCore.PROPERTY_CREATED.getLocalName()));
-      if (collection.getOutputFields().containsKey("duration"))
-        collection.removeField(collection.getOutputFields().get("duration"));
-      if (collection.getOutputFields().containsKey(DublinCore.PROPERTY_IDENTIFIER.getLocalName()))
-        collection.removeField(collection.getOutputFields().get(DublinCore.PROPERTY_IDENTIFIER.getLocalName()));
-      if (collection.getOutputFields().containsKey(DublinCore.PROPERTY_SOURCE.getLocalName()))
-        collection.removeField(collection.getOutputFields().get(DublinCore.PROPERTY_SOURCE.getLocalName()));
-      if (collection.getOutputFields().containsKey("startDate"))
-        collection.removeField(collection.getOutputFields().get("startDate"));
-      if (collection.getOutputFields().containsKey("startTime"))
-        collection.removeField(collection.getOutputFields().get("startTime"));
-      if (collection.getOutputFields().containsKey("location"))
-        collection.removeField(collection.getOutputFields().get("location"));
+    MetadataList metadataList = new MetadataList();
 
-      if (collection.getOutputFields().containsKey(DublinCore.PROPERTY_PUBLISHER.getLocalName())) {
-        MetadataField publisher = collection.getOutputFields().get(DublinCore.PROPERTY_PUBLISHER.getLocalName());
-        Map<String, String> users = new HashMap<String, String>();
-        if (publisher.getCollection() != null) {
-          users = publisher.getCollection();
-        }
-        String loggedInUser = getSecurityService().getUser().getName();
-        if (!users.containsKey(loggedInUser)) {
-          users.put(loggedInUser, loggedInUser);
-        }
-        publisher.setValue(loggedInUser);
+    // Common metadata
+    EventCatalogUIAdapter commonCatalogUiAdapter = getIndexService().getCommonEventCatalogUIAdapter();
+    DublinCoreMetadataCollection commonMetadata = commonCatalogUiAdapter.getRawFields(getCollectionQueryOverrides());
+
+    if (commonMetadata.getOutputFields().containsKey(DublinCore.PROPERTY_CREATED.getLocalName()))
+      commonMetadata.removeField(commonMetadata.getOutputFields().get(DublinCore.PROPERTY_CREATED.getLocalName()));
+    if (commonMetadata.getOutputFields().containsKey("duration"))
+      commonMetadata.removeField(commonMetadata.getOutputFields().get("duration"));
+    if (commonMetadata.getOutputFields().containsKey(DublinCore.PROPERTY_IDENTIFIER.getLocalName()))
+      commonMetadata.removeField(commonMetadata.getOutputFields().get(DublinCore.PROPERTY_IDENTIFIER.getLocalName()));
+    if (commonMetadata.getOutputFields().containsKey(DublinCore.PROPERTY_SOURCE.getLocalName()))
+      commonMetadata.removeField(commonMetadata.getOutputFields().get(DublinCore.PROPERTY_SOURCE.getLocalName()));
+    if (commonMetadata.getOutputFields().containsKey("startDate"))
+      commonMetadata.removeField(commonMetadata.getOutputFields().get("startDate"));
+    if (commonMetadata.getOutputFields().containsKey("startTime"))
+      commonMetadata.removeField(commonMetadata.getOutputFields().get("startTime"));
+    if (commonMetadata.getOutputFields().containsKey("location"))
+      commonMetadata.removeField(commonMetadata.getOutputFields().get("location"));
+
+    // Set publisher to user
+    if (commonMetadata.getOutputFields().containsKey(DublinCore.PROPERTY_PUBLISHER.getLocalName())) {
+      MetadataField publisher = commonMetadata.getOutputFields().get(DublinCore.PROPERTY_PUBLISHER.getLocalName());
+      Map<String, String> users = new HashMap<>();
+      if (publisher.getCollection() != null) {
+        users = publisher.getCollection();
       }
-
-      if (getOnlySeriesWithWriteAccessEventModal()) {
-        MetadataField seriesField = collection.getOutputFields().get(DublinCore.PROPERTY_IS_PART_OF.getLocalName());
-        if (seriesField != null) {
-          seriesField.setCollection(getSeriesEndpoint().getUserSeriesByAccess(true));
-        }
+      String loggedInUser = getSecurityService().getUser().getName();
+      if (!users.containsKey(loggedInUser)) {
+        users.put(loggedInUser, loggedInUser);
       }
-
-      metadataList.add(getIndexService().getCommonEventCatalogUIAdapter(), collection);
+      publisher.setValue(loggedInUser);
     }
+
+    metadataList.add(commonCatalogUiAdapter, commonMetadata);
+
+    // Extended metadata
+    List<EventCatalogUIAdapter> extendedCatalogUIAdapters = getIndexService().getExtendedEventCatalogUIAdapters();
+    for (EventCatalogUIAdapter extendedCatalogUIAdapter : extendedCatalogUIAdapters) {
+      metadataList.add(extendedCatalogUIAdapter, extendedCatalogUIAdapter.getRawFields());
+    }
+
     return okJson(MetadataJson.listToJson(metadataList, true));
   }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ListProvidersEndpoint.java
@@ -205,7 +205,7 @@ public class ListProvidersEndpoint {
   public Response getFilters(@PathParam("page") final String page, @Context HttpHeaders headers)
           throws ListProviderException {
 
-    ResourceListQuery query = new ResourceListQueryImpl();
+    ResourceListQuery query;
 
     if ("series".equals(page)) {
       query = new SeriesListQuery();
@@ -236,7 +236,7 @@ public class ListProvidersEndpoint {
       if ("events".equals(page) && seriesEndpoint.getOnlySeriesWithWriteAccessEventsFilter()) {
         Map<String, String> seriesWriteAccess = seriesEndpoint.getUserSeriesByAccess(true);
         return RestUtils.okJson(JSONUtils.filtersToJSONSeriesWriteAccess(query, listProvidersService,
-                securityService.getOrganization(), seriesWriteAccess));
+                seriesWriteAccess));
       } else {
         return RestUtils.okJson(JSONUtils.filtersToJSON(query, listProvidersService, securityService.getOrganization()));
       }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -69,6 +69,7 @@ import org.opencastproject.elasticsearch.index.theme.IndexTheme;
 import org.opencastproject.elasticsearch.index.theme.ThemeSearchQuery;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.exception.IndexServiceException;
+import org.opencastproject.index.service.resources.list.provider.SeriesListProvider;
 import org.opencastproject.index.service.resources.list.query.SeriesListQuery;
 import org.opencastproject.index.service.util.RestUtils;
 import org.opencastproject.list.api.ListProviderException;
@@ -697,15 +698,6 @@ public class SeriesEndpoint implements ManagedService {
    *         depending on the parameter
    */
   public Map<String, String> getUserSeriesByAccess(boolean writeAccess) {
-    String listProviderName = null;
-    MetadataField seriesMetadataField = indexService.getCommonEventCatalogUIAdapter().getRawFields().getOutputFields()
-        .get(DublinCore.PROPERTY_IS_PART_OF.getLocalName());
-    if (seriesMetadataField != null && StringUtils.isNotEmpty(seriesMetadataField.getListprovider())) {
-      listProviderName = seriesMetadataField.getListprovider();
-    }
-    if (StringUtils.isEmpty(listProviderName)) {
-      listProviderName = "SERIES";
-    }
     SeriesListQuery query = new SeriesListQuery();
     if (writeAccess) {
       query.withoutPermissions();
@@ -713,7 +705,7 @@ public class SeriesEndpoint implements ManagedService {
       query.withWritePermission(true);
     }
     try {
-      return listProvidersService.getList(listProviderName, query, true);
+      return listProvidersService.getList(SeriesListProvider.PROVIDER_PREFIX, query, true);
     } catch (ListProviderException e) {
       logger.warn("Could not perform search query.", e);
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -531,6 +531,7 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
     EasyMock.expect(indexService.getSeries("seriesId", searchIndex)).andReturn(Opt.some(series)).anyTimes();
     EasyMock.expect(indexService.getEventMediapackage(event)).andReturn(mp1).anyTimes();
     EasyMock.expect(indexService.getEventCatalogUIAdapters()).andReturn(eventCatalogAdapterList).anyTimes();
+    EasyMock.expect(indexService.getExtendedEventCatalogUIAdapters()).andReturn(Collections.emptyList()).anyTimes();
     EasyMock.expect(indexService.getCommonEventCatalogUIAdapter()).andReturn(eventCatalogAdapterList.get(0)).anyTimes();
     EasyMock.expect(indexService.getEventSource(event)).andReturn(Source.SCHEDULE).anyTimes();
     EasyMock.expect(indexService.getEventSource(event2)).andReturn(Source.ARCHIVE).anyTimes();

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestSeriesEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestSeriesEndpoint.java
@@ -227,7 +227,6 @@ public class TestSeriesEndpoint extends SeriesEndpoint {
 
     IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
     indexServiceImpl.addCatalogUIAdapter(dublinCoreAdapter);
-    indexServiceImpl.setCommonSeriesCatalogUIAdapter(dublinCoreAdapter);
     indexServiceImpl.setSecurityService(securityService);
     indexServiceImpl.setSeriesService(seriesService);
 

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/CatalogUIAdapter.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/CatalogUIAdapter.java
@@ -20,7 +20,10 @@
  */
 package org.opencastproject.metadata.dublincore;
 
+import org.opencastproject.list.api.ResourceListQuery;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+
+import java.util.Map;
 
 /**
  * A {@link CatalogUIAdapter} converts between a concrete {@link org.opencastproject.metadata.api.MetadataCatalog}
@@ -55,5 +58,15 @@ public interface CatalogUIAdapter {
    * @return The fields with raw data
    */
   DublinCoreMetadataCollection getRawFields();
+
+  /**
+   * Returns all fields of this catalog in a raw data format. Allows to hand over custom queries to fill the collection
+   * of a metadata field (defined by its output id) from a list provider.
+   *
+   * @param collectionQueryOverrides
+   *          A map of custom list provider queries mapped to metadata fields by the output id. Can be empty.
+   * @return The fields with raw data
+   */
+  DublinCoreMetadataCollection getRawFields(Map<String, ResourceListQuery> collectionQueryOverrides);
 
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
@@ -289,6 +289,12 @@ public interface IndexService {
   List<EventCatalogUIAdapter> getEventCatalogUIAdapters();
 
   /**
+   * @return A {@link List} of extended {@link EventCatalogUIAdapter} that provide the metadata to the front end.
+   * Does not contain the common {@link EventCatalogUIAdapter}.
+   */
+  List<EventCatalogUIAdapter> getExtendedEventCatalogUIAdapters();
+
+  /**
    * @return the common {@link EventCatalogUIAdapter}
    */
   EventCatalogUIAdapter getCommonEventCatalogUIAdapter();

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -452,6 +452,14 @@ public class IndexServiceImpl implements IndexService {
   }
 
   @Override
+  public List<EventCatalogUIAdapter> getExtendedEventCatalogUIAdapters() {
+    List<EventCatalogUIAdapter> catalogUiAdapters = new ArrayList<>(
+            getEventCatalogUIAdapters(securityService.getOrganization().getId()));
+    catalogUiAdapters.remove(getCommonEventCatalogUIAdapter());
+    return catalogUiAdapters;
+  }
+
+  @Override
   public List<SeriesCatalogUIAdapter> getSeriesCatalogUIAdapters() {
     return new LinkedList<>(getSeriesCatalogUIAdapters(securityService.getOrganization().getId()));
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -122,8 +122,6 @@ import org.opencastproject.workflow.api.WorkflowService;
 import org.opencastproject.workflow.api.WorkflowSet;
 import org.opencastproject.workspace.api.Workspace;
 
-import com.entwinemedia.fn.Fn2;
-import com.entwinemedia.fn.Stream;
 import com.entwinemedia.fn.data.Opt;
 import com.google.common.net.MediaType;
 
@@ -170,6 +168,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -198,9 +197,6 @@ public class IndexServiceImpl implements IndexService {
   private Pattern patternCatalog = Pattern.compile(catalogRegex);
   private Pattern patternTrack = Pattern.compile(trackRegex);
   private Pattern patternNumberedAsset = Pattern.compile(numberedAssetRegex);
-
-  private EventCatalogUIAdapter eventCatalogUIAdapter;
-  private SeriesCatalogUIAdapter seriesCatalogUIAdapter;
 
   private AclServiceFactory aclServiceFactory;
   private AuthorizationService authorizationService;
@@ -259,26 +255,6 @@ public class IndexServiceImpl implements IndexService {
    */
   public void setEventCommentService(EventCommentService eventCommentService) {
     this.eventCommentService = eventCommentService;
-  }
-
-  /**
-   * OSGi callback to add the event dublincore {@link EventCatalogUIAdapter} instance.
-   *
-   * @param eventCatalogUIAdapter
-   *          the adapter to set
-   */
-  public void setCommonEventCatalogUIAdapter(CommonEventCatalogUIAdapter eventCatalogUIAdapter) {
-    this.eventCatalogUIAdapter = eventCatalogUIAdapter;
-  }
-
-  /**
-   * OSGi callback to add the series dublincore {@link SeriesCatalogUIAdapter} instance.
-   *
-   * @param seriesCatalogUIAdapter
-   *          the adapter to set
-   */
-  public void setCommonSeriesCatalogUIAdapter(CommonSeriesCatalogUIAdapter seriesCatalogUIAdapter) {
-    this.seriesCatalogUIAdapter = seriesCatalogUIAdapter;
   }
 
   /**
@@ -419,22 +395,9 @@ public class IndexServiceImpl implements IndexService {
     return aclServiceFactory.serviceFor(securityService.getOrganization());
   }
 
-  private static final Fn2<EventCatalogUIAdapter, String, Boolean> eventOrganizationFilter = new Fn2<EventCatalogUIAdapter, String, Boolean>() {
-    @Override
-    public Boolean apply(EventCatalogUIAdapter catalogUIAdapter, String organization) {
-      return organization.equals(catalogUIAdapter.getOrganization());
-    }
-  };
-
-  private static final Fn2<SeriesCatalogUIAdapter, String, Boolean> seriesOrganizationFilter = new Fn2<SeriesCatalogUIAdapter, String, Boolean>() {
-    @Override
-    public Boolean apply(SeriesCatalogUIAdapter catalogUIAdapter, String organization) {
-      return catalogUIAdapter.getOrganization().equals(organization);
-    }
-  };
-
   public List<EventCatalogUIAdapter> getEventCatalogUIAdapters(String organization) {
-    return Stream.$(eventCatalogUIAdapters).filter(eventOrganizationFilter._2(organization)).toList();
+    return eventCatalogUIAdapters.stream().filter(a -> organization.equals(a.getOrganization()))
+            .collect(Collectors.toList());
   }
 
   /**
@@ -443,7 +406,18 @@ public class IndexServiceImpl implements IndexService {
    * @return A {@link List} of {@link SeriesCatalogUIAdapter} that provide the metadata to the front end.
    */
   public List<SeriesCatalogUIAdapter> getSeriesCatalogUIAdapters(String organization) {
-    return Stream.$(seriesCatalogUIAdapters).filter(seriesOrganizationFilter._2(organization)).toList();
+    return seriesCatalogUIAdapters.stream().filter(a -> organization.equals(a.getOrganization()))
+            .collect(Collectors.toList());
+  }
+
+  public EventCatalogUIAdapter getCommonEventCatalogUIAdapter(String organization) {
+    return eventCatalogUIAdapters.stream().filter(a -> a instanceof CommonEventCatalogUIAdapter)
+            .filter(a -> organization.equals(a.getOrganization())).collect(Collectors.toList()).get(0);
+  }
+
+  public SeriesCatalogUIAdapter getCommonSeriesCatalogUIAdapter(String organization) {
+    return seriesCatalogUIAdapters.stream().filter(a -> a instanceof CommonSeriesCatalogUIAdapter)
+            .filter(a -> organization.equals(a.getOrganization())).collect(Collectors.toList()).get(0);
   }
 
   @Override
@@ -453,10 +427,9 @@ public class IndexServiceImpl implements IndexService {
 
   @Override
   public List<EventCatalogUIAdapter> getExtendedEventCatalogUIAdapters() {
-    List<EventCatalogUIAdapter> catalogUiAdapters = new ArrayList<>(
-            getEventCatalogUIAdapters(securityService.getOrganization().getId()));
-    catalogUiAdapters.remove(getCommonEventCatalogUIAdapter());
-    return catalogUiAdapters;
+    String organization = securityService.getOrganization().getId();
+    return eventCatalogUIAdapters.stream().filter(a -> !(a instanceof CommonEventCatalogUIAdapter))
+            .filter(a -> organization.equals(a.getOrganization())).collect(Collectors.toList());
   }
 
   @Override
@@ -466,12 +439,12 @@ public class IndexServiceImpl implements IndexService {
 
   @Override
   public EventCatalogUIAdapter getCommonEventCatalogUIAdapter() {
-    return eventCatalogUIAdapter;
+    return getCommonEventCatalogUIAdapter(securityService.getOrganization().getId());
   }
 
   @Override
   public SeriesCatalogUIAdapter getCommonSeriesCatalogUIAdapter() {
-    return seriesCatalogUIAdapter;
+    return getCommonSeriesCatalogUIAdapter(securityService.getOrganization().getId());
   }
 
   public void activate(ComponentContext cc) {
@@ -860,7 +833,7 @@ public class IndexServiceImpl implements IndexService {
     SourceType type = getSourceType(eventHttpServletRequest.getSource().get());
 
     DublinCoreMetadataCollection eventMetadata = eventHttpServletRequest.getMetadataList().get()
-            .getMetadataByAdapter(eventCatalogUIAdapter);
+            .getMetadataByAdapter(getCommonEventCatalogUIAdapter());
 
     Date currentStartDate = null;
     JSONObject sourceMetadata = (JSONObject) eventHttpServletRequest.getSource().get().get("metadata");
@@ -913,7 +886,7 @@ public class IndexServiceImpl implements IndexService {
       presenterUsernames = technicalPresenters.get();
     }
 
-    eventHttpServletRequest.getMetadataList().get().add(eventCatalogUIAdapter, eventMetadata);
+    eventHttpServletRequest.getMetadataList().get().add(getCommonEventCatalogUIAdapter(), eventMetadata);
     updateMediaPackageMetadata(eventHttpServletRequest.getMediaPackage().get(),
             eventHttpServletRequest.getMetadataList().get());
 
@@ -2027,17 +2000,6 @@ public class IndexServiceImpl implements IndexService {
   }
 
   /**
-   * @return A {@link MetadataList} with only the common SeriesCatalogUIAdapter's empty {@link DublinCoreMetadataCollection}
-   *         available
-   */
-  private MetadataList getMetadataListWithCommonSeriesCatalogUIAdapters() {
-    MetadataList metadataList = new MetadataList();
-    metadataList.add(seriesCatalogUIAdapter.getFlavor().toString(), seriesCatalogUIAdapter.getUITitle(),
-            seriesCatalogUIAdapter.getRawFields());
-    return metadataList;
-  }
-
-  /**
    * @return A {@link MetadataList} with all of the available CatalogUIAdapters empty {@link DublinCoreMetadataCollection}
    *         available
    */
@@ -2047,12 +2009,6 @@ public class IndexServiceImpl implements IndexService {
     for (SeriesCatalogUIAdapter adapter : getSeriesCatalogUIAdapters()) {
       metadataList.add(adapter.getFlavor().toString(), adapter.getUITitle(), adapter.getRawFields());
     }
-    return metadataList;
-  }
-
-  private MetadataList getMetadataListWithCommonEventCatalogUIAdapter() {
-    MetadataList metadataList = new MetadataList();
-    metadataList.add(eventCatalogUIAdapter, eventCatalogUIAdapter.getRawFields());
     return metadataList;
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventUtils.java
@@ -35,6 +35,7 @@ import com.entwinemedia.fn.Fn;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -62,13 +63,28 @@ public final class EventUtils {
    * @param event
    *          the source {@link Event}
    * @return a {@link DublinCoreMetadataCollection} instance with all the event metadata
+   *
+   * @throws ParseException
    */
   public static DublinCoreMetadataCollection getEventMetadata(Event event, EventCatalogUIAdapter eventCatalogUIAdapter)
-          throws Exception {
-    //copy metadata collection to avoid side effects
+          throws ParseException {
     DublinCoreMetadataCollection eventMetadata = new DublinCoreMetadataCollection(eventCatalogUIAdapter.getRawFields());
+    setEventMetadataValues(event, eventMetadata);
+    return eventMetadata;
+  }
 
-    //match event get methods to correct output fields
+  /**
+   * Set values of metadata fields from event.
+   *
+   * @param event
+   *          the {@link Event} from the index
+   * @param eventMetadata
+   *          a {@link DublinCoreMetadataCollection} to be modified
+   *
+   * @throws ParseException
+   */
+  public static void setEventMetadataValues(Event event, DublinCoreMetadataCollection eventMetadata)
+          throws ParseException {
     for (MetadataField field: eventMetadata.getOutputFields().values()) {
       if (field.getOutputID().equals(DublinCore.PROPERTY_TITLE.getLocalName())) {
         field.setValue(event.getTitle());
@@ -132,8 +148,6 @@ public final class EventUtils {
         }
       }
     }
-
-    return eventMetadata;
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
@@ -42,7 +42,6 @@ public class EventsListProvider implements ResourceListProvider {
   public static final String PRESENTERS_TECHNICAL = PROVIDER_PREFIX + ".PRESENTERS_TECHNICAL";
   public static final String SUBJECT = PROVIDER_PREFIX + ".SUBJECT";
   public static final String LOCATION = PROVIDER_PREFIX + ".LOCATION";
-  public static final String START_DATE = PROVIDER_PREFIX + ".START_DATE";
   public static final String PROGRESS = PROVIDER_PREFIX + ".PROGRESS";
   public static final String STATUS = PROVIDER_PREFIX + ".STATUS";
   public static final String COMMENTS = PROVIDER_PREFIX + ".COMMENTS";

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
@@ -62,11 +62,8 @@ public class SeriesListProvider implements ResourceListProvider {
   public static final String TITLE = PROVIDER_PREFIX + ".TITLE";
   public static final String TITLE_EXTENDED = PROVIDER_PREFIX + ".TITLE_EXTENDED";
   public static final String LANGUAGE = PROVIDER_PREFIX + ".LANGUAGE";
-  public static final String CREATOR = PROVIDER_PREFIX + ".CREATOR";
   public static final String ORGANIZERS = PROVIDER_PREFIX + ".ORGANIZERS";
   public static final String LICENSE = PROVIDER_PREFIX + ".LICENSE";
-  public static final String ACCESS_POLICY = PROVIDER_PREFIX + ".ACCESS_POLICY";
-  public static final String CREATION_DATE = PROVIDER_PREFIX + ".CREATION_DATE";
 
   private static final String[] NAMES = { PROVIDER_PREFIX, CONTRIBUTORS, ORGANIZERS, TITLE_EXTENDED };
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/AclsListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/AclsListQuery.java
@@ -45,7 +45,6 @@ public class AclsListQuery extends ResourceListQueryImpl {
 
   public AclsListQuery() {
     super();
-    this.availableFilters.add(createNameFilter(Option.<String> none()));
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/AgentsListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/AgentsListQuery.java
@@ -51,7 +51,6 @@ public class AgentsListQuery extends ResourceListQueryImpl {
 
   public AgentsListQuery() {
     super();
-    this.availableFilters.add(createNameFilter(Option.<String> none()));
     this.availableFilters.add(createStatusFilter(Option.<String> none()));
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
@@ -89,16 +89,16 @@ public class EventListQuery extends ResourceListQueryImpl {
 
   public EventListQuery() {
     super();
-    this.availableFilters.add(createSeriesFilter(Option.<String> none()));
-    this.availableFilters.add(createPresentersFilter(Option.<String> none()));
-    this.availableFilters.add(createTechnicalPresentersFilter(Option.<String> none()));
-    this.availableFilters.add(createContributorsFilter(Option.<String> none()));
-    this.availableFilters.add(createLocationFilter(Option.<String> none()));
-    this.availableFilters.add(createAgentFilter(Option.<String> none()));
-    this.availableFilters.add(createStartDateFilter(Option.<Tuple<Date, Date>> none()));
-    this.availableFilters.add(createStatusFilter(Option.<String> none()));
-    this.availableFilters.add(createCommentsFilter(Option.<String> none()));
-    this.availableFilters.add(createPublisherFilter(Option.<String> none()));
+    this.availableFilters.add(createSeriesFilter(Option.none()));
+    this.availableFilters.add(createPresentersFilter(Option.none()));
+    this.availableFilters.add(createTechnicalPresentersFilter(Option.none()));
+    this.availableFilters.add(createContributorsFilter(Option.none()));
+    this.availableFilters.add(createLocationFilter(Option.none()));
+    this.availableFilters.add(createAgentFilter(Option.none()));
+    this.availableFilters.add(createStartDateFilter(Option.none()));
+    this.availableFilters.add(createStatusFilter(Option.none()));
+    this.availableFilters.add(createCommentsFilter(Option.none()));
+    this.availableFilters.add(createPublisherFilter(Option.none()));
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
@@ -90,15 +90,11 @@ public class EventListQuery extends ResourceListQueryImpl {
   public EventListQuery() {
     super();
     this.availableFilters.add(createSeriesFilter(Option.none()));
-    this.availableFilters.add(createPresentersFilter(Option.none()));
-    this.availableFilters.add(createTechnicalPresentersFilter(Option.none()));
-    this.availableFilters.add(createContributorsFilter(Option.none()));
     this.availableFilters.add(createLocationFilter(Option.none()));
     this.availableFilters.add(createAgentFilter(Option.none()));
     this.availableFilters.add(createStartDateFilter(Option.none()));
     this.availableFilters.add(createStatusFilter(Option.none()));
     this.availableFilters.add(createCommentsFilter(Option.none()));
-    this.availableFilters.add(createPublisherFilter(Option.none()));
   }
 
   /**
@@ -403,7 +399,7 @@ public class EventListQuery extends ResourceListQueryImpl {
    */
   public static ResourceListFilter<Tuple<Date, Date>> createStartDateFilter(Option<Tuple<Date, Date>> period) {
     return FiltersUtils.generateFilter(period, FILTER_STARTDATE_NAME, FILTER_STARTDATE_LABEL, SourceType.PERIOD,
-            Option.some(EventsListProvider.START_DATE));
+            Option.none());
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/GroupsListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/GroupsListQuery.java
@@ -47,7 +47,6 @@ public class GroupsListQuery extends ResourceListQueryImpl {
 
   public GroupsListQuery() {
     super();
-    this.availableFilters.add(createNameFilter(Option.<String> none()));
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/SeriesListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/SeriesListQuery.java
@@ -86,9 +86,7 @@ public class SeriesListQuery extends ResourceListQueryImpl {
 
   public SeriesListQuery() {
     super();
-    this.availableFilters.add(createContributorsFilter(Option.<String> none()));
     this.availableFilters.add(createCreationDateFilter(Option.<Tuple<Date, Date>> none()));
-    this.availableFilters.add(createOrganizersFilter(Option.<String> none()));
   }
 
   /**
@@ -344,7 +342,7 @@ public class SeriesListQuery extends ResourceListQueryImpl {
    */
   public static ResourceListFilter<Tuple<Date, Date>> createCreationDateFilter(Option<Tuple<Date, Date>> period) {
     return FiltersUtils.generateFilter(period, FILTER_CREATIONDATE_NAME, FILTER_CREATIONDATE_LABEL, SourceType.PERIOD,
-            Option.some(SeriesListProvider.CREATION_DATE));
+            Option.none());
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/ThemesListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/ThemesListQuery.java
@@ -45,7 +45,6 @@ public class ThemesListQuery extends ResourceListQueryImpl {
 
   public ThemesListQuery() {
     super();
-    this.availableFilters.add(createCreatorFilter(Option.<String> none()));
   }
 
   /**

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/UsersListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/UsersListQuery.java
@@ -53,8 +53,6 @@ public class UsersListQuery extends ResourceListQueryImpl {
 
   public UsersListQuery() {
     super();
-    this.availableFilters.add(createNameFilter(Option.<String> none()));
-    this.availableFilters.add(createRoleFilter(Option.<String> none()));
     this.availableFilters.add(createProviderFilter(Option.<String> none()));
   }
 

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/util/JSONUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/util/JSONUtils.java
@@ -169,8 +169,6 @@ public final class JSONUtils {
    *          The {@link ResourceListQuery}
    * @param listProvidersService
    *          The {@link ListProvidersService} to get the possible values
-   * @param org
-   *          The {@link Organization}
    * @param series
    *          The Series with write access
    * @return
@@ -178,14 +176,11 @@ public final class JSONUtils {
    *           if the possible values can not be retrieved correctly from the list provider.
    */
   public static JValue filtersToJSONSeriesWriteAccess(ResourceListQuery query, ListProvidersService listProvidersService,
-          Organization org, Map<String, String> series) throws ListProviderException {
+          Map<String, String> series) throws ListProviderException {
 
-    List<Field> filtersJSON = new ArrayList<Field>();
-    List<Field> fields = null;
-    List<ResourceListFilter<?>> filters = query.getAvailableFilters();
-
-    for (ResourceListFilter<?> filter : filters) {
-      fields = new ArrayList<Field>();
+    List<Field> filtersJSON = new ArrayList<>();
+    for (ResourceListFilter<?> filter : query.getAvailableFilters()) {
+      List<Field> fields = new ArrayList<>();
 
       fields.add(f("type", v(filter.getSourceType().toString().toLowerCase())));
       fields.add(f("label", v(filter.getLabel())));

--- a/modules/index-service/src/main/resources/OSGI-INF/index_service.xml
+++ b/modules/index-service/src/main/resources/OSGI-INF/index_service.xml
@@ -25,11 +25,6 @@
              cardinality="1..1"
              policy="static"
              bind="setCaptureAgentStateService"/>
-  <reference name="CommonEventCatalogUIAdapter"
-             interface="org.opencastproject.index.service.catalog.adapter.events.CommonEventCatalogUIAdapter"
-             cardinality="1..1"
-             policy="static"
-             bind="setCommonEventCatalogUIAdapter"/>
   <reference name="EventCatalogUIAdapter"
              interface="org.opencastproject.metadata.dublincore.EventCatalogUIAdapter"
              cardinality="0..n"
@@ -66,11 +61,6 @@
              cardinality="1..1"
              policy="static"
              bind="setSecurityService"/>
-  <reference name="CommonSeriesCatalogUIAdapter"
-             interface="org.opencastproject.index.service.catalog.adapter.series.CommonSeriesCatalogUIAdapter"
-             cardinality="1..1"
-             policy="static"
-             bind="setCommonSeriesCatalogUIAdapter"/>
   <reference name="SeriesCatalogUIAdapter"
              interface="org.opencastproject.metadata.dublincore.SeriesCatalogUIAdapter"
              cardinality="0..n"

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -382,7 +382,6 @@ public class IndexServiceImplTest {
     IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
     indexServiceImpl.setAuthorizationService(setupAuthorizationService(mediapackage));
     indexServiceImpl.setIngestService(ingestService);
-    indexServiceImpl.setCommonEventCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.addCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.setUserDirectoryService(noUsersUserDirectoryService);
     indexServiceImpl.setSecurityService(securityService);
@@ -469,7 +468,6 @@ public class IndexServiceImplTest {
     IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
     indexServiceImpl.setAuthorizationService(setupAuthorizationService(mediapackage));
     indexServiceImpl.setIngestService(ingestService);
-    indexServiceImpl.setCommonEventCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.addCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.setUserDirectoryService(noUsersUserDirectoryService);
     indexServiceImpl.setSecurityService(securityService);
@@ -562,7 +560,6 @@ public class IndexServiceImplTest {
     IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
     indexServiceImpl.setAuthorizationService(setupAuthorizationService(mediapackage));
     indexServiceImpl.setIngestService(ingestService);
-    indexServiceImpl.setCommonEventCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.addCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.setSecurityService(securityService);
     indexServiceImpl.setUserDirectoryService(noUsersUserDirectoryService);
@@ -720,7 +717,6 @@ public class IndexServiceImplTest {
     IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
     indexServiceImpl.setAuthorizationService(setupAuthorizationService(mediapackage));
     indexServiceImpl.setIngestService(setupIngestService(mediapackage, Capture.<InputStream> newInstance()));
-    indexServiceImpl.setCommonEventCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.addCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.setSecurityService(securityService);
     indexServiceImpl.setUserDirectoryService(noUsersUserDirectoryService);
@@ -884,7 +880,6 @@ public class IndexServiceImplTest {
     IndexServiceImpl indexService = new IndexServiceImpl();
     indexService.setSecurityService(securityService);
     indexService.setSchedulerService(schedulerService);
-    indexService.setCommonEventCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexService.addCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexService.setSeriesService(seriesService);
     indexService.setWorkspace(workspace);
@@ -1055,7 +1050,7 @@ public class IndexServiceImplTest {
     IndexServiceImpl indexServiceImpl = new IndexServiceImpl();
     CommonEventCatalogUIAdapter commonEventCatalogUIAdapter = new CommonEventCatalogUIAdapter();
     commonEventCatalogUIAdapter.updated(properties);
-    indexServiceImpl.setCommonEventCatalogUIAdapter(commonEventCatalogUIAdapter);
+    indexServiceImpl.addCatalogUIAdapter(commonEventCatalogUIAdapter);
     indexServiceImpl.setUserDirectoryService(userDirectoryService);
     indexServiceImpl.setSecurityService(securityService);
 


### PR DESCRIPTION
This PR contains multiple changes to improve the performance of the admin UI for bigger systems (in this case SWITCH).

The commits in detail:
1. When loading the metadata for new or existing events, fill the series collection only once, since this might take a while if you have lots of series. To do this, we hand over a custom list provider query if we only want to show series with write access.
2. Don't load event metadata just to get the series list provider for a query, since this fills all of the metadata collections, which is expensive. Instead, just get depend on the series list provider explicitly.
3. Some aesthetic improvements suggested by Intellij, including removal of unused parameters.
4. Remove some filters for the Admin UI tables. _This change might be controversial._  This removes either filters I deemed unnecessary (mostly name filters - why list all of the names in a drop down when they are right there in the table, and can be filtered with the search field?)  or that are very expensive (all filters that list all users or roles in the system). All of these fields should still be searchable with a full text query in the search field. This will result in some tables (e.g. ACL templates) to not have filters at all.
5. The last is a bug fix for multi tenant systems that was necessary to get this to work, since I earlier changed the order of loading common and extended metadata. With this change, we will get and set the common UI catalog adapters in the index service by organization, instead of overwriting the one adapter again and again so the last organization to be loaded "wins".

Since these changes build up on each other, I would rather not split them apart. They are contained in separate commits, so I think they are still easy enough to review. However, I could file No. 4 separately if it's not deemed appropriate for a minor release.