### PR TITLE
asset-manager move to S3 duplicates identical files #3164

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
@@ -132,6 +132,19 @@ public interface AssetManager {
   RichAResult getSnapshotsById(String mpId);
 
   /**
+   * Returns a stream of {@link RichAResult} filtered by mediapackage IDs. This stream
+   * consists of all versions of all mediapackage ordered by the Version
+   *
+   * @param mpId
+   *   The mediapackage ID to filter results for
+   * @param asc
+   *   The asc {@link Boolean} decides if to order ascending (true) or descending (false)
+   * @return
+   *   The {@link RichAResult} stream filtered by mediapackage ID
+   */
+  RichAResult getSnapshotsByIdOrderedByVersion(String mpId, boolean asc);
+
+  /**
    * Returns a stream of {@link RichAResult} filtered by mediapackage ID and version
    *
    * @param mpId
@@ -144,8 +157,8 @@ public interface AssetManager {
   RichAResult getSnapshotsByIdAndVersion(String mpId, Version version);
 
   /**
-   * Returns a stream of {@link RichAResult} filtered by date. This stream consists of all versions of all mediapackages
-   * archived within the date range.
+   * Returns a stream of {@link RichAResult} filtered by date. This stream
+   * consists of all versions of all mediapackages archived within the date range.
    *
    * @param start
    *   The start {@link Date} to filter by
@@ -155,6 +168,19 @@ public interface AssetManager {
    *   The {@link RichAResult} stream filtered by date
    */
   RichAResult getSnapshotsByDate(Date start, Date end);
+
+  /**
+   * Returns a stream of {@link RichAResult} filtered by date. This stream consists of all
+   * a mediapackages which have at least one version archived within the date range.
+   *
+   * @param start
+   *   The start {@link Date} to filter by
+   * @param end
+   *   The end{@link Date} to filter by
+   * @return
+   *   The {@link RichAResult} stream filtered by date
+   */
+  RichAResult getSnapshotsByDateOrderedById(Date start, Date end);
 
   /**
    * Returns a stream of {@link RichAResult} filtered by date and mediapackage. This stream consists of all versions of
@@ -170,6 +196,24 @@ public interface AssetManager {
    *   The {@link RichAResult} stream filtered by date
    */
   RichAResult getSnapshotsByIdAndDate(String mpId, Date start, Date end);
+
+  /**
+   * Returns a stream of {@link RichAResult} filtered by date and mediapackage. 
+   * This stream consists of all versions of a mediapackage archived within the 
+   * date range ordered by there Version.
+   *
+   * @param mpId
+   *   The mediapackage ID to filter for
+   * @param start
+   *   The start {@link Date} to filter by
+   * @param end
+   *   The end {@link Date} to filter by
+   * @param asc
+   *   The asc {@link Boolean} decides if to order ascending (true) or descending (false)
+   * @return
+   *   The {@link RichAResult} stream filtered by date
+   */
+  RichAResult getSnapshotsByIdAndDateOrderedByVersion(String mpId, Date start, Date end, boolean asc);
 
   /**
    * Take a versioned snapshot of a media package.
@@ -254,7 +298,6 @@ public interface AssetManager {
    * @throws NotFoundException
    */
   void moveSnapshotsByIdAndDate(String mpId, Date start, Date end, String targetStore) throws NotFoundException;
-
 
   /* Properties */
 

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/AQueryBuilder.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/query/AQueryBuilder.java
@@ -72,6 +72,9 @@ public interface AQueryBuilder {
   /** Create a predicate to match an snapshot's media package ID. */
   Predicate mediaPackageId(String mpId);
 
+  /** Get the snapshot's "mediaPackageId" field. Use it to create a predicate. */
+  Field<String> mediapackageId();
+
   /** Get the snapshot's "seriesId" field. Use it to create a predicate. */
   Field<String> seriesId();
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AQueryBuilderDecorator.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AQueryBuilderDecorator.java
@@ -62,6 +62,10 @@ public class AQueryBuilderDecorator implements AQueryBuilder {
     return delegate.mediaPackageId(mpId);
   }
 
+  @Override public Field<String> mediapackageId() {
+    return delegate.mediapackageId();
+  }
+
   @Override public Field<String> seriesId() {
     return delegate.seriesId();
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -576,6 +576,19 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
   }
 
   @Override
+  public RichAResult getSnapshotsByIdOrderedByVersion(String mpId, boolean asc) {
+    RequireUtil.requireNotBlank(mpId, "mpId");
+    AQueryBuilder q = createQuery();
+    ASelectQuery query = baseQuery(q, mpId);
+    if (asc) {
+      query = query.orderBy(q.version().asc());
+    } else {
+      query = query.orderBy(q.version().desc());
+    }
+    return Enrichments.enrich(query.run());
+  }
+
+  @Override
   public RichAResult getSnapshotsByIdAndVersion(final String mpId, final Version version) {
     RequireUtil.requireNotBlank(mpId, "mpId");
     RequireUtil.notNull(version, "version");
@@ -594,12 +607,36 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
   }
 
   @Override
+  public RichAResult getSnapshotsByDateOrderedById(Date start, Date end) {
+    RequireUtil.notNull(start, "start");
+    RequireUtil.notNull(end, "end");
+    AQueryBuilder q = createQuery();
+    ASelectQuery query = baseQuery(q).where(q.archived().ge(start)).where(q.archived().le(end));
+    return Enrichments.enrich(query.orderBy(q.mediapackageId().asc()).run());
+  }
+
+  @Override
   public RichAResult getSnapshotsByIdAndDate(final String mpId, final Date start, final Date end) {
     RequireUtil.requireNotBlank(mpId, "mpId");
     RequireUtil.notNull(start, "start");
     RequireUtil.notNull(end, "end");
     AQueryBuilder q = createQuery();
     ASelectQuery query = baseQuery(q, mpId).where(q.archived().ge(start)).where(q.archived().le(end));
+    return Enrichments.enrich(query.run());
+  }
+
+  @Override
+  public RichAResult getSnapshotsByIdAndDateOrderedByVersion(String mpId, Date start, Date end, boolean asc) {
+    RequireUtil.requireNotBlank(mpId, "mpId");
+    RequireUtil.notNull(start, "start");
+    RequireUtil.notNull(end, "end");
+    AQueryBuilder q = createQuery();
+    ASelectQuery query = baseQuery(q, mpId).where(q.archived().ge(start)).where(q.archived().le(end));
+    if (asc) {
+      query = query.orderBy(q.version().asc());
+    } else {
+      query = query.orderBy(q.version().desc());
+    }
     return Enrichments.enrich(query.run());
   }
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerJobProducer.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerJobProducer.java
@@ -39,14 +39,17 @@ import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.RequireUtil;
 
 import com.entwinemedia.fn.data.Opt;
+import com.google.gson.Gson;
 
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 public class AssetManagerJobProducer extends AbstractJobProducer {
@@ -59,7 +62,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
   public static final Float NONTERMINAL_JOB_LOAD = 0.1f;
 
   public enum Operation {
-    MoveById, MoveByIdAndVersion, MoveByIdAndDate, MoveByDate
+    MoveById, MoveByIdAndVersion, MoveByIdAndDate, MoveByDate, MoveRecords
   }
 
   private static final String OK = "OK";
@@ -90,6 +93,42 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
     Opt<AssetStore> store = tsam.getAssetStore(storeId);
     return store.isSome();
   }
+
+  /** Utility class to collect RecordInformation for moving larger 
+   * groups of mediapackages in combined jobs.
+   */
+  private class MoveRecordInfo {
+    private final Gson gson = new Gson();
+    private int success = 0;
+    private int failed = 0;
+    private String currentMpId = "";
+    public void addSuccess() {
+      success++;
+    };
+    public void addFailed() {
+      failed ++;
+    }
+
+    public boolean isNewMpId(String mpId) {
+      if (currentMpId.equals(mpId)) {
+        return false;
+      }
+      currentMpId = mpId;
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      Map<String,Integer> result = new HashMap<>();
+      if (success > 0) {
+        result.put("OK", success);
+      }
+      if (failed > 0) {
+        result.put("FAIL", failed);
+      }
+      return gson.toJson(result);
+    }
+  };
 
   @Override
   protected String process(Job job) throws ServiceRegistryException {
@@ -145,7 +184,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
     RequireUtil.notNull(version, "version");
     RequireUtil.notEmpty(mpId, "mpId");
     RequireUtil.notEmpty(targetStorage, "targetStorage");
-    List<String> args = new LinkedList<String>();
+    List<String> args = new LinkedList<>();
     args.add(targetStorage);
     args.add(mpId);
     args.add(version.toString());
@@ -171,7 +210,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
    * @throws NotFoundException
    */
   protected String internalMoveByIdAndVersion(
-      final VersionImpl version,
+      final Version version,
       final String mpId,
       final String targetStorage
   ) throws NotFoundException {
@@ -192,7 +231,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
   public Job moveById(final String mpId, final String targetStorage) {
     RequireUtil.notEmpty(mpId, "mpId");
     RequireUtil.notEmpty(targetStorage, "targetStorage");
-    List<String> args = new LinkedList<String>();
+    List<String> args = new LinkedList<>();
     args.add(targetStorage);
     args.add(mpId);
 
@@ -204,19 +243,20 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
   }
 
   /**
-   * Spawns subjobs on a per-snapshot level to move the appropriate snapshots to their new home
+   * Moves all the appropriate snapshots to their new home
    *
    * @param mpId
    *  The mediapackage ID of the snapshot to move
    * @param targetStorage
    *  The {@link RemoteAssetStore} ID where the snapshot should be moved
    * @return
-   *  The number of subjobs spawned
+   *  The String containing the number of successful and failed moves
+   *  [<> OK ][<> FAILED ]
    */
   protected String internalMoveById(final String mpId, final String targetStorage) {
-    RichAResult results = tsam.getSnapshotsById(mpId);
-    List<Job> subjobs = spawnSubjobs(results, targetStorage);
-    return Integer.toString(subjobs.size());
+    RichAResult results = tsam.getSnapshotsByIdOrderedByVersion(mpId, true);
+    MoveRecordInfo result = moveSnapshots(results, targetStorage);
+    return result.toString();
   }
 
 
@@ -237,7 +277,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
     RequireUtil.notNull(start, "start");
     RequireUtil.notNull(end, "end");
     RequireUtil.notNull(targetStorage, "targetStorage");
-    List<String> args = new LinkedList<String>();
+    List<String> args = new LinkedList<>();
     args.add(targetStorage);
     args.add(Long.toString(start.getTime()));
     args.add(Long.toString(end.getTime()));
@@ -252,6 +292,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
 
   /**
    * Spawns subjobs on a per-snapshot level to move the appropriate snapshots to their new home
+   * Moves all the appropriate snapshots to their new home
    *
    * @param start
    *  The start {@link Date}
@@ -263,8 +304,8 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
    *  The number of subjobs spawned
    */
   protected String internalMoveByDate(final Date start, final Date end, final String targetStorage) {
-    RichAResult results = tsam.getSnapshotsByDate(start, end);
-    List<Job> subjobs = spawnSubjobs(results, targetStorage);
+    RichAResult results = tsam.getSnapshotsByDateOrderedById(start, end);
+    List<Job> subjobs = spawnSubjobs(results, start, end, targetStorage);
     return Integer.toString(subjobs.size());
   }
 
@@ -288,7 +329,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
     RequireUtil.notNull(start, "start");
     RequireUtil.notNull(end, "end");
     RequireUtil.notNull(targetStorage, "targetStorage");
-    List<String> args = new LinkedList<String>();
+    List<String> args = new LinkedList<>();
     args.add(targetStorage);
     args.add(mpId);
     args.add(Long.toString(start.getTime()));
@@ -303,7 +344,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
   }
 
   /**
-   * Spawns subjobs on a per-snapshot level to move the appropriate snapshots to their new home
+   * Moves all the appropriate snapshots to their new home
    *
    * @param mpId
    *  The mediapackage ID of the snapshot to move
@@ -314,7 +355,8 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
    * @param targetStorage
    *  The {@link RemoteAssetStore} ID where the snapshot should be moved
    * @return
-   *  The number of subjobs spawned
+   *  The JSON String containing the number of successful and failed moves
+   *  {"OK":<>,"FAIL":<>}
    */
   protected String internalMoveByIdAndDate(
       final String mpId,
@@ -322,9 +364,9 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
       final Date end,
       final String targetStorage
   ) {
-    RichAResult results = tsam.getSnapshotsByIdAndDate(mpId, start, end);
-    List<Job> subjobs = spawnSubjobs(results, targetStorage);
-    return Integer.toString(subjobs.size());
+    RichAResult results = tsam.getSnapshotsByIdAndDateOrderedByVersion(mpId, start, end, true);
+    MoveRecordInfo result = moveSnapshots(results, targetStorage);
+    return result.toString();
   }
 
   /**
@@ -337,20 +379,63 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
    * @return
    *  The set of subjobs
    */
-  private List<Job> spawnSubjobs(final RichAResult records, final String targetStorage) {
+
+  private List<Job> spawnSubjobs(
+      final RichAResult records,
+      final Date start,
+      final Date end,
+      final String targetStorage
+  ) {
     List<Job> jobs = new LinkedList<>();
+    MoveRecordInfo recordInfo = new MoveRecordInfo();
     records.forEach(new Consumer<ARecord>() {
       @Override
       public void accept(ARecord record) {
         Snapshot snap = record.getSnapshot().get();
-        jobs.add(moveByIdAndVersion(
-            snap.getVersion(),
-            snap.getMediaPackage().getIdentifier().toString(),
-            targetStorage
-        ));
+        String mediaPackageId = snap.getMediaPackage().getIdentifier().toString();
+        if (recordInfo.isNewMpId(mediaPackageId)) {
+          jobs.add(moveByIdAndDate(mediaPackageId,start,end,targetStorage));
+        }
       }
     });
     return jobs;
+  }
+
+  /**
+   * Moves all snapshot based on the stream of records from its current storage to a new target storage location
+   *
+   * @param records
+   *  The stream of records containing the snapshots to move to the new target storage
+   * @param targetStorage
+   *  The {@link RemoteAssetStore} ID where the snapshot should be moved
+   * @return
+   *  The {@link MoveRecordInfo}
+   */
+  private MoveRecordInfo moveSnapshots(final RichAResult records, final String targetStorage) {
+    final MoveRecordInfo result = new MoveRecordInfo();
+    records.forEach(new Consumer<ARecord>() {
+      @Override
+      public void accept(ARecord record) {
+        Snapshot snap = record.getSnapshot().get();
+          try {
+            logger.debug("moving Mediapackage {} Version {} from {} to {}",
+                snap.getMediaPackage().getIdentifier().toString(),
+                snap.getVersion().toString(),
+                snap.getStorageId(),
+                targetStorage
+            );
+            internalMoveByIdAndVersion(snap.getVersion(),
+                snap.getMediaPackage().getIdentifier().toString(),
+                targetStorage
+            );
+            result.addSuccess();
+          } catch (NotFoundException e) {
+            result.addFailed();
+            logger.warn(e.getMessage());
+          }
+      }
+    });
+    return result;
   }
 
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
@@ -383,7 +468,6 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
   protected UserDirectoryService getUserDirectoryService() {
     return this.userDirectoryService;
   }
-
 
   protected void setOrganizationDirectoryService(OrganizationDirectoryService os) {
     this.organizationDirectoryService = os;

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AQueryBuilderImpl.java
@@ -154,6 +154,10 @@ public final class AQueryBuilderImpl implements AQueryBuilder, EntityPaths {
     };
   }
 
+  @Override public Field<String> mediapackageId() {
+    return new SimpleSnapshotField<>(Q_SNAPSHOT.mediaPackageId);
+  }
+
   /**
    * A predicate that is based on a simple snapshot field expression.
    */

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerJobProducerTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerJobProducerTest.java
@@ -83,8 +83,9 @@ public class AssetManagerJobProducerTest
     EasyMock.replay(sr);
 
     Assert.assertEquals("Both versions should move",
-            "2", tsamjp.internalMoveById(mp[1], REMOTE_STORE_1_ID));
-    EasyMock.verify(sr);
+            "{\"OK\":2}", tsamjp.internalMoveById(mp[0], REMOTE_STORE_1_ID));
+    Assert.assertEquals("Both versions should move",
+            "{\"OK\":2}", tsamjp.internalMoveById(mp[1], REMOTE_STORE_1_ID));
   }
 
   @Test
@@ -166,16 +167,22 @@ public class AssetManagerJobProducerTest
     Thread.sleep(1);
     Date after = new Date();
     //Non terminal query, but internal test so we create terminal expectations
-    createIdAndVersionExpectation(mp[0], 0, 2);
-    createIdAndVersionExpectation(mp[1], 0, 2);
+    createIdAndDateExpectation(mp[0], before ,after);
+    createIdAndDateExpectation(mp[1], before ,after);
+
     EasyMock.replay(sr);
 
     Assert.assertEquals("No versions exist between the start and before test values",
             "0", tsamjp.internalMoveByDate(start, before, REMOTE_STORE_1_ID));
-    Assert.assertEquals("All four versions should move",
-            "4", tsamjp.internalMoveByDate(before, after, REMOTE_STORE_1_ID));
+    Assert.assertEquals("All versions should move in 2 jobs containing one mediapackage each",
+            "2", tsamjp.internalMoveByDate(before, after, REMOTE_STORE_1_ID));
     Assert.assertEquals("No versions exist after the end date",
             "0", tsamjp.internalMoveByDate(after, new Date(), REMOTE_STORE_1_ID));
+    Assert.assertEquals("Both versions of " + mp[0] + " should move",
+            "{\"OK\":2}", tsamjp.internalMoveByIdAndDate(mp[0], before, after, REMOTE_STORE_1_ID));
+    Assert.assertEquals("Both versions of " + mp[1] + " should move",
+            "{\"OK\":2}", tsamjp.internalMoveByIdAndDate(mp[1], before, after, REMOTE_STORE_1_ID));
+
     EasyMock.verify(sr);
   }
 
@@ -204,6 +211,8 @@ public class AssetManagerJobProducerTest
     EasyMock.replay(sr);
 
     tsamjp.moveByIdAndDate(mp[0], start, end, REMOTE_STORE_1_ID);
+    Assert.assertEquals("Both versions of " + mp[0] + " should move",
+            "{\"OK\":2}", tsamjp.internalMoveByIdAndDate(mp[0], start, end, REMOTE_STORE_1_ID));
 
     EasyMock.verify(sr);
   }
