### PR TITLE
Allow null value for (event) comment author email field

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -560,7 +560,8 @@ public abstract class AbstractEventEndpoint {
               f("replies", arr(eventCommentRepliesToJson(c.getReplies()))),
               f("author", obj(
                       f("name", c.getAuthor().getName()),
-                      f("email", c.getAuthor().getEmail()),
+                      // email field of the digest user is always null
+                      f("email", v(c.getAuthor().getEmail(), NULL)),
                       f("username", c.getAuthor().getUsername())
               )),
               f("id", v(c.getId().get())),
@@ -583,7 +584,8 @@ public abstract class AbstractEventEndpoint {
               f("modificationDate", v(r.getModificationDate().toInstant().toString())),
               f("author", obj(
                       f("name", r.getAuthor().getName()),
-                      f("email", r.getAuthor().getEmail()),
+                      // email field of the digest user is always null
+                      f("email", v(r.getAuthor().getEmail(), NULL)),
                       f("username", r.getAuthor().getUsername())
               ))
       );


### PR DESCRIPTION
If you create a comment from a workflow with a user without email address, like the digest user, the Admin UI event endpoint will throw an exception like this:

```
2021-11-23T08:55:26,265 | WARN  | (HttpChannel:591) - /admin-ng/event/events.json
java.lang.IllegalArgumentException: Value of field 'email' must not be null
	at com.entwinemedia.fn.data.json.Field.<init>(Field.java:31) ~[?:?]
	at com.entwinemedia.fn.data.json.Jsons.f(Jsons.java:89) ~[?:?]
	at com.entwinemedia.fn.data.json.Jsons.f(Jsons.java:93) ~[?:?]
	at org.opencastproject.adminui.endpoint.AbstractEventEndpoint.eventCommentsToJson(AbstractEventEndpoint.java:561) ~[?:?]
	at org.opencastproject.adminui.endpoint.AbstractEventEndpoint.eventToJSON(AbstractEventEndpoint.java:2549) ~[?:?]
	at org.opencastproject.adminui.endpoint.AbstractEventEndpoint.getEvents(AbstractEventEndpoint.java:2498) ~[?:?]
	at jdk.internal.reflect.GeneratedMethodAccessor70.invoke(Unknown Source) ~[?:?]
        [... shortened]
```

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
