### PR TITLE
Mediapackage directory cleanup

### DIFF
--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -289,7 +289,8 @@
               org.opencastproject.security.api;version=${project.version},
               org.opencastproject.storage;version=${project.version},
               org.opencastproject.systems;version=${project.version},
-              org.opencastproject.security.util;version=${project.version}
+              org.opencastproject.security.util;version=${project.version},
+              org.opencastproject.cleanup;version=${project.version}
             </Export-Package>
             <Provide-Capability>
               osgi.service;objectClass="org.opencastproject.util.ReadinessIndicator"

--- a/modules/common/src/main/java/org/opencastproject/cleanup/RecursiveDirectoryCleaner.java
+++ b/modules/common/src/main/java/org/opencastproject/cleanup/RecursiveDirectoryCleaner.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.cleanup;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAmount;
+
+public final class RecursiveDirectoryCleaner implements FileVisitor<Path> {
+  private final TemporalAmount days;
+  private final Path startingDirectory;
+  private static final Logger logger = LoggerFactory.getLogger(RecursiveDirectoryCleaner.class);
+
+  private RecursiveDirectoryCleaner(Path startingDirectory, TemporalAmount days) {
+    this.startingDirectory = startingDirectory;
+    this.days = days;
+  }
+
+  private boolean isEmptyDirectory(Path path) throws IOException {
+    if (Files.isDirectory(path)) {
+      try (DirectoryStream<Path> directory = Files.newDirectoryStream(path)) {
+        return !directory.iterator().hasNext();
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public FileVisitResult preVisitDirectory(Path path, BasicFileAttributes basicFileAttributes) throws IOException {
+    return FileVisitResult.CONTINUE;
+  }
+
+  @Override
+  public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
+    Instant daysBefore = ZonedDateTime.now().toInstant().minus(days);
+    if (attrs.lastModifiedTime().toInstant().isBefore(daysBefore)) {
+      logger.debug("Deleting file {}", path);
+      FileUtils.deleteQuietly(path.toFile());
+    } else {
+      logger.trace("Keeping file {}", path);
+    }
+    return FileVisitResult.CONTINUE;
+  }
+
+  @Override
+  public FileVisitResult visitFileFailed(Path path, IOException e) throws IOException {
+    logger.warn("Visiting file {} failed with exception {}", path, e);
+    return FileVisitResult.CONTINUE;
+  }
+
+  @Override
+  public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+    if (dir.equals(startingDirectory)) {
+      logger.info("Cleanup finished @{}", dir);
+    } else if (isEmptyDirectory(dir)) {
+      logger.debug("Deleting directory {}", dir);
+      FileUtils.deleteQuietly(dir.toFile());
+    } else {
+      logger.trace("Keeping directory {}", dir);
+    }
+    return FileVisitResult.CONTINUE;
+  }
+
+  public static boolean cleanDirectory(Path startingDir, Duration duration) {
+    if (!Files.exists(startingDir)) {
+      logger.warn("Directory {} to cleanup is not existing", startingDir);
+      return false;
+    }
+
+    if (!Files.isDirectory(startingDir)) {
+      logger.warn("Configuration for directory cleanup invalid. {} is a file", startingDir);
+      return false;
+    }
+
+    RecursiveDirectoryCleaner fileFilter = new RecursiveDirectoryCleaner(startingDir, duration);
+    logger.info("Starting cleanup for directory {} for entries older than {} days", startingDir, duration.toDays());
+    try {
+      Files.walkFileTree(startingDir, fileFilter);
+      return true;
+    } catch (IOException e) {
+      logger.error("Cleanup of directory {} failed", startingDir);
+      return false;
+    }
+  }
+}

--- a/modules/working-file-repository-service-api/src/main/java/org/opencastproject/workingfilerepository/api/WorkingFileRepository.java
+++ b/modules/working-file-repository-service-api/src/main/java/org/opencastproject/workingfilerepository/api/WorkingFileRepository.java
@@ -238,5 +238,5 @@ public interface WorkingFileRepository extends StorageUsage {
    * @param days
    *          files older than that will be deleted
    */
-  boolean cleanupOldFilesFromMediapackage(long days) throws IOException;
+  boolean cleanupOldFilesFromMediaPackage(long days) throws IOException;
 }

--- a/modules/working-file-repository-service-api/src/main/java/org/opencastproject/workingfilerepository/api/WorkingFileRepository.java
+++ b/modules/working-file-repository-service-api/src/main/java/org/opencastproject/workingfilerepository/api/WorkingFileRepository.java
@@ -230,4 +230,13 @@ public interface WorkingFileRepository extends StorageUsage {
    *          files older than that will be deleted
    */
   boolean cleanupOldFilesFromCollection(String collectionId, long days) throws IOException;
+
+
+  /**
+   * Cleans up media files older than the number of days passed.
+   *
+   * @param days
+   *          files older than that will be deleted
+   */
+  boolean cleanupOldFilesFromMediapackage(long days) throws IOException;
 }

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryCleaner.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryCleaner.java
@@ -144,6 +144,11 @@ public class WorkingFileRepositoryCleaner {
         logger.error("Cleaning of collection with id:{} failed", collectionId);
       }
     }
