### PR TITLE
Fix multiple extended metadata catalogs for series

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/metadataExtended.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/metadataExtended.js
@@ -106,7 +106,10 @@ angular.module('adminNg.services')
           me.updateRequiredMetadata(field.id, field.value);
         }
 
-        me.ud[target].fields[field.tabindex - 1] = field;
+        var i = me.ud[target].fields.findIndex(function (f) {
+          return f.id === field.id;
+        });
+        me.ud[target].fields[i] = field;
       };
 
       this.getFiledCatalogs = function () {


### PR DESCRIPTION
Currently it's not possible to create a series in the Admin UI when you've configured multiple extended metadata catalogs. This applies the same fix as in #2992, just for series instead of events.