### PR TITLE
merge the ldap userdirectory behaviour from 9.x into the current module

### DIFF
--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
@@ -361,7 +361,8 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
 
     // Instantiate this LDAP instance and register it as such
     LdapUserProviderInstance provider = new LdapUserProviderInstance(pid, org, searchBase, searchFilter, url, userDn,
-            password, roleAttributes, convertToUppercase, cacheSize, cacheExpiration, securityService);
+            password, roleAttributes, rolePrefix, extraRoles, excludePrefixes, convertToUppercase, cacheSize,
+            cacheExpiration, securityService);
 
     providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
 

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderInstance.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderInstance.java
@@ -23,6 +23,7 @@ package org.opencastproject.userdirectory.ldap;
 
 import org.opencastproject.security.api.CachingUserProviderMXBean;
 import org.opencastproject.security.api.JaxbOrganization;
+import org.opencastproject.security.api.JaxbRole;
 import org.opencastproject.security.api.JaxbUser;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.SecurityService;
@@ -37,6 +38,8 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
@@ -46,10 +49,12 @@ import org.springframework.security.ldap.userdetails.LdapUserDetailsService;
 
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -88,6 +93,15 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
   /** Opencast's security service */
   private SecurityService securityService;
 
+  /** The general role prefix, to be added to all the LDAP roles that do not start by one of the exclude prefixes */
+  private String rolePrefix;
+
+  /** A Set of roles to be added to all the users authenticated using this LDAP instance */
+  private Set<GrantedAuthority> setExtraRoles = new HashSet<>();
+
+  /** A Set of prefixes. When a role starts with any of these, the role prefix defined above will not be prepended */
+  private Set<String> setExcludePrefixes = new HashSet<>();
+
   /**
    * Constructs an ldap user provider with the needed settings.
    *
@@ -117,9 +131,23 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
    *          a reference to Opencast's security service
    */
   // CHECKSTYLE:OFF
-  LdapUserProviderInstance(String pid, Organization organization, String searchBase, String searchFilter, String url,
-          String userDn, String password, String roleAttributesGlob,
-          boolean convertToUppercase, int cacheSize, int cacheExpiration, SecurityService securityService) {
+  LdapUserProviderInstance(
+      String pid,
+      Organization organization,
+      String searchBase,
+      String searchFilter,
+      String url,
+      String userDn,
+      String password,
+      String roleAttributesGlob,
+      String rolePrefix,
+      String[] extraRoles,
+      String[] excludePrefixes,
+      boolean convertToUppercase,
+      int cacheSize,
+      int cacheExpiration,
+      SecurityService securityService
+  ) {
     // CHECKSTYLE:ON
     this.organization = organization;
     this.securityService = securityService;
@@ -153,11 +181,65 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
 
       mapper.setRoleAttributes(roleAttributesGlob.split(","));
 
+      if (convertToUppercase) {
+        this.rolePrefix = StringUtils.trimToEmpty(rolePrefix).toUpperCase();
+      }
+      else {
+        this.rolePrefix = StringUtils.trimToEmpty(rolePrefix);
+      }
+
+      logger.debug("Role prefix set to: \"{}\"", this.rolePrefix);
+
       // The default prefix value is "ROLE_", so we must explicitly set it to "" by default
       // Because of the parameters extraRoles and excludePrefixes, we must add the prefix manually
       mapper.setRolePrefix("");
       delegate.setUserDetailsMapper(mapper);
+
+      // Process the excludePrefixes if needed
+      if (!this.rolePrefix.isEmpty()) {
+        if (excludePrefixes != null) {
+          // "Clean" the list of exclude prefixes
+          for (String excludePrefix : excludePrefixes) {
+            String cleanPrefix = excludePrefix.trim();
+            if (!cleanPrefix.isEmpty()) {
+              if (convertToUppercase) {
+                setExcludePrefixes.add(cleanPrefix.toUpperCase());
+              }
+              else {
+                setExcludePrefixes.add(cleanPrefix);
+              }
+            }
+          }
+
+          if (logger.isDebugEnabled()) {
+            if (setExcludePrefixes.size() > 0) {
+              logger.debug("Exclude prefixes set to:");
+              for (String prefix : excludePrefixes) {
+                logger.debug("\t* {}", prefix);
+              }
+            } else {
+              logger.debug("No exclude prefixes defined");
+            }
+          }
+        }
+      }
     }
+
+    // Process extra roles
+    if (extraRoles != null) {
+      for (String extraRole : extraRoles) {
+        String finalRole = StringUtils.trimToEmpty(extraRole);
+        if (!finalRole.isEmpty()) {
+          if (convertToUppercase) {
+            setExtraRoles.add(new SimpleGrantedAuthority(finalRole.toUpperCase()));
+          } else {
+            setExtraRoles.add(new SimpleGrantedAuthority(finalRole));
+          }
+        }
+      }
+    }
+
+
 
     // Setup the caches
     cache = CacheBuilder.newBuilder().maximumSize(cacheSize).expireAfterWrite(cacheExpiration, TimeUnit.MINUTES)
@@ -259,7 +341,43 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
       }
 
       JaxbOrganization jaxbOrganization = JaxbOrganization.fromOrganization(organization);
-      User user = new JaxbUser(userDetails.getUsername(), PROVIDER_NAME, jaxbOrganization, new HashSet());
+
+      // Get the roles and add the extra roles
+      Collection<GrantedAuthority> authorities = new HashSet<>();
+      authorities.addAll(userDetails.getAuthorities());
+      authorities.addAll(setExtraRoles);
+
+      Set<JaxbRole> roles = new HashSet<>();
+      /*
+       * Please note the prefix logic for roles:
+       *
+       * - Roles that start with any of the "exclude prefixes" are left intact
+       * - In any other case, the "role prefix" is prepended to the roles read from LDAP
+       *
+       * This only applies to the prefix addition. The conversion to uppercase is independent from these
+       * considerations
+       */
+      for (GrantedAuthority authority : authorities) {
+        String strAuthority = authority.getAuthority();
+
+        boolean hasExcludePrefix = false;
+        for (String excludePrefix : setExcludePrefixes) {
+          if (strAuthority.startsWith(excludePrefix)) {
+            hasExcludePrefix = true;
+            break;
+          }
+        }
+        if (!hasExcludePrefix) {
+          strAuthority = rolePrefix + strAuthority;
+        }
+
+        logger.debug("Adding role " + strAuthority + " for user " + userName);
+
+        // Finally, add the role itself
+        roles.add(new JaxbRole(strAuthority, jaxbOrganization));
+      }
+
+      User user = new JaxbUser(userDetails.getUsername(), PROVIDER_NAME, jaxbOrganization, roles);
       cache.put(userName, user);
       return user;
     } finally {
@@ -300,7 +418,8 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
   @Override
   public Iterator<User> getUsers() {
     // TODO implement LDAP get all users
-    // FIXME We return the current user, rather than an empty list, to make sure the current user's role is displayed in
+    // FIXME We return the current user, rather than an empty list,
+    // to make sure the current user's role is displayed in
     // the admin UI (MH-12526).
     User currentUser = securityService.getUser();
     if (loadUser(currentUser.getUsername()) != null) {


### PR DESCRIPTION
This makes the module work as it did in 9.x when using it only for authorization. This does not implement all the changes present in the OpencastLdapAuthoritiesPopulator.

I've tested this in our setup, using only ldap for authorization, however this isn't tested when you use ldap for authentication + authorization. 

