### PR TITLE
Cover image surrogate problem

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<features name="opencast-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0 http://karaf.apache.org/xmlns/features/v1.3.0">
+<features name="opencast-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.3.0">
 
   <feature name="query-dsl" version="${project.version}">
     <bundle>mvn:com.google.guava/guava/${guava.version}</bundle>

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -68,7 +68,6 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/1.8.5_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.wsdl4j/1.6.3_1</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.2_3</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.12.1_1</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlbeans/2.6.0_2</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_1</bundle>

--- a/etc/branding/coverimage.xsl
+++ b/etc/branding/coverimage.xsl
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:date="http://exslt.org/dates-and-times"
-    xmlns:opencast="xalan://org.opencastproject.coverimage.impl.xsl" exclude-result-prefixes="date opencast"
-    extension-element-prefixes="date opencast">
+                xmlns:date="http://exslt.org/dates-and-times"
+                xmlns:opencast="xalan://org.opencastproject.coverimage.impl.xsl" exclude-result-prefixes="date opencast"
+                extension-element-prefixes="date opencast">
 
   <xsl:param name="width" />
   <xsl:param name="height" />
   <xsl:param name="posterimage" />
+  <xsl:variable name="title" select="string(metadata/title)" />
+  <xsl:variable name="description" select="string(metadata/description)" />
+  <xsl:variable name="date" select="metadata/date" />
+  <xsl:variable name="creators" select="string(metadata/creators)" />
+  <xsl:variable name="license" select="string(metadata/license)" />
 
   <xsl:template match="/">
-
     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1">
 
       <xsl:attribute name="width">
@@ -80,28 +84,28 @@
       <!-- Layer 3: Metadata -->
       <text class="metadata">
         <tspan class="title" y="30%" x="50%">
-          <xsl:value-of select="opencast:XsltHelper.split(metadata/title, 30, 1, false)" />
+          <xsl:value-of select="opencast:XsltHelper.split($title, 30, 1, false())" />
         </tspan>
         <tspan class="title" dy="10%" x="50%">
-          <xsl:value-of select="opencast:XsltHelper.split(metadata/title, 30, 2, true)" />
+          <xsl:value-of select="opencast:XsltHelper.split($title, 30, 2, true())" />
         </tspan>
         <tspan class="creators" dy="12%" x="50%">
-          <xsl:value-of select="opencast:XsltHelper.split(metadata/creators, 40, 1, true)" />
+          <xsl:value-of select="opencast:XsltHelper.split($creators, 40, 1, true())" />
         </tspan>
         <tspan class="description" dy="12%" x="50%">
-          <xsl:value-of select="opencast:XsltHelper.split(metadata/description, 50, 1, false)" />
+          <xsl:value-of select="opencast:XsltHelper.split($description, 50, 1, false())" />
         </tspan>
         <tspan class="description" dy="5%" x="50%">
-          <xsl:value-of select="opencast:XsltHelper.split(metadata/description, 50, 2, false)" />
+          <xsl:value-of select="opencast:XsltHelper.split($description, 50, 2, false())" />
         </tspan>
         <tspan class="description" dy="5%" x="50%">
-          <xsl:value-of select="opencast:XsltHelper.split(metadata/description, 50, 3, true)" />
+          <xsl:value-of select="opencast:XsltHelper.split($description, 50, 3, true())" />
         </tspan>
         <tspan class="presentationdate" dy="12%" x="50%">
-          <xsl:value-of select="date:format-date(metadata/date, 'MMMMMMMMMM dd, YYYY, HH:mm')" />
+          <xsl:value-of select="date:format-date($date, 'MMMMMMMMMM dd, YYYY, HH:mm')" />
         </tspan>
         <tspan class="license" dy="10%" x="50%">
-          <xsl:value-of select="metadata/license" />
+          <xsl:value-of select="$license" />
         </tspan>
       </text>
     </svg>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <batik.version>1.7</batik.version>
+    <batik.version>1.14</batik.version>
   </properties>
   <dependencies>
     <dependency>
@@ -66,6 +66,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>xmlgraphics-commons</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-anim</artifactId>
       <version>${batik.version}</version>
     </dependency>
