### PR TITLE
Match Inbox Events Against Schedule

### DIFF
--- a/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
+++ b/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
@@ -75,3 +75,18 @@ inbox.path=${karaf.data}/inbox
 #
 # Default: <empty>
 #inbox.datetime.format =
+
+# Match scheduled events
+#
+# If this is turned on, Opencast will try matching inbox files to scheduled events.
+# This requires both the `created` and the `spatial` (capture agent id) metadata fields to match.
+# For details about matching see `inbox.metadata.regex` above.
+#
+# If `spatial` and `created` can identify exactly one scheduled event, the inbox will behave like a capture agent,
+# ingesting into the previously scheduled event, using all metadata and workflow configuration set when scheduling.
+# Metadata extracted from the filename and the default inbox workflows will be discarded.
+#
+# If conditions are not met, files will still be ingested by creating a new event as usual.
+#
+# Default: false
+#inbox.schedule.match = false

--- a/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
+++ b/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
@@ -76,6 +76,15 @@ inbox.path=${karaf.data}/inbox
 # Default: <empty>
 #inbox.datetime.format =
 
+# Extract metadata via ffprobe
+#
+# If enabled, the inbox will use ffprobe to determine additional metadata like creation date and duration.
+# This will overwrite metadata possibly extracted from the filename.
+# Only metadata from the media container will be used.
+#
+# Default: false
+#inbox.metadata.ffprobe = false
+
 # Match scheduled events
 #
 # If this is turned on, Opencast will try matching inbox files to scheduled events.
@@ -86,7 +95,28 @@ inbox.path=${karaf.data}/inbox
 # ingesting into the previously scheduled event, using all metadata and workflow configuration set when scheduling.
 # Metadata extracted from the filename and the default inbox workflows will be discarded.
 #
+# If ffprobe is used to extract a duration, events from the whole duration will be matched.
+# See next option for more control over what is being matched.
+#
 # If conditions are not met, files will still be ingested by creating a new event as usual.
 #
 # Default: false
 #inbox.schedule.match = false
+
+# Overlap match threshold
+#
+# By default, a recording will match all scheduled events in its duration.
+# This may lead to problems in some situations where events may start a little bit early
+# or run a little bit late.
+#
+# In the following example, the recording would match two scheduled events,
+# leading to an error and none of them being matched:
+#
+#   |--Schedule A----| |--Schedule B----|
+#                  |--Event--------|
+#
+# To prevent such situations, you can define a threshold of how much overlap an event must have to count as a match.
+# This threshold is used *only* if multiple events are matched before the threshold is applied.
+#
+# Default: -1 (off)
+#inbox.schedule.match.threshold = 0.0

--- a/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
+++ b/etc/org.opencastproject.ingest.scanner.InboxScannerService-inbox.cfg
@@ -33,3 +33,45 @@ inbox.path=${karaf.data}/inbox
 # The time between each retry in seconds
 # Default: 300
 #inbox.tries.between.sec=300
+
+###
+# Metadata matching
+##
+
+# Regular expression to extract metadata from filename.
+#
+# By default, the filename is used as title.
+# This option lets you specify a regular expression to extract metadata.
+# To match the metadata, specify named groups in the expression.
+#
+# The following matching groups will be mapped to metadata:
+#  - title
+#  - spatial (shown as location in Opencast's user interface)
+#  - created (extracted value must match the formatter below)
+#
+# Example:
+#   filename:            2021-12-10-11-15 hs1 Biology 101.mp4
+#   regular expression:  (?<created>....-..-..-..-..) (?<spatial>[^ ]+) (?<title>.+)\\.mp4
+#   matched metadata:
+#     created:           2021-12-10-11-15
+#     spatial:           hs1
+#     title:             Biology 101
+#
+# Default: <empty>
+#inbox.metadata.regex =
+
+# Date and time format of the matched `created` metadata field.
+# This value is used to parse the date-time value.
+# It must match in order to properly recognize the recording time.
+#
+# Documentation about the format can be found at:
+#   https://www.baeldung.com/java-string-to-date#3-common-date-and-time-patterns
+#
+# Example:
+#
+#   matched string:  2021-12-10-11-15
+#   format:          yyyy-MM-dd-HH-mm
+#   result:          2021-12-10 11:15:00
+#
+# Default: <empty>
+#inbox.datetime.format =

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -203,6 +203,8 @@
               META-INF.services;-split-package:=merge-first,
               de.schlichtherle.*;-split-package:=merge-first
             </Private-Package>
+            <!-- Remove once the scheduler uses OSGi annotations and generates capabilities -->
+            <_dsannotations-options>norequirements</_dsannotations-options>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -61,6 +61,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>


### PR DESCRIPTION
Capture agents often record to filenames containing metadata which
allows us to identify an event by looking at a specific time in the
schedule of a certain location (capture agent).

If `created` and `spatial` metadata could be identified, this patch
allows us to look up the schedule, using all available event data fram
there if we had a unique match.

Data taken from the schedule, overwriting inbox data are:

- All metadata
- Workflow definition
- Workflow configuration

Notes:

- This patch fixes #3240.
- This is based on #3327.
- You want #3339 for this.

__Addition__: Use ffprobe to get additional metadata

In addition to the metadata extraction from the file name, this patch
allows users to have ffprobe run on the media files to get some
additional metadata from the media container.

The extracted metadata are creation time and duration, which may help to
match scheduled events.

With the media file now having a duration, there is now also an
additional option allowing to filter out some events which are barely
conflicting (imaging two back to back recordings and the second one
starts a minute early).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
