### PR TITLE
update karaf from version 4.2.9 to 4.2.15

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -102,10 +102,6 @@
     <bundle>mvn:org.springframework/spring-expression/${spring.version}</bundle>
     <bundle>mvn:org.springframework/spring-tx/${spring.version}</bundle>
     <bundle>mvn:org.springframework/spring-web/${spring.version}</bundle>
-
-    <!-- get updated Loog4J; REMOOVE WITH NEXT KARAF UPDATE! -->
-    <bundle>mvn:org.ops4j.pax.logging/pax-logging-api/1.11.13</bundle>
-    <bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.11.13</bundle>
   </feature>
 
   <feature name="opencast-core" version="${project.version}">

--- a/assemblies/resources/build.xml
+++ b/assemblies/resources/build.xml
@@ -26,18 +26,6 @@
     <!-- Special configuration for development -->
     <replaceregexp file="target/classes/package.xml" match="tar\.gz" replace="dir" byline="true"/>
     <replaceregexp file="target/classes/package.xml" match="baseDirectory&gt;.*&lt;/baseDirectory&gt;" replace="includeBaseDirectory&gt;false&lt;/includeBaseDirectory&gt;" byline="true"/>
-    <!-- Log4J -->
-    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-log4j2/1.11.6" replace="pax-logging-log4j2/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-log4j2/1.11.6" replace="pax-logging-log4j2/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/bin/instance" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.13/pax-logging-api-1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/bin/shell" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.13/pax-logging-api-1.11.13" byline="true"/>
-    <delete>
-      <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.11.6" includes="*" />
-      <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.11.6" includes="*" />
-    </delete>
   </target>
 
   <target if="disableJobDispatching" name="job dispatching">

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <jettison.version>1.4.1</jettison.version>
     <joda-time.version>2.10.10</joda-time.version>
     <json-simple.version>1.1.1</json-simple.version>
-    <karaf.version>4.2.9</karaf.version>
+    <karaf.version>4.2.15</karaf.version>
     <mina.version>2.1.3</mina.version>
     <node.version>v14.17.0</node.version>
     <osgi.compendium.version>5.0.0</osgi.compendium.version>


### PR DESCRIPTION
This PR updates karaf to the latest 4.2 version. The new version includes an update to pax logging version 1.11.13 

Karaf Changelog:
- upgrade to Pax Loggin 1.11.13 upgrading to log4j 2.17.1 (fixing CVE-2021-44832)
- upgrade to Apache Felix FileInstall 3.7.4 fixing deployment issue


* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