@@ -82,6 +87,11 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-codec</artifactId>
+      <version>${batik.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-constants</artifactId>
       <version>${batik.version}</version>
     </dependency>
     <dependency>
@@ -106,17 +116,17 @@
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
-      <artifactId>batik-js</artifactId>
-      <version>${batik.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-parser</artifactId>
       <version>${batik.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-rasterizer</artifactId>
+      <version>${batik.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-svgrasterizer</artifactId>
       <version>${batik.version}</version>
     </dependency>
     <dependency>
@@ -158,6 +168,11 @@
       <artifactId>xml-apis-ext</artifactId>
       <version>1.3.04</version>
     </dependency>
+    <dependency>
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
+      <version>1.7.13</version>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -184,8 +199,11 @@
             <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-anim</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-awt-util</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-bridge</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-css</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-codec</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-constants</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-dom</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-ext</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-gvt</ignoredUnusedDeclaredDependency>
@@ -196,7 +214,12 @@
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-svg-dom</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-transcoder</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-xml</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-svgrasterizer</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-rasterizer</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-util</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:xmlgraphics-commons</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>xml-apis:xml-apis-ext</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.mozilla:rhino</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
@@ -209,6 +232,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              !org.python.*,
               !org.apache.fop.*,
               com.sun.image.codec.jpeg,
               org.w3c.dom,
@@ -228,20 +252,23 @@
               batik-awt-util;inline=true,
               batik-bridge;inline=true,
               batik-codec;inline=true,
+              batik-constants;inline=true,
               batik-css;inline=true,
               batik-dom;inline=true,
               batik-ext;inline=true,
               batik-gvt;inline=true,
-              batik-js;inline=true,
               batik-parser;inline=true,
               batik-rasterizer;inline=true,
+              batik-svgrasterizer;inline=true,
               batik-script;inline=true,
               batik-svggen;inline=true,
               batik-svg-dom;inline=true,
               batik-transcoder;inline=true,
               batik-util;inline=true,
               batik-xml;inline=true,
-              xml-apis-ext;inline=true
+              xml-apis-ext;inline=true,
+              xmlgraphics-commons;inline=true,
+              rhino;inline=true
             </Embed-Dependency>
           </instructions>
         </configuration>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -158,10 +158,6 @@
       <artifactId>xml-apis-ext</artifactId>
       <version>1.3.04</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.xalan</artifactId>
-    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -201,7 +197,6 @@
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-transcoder</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-xml</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>xml-apis:xml-apis-ext</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.apache.servicemix.bundles:org.apache.servicemix.bundles.xalan</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/AbstractCoverImageService.java
+++ b/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/AbstractCoverImageService.java
@@ -44,7 +44,6 @@ import org.apache.batik.apps.rasterizer.DestinationType;
 import org.apache.batik.apps.rasterizer.SVGConverter;
 import org.apache.batik.apps.rasterizer.SVGConverterException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +54,6 @@ import org.xml.sax.SAXException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
@@ -154,9 +152,8 @@ public abstract class AbstractCoverImageService extends AbstractJobProducer impl
     URI result;
     File tempSvg = null;
     File tempPng = null;
-    StringReader xmlReader = null;
 
-    try {
+    try (StringReader xmlReader =  new StringReader(xml)) {
       Document xslDoc = parseXsl(xsl);
 
       // Create temp SVG file for transformation result
@@ -164,7 +161,6 @@ public abstract class AbstractCoverImageService extends AbstractJobProducer impl
       Result svg = new StreamResult(tempSvg);
 
       // Load Metadata (from resources)
-      xmlReader = new StringReader(xml);
       InputSource xmlSource = new InputSource(xmlReader);
 
       // Transform XML metadata with stylesheet to SVG
@@ -174,27 +170,18 @@ public abstract class AbstractCoverImageService extends AbstractJobProducer impl
       tempPng = createTempFile(job, ".png");
       rasterizeSvg(tempSvg, tempPng);
 
-      FileInputStream in = null;
-      try {
-        in = new FileInputStream(tempPng);
+      try (FileInputStream in = new FileInputStream(tempPng)) {
         result = workspace.putInCollection(COVERIMAGE_WORKSPACE_COLLECTION, job.getId() + "_coverimage.png", in);
         log.debug("Put the cover image into the workspace ({})", result);
-      } catch (FileNotFoundException e) {
-        // should never happen...
-        throw new CoverImageException(e);
       } catch (IOException e) {
         log.warn("Error while putting resulting image into workspace collection '{}': {}",
                 COVERIMAGE_WORKSPACE_COLLECTION, e);
         throw new CoverImageException("Error while putting resulting image into workspace collection", e);
-      } finally {
-        IOUtils.closeQuietly(in);
       }
     } finally {
       FileUtils.deleteQuietly(tempSvg);
       FileUtils.deleteQuietly(tempPng);
       log.debug("Removed temporary files");
-
-      IOUtils.closeQuietly(xmlReader);
     }
 
     return (Attachment) MediaPackageElementBuilderFactory.newInstance().newElementBuilder()

--- a/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/CoverImageServiceOsgiImpl.java
+++ b/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/CoverImageServiceOsgiImpl.java
@@ -27,28 +27,9 @@ import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.workspace.api.Workspace;
 
-import org.apache.batik.ext.awt.image.GraphicsUtil;
-import org.apache.batik.ext.awt.image.codec.jpeg.JPEGRegistryEntry;
-import org.apache.batik.ext.awt.image.renderable.DeferRable;
-import org.apache.batik.ext.awt.image.renderable.Filter;
-import org.apache.batik.ext.awt.image.renderable.RedRable;
-import org.apache.batik.ext.awt.image.rendered.Any2sRGBRed;
-import org.apache.batik.ext.awt.image.rendered.CachableRed;
-import org.apache.batik.ext.awt.image.rendered.FormatRed;
-import org.apache.batik.ext.awt.image.spi.ImageTagRegistry;
-import org.apache.batik.util.ParsedURL;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.awt.geom.Rectangle2D;
-import java.awt.image.BufferedImage;
-import java.awt.image.ColorModel;
-import java.awt.image.WritableRaster;
-import java.io.IOException;
-import java.io.InputStream;
-
-import javax.imageio.ImageIO;
 
 /**
  * Implementation of {@link AbstractCoverImageService} for use in OSGi environment
@@ -67,86 +48,6 @@ public class CoverImageServiceOsgiImpl extends AbstractCoverImageService {
   @Override
   public void activate(ComponentContext cc) {
     super.activate(cc);
-    // CHECKSTYLE:OFF
-    // See
-    // http://www.stichlberger.com/software/workaround-for-batiks-noclassdeffounderrorclassnotfoundexception-truncatedfileexception/
-    // CHECKSTYLE:ON
-    // ---------------
-    // add this code before you use batik (make sure is runs only once)
-    // via the lower priority this subclass is registered before JPEGRegistryEntry
-    // and prevents JPEGRegistryEntry.handleStream from breaking when used on a non Sun/Oracle JDK
-    JPEGRegistryEntry entry = new JPEGRegistryEntry() {
-
-      @Override
-      public float getPriority() {
-        // higher than that of JPEGRegistryEntry (which is 1000)
-        return 500;
-      }
-
-      /**
-       * Decode the Stream into a RenderableImage
-       *
-       * @param inIS
-       *          The input stream that contains the image.
-       * @param origURL
-       *          The original URL, if any, for documentation purposes only. This may be null.
-       * @param needRawData
-       *          If true the image returned should not have any default color correction the file may specify applied.
-       */
-      @Override
-      public Filter handleStream(InputStream inIS, ParsedURL origURL, boolean needRawData) {
-        // Code from org.apache.batik.ext.awt.image.codec.jpeg.JPEGRegistryEntry#handleStream
-        // Reading image with ImageIO to prevent NoClassDefFoundError on OpenJDK
-
-        final DeferRable dr = new DeferRable();
-        final InputStream is = inIS;
-        final String errCode;
-        final Object[] errParam;
-        if (origURL != null) {
-          errCode = ERR_URL_FORMAT_UNREADABLE;
-          errParam = new Object[] { "JPEG", origURL };
-        } else {
-          errCode = ERR_STREAM_FORMAT_UNREADABLE;
-          errParam = new Object[] { "JPEG" };
-        }
-
-        Thread t = new Thread() {
-          @Override
-          public void run() {
-            Filter filt;
-            try {
-              BufferedImage image;
-              image = ImageIO.read(is);
-              dr.setBounds(new Rectangle2D.Double(0, 0, image.getWidth(), image.getHeight()));
-              CachableRed cr;
-              cr = GraphicsUtil.wrap(image);
-              cr = new Any2sRGBRed(cr);
-              cr = new FormatRed(cr, GraphicsUtil.sRGB_Unpre);
-              WritableRaster wr = (WritableRaster) cr.getData();
-              ColorModel cm = cr.getColorModel();
-              image = new BufferedImage(cm, wr, cm.isAlphaPremultiplied(), null);
-              cr = GraphicsUtil.wrap(image);
-              filt = new RedRable(cr);
-            } catch (IOException ioe) {
-              // Something bad happened here...
-              filt = ImageTagRegistry.getBrokenLinkImage(this, errCode, errParam);
-            } catch (ThreadDeath td) {
-              filt = ImageTagRegistry.getBrokenLinkImage(this, errCode, errParam);
-              dr.setSource(filt);
-              throw td;
-            } catch (Throwable t) {
-              filt = ImageTagRegistry.getBrokenLinkImage(this, errCode, errParam);
-            }
-
-            dr.setSource(filt);
-          }
-        };
-        t.start();
-        return dr;
-      }
-    };
-
-    ImageTagRegistry.getRegistry().register(entry);
 
     logger.info("Cover image service activated");
   }

--- a/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/xsl/XsltHelper.java
+++ b/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/xsl/XsltHelper.java
@@ -65,9 +65,9 @@ public final class XsltHelper {
         /* Abbreviate lines using ellipsis. Because of word wrapping, the line length can be less than maxChars.
            That case is covered by first appending the ellipsis and then applying abbreviate */
         String lastLine = lines[line - 1] + "...";
-        return StringUtils.abbreviate(lastLine, maxChars);
+        return StringUtils.abbreviate(lastLine, maxChars).trim();
       } else {
-        return lines[line - 1];
+        return lines[line - 1].trim();
       }
     } else {
       return null;


### PR DESCRIPTION
During the transformation of the coverimage.xsl file, the emojis get escaped as surrogate pairs, which will result in an invalid XML/SVG file. (https://issues.apache.org/jira/browse/XALANJ-2617)
```

2021-11-19 21:52:28,614 | WARN  | (CoverImageWorkflowOperationHandlerBase:212) - No attachment with the flavor 'presenter/coverbackground' found in media package 'a8e7b9d6-9743-42fa-a4a6-fa3586e54c2d'
About to transcoder source of type: org.apache.batik.apps.rasterizer.SVGConverterFileSource
org.apache.batik.transcoder.TranscoderException: null
Enclosed Exception:
Character reference "&#55357" is an invalid XML character.
        at org.apache.batik.transcoder.XMLAbstractTranscoder.transcode(XMLAbstractTranscoder.java:136)
        at org.apache.batik.transcoder.SVGAbstractTranscoder.transcode(SVGAbstractTranscoder.java:156)
        at org.apache.batik.apps.rasterizer.SVGConverter.transcode(SVGConverter.java:1001)
        at org.apache.batik.apps.rasterizer.SVGConverter.execute(SVGConverter.java:717)
        at org.opencastproject.coverimage.impl.AbstractCoverImageService.rasterizeSvg(AbstractCoverImageService.java:289)
        at org.opencastproject.coverimage.impl.AbstractCoverImageService.generateCoverImageInternal(AbstractCoverImageService.java:175)
        at org.opencastproject.coverimage.impl.AbstractCoverImageService.process(AbstractCoverImageService.java:127)
        at org.opencastproject.job.api.AbstractJobProducer$JobRunner.call(AbstractJobProducer.java:313)
        at org.opencastproject.job.api.AbstractJobProducer$JobRunner.call(AbstractJobProducer.java:272)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
2021-11-19 21:52:33,635 | INFO  | (CoverImageWorkflowOperationHandlerBase:184) - Cover Image Workflow finished successfully for media package 'a8e7b9d6-9743-42fa-a4a6-fa3586e54c2d' within 25ms
```
Using the JDK internal version of Xalan successfully generates the SVG, but a batik bug appears.
![coverimage-batik-1-7](https://user-images.githubusercontent.com/35195803/142700807-d6ddb80a-c3e2-4134-a5f2-33a05d0bd5b9.png)

After updating the batik dependency to the latest version 1.14 a new bug appears less severe than the others.

![coverimage-batik-1-14](https://user-images.githubusercontent.com/35195803/142701035-b4150b52-693b-4c97-b2c8-e3a6dfbc197d.png)

Maybe someone has an idea how to fix the last bug. I will investigate further, but the current result is already far better than the previous one, so I decided to create the PR.

Fixes #2499 (More or less)

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
