### PR TITLE
Update Stand-alone Editor to 2021-12-10

### DIFF
--- a/docs/guides/admin/docs/modules/editor.md
+++ b/docs/guides/admin/docs/modules/editor.md
@@ -15,7 +15,7 @@ Accessing The Editor
 You can access the editor by providing an event identifier to the web interface like this:
 
 ```
-/editor-ui/index.html?mediaPackageId=<ID>
+/editor-ui/index.html?id=<ID>
 ```
 
 

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-08-17/oc-editor-2021-08-17.tar.gz</editor.url>
-    <editor.sha256>151bbb6693b715e656598a2ae62a8299675690f372cf12ca180cc57dcebd5776</editor.sha256>
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-12-10/oc-editor-2021-12-10.tar.gz</editor.url>
+    <editor.sha256>0691936bcfc835b1823aabc9ee89281a7b166b690fbfda6c4e20383156e9d723</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
This patch updates the stand-alone video editor to version 2021-12-10
which contains a lot of bug fixes and usability improvements.

For more details, please find the release notes at:

- https://github.com/elan-ev/opencast-editor/releases/tag/2021-12-10

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
