### PR TITLE
start-workflow-wfh allows to pass mediapackage id from previous WFH

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
@@ -16,8 +16,8 @@ For each duplicated event the new media package ID is stored as a workflow prope
 
 |Name                                    |Example                                                             |Description                                    |
 |----------------------------------------|--------------------------------------------------------------------|-----------------------------------------------|
-|duplicate\_media\_package\_*number*\_id |`duplicate\_media\_package\_1\_id=e72f2265-472a-49ae-bc04-8301d94b4b1a` |Media package ID of the duplicated event       | \*
-|duplicate\_media\_package\_ids          |`duplicate\_media\_package\_ids=e72f2265-472a-49ae-bc04-8301d94b4b1a, a32e2265-472a-49ae-bc04-8351d94b4b1c` | comma separated list of Media package IDs of the duplicated event |
+|duplicate\_media\_package\_*number*\_id |`duplicate_media_package_1_id=e72f2265-472a-49ae-bc04-8301d94b4b1a` |Media package ID of the duplicated event       | \*
+|duplicate\_media\_package\_ids          |`duplicate_media_package_ids=e72f2265-472a-49ae-bc04-8301d94b4b1a, a32e2265-472a-49ae-bc04-8351d94b4b1c` | comma separated list of Media package IDs of the duplicated event |
 
 \* will be deprecated
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
@@ -16,7 +16,10 @@ For each duplicated event the new media package ID is stored as a workflow prope
 
 |Name                                    |Example                                                             |Description                                    |
 |----------------------------------------|--------------------------------------------------------------------|-----------------------------------------------|
-|duplicate\_media\_package\_*number*\_id |`duplicate_media_package_1_id=e72f2265-472a-49ae-bc04-8301d94b4b1a` |Media package ID of the duplicated event       |
+|duplicate\_media\_package\_*number*\_id |`duplicate\_media\_package\_1\_id=e72f2265-472a-49ae-bc04-8301d94b4b1a` |Media package ID of the duplicated event       | \*
+|duplicate\_media\_package\_ids          |`duplicate\_media\_package\_ids=e72f2265-472a-49ae-bc04-8301d94b4b1a, a32e2265-472a-49ae-bc04-8351d94b4b1c` | comma separated list of Media package IDs of the duplicated event |
+
+\* will be deprecated
 
 Parameter Table
 ---------------

--- a/docs/guides/admin/docs/workflowoperationhandlers/start-workflow-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/start-workflow-woh.md
@@ -20,7 +20,7 @@ The StartWorkflowWorkflowOperationHandler can be used to start a new workflow fo
 <operation id="start-workflow">
   <configurations>
     <configuration key="workflow-definition">fast</configuration>
-    <configuration key="media-packages">${duplicate\_media\_package\_ids}</configuration>
+    <configuration key="media-packages">${duplicate_media_package_ids}</configuration>
     <configuration key="key">value</configuration>
     <configuration key="publish">true</configuration>
   </configurations>

--- a/docs/guides/admin/docs/workflowoperationhandlers/start-workflow-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/start-workflow-woh.md
@@ -8,7 +8,7 @@ The StartWorkflowWorkflowOperationHandler can be used to start a new workflow fo
 
 |Configuration Key         |Example                              |Description                                     |
 |--------------------------|-------------------------------------|------------------------------------------------|
-|media-package\*           |e72f2265-472a-49ae-bc04-8301d94b4b1a |The ID of the media package that should be used |
+|media-packages\*          |e72f2265-472a-49ae-bc04-8301d94b4b1a, a32e2265-472a-49ae-bc04-8351d94b4b1c |comma separated list of the media package ids that should be used |
 |workflow-definition\*     |fast                                 |The workflow definition that should be used     |
 |*configProperty*          |abc / false                          |Workflow configuration property                 |
 
@@ -20,7 +20,7 @@ The StartWorkflowWorkflowOperationHandler can be used to start a new workflow fo
 <operation id="start-workflow">
   <configurations>
     <configuration key="workflow-definition">fast</configuration>
-    <configuration key="media-package">e72f2265-472a-49ae-bc04-8301d94b4b1a</configuration>
+    <configuration key="media-packages">${duplicate\_media\_package\_ids}</configuration>
     <configuration key="key">value</configuration>
     <configuration key="publish">true</configuration>
   </configurations>

--- a/etc/workflows/duplicate-event.xml
+++ b/etc/workflows/duplicate-event.xml
@@ -59,6 +59,14 @@
       </configurations>
     </operation>
 
