### PR TITLE
Fix possible type change in external API

### DIFF
--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -22,6 +22,7 @@ package org.opencastproject.external.endpoint;
 
 import static com.entwinemedia.fn.Stream.$;
 import static com.entwinemedia.fn.data.json.Jsons.BLANK;
+import static com.entwinemedia.fn.data.json.Jsons.NULL;
 import static com.entwinemedia.fn.data.json.Jsons.arr;
 import static com.entwinemedia.fn.data.json.Jsons.f;
 import static com.entwinemedia.fn.data.json.Jsons.obj;
@@ -1062,7 +1063,7 @@ public class EventsEndpoint implements ManagedService {
       }
     } else {
       fields.add(f("start", v(event.getRecordingStartDate(), BLANK)));
-      fields.add(f("duration", v(event.getDuration(), BLANK)));
+      fields.add(f("duration", v(event.getDuration(), NULL)));
     }
 
     if (StringUtils.trimToNull(event.getSubject()) != null) {
@@ -1662,7 +1663,7 @@ public class EventsEndpoint implements ManagedService {
               f("url", v(getSignedUrl(track.getURI(), sign), BLANK)), f("flavor", v(track.getFlavor(), BLANK)),
               f("size", v(track.getSize())), f("checksum", v(track.getChecksum(), BLANK)),
               f("tags", arr(track.getTags())), f("has_audio", v(track.hasAudio())),
-              f("has_video", v(track.hasVideo())), f("duration", v(track.getDuration(), BLANK)),
+              f("has_video", v(track.hasVideo())), f("duration", v(track.getDuration(), NULL)),
               f("description", v(track.getDescription(), BLANK))).merge(trackInfo));
     }
     return tracks;


### PR DESCRIPTION
PR #3148 introduced a possible type change in the external API from int
to string for the duration field of tracks in case the field is `null`.
As discussed, this PR changes the return value to JSON `null` instead.

Note that the behavior is still inconsistend when it comes to durations:

* `{eventId}/media` will omit the field
* Event duration has a type change to `""`
* this changes Track duration to `null`

IMO I would leave the behavior of `{eventId}/media` as this is done with
all the fields. I'm unsure about Event duration though as this could be
considered an API change (the last one is none as a default value was
only introduced with 11.x). What do you think?

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
