### PR TITLE
Fix Javadocs

### DIFF
--- a/.github/workflows/test-opencast-site.yml
+++ b/.github/workflows/test-opencast-site.yml
@@ -1,0 +1,74 @@
+name: Test Opencast Site
+
+on:
+  pull_request:
+    paths:
+      - 'pom.xml'
+      - 'modules/**'
+      - '.github/**'
+  push:
+    paths:
+      - 'pom.xml'
+      - 'modules/**'
+      - '.github/**'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java:
+          - 11
+          - 13
+    name: build (java ${{ matrix.java }})
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: cache local maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+
+      - name: install dependencies
+        run: |
+          sudo apt update -q
+          sudo apt install -y -q \
+            bzip2 \
+            ffmpeg \
+            gzip \
+            hunspell \
+            hunspell-de-de \
+            procps \
+            s3cmd \
+            sox \
+            tar \
+            tesseract-ocr \
+            tesseract-ocr-deu \
+            unzip
+
+      - name: prepare build
+        run: |
+          sed -i 's/build --skipTests=${skipTests}/build --skipTests=true/' modules/admin-ui-frontend/pom.xml
+
+      - name: nuke the markers
+        run: |
+          find ~/.m2 -name _remote.repositories -exec rm -v {} \;
+
+      - name: build site docs
+        run: |
+          mvn site -P 'none,!frontend' \
+            --batch-mode \
+            -Daggregate=true \
+            -Dcheckstyle.skip=true \
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+            -Dhttp.keepAlive=false \
+            -Dmaven.wagon.http.pool=false \
+            -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManager.java
@@ -37,21 +37,21 @@ import java.util.List;
  * It also supports the association of {@linkplain Property properties} to a
  * history of snapshots which is called an episode.
  *
- * <h1>Terms</h1>
- * <h2>Snapshot</h2>
+ * <h2>Terms</h2>
+ * <h3>Snapshot</h3>
  * A snapshot saves a particular version of a media package. Snapshots are
  * immutable and can only be deleted.
  *
- * <h2>Episode</h2>
+ * <h3>Episode</h3>
  * An episode is the set of snapshots of a media package.
  *
- * <h2>Properties</h2>
+ * <h3>Properties</h3>
  * Properties are associated with an episode and have a volatile character.
  * They support the quick and easy storage of meta data.
  * This removes the need for services to create their own persistence layer if
  * they want to associate metadata with a media package.
  *
- * <h1>Notes</h1>
+ * <h2>Notes</h2>
  * Media package IDs are considered to be unique throughout the whole system.
  * The organization ID is just a discriminator and not necessary to uniquely identify a media package.
  */

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerJobProducer.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerJobProducer.java
@@ -251,7 +251,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
    *  The {@link RemoteAssetStore} ID where the snapshot should be moved
    * @return
    *  The String containing the number of successful and failed moves
