### PR TITLE
Fix port checking

### DIFF
--- a/assemblies/resources/bin/check_ports
+++ b/assemblies/resources/bin/check_ports
@@ -41,7 +41,7 @@ if [ "$PROGNAME" = "start-opencast" ] && [ "$nargs" -eq "0" ]; then
       return 0;
     fi
     if [ -d /proc/net ] ; then
-      if cat /proc/net/tcp* | awk '{print $2, $3, $4}' | grep " 0[1A]$" | grep -q "$hexPort"; then
+      if cat /proc/net/tcp* | awk '{print $2, $4}' | grep " 0[1A]$" | grep -q "$hexPort"; then
         return 1;
       fi
     else


### PR DESCRIPTION
Opencast's start script includes a check for if the TCP port Opencast
wants to use is already in use. Unfortunately, this would also check if
you are connected to this host on another machine. This prevented me
from starting Opencast while I was accessing Opencast on another
machine.

This patch improves the situation by looking at local TCP ports only.

Reference: [`/proc/net/tcp`](https://www.kernel.org/doc/Documentation/networking/proc_net_tcp.txt)

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
