### PR TITLE
Update to Pax Logging 1.11.11 (9.x)

### DIFF
--- a/assemblies/dist-develop/resources/shell.init.script.append
+++ b/assemblies/dist-develop/resources/shell.init.script.append
@@ -1,5 +1,5 @@
 
 echo "\u001B[1mDevelopment distribution\u001B[0m: Automatically launching \u001B[1m'log:tail'\u001B[0m.\n"
 
-sleep 1
+sleep 2
 log:tail

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -101,6 +101,10 @@
     <bundle>mvn:org.springframework/spring-expression/${spring.version}</bundle>
     <bundle>mvn:org.springframework/spring-tx/${spring.version}</bundle>
     <bundle>mvn:org.springframework/spring-web/${spring.version}</bundle>
+
+    <!-- get updated Loog4J; REMOOVE WITH NEXT KARAF UPDATE! -->
+    <bundle>mvn:org.ops4j.pax.logging/pax-logging-api/1.11.11</bundle>
+    <bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.11.11</bundle>
   </feature>
 
   <feature name="opencast-core" version="${project.version}">

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -159,6 +159,14 @@
                   <!-- Special configuration for development -->
                   <replaceregexp file="target/classes/package.xml" match="tar\.gz" replace="dir" byline="true"/>
                   <replaceregexp file="target/classes/package.xml" match="baseDirectory&gt;.*&lt;/baseDirectory&gt;" replace="includeBaseDirectory&gt;false&lt;/includeBaseDirectory&gt;" byline="true"/>
+                  <!-- Log4J -->
+                  <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.11" byline="true"/>
+                  <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.11" byline="true"/>
+                  <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-log4j2/1.11.6" replace="pax-logging-api/1.11.11" byline="true"/>
+                  <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.11" byline="true"/>
+                  <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-log4j2/1.11.6" replace="pax-logging-api/1.11.11" byline="true"/>
+                  <replaceregexp file="target/assembly/bin/instance" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.11/pax-logging-api-1.11.11" byline="true"/>
+                  <replaceregexp file="target/assembly/bin/shell" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.11/pax-logging-api-1.11.11" byline="true"/>
                 </target>
               </configuration>
               <goals>


### PR DESCRIPTION
This is a hot-patch for Apache Karaf, updating Pax Logging to version
1.11.11. The [new version contains Log4j2 2.16.0](https://github.com/ops4j/org.ops4j.pax.logging/commits/logging-1.11.11/pax-logging-api).

This is a variant of pull request #3275 for Opencast 9.x.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
