### PR TITLE
Fix Database Connection Tests

### DIFF
--- a/modules/db/src/main/java/org/opencastproject/db/Activator.java
+++ b/modules/db/src/main/java/org/opencastproject/db/Activator.java
@@ -167,9 +167,9 @@ public class Activator implements BundleActivator {
       throw new RuntimeException("Unable to verify SQL credentials have required permissions!", e);
     } finally {
       try {
-        statement.executeQuery("DROP TABLE " + tableName + ";");
+        statement.executeUpdate("DROP TABLE " + tableName + ";");
       } catch (Exception e) {
-        logger.warn("Unable to delete temp table {}, please remove this yourself!", tableName);
+        logger.warn("Unable to delete temp table {}, please remove this yourself!", tableName, e);
       }
     }
 


### PR DESCRIPTION
Starting Opencast with PostgreSQL configured you end up with a database error
being logged:

```
2021-12-20 21:47:06,778 | WARN  | (Activator:172) - Unable to delete temp table oc_temp_808069, please remove this yourself!
org.postgresql.util.PSQLException: No results were returned by the query.
        at org.postgresql.jdbc.PgStatement.executeQuery(PgStatement.java:237) ~[!/:?]
        at com.mchange.v2.c3p0.impl.NewProxyStatement.executeQuery(NewProxyStatement.java:327) ~[!/:?]
        at org.opencastproject.db.Activator.start(Activator.java:170) [!/:?]
        at org.apache.felix.framework.util.SecureAction.startActivator(SecureAction.java:697) [org.apache.felix.framework-5.6.12.jar:?]
        at org.apache.felix.framework.Felix.activateBundle(Felix.java:2240) [org.apache.felix.framework-5.6.12.jar:?]
        at org.apache.felix.framework.Felix.startBundle(Felix.java:2146) [org.apache.felix.framework-5.6.12.jar:?]
        at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:998) [org.apache.felix.framework-5.6.12.jar:?]
        at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:984) [org.apache.felix.framework-5.6.12.jar:?]
        at org.apache.karaf.features.internal.service.BundleInstallSupportImpl.startBundle(BundleInstallSupportImpl.java:165) [!/:?]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.startBundle(FeaturesServiceImpl.java:1153) [!/:?]
        at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:1036) [!/:?]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.doProvision(FeaturesServiceImpl.java:1062) [!/:?]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.lambda$doProvisionInThread$13(FeaturesServiceImpl.java:998) [!/:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
```

While the error is inconsequential and the table is actually even removed, the
warning is confusing and not accurate.  This patch fixes the problem.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
