### PR TITLE
Prevent API failing on empty files

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventHttpServletRequest.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventHttpServletRequest.java
@@ -170,7 +170,11 @@ public class EventHttpServletRequest {
           if (item.isFormField()) {
             setFormField(eventCatalogUIAdapters, eventHttpServletRequest, item, fieldName, startDatePattern, startTimePattern);
           } else {
-            ingestFile(ingestService, eventHttpServletRequest, item);
+            if (!item.getName().isBlank()) {
+              ingestFile(ingestService, eventHttpServletRequest, item);
+            } else {
+              logger.debug("Skipping field {} due to missing filename", item.getFieldName());
+            }
           }
         }
       } else {


### PR DESCRIPTION
This patch fixes the problem that the REST docs include fields to upload
files foor the `POST /api/events` requests which will result in empty
fields being send when trying to schedule over which Opencast will
stumble and fall (500 Internal Server Error).

This patch makes the API ignore empty file fields in the
multipart/form-data request.

This fixes #3249

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
