### PR TITLE
Fixes OSGi error when shutting down Opencast

### DIFF
--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -895,6 +895,13 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
   }
 
+  public void unsetDownloadDistributionService(DownloadDistributionService service) {
+    if (distributionServiceType.equalsIgnoreCase(service.getDistributionType())
+        && downloadDistributionService.equals(service)) {
+      this.downloadDistributionService = null;
+    }
+  }
+
   public void setWorkspace(Workspace ws) {
     this.workspace = ws;
   }


### PR DESCRIPTION
Fixes #3417

Add DownloadDistributionService unbind method to LiveScheduleServiceImpl.
The error only affects 11.x it's already fixed in develop.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
