### PR TITLE
Use comma as separator for WFR cleanup config

### DIFF
--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -180,7 +180,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
     // Determine which collections should be garbage collected
     List<String> collectionsToCleanUp = null;
     String[] cleanupCollections = StringUtils.split(StringUtils.trimToNull(
-            cc.getBundleContext().getProperty(WORKING_FILE_REPOSITORY_CLEANUP_COLLECTIONS_KEY)));
+            cc.getBundleContext().getProperty(WORKING_FILE_REPOSITORY_CLEANUP_COLLECTIONS_KEY)),',');
     if (cleanupCollections != null) {
       collectionsToCleanUp = Arrays.asList(cleanupCollections);
     }

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -180,7 +180,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
     // Determine which collections should be garbage collected
     List<String> collectionsToCleanUp = null;
     String[] cleanupCollections = StringUtils.split(StringUtils.trimToNull(
-            cc.getBundleContext().getProperty(WORKING_FILE_REPOSITORY_CLEANUP_COLLECTIONS_KEY)),',');
+            cc.getBundleContext().getProperty(WORKING_FILE_REPOSITORY_CLEANUP_COLLECTIONS_KEY)), ',');
     if (cleanupCollections != null) {
       collectionsToCleanUp = Arrays.asList(cleanupCollections);
     }

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -179,10 +179,10 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
 
     // Determine which collections should be garbage collected
     List<String> collectionsToCleanUp = null;
-    String[] cleanupCollections = StringUtils.split(StringUtils.trimToNull(
-            cc.getBundleContext().getProperty(WORKING_FILE_REPOSITORY_CLEANUP_COLLECTIONS_KEY)), ',');
-    if (cleanupCollections != null) {
-      collectionsToCleanUp = Arrays.asList(cleanupCollections);
+    String collectionsToCleanUpStr = StringUtils.trimToNull(
+            cc.getBundleContext().getProperty(WORKING_FILE_REPOSITORY_CLEANUP_COLLECTIONS_KEY));
+    if (collectionsToCleanUpStr != null) {
+      collectionsToCleanUp = Arrays.asList(collectionsToCleanUpStr.split("\\s*,\\s*"));
     }
 
     // Start cleanup scheduler if we have sensible cleanup values:


### PR DESCRIPTION
It is possible to specify multiple collections for the Working File Repository cleanup. The comment on how to configure the cleanup in the custom.properties file says: 
_A comma separated lists of collections in the working file repository that should be cleaned up._ 
but actually the split operation in the code expects spaces between each collection. Thus this PR changes the implementation to match the documentation.  

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
