### PR TITLE
Fix metadata for multitenancy

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -24,6 +24,7 @@ package org.opencastproject.index.service.impl;
 import static org.opencastproject.assetmanager.api.AssetManager.DEFAULT_OWNER;
 import static org.opencastproject.assetmanager.api.fn.Enrichments.enrich;
 import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_IDENTIFIER;
+import static org.opencastproject.security.api.DefaultOrganization.DEFAULT_ORGANIZATION_ID;
 import static org.opencastproject.workflow.api.ConfiguredWorkflow.workflow;
 
 import org.opencastproject.assetmanager.api.AssetManager;
@@ -160,6 +161,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
@@ -411,13 +413,35 @@ public class IndexServiceImpl implements IndexService {
   }
 
   public EventCatalogUIAdapter getCommonEventCatalogUIAdapter(String organization) {
-    return eventCatalogUIAdapters.stream().filter(a -> a instanceof CommonEventCatalogUIAdapter)
-            .filter(a -> organization.equals(a.getOrganization())).collect(Collectors.toList()).get(0);
+    Optional<EventCatalogUIAdapter> orgEventCatalogUIAdapter = eventCatalogUIAdapters.stream()
+            .filter(a -> a instanceof CommonEventCatalogUIAdapter)
+            .filter(a -> organization.equals(a.getOrganization()))
+            .findFirst();
+
+    if (orgEventCatalogUIAdapter.isPresent()) {
+      return orgEventCatalogUIAdapter.get();
+    } else if (organization != DEFAULT_ORGANIZATION_ID) {
+      return getCommonEventCatalogUIAdapter(DEFAULT_ORGANIZATION_ID);
+    } else {
+       throw new IllegalStateException("Common event metadata for " + DEFAULT_ORGANIZATION_ID + " needs to be "
+               + "configured!");
+    }
   }
 
   public SeriesCatalogUIAdapter getCommonSeriesCatalogUIAdapter(String organization) {
-    return seriesCatalogUIAdapters.stream().filter(a -> a instanceof CommonSeriesCatalogUIAdapter)
-            .filter(a -> organization.equals(a.getOrganization())).collect(Collectors.toList()).get(0);
+    Optional<SeriesCatalogUIAdapter> orgSeriesCatalogUIAdapter = seriesCatalogUIAdapters.stream()
+            .filter(a -> a instanceof CommonSeriesCatalogUIAdapter)
+            .filter(a -> organization.equals(a.getOrganization()))
+            .findFirst();
+
+    if (orgSeriesCatalogUIAdapter.isPresent()) {
+      return orgSeriesCatalogUIAdapter.get();
+    } else if (organization != DEFAULT_ORGANIZATION_ID) {
+      return getCommonSeriesCatalogUIAdapter(DEFAULT_ORGANIZATION_ID);
+    } else {
+      throw new IllegalStateException("Common series metadata for " + DEFAULT_ORGANIZATION_ID + " needs to be "
+              + "configured!");
+    }
   }
 
   @Override


### PR DESCRIPTION
This aims to fix the NPE introduced by #3172 for multi-tenant systems. This does two things:

1. Fall back to the common ui adapter for the default tenant if there is no common ui adapter for the current organization. This is similar to the behavior before the change.
2. Switch the loading order of common and extended metadata for events in the admin ui back to how it was, so the common metadata adapter overwrites any extended adapters with the same flavor. This is because the common adapter gets a ton of special treatment that extended metadata does not, e.g. removing certain fields. This means that at least for this, the copies of the common metadata adapter for other tenants that's recommended in the docs is not actually used. Not sure if it's used in other place. Again, this is similar to how it was before the last change.

Ideally, there will be a future change that will make the whole thing much more reasonable (marking common metadata for other tenants as common, allowing multiple common metadata adapters, not requiring copies of the metadata config for multi-tenancy in the docs, ...) but that would not be appropriate for a minor release, so for this fix, I tried to be as minimalist as possible and just revert to old behavior.