### PR TITLE
Save Buttons for Metadata

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -733,7 +733,7 @@ angular.module('adminNg.controllers')
 
     $scope.close = function() {
       if (($scope.unsavedChanges([$scope.commonMetadataCatalog]) === false
-           && $scope.unsavedChanges($scope.extendedMetadataCatalogs))
+           && $scope.unsavedChanges($scope.extendedMetadataCatalogs)  === false)
           || confirmUnsaved()) {
         Modal.$scope.close();
       }
@@ -742,9 +742,12 @@ angular.module('adminNg.controllers')
     $scope.unsavedChanges = function(catalogs) {
       if (angular.isDefined(catalogs)) {
         return catalogs.some(function(catalog) {
-          return catalog.fields.some(function(field) {
-            return field.dirty === true;
-          });
+          if (angular.isDefined(catalog)) {
+            return catalog.fields.some(function(field) {
+              return field.dirty === true;
+            });
+          }
+          return false;
         });
       }
       return false;

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -28,15 +28,15 @@ angular.module('adminNg.controllers')
   'EventWorkflowDetailsResource', 'ResourcesListResource', 'RolesResource', 'EventAccessResource',
   'EventPublicationsResource', 'EventSchedulingResource','NewEventProcessingResource', 'CaptureAgentsResource',
   'ConflictCheckResource', 'Language', 'JsHelper', '$sce', '$timeout', 'EventHelperService', 'UploadAssetOptions',
-  'EventUploadAssetResource', 'Table', 'SchedulingHelperService', 'StatisticsReusable',
+  'EventUploadAssetResource', 'Table', 'SchedulingHelperService', 'StatisticsReusable', 'Modal', '$translate',
   function ($scope, Notifications, EventTransactionResource, EventMetadataResource, EventAssetsResource,
     EventAssetCatalogsResource, CommentResource, EventWorkflowsResource, EventWorkflowActionResource,
     EventWorkflowDetailsResource, ResourcesListResource, RolesResource, EventAccessResource,
     EventPublicationsResource, EventSchedulingResource, NewEventProcessingResource, CaptureAgentsResource,
     ConflictCheckResource, Language, JsHelper, $sce, $timeout, EventHelperService, UploadAssetOptions,
-    EventUploadAssetResource, Table, SchedulingHelperService, StatisticsReusable) {
+    EventUploadAssetResource, Table, SchedulingHelperService, StatisticsReusable, Modal, $translate) {
 
-    var saveFns = {},
+    var metadataChangedFns = {},
         me = this,
         NOTIFICATION_CONTEXT = 'events-access',
         SCHEDULING_CONTEXT = 'event-scheduling',
@@ -276,29 +276,37 @@ angular.module('adminNg.controllers')
           });
 
           $scope.metadata =  EventMetadataResource.get({ id: id }, function (metadata) {
-            var episodeCatalogIndex;
+            $scope.extendedMetadataCatalogs = [];
             angular.forEach(metadata.entries, function (catalog, index) {
+              // common metadata
               if (catalog.flavor === mainCatalog) {
-                $scope.episodeCatalog = catalog;
-                episodeCatalogIndex = index;
-                var keepGoing = true;
-                var tabindex = 2;
-                angular.forEach(catalog.fields, function (entry) {
-                  if (entry.id === 'title' && angular.isString(entry.value)) {
-                    $scope.titleParams = { resourceId: entry.value.substring(0,70) };
-                  }
-                  if (keepGoing && entry.locked) {
-                    metadata.locked = entry.locked;
-                    keepGoing = false;
-                  }
-                  entry.tabindex = tabindex ++;
-                });
+                $scope.commonMetadataCatalog = catalog;
+              // extended metadata
+              } else {
+                $scope.extendedMetadataCatalogs.push(catalog);
               }
+
+              // hook up tabindex
+              var tabindex = 2;
+              angular.forEach(catalog.fields, function (entry) {
+                entry.tabindex = tabindex ++;
+                // find title
+                if (catalog.flavor === mainCatalog && entry.id === 'title' && angular.isString(entry.value)) {
+                  $scope.titleParams = { resourceId: entry.value.substring(0,70) };
+                }
+                // metadata locked?
+                if (entry.locked) {
+                  metadata.locked = entry.locked;
+                }
+                // save original values
+                if (entry.value instanceof Array) {
+                  entry.oldValue = entry.value.slice(0);
+                } else {
+                  entry.oldValue = entry.value;
+                }
+              });
             });
 
-            if (angular.isDefined(episodeCatalogIndex)) {
-              metadata.entries.splice(episodeCatalogIndex, 1);
-            }
           });
 
           //<===============================
@@ -430,8 +438,8 @@ angular.module('adminNg.controllers')
 
           $scope.roles = RolesResource.queryNameOnly({limit: -1, target:'ACL' });
 
