### PR TITLE
Add DublinCore Catalog to Scheduler JSON

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
@@ -578,10 +578,13 @@ public class SchedulerRestService {
         }
       }
 
-      var result = new ArrayList<TechnicalMetadata>();
+      var result = new ArrayList<Map<String, Object>>();
       for (var event: service.search(agent, Opt.none(), Opt.none(), Opt.some(new Date()), endDate)) {
         var id = event.getIdentifier().toString();
-        result.add(service.getTechnicalMetadata(id));
+        result.add(Map.of(
+                "data", service.getTechnicalMetadata(id),
+                "episode-dublincore", service.getDublinCore(id).toXmlString()
+                ));
       }
 
       final ResponseBuilder response = Response.ok(gson.toJson(result));


### PR DESCRIPTION
This patch adds the episode Dublin Core catalog to the JSON version of
the capture agent calendars. The new JSON response will look like this:

```json
[
  {
    "agent": {…},
    "episode-dublincore": {…}
  }
]
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
