### PR TITLE
Fix Typo in ES Options File

### DIFF
--- a/docs/guides/admin/docs/installation/rpm-el7.md
+++ b/docs/guides/admin/docs/installation/rpm-el7.md
@@ -101,7 +101,7 @@ yum install elasticsearch-oss
 Opencast automatically configures the search index once it is connected.
 The default configuration will work for a local Elasticsearch with no modifications.
 The only exception for this is to add a configuration to mitigate Log4Shell.
-For this, add a file `/etc/elasticsearch/jvm.options.d/log4shell` with the content:
+For this, add a file `/etc/elasticsearch/jvm.options.d/log4shell.options` with the content:
 
 ```
 -Dlog4j2.formatMsgNoLookups=true

--- a/docs/guides/admin/docs/installation/rpm-el8.md
+++ b/docs/guides/admin/docs/installation/rpm-el8.md
@@ -108,7 +108,7 @@ dnf install elasticsearch-oss
 Opencast automatically configures the search index once it is connected.
 The default configuration will work for a local Elasticsearch with no modifications.
 The only exception for this is to add a configuration to mitigate Log4Shell.
-For this, add a file `/etc/elasticsearch/jvm.options.d/log4shell` with the content:
+For this, add a file `/etc/elasticsearch/jvm.options.d/log4shell.options` with the content:
 
 ```
 -Dlog4j2.formatMsgNoLookups=true


### PR DESCRIPTION
This patch fixes a typo in the installation guide which is missing the
`.options` extention from the file used for Log4Shell mitigation.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
