### PR TITLE
Allow metadata editting

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -668,8 +668,6 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       Date start = extendedEventDto.getStartDate();
       Date end = extendedEventDto.getEndDate();
 
-      verifyActive(mpId, end);
-
       if ((startDateTime.isSome() || endDateTime.isSome()) && endDateTime.getOr(end).before(startDateTime.getOr(start)))
         throw new SchedulerException("The end date is before the start date");
 
@@ -825,19 +823,6 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       return Opt.some(DublinCores.read(inputStream));
     } finally {
       IOUtils.closeQuietly(inputStream);
-    }
-  }
-
-  private void verifyActive(String eventId, Date end) throws SchedulerException {
-    if (end == null) {
-      throw new IllegalArgumentException("Start and/or end date for event ID " + eventId + " is not set");
-    }
-    // TODO: Assumption of no TimeZone adjustment because catalog temporal is local to server
-    if (new Date().after(end)) {
-      logger.info("Event ID {} has already ended as its end time was {} and current time is {}", eventId,
-          DateTimeSupport.toUTC(end.getTime()), DateTimeSupport.toUTC(new Date().getTime()));
-      throw new SchedulerException("Event ID " + eventId + " has already ended at "
-              + DateTimeSupport.toUTC(end.getTime()) + " and now is " + DateTimeSupport.toUTC(new Date().getTime()));
     }
   }
 

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -705,41 +705,6 @@ public class SchedulerServiceImplTest {
     assertEquals(2, events.size());
   }
 
-  /**
-   * Test for failure updating past events
-   */
-  @Test(expected = SchedulerException.class)
-  public void testUpdateExpiredEvent() throws Exception {
-    long currentTime = System.currentTimeMillis();
-
-    final String initialTitle = "Recording 1";
-    final MediaPackage mediaPackage = generateEvent(Opt.<String> none());
-    final Date startDateTime = new Date(currentTime - 20 * 1000);
-    final Date endTime = new Date(currentTime - 10 * 1000);
-    final DublinCoreCatalog initalEvent = generateEvent("Device A", Opt.<String> none(), Opt.some(initialTitle),
-            startDateTime, endTime);
-    String catalogId = addDublinCore(Opt.<String> none(), mediaPackage, initalEvent);
-
-    Map<String, String> caMetadata = map(tuple("org.opencastproject.workflow.config.archiveOp", "true"),
-            tuple("org.opencastproject.workflow.definition", "full"));
-
-    schedSvc.addEvent(startDateTime, endTime, "Device A", Collections.<String> emptySet(), mediaPackage, wfProperties,
-            caMetadata, Opt.<String> none());
-
-    MediaPackage mp = schedSvc.getMediaPackage(mediaPackage.getIdentifier().toString());
-    Assert.assertEquals(mediaPackage, mp);
-
-    // test single update
-    final String updatedTitle1 = "Recording 2";
-    final DublinCoreCatalog updatedEvent1 = generateEvent("Device A", Opt.some(mediaPackage.getIdentifier().toString()),
-            Opt.some(updatedTitle1), startDateTime, endTime);
-    addDublinCore(Opt.some(catalogId), mediaPackage, updatedEvent1);
-    schedSvc.updateEvent(mediaPackage.getIdentifier().toString(), Opt.<Date> none(), Opt.<Date> none(),
-            Opt.<String> none(), Opt.<Set<String>> none(), Opt.some(mediaPackage), Opt.some(wfPropertiesUpdated),
-            Opt.<Map<String, String>> none());
-    Assert.fail("Schedule should not update a recording that has ended (single)");
-  }
-
   @Test(expected = SchedulerException.class)
   public void testConflictCreation() throws Exception {
     long currentTime = System.currentTimeMillis();


### PR DESCRIPTION
This patch removes a check which would prevent users from editing
metadata of scheduled events which start time has already passed.

Editing such metadata in the admin interface will fail silently with no
feedback for users but many errors in the logs:

```
2022-01-10 21:42:32,986 | INFO  | (SchedulerServiceImpl:837) - Event ID ba78ec72-6d8c-40f8-807c-67d6a6764a39 has already ended as its end time was 2022-01-10T16:10:00Z and current time is 2022-01-10T20:42:32Z
2022-01-10 21:42:32,987 | ERROR | (IndexServiceImpl:1303) - Unable to update scheduled event ba78ec72-6d8c-40f8-807c-67d6a6764a39 with metadata [...] because
org.opencastproject.scheduler.api.SchedulerException: Event ID ba78ec72-6d8c-40f8-807c-67d6a6764a39 has already ended at 2022-01-10T16:10:00Z and now is 2022-01-10T20:42:32Z
        at org.opencastproject.scheduler.impl.SchedulerServiceImpl.verifyActive(SchedulerServiceImpl.java:840) ~[?:?]
        at org.opencastproject.scheduler.impl.SchedulerServiceImpl.updateEventInternal(SchedulerServiceImpl.java:671) ~[?:?]
        at org.opencastproject.scheduler.impl.SchedulerServiceImpl.updateEvent(SchedulerServiceImpl.java:619) ~[?:?]
```

I see no reason why we shouldn't allow users to edit e.g. the title of
such events and this patch now makes it possible.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
