### PR TITLE
Fix Scheduler Conflict Checks

### DIFF
--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
@@ -362,7 +362,7 @@ public interface SchedulerService {
    * @param captureDeviceID
    *          capture device ID for which conflicting events are searched for
    * @param startDate
-   *          start date of of conflicting period
+   *          start date of conflicting period
    * @param endDate
    *          end date of conflicting period
    * @return a {@link MediaPackage} list of all conflicting events

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1048,12 +1048,14 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     try {
       final Organization organization = securityService.getOrganization();
       final User user = SecurityUtil.createSystemUser(systemUserName, organization);
-      List<MediaPackage> conflictingEvents = new ArrayList();
+      List<MediaPackage> conflictingEvents = new ArrayList<>();
 
       SecurityUtil.runAs(securityService, organization, user, () -> {
         try {
-          conflictingEvents.addAll(persistence.getEvents(captureDeviceID, startDate, endDate, Util.EVENT_MINIMUM_SEPARATION_MILLISECONDS)
-            .stream().map(this::getEventMediaPackage).collect(Collectors.toList()));
+          persistence.getEvents(captureDeviceID, startDate, endDate, Util.EVENT_MINIMUM_SEPARATION_MILLISECONDS)
+                  .stream()
+                  .map(id -> getEventMediaPackage(id, false))
+                  .forEach(conflictingEvents::add);
         } catch (SchedulerServiceDatabaseException e) {
           logger.error("Failed to get conflicting events", e);
         }
@@ -1603,17 +1605,24 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
     return wfPropertiesString.toString();
   }
 
-  private MediaPackage getEventMediaPackage(String mediaPackageId) {
+  private MediaPackage getEventMediaPackage(final String mediaPackageId, boolean checkOwner) {
     AQueryBuilder query = assetManager.createQuery();
-    AResult result = query.select(query.snapshot())
-            .where(withOrganization(query).and(query.mediaPackageId(mediaPackageId)).and(withOwner(query))
-            .and(query.version().isLatest()))
-            .run();
-    Opt<ARecord> record = result.getRecords().head();
+    var predicate = withOrganization(query)
+            .and(query.mediaPackageId(mediaPackageId))
+            .and(query.version().isLatest());
+    if (checkOwner) {
+      predicate = predicate.and(withOwner(query));
+    }
+
+    Opt<ARecord> record = query.select(query.snapshot()).where(predicate).run().getRecords().head();
     if (record.isNone())
       throw new RuntimeNotFoundException(new NotFoundException());
 
     return record.bind(recordToMp).get();
+  }
+
+  private MediaPackage getEventMediaPackage(final String mediaPackageId) {
+    return getEventMediaPackage(mediaPackageId, true);
   }
 
   /**


### PR DESCRIPTION
This patch fixes the scheduler's conflict checks which previously broke
spectacularly if someone already ingested media to one of the found
scheduled events.

The scheduler woould then find the conflict but would fail to retrieve
the media package since it wouldn't be the owner of that event in the
asset manager any longer. That does not make a lot of sense for a
conflict check where you just want to get the information.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
