### PR TITLE
Fixed NPE on cloned events

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -777,7 +777,8 @@ public abstract class AbstractEventEndpoint {
 
     JSONObject json = new JSONObject();
 
-    if (WorkflowUtil.isActive(optEvent.get().getWorkflowState())) {
+    if (StringUtils.isNotBlank(optEvent.get().getWorkflowState())
+        && WorkflowUtil.isActive(optEvent.get().getWorkflowState())) {
       json.put("active", true);
     } else {
       json.put("active", false);


### PR DESCRIPTION
On cloned events the workflow state is not set. Editor call periodically the AdminUI fasade for active workflows for the event. As the Workflow state is null a NPE occur and we get HTTP 500.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
