### PR TITLE
Fix Files Accessible to External Parties 

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -313,6 +313,8 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
   private boolean skipCatalogs = DEFAULT_SKIP;
   private boolean skipAttachments = DEFAULT_SKIP;
 
+  protected boolean testMode = false;
+
   /**
    * Creates a new ingest service instance.
    */
@@ -1583,8 +1585,11 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
           throw new IOException(uri + " returns http " + httpStatusCode);
         }
         in = response.getEntity().getContent();
-      } else {
+        //If it does not start with file, or we're in test mode (ie, to allow arbitrary file:// access)
+      } else if (!uri.toString().startsWith("file") || testMode) {
         in = uri.toURL().openStream();
+      } else {
+        throw new IOException("Refusing to fetch files from the local filesystem");
       }
       String fileName = FilenameUtils.getName(uri.getPath());
       if (isBlank(FilenameUtils.getExtension(fileName)))

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
@@ -308,6 +308,10 @@ public class IngestServiceImplTest {
     service.setServiceRegistry(serviceRegistry);
     service.defaultWorkflowDefinionId = "sample";
     serviceRegistry.registerService(service);
+    Dictionary<String, String> p = new Hashtable<>();
+    p.put(IngestServiceImpl.DOWNLOAD_SOURCE, "http://localhost.*|http://www.test.com/.*");
+    service.updated(p);
+    service.testMode = true;
   }
 
   @After


### PR DESCRIPTION
This issue allows users who have the ability to add content and view mediapackages to add potentially sensitive files
to that mediapackage.  This includes all Opencast configuration files containing credentials (LMS, DB credentials), as
well as any other insufficiently restricted file.  Badly permissioned config files in /etc?  Now attached to your MP!

Filed as GHSA-59g4-hpg3-3gcp
This is a backport from Opencast 10.6.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
