### PR TITLE
Automated Release Title

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -37,13 +37,17 @@ jobs:
             -DskipTests \
             -Dcheckstyle.skip=true
 
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
       - name: create new release
         uses: softprops/action-gh-release@v1
         with:
           files: build/opencast-dist-*.tar.gz
           draft: true
           fail_on_unmatched_files: true
-          name: Opencast ${GITHUB_REF#refs/heads/}
+          name: Opencast ${{ steps.get_version.outputs.VERSION }}
           body: |
             This release …
             For further information, please take a look at:


### PR DESCRIPTION
This patch should actually set the title in automatically generated
GitHub releases. The patch [is based on random information I found in
this thing called the internet](https://github.community/t/how-to-get-just-the-tag-name/16241/6).

I did not test this but it looks sensible and shouldn't make anything
worse. Let's just try this?

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
