### PR TITLE
Fix Date Time Picker

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-    <!-- build:css styles/vendor.css -->
+    <!-- build:css(./) styles/vendor.css -->
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/jqueryui-timepicker-addon/dist/jquery-ui-timepicker-addon.css" />
     <link rel="stylesheet" href="bower_components/angular-hotkeys/build/hotkeys.css" />

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/datetimepickerDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/datetimepickerDirective.js
@@ -61,9 +61,14 @@ angular.module('adminNg.directives')
         };
 
 
-        var optionsObj = {};
-        optionsObj.timeInput = true;
-        optionsObj.showButtonPanel = true;
+        var optionsObj = {
+          controlType: 'select',
+          showMillisec: false,
+          showMicrosec: false,
+          showTimezone: false,
+          oneLine: true,
+          timeFormat: 'HH:mm'
+        };
         optionsObj.onClose = function () {
           var newDate = element.datetimepicker('getDate');
           setTimeout(function(){

--- a/modules/admin-ui-frontend/app/styles/mixins/_button.scss
+++ b/modules/admin-ui-frontend/app/styles/mixins/_button.scss
@@ -240,6 +240,14 @@ button {
     display: inline-block;
 }
 
+// Exception for datetimepicker
+.ui-datepicker-buttonpane {
+  button {
+    height: initial;
+    min-width: initial;
+  }
+}
+
 // Buttons
 .add-btn {
     @include btn(green);

--- a/modules/admin-ui-frontend/app/styles/vendor/datepicker.scss
+++ b/modules/admin-ui-frontend/app/styles/vendor/datepicker.scss
@@ -1301,23 +1301,17 @@
   }
 
   .ui-widget-header .ui-state-default {
-    width: 26px;
     border: 1px solid #dddddd;
     background: #fff;
     font-weight: 400;
-    padding-bottom: 6px;
-    padding-top: 6px;
   }
 
   .ui-state-default,
   .ui-widget-content .ui-state-default,
   .ui-widget-header .ui-state-default {
-    width: 26px;
     border: 1px solid #dddddd;
     background: #fff;
     font-weight: 400;
-    padding-bottom: 6px;
-    padding-top: 6px;
     color: #000;
   }
 


### PR DESCRIPTION
This patch fixes the interface of the date time picker which was missing
all its style attributes since they were not properly included in bower
and was additionally partially overwritten by random other attributes.

This also caused hidden fields like microseconds to show up which was
not helpful.

To make things even simpler, this also switches from the slider
interface for times to the selector interface, which is much more
common.

![screenshot-from-2021-11-29_22-39-16](https://user-images.githubusercontent.com/1008395/144075709-8ec4b240-2f31-4b8d-a5dd-9d20d50e1985.png)

_Other than depicted, this is now asking for hour and minute only as discussed in the technical meeting._

This fixes #1976

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
