### PR TITLE
Fix branches on docs.opencast.org

### DIFF
--- a/docs/guides/.infrastructure/generate-versions
+++ b/docs/guides/.infrastructure/generate-versions
@@ -7,7 +7,7 @@ from jinja2 import Template
 
 
 RELEASE_URL = 'https://api.github.com/repos/opencast/opencast/releases'
-BRANCH_URL = 'https://api.github.com/repos/opencast/opencast/branches'
+BRANCH_URL = 'https://api.github.com/repos/opencast/opencast/branches?per_page=100'
 
 
 def main():


### PR DESCRIPTION
It seems like a lot of dependabot branches may make the script
generating the landing page of docs.opencast.org miss some branches.
This patch increases the number of branches requested as a (non perfect)
quick-fix.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
