### PR TITLE
Changed embed code selection design

### DIFF
--- a/modules/admin-ui-frontend/app/styles/views/modals/_embedded-code.scss
+++ b/modules/admin-ui-frontend/app/styles/views/modals/_embedded-code.scss
@@ -21,19 +21,20 @@
 
 .embedSizeButton {
     display: inline-block;
-    background-color: #466DC3;
-    border: 1px solid silver;
+    background-color: #E2E1E1;
+    border: 1px solid #CCC;
     border-radius: 10px;
     cursor: pointer;
     margin-right: 5px;
     vertical-align: middle;
     font-size: 14px;
     text-align: center;
-    color: white;
+    color: black;
 }
 
 .embedSizeButtonSelected {
-    border: 5px solid #FFE04F;
+    //border: 5px solid #FFE04F;
+    border: 3px solid #24425c;
 }
 
 .copyConfirm {

--- a/modules/admin-ui-frontend/app/styles/views/modals/_embedded-code.scss
+++ b/modules/admin-ui-frontend/app/styles/views/modals/_embedded-code.scss
@@ -33,7 +33,6 @@
 }
 
 .embedSizeButtonSelected {
-    //border: 5px solid #FFE04F;
     border: 3px solid #24425c;
 }
 


### PR DESCRIPTION
This fixes #3214

Looks now like this:
![code-design](https://user-images.githubusercontent.com/93541078/146538280-97a15628-b812-48bc-ae73-9678b448927f.png)

