### PR TITLE
Fix REST Test Network Bindings

### DIFF
--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.impl.AdminUIConfiguration;
@@ -70,7 +69,8 @@ import io.restassured.http.ContentType;
 import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
 public class AbstractEventEndpointTest {
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestEventEndpoint.class,
+  private static final RestServiceTestEnv rt = testEnvForClasses(
+          TestEventEndpoint.class,
           NotFoundExceptionMapper.class);
 
   public static TestEnv testEnv() {

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AclEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AclEndpointTest.java
@@ -24,7 +24,6 @@ package org.opencastproject.adminui.endpoint;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
@@ -50,8 +49,7 @@ import io.restassured.http.ContentType;
 
 public class AclEndpointTest {
 
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestAclEndpoint.class,
-          NotFoundExceptionMapper.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestAclEndpoint.class, NotFoundExceptionMapper.class);
 
   private JSONParser parser;
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/CaptureAgentsEndpointTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -47,8 +46,8 @@ import java.io.IOException;
 import io.restassured.http.ContentType;
 
 public class CaptureAgentsEndpointTest {
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestCaptureAgentsEndpoint.class);
-  private JSONParser parser = new JSONParser();
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestCaptureAgentsEndpoint.class);
+  private final JSONParser parser = new JSONParser();
 
   private JSONObject getCaptureAgent(String name, JSONArray captureAgents) {
     JSONObject result = null;

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/JobEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/JobEndpointTest.java
@@ -24,7 +24,6 @@ package org.opencastproject.adminui.endpoint;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
@@ -48,7 +47,7 @@ import io.restassured.http.ContentType;
 import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
 public class JobEndpointTest {
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestJobEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestJobEndpoint.class);
 
   private JSONParser parser;
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ListProvidersEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ListProvidersEndpointTest.java
@@ -25,7 +25,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasValue;
 import static org.junit.Assert.assertEquals;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -44,7 +43,7 @@ import io.restassured.response.Response;
 import io.restassured.response.ResponseBody;
 
 public class ListProvidersEndpointTest {
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestListProvidersEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestListProvidersEndpoint.class);
 
   private JSONParser parser;
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/SeriesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/SeriesEndpointTest.java
@@ -23,7 +23,6 @@ package org.opencastproject.adminui.endpoint;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -47,7 +46,7 @@ import io.restassured.http.ContentType;
 
 public class SeriesEndpointTest {
 
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestSeriesEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestSeriesEndpoint.class);
 
   private JSONParser parser;
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServerEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServerEndpointTest.java
@@ -23,7 +23,6 @@ package org.opencastproject.adminui.endpoint;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
@@ -45,7 +44,7 @@ import java.io.InputStreamReader;
 import io.restassured.http.ContentType;
 
 public class ServerEndpointTest {
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestServerEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestServerEndpoint.class);
 
   private JSONParser parser;
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServicesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ServicesEndpointTest.java
@@ -23,7 +23,6 @@ package org.opencastproject.adminui.endpoint;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
@@ -52,7 +51,7 @@ public class ServicesEndpointTest {
   private static final String TEST_DATA_JSON = "/services.json";
 
   /** REST endpoint test environment. */
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestServicesEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestServicesEndpoint.class);
 
   /** Json parser. */
   private JSONParser parser;

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TasksEndpointTest.java
@@ -23,7 +23,6 @@ package org.opencastproject.adminui.endpoint;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -45,7 +44,7 @@ import io.restassured.http.ContentType;
 
 public class TasksEndpointTest {
 
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestTasksEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestTasksEndpoint.class);
 
   private JSONParser parser;
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ThemesEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/ThemesEndpointTest.java
@@ -25,7 +25,6 @@ import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.NotFoundExceptionMapper;
@@ -51,7 +50,8 @@ import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
 public class ThemesEndpointTest {
   private static final Logger logger = LoggerFactory.getLogger(ThemesEndpointTest.class);
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestThemesEndpoint.class,
+  private static final RestServiceTestEnv rt = testEnvForClasses(
+          TestThemesEndpoint.class,
           NotFoundExceptionMapper.class);
   /** A parser for handling JSON documents inside the body of a request. */
   private final JSONParser parser = new JSONParser();

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersEndpointTest.java
@@ -24,7 +24,6 @@ package org.opencastproject.adminui.endpoint;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.adminui.util.ServiceEndpointTestsUtil;
@@ -48,7 +47,7 @@ import java.io.InputStreamReader;
 import io.restassured.http.ContentType;
 
 public class UsersEndpointTest {
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestUsersEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestUsersEndpoint.class);
 
   private JSONParser parser;
 

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersSettingsEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/UsersSettingsEndpointTest.java
@@ -24,7 +24,6 @@ package org.opencastproject.adminui.endpoint;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -51,7 +50,7 @@ import io.restassured.http.ContentType;
 
 public class UsersSettingsEndpointTest {
   private static final Logger logger = LoggerFactory.getLogger(UsersSettingsEndpointTest.class);
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(), TestUserSettingsEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestUserSettingsEndpoint.class);
 
   private JSONParser parser;
 

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -153,11 +153,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-server</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-rest-test-environment</artifactId>
       <version>${project.version}</version>

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/AbstractAclServiceRestEndpoint.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/AbstractAclServiceRestEndpoint.java
@@ -87,8 +87,6 @@ public abstract class AbstractAclServiceRestEndpoint {
 
   protected abstract AclServiceFactory getAclServiceFactory();
 
-  protected abstract String getEndpointBaseUrl();
-
   protected abstract SecurityService getSecurityService();
 
   protected abstract AssetManager getAssetManager();

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpoint.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpoint.java
@@ -93,11 +93,6 @@ public final class OsgiAclServiceRestEndpoint extends AbstractAclServiceRestEndp
   }
 
   @Override
-  protected String getEndpointBaseUrl() {
-    return endpointBaseUrl;
-  }
-
-  @Override
   protected SecurityService getSecurityService() {
     return securityService;
   }

--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpointTest.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpointTest.java
@@ -24,13 +24,12 @@ package org.opencastproject.authorization.xacml.manager.endpoint;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForCustomConfig;
+import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.security.api.Permissions.Action;
 import org.opencastproject.test.rest.RestServiceTestEnv;
 import org.opencastproject.util.UrlSupport;
 
-import org.glassfish.jersey.server.ResourceConfig;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.After;
@@ -262,8 +261,7 @@ public class OsgiAclServiceRestEndpointTest {
 
   // --
 
-  private static final RestServiceTestEnv env = testEnvForCustomConfig(TestRestService.BASE_URL,
-          new ResourceConfig(TestRestService.class, NotFoundExceptionMapper.class));
+  private static final RestServiceTestEnv env = testEnvForClasses(TestRestService.class, NotFoundExceptionMapper.class);
 
   @BeforeClass
   public static void oneTimeSetUp() {

--- a/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
+++ b/modules/authorization-manager/src/test/java/org/opencastproject/authorization/xacml/manager/endpoint/TestRestService.java
@@ -22,7 +22,6 @@
 package org.opencastproject.authorization.xacml.manager.endpoint;
 
 import static com.entwinemedia.fn.Stream.$;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.util.persistence.PersistenceUtil.newTestEntityManagerFactory;
 
 import org.opencastproject.assetmanager.api.AssetManager;
@@ -70,8 +69,6 @@ import com.entwinemedia.fn.data.Opt;
 import org.easymock.EasyMock;
 import org.junit.Ignore;
 
-import java.net.URL;
-
 import javax.persistence.EntityManagerFactory;
 import javax.ws.rs.Path;
 
@@ -80,8 +77,6 @@ import javax.ws.rs.Path;
 // put @Ignore here to prevent maven surefire from complaining about missing test methods
 @Ignore
 public class TestRestService extends AbstractAclServiceRestEndpoint {
-
-  public static final URL BASE_URL = localhostRandomPort();
 
   // Declare this dependency static since the TestRestService gets instantiated multiple times.
   // Haven't found out who's responsible for this but that's the way it is.
@@ -215,11 +210,6 @@ public class TestRestService extends AbstractAclServiceRestEndpoint {
     EasyMock.expect(assetManager.createQuery()).andReturn(query).anyTimes();
     EasyMock.replay(assetManager, version, query, predicate, select, result, record, snapshot);
     return assetManager;
-  }
-
-  @Override
-  protected String getEndpointBaseUrl() {
-    return BASE_URL.toString();
   }
 
 }

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
@@ -24,7 +24,6 @@ import static io.restassured.RestAssured.given;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -40,7 +39,7 @@ import org.junit.Test;
 public class BaseEndpointTest {
 
   /** The REST test environment */
-  private static final RestServiceTestEnv env = testEnvForClasses(localhostRandomPort(), TestBaseEndpoint.class);
+  private static final RestServiceTestEnv env = testEnvForClasses(TestBaseEndpoint.class);
 
   private static final JSONParser parser = new JSONParser();
 

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/CaptureAgentsEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/CaptureAgentsEndpointTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertThat;
 import static org.opencastproject.external.endpoint.TestCaptureAgentsEndpoint.UNKNOWN_AGENT;
 import static org.opencastproject.external.endpoint.TestCaptureAgentsEndpoint.loadAgents;
 import static org.opencastproject.external.endpoint.TestCaptureAgentsEndpoint.toJson;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.capture.admin.api.Agent;
@@ -46,7 +45,7 @@ import java.util.List;
 import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
 public class CaptureAgentsEndpointTest {
-  private static final RestServiceTestEnv env = testEnvForClasses(localhostRandomPort(), TestCaptureAgentsEndpoint.class);
+  private static final RestServiceTestEnv env = testEnvForClasses(TestCaptureAgentsEndpoint.class);
 
   private static List<Agent> allAgents;
 

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/EventsEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/EventsEndpointTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.capture.CaptureParameters;
@@ -55,7 +54,7 @@ import java.util.Map;
 import uk.co.datumedge.hamcrest.json.SameJSONAs;
 
 public class EventsEndpointTest {
-  private static final RestServiceTestEnv env = testEnvForClasses(localhostRandomPort(), TestEventsEndpoint.class);
+  private static final RestServiceTestEnv env = testEnvForClasses(TestEventsEndpoint.class);
 
    @BeforeClass
    public static void oneTimeSetUp() {

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SecurityEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SecurityEndpointTest.java
@@ -25,7 +25,6 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_ACCEPTABLE;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 import static org.opencastproject.util.DateTimeSupport.fromUTC;
 import static org.opencastproject.util.DateTimeSupport.toUTC;
@@ -47,7 +46,7 @@ public class SecurityEndpointTest {
   private static final String APP_V1_0_0_XML = "application/v1.0.0+xml";
 
   /** The REST test environment */
-  private static final RestServiceTestEnv env = testEnvForClasses(localhostRandomPort(), TestSecurityEndpoint.class);
+  private static final RestServiceTestEnv env = testEnvForClasses(TestSecurityEndpoint.class);
 
   /** The json parser */
   private static final JSONParser parser = new JSONParser();

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SeriesEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/SeriesEndpointTest.java
@@ -32,7 +32,6 @@ import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -55,7 +54,7 @@ public class SeriesEndpointTest {
   private static final String APP_V1_0_0_XML = "application/v1.0.0+xml";
 
   /** The REST test environment */
-  private static final RestServiceTestEnv env = testEnvForClasses(localhostRandomPort(), TestSeriesEndpoint.class);
+  private static final RestServiceTestEnv env = testEnvForClasses(TestSeriesEndpoint.class);
 
   /** The json parser */
   private static final JSONParser parser = new JSONParser();

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpointTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -40,8 +39,7 @@ import org.junit.Test;
 
 public class WorkflowDefinitionsEndpointTest {
 
-  private static final RestServiceTestEnv env = testEnvForClasses(localhostRandomPort(),
-          TestWorkflowDefinitionsEndpoint.class);
+  private static final RestServiceTestEnv env = testEnvForClasses(TestWorkflowDefinitionsEndpoint.class);
 
   private static final JSONParser parser = new JSONParser();
 

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/WorkflowsEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/WorkflowsEndpointTest.java
@@ -30,7 +30,6 @@ import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -46,7 +45,7 @@ import io.restassured.http.ContentType;
 
 public class WorkflowsEndpointTest {
 
-  private static final RestServiceTestEnv env = testEnvForClasses(localhostRandomPort(), TestWorkflowsEndpoint.class);
+  private static final RestServiceTestEnv env = testEnvForClasses(TestWorkflowsEndpoint.class);
 
   private static final JSONParser parser = new JSONParser();
 

--- a/modules/kernel/src/test/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpointTest.java
+++ b/modules/kernel/src/test/java/org/opencastproject/kernel/bundleinfo/BundleInfoRestEndpointTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.kernel.bundleinfo.BundleInfoImpl.bundleInfo;
 import static org.opencastproject.kernel.bundleinfo.BundleInfoRestEndpoint.bundleInfoJson;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 import static org.opencastproject.util.ReflectionUtil.run;
 import static org.opencastproject.util.data.Option.none;
@@ -55,8 +54,7 @@ import io.restassured.path.json.JsonPath;
  * the number and the string.
  */
 public class BundleInfoRestEndpointTest {
-  private static final RestServiceTestEnv rt = testEnvForClasses(localhostRandomPort(),
-          TestBundleInfoRestEndpoint.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestBundleInfoRestEndpoint.class);
 
   private static PersistenceEnv penv;
 

--- a/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/AbstractOaiPmhServerInfoRestEndpointTest.java
+++ b/modules/oaipmh/src/test/java/org/opencastproject/oaipmh/server/AbstractOaiPmhServerInfoRestEndpointTest.java
@@ -22,7 +22,6 @@ package org.opencastproject.oaipmh.server;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -33,7 +32,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class AbstractOaiPmhServerInfoRestEndpointTest {
-  private static final RestServiceTestEnv env = testEnvForClasses(localhostRandomPort(), TestRestService.class);
+  private static final RestServiceTestEnv env = testEnvForClasses(TestRestService.class);
 
   @Test
   public void testHasRepo() throws Exception {

--- a/modules/publication-service-oaipmh-remote/src/test/java/org/opencastproject/publication/oaipmh/endpoint/OaiPmhPublicationRestServiceTest.java
+++ b/modules/publication-service-oaipmh-remote/src/test/java/org/opencastproject/publication/oaipmh/endpoint/OaiPmhPublicationRestServiceTest.java
@@ -22,7 +22,6 @@ package org.opencastproject.publication.oaipmh.endpoint;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
-import static org.opencastproject.test.rest.RestServiceTestEnv.localhostRandomPort;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 import static org.opencastproject.util.UrlSupport.uri;
 
@@ -47,7 +46,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.URI;
-import java.net.URL;
 import java.util.HashSet;
 
 /**
@@ -80,9 +78,9 @@ public class OaiPmhPublicationRestServiceTest {
     final ServiceRegistry registry = EasyMock.createNiceMock(ServiceRegistry.class);
     final ServiceRegistration registration = EasyMock.createNiceMock(ServiceRegistration.class);
     EasyMock.expect(registration.getHost())
-        .andReturn(url.getProtocol() + "://" + url.getHost() + ":" + url.getPort())
+        .andReturn(rt.host(""))
         .anyTimes();
-    EasyMock.expect(registration.getPath()).andReturn(url.getPath()).anyTimes();
+    EasyMock.expect(registration.getPath()).andReturn("").anyTimes();
     EasyMock.expect(registry.getServiceRegistrationsByLoad(EasyMock.anyString()))
         .andReturn(ListBuilders.SIA.mk(registration))
         .anyTimes();
@@ -114,8 +112,7 @@ public class OaiPmhPublicationRestServiceTest {
     }
   }
 
-  private static final URL url = localhostRandomPort();
-  private static final RestServiceTestEnv rt = testEnvForClasses(url, TestOaiPmhPublicationRestService.class);
+  private static final RestServiceTestEnv rt = testEnvForClasses(TestOaiPmhPublicationRestService.class);
 
   // Great. Checkstyle: "This method should no be static". JUnit: "Method setUp() should be static." ;)
   // CHECKSTYLE:OFF

--- a/modules/rest-test-environment/src/main/java/org/opencastproject/test/rest/RestServiceTestEnv.java
+++ b/modules/rest-test-environment/src/main/java/org/opencastproject/test/rest/RestServiceTestEnv.java
@@ -21,11 +21,9 @@
 
 package org.opencastproject.test.rest;
 
-import static org.opencastproject.util.data.Option.some;
 import static org.opencastproject.util.data.functions.Misc.chuck;
 
 import org.opencastproject.util.UrlSupport;
-import org.opencastproject.util.data.Option;
 
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -35,9 +33,8 @@ import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
+import java.net.BindException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -87,10 +84,10 @@ import java.util.concurrent.ThreadLocalRandom;
  * </pre>
  */
 public final class RestServiceTestEnv {
-  private Server hs;
+  private Server server;
 
-  private final URL baseUrl;
-  private final Option<? extends ResourceConfig> cfg;
+  private URL baseUrl = null;
+  private final ResourceConfig cfg;
 
   private static final Logger logger = LoggerFactory.getLogger(RestServiceTestEnv.class);
 
@@ -98,51 +95,20 @@ public final class RestServiceTestEnv {
    * Create an environment for <code>baseUrl</code>. The base URL should be the URL where the service to test is
    * mounted, e.g. http://localhost:8090/test
    */
-  private RestServiceTestEnv(URL baseUrl, Option<? extends ResourceConfig> cfg) {
-    this.baseUrl = baseUrl;
+  private RestServiceTestEnv(ResourceConfig cfg) {
     this.cfg = cfg;
   }
 
-  public static RestServiceTestEnv testEnvForClasses(URL baseUrl, Class... restServices) {
-    return new RestServiceTestEnv(baseUrl, some(new ResourceConfig(restServices)));
-  }
-
-  public static RestServiceTestEnv testEnvForCustomConfig(URL baseUrl, ResourceConfig cfg) {
-    return new RestServiceTestEnv(baseUrl, some(cfg));
-  }
-
-  /**
-   * Return a localhost base URL with a random port between 8081 and 9000. The method features a port usage detection to
-   * ensure it returns a free port.
-   */
-  public static synchronized URL localhostRandomPort() {
-    for (int tries = 100; tries > 0; tries--) {
-      final int random = ThreadLocalRandom.current().nextInt(62000);
-      final URL url = UrlSupport.url("http", "127.0.0.1", 3000 + random);
-      try {
-        final URLConnection con = url.openConnection();
-        con.setConnectTimeout(1000);
-        con.setReadTimeout(1000);
-        con.getInputStream();
-        Thread.sleep(100);
-      } catch (IOException e) {
-        logger.debug("Selected URL: {}", url);
-        return url;
-      } catch (InterruptedException e) {
-        // ignore sleep interruption
-      }
-    }
-    throw new RuntimeException("Cannot find free port. Giving up.");
+  public static RestServiceTestEnv testEnvForClasses(Class<?>... restServices) {
+    return new RestServiceTestEnv(new ResourceConfig(restServices));
   }
 
   /** Create a URL suitable for rest-assured's post(), get() e.al. methods. */
   public String host(String path) {
+    if (baseUrl == null) {
+      throw new RuntimeException("Server not yet started");
+    }
     return UrlSupport.url(baseUrl, path).toString();
-  }
-
-  /** Return the port the configured server is running on. */
-  public int getPort() {
-    return baseUrl.getPort();
   }
 
   /**
@@ -152,15 +118,26 @@ public final class RestServiceTestEnv {
    */
   public void setUpServer() {
     try {
-      // cut of any base pathbasestUrl might have
-      int port = baseUrl.getPort();
-      logger.info("Start http server at port " + port);
-      hs = new Server(port);
-      ServletContainer servletContainer = cfg.isSome() ? new ServletContainer(cfg.get()) : new ServletContainer();
-      ServletHolder jerseyServlet = new ServletHolder(servletContainer);
-      ServletContextHandler context = new ServletContextHandler(hs, "/");
-      context.addServlet(jerseyServlet, "/*");
-      hs.start();
+      for (int tries = 100; tries > 0; tries--) {
+        try {
+          final int port = 3000 + tries + ThreadLocalRandom.current().nextInt(62000);
+          logger.error("Start http server at port {}", port);
+          server = new Server(port);
+          ServletContainer servletContainer = new ServletContainer(cfg);
+          ServletHolder jerseyServlet = new ServletHolder(servletContainer);
+          ServletContextHandler context = new ServletContextHandler(server, "/");
+          context.addServlet(jerseyServlet, "/*");
+          server.start();
+          baseUrl = UrlSupport.url("http", "127.0.0.1", port);
+          return;
+        } catch (BindException e) {
+          // Rethrow exception after last try
+          if (tries == 1) {
+            throw e;
+          }
+          Thread.sleep(100);
+        }
+      }
     } catch (Exception e) {
       chuck(e);
     }
@@ -168,10 +145,10 @@ public final class RestServiceTestEnv {
 
   /** Call in @AfterClass annotated method. */
   public void tearDownServer() {
-    if (hs != null) {
+    if (server != null) {
       logger.info("Stop http server");
       try {
-        hs.stop();
+        server.stop();
       } catch (Exception e) {
         logger.warn("Stop http server - failed {}", e.getMessage());
       }


### PR DESCRIPTION
Using the REST tests environment, Opencast's tests would randomly fail
with ports seemingly being already in use, causing the bind of the test
server to fail.

This patch changes the test environment behavior to select a random port
and the directly trying a bind instead of selecting a port in advance.
This should cause the test server to select another port if the bind
fails.

This (hopefully) fixes #2098

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
