### PR TITLE
handle null or empty workflow state

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowUtil.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowUtil.java
@@ -47,6 +47,10 @@ public final class WorkflowUtil {
    * @return True if the workflow is currently active, not stopped or failed.
    */
   public static boolean isActive(String workflowState) {
-    return !WorkflowState.valueOf(workflowState).isTerminated();
+    if (workflowState == null || workflowState.isBlank()) {
+      return false;
+    } else {
+      return !WorkflowState.valueOf(workflowState).isTerminated();
+    }
   }
 }


### PR DESCRIPTION
The standalone editor fails to edit an event if the workflow state is null/empty, which causes an NPE on retrieving the edit metadata. Since the index can contain this "faulty" data, this particular case should also be caught and handled as an event without active workflow.

https://github.com/opencast/opencast/blob/90b61d3e3032e280902291e59f5066a34c3622eb/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java#L632-L648

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
