### PR TITLE
Improve GitHub Actions Concurrency Configuration

### DIFF
--- a/.github/workflows/deploy-crowdin-keys.yml
+++ b/.github/workflows/deploy-crowdin-keys.yml
@@ -6,6 +6,10 @@ on:
       - develop
       - 'r/*.x'
 
+concurrency:
+  group: crowdin-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-translation-keys:
     if: github.repository_owner == 'opencast'

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,7 +7,7 @@ on:
       - 'develop'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: docs-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This patch improves the GitHub Actions concurrency configuration by
moving the documentation deployment into it's own concurrency namespace
and by ensuring that the last commit on a branch will win when deploying
to Crowdin.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
