### PR TITLE
Warn against using CIFS for Inbox

### DIFF
--- a/docs/guides/admin/docs/configuration/inbox.md
+++ b/docs/guides/admin/docs/configuration/inbox.md
@@ -6,6 +6,11 @@ For most purposes, we recommend using the Ingest REST API instead of the inbox.
 It is more reliable and provides instant feedback if a problem occurs.
 </div>
 
+<div class=warn>
+Do not use the inbox on a CIFS mount.
+The mount may report inaccurate metadata, which may break ingests or cause files to not be recognized.
+</div>
+
 
 Overview
 --------


### PR DESCRIPTION
This patch updates the Inbox documentation, warning against using a CIFS
mount for the inbox.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
