### PR TITLE
Elasticsearch Retry Config

### DIFF
--- a/docs/guides/admin/docs/configuration/elasticsearch.md
+++ b/docs/guides/admin/docs/configuration/elasticsearch.md
@@ -27,13 +27,21 @@ Additionally, the following settings can be configured in
 `org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg`:
 * `index.indentifier`
 * `index.name`
+* `max.retry.attempts.get`
+* `max.retry.attempts.update`
+* `retry.waiting.period.get`
+* `retry.waiting.period.update`
 
 The identifier defines which index opencast is looking for. This might be interesting if you run an
 Elasticsearch cluster and want to follow a naming scheme. But you should be aware that the index actually consists of
 multiple subindices whose identifiers will be appended to the base name with an _ (e.g. "opencast_event").
-If an index doesn't exist, Opencast will create it.
+If an index doesn't exist, Opencast will create it. The name is used for logging purposes only.
 
-The name is used for logging purposes only.
+The max retry attempts and the waiting periods will be used in case of an ElasticsearchStatusException, e.g. if there
+are too many concurrent requests. The retry behavior can be configured differently for get and update/delete requests.
+This way you could set more retry attempts for index updates because of the more serious consequences if those requests
+fail. The waiting period is used to not overwhelm the Elasticsearch with retry requests, making the problem worse. By
+default, no retry will be attempted.
 
 Version
 -------

--- a/docs/guides/admin/docs/releasenotes/elasticsearch-retry-config.txt
+++ b/docs/guides/admin/docs/releasenotes/elasticsearch-retry-config.txt
@@ -1,0 +1,6 @@
+In case a request to Elasticsearch fails because of an ElasticsearchStatusException, you can now configure Opencast to
+try again. For this, set max.retry.attempts in `org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg` to
+something higher than 0. Set retry.waiting.period to a time period in ms to wait between retries (default: 1 second) so
+you don't overwhelm Elasticsearch. Both parameters can be configured separately for read-only actions and those that
+also update or delete, since arguably the success of the latter is more important. Changing this config does not require
+a restart of Opencast. See our [Elasticsearch docs](../configuration/elasticsearch.md) for more details.

--- a/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
+++ b/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
@@ -7,11 +7,11 @@
 # Default: opencast
 #index.identifier=opencast
 
+# Config that can be updated during runtime:
+
 # The index name. Will be used for logging.
 # Default: Elasticsearch
 #index.name=Elasticsearch
-
-# Config that can be updated during runtime:
 
 # How many times to retry get requests to the Elasticsearch in case of ElasticsearchStatusException.
 # Default: None

--- a/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
+++ b/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
@@ -14,12 +14,12 @@
 #index.name=Elasticsearch
 
 # How many times to retry get requests to the Elasticsearch in case of ElasticsearchStatusException.
-# Default: None
+# Default: 0
 #max.retry.attempts.get=0
 
 # How many times to retry update requests to the Elasticsearch in case of ElasticsearchStatusException (includes reads
 # necessary for updates).
-# Default: None
+# Default: 0
 #max.retry.attempts.update=0
 
 # How long to wait between retry attempts of get requests (in milliseconds).

--- a/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
+++ b/etc/org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg
@@ -1,5 +1,7 @@
 # Elasticsearch index configuration
 
+# Config that cannot be updated during runtime:
+
 # The base identifier of the Elasticsearch index. Subindices will be named after the following schema:
 # identifier_subindex, e.g. opencast_event. If an index with this name doesn't exist, Opencast will create it.
 # Default: opencast
@@ -8,3 +10,22 @@
 # The index name. Will be used for logging.
 # Default: Elasticsearch
 #index.name=Elasticsearch
+
+# Config that can be updated during runtime:
+
+# How many times to retry get requests to the Elasticsearch in case of ElasticsearchStatusException.
+# Default: None
+#max.retry.attempts.get=0
+
+# How many times to retry update requests to the Elasticsearch in case of ElasticsearchStatusException (includes reads
+# necessary for updates).
+# Default: None
+#max.retry.attempts.update=0
+
+# How long to wait between retry attempts of get requests (in milliseconds).
+# Default: 1s
+#retry.waiting.period.get=1000
+
+# How long to wait between retry attempts of update requests (in milliseconds).
+# Default: 1s
+#retry.waiting.period.update=1000

