### PR TITLE
Fixed Admin UI Endpoint Configuration not loading on Opencast startup

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -39,6 +39,7 @@ import org.opencastproject.workflow.api.WorkflowService;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
@@ -245,6 +246,7 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint {
     this.urlSigningService = urlSigningService;
   }
 
+  @Activate
   @Modified
   public void modified(ComponentContext cc) {
     Dictionary<String, Object> properties = cc.getProperties();

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -124,15 +124,11 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
-import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DELETE;
@@ -237,18 +233,14 @@ public class SeriesEndpoint {
   }
 
   @Activate
-  protected void activate(ComponentContext cc) {
+  protected void activate(ComponentContext cc, Map<String, Object> properties) {
     if (cc != null) {
       String ccServerUrl = cc.getBundleContext().getProperty(OpencastConstants.SERVER_URL_PROPERTY);
       logger.debug("Configured server url is {}", ccServerUrl);
       if (ccServerUrl != null)
         this.serverUrl = ccServerUrl;
 
-      Dictionary dict = cc.getProperties();
-      List<String> keys = Collections.list(dict.keys());
-      Map<String, Object> dictCopy = keys.stream()
-              .collect(Collectors.toMap(Function.identity(), dict::get));
-      modified(dictCopy);
+      modified(properties);
     }
     logger.info("Activate series endpoint");
   }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -124,11 +124,15 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.DELETE;
@@ -239,6 +243,12 @@ public class SeriesEndpoint {
       logger.debug("Configured server url is {}", ccServerUrl);
       if (ccServerUrl != null)
         this.serverUrl = ccServerUrl;
+
+      Dictionary dict = cc.getProperties();
+      List<String> keys = Collections.list(dict.keys());
+      Map<String, Object> dictCopy = keys.stream()
+              .collect(Collectors.toMap(Function.identity(), dict::get));
+      modified(dictCopy);
     }
     logger.info("Activate series endpoint");
   }

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/impl/AdminUIConfiguration.java
@@ -26,6 +26,7 @@ import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.slf4j.Logger;
@@ -266,6 +267,7 @@ public class AdminUIConfiguration {
     return retractWorkflowId;
   }
 
+  @Activate
   @Modified
   public void modified(Map<String, Object> properties) {
     if (properties == null) {

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestSeriesEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestSeriesEndpoint.java
@@ -231,7 +231,7 @@ public class TestSeriesEndpoint extends SeriesEndpoint {
     this.setSecurityService(securityService);
     this.setAclServiceFactory(aclServiceFactory);
     this.setIndexService(indexServiceImpl);
-    this.activate(null);
+    this.activate(null, null);
   }
 
   private Series createSeries(String id, String title, String contributor, String organizer, long time, Long themeId) {


### PR DESCRIPTION
As mentioned in PR #3049 by @KatrinIhler, said PR caused some of the admin ui endpoint configuration files to not be read on Opencast start-up anymore, but only when the configuration files were modified at runtime. This should fix that.