@@ -219,12 +228,11 @@ public class AssetManagerJobProducerTest
     EasyMock.replay(sr);
 
     Assert.assertEquals("No versions exist between the start and before test values",
-            "0", tsamjp.internalMoveByIdAndDate("fake", start, before, REMOTE_STORE_1_ID));
+            "{}", tsamjp.internalMoveByIdAndDate("fake", start, before, REMOTE_STORE_1_ID));
     Assert.assertEquals("Both versions of " + mp[1] + " should move",
-            "2", tsamjp.internalMoveByIdAndDate(mp[1], before, after, REMOTE_STORE_1_ID));
+            "{\"OK\":2}", tsamjp.internalMoveByIdAndDate(mp[1], before, after, REMOTE_STORE_1_ID));
     Assert.assertEquals("No versions of " + mp[1] + " should move",
-            "0", tsamjp.internalMoveByIdAndDate(mp[1], after, new Date(), REMOTE_STORE_1_ID));
-    EasyMock.verify(sr);
+            "{}", tsamjp.internalMoveByIdAndDate(mp[1], after, new Date(), REMOTE_STORE_1_ID));
   }
 
   @Test


### PR DESCRIPTION
This fixes the asset manager move to s3 file duplication - issue #3164 fix for 10.x

This version combines the up to now individual moves of a media package on a by version to by mediapackage group.
when using:

    moveById moves all versions of a mediapackage in order first to last within one job
    moveByIdAndDate moves all versions of a mediapackage within a date-range in order first to last within one job
    moveByDate moves all mediapackages in a date-range fetching them as individual mediapackages to then use moveByIdAndDate ... i.e. create a job for each mediapackage to then move all versions of that mediapackage which are in the date-range
