### PR TITLE
Automate GitHub Release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,52 @@
+on:
+  push:
+    tags:
+      - '*.*'
+
+name: Create new release
+jobs:
+  build:
+    name: Create release from tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: install dependencies
+        run: |
+          sudo apt update -q
+          sudo apt install -y -q \
+            bzip2 \
+            gzip \
+            tar \
+            unzip
+
+      - name: build opencast
+        run: |
+          mvn clean install \
+            --batch-mode \
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+            -Dhttp.keepAlive=false \
+            -Dmaven.wagon.http.pool=false \
+            -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 \
+            -DskipTests \
+            -Dcheckstyle.skip=true
+
+      - name: create new release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/opencast-dist-*.tar.gz
+          draft: true
+          fail_on_unmatched_files: true
+          name: Opencast ${GITHUB_REF#refs/heads/}
+          body: |
+            This release …
+            For further information, please take a look at:
+
+            - [Release notes](#)
+            - [Changelog](#)

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -317,8 +317,12 @@ The following steps outline the necessary steps for cutting the final release:
 8. Push the built artifacts to Maven. Bug the QA Coordinator to do this so that he remembers to set this up from the CI
     servers. If you want to do this yourself please read the [infra documentation](infrastructure/maven-repository.md#pushing-to-maven-central).
 
-9. Create a new release on GitHub using the [graphical user interface](https://github.com/opencast/opencast/releases)
-    to upload the distribution tarballs.
+9. Check the “Create new release” GitHub Actions workflow.
+   It will automatically build and upload the release tarballs and create a new release draft.
+   Once it is finished, review the draft, adjust the description and publish the release.
+
+   If the workflow fails, investigate what was going wrong and either restart the workflow or create the release
+   manually in the GitHub user interface.
 
 Finally, send a release notice to Opencast's announcement list. Note that posting to this list is restricted to those
 who need access to avoid general discussions on that list. In case you do not already have permissions to post on this


### PR DESCRIPTION
This patch automates building the release tarballs and creating a
release on GitHub.

The workflow will only create a `Draft` release, allowing release
managers to review the release before publication.

This should be a lot faster and less error-prone than release managers
building the tarballs at home and uploading them manually.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