--- a/modules/elasticsearch-index/pom.xml
+++ b/modules/elasticsearch-index/pom.xml
@@ -71,16 +71,6 @@
     </dependency>
     <!-- elasticsearch -->
     <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-high-level-client</artifactId>
-      <version>${elasticsearch.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
-      <version>${elasticsearch.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
       <version>${elasticsearch.version}</version>

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -170,6 +170,12 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
             DEFAULT_RETRY_WAITING_PERIOD_UPDATE);
     logger.info("Max retry attempts for update requests set to {}, timeout set to {} ms.", maxRetryAttemptsUpdate,
             retryWaitingPeriodUpdate);
+
+    if (maxRetryAttemptsGet < 0 || maxRetryAttemptsUpdate < 0 || retryWaitingPeriodGet < 0
+            || retryWaitingPeriodUpdate < 0) {
+      logger.warn("You have configured negative values for max attempts or retry periods. Is this intended? This is "
+              + "equivalent to setting those values to 0.");
+    }
   }
 
   /**

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -45,7 +45,6 @@ import org.opencastproject.util.NotFoundException;
 
 import com.google.common.util.concurrent.Striped;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -80,13 +79,6 @@ import javax.xml.bind.Unmarshaller;
         service = { ElasticsearchIndex.class }
 )
 public class ElasticsearchIndex extends AbstractElasticsearchIndex {
-
-  /** The name of this index */
-  private static final String INDEX_IDENTIFIER_PROPERTY = "index.identifier";
-  private static final String DEFAULT_INDEX_IDENTIFIER = "opencast";
-
-  private static final String INDEX_NAME_PROPERTY = "index.name";
-  private static final String DEFAULT_INDEX_NAME = "Elasticsearch";
 
   /** Retry configuration */
   private int maxRetryAttemptsGet;
@@ -134,19 +126,14 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
    */
   @Activate
   public void activate(BundleContext bundleContext, Map<String, Object> properties) throws ComponentException {
-    super.activate(bundleContext);
+    super.activate(properties, bundleContext);
+    modified(properties);
 
-    String indexIdentifier = StringUtils.defaultIfBlank((String) properties
-                    .get(INDEX_IDENTIFIER_PROPERTY), DEFAULT_INDEX_IDENTIFIER);
-    String indexName = StringUtils.defaultIfBlank((String) properties.get(INDEX_NAME_PROPERTY),
-            DEFAULT_INDEX_NAME);
     try {
-      init(indexIdentifier, indexName, INDEX_VERSION);
+      init(INDEX_VERSION);
     } catch (Throwable t) {
       throw new ComponentException("Error initializing elastic search index", t);
     }
-
-    modified(properties);
   }
 
   /**
@@ -168,6 +155,8 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
    */
   @Modified
   public void modified(Map<String, Object> properties) {
+    super.modified(properties);
+
     maxRetryAttemptsGet = NumberUtils.toInt((String) properties.get(MAX_RETRY_ATTEMPTS_GET_PROPERTY),
             DEFAULT_MAX_RETRY_ATTEMPTS_GET);
     retryWaitingPeriodGet = NumberUtils.toInt((String) properties.get(RETRY_WAITING_PERIOD_GET_PROPERTY),


### PR DESCRIPTION
This adds configuration options to Elasticsearch for retrying failed requests. This is helpful if the index is temporarily unavailable, e.g. if Elasticsearch doesn't have enough heap to fulfill the request. You can set how many times a retry will be attempted, as well as how long to wait between attempts. These can be configured separately for simple get requests and for requests that also update or delete, since the latter are usually more important. Note that a get request that is necessary for an update will be considered part of the update, so those config settings apply.

Additionally I cleaned up some code (mostly recommendations from Intellij), and also made the index name (not identifier) changeable during runtime. Updates to the documentation and text for the release notes are included.

@wsmirnow asked me to aim this at OC 10, but as this depends on #2857, that's unfortunately not possible. Not sure if OC 11 is the right branch, since it isn't out yet, or if this would be better aimed at develop because this adds functionality to existing code. Any opinions?
