### PR TITLE
Improve deleting events from index

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -529,7 +529,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
    * @param index
    *         The API index to update
    */
-  private void removeEventFromIndex(String eventId, ElasticsearchIndex index) {
+  private void removeArchivedVersionFromIndex(String eventId, ElasticsearchIndex index) {
     final String orgId = securityService.getOrganization().getId();
     final User user = securityService.getUser();
     logger.debug("Received AssetManager delete episode message {}", eventId);
@@ -869,7 +869,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     messageSender.sendObjectMessage(AssetManagerItem.ASSETMANAGER_QUEUE, MessageSender.DestinationType.Queue,
             AssetManagerItem.deleteEpisode(mpId, new Date()));
 
-    removeEventFromIndex(mpId, index);
+    removeArchivedVersionFromIndex(mpId, index);
   }
 
   /**

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -530,14 +530,23 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
    *         The API index to update
    */
   private void removeEventFromIndex(String eventId, ElasticsearchIndex index) {
-    final String organization = securityService.getOrganization().getId();
+    final String orgId = securityService.getOrganization().getId();
     final User user = securityService.getUser();
     logger.debug("Received AssetManager delete episode message {}", eventId);
+
+    Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
+      if (!eventOpt.isPresent()) {
+        logger.warn("Event {} not found for deletion", eventId);
+        return Optional.empty();
+      }
+      Event event = eventOpt.get();
+      event.setArchiveVersion(null);
+      return Optional.of(event);
+    };
+
     try {
-      index.deleteAssets(organization, user, eventId);
+      index.addOrUpdateEvent(eventId, updateFunction, orgId, user);
       logger.debug("Event {} removed from the {} index", eventId, index.getIndexName());
-    } catch (NotFoundException e) {
-      logger.warn("Event {} not found for deletion", eventId);
     } catch (SearchIndexException e) {
       logger.error("Error deleting the event {} from the {} index.", eventId, index.getIndexName(), e);
     }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/api/IndexService.java
@@ -122,8 +122,6 @@ public interface IndexService {
    *
    * @param event
    *          The event to remove.
-   * @param doOnNotFound
-   *      What to do when the event could not be found.
    * @param retractWorkflowId
    *          The id of the workflow to use to retract the event if necessary.
    * @return A result which tells if the event was removed, removal failed, or the event is being retracted and will be removed later.
@@ -134,8 +132,8 @@ public interface IndexService {
    * @throws NotFoundException
    *           If the configured retract workflow cannot be found. This is most likely a configuration issue.
    */
-  EventRemovalResult removeEvent(Event event, Runnable doOnNotFound, String retractWorkflowId)
-      throws UnauthorizedException, WorkflowDatabaseException, NotFoundException;
+  EventRemovalResult removeEvent(Event event, String retractWorkflowId) throws UnauthorizedException,
+          WorkflowDatabaseException, NotFoundException;
 
   /**
    * Removes an event.

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/Retraction.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/Retraction.java
@@ -27,12 +27,10 @@ import org.opencastproject.security.api.User;
 public final class Retraction {
   private User user;
   private Organization organization;
-  private Runnable doOnNotFound;
 
-  public Retraction(User user, Organization organization, Runnable doOnNotFound) {
+  public Retraction(User user, Organization organization) {
     this.user = user;
     this.organization = organization;
-    this.doOnNotFound = doOnNotFound;
   }
 
   public User getUser() {
@@ -49,13 +47,5 @@ public final class Retraction {
 
   public void setOrganization(Organization organization) {
     this.organization = organization;
-  }
-
-  public Runnable getDoOnNotFound() {
-    return this.doOnNotFound;
-  }
-
-  public void setDoOnNotFound(Runnable doOnNotFound) {
-    this.doOnNotFound = doOnNotFound;
   }
 }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/RetractionListener.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/RetractionListener.java
@@ -75,7 +75,6 @@ public final class RetractionListener implements WorkflowListener {
           logger.warn("Not authorized to delete retracted media package {}", mpId);
         } catch (NotFoundException e) {
           logger.warn("Unable to delete retracted media package {} because it could not be found", mpId);
-          retraction.getDoOnNotFound().run();
         } catch (Exception e) {
           logger.warn("Unable to delete retracted media package {}:", mpId, e);
         }

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -527,8 +527,8 @@ public class LtiServiceImpl implements LtiService, ManagedService {
       if (event.isNone()) {
         throw new RuntimeException("Event '" + id + "' not found");
       }
-      final IndexService.EventRemovalResult eventRemovalResult = indexService.removeEvent(event.get(), () -> {
-      }, retractWorkflowId);
+      final IndexService.EventRemovalResult eventRemovalResult = indexService.removeEvent(event.get(),
+              retractWorkflowId);
       if (eventRemovalResult == IndexService.EventRemovalResult.GENERAL_FAILURE) {
         throw new RuntimeException("Error deleting event: " + eventRemovalResult);
       }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -859,37 +859,44 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
           throws NotFoundException, SchedulerException {
     notEmpty(mediaPackageId, "mediaPackageId");
 
+    boolean notFoundInDatabase = false;
+    boolean notFoundInAssetManager;
     try {
-      // Check if there are properties only from scheduler
-      AQueryBuilder query = assetManager.createQuery();
-      long deletedProperties = 0;
-      Opt<ExtendedEventDto> extEvtOpt = persistence.getEvent(mediaPackageId);
-      if (extEvtOpt.isSome()) {
-        String agentId = extEvtOpt.get().getCaptureAgentId();
-        persistence.deleteEvent(mediaPackageId);
-        if (StringUtils.isNotEmpty(agentId))
-          touchLastEntry(agentId);
+      // Remove from database
+      try {
+        Opt<ExtendedEventDto> extEvtOpt = persistence.getEvent(mediaPackageId);
+        if (extEvtOpt.isSome()) {
+          String agentId = extEvtOpt.get().getCaptureAgentId();
+          persistence.deleteEvent(mediaPackageId);
+          if (StringUtils.isNotEmpty(agentId)) {
+            touchLastEntry(agentId);
+          }
+        } else {
+          notFoundInDatabase = true;
+        }
+      } catch (NotFoundException e) {
+        notFoundInDatabase = true;
       }
 
       // Delete scheduler snapshot
+      AQueryBuilder query = assetManager.createQuery();
       long deletedSnapshots = query.delete(SNAPSHOT_OWNER, query.snapshot())
               .where(withOrganization(query).and(query.mediaPackageId(mediaPackageId)))
               .name("delete episode").run();
-
-      if (deletedProperties + deletedSnapshots == 0)
-        throw new NotFoundException();
+      notFoundInAssetManager = deletedSnapshots == 0;
 
       // Update live event
       sendSchedulerMessage(new SchedulerItemList(mediaPackageId, SchedulerItem.delete()));
 
       // Update API index
-      removeSchedulingFromIndex(mediaPackageId, index);
-
-    } catch (NotFoundException | SchedulerException e) {
-      throw e;
+      removeSchedulingInfoFromIndex(mediaPackageId, index);
     } catch (Exception e) {
       logger.error("Could not remove event '{}' from persistent storage: {}", mediaPackageId, e);
       throw new SchedulerException(e);
+    }
+
+    if (notFoundInDatabase && notFoundInAssetManager) {
+      throw new NotFoundException();
     }
   }
 
@@ -1489,7 +1496,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    * @param mediaPackageId
    * @param index
    */
-  private void removeSchedulingFromIndex(String mediaPackageId, ElasticsearchIndex index) {
+  private void removeSchedulingInfoFromIndex(String mediaPackageId, ElasticsearchIndex index) {
     String orgId = getSecurityService().getOrganization().getId();
     User user = getSecurityService().getUser();
 

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -676,7 +676,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     logger.debug("Removing series {} from the {} index.", seriesId, index.getIndexName());
 
     try {
-      index.delete(Series.DOCUMENT_TYPE, seriesId, orgId);
+      index.deleteSeries(seriesId, orgId);
       logger.debug("Series {} removed from the {} index.", seriesId, index.getIndexName());
     } catch (SearchIndexException e) {
       logger.error("Series {} couldn't be removed from the {} index.", seriesId, index.getIndexName(), e);

--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
@@ -375,7 +375,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
     logger.debug("Removing theme {} from the {} index.", themeId, index.getIndexName());
 
     try {
-      index.delete(IndexTheme.DOCUMENT_TYPE, Long.toString(themeId), orgId);
+      index.deleteTheme(Long.toString(themeId), orgId);
       logger.debug("Theme {} removed from the {} index", themeId, index.getIndexName());
     } catch (SearchIndexException e) {
       logger.error("Error deleting the theme {} from the {} index", themeId, index.getIndexName(), e);

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -39,6 +39,7 @@ import org.opencastproject.assetmanager.api.query.Predicate;
 import org.opencastproject.assetmanager.api.query.Target;
 import org.opencastproject.assetmanager.api.query.VersionField;
 import org.opencastproject.elasticsearch.api.SearchResult;
+import org.opencastproject.elasticsearch.api.SearchResultItem;
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.objects.event.EventSearchQuery;
 import org.opencastproject.job.api.JobContext;
@@ -317,6 +318,7 @@ public class WorkflowServiceImplTest {
     dao.setAssetManager(assetManager);
 
     SearchResult result = EasyMock.createNiceMock(SearchResult.class);
+    EasyMock.expect(result.getItems()).andReturn(new SearchResultItem[0]).anyTimes();
 
     final ElasticsearchIndex index = EasyMock.createNiceMock(ElasticsearchIndex.class);
     EasyMock.expect(index.getIndexName()).andReturn("index").anyTimes();


### PR DESCRIPTION
This contains a bugfix and some improvements when deleting events from the index. The whole thing is kinda messy, so I'll try to summarize what I did:
- Move partial deletion of scheduling information, workflow information and asset version of indexed events into their respective services since the index itself shouldn't be aware of the details
- Make these partial delete methods use the regular update functionality of the index - this fixes a bug where the event wasn't locked when making these changes, which could lead to unintended side effects like events not getting deleted properly
- Completely remove the heuristic that if an indexed event has neither a asset version, workflows and scheduling information, we want to delete the event. This is bad and whoever wrote that should feel bad.
- Instead, explicitly delete the whole event at the end of the removeEvent() method of the index service - since, you know, we know that's what we wanna do here.
- This makes it necessary for the index service to know the Elasticsearch index, but since we only got one now, that's fine. Maybe we should change the rest of the code accordingly (not handing the index over from the endpoints), but that's not really important.
- Delete the event if the three services AssetManager, SchedulerService and WorkflowService either succesfully deleted their stuff, or couldn't find it. I believe that catches a few edge cases that could lead to trouble before, like a service not finding the relevant data in their database and then not removing their stuff from the index. Doesn't matter now.
- This also makes the doOnNotFound handler in the admin ui and external api endpoints unnecessary. Yay, less code.
- The partial deletion stuff is still relevant in other cases (e.g. deleting a workflow from an event), so I couldn't get rid of it entirely.
- For the SchedulerService and WorkflowService, I tried to ensure that the partial deletion from the index also happens in case of Not Found exceptions. The AssetManager is unfortunately pretty decoupled from that information, so I couldn't manage it there.
- Fixed the scheduler service logic regarding Not Found since hat seemed to be broken by a prior change.
- Made the removal of a workflow instance from the Elasticsearch index independent of whether we can find the instance in the solr index so we can also do that on Not Found.
- I wrote wrapper methods of the index delete() method for the respective index objects since I felt we were exposing too many details there.
- Additionally I did some minor code style changes and fixed stuff Intellij warned me about for code I was already working on.

Edit: I changed the values of the removedScheduling, removedWorkflow, ... variables in the index service to only be true if there was actually something removed, not in case of Not Found, and introduced a bug in the return value with that, so now that's considered there.