### PR TITLE
Fix NullPointerException in `CachedJWT` if `exp` claim does not exist

### DIFF
--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/CachedJWT.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/CachedJWT.java
@@ -57,7 +57,7 @@ public class CachedJWT {
    * @return Boolean indicating whether the cached JWT has expired.
    */
   public boolean hasExpired() {
-    return !this.expiresAt.after(new Date());
+    return this.expiresAt != null && !this.expiresAt.after(new Date());
   }
 
   /**

--- a/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTGenerator.java
+++ b/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTGenerator.java
@@ -132,6 +132,21 @@ public final class JWTGenerator {
     );
   }
 
+  public String generateValidNonExpiringSymmetricJWT() {
+    return generateValidNonExpiringJWT(getSymmetricAlgorithm());
+  }
+
+  private String generateValidNonExpiringJWT(Algorithm algorithm) {
+    return JWT.create()
+        .withIssuer(issuer)
+        .withAudience(clientId)
+        .withClaim(usernameKey, username)
+        .withClaim(nameKey, name)
+        .withClaim(emailKey, email)
+        .withClaim(rolesKey, roles)
+        .sign(algorithm);
+  }
+
   public String getUsernameMapping() {
     return "['" + usernameKey + "'].asString()";
   }

--- a/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTLoginTest.java
+++ b/modules/security-jwt/src/test/java/org/opencastproject/security/jwt/JWTLoginTest.java
@@ -306,4 +306,23 @@ public class JWTLoginTest {
     assertNull(username);
   }
 
+  @Test
+  public void testNonExpiringLoginWithCache() {
+    Object username;
+    String jwt = generator.generateValidNonExpiringSymmetricJWT();
+
+    username = authFilter.getPreAuthenticatedPrincipal(
+        mockRequest(jwt)
+    );
+    assertEquals(username, generator.getUsername());
+
+    // Make sure that the cache is used and no calls to the mocked user reference provider are made
+    reset(userReferenceProvider);
+
+    username = authFilter.getPreAuthenticatedPrincipal(
+        mockRequest(jwt)
+    );
+    assertEquals(username, generator.getUsername());
+  }
+
 }


### PR DESCRIPTION
The `exp` claim is optional: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
If it is not present, the token is treated as not having an expiration
time.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
