### PR TITLE
Remove Unused Additional Log4J

### DIFF
--- a/modules/elasticsearch-impl/pom.xml
+++ b/modules/elasticsearch-impl/pom.xml
@@ -52,6 +52,12 @@
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
       <version>${elasticsearch.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch</groupId>
@@ -126,13 +132,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
 
-    <!-- logging -->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.11.1</version>
-    </dependency>
-
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -160,7 +159,6 @@
             <ignoredUnusedDeclaredDependency>org.apache.lucene:lucene-join</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.lucene:lucene-queryparser</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>com.carrotsearch:hppc</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpcore</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpcore-osgi</ignoredUnusedDeclaredDependency>
@@ -193,6 +191,7 @@
               !org.HdrHistogram.*,
               !org.apache.kafka.clients.producer.*,
               !org.apache.logging.log4j.util.internal,
+              !org.apache.logging.log4j.core*,
               !org.apache.lucene.*,
               !javax.activation.*,
               !javax.annotation,
@@ -222,8 +221,7 @@
               lucene-queryparser,
               rank-eval-client,
               httpasyncclient,
-              hppc,
-              log4j-core
+              hppc
             </Embed-Dependency>
             <_exportcontents>
               org.elasticsearch.*,


### PR DESCRIPTION
Opencast included an additional version of Log4J via its elasticsearch
module. The dependency seems to be unused. To avoid confusion, this
pull requests removes it completely.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