+    try {
+      workingFileRepository.cleanupOldFilesFromMediapackage(maxAge);
+    } catch (IOException e) {
+      logger.error("Cleaning of mediapackages failed");
+    }
   }
 
   // --

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryCleaner.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryCleaner.java
@@ -145,7 +145,7 @@ public class WorkingFileRepositoryCleaner {
       }
     }
     try {
-      workingFileRepository.cleanupOldFilesFromMediapackage(maxAge);
+      workingFileRepository.cleanupOldFilesFromMediaPackage(maxAge);
     } catch (IOException e) {
       logger.error("Cleaning of mediapackages failed");
     }

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.workingfilerepository.impl;
 
+import org.opencastproject.cleanup.RecursiveDirectoryCleaner;
 import org.opencastproject.rest.RestConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
@@ -55,10 +56,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -945,6 +948,13 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
     }
 
     return true;
+  }
+
+  @Override
+  public boolean cleanupOldFilesFromMediapackage(long days) throws IOException {
+    return RecursiveDirectoryCleaner.cleanDirectory(
+            Paths.get(rootDirectory, MEDIAPACKAGE_PATH_PREFIX),
+            Duration.ofDays(days));
   }
 
   /**

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -951,7 +951,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
   }
 
   @Override
-  public boolean cleanupOldFilesFromMediapackage(long days) throws IOException {
+  public boolean cleanupOldFilesFromMediaPackage(long days) throws IOException {
     return RecursiveDirectoryCleaner.cleanDirectory(
             Paths.get(rootDirectory, MEDIAPACKAGE_PATH_PREFIX),
             Duration.ofDays(days));

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryRestEndpoint.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryRestEndpoint.java
@@ -265,12 +265,12 @@ public class WorkingFileRepositoryRestEndpoint extends WorkingFileRepositoryImpl
 
   @DELETE
   @Path(WorkingFileRepository.COLLECTION_PATH_PREFIX + "cleanup/mediapackage/{numberOfDays}")
-  @RestQuery(name = "cleanupOldFilesFromCollection", description = "Remove files and directories from the working file repository under /mediapackage that are older than N days", returnDescription = "No content", pathParameters = {
+  @RestQuery(name = "cleanupOldFilesFromMediaPackage", description = "Remove files and directories from the working file repository under /mediapackage that are older than N days", returnDescription = "No content", pathParameters = {
           @RestParameter(name = "numberOfDays", description = "files older than this number of days will be deleted", isRequired = true, type = STRING) }, responses = {
           @RestResponse(responseCode = SC_NO_CONTENT, description = "Files deleted")})
   public Response restCleanupOldFilesFromMediaPackage(@PathParam("numberOfDays") long days) {
     try {
-      this.cleanupOldFilesFromMediapackage(days);
+      this.cleanupOldFilesFromMediaPackage(days);
       return Response.noContent().build();
     } catch (Exception e) {
       return Response.serverError().entity(e.getMessage()).build();

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryRestEndpoint.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryRestEndpoint.java
@@ -263,6 +263,20 @@ public class WorkingFileRepositoryRestEndpoint extends WorkingFileRepositoryImpl
     }
   }
 
+  @DELETE
+  @Path(WorkingFileRepository.COLLECTION_PATH_PREFIX + "cleanup/mediapackage/{numberOfDays}")
+  @RestQuery(name = "cleanupOldFilesFromCollection", description = "Remove files and directories from the working file repository under /mediapackage that are older than N days", returnDescription = "No content", pathParameters = {
+          @RestParameter(name = "numberOfDays", description = "files older than this number of days will be deleted", isRequired = true, type = STRING) }, responses = {
+          @RestResponse(responseCode = SC_NO_CONTENT, description = "Files deleted")})
+  public Response restCleanupOldFilesFromMediaPackage(@PathParam("numberOfDays") long days) {
+    try {
+      this.cleanupOldFilesFromMediapackage(days);
+      return Response.noContent().build();
+    } catch (Exception e) {
+      return Response.serverError().entity(e.getMessage()).build();
+    }
+  }
+
   @GET
   @Path(WorkingFileRepository.MEDIAPACKAGE_PATH_PREFIX + "{mediaPackageID}/{mediaPackageElementID}")
   @RestQuery(name = "get", description = "Gets the file from the working repository under /mediaPackageID/mediaPackageElementID", returnDescription = "The file", pathParameters = {

--- a/modules/working-file-repository-service-impl/src/test/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryTest.java
+++ b/modules/working-file-repository-service-impl/src/test/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryTest.java
@@ -248,9 +248,9 @@ public class WorkingFileRepositoryTest {
   }
 
   @Test
-  public void testCleanupOldFilesFromMediapackageNothingToDelete() throws Exception {
+  public void testCleanupOldFilesFromMediaPackageNothingToDelete() throws Exception {
     // Cleanup files older than 1 day, nothing should be deleted
-    boolean result = repo.cleanupOldFilesFromMediapackage(1);
+    boolean result = repo.cleanupOldFilesFromMediaPackage(1);
     Assert.assertTrue(result);
     File file = null;
     file = repo.getFile(mediaPackageID, mediaPackageElementID);
@@ -258,9 +258,9 @@ public class WorkingFileRepositoryTest {
   }
 
   @Test
-  public void testCleanupOldFilesFromMediapackageSomethingToDelete() throws Exception {
-    // Cleanup files older than 1 day, nothing should be deleted
-    boolean result = repo.cleanupOldFilesFromMediapackage(0);
+  public void testCleanupOldFilesFromMediaPackageSomethingToDelete() throws Exception {
+    // Cleanup files older than 1 day, something should be deleted
+    boolean result = repo.cleanupOldFilesFromMediaPackage(0);
     Assert.assertTrue(result);
     File file = null;
     try {

--- a/modules/working-file-repository-service-impl/src/test/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryTest.java
+++ b/modules/working-file-repository-service-impl/src/test/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryTest.java
@@ -247,4 +247,28 @@ public class WorkingFileRepositoryTest {
     Assert.assertFalse(result);
   }
 
+  @Test
+  public void testCleanupOldFilesFromMediapackageNothingToDelete() throws Exception {
+    // Cleanup files older than 1 day, nothing should be deleted
+    boolean result = repo.cleanupOldFilesFromMediapackage(1);
+    Assert.assertTrue(result);
+    File file = null;
+    file = repo.getFile(mediaPackageID, mediaPackageElementID);
+    Assert.assertNotNull(file);
+  }
+
+  @Test
+  public void testCleanupOldFilesFromMediapackageSomethingToDelete() throws Exception {
+    // Cleanup files older than 1 day, nothing should be deleted
+    boolean result = repo.cleanupOldFilesFromMediapackage(0);
+    Assert.assertTrue(result);
+    File file = null;
+    try {
+      file = repo.getFile(mediaPackageID, mediaPackageElementID);
+      Assert.fail();
+    } catch (NotFoundException e) {
+      Assert.assertNull(file);
+    }
+  }
+
 }

--- a/modules/working-file-repository-service-remote/src/main/java/org/opencastproject/workingfilerepository/remote/WorkingFileRepositoryRemoteImpl.java
+++ b/modules/working-file-repository-service-remote/src/main/java/org/opencastproject/workingfilerepository/remote/WorkingFileRepositoryRemoteImpl.java
@@ -239,7 +239,7 @@ public class WorkingFileRepositoryRemoteImpl extends RemoteBase implements Worki
   }
 
   @Override
-  public boolean cleanupOldFilesFromMediapackage(long days) throws IOException {
+  public boolean cleanupOldFilesFromMediaPackage(long days) throws IOException {
     String url = UrlSupport.concat(new String[] { MEDIAPACKAGE_PATH_PREFIX, Long.toString(days) });
     HttpDelete del = new HttpDelete(url);
     HttpResponse response = getResponse(del, SC_NO_CONTENT);

--- a/modules/working-file-repository-service-remote/src/main/java/org/opencastproject/workingfilerepository/remote/WorkingFileRepositoryRemoteImpl.java
+++ b/modules/working-file-repository-service-remote/src/main/java/org/opencastproject/workingfilerepository/remote/WorkingFileRepositoryRemoteImpl.java
@@ -238,6 +238,21 @@ public class WorkingFileRepositoryRemoteImpl extends RemoteBase implements Worki
     throw new RuntimeException("Error removing older files from collection");
   }
 
+  @Override
+  public boolean cleanupOldFilesFromMediapackage(long days) throws IOException {
+    String url = UrlSupport.concat(new String[] { MEDIAPACKAGE_PATH_PREFIX, Long.toString(days) });
+    HttpDelete del = new HttpDelete(url);
+    HttpResponse response = getResponse(del, SC_NO_CONTENT);
+    try {
+      if (response != null) {
+        return SC_NO_CONTENT == response.getStatusLine().getStatusCode();
+      }
+    } finally {
+      closeConnection(response);
+    }
+    throw new RuntimeException("Error removing older files from collection");
+  }
+
   protected JSONObject getStorageReport() {
     String url = UrlSupport.concat(new String[] { "storage" });
     HttpGet get = new HttpGet(url);

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -37,6 +37,7 @@ import static org.opencastproject.util.data.Prelude.sleep;
 
 import org.opencastproject.assetmanager.util.AssetPathUtils;
 import org.opencastproject.assetmanager.util.DistributionPathUtils;
+import org.opencastproject.cleanup.RecursiveDirectoryCleaner;
 import org.opencastproject.mediapackage.identifier.Id;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.TrustedHttpClient;
@@ -84,9 +85,10 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.time.Duration;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -929,28 +931,8 @@ public final class WorkspaceImpl implements Workspace {
               + "avoid deleting data in use by running workflows.");
     }
 
-    // Get workspace root directly
-    final File workspaceDirectory = new File(wsRoot);
-    logger.info("Starting cleanup of workspace at {}", workspaceDirectory);
-
-    long now = new Date().getTime();
-    for (File file: FileUtils.listFiles(workspaceDirectory, null, true)) {
-      long fileLastModified = file.lastModified();
-      // Ensure file/dir is older than maxAge
-      long fileAgeInSeconds = (now - fileLastModified) / 1000;
-      if (fileLastModified == 0 || fileAgeInSeconds < maxAgeInSeconds) {
-        logger.debug("File age ({}) < max age ({}) or unknown: Skipping {} ", fileAgeInSeconds, maxAgeInSeconds, file);
-        continue;
-      }
-
-      // Delete old files
-      if (FileUtils.deleteQuietly(file)) {
-        logger.info("Deleted {}", file);
-      } else {
-        logger.warn("Could not delete {}", file);
-      }
-    }
-    logger.info("Finished cleanup of workspace");
+    // Clean workspace root directly
+    RecursiveDirectoryCleaner.cleanDirectory(Paths.get(wsRoot), Duration.ofSeconds(maxAgeInSeconds));
   }
 
   @Override

--- a/modules/workspace-impl/src/test/java/org/opencastproject/workspace/impl/WorkspaceImplTest.java
+++ b/modules/workspace-impl/src/test/java/org/opencastproject/workspace/impl/WorkspaceImplTest.java
@@ -57,6 +57,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -283,7 +284,7 @@ public class WorkspaceImplTest {
     workspace.cleanup(-1);
     Assert.assertEquals(0L, workspace.getUsedSpace().get().longValue());
 
-    File file = new File(PathSupport.concat(new String[] { workspaceRoot, "test", "c1", "bar.mov" }));
+    File file = Paths.get(workspaceRoot, "test", "c1", "bar.mov").toFile();
     FileUtils.write(file, "asdf", StandardCharsets.UTF_8);
     file.deleteOnExit();
 
@@ -300,8 +301,10 @@ public class WorkspaceImplTest {
 
     Prelude.sleep(1100L);
 
+    Assert.assertTrue(Paths.get(workspaceRoot, "test", "c1").toFile().exists());
     workspace.cleanup(1);
     Assert.assertEquals(0L, workspace.getUsedSpace().get().longValue());
+    Assert.assertFalse(Paths.get(workspaceRoot, "test").toFile().exists());
   }
 
 }


### PR DESCRIPTION
Currently directories in the mediapackage folder of the Working File Repository and the Workspace will never be deleted. If you have a large installation like SWITCH it is impossible to use unix tools like `du` or `ls` to browse these directories or to find out how much disk space is used by each subfolder. Also the mediapackage folder inside the WFR is never cleaned up in any way.

This PR tries to improve the cleanup process of WFR and Workspace in the following ways:
1. Add a cleanup of old files in the mediapackage folder of the Working File Repository (including directories). 
2. Remove unused directories during the Workspace cleanup
3. Use the same implementation for both modules     

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