+    <operation
+      id="start-workflow">
+      <configurations>
+        <configuration key="media-packages">${duplicate_media_package_ids}</configuration>
+        <configuration key="workflow-definition">fast</configuration>
+      </configurations>
+    </operation>
+
     <!-- Clean up work artifacts -->
 
     <operation

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -303,8 +303,9 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
           + originalEpisodeDc.length + " episode dublin cores while it is expected to have exactly 1. Aborting.");
     }
 
+    String mpIds = "";
+    String sep = "";
     Map<String, String> properties = new HashMap<>();
-
     for (int i = 0; i < numberOfEvents; i++) {
       final List<URI> temporaryFiles = new ArrayList<>();
       MediaPackage newMp = null;
@@ -365,12 +366,15 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
 
         // Store media package ID as workflow property
         properties.put("duplicate_media_package_" + (i + 1) + "_id", newMp.getIdentifier().toString());
+        mpIds += sep + newMp.getIdentifier().toString();
+        sep = ", ";
       } catch (IOException | MediaPackageException e) {
         throw new WorkflowOperationException(e);
       } finally {
         cleanup(temporaryFiles, Optional.ofNullable(newMp));
       }
     }
+    properties.put("duplicate_media_package_ids", mpIds);
     return createResult(mediaPackage, properties, Action.CONTINUE, 0);
   }
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandler.java
@@ -53,7 +53,10 @@ public class StartWorkflowWorkflowOperationHandler extends AbstractWorkflowOpera
   private static final Logger logger = LoggerFactory.getLogger(StartWorkflowWorkflowOperationHandler.class);
 
   /** Name of the configuration option that provides the media package ID */
-  public static final String MEDIA_PACKAGE_ID = "media-packages";
+  @Deprecated
+  public static final String MEDIA_PACKAGE_ID = "media-package";
+
+  public static final String MEDIA_PACKAGE_IDS = "media-packages";
 
   /** Name of the configuration option that provides the workflow definition ID */
   public static final String WORKFLOW_DEFINITION = "workflow-definition";
@@ -87,13 +90,17 @@ public class StartWorkflowWorkflowOperationHandler extends AbstractWorkflowOpera
           throws WorkflowOperationException {
 
     final WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
-    final String configuredMediaPackageIDs = trimToEmpty(operation.getConfiguration(MEDIA_PACKAGE_ID));
+    String mediaPackageIDs = trimToEmpty(operation.getConfiguration(MEDIA_PACKAGE_IDS));
+    if ("".equals(mediaPackageIDs)) {
+      mediaPackageIDs = trimToEmpty(operation.getConfiguration(MEDIA_PACKAGE_ID));
+    }
+    final String configuredMediaPackageIDs = mediaPackageIDs;
     final String configuredWorkflowDefinition = trimToEmpty(operation.getConfiguration(WORKFLOW_DEFINITION));
     final Boolean failOnError = operation.isFailWorkflowOnException();
     // Get workflow parameter
     final Map<String, String> properties = new HashMap<>();
     for (String key : operation.getConfigurationKeys()) {
-      if (MEDIA_PACKAGE_ID.equals(key) || WORKFLOW_DEFINITION.equals(key)) {
+      if (MEDIA_PACKAGE_ID.equals(key) || MEDIA_PACKAGE_IDS.equals(key) || WORKFLOW_DEFINITION.equals(key)) {
         continue;
       }
       properties.put(key, operation.getConfiguration(key));
@@ -123,6 +130,7 @@ public class StartWorkflowWorkflowOperationHandler extends AbstractWorkflowOpera
           errors += delim + errstr;
           delim = "\n";
         }
+        continue;
       }
       final MediaPackage mp = mpOpt.get();
       try {

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandlerTest.java
@@ -88,6 +88,7 @@ public class StartWorkflowWorkflowOperationHandlerTest {
     operation.setConfiguration(WORKFLOW_DEFINITION, WD_ID);
     operation.setConfiguration("workflowConfigurations", "true");
     operation.setConfiguration("key", "value");
+    operation.setFailWorkflowOnException(true);
 
     workflowInstance = new WorkflowInstanceImpl();
     workflowInstance.setMediaPackage(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());


### PR DESCRIPTION
Update StartWF WFH to allow passing MP ids in from previous WF operations. this can be useful for Duplicate MP workflows that can then start other operation on the duplicates
