### PR TITLE
Use 1970-01-02 as dummy value in MySQL migration

### DIFF
--- a/docs/upgrade/10_to_11/mysql5.sql
+++ b/docs/upgrade/10_to_11/mysql5.sql
@@ -9,6 +9,9 @@ ALTER TABLE oc_assets_asset MODIFY COLUMN mime_type VARCHAR (255);
 -- could reasonably assume that almost all modification dates of real world series are unique. So
 -- we instead derive the modification dates from the series' events. Unix epoch only for series
 -- without events.
+--
+-- We use 1970-01-02 instead of 1970-01-01 to work around possible timezone problems. The exact value 
+-- doesn't matter anyway.
 ALTER TABLE oc_series ADD deletion_date TIMESTAMP NULL;
 ALTER TABLE oc_series ADD modified_date TIMESTAMP NULL;
 UPDATE oc_series
@@ -18,6 +21,6 @@ UPDATE oc_series
             WHERE oc_search.series_id = oc_series.id
     );
 UPDATE oc_series
-    SET modified_date = TIMESTAMP '1970-01-01 00:00:01'
+    SET modified_date = TIMESTAMP '1970-01-02 00:00:01'
     WHERE modified_date IS NULL;
 ALTER TABLE oc_series MODIFY modified_date TIMESTAMP NOT NULL;


### PR DESCRIPTION
This is a workaround for timezone issues. The exact value doesn't matter, so just 
adding a day is the easiest option to fix problems like this:
https://groups.google.com/a/opencast.org/g/users/c/335SnoOC2tQ

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
