### PR TITLE
Show input selection only if applicable

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
@@ -267,8 +267,8 @@
                 </select>
               </td>
             </tr>
-            <tr>
-              <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.INPUTS' | translate }} <i class="required">*</i></td>
+            <tr ng-if="wizard.step.ud.SCHEDULE_SINGLE.device.inputs.length">
+              <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.INPUTS' | translate }}</td>
               <td>
                 <label ng-repeat="inputMethod in wizard.step.ud.SCHEDULE_SINGLE.device.inputs">
                   <input type="checkbox"
@@ -414,8 +414,8 @@
                 </select>
               </td>
             </tr>
-            <tr>
-              <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.INPUTS' | translate }} <i class="required">*</i></td>
+            <tr ng-if="wizard.step.ud.SCHEDULE_MULTIPLE.device.inputs.length">
+              <td>{{ 'EVENTS.EVENTS.NEW.SOURCE.PLACEHOLDER.INPUTS' | translate }}</td>
               <td>
                 <label ng-repeat="inputMethod in wizard.step.ud.SCHEDULE_MULTIPLE.device.inputs">
                   <input type="checkbox" ng-model="wizard.step.ud.SCHEDULE_MULTIPLE.device.inputMethods[inputMethod.id]" tabindex="20" />


### PR DESCRIPTION
This patch removes the input selection from being marked as required
(since it is not) and will no more show an empty selection if a capture
agent does not have multiple inputs. This will hopefully avoid some
confusion around this option.


https://user-images.githubusercontent.com/1008395/147958397-7c588f88-9a1d-4910-9a9f-9f78e89906cb.mp4



### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
