### PR TITLE
Fixed Typo in Logging Statement

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
@@ -163,12 +163,12 @@ public class Ingestor implements Runnable {
                   try {
                     title = matcher.group("title");
                   } catch (IllegalArgumentException e) {
-                    logger.debug("{} matches no title in {}", metadataPattern.get(), artifact.getName(), e);
+                    logger.debug("{} matches no 'title' in {}", metadataPattern.get(), artifact.getName(), e);
                   }
                   try {
                     dcc.add(DublinCore.PROPERTY_SPATIAL, matcher.group("spatial"));
                   } catch (IllegalArgumentException e) {
-                    logger.debug("{} matches no spatial in {}", metadataPattern.get(), artifact.getName(), e);
+                    logger.debug("{} matches no 'spatial' in {}", metadataPattern.get(), artifact.getName(), e);
                   }
                   try {
                     var value = matcher.group("created");
@@ -179,7 +179,7 @@ public class Ingestor implements Runnable {
                   } catch (DateTimeParseException e) {
                     logger.warn("Matched date does not match configured date-time format", e);
                   } catch (IllegalArgumentException e) {
-                    logger.debug("{} matches no spatial in {}", metadataPattern, artifact.getName(), e);
+                    logger.debug("{} matches no 'created' in {}", metadataPattern.get(), artifact.getName(), e);
                   }
                 } else {
                   logger.debug("Regular expression {} does not match {}", metadataPattern.get(), artifact.getName());


### PR DESCRIPTION
This patch fixes a typo in the logging statement which was complaining
about the wrong group not being matched.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