-   *  [<> OK ][<> FAILED ]
+   *  [0 OK ][0 FAILED ]
    */
   protected String internalMoveById(final String mpId, final String targetStorage) {
     RichAResult results = tsam.getSnapshotsByIdOrderedByVersion(mpId, true);
@@ -356,7 +356,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
    *  The {@link RemoteAssetStore} ID where the snapshot should be moved
    * @return
    *  The JSON String containing the number of successful and failed moves
-   *  {"OK":<>,"FAIL":<>}
+   *  {"OK": 0,"FAIL": 0}
    */
   protected String internalMoveByIdAndDate(
       final String mpId,

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/package-info.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/package-info.java
@@ -26,7 +26,7 @@
 /**
  * Default query implementation.
  *
- * <h1>General implementation notes</h1>
+ * <h2>General implementation notes</h2>
  * Do not alias entities when creating Querydsl fragments like this
  * <code>new QPropertyDto("alias")</code>.
  * The code generator in {@link org.opencastproject.assetmanager.impl.query.AbstractASelectQuery#run()}

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/XMLCatalogImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/XMLCatalogImpl.java
@@ -83,7 +83,7 @@ import javax.xml.transform.TransformerException;
  * <li>xsi - http://www.w3.org/2001/XMLSchema-instance
  * </ul>
  * <p>
- * <h3>Limitations</h3>
+ * <h2>Limitations</h2>
  * XMLCatalog supports only <em>one</em> prefix binding per namespace name, so you cannot create documents like the
  * following using XMLCatalog:
  *

--- a/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfile.java
+++ b/modules/composer-service-api/src/main/java/org/opencastproject/composer/api/EncodingProfile.java
@@ -163,7 +163,7 @@ public interface EncodingProfile {
    * no such key was defined.
    * <p>
    * Note that <code>key</code> must not contain the media format prefix, so if
-   * the configured entry was <tt>mediaformat.format.xyz.test</tt>, then the key
+   * the configured entry was <code>mediaformat.format.xyz.test</code>, then the key
    * to access the value must simply be <code>test</code>.
    * </p>
    *

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
@@ -50,7 +50,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * The <tt>prepare media</tt> operation will make sure that media where audio and video track come in separate files
+ * The <code>prepare media</code> operation will make sure that media where audio and video track come in separate files
  * will be muxed prior to further processing.
  */
 public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperationHandler {

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
@@ -57,7 +57,7 @@ import java.util.TreeMap;
 import java.util.function.Function;
 
 /**
- * The <tt></tt> operation will make sure that media where hls playlists and video track come in separate files
+ * The <code></code> operation will make sure that media where hls playlists and video track come in separate files
  * will have appropriately references prior to further processing such as inspection.
  */
 public class SanitizeAdaptiveWorkflowOperationHandler extends AbstractWorkflowOperationHandler {

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCore.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCore.java
@@ -52,7 +52,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
  * <a href="http://dublincore.org/documents/dc-xml-guidelines/">http://dublincore.org/documents/dc-xml-guidelines/</a>
  * Section 5 for further information.
  * <p>
- * <h3>Current limitations</h3>
+ * <h2>Current limitations</h2>
  * <ul>
  * <li>This interface assumes that Dublin Core metadata is stored as XML. According to the Dublin Core specification
  * this is not necessary.

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastDctermsDublinCore.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/OpencastDctermsDublinCore.java
@@ -63,7 +63,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 /**
  * {@link DublinCoreCatalog} wrapper to deal with DublinCore metadata according to the Opencast schema.
  * <p>
- * <h3>General behaviour</h3>
+ * <h2>General behaviour</h2>
  * <ul>
  * <li>Set methods that take a string parameter only execute if the string is not blank.
  * <li>Set methods that take a list of strings only execute if the list contains at least one non-blank string.

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/InboxScannerService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/InboxScannerService.java
@@ -72,7 +72,7 @@ import java.util.Objects;
  * can be arbitrarily chosen and has no further meaning. <code>inbox-scanned-pid</code> must confirm to the PID given to
  * the InboxScanner in the declarative service (DS) configuration <code>OSGI-INF/inbox-scanner-service.xml</code>.
  *
- * <h3>Implementation notes</h3>
+ * <h2>Implementation notes</h2>
  * Monitoring leverages Apache FileInstall by implementing {@link ArtifactInstaller}.
  *
  * @see Ingestor

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/harvester/OaiPmhHarvester.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/harvester/OaiPmhHarvester.java
@@ -62,7 +62,7 @@ import javax.persistence.EntityManagerFactory;
  * the retrieved records to the configured {@link RecordHandler} for the actual processing.
  * <p>
  * todo
- * <h3>Currently not supported</h3>
+ * <h2>Currently not supported</h2>
  * <ul>
  * <li>Recovery from network errors while processing a resumable request. Currently
  * the request sequence terminates and processing goes on with the next configured repository.

--- a/modules/rest-test-environment/src/main/java/org/opencastproject/test/rest/RestServiceTestEnv.java
+++ b/modules/rest-test-environment/src/main/java/org/opencastproject/test/rest/RestServiceTestEnv.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ThreadLocalRandom;
  * The REST endpoint to test needs a no-arg constructor in order to be created by the framework.
  * <p>
  * Write REST unit tests using <a href="http://code.google.com/p/rest-assured/">rest assured</a>.
- * <h3>Example Usage</h3>
+ * <h2>Example Usage</h2>
  * 
  * <pre>
  *   import static com.jayway.restassured.RestAssured.*;

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Category.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Category.java
@@ -25,7 +25,7 @@ package org.opencastproject.feed.api;
 /**
  * Categories are used in conjunction with the dublin core module.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://https://rome.dev.java.net).
  */
 public interface Category {

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Content.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Content.java
@@ -25,7 +25,7 @@ package org.opencastproject.feed.api;
 /**
  * Models a content entry, used for descriptions and title elements in feeds and feed entries.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://https://rome.dev.java.net).
  */
 public interface Content {

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Enclosure.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Enclosure.java
@@ -25,7 +25,7 @@ package org.opencastproject.feed.api;
 /**
  * An enclose is an optional part of a feed entry.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://https://rome.dev.java.net).
  */
 public interface Enclosure {

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Feed.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Feed.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * This interface defines the methods of a general feed.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://https://rome.dev.java.net).
  */
 public interface Feed {

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/FeedEntry.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/FeedEntry.java
@@ -28,7 +28,7 @@ import java.util.List;
 /**
  * Feed entries are the child elements of an rrs/atom feed.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://rome.dev.java.net).
  */
 public interface FeedEntry {

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/FeedExtension.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/FeedExtension.java
@@ -26,7 +26,7 @@ package org.opencastproject.feed.api;
  * Modules are external namespaces than can be baked into a feed. A good example of such a module is the dublin core
  * extension.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://https://rome.dev.java.net).
  */
 public interface FeedExtension {

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Image.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Image.java
@@ -25,7 +25,7 @@ package org.opencastproject.feed.api;
 /**
  * Images are used to add visual content to feeds and feed entries.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://https://rome.dev.java.net).
  */
 public interface Image {

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Link.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Link.java
@@ -25,7 +25,7 @@ package org.opencastproject.feed.api;
 /**
  * Links are used to add references to external entities.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://https://rome.dev.java.net).
  */
 public interface Link {

--- a/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Person.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/feed/api/Person.java
@@ -25,7 +25,7 @@ package org.opencastproject.feed.api;
 /**
  * This interface provides the methods for defining a person object contained in a feed like authors and contributors.
  * <p>
- * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <tt>Rome</tt>
+ * Note that this interface is heavily inspired and backed by the excellent rss/atom feed library <code>Rome</code>
  * (http://https://rome.dev.java.net).
  */
 public interface Person {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
@@ -78,7 +78,7 @@ import javax.ws.rs.core.Variant;
  *     http://localhost/feeds/Atom/1.0/favorites
  * </pre>
  *
- * which would indicate a requeste to an atom 1.0 feed with <tt>favourites</tt> being the query.
+ * which would indicate a requeste to an atom 1.0 feed with <code>favourites</code> being the query.
  *
  * The servlet returns a HTTP status 200 with the feed data.
  * If the feed could not be found because the query is unknown a HTTP error 404 is returned

--- a/modules/user-interface-configuration/src/main/java/org/opencastproject/uiconfig/UIConfigRest.java
+++ b/modules/user-interface-configuration/src/main/java/org/opencastproject/uiconfig/UIConfigRest.java
@@ -93,7 +93,7 @@ public class UIConfigRest {
   /**
    * OSGI callback for activating this component
    *
-   * @param cc
+   * @param context
    *          the osgi component context
    */
   public void activate(ComponentContext cc) throws ConfigurationException {

--- a/modules/user-interface-configuration/src/main/java/org/opencastproject/uiconfig/UIConfigRest.java
+++ b/modules/user-interface-configuration/src/main/java/org/opencastproject/uiconfig/UIConfigRest.java
@@ -93,7 +93,7 @@ public class UIConfigRest {
   /**
    * OSGI callback for activating this component
    *
-   * @param context
+   * @param cc
    *          the osgi component context
    */
   public void activate(ComponentContext cc) throws ConfigurationException {

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <jackson.version>2.12.3</jackson.version>
     <jakarta.mail.version>1.6.7</jakarta.mail.version>
     <java.release>11</java.release>
+    <javadoc-plugin.version>3.3.1</javadoc-plugin.version>
     <jersey.version>2.29.1</jersey.version>
     <jettison.version>1.4.1</jettison.version>
     <joda-time.version>2.10.10</joda-time.version>
@@ -497,7 +498,7 @@
                   <pluginExecutionFilter>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <versionRange>[3.0.0,)</versionRange>
+                    <versionRange>3.15.0</versionRange>
                     <goals>
                       <goal>pmd</goal>
                       <goal>cpd</goal>
@@ -543,11 +544,23 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <!-- NOTE: this should match the settings for the reporting plugin below -->
-          <version>2.10.4</version>
+          <version>$(javadoc-plugin.version}</version>
           <configuration>
             <detectJavaApiLink>true</detectJavaApiLink>
             <maxmemory>512m</maxmemory>
             <quiet>true</quiet>
+            <additionalDependencies>
+              <additionalDependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>2.9.3</version>
+              </additionalDependency>
+              <additionalDependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analyzers</artifactId>
+                <version>2.9.3</version>
+              </additionalDependency>
+            </additionalDependencies>
           </configuration>
           <executions>
             <execution>
@@ -596,7 +609,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.6</version>
+          <version>3.10.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -648,7 +661,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.6</version>
+          <version>3.15.0</version>
           <configuration>
             <!--<includeTests>true</includeTests> -->
             <typeResolution>true</typeResolution>
@@ -761,7 +774,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
+            <version>${javadoc-plugin.version}</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -1849,12 +1862,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <!-- NOTE: this should match the settings for the build plugin above -->
-        <version>2.10.4</version>
+        <version>${javadoc-plugin.version}</version>
         <configuration>
-          <!-- <aggregate>true</aggregate> -->
-          <!-- <detectLinks>true</detectLinks> -->
-          <!-- http://jira.codehaus.org/browse/MJAVADOC-273 -->
           <detectJavaApiLink>true</detectJavaApiLink>
           <maxmemory>512m</maxmemory>
           <quiet>true</quiet>


### PR DESCRIPTION
With Opencast 11 our javadocs broke.  In part this was due to the migration from JDK 8 to 11,
but the majority of those issues have already been corrected by this point.  The current
issue, which this commit resolves, is that various Lucene packages (from modules/solr) are
not found by javadocs when the aggregation step happens.  We have to manually add these to
the javadoc plugin to make sure that it can find them.

README: When testing aggregation bugs you can *massively* speed up testing by using the
javadocs.sh file generated in target/site/apidocs (from project root).  This file disappears
as part of the javadoc generation process, so you won't find it unless something goes wrong :)

Fixes #2085

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
