### PR TITLE
fix editor remote endpoint 403 error

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -294,7 +294,7 @@
     <sec:intercept-url pattern="/studio/**" access="ROLE_ADMIN, ROLE_STUDIO" />
 
     <!-- Enable access to Opencast Editor -->
-    <sec:intercept-url pattern="/editor/**" access="ROLE_USER" />
+    <sec:intercept-url pattern="/editor/**" access="ROLE_ADMIN, ROLE_USER" />
     <sec:intercept-url pattern="/editor-ui/**" access="ROLE_USER" />
 
     <!-- Enable anonymous access to the annotation and the series endpoints -->


### PR DESCRIPTION
The editor remote service cannot request the editor service because the
digest user only has the ROLE_ADMIN and ROLE_SUDO. The ROLE_ADMIN is
missing in the security XML (intercept-url /editor/**) and leads to a
403 error while accessing the service.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
