### PR TITLE
Update Elasticsearch container image to 7.10.2

### DIFF
--- a/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-all-sql.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   elasticsearch:
     container_name: opencast-elasticsearch
-    image: docker.io/library/elasticsearch:7.9.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300

--- a/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-mariadb.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   elasticsearch:
     container_name: opencast-elasticsearch
-    image: docker.io/library/elasticsearch:7.9.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300

--- a/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose-postgresql.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   elasticsearch:
     container_name: opencast-elasticsearch
-    image: docker.io/library/elasticsearch:7.9.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300

--- a/docs/scripts/devel-dependency-containers/docker-compose.yml
+++ b/docs/scripts/devel-dependency-containers/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   elasticsearch:
     container_name: opencast-elasticsearch
-    image: docker.io/library/elasticsearch:7.9.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
     ports:
       - 127.0.0.1:9200:9200
       - 127.0.0.1:9300:9300


### PR DESCRIPTION
This updates the container image used in the dev compose files to
7.10.2, the latest 7.10.x release. The image is now comming from Elastic
and not form Docker Hub as this only has 7.10.1.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
