### PR TITLE
Link Configuration Files in GitHub

### DIFF
--- a/docs/guides/admin/docs/javascript/extra.js
+++ b/docs/guides/admin/docs/javascript/extra.js
@@ -50,12 +50,30 @@ function addTitleToCodeTag() {
     SPAN.classList.add("etc-span");
     SPAN.title = '"etc" represents the configuration directory of Opencast.\nThis directory is often located at "/etc/opencast".';
 
+    let branch = 'develop';
+    if (window.location.host == 'docs.opencast.org') {
+        branch = window.location.pathname.substring(1).replace(/\/admin.*/, '');
+    }
+    const repobase = `https://github.com/opencast/opencast/blob/${branch}/`;
+
     var codeElementList = document.getElementsByTagName("CODE");
     for (var i = 0; i < codeElementList.length; i++) {
         var CODE = codeElementList[i];
+
         if (typeof CODE.innerText !== 'undefined') {
             if (CODE.innerText.startsWith('etc/')) {
                 CODE.innerHTML = CODE.innerHTML.replace(/^etc/, SPAN.outerHTML);
+
+                // Link repository
+                let a = document.createElement('a');
+                a.innerText = '⇲';
+                a.title = 'Find configuration file in repository';
+                a.style.transform = 'rotate(-90deg)';
+                a.style.display = 'inline-block';
+                a.style.verticalAlign = 'super';
+                a.style.fontSize = '.83em';
+                a.href = repobase + CODE.innerText + '#repo-content-pjax-container';
+                CODE.parentNode.insertBefore(a, CODE.nextSibling);
             }
         }
     }

--- a/docs/guides/admin/docs/javascript/extra.js
+++ b/docs/guides/admin/docs/javascript/extra.js
@@ -66,12 +66,8 @@ function addTitleToCodeTag() {
 
                 // Link repository
                 let a = document.createElement('a');
-                a.innerText = '⇲';
-                a.title = 'Find configuration file in repository';
-                a.style.transform = 'rotate(-90deg)';
-                a.style.display = 'inline-block';
-                a.style.verticalAlign = 'super';
-                a.style.fontSize = '.83em';
+                a.innerHTML = '<i style="color: black; vertical-align: super; margin: -5px 0 0 2px" class="fa fa-github"></i>'
+                a.title = 'Find configuration file in GitHub repository';
                 a.href = repobase + CODE.innerText + '#repo-content-pjax-container';
                 CODE.parentNode.insertBefore(a, CODE.nextSibling);
             }


### PR DESCRIPTION
This patch automatically links configuration files referenced in the
documentation to the actual configuration files in GitHub. This is done
in addition to the tooltip added to `etc/` explaining where to find
these files.


![Screenshot from 2021-12-03 14-31-32](https://user-images.githubusercontent.com/1008395/144611171-8f32c7a3-068b-4416-b61c-366e91e2ba62.png)

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
