### PR TITLE
Fix Ingest Download Configuration

### DIFF
--- a/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
+++ b/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
@@ -46,10 +46,11 @@
 #job.load.ingest.zip=0.2
 
 # The Ingest Service is capable of downloading tracks/attachments itself from URLs.
-# The Credentials can be set for an external source (example: https://develop.opencast.org)
+# The credentials can be set for an external source (example: https://develop.opencast.org).
+# For example, this can be used to make Opencast download files from another Opencast.
 # The source is written as a regular expression.
 # Example for two sources: (.*)//develop.opencast.org/(.*)|(.*)//stable.opencast.org/(.*)
 # Default: <empty>
-#download.source = http://localhost/.*
-#download.user = opencast_system_account
-#download.password = CHANGE_ME
+#org.opencastproject.download.source = http://localhost/.*
+#org.opencastproject.download.user = opencast_system_account
+#org.opencastproject.download.password = CHANGE_ME


### PR DESCRIPTION
This patch fixes the configuration examples for the download credentials
available in the ingest service which can be used to directly download
files from another Opencast cluster but which configuration keys were
not matching the internal code.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
