### PR TITLE
Update pax logging from version 1.11.13 to 1.11.14

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -104,8 +104,8 @@
     <bundle>mvn:org.springframework/spring-web/${spring.version}</bundle>
 
     <!-- get updated Loog4J; REMOOVE WITH NEXT KARAF UPDATE! -->
-    <bundle>mvn:org.ops4j.pax.logging/pax-logging-api/1.11.13</bundle>
-    <bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.11.13</bundle>
+    <bundle>mvn:org.ops4j.pax.logging/pax-logging-api/1.11.14</bundle>
+    <bundle>mvn:org.ops4j.pax.logging/pax-logging-log4j2/1.11.14</bundle>
   </feature>
 
   <feature name="opencast-core" version="${project.version}">

--- a/assemblies/resources/build.xml
+++ b/assemblies/resources/build.xml
@@ -27,13 +27,13 @@
     <replaceregexp file="target/classes/package.xml" match="tar\.gz" replace="dir" byline="true"/>
     <replaceregexp file="target/classes/package.xml" match="baseDirectory&gt;.*&lt;/baseDirectory&gt;" replace="includeBaseDirectory&gt;false&lt;/includeBaseDirectory&gt;" byline="true"/>
     <!-- Log4J -->
-    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-log4j2/1.11.6" replace="pax-logging-log4j2/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-log4j2/1.11.6" replace="pax-logging-log4j2/1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/bin/instance" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.13/pax-logging-api-1.11.13" byline="true"/>
-    <replaceregexp file="target/assembly/bin/shell" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.13/pax-logging-api-1.11.13" byline="true"/>
+    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.14" byline="true"/>
+    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.14" byline="true"/>
+    <replaceregexp file="target/assembly/system/org/apache/karaf/features/framework/4.2.9/framework-4.2.9-features.xml" match="pax-logging-log4j2/1.11.6" replace="pax-logging-log4j2/1.11.14" byline="true"/>
+    <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-api/1.11.6" replace="pax-logging-api/1.11.14" byline="true"/>
+    <replaceregexp file="target/assembly/etc/startup.properties" match="pax-logging-log4j2/1.11.6" replace="pax-logging-log4j2/1.11.14" byline="true"/>
+    <replaceregexp file="target/assembly/bin/instance" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.14/pax-logging-api-1.11.14" byline="true"/>
+    <replaceregexp file="target/assembly/bin/shell" match="1.11.6/pax-logging-api-1.11.6" replace="1.11.14/pax-logging-api-1.11.14" byline="true"/>
     <delete>
       <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-api/1.11.6" includes="*" />
       <fileset dir="target/assembly/system/org/ops4j/pax/logging/pax-logging-log4j2/1.11.6" includes="*" />


### PR DESCRIPTION
Updates pax-logging from 1.11.13 to 1.11.14

Fixes following vulnerabilities from dependencies:
CVE-2022-23305
CVE-2022-23302
CVE-2021-4104
CVE-2019-17571

This PR is based on #3414 

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
