### PR TITLE
duplicate WFH changes title and StartDateTime

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
@@ -33,6 +33,10 @@ Parameter Table
 |copy-number-prefix   |`copy`                                     |The prefix used for the number of the copy which is appended to the title of the new event.     |
 |number-of-events     |`2`                                        |How many events to create.|
 |max-number-of-events |`1000`                                     |How many events are allowed to be created at maximum.|
+|no-suffix            |`true`                                     |Boolean to decide if the number suffix (`copy #`) is not attached (true ... no attachment, false ...`copy #` is attached) |
+|set-series-id        |`3547a900-e0ee-4e3f-9e67-2157cd42c700`     |Id of the series the copied events should be added to |
+|set-title            |`copy of mediapackage`                     |Title of the newly created events. If `no-suffix` is set to `false` a `copy #` will be attached |
+|set-start-date-time  |`2021-12-02 22:22:22`                      |Date and time to be set on the newly created events.|
 
 
 Operation Example
@@ -47,7 +51,11 @@ Operation Example
         <configuration key="source-flavors">*/*</configuration>
         <configuration key="number-of-events">${numberOfEvents}</configuration>
         <configuration key="max-number-of-events">1000</configuration>
-        <configuration key="target-tags"></configuration>
+        <configuration key="target-tags"></configuration> 
+        <configuration key="no-suffix">false</configuration
+        <configuration key="set-series-id">${seriesId}</configuration>
+        <configuration key="set-title">${mpTitle}</configuration>
+        <configuration key="set-start-date-time">${startDate} ${startTime}</configuration>
         <configuration key="property-namespaces">
           org.opencastproject.assetmanager.security
         </configuration>

--- a/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/duplicate-event-woh.md
@@ -16,8 +16,8 @@ For each duplicated event the new media package ID is stored as a workflow prope
 
 |Name                                    |Example                                                             |Description                                    |
 |----------------------------------------|--------------------------------------------------------------------|-----------------------------------------------|
-|duplicate\_media\_package\_*number*\_id |`duplicate_media_package_1_id=e72f2265-472a-49ae-bc04-8301d94b4b1a` |Media package ID of the duplicated event       | \*
-|duplicate\_media\_package\_ids          |`duplicate_media_package_ids=e72f2265-472a-49ae-bc04-8301d94b4b1a, a32e2265-472a-49ae-bc04-8351d94b4b1c` | comma separated list of Media package IDs of the duplicated event |
+|duplicate_media_package_*number*_id     |`duplicate_media_package_1_id=e72f2265-472a-49ae-bc04-8301d94b4b1a` |Media package ID of the duplicated event       | \*
+|duplicate_media_package_ids             |`duplicate_media_package_ids=e72f2265-472a-49ae-bc04-8301d94b4b1a, a32e2265-472a-49ae-bc04-8351d94b4b1c` | comma separated list of Media package IDs of the duplicated event |
 
 \* will be deprecated
 

--- a/etc/workflows/duplicate-event.xml
+++ b/etc/workflows/duplicate-event.xml
@@ -12,18 +12,44 @@
     <![CDATA[
       <div id="workflow-configuration">
         <fieldset>
-          <input
-            id="numberOfEvents"
-            name="numberOfEvents"
-            type="number"
-            class="configField"
-            onkeypress="return event.charCode > 47"
-            oninput="checkValueInBounds()"
-            min="1"
-            value="1"
-            max="25"
-            />
-          <label for="numberOfEvents">Number of Events</label>
+          <br/>
+          <div>
+            <label for="mpTitle" style="width: 150px;" >Title of Duplicate:</label>
+            <input id="mpTitle" name="mpTitle" type="text" style="width: 400px;" value=" " class="configField" />
+          </div>
+          <br/>
+          <div>
+            <label for="seriesId" style="width: 150px;" >Series Id:</label>
+            <input id="seriesId" name="seriesId" type="text" maxlength="255" style="width: 400px;" value=" " class="configField" />
+          </div>
+          <br/>
+          <div>
+            <label for="startDate" style="width: 150px;">StartDate:</label>
+            <input id="startDate" name="startDate" type="date" style="width: 200px;" value=" " class="configField" />
+            <input id="startTime" name="startTime" type="time"  style="width: 190px;" value=" " class="configField" />
+          </div>
+          <br/>
+          <div>
+            <label for="numberOfEvents" style="width: 150px;">Number of Events</label>
+            <input
+              id="numberOfEvents"
+              name="numberOfEvents"
+              type="number"
+              class="configField"
+              onkeypress="return event.charCode > 47"
+              oninput="checkValueInBounds()"
+              min="1"
+              value="1"
+              max="25"
+            /> 
+          </div>
+          <br/>
+          <div>
+            <fieldset>
+              <input id="noCopySuffix" name="noCopySuffix" type="checkbox" class="configField" value="false" />
+              <label for="noCopySuffix">Do not use copy suffix</label>
+            </fieldset>
+          </div>
         </fieldset>
       </div>
 
@@ -53,8 +79,12 @@
       <configurations>
         <configuration key="source-flavors">*/*</configuration>
         <configuration key="number-of-events">${numberOfEvents}</configuration>