-          //MH-11716: We have to wait for both the access (series ACL), and the roles (list of system roles)
-          //to resolve before we can add the roles that are present in the series but not in the system
+          //MH-11716: We have to wait for both the access (event ACL), and the roles (list of system roles)
+          //to resolve before we can add the roles that are present in the event but not in the system
           $scope.access.$promise.then(function () {
             $scope.roles.$promise.then(function() {
               angular.forEach(Object.keys($scope.access.episode_access.privileges), function(newRole) {
@@ -694,52 +702,125 @@ angular.module('adminNg.controllers')
 
     // Generate proxy function for the save metadata function based on the given flavor
     // Do not generate it
-    $scope.getSaveFunction = function (flavor) {
-      var fn = saveFns[flavor],
-          catalog;
+    $scope.getMetadataChangedFunction = function (flavor) {
+      var fn = metadataChangedFns[flavor];
+      var catalog;
 
       if (angular.isUndefined(fn)) {
-        if ($scope.episodeCatalog.flavor === flavor) {
-          catalog = $scope.episodeCatalog;
-        } else {
-          angular.forEach($scope.metadata.entries, function (c) {
-            if (flavor === c.flavor) {
-              catalog = c;
-            }
-          });
-        }
+        angular.forEach($scope.metadata.entries, function (c) {
+          if (flavor === c.flavor) {
+            catalog = c;
+          }
+        });
 
         fn = function (id, callback) {
-          $scope.metadataSave(id, callback, catalog);
+          $scope.metadataChanged(id, callback, catalog);
         };
 
-        saveFns[flavor] = fn;
+        metadataChangedFns[flavor] = fn;
       }
       return fn;
     };
 
-    $scope.metadataSave = function (id, callback, catalog) {
-      catalog.attributeToSend = id;
+    $translate('CONFIRMATIONS.WARNINGS.UNSAVED_CHANGES').then(function (translation) {
+      window.unloadConfirmMsg = translation;
+    }).catch(angular.noop);
 
-      if (Object.prototype.hasOwnProperty.call(catalog, 'fields')) {
-        for (var fieldNo in catalog.fields) {
-          var field = catalog.fields[fieldNo];
+    var confirmUnsaved = function() {
+      // eslint-disable-next-line
+      return confirm(window.unloadConfirmMsg);
+    };
 
+    $scope.close = function() {
+      if (($scope.unsavedChanges([$scope.commonMetadataCatalog]) === false
+           && $scope.unsavedChanges($scope.extendedMetadataCatalogs))
+          || confirmUnsaved()) {
+        Modal.$scope.close();
+      }
+    };
+
+    $scope.unsavedChanges = function(catalogs) {
+      if (angular.isDefined(catalogs)) {
+        return catalogs.some(function(catalog) {
+          return catalog.fields.some(function(field) {
+            return field.dirty === true;
+          });
+        });
+      }
+      return false;
+    };
+
+    $scope.metadataChanged = function (id, callback, catalog) {
+      // Mark the saved attribute as dirty
+      angular.forEach(catalog.fields, function (entry) {
+        if (entry.id === id) {
+          if (differentValue(entry)) {
+            entry.dirty = true;
+          } else {
+            entry.dirty = false;
+          }
+        }
+      });
+
+      if (angular.isDefined(callback)) {
+        callback();
+      }
+    };
+
+    var differentValue = function(entry) {
+      if (!entry.value && !entry.oldValue) {
+        return false;
+      }
+
+      if ((!entry.value && entry.oldValue) || (entry.value && !entry.oldValue)) {
+        return true;
+      }
+
+      if (entry.value instanceof Array) {
+        if (entry.value.length != entry.oldValue.length) {
+          return true;
+        }
+        for (var i = 0; i < entry.value.length; i++) {
+          if (entry.value[i] !== entry.oldValue[i]) {
+            return true;
+          }
+        }
+        return false;
+      } else {
+        return (entry.value !== entry.oldValue);
+      }
+    };
+
+    $scope.metadataSave = function (catalogs) {
+      var catalogsWithUnsavedChanges = catalogs.filter(function(catalog) {
+        return catalog.fields.some(function(field) {
+          return field.dirty === true;
+        });
+      });
+
+      catalogsWithUnsavedChanges.forEach(function(catalog) {
+        // don't send collections
+        catalog.fields.forEach(function(field) {
           if (Object.prototype.hasOwnProperty.call(field, 'collection')) {
             field.collection = [];
           }
-        }
-      }
+        });
 
-      EventMetadataResource.save({ id: $scope.resourceId }, catalog,  function () {
-        if (angular.isDefined(callback)) {
-          callback();
-        }
-        // Mark the saved attribute as saved
-        angular.forEach(catalog.fields, function (entry) {
-          if (entry.id === id) {
-            entry.saved = true;
-          }
+        EventMetadataResource.save({ id: $scope.resourceId }, catalog,  function () {
+          var notificationContext = catalog === $scope.commonMetadataCatalog ? 'events-metadata-common'
+            : 'events-metadata-extended';
+          Notifications.add('info', 'SAVED_METADATA', notificationContext, 1200);
+
+          // Unmark entries
+          angular.forEach(catalog.fields, function (entry) {
+            entry.dirty = false;
+            // new original value
+            if (entry.value instanceof Array) {
+              entry.oldValue = entry.value.slice(0);
+            } else {
+              entry.oldValue = entry.value;
+            }
+          });
         });
       });
     };

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -324,7 +324,7 @@ angular.module('adminNg.controllers')
 
     $scope.close = function() {
       if (($scope.unsavedChanges([$scope.commonMetadataCatalog]) === false
-           && $scope.unsavedChanges($scope.extendedMetadataCatalogs))
+           && $scope.unsavedChanges($scope.extendedMetadataCatalogs) === false)
           || confirmUnsaved()) {
         Modal.$scope.close();
       }
@@ -333,9 +333,12 @@ angular.module('adminNg.controllers')
     $scope.unsavedChanges = function(catalogs) {
       if (angular.isDefined(catalogs)) {
         return catalogs.some(function(catalog) {
-          return catalog.fields.some(function(field) {
-            return field.dirty === true;
-          });
+          if (angular.isDefined(catalog)) {
+            return catalog.fields.some(function(field) {
+              return field.dirty === true;
+            });
+          }
+          return false;
         });
       }
       return false;

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -24,11 +24,11 @@
 angular.module('adminNg.controllers')
 .controller('SerieCtrl', ['$scope', 'SeriesMetadataResource', 'SeriesEventsResource', 'SeriesAccessResource',
   'SeriesThemeResource', 'ResourcesListResource', 'RolesResource', 'Notifications', 'AuthService',
-  'StatisticsReusable', '$http',
+  'StatisticsReusable', '$http', 'Modal', '$translate',
   function ($scope, SeriesMetadataResource, SeriesEventsResource, SeriesAccessResource, SeriesThemeResource,
-    ResourcesListResource, RolesResource, Notifications, AuthService, StatisticsReusable, $http) {
+    ResourcesListResource, RolesResource, Notifications, AuthService, StatisticsReusable, $http, Modal, $translate) {
 
-    var saveFns = {}, aclNotification,
+    var metadataChangedFns = {}, aclNotification,
         me = this,
         NOTIFICATION_CONTEXT = 'series-acl',
         mainCatalog = 'dublincore/series', fetchChildResources,
@@ -133,35 +133,46 @@ angular.module('adminNg.controllers')
         previousProviderData);
 
       $scope.metadata = SeriesMetadataResource.get({ id: id }, function (metadata) {
-        var seriesCatalogIndex, keepGoing = true;
+        $scope.extendedMetadataCatalogs = [];
         angular.forEach(metadata.entries, function (catalog, index) {
+          // common metadata
           if (catalog.flavor === mainCatalog) {
-            $scope.seriesCatalog = catalog;
-            seriesCatalogIndex = index;
-            var tabindex = 2;
-            angular.forEach(catalog.fields, function (entry) {
-              if (entry.id === 'title' && angular.isString(entry.value)) {
-                $scope.titleParams = { resourceId: entry.value.substring(0,70) };
-              }
-              if (keepGoing && entry.locked) {
-                metadata.locked = entry.locked;
-                keepGoing = false;
-              }
-              entry.tabindex = tabindex++;
-            });
+            $scope.commonMetadataCatalog = catalog;
+          // extended metadata
+          } else {
+            $scope.extendedMetadataCatalogs.push(catalog);
           }
-        });
 
-        if (angular.isDefined(seriesCatalogIndex)) {
-          metadata.entries.splice(seriesCatalogIndex, 1);
-        }
+          // hook up tab index
+          var tabindex = 2;
+          angular.forEach(catalog.fields, function (entry) {
+            entry.tabindex = tabindex++;
+
+            // find title
+            if (catalog.flavor === mainCatalog && entry.id === 'title' && angular.isString(entry.value)) {
+              $scope.titleParams = { resourceId: entry.value.substring(0,70) };
+            }
+
+            // metadata locked?
+            if (entry.locked) {
+              metadata.locked = entry.locked;
+            }
+
+            // save original values
+            if (entry.value instanceof Array) {
+              entry.oldValue = entry.value.slice(0);
+            } else {
+              entry.oldValue = entry.value;
+            }
+          });
+        });
 
         $http.get('/admin-ng/feeds/feeds')
         .then( function(response) {
           $scope.feedContent = response.data;
-          for (var i = 0; i < $scope.seriesCatalog.fields.length; i++) {
-            if($scope.seriesCatalog.fields[i].id === 'identifier'){
-              $scope.uid = $scope.seriesCatalog.fields[i].value;
+          for (var i = 0; i < $scope.commonMetadataCatalog.fields.length; i++) {
+            if($scope.commonMetadataCatalog.fields[i].id === 'identifier'){
+              $scope.uid = $scope.commonMetadataCatalog.fields[i].value;
             }
           }
           for (var j = 0; j < response.data.length; j++) {
@@ -269,26 +280,22 @@ angular.module('adminNg.controllers')
 
     // Generate proxy function for the save metadata function based on the given flavor
     // Do not generate it
-    $scope.getSaveFunction = function (flavor) {
-      var fn = saveFns[flavor],
-          catalog;
+    $scope.getMetadataChangedFunction = function (flavor) {
+      var fn = metadataChangedFns[flavor];
+      var catalog;
 
       if (angular.isUndefined(fn)) {
-        if ($scope.seriesCatalog.flavor === flavor) {
-          catalog = $scope.seriesCatalog;
-        } else {
-          angular.forEach($scope.metadata.entries, function (c) {
-            if (flavor === c.flavor) {
-              catalog = c;
-            }
-          });
-        }
+        angular.forEach($scope.metadata.entries, function (c) {
+          if (flavor === c.flavor) {
+            catalog = c;
+          }
+        });
 
         fn = function (id, callback) {
-          $scope.metadataSave(id, callback, catalog);
+          $scope.metadataChanged(id, callback, catalog);
         };
 
-        saveFns[flavor] = fn;
+        metadataChangedFns[flavor] = fn;
       }
       return fn;
     };
@@ -306,29 +313,106 @@ angular.module('adminNg.controllers')
       return 'export_series_' + $scope.resourceId + '_' + sanitizedStatsTitle + '.csv';
     };
 
-    $scope.metadataSave = function (id, callback, catalog) {
-      catalog.attributeToSend = id;
+    $translate('CONFIRMATIONS.WARNINGS.UNSAVED_CHANGES').then(function (translation) {
+      window.unloadConfirmMsg = translation;
+    }).catch(angular.noop);
 
-      if (Object.prototype.hasOwnProperty.call(catalog, 'fields')) {
-        for (var fieldNo in catalog.fields) {
-          var field = catalog.fields[fieldNo];
+    var confirmUnsaved = function() {
+      // eslint-disable-next-line
+      return confirm(window.unloadConfirmMsg);
+    };
 
+    $scope.close = function() {
+      if (($scope.unsavedChanges([$scope.commonMetadataCatalog]) === false
+           && $scope.unsavedChanges($scope.extendedMetadataCatalogs))
+          || confirmUnsaved()) {
+        Modal.$scope.close();
+      }
+    };
+
+    $scope.unsavedChanges = function(catalogs) {
+      if (angular.isDefined(catalogs)) {
+        return catalogs.some(function(catalog) {
+          return catalog.fields.some(function(field) {
+            return field.dirty === true;
+          });
+        });
+      }
+      return false;
+    };
+
+    $scope.metadataChanged = function (id, callback, catalog) {
+      // Mark the saved attribute as dirty
+      angular.forEach(catalog.fields, function (entry) {
+        if (entry.id === id) {
+          if (differentValue(entry)) {
+            entry.dirty = true;
+          } else {
+            entry.dirty = false;
+          }
+        }
+      });
+
+      if (angular.isDefined(callback)) {
+        callback();
+      }
+    };
+
+    var differentValue = function(entry) {
+      if (!entry.value && !entry.oldValue) {
+        return false;
+      }
+
+      if ((!entry.value && entry.oldValue) || (entry.value && !entry.oldValue)) {
+        return true;
+      }
+
+      if (entry.value instanceof Array) {
+        if (entry.value.length != entry.oldValue.length) {
+          return true;
+        }
+
+        for (var i = 0; i < entry.value.length; i++) {
+          if (entry.value[i] !== entry.oldValue[i]) {
+            return true;
+          }
+        }
+        return false;
+      } else {
+        return (entry.value !== entry.oldValue);
+      }
+    };
+
+    $scope.metadataSave = function (catalogs) {
+      var catalogsWithUnsavedChanges = catalogs.filter(function(catalog) {
+        return catalog.fields.some(function(field) {
+          return field.dirty === true;
+        });
+      });
+
+      catalogsWithUnsavedChanges.forEach(function(catalog) {
+        // don't send collections
+        catalog.fields.forEach(function(field) {
           if (Object.prototype.hasOwnProperty.call(field, 'collection')) {
             field.collection = [];
           }
-        }
-      }
+        });
 
-      SeriesMetadataResource.save({ id: $scope.resourceId }, catalog,  function () {
-        if (angular.isDefined(callback)) {
-          callback();
-        }
+        SeriesMetadataResource.save({ id: $scope.resourceId }, catalog,  function () {
+          var notificationContext = catalog === $scope.commonMetadataCatalog ? 'series-metadata-common'
+            : 'series-metadata-extended';
+          Notifications.add('info', 'SAVED_METADATA', notificationContext, 1200);
 
-        // Mark the saved attribute as saved
-        angular.forEach(catalog.fields, function (entry) {
-          if (entry.id === id) {
-            entry.saved = true;
-          }
+          // Unmark entries
+          angular.forEach(catalog.fields, function (entry) {
+            entry.dirty = false;
+            // new original value
+            if (entry.value instanceof Array) {
+              entry.oldValue = entry.value.slice(0);
+            } else {
+              entry.oldValue = entry.value;
+            }
+          });
         });
       });
     };

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableBooleanValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableBooleanValue.html
@@ -1,6 +1,6 @@
 <div ng-form="innerForm">
   <i class="edit fa fa-pencil-square"></i>
-  <i class="saved fa fa-check" ng-class="{ active: params.saved }"></i>
+  <i class="changed fa fa-check" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <input type="checkbox"
          ng-model="params.value" ng-change="submit()"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableDateValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableDateValue.html
@@ -1,7 +1,7 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
   &nbsp;<span ng-show="!editMode">{{ params.value | localizeDate:'dateTime'  }}</span>
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
-  <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
+  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <input ng-keyup="keyUp($event)" type="text" datetimepicker
                                   ng-model="params.value" editMode="false" tabindex="{{ params.tabindex }}" select="submit()"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiSelect.html
@@ -6,7 +6,7 @@
   </ul>
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
-  <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
+  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <div class="editable-select" ng-if="editMode">
     <input type="text" ng-blur="onBlur()" ng-required="params.required" tabindex="{{ params.tabindex }}"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiValue.html
@@ -6,7 +6,7 @@
   </ul>
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
-  <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
+  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <div class="editable-select" ng-if="editMode">
     <input type="text" ng-model="data.value"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleSelect.html
@@ -3,7 +3,7 @@
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode && collection.length != 0" ng-focus="enterEditMode()"
      tabindex="{{ collection.length != 0 ? params.tabindex : -1 }}"></i>
-  <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
+  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <div class="editable-select" ng-if="editMode" ng-keyup="keyUp($event)" ng-mousedown="$event.stopPropagation()"
        ng-click="$event.stopPropagation()">

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleValue.html
@@ -3,7 +3,7 @@
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()"
                                                           tabindex="{{ params.tabindex }}" focushere="{{ params.tabindex }}"></i>
-  <i class="saved fa fa-check" ng-show="!editMode" ng-class="{ active: params.saved }"></i>
+  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <textarea ng-keydown="keyDown($event)"
             ng-keyup="keyUp($event)"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -12,7 +12,7 @@
     <a ng-click="openTab('metadata')" data-modal-tab="metadata" ng-class="{ active: tab == 'metadata' }" translate="EVENTS.EVENTS.DETAILS.TABS.METADATA" with-role="ROLE_UI_EVENTS_DETAILS_METADATA_VIEW">
       <!-- Metadata -->
     </a>
-    <a ng-if="metadata.entries.length > 0" ng-click="openTab('extended-metadata')" data-modal-tab="extended-metadata" ng-class="{ active: tab == 'extended-metadata' }" translate="EVENTS.EVENTS.DETAILS.TABS.EXTENDED-METADATA" with-role="ROLE_UI_EVENTS_DETAILS_METADATA_VIEW">
+    <a ng-if="extendedMetadataCatalogs.length > 0" ng-click="openTab('extended-metadata')" data-modal-tab="extended-metadata" ng-class="{ active: tab == 'extended-metadata' }" translate="EVENTS.EVENTS.DETAILS.TABS.EXTENDED-METADATA" with-role="ROLE_UI_EVENTS_DETAILS_METADATA_VIEW">
       <!-- Ext-Metadata -->
     </a>
 
@@ -86,6 +86,7 @@
 
   <div class="modal-content" data-modal-tab-content="metadata">
     <div class="modal-body">
+      <div data-admin-ng-notifications="" context="events-metadata-common"></div>
       <div data-admin-ng-notifications="" context="events-access"></div>
       <div data-admin-ng-notification="" data-type="warning" show="metadata.locked" message="{{ metadata.locked }}"></div>
       <div class="full-col">
@@ -93,14 +94,14 @@
           <header><span translate="EVENTS.EVENTS.DETAILS.METADATA.CAPTION"><!-- Event details --></span></header>
           <div class="obj-container">
             <table class="main-tbl">
-              <tr ng-repeat="(idx, row) in episodeCatalog.fields">
+              <tr ng-repeat="(idx, row) in commonMetadataCatalog.fields">
                 <td>
                   <span translate="{{ row.label }}"></span>
                   <i ng-show="row.required" class="required">*</i>
                 </td>
                 <td admin-ng-editable
                     required-role="ROLE_UI_EVENTS_DETAILS_METADATA_EDIT"
-                    params="row" save="getSaveFunction(episodeCatalog.flavor)"
+                    params="row" save="getMetadataChangedFunction(commonMetadataCatalog.flavor)"
                     sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
@@ -109,25 +110,34 @@
         </div>
       </div>
     </div>
+    <footer>
+      <a
+        class="submit"
+        ng-class="{disabled: metadata.locked || !unsavedChanges([commonMetadataCatalog])}"
+        ng-click="metadataSave([commonMetadataCatalog])">
+        {{ "SAVE" | translate}}
+      </a>
+    </footer>
   </div>
 
-  <div class="modal-content" data-modal-tab-content="extended-metadata" ng-if="metadata.entries.length > 0">
+  <div class="modal-content" data-modal-tab-content="extended-metadata" ng-if="extendedMetadataCatalogs.length > 0">
     <div class="modal-body">
+      <div data-admin-ng-notifications="" context="events-metadata-extended"></div>
       <div data-admin-ng-notifications="" context="events-access"></div>
       <div data-admin-ng-notification="" type="warning" show="metadata.locked" message="{{ metadata.locked }}"></div>
       <div class="full-col">
-        <div class="obj tbl-details" ng-repeat="catalog in metadata.entries">
-          <header><span>{{ catalog.title | translate }}</span></header>
+        <div class="obj tbl-details" ng-repeat="extendedMetadataCatalog in extendedMetadataCatalogs">
+          <header><span>{{ extendedMetadataCatalog.title | translate }}</span></header>
           <div class="obj-container">
             <table class="main-tbl">
-              <tr ng-repeat="row in catalog.fields track by $index">
+              <tr ng-repeat="row in extendedMetadataCatalog.fields track by $index">
                 <td>
                   <span translate="{{ row.label }}"></span>
                   <i ng-show="row.required" class="required">*</i>
                 </td>
                 <td admin-ng-editable
                     required-role="ROLE_UI_EVENTS_DETAILS_METADATA_EDIT"
-                    params="row" save="getSaveFunction(catalog.flavor)"
+                    params="row" save="getMetadataChangedFunction(extendedMetadataCatalog.flavor)"
                     sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
@@ -136,6 +146,14 @@
         </div>
       </div>
     </div>
+    <footer>
+      <a
+        class="submit"
+        ng-class="{disabled: metadata.locked || !unsavedChanges(extendedMetadataCatalogs)}"
+        ng-click="metadataSave(extendedMetadataCatalogs)">
+        {{ "SAVE" | translate}}
+      </a>
+    </footer>
   </div>
 
   <div class="modal-content" data-modal-tab-content="assets">

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
@@ -19,7 +19,7 @@
        with-role="ROLE_UI_SERIES_DETAILS_METADATA_VIEW">
       <!-- Metadata -->
     </a>
-    <a ng-if="metadata.entries.length > 0"
+    <a ng-if="extendedMetadataCatalogs.length > 0"
        ng-click="openTab('extended-metadata')"
        data-modal-tab="extended-metadata"
        ng-class="{ active: tab == 'extended-metadata' }"
@@ -73,20 +73,21 @@
   <!-- Metadata view -->
   <div class="modal-content" data-modal-tab-content="metadata">
     <div class="modal-body">
+      <div data-admin-ng-notifications="" context="series-metadata-common"></div>
       <div data-admin-ng-notification="" type="warning" show="metadata.locked" message="{{ metadata.locked }}"></div>
       <div class="full-col">
         <div class="obj tbl-list">
           <header class="no-expand" translate="EVENTS.SERIES.DETAILS.TABS.METADATA"><!-- Metadata --></header>
           <div class="obj-container">
             <table class="main-tbl">
-              <tr ng-repeat="row in seriesCatalog.fields">
+              <tr ng-repeat="row in commonMetadataCatalog.fields">
                 <td>
                   <span translate="{{ row.label }}"></span>
                   <i ng-show="row.required" class="required">*</i>
                 </td>
                 <td admin-ng-editable
                     required-role="ROLE_UI_SERIES_DETAILS_METADATA_EDIT"
-                    params="row" save="getSaveFunction(seriesCatalog.flavor)"
+                    params="row" save="getMetadataChangedFunction(commonMetadataCatalog.flavor)"
                     sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
@@ -95,25 +96,34 @@
         </div>
       </div>
     </div>
+    <footer>
+      <a
+        class="submit"
+        ng-class="{disabled: metadata.locked || !unsavedChanges([commonMetadataCatalog])}"
+        ng-click="metadataSave([commonMetadataCatalog])">
+        {{ "SAVE" | translate}}
+      </a>
+    </footer>
   </div>
 
   <!-- Extended metadata view -->
-  <div class="modal-content" data-modal-tab-content="extended-metadata" ng-if="metadata.entries.length > 0">
+  <div class="modal-content" data-modal-tab-content="extended-metadata" ng-if="extendedMetadataCatalogs.length > 0">
     <div class="modal-body">
+      <div data-admin-ng-notifications="" context="series-metadata-extended"></div>
       <div data-admin-ng-notification="" type="warning" show="metadata.locked" message="{{ metadata.locked }}"></div>
       <div class="full-col">
-        <div class="obj tbl-list" ng-repeat="catalog in metadata.entries">
-          <header>{{ catalog.title }}</header>
+        <div class="obj tbl-list" ng-repeat="extendedMetadataCatalog in extendedMetadataCatalogs">
+          <header>{{ extendedMetadataCatalog.title }}</header>
           <div class="obj-container">
             <table class="main-tbl">
-              <tr ng-repeat="row in catalog.fields">
+              <tr ng-repeat="row in extendedMetadataCatalog.fields">
                 <td>
                   <span translate="{{ row.label }}"></span>
                   <i ng-show="row.required" class="required">*</i>
                 </td>
                 <td admin-ng-editable
                     required-role="ROLE_UI_SERIES_DETAILS_METADATA_EDIT"
-                    params="row" save="getSaveFunction(catalog.flavor)"
+                    params="row" save="getMetadataChangedFunction(extendedMetadataCatalog.flavor)"
                     sanitize-xml="row.value" ng-model="row.value">
                 </td>
               </tr>
@@ -122,6 +132,14 @@
         </div>
       </div>
     </div>
+    <footer>
+      <a
+        class="submit"
+        ng-class="{disabled: metadata.locked || !unsavedChanges(extendedMetadataCatalogs)}"
+        ng-click="metadataSave(extendedMetadataCatalogs)">
+        {{ "SAVE" | translate}}
+      </a>
+    </footer>
   </div>
 
   <!-- Permission view -->

--- a/modules/admin-ui-frontend/app/styles/main.scss
+++ b/modules/admin-ui-frontend/app/styles/main.scss
@@ -519,18 +519,23 @@ table.main-tbl {
   td{
     .fa-check {
       float: right;
-      color: $green;
       margin-top: 3px;
       font-size: 18px;
       opacity: 0;
       visibility: hidden;
       @include transition(all .2s);
 
-      &.active {
+      &.saved {
         opacity: 1;
         visibility: visible;
+        color: $green;
       }
 
+      &.dirty {
+        opacity: 1;
+        visibility: visible;
+        color: $red;
+      }
     } // fa-check
   }
 }

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -130,7 +130,8 @@
      },
      "WARNINGS": {
        "SERIES_HAS_EVENTS": "This series does contain events. Deleting the series will not delete the events.",
-       "EVENT_WILL_BE_GONE": "If you continue, the event will be irrevocably gone."
+       "EVENT_WILL_BE_GONE": "If you continue, the event will be irrevocably gone.",
+       "UNSAVED_CHANGES": "You have unsaved changes. If you continue, those changes will be discarded. Are you sure that you want to continue?"
      },
      "ERRORS": {
        "SERIES_HAS_EVENTS": "This series cannot be deleted as it still contains events."
@@ -207,6 +208,7 @@
      "INVALID_ACL_RULES":   "Rules have to contain a valid role and read or/and write right(s).",
      "MISSING_ACL_RULES":   "At least one role with Read and Write permissions is required!",
      "SAVED_ACL_RULES":   "The access rules have been saved.",
+     "SAVED_METADATA":   "The metadata has been saved.",
      "SERIES_THEME_REPROCESS_EXISTING_EVENTS": "The existing events in this series will need to be reprocessed",
      "SERIES_ACL_LOCKED": "Editing Access Policies is not allowed when operations are running on an event that is part of the series",
      "SERIES_ACL_MISSING_READWRITE_ROLE": "The Access Policy requires at least one role with Read and Write permissions.",

--- a/modules/admin-ui-frontend/test/test/unit/modules/events/controllers/eventControllerSpec.js
+++ b/modules/admin-ui-frontend/test/test/unit/modules/events/controllers/eventControllerSpec.js
@@ -13,7 +13,8 @@ describe('Event controller', function () {
         $provide.value('Language', service);
     }));
 
-    beforeEach(inject(function ($rootScope, _$controller_, _$httpBackend_, _UsersResource_, _EventAccessResource_, _EventMetadataResource_, _Notifications_) {
+    beforeEach(inject(function ($rootScope, _$controller_, _$httpBackend_, _UsersResource_, _EventAccessResource_,
+      _EventMetadataResource_, _Notifications_) {
         $scope = $rootScope.$new();
         $scope.resourceId = '1a2a040b-ef73-4323-93dd-052b86036b75';
         $controller = _$controller_;
@@ -33,12 +34,17 @@ describe('Event controller', function () {
         $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata.json')
             .respond(JSON.stringify(getJSONFixture('admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata.json')));
         $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/publications.json').respond('{}');
-        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/media/media.json').respond('{}');
-        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/attachment/attachments.json').respond('{}');
-        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/catalog/catalogs.json').respond('{}');
-        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/publication/publications.json').respond('{}');
+        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/media/media.json')
+            .respond('{}');
+        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/attachment/attachments.json')
+            .respond('{}');
+        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/catalog/catalogs.json')
+            .respond('{}');
+        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/publication/publications.json')
+            .respond('{}');
         $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/asset/assets.json').respond('{}');
-        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/scheduling.json').respond(JSON.stringify({"metadata": {"start":"","end":""}}));
+        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/scheduling.json')
+            .respond(JSON.stringify({"metadata": {"start":"","end":""}}));
         $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/workflows.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/access.json')
             .respond(JSON.stringify(getJSONFixture('admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/access.json')));
@@ -52,7 +58,8 @@ describe('Event controller', function () {
         $httpBackend.whenGET('/admin-ng/resources/PUBLICATION.CHANNELS.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/event/new/processing?tags=schedule')
             .respond(JSON.stringify(getJSONFixture('admin-ng/event/new/processing')));
-        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/hasActiveTransaction').respond('false');
+        $httpBackend.whenGET('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/hasActiveTransaction')
+            .respond('false');
         $httpBackend.whenGET('/admin-ng/capture-agents/agents.json').respond(JSON.stringify({"results":[],"total":0}));
         $httpBackend.whenGET('/admin-ng/capture-agents/agents.json?inputs=true')
             .respond(JSON.stringify({"results":[],"total":0}));
@@ -63,6 +70,18 @@ describe('Event controller', function () {
 
 
         $controller('EventCtrl', {$scope: $scope});
+    });
+
+    it('fetches event metadata', function () {
+        expect($scope.metadata.entries).toBeUndefined();
+        expect($scope.commonMetadataCatalog).toBeUndefined();
+        expect($scope.extendedMetadataCatalogs).toBeUndefined();
+        $httpBackend.flush();
+        expect($scope.metadata.entries).toBeDefined();
+        expect($scope.metadata.entries.length).toBe(3);
+        expect($scope.commonMetadataCatalog).toBeDefined();
+        expect($scope.extendedMetadataCatalogs).toBeDefined();
+        expect($scope.extendedMetadataCatalogs.length).toBe(2);
     });
 
     it('retrieves records from the server when the resource ID changes', function () {
@@ -124,7 +143,8 @@ describe('Event controller', function () {
         });
 
         it('sends a POST request resolving the issue', function () {
-            $httpBackend.expectPOST('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/comment/1902/reply', function (data) {
+            $httpBackend.expectPOST('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/comment/1902/reply',
+              function (data) {
                 if (data === $.param({ text: 'My response', resolved: false })) {
                     return true;
                 } else {
@@ -136,10 +156,11 @@ describe('Event controller', function () {
             $httpBackend.flush();
         });
 
-        it('sends a POST request keeing the issue unresolved', function () {
+        it('sends a POST request keeping the issue unresolved', function () {
             $scope.myComment.resolved = false;
 
-            $httpBackend.expectPOST('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/comment/1902/reply', function (data) {
+            $httpBackend.expectPOST('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/comment/1902/reply',
+              function (data) {
                 if (data === $.param({ text: 'My response', resolved: false })) {
                     return true;
                 } else {
@@ -161,17 +182,17 @@ describe('Event controller', function () {
             $scope.$broadcast('change', '1a2a040b-ef73-4323-93dd-052b86036b75');
         });
 
-        it('isolates dublincore/episode catalog', function () {
-            $scope.$watch('episodeCatalog', function (newCatalog) {
-                expect(newCatalog.length).toEqual(catalogs[0].length);
+        it('extracts the common metadata catalog', function () {
+            $scope.$watch('commonMetadataCatalog', function (newCatalog) {
+                expect(newCatalog.flavor).toEqual(catalogs[0].flavor);
             });
         });
 
-        it('prepares the extended-metadata catalogs', function () {
+        it('extracts the extended metadata catalogs', function () {
             $scope.metadata.$promise.then(function () {
-                expect($scope.metadata.entries.length).toBe(2);
-                angular.forEach($scope.metadata.entries, function (catalog, index)  {
-                    expect(catalog).toEqual(catalogs[index + 1]);
+                expect($scope.extendedMetadataCatalogs.length).toBe(2);
+                angular.forEach($scope.extendedMetadataCatalogs, function (newCatalog, index)  {
+                    expect(newCatalog.flavor).toEqual(catalogs[index + 1].flavor);
                 });
             });
         });
@@ -187,75 +208,132 @@ describe('Event controller', function () {
         });
     });
 
+    describe('#unsavedChanges', function() {
+        it('has unsaved changes', function () {
+
+            expect($scope.unsavedChanges([{fields: [{dirty: true}]}])).toBe(true);
+            expect($scope.unsavedChanges([{fields: [{dirty: false}, {dirty: true}]},
+              {fields: [{dirty: false}]}])).toBe(true);
+           expect($scope.unsavedChanges([{fields: [{dirty: true}]},
+              {fields: [{dirty: true}]}])).toBe(true);
+        });
+
+        it('doesn\'t have unsaved changes', function () {
+            expect($scope.unsavedChanges([{fields: [{dirty: false}]}])).toBe(false);
+            expect($scope.unsavedChanges([{fields: [{dirty: false}, {dirty: false}]},
+              {fields: [{dirty: false}]}])).toBe(false);
+        });
+    });
+
+    describe('#metadataChanged', function () {
+        var fn, callbackObject = {
+            callback: function () {}
+        };
+
+        beforeEach(function () {
+            spyOn($scope, 'metadataChanged').and.callThrough();
+            spyOn(callbackObject, 'callback');
+            $httpBackend.flush();
+        });
+
+
+        it('does\'t mark fields dirty when value hasn\'t changed', function () {
+            expect($scope.unsavedChanges([$scope.commonMetadataCatalog])).toBe(false);
+            fn = $scope.getMetadataChangedFunction('dublincore/episode'),
+            fn('title', callbackObject.callback);
+            expect($scope.metadataChanged).toHaveBeenCalledWith('title', callbackObject.callback,
+              $scope.commonMetadataCatalog);
+            expect(callbackObject.callback).toHaveBeenCalled();
+            expect($scope.unsavedChanges([$scope.commonMetadataCatalog])).toBe(false);
+            expect($scope.commonMetadataCatalog.fields[0].dirty).toBe(false);
+        });
+
+        it('marks field in the common metadata catalog as dirty', function () {
+            expect($scope.unsavedChanges([$scope.commonMetadataCatalog])).toBe(false);
+            $scope.commonMetadataCatalog.fields[0].value = "New Title";
+            fn = $scope.getMetadataChangedFunction('dublincore/episode'),
+            fn('title', callbackObject.callback);
+            expect($scope.metadataChanged).toHaveBeenCalledWith('title', callbackObject.callback,
+              $scope.commonMetadataCatalog);
+            expect(callbackObject.callback).toHaveBeenCalled();
+            expect($scope.unsavedChanges([$scope.commonMetadataCatalog])).toBe(true);
+            expect($scope.commonMetadataCatalog.fields[0].dirty).toBe(true);
+        });
+
+        it('marks field in the extended metadata catalog as dirty', function () {
+            expect($scope.unsavedChanges($scope.extendedMetadataCatalogs)).toBe(false);
+            $scope.extendedMetadataCatalogs[0].fields[0].value = "New Title";
+            fn = $scope.getMetadataChangedFunction('dublincore/extended-1'),
+            fn('title', callbackObject.callback);
+            expect($scope.metadataChanged).toHaveBeenCalledWith('title', callbackObject.callback,
+              $scope.extendedMetadataCatalogs[0]);
+            expect(callbackObject.callback).toHaveBeenCalled();
+            expect($scope.unsavedChanges($scope.extendedMetadataCatalogs)).toBe(true);
+            expect($scope.extendedMetadataCatalogs[0].fields[0].dirty).toBe(true);
+        });
+    });
+
     describe('#metadataSave', function () {
-        var catalog = {
-                flavor: 'dublincore/episode',
-                fields: [{
-                    id: 'title'
-                }]
-            };
 
-        it('saves the event record', function () {
-            spyOn(EventMetadataResource, 'save');
-            $scope.metadataSave('title', undefined, catalog);
-
-            expect(EventMetadataResource.save)
-                .toHaveBeenCalledWith({ id: '1a2a040b-ef73-4323-93dd-052b86036b75'}, catalog, jasmine.any(Function));
+        beforeEach(function () {
+            spyOn(EventMetadataResource, 'save').and.callThrough();
         });
 
-        it('marks the saved attribute as saved', function () {
-            $scope.metadataSave('title', undefined, catalog);
-            $httpBackend.whenPUT('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata')
-                .respond(JSON.stringify(
-                    [{'flavor': 'dublincore/episode',
-                         'title': 'EVENTS.EVENTS.DETAILS.CATALOG.EPISODE',
-                         'fields': [{id: 'title'
-                         }, {id: 'series'
-                         }]
-                    }]
-                ));
+        it('doesn\'t save when no field marked as dirty', function () {
+            var catalog = {fields: [{ dirty: false }]};
+            $scope.metadataSave([catalog]);
+            expect(EventMetadataResource.save).not.toHaveBeenCalled();
+        });
+
+        it('saves when field marked as dirty', function () {
+            var catalog = {fields: [{ dirty: true }]};
+            $scope.metadataSave([catalog]);
+            expect(EventMetadataResource.save).toHaveBeenCalledWith({id: '1a2a040b-ef73-4323-93dd-052b86036b75'},
+              catalog, jasmine.any(Function));
+            $httpBackend.expectPUT('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata').respond(200);
             $httpBackend.flush();
-
-            expect(catalog.fields[0].saved).toBe(true);
+            expect(catalog.fields[0].dirty).toBe(false);
         });
 
-        it('calls the provided callback on success', function () {
-            var callback = jasmine.createSpy();
-            $scope.metadataSave('title', callback, catalog);
-            $httpBackend.whenPUT('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata').respond(200);
+        it('resets old value when saving', function () {
+            var catalog = {fields: [{ dirty: true, value: 'blub', oldValue: 'blah' }]};
+            $scope.metadataSave([catalog]);
+            expect(EventMetadataResource.save).toHaveBeenCalledWith({id: '1a2a040b-ef73-4323-93dd-052b86036b75'},
+              catalog, jasmine.any(Function));
+            $httpBackend.expectPUT('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata').respond(200);
             $httpBackend.flush();
-
-            expect(callback).toHaveBeenCalled();
+            expect(catalog.fields[0].value).toBe('blub');
+            expect(catalog.fields[0].oldValue).toBe('blub');
         });
 
-        describe('getSaveFn', function () {
-            var fn, callbackObject = {
-                    callback: function () {}
-                };
+        it('saves multiple catalogs', function () {
+            var catalog = {fields: [{ dirty: true }]};
+            var catalog2 = {fields: [{ dirty: true }]};
+            $scope.metadataSave([catalog, catalog2]);
+            expect(EventMetadataResource.save).toHaveBeenCalledWith({id: '1a2a040b-ef73-4323-93dd-052b86036b75'},
+              catalog, jasmine.any(Function));
+            expect(EventMetadataResource.save).toHaveBeenCalledWith({id: '1a2a040b-ef73-4323-93dd-052b86036b75'},
+              catalog2, jasmine.any(Function));
+            $httpBackend.expectPUT('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata').respond(200);
+            $httpBackend.expectPUT('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata').respond(200);
+            $httpBackend.flush();
+            expect(catalog.fields[0].dirty).toBe(false);
+            expect(catalog2.fields[0].dirty).toBe(false);
+        });
 
-            beforeEach(function () {
-                $httpBackend.flush();
-                spyOn($scope, 'metadataSave').and.callThrough();
-                spyOn(callbackObject, 'callback');
-                spyOn(EventMetadataResource, 'save').and.callThrough();
-                $httpBackend.expectPUT('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata').respond(200);
-            });
-
-            it('saves fields in the dublincore/series catalog', function () {
-                fn = $scope.getSaveFunction('dublincore/episode'),
-                fn('title', callbackObject.callback);
-                $httpBackend.flush();
-                expect($scope.metadataSave).toHaveBeenCalledWith('title', callbackObject.callback, $scope.episodeCatalog);
-                expect(callbackObject.callback).toHaveBeenCalled();
-            });
-
-            it('saves fields in the dublincore/extended-1 catalog', function () {
-                fn = $scope.getSaveFunction('dublincore/extended-1'),
-                fn('title', callbackObject.callback);
-                $httpBackend.flush();
-                expect($scope.metadataSave).toHaveBeenCalledWith('title', callbackObject.callback, $scope.metadata.entries[0]);
-                expect(callbackObject.callback).toHaveBeenCalled();
-            });
+        it('saves one of multiple catalogs', function () {
+            var catalog = {fields: [{ dirty: true, value: 'blub', oldValue: 'blah' }]};
+            var catalog2 = {fields: [{ dirty: false, value: 'blub', oldValue: 'blah' }]};
+            $scope.metadataSave([catalog, catalog2]);
+            expect(EventMetadataResource.save).toHaveBeenCalledWith({id: '1a2a040b-ef73-4323-93dd-052b86036b75'},
+              catalog, jasmine.any(Function));
+            expect(EventMetadataResource.save).not.toHaveBeenCalledWith({id: '1a2a040b-ef73-4323-93dd-052b86036b75'},
+              catalog2, jasmine.any(Function));
+            $httpBackend.expectPUT('/admin-ng/event/1a2a040b-ef73-4323-93dd-052b86036b75/metadata').respond(200);
+            $httpBackend.flush();
+            expect(catalog.fields[0].dirty).toBe(false);
+            expect(catalog.fields[0].oldValue).toBe('blub');
+            expect(catalog2.fields[0].oldValue).toBe('blah');
         });
     });
 
@@ -281,7 +359,8 @@ describe('Event controller', function () {
             expect(EventAccessResource.save).toHaveBeenCalledWith({
                 id: $scope.resourceId,
             }, {
-                acl: { ace: [ { action : 'read', allow : true, role : 'admin' }, { action : 'write', allow : true, role : 'admin' } ] },
+                acl: { ace: [ { action : 'read', allow : true, role : 'admin' },
+                  { action : 'write', allow : true, role : 'admin' } ] },
                 override: true
             }, jasmine.any(Function), jasmine.any(Function));
         });

--- a/modules/admin-ui-frontend/test/test/unit/modules/events/controllers/serieControllerSpec.js
+++ b/modules/admin-ui-frontend/test/test/unit/modules/events/controllers/serieControllerSpec.js
@@ -1,5 +1,6 @@
 describe('Serie controller', function () {
-    var $scope, $httpBackend, $controller, $timeout, SeriesMetadataResource, SeriesAccessResource, SeriesThemeResource, Notifications;
+    var $scope, $httpBackend, $controller, $timeout, SeriesMetadataResource, SeriesAccessResource, SeriesThemeResource,
+      Notifications;
 
     beforeEach(module('adminNg'));
 
@@ -12,7 +13,8 @@ describe('Serie controller', function () {
         $provide.value('Language', service);
     }));
 
-    beforeEach(inject(function ($rootScope, _$controller_, _$timeout_, _$httpBackend_, _SeriesMetadataResource_, _SeriesAccessResource_, _SeriesThemeResource_, _Notifications_) {
+    beforeEach(inject(function ($rootScope, _$controller_, _$timeout_, _$httpBackend_, _SeriesMetadataResource_,
+      _SeriesAccessResource_, _SeriesThemeResource_, _Notifications_) {
         $scope = $rootScope.$new();
         $scope.resourceId = '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c';
         $controller = _$controller_;
@@ -31,12 +33,16 @@ describe('Serie controller', function () {
             .respond(JSON.stringify(getJSONFixture('admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/metadata.json')));
         $httpBackend.whenGET('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/events.json')
             .respond(JSON.stringify(getJSONFixture('admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/events.json')));
-        $httpBackend.whenGET('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/access.json').respond(JSON.stringify(getJSONFixture('admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/access.json')));
+        $httpBackend.whenGET('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/access.json')
+            .respond(JSON.stringify(getJSONFixture('admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/access.json')));
         $httpBackend.whenGET('/admin-ng/themes/themes.json').respond('{}');
-        $httpBackend.whenGET('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/theme.json').respond(JSON.stringify(getJSONFixture('admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/theme.json')));
+        $httpBackend.whenGET('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/theme.json')
+            .respond(JSON.stringify(getJSONFixture('admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/theme.json')));
         $httpBackend.whenPUT('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/theme').respond('{}');
-        $httpBackend.whenGET('/admin-ng/resources/THEMES.NAME.json').respond({1001: 'Heinz das Pferd', 1002: 'Full Fledged', 401: 'Doc Test'});
-        $httpBackend.whenGET('/admin-ng/resources/THEMES.DESCRIPTION.json').respond({901: 'theme1 description', 902: 'theme2 desc\nsecond line'});
+        $httpBackend.whenGET('/admin-ng/resources/THEMES.NAME.json')
+            .respond({1001: 'Heinz das Pferd', 1002: 'Full Fledged', 401: 'Doc Test'});
+        $httpBackend.whenGET('/admin-ng/resources/THEMES.DESCRIPTION.json')
+            .respond({901: 'theme1 description', 902: 'theme2 desc\nsecond line'});
         $httpBackend.whenGET('/admin-ng/resources/ACL.json').respond('{}');
         $httpBackend.whenGET('/admin-ng/feeds/feeds').respond('{}');
         $httpBackend.whenGET('/admin-ng/resources/ACL.ACTIONS.json').respond('{}');
@@ -51,9 +57,14 @@ describe('Serie controller', function () {
 
     it('fetches series metadata', function () {
         expect($scope.metadata.entries).toBeUndefined();
+        expect($scope.commonMetadataCatalog).toBeUndefined();
+        expect($scope.extendedMetadataCatalogs).toBeUndefined();
         $httpBackend.flush();
         expect($scope.metadata.entries).toBeDefined();
-        expect($scope.metadata.entries.length).toBe(2);
+        expect($scope.metadata.entries.length).toBe(3);
+        expect($scope.commonMetadataCatalog).toBeDefined();
+        expect($scope.extendedMetadataCatalogs).toBeDefined();
+        expect($scope.extendedMetadataCatalogs.length).toBe(2);
     });
 
     it('retrieves the record from the server when the resource ID changes', function () {
@@ -73,16 +84,16 @@ describe('Serie controller', function () {
             $scope.$broadcast('change', '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c');
         });
 
-        it('isolates dublincore/series catalog', function () {
-            $scope.$watch('seriesCatalog', function (newCatalog) {
+        it('extracts the common metadata catalog', function () {
+            $scope.$watch('commonMetadataCatalog', function (newCatalog) {
                 expect(newCatalog.flavor).toEqual(catalogs[0].flavor);
             });
         });
 
-        it('prepares the extended-metadata catalogs', function () {
+        it('extracts the extended metadata catalogs', function () {
             $scope.metadata.$promise.then(function () {
-                expect($scope.metadata.entries.length).toBe(2);
-                angular.forEach($scope.metadata.entries, function (catalog, index)  {
+                expect($scope.extendedMetadataCatalogs.length).toBe(2);
+                angular.forEach($scope.extendedMetadataCatalogs, function (catalog, index)  {
                     expect(catalog.fields.length).toEqual(catalogs[index + 1].fields.length);
                 });
             });
@@ -114,42 +125,130 @@ describe('Serie controller', function () {
         });
     });
 
-    describe('#metadataSave', function () {
+    describe('#unsavedChanges', function() {
+        it('has unsaved changes', function () {
 
-        it('saves the event record', function () {
-            spyOn(SeriesMetadataResource, 'save');
-            $scope.metadataSave('test', function () {}, {fields: []});
-
-            expect(SeriesMetadataResource.save).toHaveBeenCalledWith({id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c'}, {fields: [], attributeToSend: 'test'}, jasmine.any(Function));
+            expect($scope.unsavedChanges([{fields: [{dirty: true}]}])).toBe(true);
+            expect($scope.unsavedChanges([{fields: [{dirty: false}, {dirty: true}]},
+              {fields: [{dirty: false}]}])).toBe(true);
+           expect($scope.unsavedChanges([{fields: [{dirty: true}]},
+              {fields: [{dirty: true}]}])).toBe(true);
         });
 
-        describe('catalog selection', function () {
-            var fn, callbackObject = {
-                    callback: function () {}
-                };
-            beforeEach(function () {
-                $httpBackend.flush();
-                spyOn($scope, 'metadataSave').and.callThrough();
-                spyOn(callbackObject, 'callback');
-                spyOn(SeriesMetadataResource, 'save').and.callThrough();
-                $httpBackend.expectPUT('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/metadata').respond(200);
-            });
+        it('doesn\'t have unsaved changes', function () {
+            expect($scope.unsavedChanges([{fields: [{dirty: false}]}])).toBe(false);
+            expect($scope.unsavedChanges([{fields: [{dirty: false}, {dirty: false}]},
+              {fields: [{dirty: false}]}])).toBe(false);
+        });
+    });
 
-            it('saves fields in the dublincore/series catalog', function () {
-                fn = $scope.getSaveFunction('dublincore/series'),
-                fn('title', callbackObject.callback);
-                $httpBackend.flush();
-                expect($scope.metadataSave).toHaveBeenCalledWith('title', callbackObject.callback, $scope.seriesCatalog);
-                expect(callbackObject.callback).toHaveBeenCalled();
-            });
+    describe('#metadataChanged', function () {
+        var fn, callbackObject = {
+            callback: function () {}
+        };
 
-            it('saves fields in the dublincore/extended-1 catalog', function () {
-                fn = $scope.getSaveFunction('dublincore/extended-1'),
-                fn('title', callbackObject.callback);
-                $httpBackend.flush();
-                expect($scope.metadataSave).toHaveBeenCalledWith('title', callbackObject.callback, $scope.metadata.entries[0]);
-                expect(callbackObject.callback).toHaveBeenCalled();
-            });
+        beforeEach(function () {
+            spyOn($scope, 'metadataChanged').and.callThrough();
+            spyOn(callbackObject, 'callback');
+            $httpBackend.flush();
+        });
+
+        it('does\'t mark fields dirty when value hasn\'t changed', function () {
+            expect($scope.unsavedChanges([$scope.commonMetadataCatalog])).toBe(false);
+            fn = $scope.getMetadataChangedFunction('dublincore/series'),
+            fn('title', callbackObject.callback);
+            expect($scope.metadataChanged).toHaveBeenCalledWith('title', callbackObject.callback,
+              $scope.commonMetadataCatalog);
+            expect(callbackObject.callback).toHaveBeenCalled();
+            expect($scope.unsavedChanges([$scope.commonMetadataCatalog])).toBe(false);
+            expect($scope.commonMetadataCatalog.fields[0].dirty).toBe(false);
+        });
+
+        it('marks field in the common metadata catalog as dirty', function () {
+            expect($scope.unsavedChanges([$scope.commonMetadataCatalog])).toBe(false);
+            $scope.commonMetadataCatalog.fields[0].value = "New Title";
+            fn = $scope.getMetadataChangedFunction('dublincore/series'),
+            fn('title', callbackObject.callback);
+            expect($scope.metadataChanged).toHaveBeenCalledWith('title', callbackObject.callback,
+              $scope.commonMetadataCatalog);
+            expect(callbackObject.callback).toHaveBeenCalled();
+            expect($scope.unsavedChanges([$scope.commonMetadataCatalog])).toBe(true);
+            expect($scope.commonMetadataCatalog.fields[0].dirty).toBe(true);
+        });
+
+        it('marks field in the extended metadata catalog as dirty', function () {
+            expect($scope.unsavedChanges($scope.extendedMetadataCatalogs)).toBe(false);
+            $scope.extendedMetadataCatalogs[0].fields[0].value = "New Title";
+            fn = $scope.getMetadataChangedFunction('dublincore/extended-1'),
+            fn('title', callbackObject.callback);
+            expect($scope.metadataChanged).toHaveBeenCalledWith('title', callbackObject.callback,
+              $scope.extendedMetadataCatalogs[0]);
+            expect(callbackObject.callback).toHaveBeenCalled();
+            expect($scope.unsavedChanges($scope.extendedMetadataCatalogs)).toBe(true);
+            expect($scope.extendedMetadataCatalogs[0].fields[0].dirty).toBe(true);
+        });
+    });
+
+    describe('#metadataSave', function () {
+        beforeEach(function () {
+            spyOn(SeriesMetadataResource, 'save').and.callThrough();
+        });
+
+        it('doesn\'t save when no field marked as dirty', function () {
+            var catalog = {fields: [{ dirty: false }]};
+            $scope.metadataSave([catalog]);
+            expect(SeriesMetadataResource.save).not.toHaveBeenCalled();
+        });
+
+        it('saves when field marked as dirty', function () {
+            var catalog = {fields: [{ dirty: true }]};
+            $scope.metadataSave([catalog]);
+            expect(SeriesMetadataResource.save).toHaveBeenCalledWith({id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c'},
+              catalog, jasmine.any(Function));
+            $httpBackend.expectPUT('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/metadata').respond(200);
+            $httpBackend.flush();
+            expect(catalog.fields[0].dirty).toBe(false);
+        });
+
+        it('resets old value when saving', function () {
+            var catalog = {fields: [{ dirty: true, value: 'blub', oldValue: 'blah' }]};
+            $scope.metadataSave([catalog]);
+            expect(SeriesMetadataResource.save).toHaveBeenCalledWith({id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c'},
+              catalog, jasmine.any(Function));
+            $httpBackend.expectPUT('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/metadata').respond(200);
+            $httpBackend.flush();
+            expect(catalog.fields[0].value).toBe('blub');
+            expect(catalog.fields[0].oldValue).toBe('blub');
+        });
+
+        it('saves multiple catalogs', function () {
+            var catalog = {fields: [{ dirty: true }]};
+            var catalog2 = {fields: [{ dirty: true }]};
+            $scope.metadataSave([catalog, catalog2]);
+            expect(SeriesMetadataResource.save).toHaveBeenCalledWith({id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c'},
+              catalog, jasmine.any(Function));
+            expect(SeriesMetadataResource.save).toHaveBeenCalledWith({id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c'},
+              catalog2, jasmine.any(Function));
+            $httpBackend.expectPUT('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/metadata').respond(200);
+            $httpBackend.expectPUT('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/metadata').respond(200);
+            $httpBackend.flush();
+            expect(catalog.fields[0].dirty).toBe(false);
+            expect(catalog2.fields[0].dirty).toBe(false);
+        });
+
+        it('saves one of multiple catalogs', function () {
+            var catalog = {fields: [{ dirty: true, value: 'blub', oldValue: 'blah' }]};
+            var catalog2 = {fields: [{ dirty: false, value: 'blub', oldValue: 'blah' }]};
+            $scope.metadataSave([catalog, catalog2]);
+            expect(SeriesMetadataResource.save).toHaveBeenCalledWith({id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c'},
+              catalog, jasmine.any(Function));
+            expect(SeriesMetadataResource.save).not.toHaveBeenCalledWith({id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c'},
+              catalog2, jasmine.any(Function));
+            $httpBackend.expectPUT('/admin-ng/series/73f9b7ab-1d8f-4c75-9da1-ceb06736d82c/metadata').respond(200);
+            $httpBackend.flush();
+            expect(catalog.fields[0].dirty).toBe(false);
+            expect(catalog.fields[0].oldValue).toBe('blub');
+            expect(catalog2.fields[0].oldValue).toBe('blah');
         });
     });
 


### PR DESCRIPTION
This PR introduces save buttons for the metadata of existing series and events in the Admin UI, similarly to what #1285 attempted. This change affects both the common and extended metadata tab. Now, when changing the value of a metadata field, instead of directly sending a request to the back end, the field is only marked as dirty. The request is only sent when the user clicks the save button. If the user attempts to close the window with unsaved changes, a window with a warning will pop up.
I changed the tests accordingly and added a few new ones, hopefully covering most cases where things could go wrong. But I didn't manage to actually test this today, so this is a draft PR for now. (@gregorydlogan This way you can already take a look at it without having to wait for tomorrow. :))
However, an older version of the series changes has already been running on a production system for over a month and the code is very similar to the one for the event metadata, so hopefully there won't be too many nasty surprises. I'm gonna take another look at this tomorrow and then also add some screenshots.