### PR TITLE
Log4Shell Mitigation for Development Containers

### DIFF
--- a/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
@@ -8,6 +8,7 @@ services:
       - 127.0.0.1:9300:9300
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
   activemq:
     container_name: opencast-activemq
     image: quay.io/lkiesow/activemq

--- a/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
@@ -8,6 +8,7 @@ services:
       - 127.0.0.1:9300:9300
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
   activemq:
     container_name: opencast-activemq
     image: quay.io/lkiesow/activemq

--- a/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
@@ -8,6 +8,7 @@ services:
       - 127.0.0.1:9300:9300
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
   activemq:
     container_name: opencast-activemq
     image: quay.io/lkiesow/activemq

--- a/docs/scripts/devel-dependency-containers/docker-compose.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - 127.0.0.1:9300:9300
     environment:
       discovery.type: single-node
+      ES_JAVA_OPTS: '-Dlog4j2.formatMsgNoLookups=true'
   activemq:
     container_name: opencast-activemq
     image: quay.io/lkiesow/activemq


### PR DESCRIPTION
While this is certainly not that important since they *should* only ever
be available locally, this applies the mitigation for CVE-2021-44228
just in case.

---

To test this:

```
❯ cd docs/scripts/devel-dependency-containers
❯ podman-compose up -d  
[…]
❯ ps ax | grep elastic | grep log4j2.formatMsgNoLookups=true
 106424 ?        Sl     0:06 /usr/share/elasticsearch/jdk/bin/java -Xshare:auto -Des.networkaddress.cache.ttl=60 -Des.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Djava.locale.providers=SPI,COMPAT -Xms1g -Xmx1g -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -Djava.io.tmpdir=/tmp/elasticsearch-2505631817250242625 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=data -XX:ErrorFile=logs/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m -Des.cgroups.hierarchy.override=/ -Dlog4j2.formatMsgNoLookups=true -XX:MaxDirectMemorySize=536870912 -Des.path.home=/usr/share/elasticsearch -Des.path.conf=/usr/share/elasticsearch/config -Des.distribution.flavor=default -Des.distribution.type=docker -Des.bundled_jdk=true -cp /usr/share/elasticsearch/lib/* org.elasticsearch.bootstrap.Elasticsearch -Ediscovery.type=single-node
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