+        <configuration key="set-series-id">${seriesId}</configuration>
+        <configuration key="set-title">${mpTitle}</configuration>
+        <configuration key="set-start-date-time">${startDate} ${startTime}</configuration>
         <configuration key="target-tags"></configuration>
         <configuration key="property-namespaces">org.opencastproject.assetmanager.security,org.opencastproject.workflow.configuration</configuration>
+        <configuration key="no-suffix">${noCopySuffix}</configuration>        
         <configuration key="copy-number-prefix">copy</configuration>
       </configurations>
     </operation>

--- a/etc/workflows/duplicate-event.xml
+++ b/etc/workflows/duplicate-event.xml
@@ -41,7 +41,7 @@
               min="1"
               value="1"
               max="25"
-            /> 
+            />
           </div>
           <br/>
           <div>
@@ -84,7 +84,7 @@
         <configuration key="set-start-date-time">${startDate} ${startTime}</configuration>
         <configuration key="target-tags"></configuration>
         <configuration key="property-namespaces">org.opencastproject.assetmanager.security,org.opencastproject.workflow.configuration</configuration>
-        <configuration key="no-suffix">${noCopySuffix}</configuration>        
+        <configuration key="no-suffix">${noCopySuffix}</configuration>
         <configuration key="copy-number-prefix">copy</configuration>
       </configurations>
     </operation>

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -391,7 +391,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
         }
 
         // Create and add new episode dublin core with changed title
