### PR TITLE
Password strength indicator

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -306,6 +306,7 @@
     <script src="scripts/shared/directives/callOnSearchDirective.js"></script>
     <script src="scripts/shared/directives/oldDropdownDirective.js"></script>
     <script src="scripts/shared/directives/passwordCheckDirective.js"></script>
+    <script src="scripts/shared/directives/passwordStrengthDirective.js"></script>
     <script src="scripts/shared/directives/selectBoxDirective.js"></script>
     <script src="scripts/shared/directives/navDirective.js"></script>
     <script src="scripts/shared/directives/tableDirective.js"></script>

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/passwordStrengthDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/passwordStrengthDirective.js
@@ -41,45 +41,92 @@ angular.module('adminNg.directives')
         link: function (scope, elem, attrs, ctrl) {
           scope.$watch('password', function (pw) {
 
-            scope.strength =
-                isValid(pw && /[A-Z]/.test(pw)) +
-                isValid(pw && /[a-z]/.test(pw)) +
-                isValid(pw && /\d/.test(pw)) +
-                isValid(pw && /(?=.*\W)/.test(pw)) +
-                isValid(pw && /^.{8,}$/.test(pw));
+            scope.rule =
+                requirements(pw && /[A-Z]/.test(pw)) +
+                requirements(pw && /[a-z]/.test(pw)) +
+                requirements(pw && /\d/.test(pw)) +
+                requirements(pw && /(?=.*\W)/.test(pw)) +
+                requirements(pw && /^.{8,}$/.test(pw));
 
-            var bar = 'background:white; width:0%;';
-            var pw_strength = '';
-            setProgBar(scope.strength);
+            // bad passwords from https://en.wikipedia.org/wiki/List_of_the_most_common_passwords
+            // plus Opencast's default password
+            const bad_passwords = ['0', '111111', '1111111', '123', '123123', '123321',
+              '1234', '12345', '123456', '1234567', '12345678', '123456789', '1234567890',
+              '12345679', '123qwe', '18atcskd2w', '1q2w3e', '1q2w3e4r', '1q2w3e4r5t',
+              '3rjs1la7qe', '555555', '654321', '666666', '7777777', '888888',
+              '987654321', 'aa12345678', 'abc123', 'admin', 'dragon', 'Dragon', 'google',
+              'iloveyou', 'Iloveyou', 'lovely', 'Monkey', 'mynoob', 'password',
+              'password1', 'password12', 'password123', 'princess', 'qwerty', 'qwerty123', 'qwertyuiop',
+              'Qwertyuiop', 'welcome', 'zxcvbnm', 'opencast' ];
 
-            function isValid(rule) {
+            var bar_color = 'background:white;';
+            var bar_width = 'width:0%;';
+            var bar_text = '';
+            var strength = calcStrength(scope.rule, pw);
+
+            setProgBar(strength);
+
+            function requirements(rule) {
               return rule ? 1 : 0;
             }
 
-            function setProgBar(validRules) {
-              if (validRules == 1) {
-                bar = 'background:red; width:20%;';
-                pw_strength = 'Very Weak';
+            function calcStrength(rule, pw){
+
+              if (bad_passwords.indexOf(pw) > -1) {
+                strength = 0;
+                return strength;
               }
-              else if (validRules == 2) {
-                bar = 'background:darkorange; width:40%;';
-                pw_strength = 'Weak';
-              }
-              else if (validRules == 3) {
-                bar = 'background:gold; width:60%;';
-                pw_strength = 'Good';
-              }
-              else if (validRules == 4) {
-                bar = 'background:green; width:80%;';
-                pw_strength = 'Strong';
-              }
-              else if (validRules == 5) {
-                bar = 'background:#388ed6; width:100%;';
-                pw_strength = 'Very Strong';
-              }
-              document.getElementById('bar').style = bar;
-              document.getElementById('pw').innerHTML = pw_strength;
+              // for every unused rule/requirement = -5 points
+              var usedRules = (rule - 5) * 5;
+
+              var uniqueChars = (pw.split('').sort().join('').replace(/(.)\1+/g, '').length) * 2;
+              var pw_length = pw.length * 4;
+              var lowerCase = (pw.length - pw.replace(/[a-z]/g, '').length) * 2;
+              var upperCase = (pw.length - pw.replace(/[A-Z]/g, '').length) * 2;
+              var number = (pw.length - pw.replace(/[0-9]/g, '').length) * 4;
+              var symbol = (pw.length - pw.replace(/\W/g, '').length) * 6;
+
+              var strength = usedRules + uniqueChars + pw_length + lowerCase + upperCase + number + symbol;
+              return strength;
             }
+
+            function setProgBar(strength) {
+
+              if (strength >= 90) {
+                bar_color = 'background:#388ed6;';
+                bar_width = 'width:' + strength + '%;';
+                bar_text = 'Very strong';
+              }
+              else if (strength >= 70) {
+                bar_color = 'background:green;';
+                bar_width = 'width:' + strength + '%;';
+                bar_text = 'Strong';
+              }
+              else if (strength >= 50) {
+                bar_color = 'background:gold;';
+                bar_width = 'width:' + strength + '%;';
+                bar_text = 'Good';
+              }
+              else if (strength >= 30) {
+                bar_color = 'background:darkorange;';
+                bar_width = 'width:' + strength + '%;';
+                bar_text = 'Weak';
+              }
+              else if (strength >= 1) {
+                bar_color = 'background:red;';
+                bar_width = 'width:' + strength + '%;';
+                bar_text = 'Very weak';
+              }
+              else if (strength == 0){
+                bar_color = 'background:white;';
+                bar_width = 'width:' + 0 + '%;';
+                bar_text = 'Bad password';
+              }
+
+              document.getElementById('bar').style = bar_color + bar_width;
+              document.getElementById('pw').innerText = bar_text;
+            }
+
           });
 
         },
@@ -87,7 +134,7 @@ angular.module('adminNg.directives')
                 '<div class="progress pw-strength">' +
                     '<div id="bar" class="progress-bar"></div>' +
                 '</div>' +
-                '<label id="pw" style="text-align: left;">{{pw_strength}}</label>'
+                '<label id="pw" style="text-align: left;">{{bar_text}}</label>'
       };
     }
     ]);

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/passwordStrengthDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/passwordStrengthDirective.js
@@ -32,53 +32,62 @@
 
 angular.module('adminNg.directives')
     .directive('pwStrength', [function () {
-        return {
-            restrict: 'E',
-            scope: {
-                password: '=ngModel'
-            },
+      return {
+        restrict: 'E',
+        scope: {
+          password: '=ngModel'
+        },
 
-            link: function (scope, elem, attrs, ctrl) {
-                scope.$watch('password', function (pw) {
+        link: function (scope, elem, attrs, ctrl) {
+          scope.$watch('password', function (pw) {
 
-                    scope.strength =
-                        isValid(pw && /[A-Z]/.test(pw)) +
-                        isValid(pw && /[a-z]/.test(pw)) +
-                        isValid(pw && /\d/.test(pw)) +
-                        isValid(pw && /(?=.*\W)/.test(pw)) +
-                        isValid(pw && /^.{8,}$/.test(pw));
+            scope.strength =
+                isValid(pw && /[A-Z]/.test(pw)) +
+                isValid(pw && /[a-z]/.test(pw)) +
+                isValid(pw && /\d/.test(pw)) +
+                isValid(pw && /(?=.*\W)/.test(pw)) +
+                isValid(pw && /^.{8,}$/.test(pw));
 
-                    var bar = "background:white; width:0%;"
-                    setColor(scope.strength);
+            var bar = 'background:white; width:0%;';
+            var pw_strength = '';
+            setProgBar(scope.strength);
 
-                    function isValid(rule) {
-                        return rule ? 1 : 0;
-                    }
+            function isValid(rule) {
+              return rule ? 1 : 0;
+            }
 
-                    function setColor(validRules) {
-                        if (validRules == 1) {
-                            bar = "background:red; width:20%;"
-                        }
-                        else if (validRules == 2) {
-                            bar = "background:orange; width:40%;"
-                        }
-                        else if (validRules == 3) {
-                            bar = "background:yellow; width:60%;"
-                        }
-                        else if (validRules == 4) {
-                            bar = "background:green; width:80%;"
-                        }
-                        else if (validRules == 5) {
-                            bar = "background:darkgreen; width:100%;"
-                        }
-                        document.getElementById('bar').style = bar;
-                    }
-                });
+            function setProgBar(validRules) {
+              if (validRules == 1) {
+                bar = 'background:red; width:20%;';
+                pw_strength = 'Very Weak';
+              }
+              else if (validRules == 2) {
+                bar = 'background:darkorange; width:40%;';
+                pw_strength = 'Weak';
+              }
+              else if (validRules == 3) {
+                bar = 'background:gold; width:60%;';
+                pw_strength = 'Good';
+              }
+              else if (validRules == 4) {
+                bar = 'background:green; width:80%;';
+                pw_strength = 'Strong';
+              }
+              else if (validRules == 5) {
+                bar = 'background:#388ed6; width:100%;';
+                pw_strength = 'Very Strong';
+              }
+              document.getElementById('bar').style = bar;
+              document.getElementById('pw').innerHTML = pw_strength;
+            }
+          });
 
-            },
-            template: '<div class="progress pw-strength">' +
-                '<div id="bar" class="progress-bar"></div>' +
-                '</div>'
-        }
+        },
+        template:
+                '<div class="progress pw-strength">' +
+                    '<div id="bar" class="progress-bar"></div>' +
+                '</div>' +
+                '<label id="pw" style="text-align: left;">{{pw_strength}}</label>'
+      };
     }
     ]);

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/passwordStrengthDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/passwordStrengthDirective.js
@@ -31,7 +31,7 @@
 'use strict';
 
 angular.module('adminNg.directives')
