### PR TITLE
Extend Metadata Extraction in Inbox

### DIFF
--- a/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
+++ b/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
@@ -33,3 +33,45 @@ inbox.path=${karaf.data}/inbox
 # The time between each retry in seconds
 # Default: 300
 #inbox.tries.between.sec=300
+
+###
+# Metadata matching
+##
+
+# Regular expression to extract metadata from filename.
+#
+# By default, the filename is used as title.
+# This option lets you specify a regular expression to extract metadata.
+# To match the metadata, specify named groups in the expression.
+#
+# The following matching groups will be mapped to metadata:
+#  - title
+#  - spatial (shown as location in Opencast's user interface)
+#  - created (extracted value must match the formatter below)
+#
+# Example:
+#   filename:            2021-12-10-11-15 hs1 Biology 101.mp4
+#   regular expression:  (?<created>....-..-..-..-..) (?<spatial>[^ ]+) (?<title>.+)\\.mp4
+#   matched metadata:
+#     created:           2021-12-10-11-15
+#     spatial:           hs1
+#     title:             Biology 101
+#
+# Default: <empty>
+#inbox.metadata.regex =
+
+# Date and time format of the matched `created` metadata field.
+# This value is used to parse the date-time value.
+# It must match in order to properly recognize the recording time.
+#
+# Documentation about the format can be found at:
+#   https://www.baeldung.com/java-string-to-date#3-common-date-and-time-patterns
+#
+# Example:
+#
+#   matched string:  2021-12-10-11-15
+#   format:          yyyy-MM-dd-HH-mm
+#   result:          2021-12-10 11:15:00
+#
+# Default: <empty>
+#inbox.datetime.format =


### PR DESCRIPTION
Opencast's inbox allows you to add zipped media packages which may
contain arbitrary metadata but are very complex or to add simple files,
which file names will end up as the new event's title. It would be nice
if it would be possible to extract a few more basic metadata from the
filename.

File names like these are commonly generated by capture devices:

```
2020-02-07-hs1-Introduction to Biology.mp4
 |    |  |  |  |                     |
year  |  |  |  +----------+----------+
   month |  |             |
        day |           title
        location
```

To improve the situation, and to be as flexible as necessary, we would
like to allow for specifying regular expressions as matchers for a few
basic metadata.

This resolves #3239

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
