### PR TITLE
Fix pax-logging in startup.properties

### DIFF
--- a/assemblies/resources/build.xml
+++ b/assemblies/resources/build.xml
@@ -29,9 +29,9 @@
     <!-- Log4J -->
     <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.12" byline="true"/>
     <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.12" byline="true"/>
-    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-log4j2/1.11.6" replace="pax-logging-api/1.11.12" byline="true"/>
+    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-log4j2/1.11.6" replace="pax-logging-log4j2/1.11.12" byline="true"/>
     <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.12" byline="true"/>
-    <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-log4j2/1.11.6" replace="pax-logging-api/1.11.12" byline="true"/>
+    <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-log4j2/1.11.6" replace="pax-logging-log4j2/1.11.12" byline="true"/>
     <replaceregexp file="target/assembly/bin/instance" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.12/pax-logging-api-1.11.12" byline="true"/>
     <replaceregexp file="target/assembly/bin/shell" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.12/pax-logging-api-1.11.12" byline="true"/>
     <delete>


### PR DESCRIPTION
This patch fixes some pax-logging replacements done when assembling
Opencast's distributions.

The reason why Opencast works as expected even without this patch is,
that we had to make sure to include the new bundles in the distribution
and the easiest way of doing that was for Opencast's Karaf features to
require the bundles.

That is why `pax-logging-log4j2` will automatically be started when
starting any of Opencast's Karaf features, automatically mitigating the
replacement error.

The only side-effect was that the logger's start level was slightly
higher than before. In practice, that meant that logging would start
about a second later.

This patch now ensures the start level again drops to `8` and no one
gets confused about why we have `pax-logging-api` twice in the
`startup.properties`.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
