### PR TITLE
Assure that S3 upload runtime exceptions are logged

### DIFF
--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
@@ -253,11 +253,11 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
     // Use TransferManager to take advantage of multipart upload.
     // TransferManager processes all transfers asynchronously, so this call will return immediately.
     logger.info("Uploading {} to archive bucket {}...", objectName, bucketName);
-    Upload upload = s3TransferManager.upload(bucketName, objectName, origin);
-    long start = System.currentTimeMillis();
 
     S3Object obj = null;
     try {
+      Upload upload = s3TransferManager.upload(bucketName, objectName, origin);
+      long start = System.currentTimeMillis();
       // Block and wait for the upload to finish
       upload.waitForCompletion();
       logger.info("Upload of {} to archive bucket {} completed in {} seconds",
@@ -272,9 +272,13 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
       return new AwsUploadOperationResult(objectName, versionId);
     } catch (InterruptedException e) {
       throw new AssetStoreException("Operation interrupted", e);
+    } catch (Exception e) {
+      throw new AssetStoreException("Upload failed", e);
     } finally {
       try {
-        obj.close();
+        if (obj != null) {
+          obj.close();
+        }
       } catch (IOException e) {
         //Swallow and ignore
       }


### PR DESCRIPTION
If an upload to S3 fails with a runtime exception, the exception is never logged. Instead a NPE is thrown because the current code tries to close an object that was never instantiated. This PR tries to fix this bug.  

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
