### PR TITLE
Index Extended Metadata

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -473,12 +473,12 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
   }
 
   /**
-   * Update the event in the API index.
+   * Update the event in the Elasticsearch index.
    *
    * @param snapshot
    *         The newest snapshot of the event to update
    * @param index
-   *         The API index to update
+   *         The Elasticsearch index to update
    */
   private void updateEventInIndex(Snapshot snapshot) {
     final MediaPackage mp = snapshot.getMediaPackage();
@@ -531,12 +531,12 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
   }
 
   /**
-   * Remove the event from the API index
+   * Remove the event from the Elasticsearch index
    *
    * @param eventId
    *         The id of the event to remove
    * @param index
-   *         The API index to update
+   *         The Elasticsearch index to update
    */
   private void removeArchivedVersionFromIndex(String eventId) {
     final String orgId = securityService.getOrganization().getId();

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -133,6 +133,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -530,7 +531,8 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
       // extended metadata
       event.resetExtendedMetadata();  // getting rid of old data
-      for (EventCatalogUIAdapter extendedCatalogUIAdapter : extendedEventCatalogUIAdapters.get(organization)) {
+      for (EventCatalogUIAdapter extendedCatalogUIAdapter : extendedEventCatalogUIAdapters.getOrDefault(organization,
+              Collections.emptyList())) {
         for (Catalog catalog: mp.getCatalogs(extendedCatalogUIAdapter.getFlavor())) {
           try (InputStream in = workspace.read(catalog.getURI())) {
             EventIndexUtils.updateEventExtendedMetadata(event, DublinCores.read(in),

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclServiceImpl.java
@@ -112,7 +112,7 @@ public final class AclServiceImpl implements AclService {
   }
 
   /**
-   * Update the Managed ACL in the events and series in the API index.
+   * Update the Managed ACL in the events and series in the Elasticsearch index.
    *
    * @param currentAclName
    *         the current name of the managed acl
@@ -135,7 +135,7 @@ public final class AclServiceImpl implements AclService {
   }
 
   /**
-   * Remove the Managed ACL from the events and series in the API index.
+   * Remove the Managed ACL from the events and series in the Elasticsearch index.
    *
    * @param currentAclName
    *         the current name of the managed acl
@@ -156,7 +156,7 @@ public final class AclServiceImpl implements AclService {
   }
 
   /**
-   * Update or remove the Managed Acl for the series in the API index.
+   * Update or remove the Managed Acl for the series in the Elasticsearch index.
    *
    * @param currentAclName
    *         the current name of the managed acl
@@ -206,7 +206,7 @@ public final class AclServiceImpl implements AclService {
   }
 
   /**
-   * Update or remove the Managed Acl for the events in the API index.
+   * Update or remove the Managed Acl for the events in the Elasticsearch index.
    *
    * @param currentAclName
    *         the current name of the managed acl

--- a/modules/common/src/main/java/org/opencastproject/util/jaxb/ExtendedMetadataAdapter.java
+++ b/modules/common/src/main/java/org/opencastproject/util/jaxb/ExtendedMetadataAdapter.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.util.jaxb;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlValue;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * An adapter to transform a map with extended metadata into an object that can be represented in XMl, and back.
+ */
+public class ExtendedMetadataAdapter extends XmlAdapter<ExtendedMetadataAdapter.ExtendedMetadata,
+        Map<String, Map<String, List<String>>>> {
+
+  @Override
+  public ExtendedMetadata marshal(Map<String, Map<String, List<String>>> map) {
+    List<ExtendedMetadataEntry> entries = new ArrayList<>();
+    for (String catalogType: map.keySet()) {
+      Map<String, List<String>> catalog = map.get(catalogType);
+
+      for (String fieldName: catalog.keySet()) {
+        List<String> values = catalog.get(fieldName);
+        entries.add(new ExtendedMetadataEntry(catalogType, fieldName, values));
+      }
+    }
+    return new ExtendedMetadata(entries);
+  }
+
+  @Override
+  public Map<String, Map<String, List<String>>> unmarshal(ExtendedMetadata extendedMetadata) {
+    Map<String, Map<String, List<String>>> map = new HashMap<>();
+    for (ExtendedMetadataEntry entry: extendedMetadata.getEntries()) {
+      String catalogType = entry.getCatalogType();
+      String fieldName = entry.getFieldName();
+      List<String> values = entry.getValues();
+
+      Map<String, List<String>> catalog = map.computeIfAbsent(catalogType, c -> new HashMap<>());
+      catalog.put(fieldName, values);
+    }
+    return map;
+  }
+
+  /**
+   * These classes are used to represent the extended metadata map in XML.
+   */
+
+  protected static class ExtendedMetadata {
+    @XmlElement(name = "entry")
+    private List<ExtendedMetadataEntry> entries;
+
+    public ExtendedMetadata() {
+      // needed by JAXB
+    }
+
+    public ExtendedMetadata(List<ExtendedMetadataEntry> entries) {
+      this.entries = entries;
+    }
+
+    public List<ExtendedMetadataEntry> getEntries() {
+      return entries;
+    }
+  }
+
+  protected static class ExtendedMetadataEntry {
+    @XmlAttribute
+    private String catalogType;
+    @XmlAttribute
+    private String fieldName;
+    @XmlValue
+    private List<String> values;
+
+    public ExtendedMetadataEntry() {
+      // needed by JAXB
+    }
+
+    public ExtendedMetadataEntry(String catalogType, String fieldName, List<String> values) {
+      this.catalogType = catalogType;
+      this.fieldName = fieldName;
+      this.values = values;
+    }
+
+    public String getCatalogType() {
+      return catalogType;
+    }
+
+    public String getFieldName() {
+      return fieldName;
+    }
+
+    public List<String> getValues() {
+      return values;
+    }
+  }
+}

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreByteFormat.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreByteFormat.java
@@ -20,7 +20,13 @@
  */
 package org.opencastproject.metadata.dublincore;
 
-import java.io.ByteArrayInputStream;
+import org.json.simple.parser.ParseException;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * Byte serialization of Dublin Core catalogs.
@@ -29,8 +35,29 @@ public final class DublinCoreByteFormat {
   private DublinCoreByteFormat() {
   }
 
-  public static DublinCoreCatalog read(byte[] bytes) {
-    return DublinCores.read(new ByteArrayInputStream(bytes));
+  /**
+   * Parse a Dublin Core catalog represented by a byte array. Will recognize if it's in JSON or XML format and use
+   * the correct method.
+   *
+   * @param bytes
+   *         the catalog represented by a byte array
+   * @return the catalog
+   * @throws IOException
+   *         if the input can't be read
+   * @throws ParseException
+   *         if setting up the JSON parser failed
+   * @throws ParserConfigurationException
+   *         if setting up the XML parser failed
+   * @throws SAXException
+   *         if an error occurred while parsing the XML catalog
+   */
+  public static DublinCoreCatalog read(byte[] bytes)
+          throws IOException, ParseException, ParserConfigurationException, SAXException {
+    final String catalogString = new String(bytes, StandardCharsets.UTF_8);
+    if (DublinCoreJsonFormat.isJson(catalogString)) {
+      return DublinCoreJsonFormat.read(catalogString);
+    } else {
+      return DublinCoreXmlFormat.read(catalogString);
+    }
   }
-
 }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreJsonFormat.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreJsonFormat.java
@@ -33,7 +33,6 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -59,7 +58,7 @@ public final class DublinCoreJsonFormat {
    * Read a JSON encoded catalog from a string.
    */
   @Nonnull
-  public static DublinCoreCatalog read(String json) throws IOException, ParseException {
+  public static DublinCoreCatalog read(String json) throws ParseException {
     return read((JSONObject) new JSONParser().parse(json));
   }
 
@@ -159,5 +158,17 @@ public final class DublinCoreJsonFormat {
       }
     }
     return json;
+  }
+
+  /**
+   * Checks if the catalog string is in JSON format.
+   *
+   * @param catalogString
+   *         Dublin Core catalog as a string
+   * @return
+   *         true if it's in JSON format
+   */
+  public static boolean isJson(String catalogString) {
+    return catalogString.startsWith("{");
   }
 }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCores.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCores.java
@@ -175,7 +175,7 @@ public final class DublinCores {
     } catch (IOException e) {
       throw new RuntimeException("Unable to read DublinCore from stream", e);
     }
-    if (ser.startsWith("{")) {
+    if (DublinCoreJsonFormat.isJson(ser)) {
       try {
         return DublinCoreJsonFormat.read(ser);
       } catch (Exception e) {

--- a/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/IndexSchema.java
+++ b/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/IndexSchema.java
@@ -23,7 +23,7 @@
 package org.opencastproject.elasticsearch.impl;
 
 /**
- * Standard fields for an API index.
+ * Standard fields for an Elasticsearch index.
  */
 public interface IndexSchema {
 

--- a/modules/elasticsearch-impl/src/main/resources/elasticsearch/event-mapping.json
+++ b/modules/elasticsearch-impl/src/main/resources/elasticsearch/event-mapping.json
@@ -164,6 +164,13 @@
              "match_mapping_type" : "string",
              "mapping" : { "type" : "keyword" }
             }
+         },
+         {
+           "extended_metadata_template" : {
+             "match" : "extended_metadata_*",
+             "match_mapping_type" : "string",
+             "mapping" : { "type" : "keyword" }
+           }
          }
      ]
 }

--- a/modules/elasticsearch-impl/src/main/resources/elasticsearch/series-mapping.json
+++ b/modules/elasticsearch-impl/src/main/resources/elasticsearch/series-mapping.json
@@ -50,6 +50,13 @@
                "match_mapping_type" : "string",
                "mapping" : { "type" : "keyword" }
               }
+           },
+           {
+             "extended_metadata_template" : {
+               "match" : "extended_metadata_*",
+               "match_mapping_type" : "string",
+               "mapping" : { "type" : "keyword" }
+             }
            }
        ]
 }

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/Event.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/Event.java
@@ -26,6 +26,7 @@ import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.scheduler.api.RecordingState;
 import org.opencastproject.util.IoSupport;
 import org.opencastproject.util.XmlSafeParser;
+import org.opencastproject.util.jaxb.ExtendedMetadataAdapter;
 import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
 
 import org.apache.commons.lang3.StringUtils;
@@ -59,6 +60,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -72,7 +74,7 @@ import javax.xml.stream.XMLStreamWriter;
     propOrder = {
         "identifier", "organization", "title", "description", "subject", "location", "presenters",
         "contributors", "seriesId", "seriesName", "language", "source", "created", "creator",
-        "publisher", "license", "rights", "accessPolicy", "managedAcl", "workflowState",
+        "publisher", "license", "rights", "extendedMetadata", "accessPolicy", "managedAcl", "workflowState",
         "workflowId", "workflowDefinitionId", "recordingStartTime", "recordingEndTime", "duration",
         "hasComments", "hasOpenComments", "hasPreview", "needsCutting", "publications",
         "archiveVersion", "recordingStatus", "eventStatus", "agentId", "agentConfigurations",
@@ -184,6 +186,10 @@ public class Event implements IndexObject {
   /** The rights of the event */
   @XmlElement(name = "rights")
   private String rights = null;
+
+  @XmlElement(name = "extendedMetadata")
+  @XmlJavaTypeAdapter(ExtendedMetadataAdapter.class)
+  private Map<String, Map<String, List<String>>> extendedMetadata = new HashMap();
 
   /** The access policy of the event */
   @XmlElement(name = "access_policy")
@@ -1056,6 +1062,34 @@ public class Event implements IndexObject {
    */
   public void setTechnicalPresenters(List<String> technicalPresenters) {
     this.technicalPresenters = technicalPresenters;
+  }
+
+  /**
+   * Sets the external metadata for a catalog flavor.
+   *
+   * @param type
+   *         The catalog type
+   * @param metadata
+   *         The metadata
+   */
+  public void setExtendedMetadata(String type, Map<String, List<String>> metadata) {
+    extendedMetadata.put(type, metadata);
+  }
+
+  /**
+   * Removes all external metadata.
+   */
+  public void resetExtendedMetadata() {
+    extendedMetadata.clear();
+  }
+
+  /**
+   * Returns the extended metadata
+   *
+   * @return the extended metadata in a map by catalog type
+   */
+  public Map<String, Map<String, List<String>>> getExtendedMetadata() {
+    return extendedMetadata;
   }
 
   /**

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexSchema.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexSchema.java
@@ -44,6 +44,9 @@ public interface EventIndexSchema extends IndexSchema {
   /** The event series name */
   String SERIES_NAME = "series_name";
 
+  /** The key in the input documents representing the prefix to extended metadata */
+  String EXTENDED_METADATA_PREFIX = "extended_metadata_";
+
   /** The access policy */
   String ACCESS_POLICY = "access_policy";
 

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventIndexUtils.java
@@ -27,14 +27,18 @@ import org.opencastproject.elasticsearch.api.SearchResult;
 import org.opencastproject.elasticsearch.impl.SearchMetadataCollection;
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.objects.series.Series;
+import org.opencastproject.elasticsearch.index.objects.series.SeriesIndexSchema;
 import org.opencastproject.elasticsearch.index.objects.series.SeriesSearchQuery;
 import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.Catalog;
+import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.metadata.dublincore.DCMIPeriod;
 import org.opencastproject.metadata.dublincore.DublinCore;
+import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
 import org.opencastproject.security.api.AccessControlEntry;
 import org.opencastproject.security.api.AccessControlList;
@@ -203,6 +207,10 @@ public final class EventIndexUtils {
       metadata.addField(EventIndexSchema.CONTRIBUTOR, contributors.toArray(new String[contributors.size()]), true);
     }
 
+    if (!event.getExtendedMetadata().isEmpty()) {
+      addExtendedMetadata(metadata, event.getExtendedMetadata());
+    }
+
     if (StringUtils.isNotBlank(event.getAccessPolicy())) {
       metadata.addField(EventIndexSchema.ACCESS_POLICY, event.getAccessPolicy(), true);
       addAuthorization(metadata, event.getAccessPolicy());
@@ -303,6 +311,26 @@ public final class EventIndexUtils {
   }
 
   /**
+   * Adds extended metadata fields to the input document
+   *
+   * @param doc
+   *          the input document
+   * @param extendedMetadata
+   *          the extended metadata map
+   */
+  private static void addExtendedMetadata(SearchMetadataCollection doc, Map<String, Map<String,
+          List<String>>> extendedMetadata) {
+    for (String type: extendedMetadata.keySet()) {
+      Map<String, List<String>> extendedMetadataByType = extendedMetadata.get(type);
+      for (String name: extendedMetadataByType.keySet()) {
+        List<String> values = extendedMetadataByType.get(name);
+        String fieldName = SeriesIndexSchema.EXTENDED_METADATA_PREFIX.concat(type + "_" + name);
+        doc.addField(fieldName, values, true);
+      }
+    }
+  }
+
+  /**
    * Adds authorization fields to the input document.
    *
    * @param doc
@@ -311,11 +339,11 @@ public final class EventIndexUtils {
    *          the access control list string
    */
   private static void addAuthorization(SearchMetadataCollection doc, String aclString) {
-    Map<String, List<String>> permissions = new HashMap<String, List<String>>();
+    Map<String, List<String>> permissions = new HashMap<>();
 
     // Define containers for common permissions
     for (Action action : Permissions.Action.values()) {
-      permissions.put(action.toString(), new ArrayList<String>());
+      permissions.put(action.toString(), new ArrayList<>());
     }
 
     AccessControlList acl = AccessControlParser.parseAclSilent(aclString);
@@ -326,7 +354,7 @@ public final class EventIndexUtils {
       }
       List<String> actionPermissions = permissions.get(entry.getAction());
       if (actionPermissions == null) {
-        actionPermissions = new ArrayList<String>();
+        actionPermissions = new ArrayList<>();
         permissions.put(entry.getAction(), actionPermissions);
       }
       actionPermissions.add(entry.getRole());
@@ -337,6 +365,30 @@ public final class EventIndexUtils {
       String fieldName = EventIndexSchema.ACL_PERMISSION_PREFIX.concat(entry.getKey());
       doc.addField(fieldName, entry.getValue(), false);
     }
+  }
+
+  /**
+   * Update extended metadata for event from dublin core catalog.
+   *
+   * @param event
+   *         The event
+   * @param dc
+   *         The dublin core catalog with extended metadata
+   * @param flavor
+   *         The flavor of the extended metadata
+   * @return
+   *         The updated event
+   */
+  public static Event updateEventExtendedMetadata(Event event, DublinCoreCatalog dc, MediaPackageElementFlavor flavor) {
+    Map<String, List<String>> map = new HashMap();
+    Set<EName> eNames = dc.getProperties();
+    for (EName eName: eNames) {
+      String name = eName.getLocalName();
+      List<String> values = dc.get(eName, DublinCore.LANGUAGE_ANY);
+      map.put(name, values);
+    }
+    event.setExtendedMetadata(flavor.toString(), map);
+    return event;
   }
 
   /**

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/Series.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/Series.java
@@ -26,6 +26,7 @@ import org.opencastproject.util.DateTimeSupport.UtcTimestampAdapter;
 import org.opencastproject.util.EqualsUtil;
 import org.opencastproject.util.IoSupport;
 import org.opencastproject.util.XmlSafeParser;
+import org.opencastproject.util.jaxb.ExtendedMetadataAdapter;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -65,8 +66,8 @@ import javax.xml.stream.XMLStreamWriter;
  * Object wrapper for a series.
  */
 @XmlType(name = "series", namespace = IndexObject.INDEX_XML_NAMESPACE, propOrder = { "identifier", "title",
-        "description", "subject", "organization", "language", "creator", "license", "accessPolicy", "managedAcl",
-        "createdDateTime", "organizers", "contributors", "publishers", "rightsHolder", "theme" })
+        "description", "subject", "organization", "language", "creator", "license", "extendedMetadata", "accessPolicy",
+        "managedAcl", "createdDateTime", "organizers", "contributors", "publishers", "rightsHolder", "theme" })
 @XmlRootElement(name = "series", namespace = IndexObject.INDEX_XML_NAMESPACE)
 @XmlAccessorType(XmlAccessType.NONE)
 public class Series implements IndexObject {
@@ -108,6 +109,10 @@ public class Series implements IndexObject {
   /** The license of the series */
   @XmlElement(name = "license")
   private String license = null;
+
+  @XmlElement(name = "extendedMetadata")
+  @XmlJavaTypeAdapter(ExtendedMetadataAdapter.class)
+  private Map<String, Map<String, List<String>>> extendedMetadata = new HashMap();
 
   /** The access policy of the series */
   @XmlElement(name = "access_policy")
@@ -504,6 +509,44 @@ public class Series implements IndexObject {
    */
   public Long getTheme() {
     return theme;
+  }
+
+  /**
+   * Sets the external metadata for a catalog type.
+   *
+   * @param type
+   *         The catalog type
+   * @param metadata
+   *         The metadata
+   */
+  public void setExtendedMetadata(String type, Map<String, List<String>> metadata) {
+    extendedMetadata.put(type, metadata);
+  }
+
+  /**
+   * Removes the external metadata for a catalog type.
+   *
+   * @param type
+   *         The catalog type
+   */
+  public void removeExtendedMetadata(String type) {
+    extendedMetadata.remove(type);
+  }
+
+  /**
+   * Removes all external metadata.
+   */
+  public void resetExtendedMetadata() {
+    extendedMetadata.clear();
+  }
+
+  /**
+   * Returns the extended metadata
+   *
+   * @return the extended metadata in a map by catalog type
+   */
+  public Map<String, Map<String, List<String>>> getExtendedMetadata() {
+    return extendedMetadata;
   }
 
   /**

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesIndexSchema.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesIndexSchema.java
@@ -55,6 +55,9 @@ public interface SeriesIndexSchema extends IndexSchema {
   /** The license of the series */
   String LICENSE = "license";
 
+  /** The key in the input documents representing the prefix to extended metadata */
+  String EXTENDED_METADATA_PREFIX = "extended_metadata_";
+
   /** The access policy of the series */
   String ACCESS_POLICY = "access_policy";
 

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -151,10 +151,10 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
   }
 
   /**
-   * OSgi callback for the API index.
+   * OSgi callback for the Elasticsearch index.
    *
    * @param index
-   *          the API index.
+   *          the Elasticsearch index.
    */
   @Reference
   public void setIndex(ElasticsearchIndex index) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Dictionary;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -120,6 +121,8 @@ public class CatalogUIAdapterFactory implements ManagedServiceFactory {
     final String type = getCfg(properties, CONF_TYPE_KEY);
     Option<String> optCommonMetadata = getOptCfg(properties, CONF_COMMON_METADATA_KEY);
     final boolean isCommonMetadata = optCommonMetadata.isSome() ? Boolean.parseBoolean(optCommonMetadata.get()) : false;
+    Dictionary serviceProperties = new Properties();
+    serviceProperties.put("common-metadata", isCommonMetadata);
 
     // Check for valid configuration values
     if (!(CATALOG_TYPE_EVENTS.equalsIgnoreCase(type) || CATALOG_TYPE_SERIES.equalsIgnoreCase(type))) {
@@ -155,7 +158,7 @@ public class CatalogUIAdapterFactory implements ManagedServiceFactory {
           adapter.updated(properties);
 
           ServiceRegistration<?> configurationRegistration = bundleContext.registerService(adapterClassesNames, adapter,
-                  null);
+                  serviceProperties);
           adapterServiceRegistrations.put(pid, configurationRegistration);
         }
         break;
@@ -186,7 +189,7 @@ public class CatalogUIAdapterFactory implements ManagedServiceFactory {
           adapter.updated(properties);
 
           ServiceRegistration<?> adapterServiceRegistration = bundleContext.registerService(adapterClassesNames,
-                  adapter, null);
+                  adapter, serviceProperties);
           adapterServiceRegistrations.put(pid, adapterServiceRegistration);
         }
         break;

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
@@ -122,7 +122,7 @@ public class CatalogUIAdapterFactory implements ManagedServiceFactory {
     Option<String> optCommonMetadata = getOptCfg(properties, CONF_COMMON_METADATA_KEY);
     final boolean isCommonMetadata = optCommonMetadata.isSome() ? Boolean.parseBoolean(optCommonMetadata.get()) : false;
     Dictionary serviceProperties = new Properties();
-    serviceProperties.put("common-metadata", isCommonMetadata);
+    serviceProperties.put(CONF_COMMON_METADATA_KEY, isCommonMetadata);
 
     // Check for valid configuration values
     if (!(CATALOG_TYPE_EVENTS.equalsIgnoreCase(type) || CATALOG_TYPE_SERIES.equalsIgnoreCase(type))) {

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/series/ConfigurableSeriesDCCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/series/ConfigurableSeriesDCCatalogUIAdapter.java
@@ -39,11 +39,15 @@ import org.opencastproject.util.RequireUtil;
 
 import com.entwinemedia.fn.data.Opt;
 
+import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.Arrays;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * A series catalog UI adapter that is managed by a configuration.
@@ -100,25 +104,17 @@ public class ConfigurableSeriesDCCatalogUIAdapter extends ConfigurableDCCatalogU
         dc.setFlavor(flavor);
         return Opt.some(dc);
       }
-    } catch (SeriesException e) {
-      logger.error("Error while loading DublinCore catalog of series '{}': {}", seriesId, e);
+    } catch (SeriesException | IOException | ParseException | ParserConfigurationException | SAXException e) {
+      logger.error("Error while loading DublinCore catalog {} of series '{}'", flavor, seriesId, e);
       return Opt.none();
     }
   }
 
   protected boolean saveDublinCoreCatalog(String seriesId, DublinCoreCatalog dc) {
     try {
-      final byte[] dcData = dc.toXmlString().getBytes("UTF-8");
-      if (getSeriesService().getSeriesElementData(seriesId, flavor.getType()).isSome()) {
-        return getSeriesService().updateSeriesElement(seriesId, flavor.getType(), dcData);
-      } else {
-        return getSeriesService().addSeriesElement(seriesId, flavor.getType(), dcData);
-      }
-    } catch (IOException e) {
-      logger.error("Error while serializing the dublin core catalog to XML", e);
-      return false;
+      return getSeriesService().updateExtendedMetadata(seriesId, flavor.getType(), dc);
     } catch (SeriesException e) {
-      logger.error("Error while saving the series element", e);
+      logger.error("Error while saving the series Dublin Core catalog", e);
       return false;
     }
   }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1355,7 +1355,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
       // Update live event
       sendSchedulerUpdate(new SchedulerItemList(id, SchedulerItem.deleteRecordingState()));
-      
+
       // Update Elasticsearch index
       removeRecordingStatusFromIndex(id);
     } catch (NotFoundException e) {

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -354,10 +354,10 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   }
 
   /**
-   * OSgi callback to set the API index.
+   * OSgi callback to set the Elasticsearch index.
    *
    * @param index
-   *          the API index.
+   *          the Elasticsearch index.
    */
   @Reference
   public void setIndex(ElasticsearchIndex index) {
@@ -482,7 +482,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       updateLiveEvent(mediaPackageId, Opt.some(acl), dublinCore, Opt.some(startDateTime),
               Opt.some(endDateTime), Opt.some(captureAgentId), Opt.some(finalCaProperties));
 
-      // Update API index
+      // Update Elasticsearch index
       updateEventInIndex(mediaPackageId, Opt.some(acl), dublinCore, Opt.some(startDateTime), Opt.some(endDateTime),
           Opt.some(userIds), Opt.some(captureAgentId), Opt.some(finalCaProperties), Opt.none());
 
@@ -628,7 +628,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         updateLiveEvent(mediaPackageId, some(acl), dublinCore, Opt.some(startDateTime), Opt.some(endDateTime),
                 Opt.some(captureAgentId), Opt.some(finalCaProperties));
 
-        // Update API index
+        // Update Elasticsearch index
         updateEventInIndex(mediaPackageId, some(acl), dublinCore, Opt.some(startDateTime), Opt.some(endDateTime),
                 Opt.some(userIds), Opt.some(captureAgentId), Opt.some(finalCaProperties), Opt.none());
 
@@ -821,7 +821,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       updateLiveEvent(mpId, acl, dublinCore, startDateTime, endDateTime, Opt.some(agentId),
               finalCaProperties);
 
-      // Update API index
+      // Update Elasticsearch index
       updateEventInIndex(mpId, acl, dublinCore, startDateTime, endDateTime, userIds, Opt.some(agentId),
               finalCaProperties, Opt.none());
 
@@ -901,7 +901,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       // Update live event
       sendSchedulerUpdate(new SchedulerItemList(mediaPackageId, SchedulerItem.delete()));
 
-      // Update API index
+      // Update Elasticsearch index
       removeSchedulingInfoFromIndex(mediaPackageId);
     } catch (Exception e) {
       logger.error("Could not remove event '{}' from persistent storage: {}", mediaPackageId, e);
@@ -1296,7 +1296,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
         sendSchedulerUpdate(new SchedulerItemList(r.getID(), Collections.singletonList(SchedulerItem
                 .updateRecordingStatus(r.getState(), r.getLastCheckinTime()))));
 
-        // Update API index
+        // Update Elasticsearch index
         updateEventInIndex(r.getID(), Opt.none(), Opt.none(), Opt.none(), Opt.none(), Opt.none(),
                 Opt.none(), Opt.none(), Opt.some(r.getState()));
       } else {
@@ -1355,8 +1355,8 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
       // Update live event
       sendSchedulerUpdate(new SchedulerItemList(id, SchedulerItem.deleteRecordingState()));
-
-      // Update API index
+      
+      // Update Elasticsearch index
       removeRecordingStatusFromIndex(id);
     } catch (NotFoundException e) {
       throw e;
@@ -1407,7 +1407,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   }
 
   /**
-   * Update the event in the API index. Fields will only be updated of the corresponding Opt is not none.
+   * Update the event in the Elasticsearch index. Fields will only be updated of the corresponding Opt is not none.
    *
    * @param mediaPackageId
    * @param index
@@ -1479,7 +1479,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   }
 
   /**
-   * Set recording status to null for this event in the API index.
+   * Set recording status to null for this event in the Elasticsearch index.
    *
    * @param mediaPackageId
    * @param index
@@ -1504,7 +1504,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   }
 
   /**
-   * Remove scheduling information for this event from the API index.
+   * Remove scheduling information for this event from the Elasticsearch index.
    *
    * @param mediaPackageId
    * @param index

--- a/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
+++ b/modules/series-service-api/src/main/java/org/opencastproject/series/api/SeriesService.java
@@ -150,6 +150,22 @@ public interface SeriesService {
           throws SeriesException, UnauthorizedException;
 
   /**
+   * Updates the extended metadata of a series from a Dublin Core catalog.
+   *
+   * @param seriesId
+   *         the series identifier
+   * @param type
+   *         the type of dublin core catalog
+   * @param dc
+   *         the dublin core catalog with extended metadata
+   *
+   * @return true if the extended metadata could be updated
+   * @throws SeriesException
+   *           if an error occurred during updating of the extended metadata
+   */
+  boolean updateExtendedMetadata(String seriesId, String type, DublinCoreCatalog dc) throws SeriesException;
+
+  /**
    * Returns all the elements of a series in a map. The key of the map marks the element type. If
    * the series does not contain any elements, an empty map is returned. If the series does not
    * exist, {@code Opt.none()} is returned.
@@ -177,31 +193,15 @@ public interface SeriesService {
   Opt<byte[]> getSeriesElementData(String seriesId, String type) throws SeriesException;
 
   /**
-   * Adds a new element to a series.
+   * Creates or updates an element of a series.
    *
    * @param seriesId
    *          the series identifier
    * @param type
-   *          the type of the new element
+   *          the type of the element
    * @param data
-   *          the data of the new element
-   * @return true, if the element could be added; false if an element with the given key already exists or if there is
-   *         no series with the given identifier.
-   * @throws SeriesException
-   *           if an error occurs while saving the element
-   */
-  boolean addSeriesElement(String seriesId, String type, byte[] data) throws SeriesException;
-
-  /**
-   * Updates an existing element of a series.
-   *
-   * @param seriesId
-   *          the series identifier
-   * @param type
-   *          the type of the new element
-   * @param data
-   *          the data of the new element
-   * @return true if the element could be updated; false if no such element/series exists
+   *          the data of the element
+   * @return true if the element could be created or updated
    * @throws SeriesException
    *           if an error occurs while updating the element
    */

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
@@ -1237,7 +1237,7 @@ public class SeriesRestService {
   }
 
   @PUT
-  @Path("{seriesId}/extended-metadata/{type}")
+  @Path("{seriesId}/extendedMetadata/{type}")
   @RestQuery(
           name = "updateExtendedMetadata",
           description = "Updates extended metadata of a series",
@@ -1245,11 +1245,13 @@ public class SeriesRestService {
           pathParameters = {
                   @RestParameter(name = "seriesId", description = "The series identifier", type = STRING,
                           isRequired = true),
-                  @RestParameter(name = "type", description = "The catalog type", type = STRING,
-                          isRequired = true),
+                  @RestParameter(name = "type", description = "The type of the catalog flavor", type = STRING,
+                          isRequired = true)
+          },
+          restParameters = {
                   @RestParameter(name = "dc", description = "The catalog with extended metadata.", type = TEXT,
                           isRequired = true, defaultValue = SAMPLE_DUBLIN_CORE
-                  ),
+                  )
           },
           responses = {
                   @RestResponse(responseCode = SC_NO_CONTENT, description = "Extended metadata updated"),

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
@@ -1237,6 +1237,55 @@ public class SeriesRestService {
   }
 
   @PUT
+  @Path("{seriesId}/extended-metadata/{type}")
+  @RestQuery(
+          name = "updateExtendedMetadata",
+          description = "Updates extended metadata of a series",
+          returnDescription = "An empty response",
+          pathParameters = {
+                  @RestParameter(name = "seriesId", description = "The series identifier", type = STRING,
+                          isRequired = true),
+                  @RestParameter(name = "type", description = "The catalog type", type = STRING,
+                          isRequired = true),
+                  @RestParameter(name = "dc", description = "The catalog with extended metadata.", type = TEXT,
+                          isRequired = true, defaultValue = SAMPLE_DUBLIN_CORE
+                  ),
+          },
+          responses = {
+                  @RestResponse(responseCode = SC_NO_CONTENT, description = "Extended metadata updated"),
+                  @RestResponse(responseCode = SC_CREATED, description = "Extended metadata created"),
+                  @RestResponse(responseCode = SC_INTERNAL_SERVER_ERROR,
+                          description = "Error while processing the request")
+          }
+  )
+  public Response putSeriesExtendedMetadata(
+          @PathParam("seriesId") String seriesId,
+          @PathParam("type") String type,
+          @FormParam("dc") String dcString
+  ) {
+    try {
+      DublinCoreCatalog dc = dcService.load(new ByteArrayInputStream(dcString.getBytes(StandardCharsets.UTF_8)));
+      boolean elementExists = seriesService.getSeriesElementData(seriesId, type).isSome();
+      if (seriesService.updateExtendedMetadata(seriesId, type, dc)) {
+        if (elementExists) {
+          return R.noContent();
+        } else {
+          return R.created(URI.create(UrlSupport.concat(serverUrl, serviceUrl, seriesId, "elements", type)));
+        }
+      } else {
+        return R.serverError();
+      }
+    } catch (IOException e) {
+      logger.warn("Could not deserialize dublin core catalog", e);
+      return Response.status(BAD_REQUEST).build();
+    } catch (SeriesException e) {
+      logger.warn("Error while updating extended metadata of series '{}'", seriesId, e);
+      return R.serverError();
+    }
+  }
+
+
+  @PUT
   @Path("{seriesId}/elements/{elementType}")
   @RestQuery(
       name = "updateSeriesElement",
@@ -1261,18 +1310,15 @@ public class SeriesRestService {
     try {
       is = request.getInputStream();
       final byte[] data = IOUtils.toByteArray(is);
-      if (seriesService.getSeriesElementData(seriesId, elementType).isSome()) {
-        if (seriesService.updateSeriesElement(seriesId, elementType, data)) {
+      boolean elementExists = seriesService.getSeriesElementData(seriesId, elementType).isSome();
+      if (seriesService.updateSeriesElement(seriesId, elementType, data)) {
+        if (elementExists) {
           return R.noContent();
         } else {
-          return R.serverError();
+          return R.created(URI.create(UrlSupport.concat(serverUrl, serviceUrl, seriesId, "elements", elementType)));
         }
       } else {
-        if (seriesService.addSeriesElement(seriesId, elementType, data)) {
-          return R.created(URI.create(UrlSupport.concat(serverUrl, serviceUrl, seriesId, "elements", elementType)));
-        } else {
-          return R.serverError();
-        }
+        return R.serverError();
       }
     } catch (IOException e) {
       logger.error("Error while trying to read from request", e);

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -116,7 +116,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   /** The system user name */
   private String systemUserName;
 
-  /** The API index */
+  /** The Elasticsearch index */
   private ElasticsearchIndex index;
 
   private AclServiceFactory aclServiceFactory;
@@ -155,7 +155,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     this.updateHandlers.remove(handler);
   }
 
-  /** OSGi callbacks for setting the API index. */
+  /** OSGi callbacks for setting the Elasticsearch index. */
   @Reference
   public void setElasticsearchIndex(ElasticsearchIndex index) {
     this.index = index;
@@ -252,7 +252,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
 
       try {
         updated = persistence.storeSeriesAccessControl(seriesId, accessControl);
-        //update API index
+        //update Elasticsearch index
         updateSeriesAclInIndex(seriesId, accessControl);
         // still sent for other asynchronous updates
         triggerEventHandlers(SeriesItem.updateAcl(seriesId, accessControl, overrideEpisodeAcl));
@@ -287,7 +287,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   public void deleteSeries(final String seriesID) throws SeriesException, NotFoundException {
     try {
       persistence.deleteSeries(seriesID);
-      // remove from API index
+      // remove from Elasticsearch index
       removeSeriesFromIndex(seriesID);
       // still sent for other asynchronous updates
       triggerEventHandlers(SeriesItem.delete(seriesID));
@@ -373,7 +373,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     try {
       persistence.updateSeriesProperty(seriesID, propertyName, propertyValue);
 
-      // update API index
+      // update Elasticsearch index
       if (propertyName.equals(THEME_PROPERTY_NAME)) {
         updateThemePropertyInIndex(seriesID, Optional.ofNullable(propertyValue));
       }
@@ -394,7 +394,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     try {
       persistence.deleteSeriesProperty(seriesID, propertyName);
 
-      // update API index
+      // update Elasticsearch index
       if (propertyName.equals(THEME_PROPERTY_NAME)) {
         updateThemePropertyInIndex(seriesID, Optional.empty());
       }
@@ -576,12 +576,12 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   }
 
   /**
-   * Remove series from API index.
+   * Remove series from Elasticsearch index.
    *
    * @param seriesId
    *          The series id
    * @param index
-   *          The API index to update
+   *          The Elasticsearch index to update
    */
   private void removeSeriesFromIndex(String seriesId) {
     String orgId = securityService.getOrganization().getId();
@@ -596,12 +596,12 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   }
 
   /**
-   * Update series metadata in API index. Also update events if series title has changed (optional).
+   * Update series metadata in Elasticsearch index. Also update events if series title has changed (optional).
    *
    * @param seriesId
    *          The series id
    * @param index
-   *          The API index to update
+   *          The Elasticsearch index to update
    * @param dc
    *          The dublin core catalog
    */
@@ -615,7 +615,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   }
 
   /**
-   * Get the function to update the metadata for a series in an API index.
+   * Get the function to update the metadata for a series in an Elasticsearch index.
    *
    * @param seriesId
    *          The series id
@@ -653,12 +653,12 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   }
 
   /**
-   * Update series acl in API index.
+   * Update series acl in Elasticsearch index.
    *
    * @param seriesId
    *          The series id
    * @param index
-   *          The API index to update
+   *          The Elasticsearch index to update
    * @param acl
    *          The acl to update
    */
@@ -670,7 +670,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   }
 
   /**
-   * Get the function to update the acl for a series in an API index.
+   * Get the function to update the acl for a series in an Elasticsearch index.
    *
    * @param seriesId
    *          The series id
@@ -697,14 +697,14 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   }
 
   /**
-   * Update series theme property in an API index.
+   * Update series theme property in an Elasticsearch index.
    *
    * @param seriesId
    *          The series id
    * @param propertyValueOpt
    *          The value of the property (optional)
    * @param index
-   *          The API index to update
+   *          The Elasticsearch index to update
    */
   private void updateThemePropertyInIndex(String seriesId, Optional<String> propertyValueOpt) {
     String orgId = securityService.getOrganization().getId();
@@ -715,7 +715,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   }
 
   /**
-   * Get the function to update the theme property for a series in an API index.
+   * Get the function to update the theme property for a series in an Elasticsearch index.
    *
    * @param seriesId
    *          The series id
@@ -739,7 +739,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   }
 
   /**
-   * Update a series in an API index.
+   * Update a series in an Elasticsearch index.
    *
    * @param seriesId
    *          The series id

--- a/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
+++ b/modules/series-service-impl/src/test/java/org/opencastproject/series/impl/SeriesServiceImplTest.java
@@ -344,8 +344,8 @@ public class SeriesServiceImplTest {
     seriesService.updateSeries(testCatalog);
     final String seriesId = testCatalog.getFirst(DublinCoreCatalog.PROPERTY_IDENTIFIER);
 
-    assertTrue(seriesService.addSeriesElement(seriesId, ELEMENT_TYPE, ELEMENT_DATA_1));
-    assertFalse(seriesService.addSeriesElement(seriesId, ELEMENT_TYPE, ELEMENT_DATA_1));
+    assertTrue(seriesService.updateSeriesElement(seriesId, ELEMENT_TYPE, ELEMENT_DATA_1)); // creating
+    assertTrue(seriesService.updateSeriesElement(seriesId, ELEMENT_TYPE, ELEMENT_DATA_1));  // updating
     assertArrayEquals(ELEMENT_DATA_1, seriesService.getSeriesElementData(seriesId, ELEMENT_TYPE).get());
 
     assertTrue(seriesService.updateSeriesElement(seriesId, ELEMENT_TYPE, ELEMENT_DATA_2));

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -534,7 +534,7 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
 
   @Override
   public boolean updateExtendedMetadata(String seriesId, String type, DublinCoreCatalog dc) throws SeriesException {
-    HttpPut put = new HttpPut("/" + seriesId + "/extended-metadata/" + type);
+    HttpPut put = new HttpPut("/" + seriesId + "/extendedMetadata/" + type);
     try {
       List<BasicNameValuePair> params = new ArrayList<>();
       params.add(new BasicNameValuePair("dc", dc.toXmlString()));

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -533,6 +533,42 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
   }
 
   @Override
+  public boolean updateExtendedMetadata(String seriesId, String type, DublinCoreCatalog dc) throws SeriesException {
+    HttpPut put = new HttpPut("/" + seriesId + "/extended-metadata/" + type);
+    try {
+      List<BasicNameValuePair> params = new ArrayList<>();
+      params.add(new BasicNameValuePair("dc", dc.toXmlString()));
+      put.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new SeriesException("Unable to assemble a remote series request for updating extended metadata of series "
+              + seriesId, e);
+    }
+
+    HttpResponse response = getResponse(put, SC_NO_CONTENT, SC_CREATED, SC_INTERNAL_SERVER_ERROR);
+    try {
+      if (response == null) {
+        throw new SeriesException(format("Error while updating extended metadata catalog of type '%s' for series '%s'",
+                type, seriesId));
+      } else {
+        final int statusCode = response.getStatusLine().getStatusCode();
+        switch (statusCode) {
+          case SC_NO_CONTENT:
+          case SC_CREATED:
+            return true;
+          case SC_INTERNAL_SERVER_ERROR:
+            throw new SeriesException(
+                    format("Error while updating extended metadata catalog of type '%s' for series '%s'", type,
+                            seriesId));
+          default:
+            throw new SeriesException(format("Unexpected status code", statusCode));
+        }
+      }
+    } finally {
+      closeConnection(response);
+    }
+  }
+
+  @Override
   public Opt<Map<String, byte[]>> getSeriesElements(String seriesID) throws SeriesException {
     HttpGet get = new HttpGet("/" + seriesID + "/elements.json");
     HttpResponse response = getResponse(get, SC_OK, SC_NOT_FOUND, SC_INTERNAL_SERVER_ERROR);
@@ -605,32 +641,6 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
   }
 
   @Override
-  public boolean addSeriesElement(String seriesID, String type, byte[] data) throws SeriesException {
-    HttpPut put = new HttpPut("/" + seriesID + "/elements/" + type);
-    put.setEntity(new ByteArrayEntity(data, ContentType.DEFAULT_BINARY));
-
-    HttpResponse response = getResponse(put, SC_CREATED, SC_INTERNAL_SERVER_ERROR);
-    try {
-      if (response == null) {
-        throw new SeriesException(format("Error while adding element of type '%s' in series '%s'", type, seriesID));
-      } else {
-        final int statusCode = response.getStatusLine().getStatusCode();
-        switch (statusCode) {
-          case SC_CREATED:
-            return true;
-          case SC_INTERNAL_SERVER_ERROR:
-            throw new SeriesException(
-                    format("Error while updating element of type '%s' in series '%s'", type, seriesID));
-          default:
-            throw new SeriesException(format("Unexpected status code", statusCode));
-        }
-      }
-    } finally {
-      closeConnection(response);
-    }
-  }
-
-  @Override
   public boolean updateSeriesElement(String seriesID, String type, byte[] data) throws SeriesException {
     HttpPut put = new HttpPut("/" + seriesID + "/elements/" + type);
     put.setEntity(new ByteArrayEntity(data, ContentType.DEFAULT_BINARY));
@@ -643,6 +653,7 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
         final int statusCode = response.getStatusLine().getStatusCode();
         switch (statusCode) {
           case SC_NO_CONTENT:
+          case SC_CREATED:
             return true;
           case SC_INTERNAL_SERVER_ERROR:
             throw new SeriesException(

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2206,7 +2206,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   }
 
   /**
-   * Remove a workflow instance from the API index.
+   * Remove a workflow instance from the Elasticsearch index.
    *
    * @param workflowInstanceId
    *         the identifier of the workflow instance to remove
@@ -2269,7 +2269,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   }
 
   /**
-   * Update a workflow instance in the API index.
+   * Update a workflow instance in the Elasticsearch index.
    *
    * @param id
    *         workflow id


### PR DESCRIPTION
With this PR, extended metadata of events and series are put into the Elasticsearch index. This can be used to filter by extended metadata fields via the full text search. The series extended metadata is indexed by the Series Service and the event extended metadata by the Asset Manager.

Some more detailed information on what this PR does/doesn't and why/why not:

1. The first commit renames "Api index" to "Elasticsearch index". This was most likely an oversight during a rebase of one of my previous PRs and I took this chance to fix this.
2. The metadata of a single catalog will be rewritten completely on each update, so fields that are no longer configured will be removed. The same is however, not entirely true for catalogs that are no longer configured - the series service lacks awareness of this, so old series catalogs may linger, though there is an endpoint to remove them in the External API.
3. I added an OSGI property to the catalog UI adapters on registration so the Asset Manager can get only those for extended metadata. This is necessary because the Asset Manager can't tell whether a catalog contains extended event metadata without them.
4. I changed the implementation of DublinCoreByteFormat so we don't swallow exceptions there.
5. I added an XML adapter to transform the map with the extended metadata, since the XML is what's used to read a series from the index, and without this change, incremental updates will lose catalogs.
5. I added a new endpoint/method to the series service so we can hand over the whole dublin core catalog instead of transforming to a byte stream and back. Since we only ever use the series element endpoints for extended metadata internally, and the endpoints aren't explicitly stable, I intend to change or remove them accordingly. (Actually, I have already begun the work, but I lack time to finish it before my vacation, so expect a separate PR in January. This might be better anyway since this change might be controversial.)

(I know this change isn't exactly pretty, but please be merciful, I really tried. :laughing:)

This work was sponsored by the University of Vienna.