-    .directive('pwStrength', [function () {
+    .directive('pwStrength', ['$translate', function ($translate) {
       return {
         restrict: 'E',
         scope: {
@@ -39,13 +39,14 @@ angular.module('adminNg.directives')
         },
 
         link: function (scope, elem, attrs, ctrl) {
+
           scope.$watch('password', function (pw) {
 
             scope.rule =
                 requirements(pw && /[A-Z]/.test(pw)) +
                 requirements(pw && /[a-z]/.test(pw)) +
                 requirements(pw && /\d/.test(pw)) +
-                requirements(pw && /(?=.*\W)/.test(pw)) +
+                requirements(pw && /\W/.test(pw)) +
                 requirements(pw && /^.{8,}$/.test(pw));
 
             // bad passwords from https://en.wikipedia.org/wiki/List_of_the_most_common_passwords
@@ -60,7 +61,6 @@ angular.module('adminNg.directives')
               'Qwertyuiop', 'welcome', 'zxcvbnm', 'opencast' ];
 
             var bar_color = 'background:white;';
-            var bar_width = 'width:0%;';
             var bar_text = '';
             var strength = calcStrength(scope.rule, pw);
 
@@ -79,14 +79,14 @@ angular.module('adminNg.directives')
               // for every unused rule/requirement = -5 points
               var usedRules = (rule - 5) * 5;
 
-              var uniqueChars = (pw.split('').sort().join('').replace(/(.)\1+/g, '').length) * 2;
+              var uniqueChars = new Set(pw).size * 2;
               var pw_length = pw.length * 4;
               var lowerCase = (pw.length - pw.replace(/[a-z]/g, '').length) * 2;
               var upperCase = (pw.length - pw.replace(/[A-Z]/g, '').length) * 2;
               var number = (pw.length - pw.replace(/[0-9]/g, '').length) * 4;
               var symbol = (pw.length - pw.replace(/\W/g, '').length) * 6;
 
-              var strength = usedRules + uniqueChars + pw_length + lowerCase + upperCase + number + symbol;
+              var strength = Math.max(1, usedRules + uniqueChars + pw_length + lowerCase + upperCase + number + symbol);
               return strength;
             }
 
@@ -94,37 +94,34 @@ angular.module('adminNg.directives')
 
               if (strength >= 90) {
                 bar_color = 'background:#388ed6;';
-                bar_width = 'width:' + strength + '%;';
-                bar_text = 'Very strong';
+                bar_text = 'USERS.USERS.DETAILS.STRENGTH.VERYSTRONG';
               }
               else if (strength >= 70) {
                 bar_color = 'background:green;';
-                bar_width = 'width:' + strength + '%;';
-                bar_text = 'Strong';
+                bar_text = 'USERS.USERS.DETAILS.STRENGTH.STRONG';
               }
               else if (strength >= 50) {
                 bar_color = 'background:gold;';
-                bar_width = 'width:' + strength + '%;';
-                bar_text = 'Good';
+                bar_text = 'USERS.USERS.DETAILS.STRENGTH.GOOD';
               }
               else if (strength >= 30) {
                 bar_color = 'background:darkorange;';
-                bar_width = 'width:' + strength + '%;';
-                bar_text = 'Weak';
+                bar_text = 'USERS.USERS.DETAILS.STRENGTH.WEAK';
               }
-              else if (strength >= 1) {
+              else if (strength >= 2) {
                 bar_color = 'background:red;';
-                bar_width = 'width:' + strength + '%;';
-                bar_text = 'Very weak';
+                bar_text = 'USERS.USERS.DETAILS.STRENGTH.VERYWEAK';
               }
-              else if (strength == 0){
+              else if (strength <= 1){
+                strength = 0;
                 bar_color = 'background:white;';
-                bar_width = 'width:' + 0 + '%;';
-                bar_text = 'Bad password';
+                bar_text = 'USERS.USERS.DETAILS.STRENGTH.BAD';
               }
 
-              document.getElementById('bar').style = bar_color + bar_width;
-              document.getElementById('pw').innerText = bar_text;
+              document.getElementById('bar').style = bar_color + 'width:' + strength + '%;';
+              $translate(bar_text).then(function(translation) {
+                document.getElementById('pw').innerText = translation;
+              });
             }
 
           });

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/passwordStrengthDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/passwordStrengthDirective.js
@@ -1,0 +1,84 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+/**
+ * @ngdoc directive
+ * @description
+ * Checks the strength of a password.
+ *
+ * @example
+ * <pw-strength ng-model="model.password"></pw-strength>
+ */
+
+'use strict';
+
+angular.module('adminNg.directives')
+    .directive('pwStrength', [function () {
+        return {
+            restrict: 'E',
+            scope: {
+                password: '=ngModel'
+            },
+
+            link: function (scope, elem, attrs, ctrl) {
+                scope.$watch('password', function (pw) {
+
+                    scope.strength =
+                        isValid(pw && /[A-Z]/.test(pw)) +
+                        isValid(pw && /[a-z]/.test(pw)) +
+                        isValid(pw && /\d/.test(pw)) +
+                        isValid(pw && /(?=.*\W)/.test(pw)) +
+                        isValid(pw && /^.{8,}$/.test(pw));
+
+                    var bar = "background:white; width:0%;"
+                    setColor(scope.strength);
+
+                    function isValid(rule) {
+                        return rule ? 1 : 0;
+                    }
+
+                    function setColor(validRules) {
+                        if (validRules == 1) {
+                            bar = "background:red; width:20%;"
+                        }
+                        else if (validRules == 2) {
+                            bar = "background:orange; width:40%;"
+                        }
+                        else if (validRules == 3) {
+                            bar = "background:yellow; width:60%;"
+                        }
+                        else if (validRules == 4) {
+                            bar = "background:green; width:80%;"
+                        }
+                        else if (validRules == 5) {
+                            bar = "background:darkgreen; width:100%;"
+                        }
+                        document.getElementById('bar').style = bar;
+                    }
+                });
+
+            },
+            template: '<div class="progress pw-strength">' +
+                '<div id="bar" class="progress-bar"></div>' +
+                '</div>'
+        }
+    }
+    ]);

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/user-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/user-modal.html
@@ -104,6 +104,11 @@
                    ng-required="action != 'edit'"
                    ng-model="user.repeatedPassword"
                    ng-class="{ disabled: !manageable, error: blurred.password && (user.repeatedPassword !== user.password || !userForm.password.$valid) }">
+
+            <div>
+              <pw-strength ng-model="user.password"></pw-strength>
+            </div>
+
           </div>
         </div>
       </div>

--- a/modules/admin-ui-frontend/app/styles/components/_form.scss
+++ b/modules/admin-ui-frontend/app/styles/components/_form.scss
@@ -205,3 +205,9 @@
         width: 100%;
     }
 }
+
+.progress, .pw-strength {
+    border-color: lightgray !important;
+    height: 8px !important;
+    margin-top: 10px !important;
+}

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-de_DE.json
@@ -1301,6 +1301,14 @@
                "RIGHT": "Ausgewählten Rollen",
                "REMOVE": "Rolle entfernen",
                "ADD": "Rolle hinzufügen"
+            },
+            "STRENGTH": {
+               "BAD": "Schlechtes Passwort",
+               "VERYWEAK": "Sehr schwaches Passwort",
+               "WEAK": "Schwaches Passwort",
+               "GOOD": "Gutes Passwort",
+               "STRONG": "Starkes Passwort",
+               "VERYSTRONG": "Sehr starkes Passwort"
             }
          }
       },

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_GB.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_GB.json
@@ -1301,6 +1301,14 @@
                "RIGHT": "Selected roles",
                "REMOVE": "Remove role",
                "ADD": "Add role"
+            },
+            "STRENGTH": {
+               "BAD": "Bad password",
+               "VERYWEAK": "Very weak password",
+               "WEAK": "Weak password",
+               "GOOD": "Good password",
+               "STRONG": "Strong password",
+               "VERYSTRONG": "Very strong password"
             }
          }
       },

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1304,7 +1304,15 @@
            "RIGHT":   "Selected roles",
            "REMOVE":  "Remove role",
            "ADD":     "Add role"
-         }
+         },
+         "STRENGTH": {
+           "BAD": "Bad password",
+           "VERYWEAK": "Very weak password",
+           "WEAK": "Weak password",
+           "GOOD": "Good password",
+           "STRONG": "Strong password",
+           "VERYSTRONG": "Very strong password"
+          }
        }
      },
      "GROUPS": {


### PR DESCRIPTION
This fixes #3215.
Simple strength bar, checks if the password contains at least one uppercase letter, one lowercase letter, one number, one special character and is at least 8 characters long. (Colors of strength-bar: red, orange, yellow, green, darkgreen)

![strength-bar-1](https://user-images.githubusercontent.com/93541078/148920412-afaf0aee-d642-4811-819b-5ee320a6a217.png)

![strength-bar-4](https://user-images.githubusercontent.com/93541078/148920514-6ce9da01-b48c-4865-a061-f7c96eb3db93.png)

![strength-bar-6](https://user-images.githubusercontent.com/93541078/148920430-00472132-8f47-4f5d-8183-f90cd410565a.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