-      newMp = copyDublinCore(mediaPackage, originalEpisodeDc[0],
+        newMp = copyDublinCore(mediaPackage, originalEpisodeDc[0],
               newMp, series, removeTags, addTags, overrideTags,
               temporaryFiles, startDate);
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -48,6 +48,8 @@ import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreUtil;
+import org.opencastproject.metadata.dublincore.OpencastMetadataCodec;
+import org.opencastproject.metadata.dublincore.Precision;
 import org.opencastproject.security.api.AccessControlList;
 import org.opencastproject.security.api.AclScope;
 import org.opencastproject.security.api.AuthorizationService;
@@ -74,9 +76,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -108,6 +114,8 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
   private static final String PLUS = "+";
   private static final String MINUS = "-";
 
+  private static final DateFormat ADMIN_UI_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
   /** Name of the configuration option that provides the source flavors we are looking for */
   public static final String SOURCE_FLAVORS_PROPERTY = "source-flavors";
 
@@ -128,6 +136,12 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
 
   /** The series ID that should be set on the copies (if unset, uses the same series) */
   public static final String SET_SERIES_ID = "set-series-id";
+
+  /** The new title that should be set on the copies (if unset, uses the old title (copy-number-prefix)) */
+  public static final String SET_TITLE = "set-title";
+
+  /** The new startDate that should be set on the copies (if unset, uses the old startDate) */
+  public static final String SET_START_DATE = "set-start-date-time";
 
   /** The default maximum number of events to create. Can be overridden. */
   public static final int MAX_NUMBER_DEFAULT = 25;
@@ -211,7 +225,9 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
     final List<String> configuredSourceTags = tagsAndFlavors.getSrcTags();
     final List<String> configuredTargetTags = tagsAndFlavors.getTargetTags();
     final boolean noSuffix = Boolean.parseBoolean(trimToEmpty(operation.getConfiguration(NO_SUFFIX)));
+    final String startDateString = trimToEmpty(operation.getConfiguration(SET_START_DATE));
     final String seriesId = trimToEmpty(operation.getConfiguration(SET_SERIES_ID));
+    final String title = trimToEmpty(operation.getConfiguration(SET_TITLE));
     final int numberOfEvents = Integer.parseInt(operation.getConfiguration(NUMBER_PROPERTY));
     final String configuredPropertyNamespaces = trimToEmpty(operation.getConfiguration(PROPERTY_NAMESPACES_PROPERTY));
     int maxNumberOfEvents = MAX_NUMBER_DEFAULT;
@@ -227,7 +243,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
 
     SeriesInformation series = null;
     AccessControlList seriesAccessControl = null;
-    if (!seriesId.isEmpty()) {
+    if (!seriesId.isEmpty() && !seriesId.startsWith("${")) {
       try {
         final DublinCoreCatalog dc = seriesService.getSeries(seriesId);
         series = new SeriesInformation(seriesId, dc, dc.get(DublinCore.PROPERTY_TITLE).get(0).getValue());
@@ -307,16 +323,49 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
     String sep = "";
     Map<String, String> properties = new HashMap<>();
     for (int i = 0; i < numberOfEvents; i++) {
+
       final List<URI> temporaryFiles = new ArrayList<>();
       MediaPackage newMp = null;
-
+      final Date startDate;
       try {
         String newMpId = workflowInstance.getConfiguration("newMpId");
         if (newMpId == null) {
           newMpId = UUID.randomUUID().toString();
         }
         // Clone the media package (without its elements)
-        newMp = copyMediaPackage(mediaPackage, series, newMpId, noSuffix, i + 1, copyNumberPrefix);
+        String useTitle;
+        if (title.isEmpty() || (title.startsWith("${") && title.endsWith("}"))) {
+          useTitle = mediaPackage.getTitle();
+        } else {
+          useTitle = title;
+        }
+        final String newTitle = noSuffix
+            ? useTitle
+            : String.format("%s (%s %d)", useTitle, copyNumberPrefix, i + 1);
+        Date mpDate = mediaPackage.getDate();
+        String date = new SimpleDateFormat("yyyy-MM-dd").format(mpDate);
+        String time = new SimpleDateFormat("HH:mm:ss").format(mpDate);
+        if (!startDateString.isEmpty()) {
+          String [] dt = startDateString.split(" ");
+          if (dt.length >= 2) {
+            if (!dt[0].startsWith("${")) {
+              date = dt[0];
+            }
+            if (!dt[1].startsWith("${")) {
+              time = (dt[1].split(":").length == 2) ? dt[1] + ":00" : dt[1];
+            }
+          }
+        }
+        try {
+          mpDate = ADMIN_UI_DATE_FORMAT.parse(date + " " + time);
+        } catch (ParseException ex) {
+          logger.info("{} could not be parsed as Date", date + " " + time);
+        }
+        logger.info("setting StartDate to {}", mpDate.toString());
+        startDate = mpDate;
+
+
+        newMp = copyMediaPackage(mediaPackage, series, newMpId, newTitle, startDate);
 
         if (series != null) {
           URI newSeriesURI = null;
@@ -342,8 +391,9 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
         }
 
         // Create and add new episode dublin core with changed title
-        newMp = copyDublinCore(mediaPackage, originalEpisodeDc[0], newMp, series, removeTags, addTags, overrideTags,
-                temporaryFiles);
+      newMp = copyDublinCore(mediaPackage, originalEpisodeDc[0],
+              newMp, series, removeTags, addTags, overrideTags,
+              temporaryFiles, startDate);
 
         // Clone regular elements
         for (final MediaPackageElement e : elements) {
@@ -424,9 +474,9 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
       final MediaPackage source,
       final SeriesInformation series,
       final String newMpId,
-      final boolean noSuffix,
-      final long copyNumber,
-      final String copyNumberPrefix) throws WorkflowOperationException {
+      final String title,
+      final Date startDate
+      ) throws WorkflowOperationException {
     // We are not using MediaPackage.clone() here, since it does "too much" for us (e.g. copies all the attachments)
     MediaPackage destination;
     try {
@@ -447,10 +497,8 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
     destination.setDuration(source.getDuration());
     destination.setLanguage(source.getLanguage());
     destination.setLicense(source.getLicense());
-    final String newTitle = noSuffix
-            ? source.getTitle()
-            : String.format("%s (%s %d)", source.getTitle(), copyNumberPrefix, copyNumber);
-    destination.setTitle(newTitle);
+    destination.setDate(startDate);
+    destination.setTitle(title);
     return destination;
   }
 
@@ -516,10 +564,13 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
       final List<String> removeTags,
       final List<String> addTags,
       final List<String> overrideTags,
-      final List<URI> temporaryFiles) throws WorkflowOperationException {
+      final List<URI> temporaryFiles,
+      final Date creationDate
+  ) throws WorkflowOperationException {
     final DublinCoreCatalog destinationDublinCore = DublinCoreUtil.loadEpisodeDublinCore(workspace, source).get();
     destinationDublinCore.setIdentifier(null);
     destinationDublinCore.setURI(sourceDublinCore.getURI());
+    destinationDublinCore.set(DublinCore.PROPERTY_CREATED, OpencastMetadataCodec.encodeDate(creationDate,Precision.Second));
     destinationDublinCore.set(DublinCore.PROPERTY_TITLE, destination.getTitle());
     if (series != null) {
       destinationDublinCore.set(DublinCore.PROPERTY_IS_PART_OF, series.id);


### PR DESCRIPTION
For rolling forward Lectures from one year to the next we need to be able to change the Title and Start Date and Time of the duplicated mediapackage. 