### PR TITLE
Handle multiple creators in Theodul

### DIFF
--- a/modules/engage-theodul-plugin-custom-mhConnection/src/main/resources/static/models/mediaPackage.js
+++ b/modules/engage-theodul-plugin-custom-mhConnection/src/main/resources/static/models/mediaPackage.js
@@ -82,8 +82,11 @@ define(["backbone", "engage/core"], function(Backbone, Engage) {
                             if (mediaPackage.dcTitle) {
                                 model.attributes.title = mediaPackage.dcTitle;
                             }
-                            if (mediaPackage.dcCreator) {
-                                model.attributes.creator = mediaPackage.dcCreator;
+                            if (mediaPackage.mediapackage.creators) {
+                                model.attributes.creator = (Array.isArray(mediaPackage.mediapackage.creators.creator)
+                                    ? mediaPackage.mediapackage.creators.creator
+                                    : [mediaPackage.mediapackage.creators.creator])
+                                    .join(', ');
                             }
                             if (mediaPackage.dcCreated) {
                                 model.attributes.date = mediaPackage.dcCreated;


### PR DESCRIPTION
This patch fixes the problem that theodul would just display a
single random creator from the dc catalog, even if the event
has multiple creators.

Fixes: #3165 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
