### PR TITLE
Remove reference annotation name attribute if possible

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/userdirectory/UIRolesRoleProvider.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/userdirectory/UIRolesRoleProvider.java
@@ -70,7 +70,7 @@ public class UIRolesRoleProvider implements RoleProvider {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/AdopterRegistrationServiceImpl.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/AdopterRegistrationServiceImpl.java
@@ -80,13 +80,13 @@ public class AdopterRegistrationServiceImpl implements Service {
   //================================================================================
 
   /** OSGi setter for the security service. */
-  @Reference(name = "securityService")
+  @Reference
   protected void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi setter for the form repository. */
-  @Reference(name = "formRepository")
+  @Reference
   protected void setFormRepository(FormRepository formRepository) {
     this.formRepository = formRepository;
   }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
@@ -83,7 +83,7 @@ public class Controller {
   protected Service registrationService;
 
   /** OSGi setter for the registration service */
-  @Reference(name = "registrationService")
+  @Reference
   public void setRegistrationService(Service registrationService) {
     this.registrationService = registrationService;
   }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/FormRepositoryImpl.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/FormRepositoryImpl.java
@@ -54,10 +54,7 @@ public class FormRepositoryImpl implements FormRepository {
   protected EntityManagerFactory emf = null;
 
   /** OSGi setter for the entity manager factory. */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.adopter)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.adopter)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -218,37 +218,37 @@ public class ScheduledDataCollector extends TimerTask {
   //================================================================================
 
   /** OSGi setter for the adopter form service. */
-  @Reference(name = "adopter-registration-service")
+  @Reference
   public void setAdopterFormService(Service adopterFormService) {
     this.adopterFormService = adopterFormService;
   }
 
   /** OSGi setter for the service registry. */
-  @Reference(name = "service-registry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
   /** OSGi setter for the asset manager. */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
 
   /** OSGi setter for the series service. */
-  @Reference(name = "series-service")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
 
   /** OSGi setter for the user provider. */
-  @Reference(name = "user-and-role-rrovider")
+  @Reference
   public void setUserAndRoleProvider(JpaUserAndRoleProvider userAndRoleProvider) {
     this.userAndRoleProvider = userAndRoleProvider;
   }
 
   /** OSGi callback for setting the security service. */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/annotation-impl/src/main/java/org/opencastproject/annotation/impl/AnnotationRestService.java
+++ b/modules/annotation-impl/src/main/java/org/opencastproject/annotation/impl/AnnotationRestService.java
@@ -108,7 +108,7 @@ public class AnnotationRestService {
    * @param service
    *          the annotation service implementation
    */
-  @Reference(name = "service-impl")
+  @Reference
   public void setService(AnnotationService service) {
     this.annotationService = service;
   }

--- a/modules/annotation-impl/src/main/java/org/opencastproject/annotation/impl/AnnotationServiceJpaImpl.java
+++ b/modules/annotation-impl/src/main/java/org/opencastproject/annotation/impl/AnnotationServiceJpaImpl.java
@@ -62,10 +62,7 @@ public class AnnotationServiceJpaImpl implements AnnotationService {
   protected SecurityService securityService;
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.annotation)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.annotation)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -76,7 +73,7 @@ public class AnnotationServiceJpaImpl implements AnnotationService {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -213,38 +213,37 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
    * OSGi dependencies
    */
 
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.assetmanager.impl)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.assetmanager.impl)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.db = new Database(emf);
   }
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "authorizationService")
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
 
-  @Reference(name = "orgDir")
+  @Reference
   public void setOrgDir(OrganizationDirectoryService orgDir) {
     this.orgDir = orgDir;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "assetStore")
+  @Reference
   public void setAssetStore(AssetStore assetStore) {
     this.assetStore = assetStore;
   }
 
   @Reference(
-      name = "remoteAssetStores",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeRemoteAssetStore"
@@ -257,22 +256,22 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     remoteStores.remove(store.getStoreType());
   }
 
-  @Reference(name = "httpAssetProvider")
+  @Reference
   public void setHttpAssetProvider(HttpAssetProvider httpAssetProvider) {
     this.httpAssetProvider = httpAssetProvider;
   }
 
-  @Reference(name = "messageSender")
+  @Reference
   public void setMessageSender(MessageSender messageSender) {
     this.messageSender = messageSender;
   }
 
-  @Reference(name = "aclServiceFactory")
+  @Reference
   public void setAclServiceFactory(AclServiceFactory aclServiceFactory) {
     this.aclServiceFactory = aclServiceFactory;
   }
 
-  @Reference(name = "index")
+  @Reference
   public void setIndex(ElasticsearchIndex index) {
     this.index = index;
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerJobProducer.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerJobProducer.java
@@ -449,7 +449,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
     return result;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -459,12 +459,12 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
     return this.serviceRegistry;
   }
 
-  @Reference(name = "assetManager")
+  @Reference
   protected void setAssetManager(AssetManager assetManager) {
     this.tsam = assetManager;
   }
 
-  @Reference(name = "security-service")
+  @Reference
   protected void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -474,7 +474,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
     return this.securityService;
   }
 
-  @Reference(name = "user-directory")
+  @Reference
   protected void setUserDirectoryService(UserDirectoryService uds) {
     this.userDirectoryService = uds;
   }
@@ -484,7 +484,7 @@ public class AssetManagerJobProducer extends AbstractJobProducer {
     return this.userDirectoryService;
   }
 
-  @Reference(name = "orgDirectory")
+  @Reference
   protected void setOrganizationDirectoryService(OrganizationDirectoryService os) {
     this.organizationDirectoryService = os;
   }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/TimedMediaArchiver.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/TimedMediaArchiver.java
@@ -187,7 +187,7 @@ public class TimedMediaArchiver extends AbstractScanner implements ManagedServic
     return SCANNER_NAME;
   }
 
-  @Reference(name = "AssetManager")
+  @Reference
   public void setAssetManager(AssetManager am) {
     this.assetManager = am;
   }
@@ -214,19 +214,19 @@ public class TimedMediaArchiver extends AbstractScanner implements ManagedServic
     }
   }
 
-  @Reference(name = "OrganizationDirectoryService")
+  @Reference
   @Override
   public void bindOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     super.bindOrganizationDirectoryService(organizationDirectoryService);
   }
 
-  @Reference(name = "SecurityService")
+  @Reference
   @Override
   public void bindSecurityService(SecurityService securityService) {
     super.bindSecurityService(securityService);
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void bindServiceRegistry(ServiceRegistry serviceRegistry) {
     super.bindServiceRegistry(serviceRegistry);

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/OsgiAssetManagerRestEndpoint.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/OsgiAssetManagerRestEndpoint.java
@@ -49,18 +49,18 @@ public class OsgiAssetManagerRestEndpoint extends AbstractTieredStorageAssetMana
   }
 
   /** OSGi DI */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
 
-  @Reference(name = "job-producer")
+  @Reference
   @Override
   public void setJobProducer(AssetManagerJobProducer assetManagerJobProducer) {
     super.setJobProducer(assetManagerJobProducer);
   }
 
-  @Reference(name = "service-registry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/OsgiEndpointHttpAssetProvider.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/endpoint/OsgiEndpointHttpAssetProvider.java
@@ -137,7 +137,7 @@ public class OsgiEndpointHttpAssetProvider implements HttpAssetProvider {
   }
 
   /** OSGi DI */
-  @Reference(name = "orgDir")
+  @Reference
   public void setOrgDir(OrganizationDirectoryService orgDir) {
     this.orgDir = orgDir;
   }

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/persistence/AwsAssetDatabaseImpl.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/persistence/AwsAssetDatabaseImpl.java
@@ -66,10 +66,7 @@ public class AwsAssetDatabaseImpl implements AwsAssetDatabase {
   }
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.assetmanager.aws.persistence)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.assetmanager.aws.persistence)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
@@ -107,14 +107,14 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
 
   /** OSGi Di */
   @Override
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     super.setWorkspace(workspace);
   }
 
   /** OSGi Di */
   @Override
-  @Reference(name = "database")
+  @Reference
   public void setDatabase(AwsAssetDatabase db) {
     super.setDatabase(db);
   }

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
@@ -78,7 +78,7 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
   /**
    * OSGi DI.
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerDeleteWorkflowOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerDeleteWorkflowOperationHandler.java
@@ -72,7 +72,7 @@ public class AssetManagerDeleteWorkflowOperationHandler extends AbstractWorkflow
   }
 
   /** OSGi DI */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -111,7 +111,7 @@ public class AssetManagerDeleteWorkflowOperationHandler extends AbstractWorkflow
     return createResult(mediaPackage, Action.CONTINUE);
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerSnapshotWorkflowOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerSnapshotWorkflowOperationHandler.java
@@ -80,7 +80,7 @@ public class AssetManagerSnapshotWorkflowOperationHandler extends AbstractWorkfl
   }
 
   /** OSGi DI */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -203,7 +203,7 @@ public class AssetManagerSnapshotWorkflowOperationHandler extends AbstractWorkfl
     return mp;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerStorageMoveOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerStorageMoveOperationHandler.java
@@ -74,13 +74,13 @@ public class AssetManagerStorageMoveOperationHandler extends AbstractWorkflowOpe
   }
 
   /** OSGi DI */
-  @Reference(name = "asset-manager-job-producer")
+  @Reference
   public void setJobProducer(AssetManagerJobProducer tsamjp) {
     this.tsamjp = tsamjp;
   }
 
   /** OSGi DI */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -140,7 +140,7 @@ public class AssetManagerStorageMoveOperationHandler extends AbstractWorkflowOpe
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpoint.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/endpoint/OsgiAclServiceRestEndpoint.java
@@ -79,25 +79,25 @@ public final class OsgiAclServiceRestEndpoint extends AbstractAclServiceRestEndp
   }
 
   /** OSGi callback for setting persistence. */
-  @Reference(name = "acl-service-factory")
+  @Reference
   public void setAclServiceFactory(AclServiceFactory aclServiceFactory) {
     this.aclServiceFactory = aclServiceFactory;
   }
 
   /** OSGi callback for setting security service. */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi DI callback. */
-  @Reference(name = "authorization-service")
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
 
   /** OSGi DI callback. */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }

--- a/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclScanner.java
+++ b/modules/authorization-manager/src/main/java/org/opencastproject/authorization/xacml/manager/impl/AclScanner.java
@@ -101,19 +101,19 @@ public class AclScanner implements ArtifactInstaller {
   }
 
   /** OSGi DI. */
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
   /** OSGi callback for setting persistence. */
-  @Reference(name = "acl-service-factory")
+  @Reference
   void setAclServiceFactory(AclServiceFactory aclServiceFactory) {
     this.aclServiceFactory = aclServiceFactory;
   }
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -342,7 +342,7 @@ public class XACMLAuthorizationService implements AuthorizationService, ManagedS
    * @param workspace
    *          the workspace to set
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -353,7 +353,7 @@ public class XACMLAuthorizationService implements AuthorizationService, ManagedS
    * @param securityService
    *          the security service
    */
-  @Reference(name = "security")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/endpoint/CaptionServiceRestEndpoint.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/endpoint/CaptionServiceRestEndpoint.java
@@ -112,7 +112,6 @@ public class CaptionServiceRestEndpoint extends AbstractJobProducerEndpoint {
    *          the caption service to set
    */
   @Reference(
-      name = "service-impl",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetCaptionService"
@@ -137,7 +136,7 @@ public class CaptionServiceRestEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/impl/CaptionServiceImpl.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/impl/CaptionServiceImpl.java
@@ -500,7 +500,7 @@ public class CaptionServiceImpl extends AbstractJobProducer implements CaptionSe
   /**
    * Setter for workspace via declarative activation
    */
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -508,7 +508,7 @@ public class CaptionServiceImpl extends AbstractJobProducer implements CaptionSe
   /**
    * Setter for remote service manager via declarative activation
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -519,7 +519,7 @@ public class CaptionServiceImpl extends AbstractJobProducer implements CaptionSe
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -530,7 +530,7 @@ public class CaptionServiceImpl extends AbstractJobProducer implements CaptionSe
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -541,7 +541,7 @@ public class CaptionServiceImpl extends AbstractJobProducer implements CaptionSe
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }

--- a/modules/caption-remote/src/main/java/org/opencastproject/caption/remote/CaptionServiceRemoteImpl.java
+++ b/modules/caption-remote/src/main/java/org/opencastproject/caption/remote/CaptionServiceRemoteImpl.java
@@ -156,12 +156,12 @@ public class CaptionServiceRemoteImpl extends RemoteBase implements CaptionServi
     throw new CaptionConverterException("Unable to get catalog languages" + input + " using a remote caption service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/endpoint/CaptureAgentStateRestService.java
@@ -119,7 +119,6 @@ public class CaptureAgentStateRestService {
   }
 
   @Reference(
-      name = "service-impl",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetService"
@@ -132,7 +131,7 @@ public class CaptureAgentStateRestService {
     this.service = null;
   }
 
-  @Reference(name = "scheduler-service")
+  @Reference
   public void setSchedulerService(SchedulerService schedulerService) {
     this.schedulerService = schedulerService;
   }

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentAdminRoleProviderImpl.java
@@ -57,7 +57,7 @@ public class CaptureAgentAdminRoleProviderImpl implements RoleProvider {
    * @param service
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(final SecurityService service) {
     this.securityService = service;
   }
@@ -65,7 +65,7 @@ public class CaptureAgentAdminRoleProviderImpl implements RoleProvider {
 
   private CaptureAgentStateService captureAgentService;
 
-  @Reference(name = "CaptureAgentStateService")
+  @Reference
   public void setCaptureAgentStateService(final CaptureAgentStateService service) {
     this.captureAgentService = service;
   }

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
@@ -115,7 +115,7 @@ public class CaptureAgentStateServiceImpl implements CaptureAgentStateService, M
   protected Object nullToken = new Object();
 
   /** OSGi DI */
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.capture.admin.impl.CaptureAgentStateServiceImpl)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.capture.admin.impl.CaptureAgentStateServiceImpl)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -124,7 +124,7 @@ public class CaptureAgentStateServiceImpl implements CaptureAgentStateService, M
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/comments-workflowoperation/src/main/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandler.java
+++ b/modules/comments-workflowoperation/src/main/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandler.java
@@ -271,23 +271,23 @@ public class CommentWorkflowOperationHandler extends AbstractWorkflowOperationHa
    * @param eventCommentService
    *          the workflow service
    */
-  @Reference(name = "event-comment-service")
+  @Reference
   public void setEventCommentService(EventCommentService eventCommentService) {
     this.eventCommentService = eventCommentService;
   }
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   void setSecurityService(SecurityService service) {
     this.securityService = service;
   }
 
-  @Reference(name = "UserDirectory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/ChainingMediaPackageSerializer.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/ChainingMediaPackageSerializer.java
@@ -65,7 +65,6 @@ public class ChainingMediaPackageSerializer implements MediaPackageSerializer {
 
   /** OSGi DI */
   @Reference(
-      name = "mpSerializers",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeMediaPackageSerializer",

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -1912,7 +1912,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @param mediaInspectionService
    *          an instance of the media inspection service
    */
-  @Reference(name = "inspection-service")
+  @Reference
   protected void setMediaInspectionService(MediaInspectionService mediaInspectionService) {
     this.inspectionService = mediaInspectionService;
   }
@@ -1923,7 +1923,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -1934,7 +1934,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -1955,7 +1955,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @param scanner
    *          the profile scanner
    */
-  @Reference(name = "profileScanner")
+  @Reference
   protected void setProfileScanner(EncodingProfileScanner scanner) {
     this.profileScanner = scanner;
   }
@@ -1966,7 +1966,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -1977,7 +1977,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -1988,7 +1988,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }
@@ -2003,7 +2003,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     return securityService;
   }
 
-  @Reference(name = "smil-service")
+  @Reference
   public void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }
@@ -2028,7 +2028,7 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
     return organizationDirectoryService;
   }
 
-  @Reference(name = "profilesReadyIndicator", target = "(artifact=encodingprofile)")
+  @Reference(target = "(artifact=encodingprofile)")
   public void setEncodingProfileReadinessIndicator(ReadinessIndicator unused) {
     //  Wait for the encoding profiles to load
   }

--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/endpoint/ComposerRestService.java
@@ -149,7 +149,7 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
   /** The smil service */
   protected SmilService smilService = null;
 
-  @Reference(name = "smil-service")
+  @Reference
   public void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }
@@ -160,7 +160,7 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -171,7 +171,7 @@ public class ComposerRestService extends AbstractJobProducerEndpoint {
    * @param composerService
    *          the composer service
    */
-  @Reference(name = "composerService")
+  @Reference
   public void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }

--- a/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
+++ b/modules/composer-service-remote/src/main/java/org/opencastproject/composer/remote/ComposerServiceRemoteImpl.java
@@ -91,7 +91,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
    * @param client
    */
   @Override
-  @Reference(name = "trustedHttpClient")
+  @Reference
   public void setTrustedHttpClient(TrustedHttpClient client) {
     this.client = client;
   }
@@ -102,7 +102,7 @@ public class ComposerServiceRemoteImpl extends RemoteBase implements ComposerSer
    * @param remoteServiceManager
    */
   @Override
-  @Reference(name = "remoteServiceManager")
+  @Reference
   public void setRemoteServiceManager(ServiceRegistry remoteServiceManager) {
     this.remoteServiceManager = remoteServiceManager;
   }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/CompositeWorkflowOperationHandler.java
@@ -138,7 +138,7 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   public void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -150,7 +150,7 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -814,7 +814,7 @@ public class CompositeWorkflowOperationHandler extends AbstractWorkflowOperation
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ConcatWorkflowOperationHandler.java
@@ -115,7 +115,7 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   public void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -127,7 +127,7 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -435,7 +435,7 @@ public class ConcatWorkflowOperationHandler extends AbstractWorkflowOperationHan
     return trackSelectors;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/DemuxWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/DemuxWorkflowOperationHandler.java
@@ -85,7 +85,7 @@ public class DemuxWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -97,7 +97,7 @@ public class DemuxWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -267,7 +267,7 @@ public class DemuxWorkflowOperationHandler extends AbstractWorkflowOperationHand
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
@@ -87,7 +87,7 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -99,7 +99,7 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -310,7 +310,7 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
 
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageConvertWorkflowOperationHandler.java
@@ -93,7 +93,7 @@ public class ImageConvertWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param composerService
    *          the composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -104,7 +104,7 @@ public class ImageConvertWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -267,7 +267,7 @@ public class ImageConvertWorkflowOperationHandler extends AbstractWorkflowOperat
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageToVideoWorkflowOperationHandler.java
@@ -91,7 +91,7 @@ public class ImageToVideoWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   public void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -103,7 +103,7 @@ public class ImageToVideoWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -189,7 +189,7 @@ public class ImageToVideoWorkflowOperationHandler extends AbstractWorkflowOperat
     };
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override  public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
   }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -129,7 +129,7 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * @param composerService
    *          the composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -141,7 +141,7 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -621,7 +621,7 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandler.java
@@ -102,7 +102,7 @@ public class MultiEncodeWorkflowOperationHandler extends AbstractWorkflowOperati
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -114,7 +114,7 @@ public class MultiEncodeWorkflowOperationHandler extends AbstractWorkflowOperati
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -547,7 +547,7 @@ public class MultiEncodeWorkflowOperationHandler extends AbstractWorkflowOperati
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PartialImportWorkflowOperationHandler.java
@@ -156,7 +156,7 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   public void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -168,12 +168,12 @@ public class PartialImportWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/PrepareAVWorkflowOperationHandler.java
@@ -101,7 +101,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -113,7 +113,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -380,7 +380,7 @@ public class PrepareAVWorkflowOperationHandler extends AbstractWorkflowOperation
     return null;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ProcessSmilWorkflowOperationHandler.java
@@ -197,7 +197,7 @@ public class ProcessSmilWorkflowOperationHandler extends AbstractWorkflowOperati
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -207,7 +207,7 @@ public class ProcessSmilWorkflowOperationHandler extends AbstractWorkflowOperati
    *
    * @param smilService
    */
-  @Reference(name = "SmilService")
+  @Reference
   protected void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }
@@ -219,12 +219,12 @@ public class ProcessSmilWorkflowOperationHandler extends AbstractWorkflowOperati
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
@@ -99,12 +99,12 @@ public class SanitizeAdaptiveWorkflowOperationHandler extends AbstractWorkflowOp
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SegmentPreviewsWorkflowOperationHandler.java
@@ -108,7 +108,7 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
    * @param composerService
    *          the composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -131,12 +131,12 @@ public class SegmentPreviewsWorkflowOperationHandler extends AbstractWorkflowOpe
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SelectStreamsWorkflowOperationHandler.java
@@ -111,12 +111,12 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param composerService
    *          the local composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(final ComposerService composerService) {
     this.composerService = composerService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
@@ -129,7 +129,7 @@ public class SelectStreamsWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(final Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/CoverImageServiceOsgiImpl.java
+++ b/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/CoverImageServiceOsgiImpl.java
@@ -70,7 +70,7 @@ public class CoverImageServiceOsgiImpl extends AbstractCoverImageService {
    * @param workspace
    *          the workspace service
    */
-  @Reference(name = "Workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -81,7 +81,7 @@ public class CoverImageServiceOsgiImpl extends AbstractCoverImageService {
    * @param serviceRegistry
    *          the service registry service
    */
-  @Reference(name = "ServiceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -92,7 +92,7 @@ public class CoverImageServiceOsgiImpl extends AbstractCoverImageService {
    * @param securityService
    *          the security service
    */
-  @Reference(name = "SecurityService")
+  @Reference
   protected void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -103,7 +103,7 @@ public class CoverImageServiceOsgiImpl extends AbstractCoverImageService {
    * @param userDirectoryService
    *          the user directory service
    */
-  @Reference(name = "UserDirectoryService")
+  @Reference
   protected void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -114,7 +114,7 @@ public class CoverImageServiceOsgiImpl extends AbstractCoverImageService {
    * @param organizationDirectoryService
    *          the organization directory service
    */
-  @Reference(name = "OrganizationDirectoryService")
+  @Reference
   protected void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }

--- a/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/endpoint/CoverImageEndpoint.java
+++ b/modules/cover-image-impl/src/main/java/org/opencastproject/coverimage/impl/endpoint/CoverImageEndpoint.java
@@ -171,7 +171,7 @@ public class CoverImageEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "ServiceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -181,7 +181,7 @@ public class CoverImageEndpoint extends AbstractJobProducerEndpoint {
    *
    * @param coverImageService
    */
-  @Reference(name = "CoverImageService")
+  @Reference
   protected void setCoverImageService(CoverImageService coverImageService) {
     this.coverImageService = coverImageService;
   }

--- a/modules/cover-image-remote/src/main/java/org/opencastproject/coverimage/remote/CoverImageServiceRemoteImpl.java
+++ b/modules/cover-image-remote/src/main/java/org/opencastproject/coverimage/remote/CoverImageServiceRemoteImpl.java
@@ -97,12 +97,12 @@ public class CoverImageServiceRemoteImpl extends RemoteBase implements CoverImag
     throw new CoverImageException("Unable to generate cover image using a remote generation service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandler.java
+++ b/modules/cover-image-workflowoperation/src/main/java/org/opencastproject/workflow/handler/coverimage/CoverImageWorkflowOperationHandler.java
@@ -62,7 +62,7 @@ public class CoverImageWorkflowOperationHandler extends CoverImageWorkflowOperat
    * @param coverImageService
    *          an instance of the cover image service
    */
-  @Reference(name = "CoverImageService")
+  @Reference
   protected void setCoverImageService(CoverImageService coverImageService) {
     this.coverImageService = coverImageService;
   }
@@ -73,7 +73,7 @@ public class CoverImageWorkflowOperationHandler extends CoverImageWorkflowOperat
    * @param workspace
    *          an instance of the workspace service
    */
-  @Reference(name = "Workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -84,10 +84,7 @@ public class CoverImageWorkflowOperationHandler extends CoverImageWorkflowOperat
    * @param srv
    *          an instance of the static metadata service
    */
-  @Reference(
-      name = "MetadataService",
-      target = "(metadata.source=dublincore)"
-  )
+  @Reference(target = "(metadata.source=dublincore)")
   protected void setStaticMetadataService(StaticMetadataService srv) {
     this.metadataService = srv;
   }
@@ -98,12 +95,12 @@ public class CoverImageWorkflowOperationHandler extends CoverImageWorkflowOperat
    * @param dcService
    *          an instance of the dublin core catalog service
    */
-  @Reference(name = "DublinCoreCatalogService")
+  @Reference
   protected void setDublinCoreCatalogService(DublinCoreCatalogService dcService) {
     this.dcService = dcService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/endpoint/CropRestEndpoint.java
+++ b/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/endpoint/CropRestEndpoint.java
@@ -97,7 +97,7 @@ public class CropRestEndpoint extends AbstractJobProducerEndpoint {
    *
    * @param serviceRegistry the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -107,7 +107,7 @@ public class CropRestEndpoint extends AbstractJobProducerEndpoint {
    *
    * @param cropService the cropper
    */
-  @Reference(name = "cropService")
+  @Reference
   protected void setCropService(CropService cropService) {
     this.cropService = cropService;
   }

--- a/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
+++ b/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
@@ -484,27 +484,27 @@ public class CropServiceImpl extends AbstractJobProducer implements CropService,
     return organizationDirectoryService;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/crop-remote/src/main/java/org/opencastproject/crop/remote/CropServiceRemoteImpl.java
+++ b/modules/crop-remote/src/main/java/org/opencastproject/crop/remote/CropServiceRemoteImpl.java
@@ -90,13 +90,13 @@ public class CropServiceRemoteImpl extends RemoteBase implements CropService {
     throw new CropException("Unable to crop track" + track + " using remote crop service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/crop-workflowoperation/src/main/java/org/opencastproject/workflow/handler/crop/CropWorkflowOperationHandler.java
+++ b/modules/crop-workflowoperation/src/main/java/org/opencastproject/workflow/handler/crop/CropWorkflowOperationHandler.java
@@ -185,7 +185,7 @@ public class CropWorkflowOperationHandler extends AbstractWorkflowOperationHandl
    * @param cropService
    *          the crop service
    */
-  @Reference(name = "CropService")
+  @Reference
   protected void setCropService(CropService cropService) {
     this.cropService = cropService;
   }
@@ -197,12 +197,12 @@ public class CropWorkflowOperationHandler extends AbstractWorkflowOperationHandl
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/distribution-service-aws-s3-remote/src/main/java/org/opencastproject/distribution/aws/s3/remote/AwsS3DistributionServiceRemoteImpl.java
+++ b/modules/distribution-service-aws-s3-remote/src/main/java/org/opencastproject/distribution/aws/s3/remote/AwsS3DistributionServiceRemoteImpl.java
@@ -190,13 +190,13 @@ public class AwsS3DistributionServiceRemoteImpl extends RemoteBase implements Aw
   //stub function
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/AwsS3DistributionServiceImpl.java
@@ -978,31 +978,31 @@ public class AwsS3DistributionServiceImpl extends AbstractDistributionService
     }
   }
 
-  @Reference(name = "workspace")
+  @Reference
   @Override
   public void setWorkspace(Workspace workspace) {
     super.setWorkspace(workspace);
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
   }
 
-  @Reference(name = "security-service")
+  @Reference
   @Override
   public void setSecurityService(SecurityService securityService) {
     super.setSecurityService(securityService);
   }
 
-  @Reference(name = "user-directory")
+  @Reference
   @Override
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     super.setUserDirectoryService(userDirectoryService);
   }
 
-  @Reference(name = "orgDirectory")
+  @Reference
   @Override
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     super.setOrganizationDirectoryService(organizationDirectoryService);

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/PresignedUrlMediaPackageSerializer.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/PresignedUrlMediaPackageSerializer.java
@@ -54,7 +54,7 @@ public class PresignedUrlMediaPackageSerializer implements MediaPackageSerialize
     logger.info("Init PresignedUrlMediaPackageSerializer");
   }
 
-  @Reference(name = "distributionService")
+  @Reference
   public void setService(AwsS3DistributionService service) {
     this.service = service;
   }

--- a/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/endpoint/AwsS3DistributionRestService.java
+++ b/modules/distribution-service-aws-s3/src/main/java/org/opencastproject/distribution/aws/s3/endpoint/AwsS3DistributionRestService.java
@@ -116,7 +116,7 @@ public class AwsS3DistributionRestService extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -125,10 +125,7 @@ public class AwsS3DistributionRestService extends AbstractJobProducerEndpoint {
    * @param service
    *          the service to set
    */
-  @Reference(
-      name = "distributionService",
-      target = "(distribution.channel=aws.s3)"
-  )
+  @Reference(target = "(distribution.channel=aws.s3)")
   public void setService(AwsS3DistributionService service) {
     this.service = service;
   }

--- a/modules/distribution-service-download-remote/src/main/java/org/opencastproject/distribution/download/remote/DownloadDistributionServiceRemoteImpl.java
+++ b/modules/distribution-service-download-remote/src/main/java/org/opencastproject/distribution/download/remote/DownloadDistributionServiceRemoteImpl.java
@@ -186,13 +186,13 @@ public class DownloadDistributionServiceRemoteImpl extends RemoteBase
         elementIds.size(), mediaPackage.getIdentifier().toString()));
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
+++ b/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/DownloadDistributionServiceImpl.java
@@ -888,37 +888,37 @@ public class DownloadDistributionServiceImpl extends AbstractDistributionService
     });
   }
 
-  @Reference(name = "WORKSPACE")
+  @Reference
   @Override
   public void setWorkspace(Workspace workspace) {
     super.setWorkspace(workspace);
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
   }
 
-  @Reference(name = "security-service")
+  @Reference
   @Override
   public void setSecurityService(SecurityService securityService) {
     super.setSecurityService(securityService);
   }
 
-  @Reference(name = "user-directory")
+  @Reference
   @Override
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     super.setUserDirectoryService(userDirectoryService);
   }
 
-  @Reference(name = "orgDirectory")
+  @Reference
   @Override
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     super.setOrganizationDirectoryService(organizationDirectoryService);
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);

--- a/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/endpoint/DownloadDistributionRestService.java
+++ b/modules/distribution-service-download/src/main/java/org/opencastproject/distribution/download/endpoint/DownloadDistributionRestService.java
@@ -104,7 +104,7 @@ public class DownloadDistributionRestService extends AbstractJobProducerEndpoint
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -113,10 +113,7 @@ public class DownloadDistributionRestService extends AbstractJobProducerEndpoint
    * @param service
    *          the service to set
    */
-  @Reference(
-      name = "distributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   public void setService(DownloadDistributionService service) {
     this.service = service;
   }

--- a/modules/distribution-service-streaming-remote/src/main/java/org/opencastproject/distribution/streaming/remote/StreamingDistributionServiceRemoteImpl.java
+++ b/modules/distribution-service-streaming-remote/src/main/java/org/opencastproject/distribution/streaming/remote/StreamingDistributionServiceRemoteImpl.java
@@ -197,12 +197,12 @@ public class StreamingDistributionServiceRemoteImpl extends RemoteBase implement
         elementIds.size(), mediaPackage.getIdentifier().toString()));
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
+++ b/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/WowzaStreamingDistributionService.java
@@ -1137,31 +1137,31 @@ public class WowzaStreamingDistributionService extends AbstractDistributionServi
     return distributionDirectory;
   }
 
-  @Reference(name = "WORKSPACE")
+  @Reference
   @Override
   public void setWorkspace(Workspace workspace) {
     super.setWorkspace(workspace);
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
   }
 
-  @Reference(name = "security-service")
+  @Reference
   @Override
   public void setSecurityService(SecurityService securityService) {
     super.setSecurityService(securityService);
   }
 
-  @Reference(name = "user-directory")
+  @Reference
   @Override
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     super.setUserDirectoryService(userDirectoryService);
   }
 
-  @Reference(name = "orgDirectory")
+  @Reference
   @Override
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     super.setOrganizationDirectoryService(organizationDirectoryService);

--- a/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/endpoint/WowzaStreamingDistributionRestService.java
+++ b/modules/distribution-service-streaming-wowza/src/main/java/org/opencastproject/distribution/streaming/wowza/endpoint/WowzaStreamingDistributionRestService.java
@@ -120,7 +120,7 @@ public class WowzaStreamingDistributionRestService extends AbstractJobProducerEn
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -129,7 +129,7 @@ public class WowzaStreamingDistributionRestService extends AbstractJobProducerEn
    * @param service
    *          the service to set
    */
-  @Reference(name = "distributionService")
+  @Reference
   public void setService(StreamingDistributionService service) {
     this.service = service;
   }

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurableAWSS3PublishWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurableAWSS3PublishWorkflowOperationHandler.java
@@ -45,24 +45,18 @@ import org.osgi.service.component.annotations.Reference;
 public class ConfigurableAWSS3PublishWorkflowOperationHandler extends ConfigurablePublishWorkflowOperationHandler {
 
   /** OSGi DI */
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=aws.s3)"
-  )
+  @Reference(target = "(distribution.channel=aws.s3)")
   void setDownloadDistributionService(DownloadDistributionService distributionService) {
     super.setDownloadDistributionService(distributionService);
   }
 
-  @Reference(
-      name = "StreamingDistributionService",
-      target = "(distribution.channel=streaming)"
-  )
+  @Reference(target = "(distribution.channel=streaming)")
   void setStreamingDistributionService(StreamingDistributionService streamingDistributionService) {
     super.setStreamingDistributionService(streamingDistributionService);
   }
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   protected void setSecurityService(SecurityService securityService) {
     super.setSecurityService(securityService);
   }

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurableAWSS3RetractWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurableAWSS3RetractWorkflowOperationHandler.java
@@ -43,10 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 public class ConfigurableAWSS3RetractWorkflowOperationHandler extends ConfigurableRetractWorkflowOperationHandler {
 
   /** OSGi DI */
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=aws.s3)"
-  )
+  @Reference(target = "(distribution.channel=aws.s3)")
   void setDownloadDistributionService(DownloadDistributionService distributionService) {
     super.setDownloadDistributionService(distributionService);
   }

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurablePublishWorkflowOperationHandler.java
@@ -130,24 +130,18 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
   static final boolean RETRACT_STREAMING_DEFAULT = false;
 
   /** OSGi DI */
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   void setDownloadDistributionService(DownloadDistributionService distributionService) {
     this.downloadDistributionService = distributionService;
   }
 
-  @Reference(
-      name = "StreamingDistributionService",
-      target = "(distribution.channel=streaming)"
-  )
+  @Reference(target = "(distribution.channel=streaming)")
   void setStreamingDistributionService(StreamingDistributionService streamingDistributionService) {
     this.streamingDistributionService = streamingDistributionService;
   }
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   protected void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -459,7 +453,7 @@ public class ConfigurablePublishWorkflowOperationHandler extends ConfigurableWor
     throw new WorkflowOperationException("There is already a Published Media, fail Stragy for Mediapackage ");
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurableRetractWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/ConfigurableRetractWorkflowOperationHandler.java
@@ -63,18 +63,12 @@ public class ConfigurableRetractWorkflowOperationHandler extends ConfigurableWor
   private StreamingDistributionService streamingDistributionService;
 
   /** OSGi DI */
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   void setDownloadDistributionService(DownloadDistributionService distributionService) {
     this.downloadDistributionService = distributionService;
   }
 
-  @Reference(
-      name = "StreamingDistributionService",
-      target = "(distribution.channel=streaming)"
-  )
+  @Reference(target = "(distribution.channel=streaming)")
   void setStreamingDistributionService(StreamingDistributionService distributionService) {
     this.streamingDistributionService = distributionService;
   }
@@ -116,7 +110,7 @@ public class ConfigurableRetractWorkflowOperationHandler extends ConfigurableWor
     return createResult(mp, Action.CONTINUE);
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PartialRetractEngageAWSS3WorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PartialRetractEngageAWSS3WorkflowOperationHandler.java
@@ -49,10 +49,7 @@ public class PartialRetractEngageAWSS3WorkflowOperationHandler extends PartialRe
    * @param downloadDistributionService
    *          the download distribution service
    */
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   public void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     super.setDownloadDistributionService(downloadDistributionService);
   }
@@ -64,7 +61,7 @@ public class PartialRetractEngageAWSS3WorkflowOperationHandler extends PartialRe
    * @param searchService
    *          an instance of the search service
    */
-  @Reference(name = "SearchService")
+  @Reference
   public void setSearchService(SearchService searchService) {
     super.setSearchService(searchService);
   }

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PartialRetractEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PartialRetractEngageWorkflowOperationHandler.java
@@ -225,31 +225,25 @@ public class PartialRetractEngageWorkflowOperationHandler extends RetractEngageW
     return hasTitle && hasTracks;
   }
 
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   @Override
   public void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     super.setDownloadDistributionService(downloadDistributionService);
   }
 
-  @Reference(name = "SearchService")
+  @Reference
   @Override
   public void setSearchService(SearchService searchService) {
     super.setSearchService(searchService);
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
   }
 
-  @Reference(
-      name = "StreamingDistributionService",
-      target = "(distribution.channel=streaming)"
-  )
+  @Reference(target = "(distribution.channel=streaming)")
   @Override
   public void setStreamingDistributionService(StreamingDistributionService streamingDistributionService) {
     super.setStreamingDistributionService(streamingDistributionService);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageAWSS3WorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageAWSS3WorkflowOperationHandler.java
@@ -52,10 +52,7 @@ public class PublishEngageAWSS3WorkflowOperationHandler extends PublishEngageWor
    * @param downloadDistributionService
    *          the download distribution service
    */
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=aws.s3)"
-  )
+  @Reference(target = "(distribution.channel=aws.s3)")
   protected void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     super.setDownloadDistributionService(downloadDistributionService);
   }
@@ -67,12 +64,12 @@ public class PublishEngageAWSS3WorkflowOperationHandler extends PublishEngageWor
    * @param searchService
    *          an instance of the search service
    */
-  @Reference(name = "SearchService")
+  @Reference
   protected void setSearchService(SearchService searchService) {
     super.setSearchService(searchService);
   }
 
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     super.setOrganizationDirectoryService(organizationDirectoryService);
   }

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandler.java
@@ -154,10 +154,7 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param streamingDistributionService
    *          the streaming distribution service
    */
-  @Reference(
-      name = "StreamingDistributionService",
-      target = "(distribution.channel=streaming)"
-  )
+  @Reference(target = "(distribution.channel=streaming)")
   protected void setStreamingDistributionService(StreamingDistributionService streamingDistributionService) {
     this.streamingDistributionService = streamingDistributionService;
   }
@@ -168,10 +165,7 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param downloadDistributionService
    *          the download distribution service
    */
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   protected void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     this.downloadDistributionService = downloadDistributionService;
   }
@@ -183,17 +177,17 @@ public class PublishEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param searchService
    *          an instance of the search service
    */
-  @Reference(name = "SearchService")
+  @Reference
   protected void setSearchService(SearchService searchService) {
     this.searchService = searchService;
   }
 
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishOaiPmhWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishOaiPmhWorkflowOperationHandler.java
@@ -105,7 +105,7 @@ public class PublishOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param publicationService
    *          the publication service
    */
-  @Reference(name = "PublicationService")
+  @Reference
   public void setPublicationService(OaiPmhPublicationService publicationService) {
     this.publicationService = publicationService;
   }
@@ -116,15 +116,12 @@ public class PublishOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param streamingDistributionService
    *          the streaming distribution service
    */
-  @Reference(
-      name = "StreamingDistributionService",
-      target = "(distribution.channel=streaming)"
-  )
+  @Reference(target = "(distribution.channel=streaming)")
   protected void setStreamingDistributionService(StreamingDistributionService streamingDistributionService) {
     this.streamingDistributionService = streamingDistributionService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishYouTubeWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PublishYouTubeWorkflowOperationHandler.java
@@ -76,12 +76,12 @@ public class PublishYouTubeWorkflowOperationHandler extends AbstractWorkflowOper
    * @param publicationService
    *          the publication service
    */
-  @Reference(name = "PublicationService")
+  @Reference
   public void setPublicationService(YouTubePublicationService publicationService) {
     this.publicationService = publicationService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RepublishOaiPmhWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RepublishOaiPmhWorkflowOperationHandler.java
@@ -119,12 +119,12 @@ public final class RepublishOaiPmhWorkflowOperationHandler extends AbstractWorkf
   }
 
   /** OSGI DI */
-  @Reference(name = "oaiPmhPublicationService")
+  @Reference
   public void setOaiPmhPublicationService(OaiPmhPublicationService oaiPmhPublicationService) {
     this.oaiPmhPublicationService = oaiPmhPublicationService;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageAWSS3WorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageAWSS3WorkflowOperationHandler.java
@@ -52,10 +52,7 @@ public class RetractEngageAWSS3WorkflowOperationHandler extends RetractEngageWor
    * @param downloadDistributionService
    *          the download distribution service
    */
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=aws.s3)"
-  )
+  @Reference(target = "(distribution.channel=aws.s3)")
   protected void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     super.setDownloadDistributionService(downloadDistributionService);
   }
@@ -67,7 +64,7 @@ public class RetractEngageAWSS3WorkflowOperationHandler extends RetractEngageWor
    * @param searchService
    *          an instance of the search service
    */
-  @Reference(name = "SearchService")
+  @Reference
   protected void setSearchService(SearchService searchService) {
     super.setSearchService(searchService);
   }

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractEngageWorkflowOperationHandler.java
@@ -85,10 +85,7 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param streamingDistributionService
    *          the streaming distribution service
    */
-  @Reference(
-      name = "StreamingDistributionService",
-      target = "(distribution.channel=streaming)"
-  )
+  @Reference(target = "(distribution.channel=streaming)")
   protected void setStreamingDistributionService(StreamingDistributionService streamingDistributionService) {
     this.streamingDistributionService = streamingDistributionService;
   }
@@ -100,10 +97,7 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    *          the download distribution service
    */
 
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   protected void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     this.downloadDistributionService = downloadDistributionService;
   }
@@ -116,12 +110,12 @@ public class RetractEngageWorkflowOperationHandler extends AbstractWorkflowOpera
    *          an instance of the search service
    */
 
-  @Reference(name = "SearchService")
+  @Reference
   protected void setSearchService(SearchService searchService) {
     this.searchService = searchService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override  public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
   }

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractOaiPmhWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractOaiPmhWorkflowOperationHandler.java
@@ -70,7 +70,7 @@ public class RetractOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param publicationService
    *          the publication service
    */
-  @Reference(name = "PublicationService")
+  @Reference
   public void setPublicationService(OaiPmhPublicationService publicationService) {
     this.publicationService = publicationService;
   }
@@ -129,7 +129,7 @@ public class RetractOaiPmhWorkflowOperationHandler extends AbstractWorkflowOpera
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractYouTubeWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/RetractYouTubeWorkflowOperationHandler.java
@@ -67,12 +67,12 @@ public class RetractYouTubeWorkflowOperationHandler extends AbstractWorkflowOper
    * @param publicationService
    *          the publication service
    */
-  @Reference(name = "PublicationService")
+  @Reference
   public void setPublicationService(YouTubePublicationService publicationService) {
     this.publicationService = publicationService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalogService.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreCatalogService.java
@@ -68,7 +68,7 @@ public class DublinCoreCatalogService implements CatalogService<DublinCoreCatalo
 
   protected Workspace workspace = null;
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImpl.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImpl.java
@@ -107,13 +107,12 @@ public class StaticMetadataServiceDublinCoreImpl implements StaticMetadataServic
 
   protected MediaPackageSerializer serializer = null;
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
   @Reference(
-      name = "serailizer",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetMediaPackageSerializer"

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
@@ -201,7 +201,7 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
    * @param ws
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   void setWorkspace(Workspace ws) {
     this.workspace = ws;
   }
@@ -213,7 +213,6 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
    *          the template scanner service
    */
   @Reference(
-      name = "EmailTemplateScanner",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetEmailTemplateScanner"
@@ -238,7 +237,7 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
    * @param incidentService
    *          the incident service
    */
-  @Reference(name = "IncidentService")
+  @Reference
   public void setIncidentService(IncidentService incidentService) {
     this.incidentService = incidentService;
   }

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/EventCommentServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/EventCommentServiceImpl.java
@@ -48,7 +48,7 @@ public class EventCommentServiceImpl implements EventCommentService {
    * @param eventCommentDatabaseService
    *          the event comment database service
    */
-  @Reference(name = "eventCommentDatabaseService")
+  @Reference
   public void setEventCommentDatabaseService(EventCommentDatabaseService eventCommentDatabaseService) {
     this.eventCommentDatabaseService = eventCommentDatabaseService;
   }

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -111,10 +111,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
   }
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.event.comment)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.event.comment)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
     this.env = PersistenceEnvs.mk(emf);
@@ -126,7 +123,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
    * @param securityService
    *          The security service
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -137,7 +134,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
    * @param userDirectoryService
    *          the user directory service
    */
-  @Reference(name = "userDirectory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -148,7 +145,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
    * @param organizationDirectoryService
    *          the organization directory service
    */
-  @Reference(name = "organization-directory-service")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
@@ -159,7 +156,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
    * @param index
    *          the API index.
    */
-  @Reference(name = "elasticsearch-index")
+  @Reference
   public void setIndex(ElasticsearchIndex index) {
     this.index = index;
   }

--- a/modules/execute-impl/src/main/java/org/opencastproject/execute/impl/ExecuteServiceImpl.java
+++ b/modules/execute-impl/src/main/java/org/opencastproject/execute/impl/ExecuteServiceImpl.java
@@ -571,7 +571,7 @@ public class ExecuteServiceImpl extends AbstractJobProducer implements ExecuteSe
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -602,7 +602,7 @@ public class ExecuteServiceImpl extends AbstractJobProducer implements ExecuteSe
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -613,7 +613,7 @@ public class ExecuteServiceImpl extends AbstractJobProducer implements ExecuteSe
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -644,7 +644,7 @@ public class ExecuteServiceImpl extends AbstractJobProducer implements ExecuteSe
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }
@@ -654,7 +654,7 @@ public class ExecuteServiceImpl extends AbstractJobProducer implements ExecuteSe
    *
    * @param workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/execute-impl/src/main/java/org/opencastproject/execute/impl/endpoint/ExecuteRestEndpoint.java
+++ b/modules/execute-impl/src/main/java/org/opencastproject/execute/impl/endpoint/ExecuteRestEndpoint.java
@@ -165,7 +165,7 @@ public class ExecuteRestEndpoint extends AbstractJobProducerEndpoint {
    *
    * @param service
    */
-  @Reference(name = "execute")
+  @Reference
   public void setExecuteService(ExecuteService service) {
     this.service = service;
   }
@@ -205,7 +205,7 @@ public class ExecuteRestEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/execute-remote/src/main/java/org/opencastproject/execute/remote/ExecuteServiceRemoteImpl.java
+++ b/modules/execute-remote/src/main/java/org/opencastproject/execute/remote/ExecuteServiceRemoteImpl.java
@@ -160,13 +160,13 @@ public class ExecuteServiceRemoteImpl extends RemoteBase implements ExecuteServi
     }
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteManyWorkflowOperationHandler.java
+++ b/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteManyWorkflowOperationHandler.java
@@ -372,7 +372,7 @@ public class ExecuteManyWorkflowOperationHandler extends AbstractWorkflowOperati
    *
    * @param service
    */
-  @Reference(name = "execute")
+  @Reference
   public void setExecuteService(ExecuteService service) {
     executeService = service;
   }
@@ -382,7 +382,7 @@ public class ExecuteManyWorkflowOperationHandler extends AbstractWorkflowOperati
    *
    * @param workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -393,12 +393,12 @@ public class ExecuteManyWorkflowOperationHandler extends AbstractWorkflowOperati
    * @param mediaInspectionService
    *          an instance of the media inspection service
    */
-  @Reference(name = "inspection-service")
+  @Reference
   protected void setMediaInspectionService(MediaInspectionService mediaInspectionService) {
     inspectionService = mediaInspectionService;
   }
 
-  @Reference(name = "registry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandler.java
+++ b/modules/execute-workflowoperation/src/main/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandler.java
@@ -291,7 +291,7 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
    * 
    * @param service
    */
-  @Reference(name = "execute")
+  @Reference
   public void setExecuteService(ExecuteService service) {
     this.executeService = service;
   }
@@ -301,7 +301,7 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
    * 
    * @param workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -312,12 +312,12 @@ public class ExecuteOnceWorkflowOperationHandler extends AbstractWorkflowOperati
    * @param mediaInspectionService
    *          an instance of the media inspection service
    */
-  @Reference(name = "inspection-service")
+  @Reference
   protected void setMediaInspectionService(MediaInspectionService mediaInspectionService) {
     this.inspectionService = mediaInspectionService;
   }
 
-  @Reference(name = "registry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
@@ -101,7 +101,7 @@ public class BaseEndpoint {
   private SecurityService securityService;
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
@@ -89,7 +89,7 @@ public class CaptureAgentsEndpoint {
   }
 
   /** OSGi DI */
-  @Reference(name = "agentStateService")
+  @Reference
   public void setAgentStateService(CaptureAgentStateService agentStateService) {
     this.agentStateService = agentStateService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -239,31 +239,31 @@ public class EventsEndpoint implements ManagedService {
   private CaptureAgentStateService agentStateService;
 
   /** OSGi DI */
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   void setElasticsearchIndex(ElasticsearchIndex elasticsearchIndex) {
     this.elasticsearchIndex = elasticsearchIndex;
   }
 
   /** OSGi DI */
-  @Reference(name = "IndexService")
+  @Reference
   public void setIndexService(IndexService indexService) {
     this.indexService = indexService;
   }
 
   /** OSGi DI */
-  @Reference(name = "IngestService")
+  @Reference
   public void setIngestService(IngestService ingestService) {
     this.ingestService = ingestService;
   }
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi DI */
-  @Reference(name = "UrlSigningService")
+  @Reference
   public void setUrlSigningService(UrlSigningService urlSigningService) {
     this.urlSigningService = urlSigningService;
   }
@@ -276,20 +276,19 @@ public class EventsEndpoint implements ManagedService {
     return schedulerService;
   }
 
-  @Reference(name = "SchedulerService")
+  @Reference
   public void setSchedulerService(SchedulerService schedulerService) {
     this.schedulerService = schedulerService;
   }
 
   /** OSGi DI. */
-  @Reference(name = "CommonEventCatalogUIAdapter")
+  @Reference
   public void setCommonEventCatalogUIAdapter(CommonEventCatalogUIAdapter eventCatalogUIAdapter) {
     this.eventCatalogUIAdapter = eventCatalogUIAdapter;
   }
 
   /** OSGi DI. */
   @Reference(
-      name = "EventCatalogUIAdapter",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeCatalogUIAdapter"
@@ -309,7 +308,7 @@ public class EventsEndpoint implements ManagedService {
   }
 
   /** OSGi DI */
-  @Reference(name = "agentStateService")
+  @Reference
   public void setAgentStateService(CaptureAgentStateService agentStateService) {
     this.agentStateService = agentStateService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -115,19 +115,19 @@ public class GroupsEndpoint {
   private SecurityService securityService;
 
   /** OSGi DI */
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   void setElasticsearchIndex(ElasticsearchIndex elasticsearchIndex) {
     this.elasticsearchIndex = elasticsearchIndex;
   }
 
   /** OSGi DI. */
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi DI */
-  @Reference(name = "groupRoleProvider")
+  @Reference
   public void setGroupRoleProvider(JpaGroupRoleProvider jpaGroupRoleProvider) {
     this.jpaGroupRoleProvider = jpaGroupRoleProvider;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
@@ -94,7 +94,7 @@ public class SecurityEndpoint implements ManagedService {
   private UrlSigningService urlSigningService;
 
   /** OSGi DI */
-  @Reference(name = "UrlSigningService")
+  @Reference
   void setUrlSigningService(UrlSigningService urlSigningService) {
     this.urlSigningService = urlSigningService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -158,25 +158,25 @@ public class SeriesEndpoint {
   private SeriesService seriesService;
 
   /** OSGi DI */
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   void setElasticsearchIndex(ElasticsearchIndex elasticsearchIndex) {
     this.elasticsearchIndex = elasticsearchIndex;
   }
 
   /** OSGi DI */
-  @Reference(name = "IndexService")
+  @Reference
   void setIndexService(IndexService indexService) {
     this.indexService = indexService;
   }
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi DI */
-  @Reference(name = "SeriesService")
+  @Reference
   void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
@@ -107,27 +107,27 @@ public class StatisticsEndpoint {
   private StatisticsService statisticsService;
   private StatisticsExportService statisticsExportService;
 
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "IndexService")
+  @Reference
   public void setIndexService(IndexService indexService) {
     this.indexService = indexService;
   }
 
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   public void setElasticsearchIndex(ElasticsearchIndex elasticsearchIndex) {
     this.elasticsearchIndex = elasticsearchIndex;
   }
 
-  @Reference(name = "StatisticsService")
+  @Reference
   public void setStatisticsService(StatisticsService statisticsService) {
     this.statisticsService = statisticsService;
   }
 
-  @Reference(name = "StatisticsExportCSV")
+  @Reference
   public void setStatisticsExportService(StatisticsExportService statisticsExportService) {
     this.statisticsExportService = statisticsExportService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
@@ -115,7 +115,7 @@ public class WorkflowDefinitionsEndpoint {
   /**
    * OSGi DI
    */
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService workflowService) {
     this.workflowService = workflowService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
@@ -131,19 +131,19 @@ public class WorkflowsEndpoint {
   private IndexService indexService;
 
   /** OSGi DI */
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService workflowService) {
     this.workflowService = workflowService;
   }
 
   /** OSGi DI */
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   public void setElasticsearchIndex(ElasticsearchIndex elasticsearchIndex) {
     this.elasticsearchIndex = elasticsearchIndex;
   }
 
   /** OSGi DI */
-  @Reference(name = "IndexService")
+  @Reference
   public void setIndexService(IndexService indexService) {
     this.indexService = indexService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalApiRoleProvider.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalApiRoleProvider.java
@@ -78,7 +78,7 @@ public class ExternalApiRoleProvider implements RoleProvider {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalGroupLoader.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalGroupLoader.java
@@ -86,7 +86,7 @@ public class ExternalGroupLoader {
    * @param groupRoleProvider
    *          the groupRoleProvider to set
    */
-  @Reference(name = "groupRoleProvider")
+  @Reference
   public void setGroupRoleProvider(JpaGroupRoleProvider groupRoleProvider) {
     this.groupRoleProvider = groupRoleProvider;
   }
@@ -95,12 +95,12 @@ public class ExternalGroupLoader {
    * @param organizationDirectoryService
    *          the organizationDirectoryService to set
    */
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/fileupload/src/main/java/org/opencastproject/fileupload/rest/FileUploadRestService.java
+++ b/modules/fileupload/src/main/java/org/opencastproject/fileupload/rest/FileUploadRestService.java
@@ -107,7 +107,6 @@ public class FileUploadRestService {
 
   // <editor-fold defaultstate="collapsed" desc="OSGi Service Stuff" >
   @Reference(
-      name = "fileupload-service",
       unbind = "unsetFileUploadService"
   )
   protected void setFileUploadService(FileUploadService service) {

--- a/modules/fileupload/src/main/java/org/opencastproject/fileupload/service/FileUploadServiceImpl.java
+++ b/modules/fileupload/src/main/java/org/opencastproject/fileupload/service/FileUploadServiceImpl.java
@@ -153,12 +153,12 @@ public class FileUploadServiceImpl implements FileUploadService, ManagedService 
     logger.info("Configuration updated. Jobs older than {} hours are deleted.", jobMaxTTL);
   }
 
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ingest-service")
+  @Reference
   protected void setIngestService(IngestService ingestService) {
     this.ingestService = ingestService;
   }

--- a/modules/hello-world-impl/src/main/java/org/opencastproject/helloworld/impl/endpoint/HelloWorldRestEndpoint.java
+++ b/modules/hello-world-impl/src/main/java/org/opencastproject/helloworld/impl/endpoint/HelloWorldRestEndpoint.java
@@ -153,7 +153,7 @@ public class HelloWorldRestEndpoint {
     return docs;
   }
 
-  @Reference(name = "helloworld-service")
+  @Reference
   public void setHelloWorldService(HelloWorldService service) {
     this.helloWorldService = service;
   }

--- a/modules/incident-workflowoperation/src/main/java/org/opencastproject/workflow/handler/incident/IncidentCreatorWorkflowOperationHandler.java
+++ b/modules/incident-workflowoperation/src/main/java/org/opencastproject/workflow/handler/incident/IncidentCreatorWorkflowOperationHandler.java
@@ -97,12 +97,12 @@ public class IncidentCreatorWorkflowOperationHandler extends AbstractWorkflowOpe
   }
 
   /** OSGi DI. */
-  @Reference(name = "nopService")
+  @Reference
   public void setNopService(NopService nopService) {
     this.nopService = nopService;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
@@ -207,19 +207,19 @@ public class CatalogUIAdapterFactory implements ManagedServiceFactory {
   }
 
   /** OSGi callback to bind {@link ListProvidersService} instance. */
-  @Reference(name = "listProvidersService")
+  @Reference
   void setListProvidersService(ListProvidersService listProvidersService) {
     this.listProvidersService = listProvidersService;
   }
 
   /** OSGi callback to bind {@link SeriesService} instance. */
-  @Reference(name = "seriesService")
+  @Reference
   void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
 
   /** OSGi callback to bind {@link Workspace} instance. */
-  @Reference(name = "workspace")
+  @Reference
   void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -238,7 +238,7 @@ public class IndexServiceImpl implements IndexService {
    * @param aclServiceFactory
    *          the factory to set
    */
-  @Reference(name = "AclServiceFactory")
+  @Reference
   public void setAclServiceFactory(AclServiceFactory aclServiceFactory) {
     this.aclServiceFactory = aclServiceFactory;
   }
@@ -249,7 +249,7 @@ public class IndexServiceImpl implements IndexService {
    * @param authorizationService
    *          the service to set
    */
-  @Reference(name = "AuthorizationService")
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -260,7 +260,7 @@ public class IndexServiceImpl implements IndexService {
    * @param captureAgentStateService
    *          the service to set
    */
-  @Reference(name = "CaptureAgentStateService")
+  @Reference
   public void setCaptureAgentStateService(CaptureAgentStateService captureAgentStateService) {
     this.captureAgentStateService = captureAgentStateService;
   }
@@ -271,7 +271,7 @@ public class IndexServiceImpl implements IndexService {
    * @param eventCommentService
    *          the service to set
    */
-  @Reference(name = "EventCommentService")
+  @Reference
   public void setEventCommentService(EventCommentService eventCommentService) {
     this.eventCommentService = eventCommentService;
   }
@@ -334,7 +334,7 @@ public class IndexServiceImpl implements IndexService {
    * @param ingestService
    *          the service to set
    */
-  @Reference(name = "IngestService")
+  @Reference
   public void setIngestService(IngestService ingestService) {
     this.ingestService = ingestService;
   }
@@ -345,7 +345,7 @@ public class IndexServiceImpl implements IndexService {
    * @param listProvidersService
    *          the service to set
    */
-  @Reference(name = "ListProvidersService")
+  @Reference
   public void setListProvidersService(ListProvidersService listProvidersService) {
     this.listProvidersService = listProvidersService;
   }
@@ -356,7 +356,7 @@ public class IndexServiceImpl implements IndexService {
    * @param assetManager
    *          the manager to set
    */
-  @Reference(name = "AssetManager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -367,7 +367,7 @@ public class IndexServiceImpl implements IndexService {
    * @param schedulerService
    *          the service to set
    */
-  @Reference(name = "SchedulerService")
+  @Reference
   public void setSchedulerService(SchedulerService schedulerService) {
     this.schedulerService = schedulerService;
   }
@@ -378,7 +378,7 @@ public class IndexServiceImpl implements IndexService {
    * @param securityService
    *          the service to set
    */
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -389,7 +389,7 @@ public class IndexServiceImpl implements IndexService {
    * @param seriesService
    *          the service to set
    */
-  @Reference(name = "SeriesService")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
@@ -400,7 +400,7 @@ public class IndexServiceImpl implements IndexService {
    * @param workflowService
    *          the service to set
    */
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService workflowService) {
     this.workflowService = workflowService;
   }
@@ -411,7 +411,7 @@ public class IndexServiceImpl implements IndexService {
    * @param workspace
    *          the workspace to set
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -422,7 +422,7 @@ public class IndexServiceImpl implements IndexService {
    * @param userDirectoryService
    *          the service to set
    */
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AclListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AclListProvider.java
@@ -66,7 +66,7 @@ public class AclListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for acl services. */
-  @Reference(name = "aclServiceFactory")
+  @Reference
   public void setAclServiceFactory(AclServiceFactory aclServiceFactory) {
     this.aclServiceFactory = aclServiceFactory;
   }
@@ -76,7 +76,7 @@ public class AclListProvider implements ResourceListProvider {
    *
    * @param securityService the security service
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AgentsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/AgentsListProvider.java
@@ -63,7 +63,7 @@ public class AgentsListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for capture-agents services. */
-  @Reference(name = "captureAgentService")
+  @Reference
   public void setCaptureAgentService(CaptureAgentStateService service) {
     this.agentsService = service;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ContributorsListProvider.java
@@ -102,13 +102,13 @@ public class ContributorsListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for users services. */
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
   /** OSGi callback for the search index. */
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   public void setIndex(ElasticsearchIndex index) {
     this.searchIndex = index;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventCommentsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventCommentsListProvider.java
@@ -79,7 +79,7 @@ public class EventCommentsListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for the event comment service. */
-  @Reference(name = "EventCommentService")
+  @Reference
   public void setEventCommentService(EventCommentService eventCommentService) {
     this.eventCommentService = eventCommentService;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/EventsListProvider.java
@@ -76,7 +76,7 @@ public class EventsListProvider implements ResourceListProvider {
     logger.info("Events list provider activated!");
   }
 
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   public void setIndex(ElasticsearchIndex index) {
     this.index = index;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/GroupsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/GroupsListProvider.java
@@ -64,7 +64,7 @@ public class GroupsListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for groups services. */
-  @Reference(name = "groupProvider")
+  @Reference
   public void setGroupProvider(JpaGroupRoleProvider groupRoleProvider) {
     this.groupRoleProvider = groupRoleProvider;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/JobsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/JobsListProvider.java
@@ -109,7 +109,7 @@ public class JobsListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for the workflow service. */
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService workflowService) {
     this.workflowService = workflowService;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/SeriesListProvider.java
@@ -89,13 +89,13 @@ public class SeriesListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for series services. */
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   public void setSearchIndex(ElasticsearchIndex searchIndex) {
     this.searchIndex = searchIndex;
   }
 
   /** OSGi callback for security service */
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServersListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServersListProvider.java
@@ -172,7 +172,7 @@ public class ServersListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for the service registry. */
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServicesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ServicesListProvider.java
@@ -136,7 +136,7 @@ public class ServicesListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for the service registry. */
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ThemesListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/ThemesListProvider.java
@@ -71,13 +71,13 @@ public class ThemesListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for the search index. */
-  @Reference(name = "ElasticsearchIndex")
+  @Reference
   public void setIndex(ElasticsearchIndex index) {
     this.searchIndex = index;
   }
 
   /** OSGi callback for the security service. */
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/UsersListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/UsersListProvider.java
@@ -75,7 +75,7 @@ public class UsersListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for users services. */
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/WorkflowsListProvider.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/provider/WorkflowsListProvider.java
@@ -60,7 +60,7 @@ public class WorkflowsListProvider implements ResourceListProvider {
   }
 
   /** OSGi callback for the workflow service. */
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService workflowService) {
     this.workflowService = workflowService;
   }

--- a/modules/ingest-download-service-impl/src/main/java/org/opencastproject/ingestdownloadservice/impl/IngestDownloadServiceImpl.java
+++ b/modules/ingest-download-service-impl/src/main/java/org/opencastproject/ingestdownloadservice/impl/IngestDownloadServiceImpl.java
@@ -127,7 +127,7 @@ public class IngestDownloadServiceImpl extends AbstractJobProducer implements In
    *
    * @param workspace the workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -137,7 +137,7 @@ public class IngestDownloadServiceImpl extends AbstractJobProducer implements In
    *
    * @param serviceRegistry the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -167,7 +167,7 @@ public class IngestDownloadServiceImpl extends AbstractJobProducer implements In
    *
    * @param securityService the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -177,7 +177,7 @@ public class IngestDownloadServiceImpl extends AbstractJobProducer implements In
    *
    * @param userDirectoryService the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -207,7 +207,7 @@ public class IngestDownloadServiceImpl extends AbstractJobProducer implements In
    *
    * @param organizationDirectory the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }

--- a/modules/ingest-download-service-impl/src/main/java/org/opencastproject/ingestdownloadservice/impl/endpoint/IngestDownloadServiceEndpoint.java
+++ b/modules/ingest-download-service-impl/src/main/java/org/opencastproject/ingestdownloadservice/impl/endpoint/IngestDownloadServiceEndpoint.java
@@ -116,7 +116,7 @@ public class IngestDownloadServiceEndpoint extends AbstractJobProducerEndpoint {
   }
 
 
-  @Reference(name = "ingest-download-service")
+  @Reference
   public void setIngestDownloadService(IngestDownloadService service) {
     this.service = service;
   }
@@ -145,7 +145,7 @@ public class IngestDownloadServiceEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/ingest-download-service-remote/src/main/java/org/opencastproject/ingestdownloadservice/remote/IngestDownloadServiceRemoteImpl.java
+++ b/modules/ingest-download-service-remote/src/main/java/org/opencastproject/ingestdownloadservice/remote/IngestDownloadServiceRemoteImpl.java
@@ -116,13 +116,13 @@ public class IngestDownloadServiceRemoteImpl extends RemoteBase implements Inges
     }
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/ingest-download-service-workflowoperation/src/main/java/org/opencastproject/workflow/handler/ingest/IngestDownloadWorkflowOperationHandler.java
+++ b/modules/ingest-download-service-workflowoperation/src/main/java/org/opencastproject/workflow/handler/ingest/IngestDownloadWorkflowOperationHandler.java
@@ -79,7 +79,7 @@ public class IngestDownloadWorkflowOperationHandler extends AbstractWorkflowOper
    *      JobContext)
    */
 
-  @Reference(name = "IngestDownloadService")
+  @Reference
   public void setIngestDownloadService(IngestDownloadService ingestDownloadService) {
     this.ingestDownloadService = ingestDownloadService;
   }
@@ -121,7 +121,7 @@ public class IngestDownloadWorkflowOperationHandler extends AbstractWorkflowOper
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImpl.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImpl.java
@@ -226,13 +226,13 @@ public class MediaInspectionServiceImpl extends AbstractJobProducer implements M
     }
   }
 
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     logger.debug("setting " + workspace);
     this.workspace = workspace;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry jobManager) {
     this.serviceRegistry = jobManager;
   }
@@ -253,7 +253,7 @@ public class MediaInspectionServiceImpl extends AbstractJobProducer implements M
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -264,7 +264,7 @@ public class MediaInspectionServiceImpl extends AbstractJobProducer implements M
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -275,7 +275,7 @@ public class MediaInspectionServiceImpl extends AbstractJobProducer implements M
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/endpoints/MediaInspectionRestEndpoint.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/endpoints/MediaInspectionRestEndpoint.java
@@ -93,7 +93,7 @@ public class MediaInspectionRestEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -104,7 +104,7 @@ public class MediaInspectionRestEndpoint extends AbstractJobProducerEndpoint {
    * @param service
    *          the inspection service
    */
-  @Reference(name = "service", cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+  @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
   public void setService(MediaInspectionService service) {
     this.service = service;
   }

--- a/modules/inspection-service-remote/src/main/java/org/opencastproject/inspection/remote/MediaInspectionServiceRemoteImpl.java
+++ b/modules/inspection-service-remote/src/main/java/org/opencastproject/inspection/remote/MediaInspectionServiceRemoteImpl.java
@@ -77,7 +77,7 @@ public class MediaInspectionServiceRemoteImpl extends RemoteBase implements Medi
    * @param client
    */
   @Override
-  @Reference(name = "trustedHttpClient")
+  @Reference
   public void setTrustedHttpClient(TrustedHttpClient client) {
     super.setTrustedHttpClient(client);
   }
@@ -88,7 +88,7 @@ public class MediaInspectionServiceRemoteImpl extends RemoteBase implements Medi
    * @param remoteServiceManager
    */
   @Override
-  @Reference(name = "remoteServiceManager")
+  @Reference
   public void setRemoteServiceManager(ServiceRegistry remoteServiceManager) {
     super.setRemoteServiceManager(remoteServiceManager);
   }

--- a/modules/inspection-workflowoperation/src/main/java/org/opencastproject/workflow/handler/inspection/InspectWorkflowOperationHandler.java
+++ b/modules/inspection-workflowoperation/src/main/java/org/opencastproject/workflow/handler/inspection/InspectWorkflowOperationHandler.java
@@ -104,7 +104,7 @@ public class InspectWorkflowOperationHandler extends AbstractWorkflowOperationHa
   /** The local workspace */
   private Workspace workspace;
 
-  @Reference(name = "dc")
+  @Reference
   public void setDublincoreService(DublinCoreCatalogService dcService) {
     this.dcService = dcService;
   }
@@ -115,7 +115,7 @@ public class InspectWorkflowOperationHandler extends AbstractWorkflowOperationHa
    * @param inspectionService
    *          the inspection service
    */
-  @Reference(name = "InspectionService")
+  @Reference
   protected void setInspectionService(MediaInspectionService inspectionService) {
     this.inspectionService = inspectionService;
   }
@@ -127,7 +127,7 @@ public class InspectWorkflowOperationHandler extends AbstractWorkflowOperationHa
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -283,7 +283,7 @@ public class InspectWorkflowOperationHandler extends AbstractWorkflowOperationHa
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoLogger.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/BundleInfoLogger.java
@@ -64,10 +64,7 @@ public class BundleInfoLogger implements BundleListener {
   private String host;
 
   /** OSGi DI */
-  @Reference(
-      name = "bundleInfoDb",
-      unbind = "unsetDb"
-  )
+  @Reference(unbind = "unsetDb")
   public void setDb(BundleInfoDb db) {
     this.db = some(db);
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/OsgiBundleInfoDb.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/OsgiBundleInfoDb.java
@@ -46,10 +46,7 @@ public class OsgiBundleInfoDb extends AbstractBundleInfoDb {
   private PersistenceEnv penv;
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.kernel)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.kernel)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/OsgiBundleInfoRestEndpoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/bundleinfo/OsgiBundleInfoRestEndpoint.java
@@ -40,7 +40,7 @@ import javax.ws.rs.Path;
 public class OsgiBundleInfoRestEndpoint extends BundleInfoRestEndpoint {
   private BundleInfoDb db;
 
-  @Reference(name = "bundleInfoDb")
+  @Reference
   public void setDb(BundleInfoDb db) {
     this.db = db;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CurrentJobFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CurrentJobFilter.java
@@ -71,7 +71,7 @@ public class CurrentJobFilter implements Filter {
    * @param serviceRegistry
    *          the serviceRegistry to set
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OAuthConsumerDetailsService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OAuthConsumerDetailsService.java
@@ -80,7 +80,7 @@ public class OAuthConsumerDetailsService implements ConsumerDetailsService, User
   /**
    * OSGi DI
    */
-  @Reference(name = "userDetailsService")
+  @Reference
   public void setDelegate(UserDetailsService delegate) {
     this.delegate = delegate;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationDirectoryServiceImpl.java
@@ -114,7 +114,7 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
   private OrgCache cache;
 
   /** OSGi DI */
-  @Reference(name = "persistence")
+  @Reference
   public void setOrgPersistence(OrganizationDatabase setOrgPersistence) {
     this.persistence = setOrgPersistence;
     this.cache = new OrgCache(60000, persistence);
@@ -124,7 +124,7 @@ public class OrganizationDirectoryServiceImpl implements OrganizationDirectorySe
    * @param configAdmin
    *          the configAdmin to set
    */
-  @Reference(name = "configAdmin")
+  @Reference
   public void setConfigurationAdmin(ConfigurationAdmin configAdmin) {
     this.configAdmin = configAdmin;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationEndpoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationEndpoint.java
@@ -109,7 +109,7 @@ public class OrganizationEndpoint {
    * @param orgDirectoryService
    *          the orgDirectoryService to set
    */
-  @Reference(name = "orgDirectoryService")
+  @Reference
   public void setOrgDirectoryService(OrganizationDirectoryService orgDirectoryService) {
     this.orgDirectoryService = orgDirectoryService;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
@@ -78,7 +78,7 @@ public class OrganizationFilter implements Filter {
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectory = organizationDirectory;
   }
@@ -161,7 +161,7 @@ public class OrganizationFilter implements Filter {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
@@ -278,7 +278,7 @@ public class RemoteUserAndOrganizationFilter implements Filter {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "securityService")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -289,7 +289,7 @@ public class RemoteUserAndOrganizationFilter implements Filter {
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectory = organizationDirectory;
   }
@@ -300,7 +300,7 @@ public class RemoteUserAndOrganizationFilter implements Filter {
    * @param userDirectory
    *          the user directory
    */
-  @Reference(name = "userDirectoryService")
+  @Reference
   void setUserDirectoryService(UserDirectoryService userDirectory) {
     this.userDirectory = userDirectory;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SecurityFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SecurityFilter.java
@@ -70,7 +70,7 @@ public final class SecurityFilter implements Filter {
   private SecurityService securityService;
 
   /** OSGi DI. */
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SecurityServiceSpringImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SecurityServiceSpringImpl.java
@@ -187,7 +187,7 @@ public class SecurityServiceSpringImpl implements SecurityService {
    * @param userDirectory
    *          the user directory
    */
-  @Reference(name = "userDirectory", cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC, unbind = "removeUserDirectory")
+  @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC, unbind = "removeUserDirectory")
   void setUserDirectory(UserDirectoryService userDirectory) {
     this.userDirectory = userDirectory;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SpringSecurityConfigurationArtifactInstaller.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SpringSecurityConfigurationArtifactInstaller.java
@@ -63,7 +63,7 @@ public class SpringSecurityConfigurationArtifactInstaller implements ArtifactIns
   protected Map<String, OsgiBundleXmlApplicationContext> appContexts = null;
 
   /** OSGi DI. */
-  @Reference(name = "securityFilter")
+  @Reference
   public void setSecurityFilter(SecurityFilter securityFilter) {
     this.securityFilter = securityFilter;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedHttpClientImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/TrustedHttpClientImpl.java
@@ -217,7 +217,6 @@ public class TrustedHttpClientImpl implements TrustedHttpClient, HttpConnectionM
    *         the serviceRegistry to set
    */
   @Reference(
-      name = "serviceRegistry",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy =  ReferencePolicy.DYNAMIC,
       unbind = "unsetServiceRegistry")
@@ -241,7 +240,7 @@ public class TrustedHttpClientImpl implements TrustedHttpClient, HttpConnectionM
    * @param securityService
    *         the security service
    */
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -252,7 +251,7 @@ public class TrustedHttpClientImpl implements TrustedHttpClient, HttpConnectionM
    * @param urlSigningService
    *        The signing service to sign urls with.
    */
-  @Reference(name = "urlSigningService")
+  @Reference
   public void setUrlSigningService(UrlSigningService urlSigningService) {
     this.urlSigningService = urlSigningService;
   }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/persistence/OrganizationDatabaseImpl.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/persistence/OrganizationDatabaseImpl.java
@@ -66,7 +66,7 @@ public class OrganizationDatabaseImpl implements OrganizationDatabase {
   protected SecurityService securityService;
 
   /** OSGi DI */
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.common)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.common)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -87,7 +87,7 @@ public class OrganizationDatabaseImpl implements OrganizationDatabase {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/ListProvidersScanner.java
+++ b/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/ListProvidersScanner.java
@@ -74,7 +74,7 @@ public class ListProvidersScanner implements ArtifactInstaller {
   /** The list providers service to add the list provider to. **/
   private ListProvidersService listProvidersService;
 
-  @Reference(name = "listProvidersService")
+  @Reference
   public void setListProvidersService(ListProvidersService listProvidersService) {
     this.listProvidersService = listProvidersService;
   }

--- a/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/ListProvidersServiceImpl.java
+++ b/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/ListProvidersServiceImpl.java
@@ -94,14 +94,13 @@ public class ListProvidersServiceImpl implements ListProvidersService {
   }
 
     /** OSGi callback for security service */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi callback for provider. */
   @Reference(
-      name = "provider",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeProvider"

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -875,33 +875,32 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
   }
 
-  @Reference(name = "dublinCoreService")
+  @Reference
   public void setDublinCoreService(DublinCoreCatalogService service) {
     this.dublinCoreService = service;
   }
 
-  @Reference(name = "searchService")
+  @Reference
   public void setSearchService(SearchService service) {
     this.searchService = service;
   }
 
-  @Reference(name = "seriesService")
+  @Reference
   public void setSeriesService(SeriesService service) {
     this.seriesService = service;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry service) {
     this.serviceRegistry = service;
   }
 
-  @Reference(name = "captureAgentService")
+  @Reference
   public void setCaptureAgentService(CaptureAgentStateService service) {
     this.captureAgentService = service;
   }
 
   @Reference(
-      name = "distributionService",
       cardinality = ReferenceCardinality.AT_LEAST_ONE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetDownloadDistributionService"
@@ -919,27 +918,27 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace ws) {
     this.workspace = ws;
   }
 
-  @Reference(name = "assetManager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
 
-  @Reference(name = "authorizationService")
+  @Reference
   public void setAuthorizationService(AuthorizationService service) {
     this.authService = service;
   }
 
-  @Reference(name = "organizationService")
+  @Reference
   public void setOrganizationService(OrganizationDirectoryService service) {
     this.organizationService = service;
   }
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService service) {
     this.securityService = service;
   }

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/AssetManagerUpdateHandler.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/AssetManagerUpdateHandler.java
@@ -104,7 +104,7 @@ public class AssetManagerUpdateHandler extends UpdateHandler {
     }
   }
 
-  @Reference(name = "liveScheduleService")
+  @Reference
   @Override
   public void setLiveScheduleService(LiveScheduleService liveScheduleService) {
     super.setLiveScheduleService(liveScheduleService);

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/LiveScheduleMessageReceiver.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/LiveScheduleMessageReceiver.java
@@ -152,18 +152,17 @@ public class LiveScheduleMessageReceiver {
   }
 
   // === Set by OSGI begin
-  @Reference(name = "messageReceiver")
+  @Reference
   public void setMessageReceiver(MessageReceiver messageReceiver) {
     this.messageReceiver = messageReceiver;
   }
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   @Reference(
-      name = "updateHandler",
       cardinality = ReferenceCardinality.AT_LEAST_ONE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeUpdateHandler"

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/SchedulerUpdateHandler.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/SchedulerUpdateHandler.java
@@ -150,12 +150,12 @@ public class SchedulerUpdateHandler extends UpdateHandler {
   }
 
   // === Set by OSGI begin
-  @Reference(name = "schedulerService")
+  @Reference
   public void setSchedulerService(SchedulerService service) {
     this.schedulerService = service;
   }
 
-  @Reference(name = "liveScheduleService")
+  @Reference
   @Override
   public void setLiveScheduleService(LiveScheduleService liveScheduleService) {
     super.setLiveScheduleService(liveScheduleService);

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/endpoint/LtiServiceRestEndpoint.java
@@ -91,7 +91,7 @@ public class LtiServiceRestEndpoint {
   private LtiService service;
 
   /** OSGi DI */
-  @Reference(name = "LtiService")
+  @Reference
   public void setService(LtiService service) {
     this.service = service;
   }

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -135,62 +135,61 @@ public class LtiServiceImpl implements LtiService, ManagedService {
   private final List<EventCatalogUIAdapter> catalogUIAdapters = new ArrayList<>();
 
   /** OSGi DI */
-  @Reference(name = "authorization-service")
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
 
   /** OSGI DI */
-  @Reference(name = "series-service")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
 
   /** OSGi DI */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
 
   /** OSGi DI */
-  @Reference(name = "workflow-service")
+  @Reference
   public void setWorkflowService(WorkflowService workflowService) {
     this.workflowService = workflowService;
   }
 
   /** OSGi DI */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
   /** OSGi DI */
-  @Reference(name = "search-index")
+  @Reference
   public void setSearchIndex(ElasticsearchIndex searchIndex) {
     this.searchIndex = searchIndex;
   }
 
   /** OSGi DI */
-  @Reference(name = "IndexService")
+  @Reference
   public void setIndexService(IndexService indexService) {
     this.indexService = indexService;
   }
 
   /** OSGi DI */
-  @Reference(name = "IngestService")
+  @Reference
   public void setIngestService(IngestService ingestService) {
     this.ingestService = ingestService;
   }
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi DI. */
   @Reference(
-      name = "EventCatalogUIAdapter",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeCatalogUIAdapter"

--- a/modules/lti-service-remote/src/main/java/org/opencastproject/lti/endpoint/LtiServiceRemoteImpl.java
+++ b/modules/lti-service-remote/src/main/java/org/opencastproject/lti/endpoint/LtiServiceRemoteImpl.java
@@ -190,13 +190,13 @@ public class LtiServiceRemoteImpl extends RemoteBase implements LtiService {
     }
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/lti/src/main/java/org/opencastproject/lti/LtiServiceGuiEndpoint.java
+++ b/modules/lti/src/main/java/org/opencastproject/lti/LtiServiceGuiEndpoint.java
@@ -87,7 +87,7 @@ public class LtiServiceGuiEndpoint {
   private LtiService service;
 
   /** OSGi DI */
-  @Reference(name = "LtiService")
+  @Reference
   public void setService(LtiService service) {
     this.service = service;
   }

--- a/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/endpoint/MessageBrokerServiceEndpoint.java
+++ b/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/endpoint/MessageBrokerServiceEndpoint.java
@@ -57,12 +57,12 @@ public class MessageBrokerServiceEndpoint {
   private MessageReceiver messageReceiver;
   private MessageSender messageSender;
 
-  @Reference(name = "messageReceiver")
+  @Reference
   public void setMessageReceiver(MessageReceiver messageReceiver) {
     this.messageReceiver = messageReceiver;
   }
 
-  @Reference(name = "messageSender")
+  @Reference
   public void setMessageSender(MessageSender messageSender) {
     this.messageSender = messageSender;
   }

--- a/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageSenderImpl.java
+++ b/modules/message-broker-impl/src/main/java/org/opencastproject/message/broker/impl/MessageSenderImpl.java
@@ -110,7 +110,7 @@ public class MessageSenderImpl extends MessageBaseFacility implements MessageSen
   }
 
   /** OSGi DI callback */
-  @Reference(name = "security-service")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/metadata/src/main/java/org/opencastproject/metadata/StaticMetadataServiceMediaPackageImpl.java
+++ b/modules/metadata/src/main/java/org/opencastproject/metadata/StaticMetadataServiceMediaPackageImpl.java
@@ -71,7 +71,7 @@ public class StaticMetadataServiceMediaPackageImpl implements StaticMetadataServ
 
   protected Workspace workspace = null;
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -236,7 +236,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * @param smtpService
    *          the smtp service
    */
-  @Reference(name = "smtpservice")
+  @Reference
   void setSmtpService(SmtpService smtpService) {
     this.smtpService = smtpService;
   }
@@ -247,7 +247,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * @param service
    *          the email template service
    */
-  @Reference(name = "EmailTemplateService")
+  @Reference
   void setEmailTemplateService(EmailTemplateService service) {
     this.emailTemplateService = service;
   }
@@ -258,12 +258,12 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * @param service
    *          the user directory service
    */
-  @Reference(name = "userDirectoryService")
+  @Reference
   void setUserDirectoryService(UserDirectoryService service) {
     this.userDirectoryService = service;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/HttpNotificationWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/HttpNotificationWorkflowOperationHandler.java
@@ -246,7 +246,7 @@ public class HttpNotificationWorkflowOperationHandler extends AbstractWorkflowOp
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/MediaPackagePostOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/MediaPackagePostOperationHandler.java
@@ -77,12 +77,12 @@ public class MediaPackagePostOperationHandler extends AbstractWorkflowOperationH
   /** search service **/
   private SearchService searchService;
 
-  @Reference(name = "search-service-impl")
+  @Reference
   public void setSearchService(SearchService searchService) {
     this.searchService = searchService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/impl/OaiPmhDatabaseImpl.java
+++ b/modules/oaipmh-persistence/src/main/java/org/opencastproject/oaipmh/persistence/impl/OaiPmhDatabaseImpl.java
@@ -83,10 +83,7 @@ public class OaiPmhDatabaseImpl extends AbstractOaiPmhDatabase {
   }
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.oaipmh)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.oaipmh)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -97,7 +94,7 @@ public class OaiPmhDatabaseImpl extends AbstractOaiPmhDatabase {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -108,7 +105,7 @@ public class OaiPmhDatabaseImpl extends AbstractOaiPmhDatabase {
    * @param workspace
    *          the workspace to set
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/oaipmh-remote/src/main/java/org/opencastproject/oaipmh/server/remote/OaiPmhServerInfoRemoteImpl.java
+++ b/modules/oaipmh-remote/src/main/java/org/opencastproject/oaipmh/server/remote/OaiPmhServerInfoRemoteImpl.java
@@ -81,13 +81,13 @@ public class OaiPmhServerInfoRemoteImpl extends RemoteBase implements OaiPmhServ
     throw new RuntimeException("Cannot contact remote service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/DefaultRepository.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/DefaultRepository.java
@@ -60,7 +60,7 @@ public class DefaultRepository extends OaiPmhRepository {
           Collections.list(new MatterhornMetadataProvider(), new MatterhornInlinedMetadataProvider());
 
   /** OSGi DI */
-  @Reference(name = "persistence")
+  @Reference
   public void setPersistence(OaiPmhDatabase persistence) {
     this.persistence = persistence;
   }

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiPmhServer.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiPmhServer.java
@@ -106,7 +106,6 @@ public final class OaiPmhServer extends HttpServlet implements OaiPmhServerInfo,
 
   /** OSGi DI. */
   @Reference(
-      name = "repository",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetRepository"
@@ -119,7 +118,7 @@ public final class OaiPmhServer extends HttpServlet implements OaiPmhServerInfo,
   }
 
   /** OSGi DI. */
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OsgiOaiPmhServerInfoRestEndpoint.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OsgiOaiPmhServerInfoRestEndpoint.java
@@ -52,7 +52,7 @@ public class OsgiOaiPmhServerInfoRestEndpoint extends AbstractOaiPmhServerInfoRe
   }
 
   /** OSGi DI. */
-  @Reference(name = "oaiPmhServerInfo")
+  @Reference
   public void setOaiPmhServerInfo(OaiPmhServerInfo oaiPmhServerInfo) {
     this.oaiPmhServerInfo = oaiPmhServerInfo;
   }

--- a/modules/presets/src/main/java/org/opencastproject/presets/impl/PresetProviderImpl.java
+++ b/modules/presets/src/main/java/org/opencastproject/presets/impl/PresetProviderImpl.java
@@ -50,12 +50,12 @@ public class PresetProviderImpl implements PresetProvider {
   /** The security service to get the current user's organization */
   private SecurityService securityService;
 
-  @Reference(name = "seriesService")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
 
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/publication-service-configurable-remote/src/main/java/org/opencastproject/publication/configurable/remote/ConfigurablePublicationServiceRemoteImpl.java
+++ b/modules/publication-service-configurable-remote/src/main/java/org/opencastproject/publication/configurable/remote/ConfigurablePublicationServiceRemoteImpl.java
@@ -148,13 +148,13 @@ public class ConfigurablePublicationServiceRemoteImpl extends RemoteBase impleme
         "Unable to publish mediapackage " + mediaPackage + " using a remote publication service.");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/publication-service-configurable/src/main/java/org/opencastproject/publication/configurable/ConfigurablePublicationServiceImpl.java
+++ b/modules/publication-service-configurable/src/main/java/org/opencastproject/publication/configurable/ConfigurablePublicationServiceImpl.java
@@ -287,30 +287,27 @@ public class ConfigurablePublicationServiceImpl extends AbstractJobProducer impl
     return this.organizationDirectoryService;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(
-      name = "DownloadDistributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   public void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     this.distributionService = downloadDistributionService;
   }

--- a/modules/publication-service-configurable/src/main/java/org/opencastproject/publication/configurable/endpoint/ConfigurablePublicationRestService.java
+++ b/modules/publication-service-configurable/src/main/java/org/opencastproject/publication/configurable/endpoint/ConfigurablePublicationRestService.java
@@ -92,12 +92,12 @@ public class ConfigurablePublicationRestService extends AbstractJobProducerEndpo
   private ConfigurablePublicationService service;
   private ServiceRegistry serviceRegistry;
 
-  @Reference(name = "publicationService")
+  @Reference
   public void setService(final ConfigurablePublicationService service) {
     this.service = service;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(final ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/publication-service-oaipmh-remote/src/main/java/org/opencastproject/publication/oaipmh/remote/OaiPmhPublicationServiceRemoteImpl.java
+++ b/modules/publication-service-oaipmh-remote/src/main/java/org/opencastproject/publication/oaipmh/remote/OaiPmhPublicationServiceRemoteImpl.java
@@ -278,12 +278,12 @@ public class OaiPmhPublicationServiceRemoteImpl extends RemoteBase implements Oa
         mediaPackage.getIdentifier().toString(), repository));
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
+++ b/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/OaiPmhPublicationServiceImpl.java
@@ -1091,52 +1091,49 @@ public class OaiPmhPublicationServiceImpl extends AbstractJobProducer implements
   }
 
   /** OSGI DI */
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
   /** OSGI DI */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGI DI */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
   /** OSGI DI */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
   /** OSGI DI */
-  @Reference(
-      name = "downloadDistributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   public void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     this.downloadDistributionService = downloadDistributionService;
   }
 
   /** OSGI DI */
-  @Reference(name = "streamingDistributionService")
+  @Reference
   public void setStreamingDistributionService(StreamingDistributionService streamingDistributionService) {
     this.streamingDistributionService = streamingDistributionService;
   }
 
   /** OSGI DI */
-  @Reference(name = "oaiPmhServerInfo")
+  @Reference
   public void setOaiPmhServerInfo(OaiPmhServerInfo oaiPmhServerInfo) {
     this.oaiPmhServerInfo = oaiPmhServerInfo;
   }
 
   /** OSGI DI */
-  @Reference(name = "persistence")
+  @Reference
   public void setOaiPmhDatabase(OaiPmhDatabase oaiPmhDatabase) {
     this.oaiPmhDatabase = oaiPmhDatabase;
   }

--- a/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/endpoint/OaiPmhPublicationRestService.java
+++ b/modules/publication-service-oaipmh/src/main/java/org/opencastproject/publication/oaipmh/endpoint/OaiPmhPublicationRestService.java
@@ -105,7 +105,7 @@ public class OaiPmhPublicationRestService extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -114,7 +114,7 @@ public class OaiPmhPublicationRestService extends AbstractJobProducerEndpoint {
    * @param service
    *          the service to set
    */
-  @Reference(name = "publicationService")
+  @Reference
   public void setService(OaiPmhPublicationService service) {
     this.service = service;
   }

--- a/modules/publication-service-youtube-remote/src/main/java/org/opencastproject/publication/youtube/remote/YouTubePublicationServiceRemoteImpl.java
+++ b/modules/publication-service-youtube-remote/src/main/java/org/opencastproject/publication/youtube/remote/YouTubePublicationServiceRemoteImpl.java
@@ -111,13 +111,13 @@ public class YouTubePublicationServiceRemoteImpl extends RemoteBase implements Y
             + " using a remote youtube publication service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/YouTubeV3PublicationServiceImpl.java
@@ -415,7 +415,7 @@ public class YouTubeV3PublicationServiceImpl
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "WORKSPACE")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -426,7 +426,7 @@ public class YouTubeV3PublicationServiceImpl
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -447,7 +447,7 @@ public class YouTubeV3PublicationServiceImpl
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -458,7 +458,7 @@ public class YouTubeV3PublicationServiceImpl
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -469,7 +469,7 @@ public class YouTubeV3PublicationServiceImpl
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }

--- a/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/endpoint/YouTubePublicationRestService.java
+++ b/modules/publication-service-youtube-v3/src/main/java/org/opencastproject/publication/youtube/endpoint/YouTubePublicationRestService.java
@@ -176,7 +176,7 @@ public class YouTubePublicationRestService extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(final ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -197,7 +197,7 @@ public class YouTubePublicationRestService extends AbstractJobProducerEndpoint {
    * @param service
    *          the service to set
    */
-  @Reference(name = "publicationService")
+  @Reference
   protected void setService(final YouTubePublicationService service) {
     this.service = service;
   }

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
@@ -127,7 +127,6 @@ public class RuntimeInfo {
   private URL serverUrl;
 
   @Reference(
-      name = "userid-role-provider",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetUserIdRoleProvider"
@@ -142,12 +141,12 @@ public class RuntimeInfo {
     }
   }
 
-  @Reference(name = "security-service")
+  @Reference
   protected void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "service-registry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/endpoint/SchedulerRestService.java
@@ -189,7 +189,6 @@ public class SchedulerRestService {
    * @param service
    */
   @Reference(
-      name = "service-impl",
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetService"
   )
@@ -212,7 +211,6 @@ public class SchedulerRestService {
    * @param prolongingService
    */
   @Reference(
-      name = "prolonging-service",
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetProlongingService"
   )
@@ -235,7 +233,6 @@ public class SchedulerRestService {
    * @param agentService
    */
   @Reference(
-      name = "agentService",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetCaptureAgentStateService"
@@ -258,7 +255,7 @@ public class SchedulerRestService {
    *
    * @param workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/CaptureNowProlongingService.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/CaptureNowProlongingService.java
@@ -124,31 +124,31 @@ public class CaptureNowProlongingService implements ManagedService {
   private ComponentContext componentContext;
 
   /** Sets the scheduler service */
-  @Reference(name = "scheduler-service")
+  @Reference
   public void setSchedulerService(SchedulerService schedulerService) {
     this.schedulerService = schedulerService;
   }
 
   /** Sets the security service */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** Sets the service registry */
-  @Reference(name = "service-registry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
   /** Sets the organization directory service */
-  @Reference(name = "organization-directory-service")
+  @Reference
   public void setOrgDirectoryService(OrganizationDirectoryService orgDirectoryService) {
     this.orgDirectoryService = orgDirectoryService;
   }
 
   /** Sets the workspace */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/OldScheduledScanner.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/OldScheduledScanner.java
@@ -99,24 +99,24 @@ public class OldScheduledScanner extends AbstractBufferScanner implements Manage
    *
    * @param service
    */
-  @Reference(name = "SchedulerService")
+  @Reference
   public void setService(SchedulerService service) {
     this.service = service;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void bindServiceRegistry(ServiceRegistry serviceRegistry) {
     super.bindServiceRegistry(serviceRegistry);
   }
 
-  @Reference(name = "OrganizationDirectoryService")
+  @Reference
   @Override
   public void bindOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     super.bindOrganizationDirectoryService(organizationDirectoryService);
   }
 
-  @Reference(name = "SecurityService")
+  @Reference
   @Override
   public void bindSecurityService(SecurityService securityService) {
     super.bindSecurityService(securityService);

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -252,7 +252,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    *
    * @param messageSender
    */
-  @Reference(name = "message-broker-sender")
+  @Reference
   public void setMessageSender(MessageSender messageSender) {
     this.messageSender = messageSender;
   }
@@ -262,7 +262,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    *
    * @param persistence
    */
-  @Reference(name = "scheduler-persistence")
+  @Reference
   public void setPersistence(SchedulerServiceDatabase persistence) {
     this.persistence = persistence;
   }
@@ -272,7 +272,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    *
    * @param seriesService
    */
-  @Reference(name = "series-service")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
@@ -282,7 +282,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    *
    * @param securityService
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -292,7 +292,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    *
    * @param assetManager
    */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -302,7 +302,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    *
    * @param workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -312,7 +312,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    *
    * @param authorizationService
    */
-  @Reference(name = "authorization-service")
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -333,7 +333,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    *
    * @param orgDirectoryService
    */
-  @Reference(name = "org-directory-service")
+  @Reference
   public void setOrgDirectoryService(OrganizationDirectoryService orgDirectoryService) {
     this.orgDirectoryService = orgDirectoryService;
   }
@@ -344,14 +344,13 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    * @param index
    *          the API index.
    */
-  @Reference(name = "elasticsearch-index")
+  @Reference
   public void setIndex(ElasticsearchIndex index) {
     this.index = index;
   }
 
   /** OSGi callback to add {@link EventCatalogUIAdapter} instance. */
   @Reference(
-      name = "event-catalog-ui-adapter",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeCatalogUIAdapter"

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/persistence/SchedulerServiceDatabaseImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/persistence/SchedulerServiceDatabaseImpl.java
@@ -72,16 +72,13 @@ public class SchedulerServiceDatabaseImpl implements SchedulerServiceDatabase {
   private static final Gson gson = new Gson();
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.scheduler.impl.persistence)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.scheduler.impl.persistence)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
 
   /** OSGi DI */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
+++ b/modules/scheduler-remote/src/main/java/org/opencastproject/scheduler/remote/SchedulerServiceRemoteImpl.java
@@ -893,12 +893,12 @@ public class SchedulerServiceRemoteImpl extends RemoteBase implements SchedulerS
     return wfPropertiesString.toString();
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/search-service-feeds/src/main/java/org/opencastproject/feed/scanner/FeedRegistrationScanner.java
+++ b/modules/search-service-feeds/src/main/java/org/opencastproject/feed/scanner/FeedRegistrationScanner.java
@@ -84,13 +84,13 @@ public class FeedRegistrationScanner implements ArtifactInstaller {
   private int sumInstalledFiles = 0;
 
   /** Sets the search service */
-  @Reference(name = "search-service-impl")
+  @Reference
   public void setSearchService(SearchService searchService) {
     this.searchService = searchService;
   }
 
   /** Sets the series service */
-  @Reference(name = "series-service-impl")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/FeedServiceImpl.java
@@ -314,7 +314,6 @@ public class FeedServiceImpl {
    *          the generator
    */
   @Reference(
-      name = "feed",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeFeedGenerator"
@@ -341,15 +340,12 @@ public class FeedServiceImpl {
    * @param securityService
    *          the security service
    */
-  @Reference(name = "security")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(
-      name = "profilesReadyIndicator",
-      target = "(artifact=feed)"
-  )
+  @Reference(target = "(artifact=feed)")
   public void setProfilesReadyIndicator(ReadinessIndicator readyIndicator) {
     //Only activate service if ReadinessIndicator is registered.
   }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -695,7 +695,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
    * @param searchService
    *          the service implementation
    */
-  @Reference(name = "service-impl")
+  @Reference
   public void setSearchService(SearchServiceImpl searchService) {
     this.searchService = searchService;
   }
@@ -706,7 +706,7 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceregistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
@@ -736,7 +736,6 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
 
   /** Dynamic reference. */
   @Reference(
-      name = "staticMetadata",
       cardinality = ReferenceCardinality.AT_LEAST_ONE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetStaticMetadataService"
@@ -760,27 +759,27 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
     this.mpeg7CatalogService = mpeg7CatalogService;
   }
 
-  @Reference(name = "search-persistence")
+  @Reference
   public void setPersistence(SearchServiceDatabase persistence) {
     this.persistence = persistence;
   }
 
-  @Reference(name = "series")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "authorization")
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -791,7 +790,7 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -802,7 +801,7 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -813,7 +812,7 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectory = organizationDirectory;
   }
@@ -857,7 +856,6 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
    *          the serializer
    */
   @Reference(
-      name = "url-rewriter",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetMediaPackageSerializer"

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -88,10 +88,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
   protected SecurityService securityService;
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.search.impl.persistence)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.search.impl.persistence)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -114,7 +111,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/search-service-remote/src/main/java/org/opencastproject/search/remote/SearchServiceRemoteImpl.java
+++ b/modules/search-service-remote/src/main/java/org/opencastproject/search/remote/SearchServiceRemoteImpl.java
@@ -278,13 +278,13 @@ public class SearchServiceRemoteImpl extends RemoteBase implements SearchService
     return url.toString();
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
+++ b/modules/security-lti/src/main/java/org/opencastproject/security/lti/LtiLaunchAuthenticationHandler.java
@@ -171,7 +171,7 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
   /** LTI roles a user must have, so a JpaUserReference is created */
   private List<String> ltiRolesForUserCreation;
 
-  @Reference(name = "UserDetailsService")
+  @Reference
   public void setUserDetailsService(UserDetailsService userDetailsService) {
     this.userDetailsService = userDetailsService;
   }
@@ -182,7 +182,7 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
    * @param userReferenceProvider
    *          the user reference provider
    */
-  @Reference(name = "ReferenceProvider")
+  @Reference
   public void setUserReferenceProvider(UserReferenceProvider userReferenceProvider) {
     this.userReferenceProvider = userReferenceProvider;
   }
@@ -193,7 +193,7 @@ public class LtiLaunchAuthenticationHandler implements OAuthAuthenticationHandle
    * @param securityService
    *          the security service
    */
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/endpoint/SeriesRestService.java
@@ -211,7 +211,7 @@ public class SeriesRestService {
    *
    * @param seriesService
    */
-  @Reference(name = "service-impl")
+  @Reference
   public void setService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
@@ -221,7 +221,7 @@ public class SeriesRestService {
    *
    * @param dcService
    */
-  @Reference(name = "dc")
+  @Reference
   public void setDublinCoreService(DublinCoreCatalogService dcService) {
     this.dcService = dcService;
   }

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -130,37 +130,37 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
   private AclServiceFactory aclServiceFactory;
 
   /** OSGi callback for setting index. */
-  @Reference(name = "series-index")
+  @Reference
   public void setIndex(SeriesServiceIndex index) {
     this.index = index;
   }
 
   /** OSGi callback for setting persistance. */
-  @Reference(name = "series-persistence")
+  @Reference
   public void setPersistence(SeriesServiceDatabase persistence) {
     this.persistence = persistence;
   }
 
   /** OSGi callback for setting the security service. */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi callback for setting the organization directory service. */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrgDirectory(OrganizationDirectoryService orgDirectory) {
     this.orgDirectory = orgDirectory;
   }
 
   /** OSGi callback for setting the message sender. */
-  @Reference(name = "message-broker-sender")
+  @Reference
   public void setMessageSender(MessageSender messageSender) {
     this.messageSender = messageSender;
   }
 
   /** OSGi callbacks for setting the API index. */
-  @Reference(name = "elasticsearch-index")
+  @Reference
   public void setElasticsearchIndex(ElasticsearchIndex index) {
     this.elasticsearchIndex = index;
   }

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -97,7 +97,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
   protected SecurityService securityService;
 
   /** OSGi DI */
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.series.impl.persistence)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.series.impl.persistence)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -118,7 +118,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -129,7 +129,7 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
    * @param dcService
    *          {@link DublinCoreCatalogService} object
    */
-  @Reference(name = "dc")
+  @Reference
   public void setDublinCoreService(DublinCoreCatalogService dcService) {
     this.dcService = dcService;
   }

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/solr/SeriesServiceSolrIndex.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/solr/SeriesServiceSolrIndex.java
@@ -148,7 +148,7 @@ public class SeriesServiceSolrIndex implements SeriesServiceIndex {
    * @param dcService
    *          {@link DublinCoreCatalogService} object
    */
-  @Reference(name = "dc")
+  @Reference
   public void setDublinCoreService(DublinCoreCatalogService dcService) {
     this.dcService = dcService;
   }
@@ -159,7 +159,7 @@ public class SeriesServiceSolrIndex implements SeriesServiceIndex {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -156,7 +156,7 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
    * @param client
    */
   @Override
-  @Reference(name = "trustedHttpClient")
+  @Reference
   public void setTrustedHttpClient(TrustedHttpClient client) {
     super.setTrustedHttpClient(client);
   }
@@ -167,7 +167,7 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
    * @param remoteServiceManager
    */
   @Override
-  @Reference(name = "remoteServiceManager")
+  @Reference
   public void setRemoteServiceManager(ServiceRegistry remoteServiceManager) {
     super.setRemoteServiceManager(remoteServiceManager);
   }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/command/MaintenanceCommand.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/command/MaintenanceCommand.java
@@ -43,7 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 public class MaintenanceCommand {
   protected ServiceRegistry serviceRegistry;
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   public void setRemoteServiceManager(ServiceRegistry remoteServiceManager) {
     this.serviceRegistry = remoteServiceManager;
   }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/NopServiceImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/NopServiceImpl.java
@@ -58,25 +58,25 @@ public final class NopServiceImpl extends OsgiAbstractJobProducer implements Nop
   }
 
   @Override
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
   }
 
   @Override
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     super.setSecurityService(securityService);
   }
 
   @Override
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     super.setUserDirectoryService(userDirectoryService);
   }
 
   @Override
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     super.setOrganizationDirectoryService(organizationDirectoryService);
   }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/OsgiIncidentService.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/OsgiIncidentService.java
@@ -93,7 +93,7 @@ public class OsgiIncidentService extends AbstractIncidentService implements Bund
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -132,7 +132,7 @@ public class OsgiIncidentService extends AbstractIncidentService implements Bund
   }
 
   /** OSGi DI */
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.serviceregistry)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.serviceregistry)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -302,7 +302,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   protected float localSystemLoad = 0.0f;
 
   /** OSGi DI */
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.common)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.common)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -2448,7 +2448,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    * @param client
    *          the trusted http client
    */
-  @Reference(name = "trustedHttpClient")
+  @Reference
   void setTrustedHttpClient(TrustedHttpClient client) {
     this.client = client;
   }
@@ -2459,7 +2459,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -2470,7 +2470,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -2481,13 +2481,13 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }
 
   /** OSGi DI. */
-  @Reference(name = "incidentService", cardinality = ReferenceCardinality.OPTIONAL, policy =  ReferencePolicy.DYNAMIC, unbind = "unsetIncidentService")
+  @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy =  ReferencePolicy.DYNAMIC, unbind = "unsetIncidentService")
   public void setIncidentService(IncidentService incidentService) {
     // Manually resolve the cyclic dependency between the incident service and the service registry
     ((OsgiIncidentService) incidentService).setServiceRegistry(this);

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/IncidentServiceEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/IncidentServiceEndpoint.java
@@ -133,7 +133,7 @@ public class IncidentServiceEndpoint {
   protected String serviceUrl = "/incidents";
 
   /** OSGi callback for setting the incident service. */
-  @Reference(name = "incidentService")
+  @Reference
   public void setIncidentService(IncidentService incidentService) {
     this.svc = incidentService;
   }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/NopServiceEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/NopServiceEndpoint.java
@@ -67,13 +67,13 @@ public class NopServiceEndpoint extends OsgiAbstractJobProducerEndpoint<NopServi
     return RestUtil.R.ok(getSvc().nop());
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
   }
 
-  @Reference(name = "nopService")
+  @Reference
   public void setService(NopService nopService) {
     super.setService((NopServiceImpl)nopService);
   }

--- a/modules/silencedetection-remote/src/main/java/org/opencastproject/silencedetection/remote/SilenceDetectionServiceRemote.java
+++ b/modules/silencedetection-remote/src/main/java/org/opencastproject/silencedetection/remote/SilenceDetectionServiceRemote.java
@@ -108,13 +108,13 @@ public class SilenceDetectionServiceRemote extends RemoteBase implements Silence
             + sourceTrack.getIdentifier() + " on remote silence detection service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/smil-impl/src/main/java/org/opencastproject/smil/endpoint/SmilServiceRest.java
+++ b/modules/smil-impl/src/main/java/org/opencastproject/smil/endpoint/SmilServiceRest.java
@@ -544,7 +544,7 @@ public class SmilServiceRest {
    *
    * @param smilService {@link SmilService} to set
    */
-  @Reference(name = "smil-service")
+  @Reference
   public void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }

--- a/modules/smil-workflowoperation/src/main/java/org/opencastproject/workflow/handler/smil/CutMarksToSmilWorkflowOperationHandler.java
+++ b/modules/smil-workflowoperation/src/main/java/org/opencastproject/workflow/handler/smil/CutMarksToSmilWorkflowOperationHandler.java
@@ -104,7 +104,7 @@ public class CutMarksToSmilWorkflowOperationHandler extends AbstractWorkflowOper
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -114,7 +114,7 @@ public class CutMarksToSmilWorkflowOperationHandler extends AbstractWorkflowOper
    */
   private SmilService smilService;
 
-  @Reference(name = "smil-service")
+  @Reference
   public void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }
@@ -305,7 +305,7 @@ public class CutMarksToSmilWorkflowOperationHandler extends AbstractWorkflowOper
     return mediaFile.getAbsolutePath();
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/sox-impl/src/main/java/org/opencastproject/sox/impl/SoxServiceImpl.java
+++ b/modules/sox-impl/src/main/java/org/opencastproject/sox/impl/SoxServiceImpl.java
@@ -419,7 +419,7 @@ public class SoxServiceImpl extends AbstractJobProducer implements SoxService, M
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -430,7 +430,7 @@ public class SoxServiceImpl extends AbstractJobProducer implements SoxService, M
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -451,7 +451,7 @@ public class SoxServiceImpl extends AbstractJobProducer implements SoxService, M
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -462,7 +462,7 @@ public class SoxServiceImpl extends AbstractJobProducer implements SoxService, M
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -473,7 +473,7 @@ public class SoxServiceImpl extends AbstractJobProducer implements SoxService, M
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }

--- a/modules/sox-impl/src/main/java/org/opencastproject/sox/impl/endpoint/SoxRestService.java
+++ b/modules/sox-impl/src/main/java/org/opencastproject/sox/impl/endpoint/SoxRestService.java
@@ -105,7 +105,7 @@ public class SoxRestService extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -116,7 +116,7 @@ public class SoxRestService extends AbstractJobProducerEndpoint {
    * @param soxService
    *          the SoX service
    */
-  @Reference(name = "composerService")
+  @Reference
   public void setSoxService(SoxService soxService) {
     this.soxService = soxService;
   }

--- a/modules/sox-remote/src/main/java/org/opencastproject/sox/remote/SoxServiceRemoteImpl.java
+++ b/modules/sox-remote/src/main/java/org/opencastproject/sox/remote/SoxServiceRemoteImpl.java
@@ -131,12 +131,12 @@ public class SoxServiceRemoteImpl extends RemoteBase implements SoxService {
             + "' using a remote audio processing service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/sox-workflowoperation/src/main/java/org/opencastproject/workflow/handler/sox/AnalyzeAudioWorkflowOperationHandler.java
+++ b/modules/sox-workflowoperation/src/main/java/org/opencastproject/workflow/handler/sox/AnalyzeAudioWorkflowOperationHandler.java
@@ -94,7 +94,7 @@ public class AnalyzeAudioWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param soxService
    *          the SoX service
    */
-  @Reference(name = "SoxService")
+  @Reference
   protected void setSoxService(SoxService soxService) {
     this.soxService = soxService;
   }
@@ -105,7 +105,7 @@ public class AnalyzeAudioWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param composerService
    *          the composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -116,7 +116,7 @@ public class AnalyzeAudioWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -250,7 +250,7 @@ public class AnalyzeAudioWorkflowOperationHandler extends AbstractWorkflowOperat
     return (Track) MediaPackageElementParser.getFromXml(job.getPayload());
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/sox-workflowoperation/src/main/java/org/opencastproject/workflow/handler/sox/NormalizeAudioWorkflowOperationHandler.java
+++ b/modules/sox-workflowoperation/src/main/java/org/opencastproject/workflow/handler/sox/NormalizeAudioWorkflowOperationHandler.java
@@ -101,7 +101,7 @@ public class NormalizeAudioWorkflowOperationHandler extends AbstractWorkflowOper
    * @param soxService
    *          the SoX service
    */
-  @Reference(name = "SoxService")
+  @Reference
   protected void setSoxService(SoxService soxService) {
     this.soxService = soxService;
   }
@@ -112,7 +112,7 @@ public class NormalizeAudioWorkflowOperationHandler extends AbstractWorkflowOper
    * @param composerService
    *          the composer service
    */
-  @Reference(name = "ComposerService")
+  @Reference
   protected void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
@@ -124,12 +124,12 @@ public class NormalizeAudioWorkflowOperationHandler extends AbstractWorkflowOper
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/static-file-service-api/src/main/java/org/opencastproject/staticfiles/endpoint/StaticFileRestService.java
+++ b/modules/static-file-service-api/src/main/java/org/opencastproject/staticfiles/endpoint/StaticFileRestService.java
@@ -142,13 +142,13 @@ public class StaticFileRestService {
   protected boolean useWebserver = false;
 
   /** OSGi callback to bind service instance. */
-  @Reference(name = "UploadStaticFileService")
+  @Reference
   public void setStaticFileService(StaticFileService staticFileService) {
     this.staticFileService = staticFileService;
   }
 
   /** OSGi callback to bind service instance. */
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/static-file-service-impl/src/main/java/org/opencastproject/staticfiles/impl/StaticFileServiceImpl.java
+++ b/modules/static-file-service-impl/src/main/java/org/opencastproject/staticfiles/impl/StaticFileServiceImpl.java
@@ -147,13 +147,13 @@ public class StaticFileServiceImpl implements StaticFileService {
   }
 
   /** OSGi DI */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi DI */
-  @Reference(name = "OrganizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService directoryService) {
     orgDirectory = directoryService;
   }

--- a/modules/statistics-export-service-impl/src/main/java/org/opencastproject/statistics/export/impl/StatisticsExportServiceImpl.java
+++ b/modules/statistics-export-service-impl/src/main/java/org/opencastproject/statistics/export/impl/StatisticsExportServiceImpl.java
@@ -148,22 +148,22 @@ public class StatisticsExportServiceImpl implements StatisticsExportService, Man
     logger.info("Deactivating Statistics Service");
   }
 
-  @Reference(name = "IndexService")
+  @Reference
   public void setIndexService(IndexService indexService) {
     this.indexService = indexService;
   }
 
-  @Reference(name = "StatisticsService")
+  @Reference
   public void setStatisticsService(StatisticsService statisticsService) {
     this.statisticsService = statisticsService;
   }
 
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "AssetManager")
+  @Reference
   public void setAssetManager(final AssetManager assetManager) {
     this.assetManager = assetManager;
   }

--- a/modules/statistics-provider-influx/src/main/java/org/opencastproject/statistics/provider/influx/StatisticsProviderInfluxService.java
+++ b/modules/statistics-provider-influx/src/main/java/org/opencastproject/statistics/provider/influx/StatisticsProviderInfluxService.java
@@ -85,7 +85,7 @@ public class StatisticsProviderInfluxService implements ManagedService, Artifact
   private Map<String, StatisticsProvider> fileNameToProvider = new ConcurrentHashMap<>();
 
 
-  @Reference(name = "statistics-service")
+  @Reference
   public void setStatisticsCoordinator(StatisticsCoordinator service) {
     this.statisticsCoordinator = service;
   }

--- a/modules/statistics-provider-random/src/main/java/org/opencastproject/statistics/provider/random/StatisticsProviderRandomService.java
+++ b/modules/statistics-provider-random/src/main/java/org/opencastproject/statistics/provider/random/StatisticsProviderRandomService.java
@@ -60,7 +60,7 @@ public class StatisticsProviderRandomService implements ArtifactInstaller {
   private StatisticsCoordinator statisticsCoordinator;
   private Map<String, StatisticsProvider> fileNameToProvider = new ConcurrentHashMap<>();
 
-  @Reference(name = "statistics-service")
+  @Reference
   public void setStatisticsCoordinator(StatisticsCoordinator service) {
     this.statisticsCoordinator = service;
   }

--- a/modules/statistics-service-impl/src/main/java/org/opencastproject/statistics/endpoint/StatisticsRestService.java
+++ b/modules/statistics-service-impl/src/main/java/org/opencastproject/statistics/endpoint/StatisticsRestService.java
@@ -101,7 +101,7 @@ public class StatisticsRestService {
    *
    * @param statisticsService
    */
-  @Reference(name = "service-impl")
+  @Reference
   public void setService(StatisticsService statisticsService) {
     this.statisticsService = statisticsService;
   }

--- a/modules/statistics-service-remote/src/main/java/org/opencastproject/statistics/remote/StatisticsServiceRemoteImpl.java
+++ b/modules/statistics-service-remote/src/main/java/org/opencastproject/statistics/remote/StatisticsServiceRemoteImpl.java
@@ -265,13 +265,13 @@ public class StatisticsServiceRemoteImpl extends RemoteBase implements Statistic
     return providers;
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/statistics-writer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/statisticswriter/StatisticsWriterWorkflowOperationHandler.java
+++ b/modules/statistics-writer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/statisticswriter/StatisticsWriterWorkflowOperationHandler.java
@@ -63,19 +63,19 @@ public class StatisticsWriterWorkflowOperationHandler extends AbstractWorkflowOp
 
   private StatisticsWriter statisticsWriter;
 
-  @Reference(name = "StatisticsWriter")
+  @Reference
   public void setStatisticsWriter(StatisticsWriter statisticsWriter) {
     this.statisticsWriter = statisticsWriter;
   }
 
   private SecurityService securityService;
 
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/termination-state-aws/src/main/java/org/opencastproject/terminationstate/aws/AutoScalingTerminationStateService.java
+++ b/modules/termination-state-aws/src/main/java/org/opencastproject/terminationstate/aws/AutoScalingTerminationStateService.java
@@ -444,7 +444,7 @@ public final class AutoScalingTerminationStateService extends AbstractJobTermina
     this.scheduler = scheduler;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/termination-state-aws/src/main/java/org/opencastproject/terminationstate/endpoint/aws/AutoScalingTerminationStateRestService.java
+++ b/modules/termination-state-aws/src/main/java/org/opencastproject/terminationstate/endpoint/aws/AutoScalingTerminationStateRestService.java
@@ -168,7 +168,6 @@ public class AutoScalingTerminationStateRestService implements TerminationStateR
    @param service termination state service instance
   */
   @Reference(
-      name = "termination-state-service",
       target = "(&(vendor.name=aws)(vendor.service=autoscaling))"
   )
   public void setService(TerminationStateService service) {

--- a/modules/termination-state-impl/src/main/java/org/opencastproject/terminationstate/endpoint/impl/TerminationStateRestServiceImpl.java
+++ b/modules/termination-state-impl/src/main/java/org/opencastproject/terminationstate/endpoint/impl/TerminationStateRestServiceImpl.java
@@ -167,7 +167,6 @@ public class TerminationStateRestServiceImpl implements TerminationStateRestServ
    @param service termination state service instance
    */
   @Reference(
-      name = "termination-state-service",
       target = "(&(vendor.name=opencast)(vendor.service=basic))"
   )
   public void setService(TerminationStateService service) {

--- a/modules/termination-state-impl/src/main/java/org/opencastproject/terminationstate/impl/TerminationStateServiceImpl.java
+++ b/modules/termination-state-impl/src/main/java/org/opencastproject/terminationstate/impl/TerminationStateServiceImpl.java
@@ -185,7 +185,7 @@ public final class TerminationStateServiceImpl extends AbstractJobTerminationSta
     this.scheduler = scheduler;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/textanalyzer-impl/src/main/java/org/opencastproject/textanalyzer/impl/TextAnalyzerServiceImpl.java
+++ b/modules/textanalyzer-impl/src/main/java/org/opencastproject/textanalyzer/impl/TextAnalyzerServiceImpl.java
@@ -323,7 +323,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -344,7 +344,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
    * @param textExtractor
    *          a text extractor implementation
    */
-  @Reference(name = "textExtractor")
+  @Reference
   protected void setTextExtractor(TextExtractor textExtractor) {
     this.textExtractor = textExtractor;
   }
@@ -355,7 +355,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -377,7 +377,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
    * @param dictionaryService
    *          an instance of the dicitonary service
    */
-  @Reference(name = "dictionaryService")
+  @Reference
   protected void setDictionaryService(DictionaryService dictionaryService) {
     this.dictionaryService = dictionaryService;
   }
@@ -388,7 +388,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -399,7 +399,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -410,7 +410,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }
@@ -451,10 +451,7 @@ public class TextAnalyzerServiceImpl extends AbstractJobProducer implements Text
             serviceRegistry);
   }
 
-  @Reference(
-      name = "profilesReadyIndicator",
-      target = "(artifact=dictionary)"
-  )
+  @Reference(target = "(artifact=dictionary)")
   public void setReadinessIndicator(ReadinessIndicator readinessIndicator) {
     //Only activate service if ReadinessIndicator is registered.
   }

--- a/modules/textanalyzer-impl/src/main/java/org/opencastproject/textanalyzer/impl/endpoint/TextAnalysisRestEndpoint.java
+++ b/modules/textanalyzer-impl/src/main/java/org/opencastproject/textanalyzer/impl/endpoint/TextAnalysisRestEndpoint.java
@@ -149,7 +149,7 @@ public class TextAnalysisRestEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -160,7 +160,7 @@ public class TextAnalysisRestEndpoint extends AbstractJobProducerEndpoint {
    * @param textAnalyzer
    *          the text analyzer
    */
-  @Reference(name = "textAnalyzer")
+  @Reference
   protected void setTextAnalyzer(TextAnalyzerService textAnalyzer) {
     this.service = textAnalyzer;
   }

--- a/modules/textanalyzer-remote/src/main/java/org/opencastproject/textanalyzer/remote/TextAnalysisRemoteImpl.java
+++ b/modules/textanalyzer-remote/src/main/java/org/opencastproject/textanalyzer/remote/TextAnalysisRemoteImpl.java
@@ -91,13 +91,13 @@ public class TextAnalysisRemoteImpl extends RemoteBase implements TextAnalyzerSe
     throw new TextAnalyzerException("Unable to analyze element '" + image + "' using a remote analysis service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/textanalyzer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/textanalyzer/TextAnalysisWorkflowOperationHandler.java
+++ b/modules/textanalyzer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/textanalyzer/TextAnalysisWorkflowOperationHandler.java
@@ -138,7 +138,7 @@ public class TextAnalysisWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param analysisService
    *          the text analysis service
    */
-  @Reference(name = "TextAnalysisService")
+  @Reference
   protected void setTextAnalyzer(TextAnalyzerService analysisService) {
     this.analysisService = analysisService;
   }
@@ -150,7 +150,7 @@ public class TextAnalysisWorkflowOperationHandler extends AbstractWorkflowOperat
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -529,12 +529,12 @@ public class TextAnalysisWorkflowOperationHandler extends AbstractWorkflowOperat
    *
    * @param composerService
    */
-  @Reference(name = "Composer")
+  @Reference
   void setComposerService(ComposerService composerService) {
     this.composer = composerService;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/themes-workflowoperation/src/main/java/org/opencastproject/workflow/handler/themes/ThemeWorkflowOperationHandler.java
+++ b/modules/themes-workflowoperation/src/main/java/org/opencastproject/workflow/handler/themes/ThemeWorkflowOperationHandler.java
@@ -132,30 +132,30 @@ public class ThemeWorkflowOperationHandler extends AbstractWorkflowOperationHand
   private Workspace workspace;
 
   /** OSGi callback for the series service. */
-  @Reference(name = "SeriesService")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
 
   /** OSGi callback for the themes database service. */
-  @Reference(name = "ThemesServiceDatabase")
+  @Reference
   public void setThemesServiceDatabase(ThemesServiceDatabase themesServiceDatabase) {
     this.themesServiceDatabase = themesServiceDatabase;
   }
 
   /** OSGi callback for the static file service. */
-  @Reference(name = "StaticFileService")
+  @Reference
   public void setStaticFileService(StaticFileService staticFileService) {
     this.staticFileService = staticFileService;
   }
 
   /** OSGi callback for the workspace. */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
@@ -104,10 +104,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
   }
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.themes)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.themes)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -118,7 +115,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
    * @param securityService
    *          the security service
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -129,19 +126,19 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
    * @param userDirectoryService
    *          the user directory service
    */
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
   /** OSGi DI */
-  @Reference(name = "organization-directory-service")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
   /** OSGi DI */
-  @Reference(name = "elasticsearch-index")
+  @Reference
   public void setIndex(ElasticsearchIndex index) {
     this.index = index;
   }

--- a/modules/timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/endpoint/TimelinePreviewsRestEndpoint.java
+++ b/modules/timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/endpoint/TimelinePreviewsRestEndpoint.java
@@ -99,7 +99,7 @@ public class TimelinePreviewsRestEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -110,7 +110,7 @@ public class TimelinePreviewsRestEndpoint extends AbstractJobProducerEndpoint {
    * @param timelinePreviewsService
    *          the timeline previews service
    */
-  @Reference(name = "timelinepreviews")
+  @Reference
   protected void setTimelinePreviewsService(TimelinePreviewsService timelinePreviewsService) {
     this.service = timelinePreviewsService;
   }

--- a/modules/timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/ffmpeg/TimelinePreviewsServiceImpl.java
+++ b/modules/timelinepreviews-ffmpeg/src/main/java/org/opencastproject/timelinepreviews/ffmpeg/TimelinePreviewsServiceImpl.java
@@ -487,7 +487,7 @@ public class TimelinePreviewsServiceImpl extends AbstractJobProducer implements
    * @param workspace
    *            an instance of the workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -498,7 +498,7 @@ public class TimelinePreviewsServiceImpl extends AbstractJobProducer implements
    * @param serviceRegistry
    *            the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -519,7 +519,7 @@ public class TimelinePreviewsServiceImpl extends AbstractJobProducer implements
    * @param securityService
    *            the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -530,7 +530,7 @@ public class TimelinePreviewsServiceImpl extends AbstractJobProducer implements
    * @param userDirectoryService
    *            the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(
       UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
@@ -542,7 +542,7 @@ public class TimelinePreviewsServiceImpl extends AbstractJobProducer implements
    * @param organizationDirectory
    *            the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(
       OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;

--- a/modules/timelinepreviews-remote/src/main/java/org/opencastproject/timelinepreviews/remote/TimelinePreviewsServiceRemote.java
+++ b/modules/timelinepreviews-remote/src/main/java/org/opencastproject/timelinepreviews/remote/TimelinePreviewsServiceRemote.java
@@ -104,13 +104,13 @@ public class TimelinePreviewsServiceRemote extends RemoteBase implements Timelin
             + " using a remote service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
+++ b/modules/timelinepreviews-workflowoperation/src/main/java/org/opencastproject/workflow/handler/timelinepreviews/TimelinePreviewsWorkflowOperationHandler.java
@@ -289,17 +289,17 @@ public class TimelinePreviewsWorkflowOperationHandler extends AbstractWorkflowOp
     }
   }
 
-  @Reference(name = "TimelinePreviewsService")
+  @Reference
   public void setTimelinePreviewsService(TimelinePreviewsService timelinePreviewsService) {
     this.timelinePreviewsService = timelinePreviewsService;
   }
 
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -657,47 +657,47 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
     return PathSupport.toSafeName(jobId + "." + extension);
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace ws) {
     this.workspace = ws;
   }
 
-  @Reference(name = "workingFileRepository")
+  @Reference
   public void setWorkingFileRepository(WorkingFileRepository wfr) {
     this.wfr = wfr;
   }
 
-  @Reference(name = "database")
+  @Reference
   public void setDatabase(TranscriptionDatabase service) {
     this.database = service;
   }
 
-  @Reference(name = "assetManager")
+  @Reference
   public void setAssetManager(AssetManager service) {
     this.assetManager = service;
   }
 
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService service) {
     this.workflowService = service;
   }

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/endpoint/AmberscriptTranscriptionRestService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/endpoint/AmberscriptTranscriptionRestService.java
@@ -84,17 +84,17 @@ public class AmberscriptTranscriptionRestService extends AbstractJobProducerEndp
     logger.debug("activate()");
   }
 
-  @Reference(name = "transcriptionService")
+  @Reference
   public void setTranscriptionService(AmberscriptTranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry service) {
     this.serviceRegistry = service;
   }
 
-  @Reference(name = "workingFileRepository")
+  @Reference
   public void setWorkingFileRepository(WorkingFileRepository wfr) {
     this.wfr = wfr;
   }

--- a/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
+++ b/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
@@ -940,52 +940,52 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
     return 0;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(name = "smtpService")
+  @Reference
   public void setSmtpService(SmtpService service) {
     this.smtpService = service;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace ws) {
     this.workspace = ws;
   }
 
-  @Reference(name = "workingFileRepository")
+  @Reference
   public void setWorkingFileRepository(WorkingFileRepository wfr) {
     this.wfr = wfr;
   }
 
-  @Reference(name = "database")
+  @Reference
   public void setDatabase(TranscriptionDatabase service) {
     this.database = service;
   }
 
-  @Reference(name = "assetManager")
+  @Reference
   public void setAssetManager(AssetManager service) {
     this.assetManager = service;
   }
 
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService service) {
     this.workflowService = service;
   }

--- a/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/endpoint/GoogleSpeechTranscriptionRestService.java
+++ b/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/endpoint/GoogleSpeechTranscriptionRestService.java
@@ -90,12 +90,12 @@ public class GoogleSpeechTranscriptionRestService extends AbstractJobProducerEnd
   public void activate(ComponentContext cc) {
   }
 
-  @Reference(name = "transcriptionService")
+  @Reference
   public void setTranscriptionService(GoogleSpeechTranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry service) {
     this.serviceRegistry = service;
   }

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/IBMWatsonTranscriptionService.java
@@ -861,52 +861,52 @@ public class IBMWatsonTranscriptionService extends AbstractJobProducer implement
     return callbackAlreadyRegistered;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(name = "smtpService")
+  @Reference
   public void setSmtpService(SmtpService service) {
     this.smtpService = service;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace ws) {
     this.workspace = ws;
   }
 
-  @Reference(name = "workingFileRepository")
+  @Reference
   public void setWorkingFileRepository(WorkingFileRepository wfr) {
     this.wfr = wfr;
   }
 
-  @Reference(name = "database")
+  @Reference
   public void setDatabase(TranscriptionDatabase service) {
     this.database = service;
   }
 
-  @Reference(name = "assetManager")
+  @Reference
   public void setAssetManager(AssetManager service) {
     this.assetManager = service;
   }
 
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService service) {
     this.workflowService = service;
   }

--- a/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/endpoint/IBMWatsonTranscriptionRestService.java
+++ b/modules/transcription-service-ibm-watson-impl/src/main/java/org/opencastproject/transcription/ibmwatson/endpoint/IBMWatsonTranscriptionRestService.java
@@ -87,12 +87,12 @@ public class IBMWatsonTranscriptionRestService extends AbstractJobProducerEndpoi
   public void activate(ComponentContext cc) {
   }
 
-  @Reference(name = "transcriptionService")
+  @Reference
   public void setTranscriptionService(IBMWatsonTranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry service) {
     this.serviceRegistry = service;
   }

--- a/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionDatabaseImpl.java
+++ b/modules/transcription-service-persistence/src/main/java/org/opencastproject/transcription/persistence/TranscriptionDatabaseImpl.java
@@ -69,10 +69,7 @@ public class TranscriptionDatabaseImpl implements TranscriptionDatabase {
     logger.info("Activating persistence manager for transcription service");
   }
 
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.transcription.persistence)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.transcription.persistence)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
@@ -153,25 +153,22 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
     return createResult(mediaPackage, Action.CONTINUE);
   }
 
-  @Reference(
-      name = "TranscriptionService",
-      target = "(provider=amberscript)"
-  )
+  @Reference(target = "(provider=amberscript)")
   public void setTranscriptionService(TranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace service) {
     this.workspace = service;
   }
 
-  @Reference(name = "captionService")
+  @Reference
   public void setCaptionService(CaptionService service) {
     this.captionService = service;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
@@ -166,15 +166,12 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
     return createResult(Action.CONTINUE);
   }
 
-  @Reference(
-      name = "TranscriptionService",
-      target = "(provider=amberscript)"
-  )
+  @Reference(target = "(provider=amberscript)")
   public void setTranscriptionService(TranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
@@ -148,25 +148,22 @@ public class AttachTranscriptionOperationHandler extends AbstractWorkflowOperati
     return createResult(mediaPackage, Action.CONTINUE);
   }
 
-  @Reference(
-      name = "TranscriptionService",
-      target = "(provider=ibm.watson)"
-  )
+  @Reference(target = "(provider=ibm.watson)")
   public void setTranscriptionService(TranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace service) {
     this.workspace = service;
   }
 
-  @Reference(name = "captionService")
+  @Reference
   public void setCaptionService(CaptionService service) {
     this.captionService = service;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechAttachTranscriptionOperationHandler.java
@@ -173,25 +173,22 @@ public class GoogleSpeechAttachTranscriptionOperationHandler extends AbstractWor
     return createResult(mediaPackage, Action.CONTINUE);
   }
 
-  @Reference(
-      name = "TranscriptionService",
-      target = "(provider=google.speech)"
-  )
+  @Reference(target = "(provider=google.speech)")
   public void setTranscriptionService(TranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace service) {
     this.workspace = service;
   }
 
-  @Reference(name = "captionService")
+  @Reference
   public void setCaptionService(CaptionService service) {
     this.captionService = service;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechStartTranscriptionOperationHandler.java
@@ -192,15 +192,12 @@ public class GoogleSpeechStartTranscriptionOperationHandler extends AbstractWork
     return createResult(Action.CONTINUE);
   }
 
-  @Reference(
-      name = "TranscriptionService",
-      target = "(provider=google.speech)"
-  )
+  @Reference(target = "(provider=google.speech)")
   public void setTranscriptionService(TranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
@@ -151,15 +151,12 @@ public class StartTranscriptionOperationHandler extends AbstractWorkflowOperatio
     return createResult(Action.CONTINUE);
   }
 
-  @Reference(
-      name = "TranscriptionService",
-      target = "(provider=ibm.watson)"
-  )
+  @Reference(target = "(provider=ibm.watson)")
   public void setTranscriptionService(TranscriptionService service) {
     this.service = service;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/SigningMediaPackageSerializer.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/SigningMediaPackageSerializer.java
@@ -73,14 +73,13 @@ public class SigningMediaPackageSerializer implements MediaPackageSerializer, Ma
   }
 
   /** OSGi DI */
-  @Reference(name = "SecurityService")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi callback for UrlSigningService */
   @Reference(
-      name = "url-signing-service",
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unsetUrlSigningService"

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/GenericUrlSigningProvider.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/GenericUrlSigningProvider.java
@@ -59,7 +59,7 @@ public class GenericUrlSigningProvider extends AbstractUrlSigningProvider {
     return "Generic URL Signing Provider";
   }
 
-  @Reference(name = "security-service")
+  @Reference
   @Override
   public void setSecurityService(SecurityService securityService) {
     super.setSecurityService(securityService);

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProvider.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProvider.java
@@ -244,7 +244,7 @@ public class WowzaUrlSigningProvider extends AbstractUrlSigningProvider {
     return base64Hash;
   }
 
-  @Reference(name = "security-service")
+  @Reference
   @Override
   public void setSecurityService(SecurityService securityService) {
     super.setSecurityService(securityService);

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/service/impl/UrlSigningEndpoint.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/service/impl/UrlSigningEndpoint.java
@@ -67,7 +67,7 @@ public class UrlSigningEndpoint {
   private UrlSigningService signingService;
 
   /** OSGi DI callback */
-  @Reference(name = "urlSigningService")
+  @Reference
   void setUrlSigningService(UrlSigningService signingService) {
     this.signingService = signingService;
   }

--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/service/impl/UrlSigningServiceImpl.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/service/impl/UrlSigningServiceImpl.java
@@ -55,7 +55,6 @@ public class UrlSigningServiceImpl implements UrlSigningService {
 
   /** OSGi callback for registering {@link UrlSigningProvider} */
   @Reference(
-      name = "urlSigningProviders",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "unregisterSigningProvider"

--- a/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilter.java
+++ b/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilter.java
@@ -84,7 +84,7 @@ public class UrlSigningFilter implements Filter, ManagedService {
   private boolean strict = true;
 
   /** OSGi DI */
-  @Reference(name = "urlSigningVerifier")
+  @Reference
   public void setUrlSigningVerifier(UrlSigningVerifier urlSigningVerifier) {
     this.urlSigningVerifier = urlSigningVerifier;
   }

--- a/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/BrightspaceUserProviderFactory.java
+++ b/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/BrightspaceUserProviderFactory.java
@@ -97,7 +97,7 @@ public class BrightspaceUserProviderFactory implements ManagedServiceFactory {
   /**
    * OSGi callback for setting the organization directory service.
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrgDirectory(OrganizationDirectoryService orgDirectory) {
     this.orgDirectory = orgDirectory;
   }

--- a/modules/userdirectory-canvas/src/main/java/org/opencastproject/userdirectory/canvas/CanvasUserRoleProvider.java
+++ b/modules/userdirectory-canvas/src/main/java/org/opencastproject/userdirectory/canvas/CanvasUserRoleProvider.java
@@ -134,14 +134,14 @@ public class CanvasUserRoleProvider implements UserProvider, RoleProvider {
 
   private OrganizationDirectoryService orgDirectory;
 
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrgDirectory(OrganizationDirectoryService orgDirectory) {
     this.orgDirectory = orgDirectory;
   }
 
   private SecurityService securityService;
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
@@ -171,19 +171,19 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
   private SecurityService securityService;
 
   /** OSGi callback for setting the organization directory service. */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrgDirectory(OrganizationDirectoryService orgDirectory) {
     this.orgDirectory = orgDirectory;
   }
 
   /** OSGi callback for setting the role group service. */
-  @Reference(name = "groupRoleProvider")
+  @Reference
   public void setGroupRoleProvider(JpaGroupRoleProvider groupRoleProvider) {
     this.groupRoleProvider = groupRoleProvider;
   }
 
   /** OSGi callback for setting the security service. */
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
+++ b/modules/userdirectory-moodle/src/main/java/org/opencastproject/userdirectory/moodle/MoodleUserProviderFactory.java
@@ -157,7 +157,7 @@ public class MoodleUserProviderFactory implements ManagedServiceFactory {
   /**
    * OSGi callback for setting the organization directory service.
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrgDirectory(OrganizationDirectoryService orgDirectory) {
     this.orgDirectory = orgDirectory;
   }

--- a/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderFactory.java
+++ b/modules/userdirectory-sakai/src/main/java/org/opencastproject/userdirectory/sakai/SakaiUserProviderFactory.java
@@ -106,7 +106,7 @@ public class SakaiUserProviderFactory implements ManagedServiceFactory {
   private OrganizationDirectoryService orgDirectory;
 
   /** OSGi callback for setting the organization directory service. */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrgDirectory(OrganizationDirectoryService orgDirectory) {
     this.orgDirectory = orgDirectory;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/AdminUserAndGroupLoader.java
@@ -336,7 +336,7 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
    * @param groupRoleProvider
    *          the groupRoleProvider to set
    */
-  @Reference(name = "groupRoleProvider")
+  @Reference
   void setGroupRoleProvider(JpaGroupRoleProvider groupRoleProvider) {
     this.groupRoleProvider = groupRoleProvider;
   }
@@ -347,7 +347,7 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
    * @param userAndRoleProvider
    *          the user and role provider to set
    */
-  @Reference(name = "userAndRoleProvider")
+  @Reference
   void setUserAndRoleProvider(JpaUserAndRoleProvider userAndRoleProvider) {
     this.userAndRoleProvider = userAndRoleProvider;
   }
@@ -358,7 +358,7 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
    * @param organizationDirectoryService
    *          the organizationDirectoryService to set
    */
-  @Reference(name = "organizationDirectoryService")
+  @Reference
   void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
     this.organizationDirectoryService.addOrganizationDirectoryListener(this);
@@ -370,7 +370,7 @@ public class AdminUserAndGroupLoader implements OrganizationDirectoryListener {
    * @param securityService
    *          the security service
    */
-  @Reference(name = "security-service")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/CustomRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/CustomRoleProvider.java
@@ -88,7 +88,7 @@ public class CustomRoleProvider implements RoleProvider {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/InMemoryUserAndRoleProvider.java
@@ -375,7 +375,7 @@ public class InMemoryUserAndRoleProvider implements UserProvider, RoleProvider, 
    * @param securityService
    *          the security service
    */
-  @Reference(name = "securityService")
+  @Reference
   void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -97,7 +97,7 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
   private ComponentContext cc;
 
   /** OSGi DI */
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.common)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.common)")
   public void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -108,7 +108,7 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -117,7 +117,7 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -126,7 +126,7 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
    * @param organizationDirectoryService
    *          the organizationDirectoryService to set
    */
-  @Reference(name = "organization-directory-service")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserAndRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserAndRoleProvider.java
@@ -110,7 +110,7 @@ public class JpaUserAndRoleProvider implements UserProvider, RoleProvider {
   private CustomPasswordEncoder passwordEncoder = new CustomPasswordEncoder();
 
   /** OSGi DI */
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.common)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.common)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -119,7 +119,7 @@ public class JpaUserAndRoleProvider implements UserProvider, RoleProvider {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -128,7 +128,7 @@ public class JpaUserAndRoleProvider implements UserProvider, RoleProvider {
    * @param groupRoleProvider
    *          the groupRoleProvider to set
    */
-  @Reference(name = "groupRoleProvider")
+  @Reference
   void setGroupRoleProvider(JpaGroupRoleProvider groupRoleProvider) {
     this.groupRoleProvider = groupRoleProvider;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
@@ -108,7 +108,7 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
   protected EntityManagerFactory emf = null;
 
   /** OSGi DI */
-  @Reference(name = "entityManagerFactory", target = "(osgi.unit.name=org.opencastproject.common)")
+  @Reference(target = "(osgi.unit.name=org.opencastproject.common)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -117,7 +117,7 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -126,7 +126,7 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
    * @param groupRoleProvider
    *          the GroupRoleProvider to set
    */
-  @Reference(name = "groupRoleProvider")
+  @Reference
   public void setGroupRoleProvider(JpaGroupRoleProvider groupRoleProvider) {
     this.groupRoleProvider = groupRoleProvider;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/OrganizationRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/OrganizationRoleProvider.java
@@ -61,7 +61,7 @@ public class OrganizationRoleProvider implements RoleProvider {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/RoleEndpoint.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/RoleEndpoint.java
@@ -69,7 +69,7 @@ public class RoleEndpoint {
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }
@@ -110,7 +110,7 @@ public class RoleEndpoint {
    * @param roleDirectoryService
    *          the roleDirectoryService to set
    */
-  @Reference(name = "roleDirectoryService")
+  @Reference
   public void setRoleDirectoryService(RoleDirectoryService roleDirectoryService) {
     this.roleDirectoryService = roleDirectoryService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -176,7 +176,6 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
    *          the user provider to add
    */
   @Reference(
-      name = "userProviders",
       cardinality = ReferenceCardinality.AT_LEAST_ONE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeUserProvider"
@@ -208,7 +207,6 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
    *          the role provider to add
    */
   @Reference(
-      name = "roleProviders",
       cardinality = ReferenceCardinality.AT_LEAST_ONE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeRoleProvider"
@@ -457,7 +455,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserEndpoint.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserEndpoint.java
@@ -82,7 +82,7 @@ public class UserEndpoint {
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserIdRoleProvider.java
@@ -91,7 +91,7 @@ public class UserIdRoleProvider implements RoleProvider, ManagedService {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -102,7 +102,7 @@ public class UserIdRoleProvider implements RoleProvider, ManagedService {
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "userDirectoryService")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/GroupRoleEndpoint.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/GroupRoleEndpoint.java
@@ -100,7 +100,7 @@ public class GroupRoleEndpoint {
    * @param jpaGroupRoleProvider
    *          the jpaGroupRoleProvider to set
    */
-  @Reference(name = "JpaGroupRoleProvider")
+  @Reference
   public void setJpaGroupRoleProvider(JpaGroupRoleProvider jpaGroupRoleProvider) {
     this.jpaGroupRoleProvider = jpaGroupRoleProvider;
   }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/UserEndpoint.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/endpoint/UserEndpoint.java
@@ -116,7 +116,7 @@ public class UserEndpoint {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -125,7 +125,7 @@ public class UserEndpoint {
    * @param jpaUserAndRoleProvider
    *          the persistenceProperties to set
    */
-  @Reference(name = "JpaUserAndRoleProvider")
+  @Reference
   public void setJpaUserAndRoleProvider(JpaUserAndRoleProvider jpaUserAndRoleProvider) {
     this.jpaUserAndRoleProvider = jpaUserAndRoleProvider;
   }

--- a/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/endpoint/UserTrackingRestService.java
+++ b/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/endpoint/UserTrackingRestService.java
@@ -105,7 +105,7 @@ public class UserTrackingRestService {
    *
    * @param service
    */
-  @Reference(name = "service-impl")
+  @Reference
   public void setService(UserTrackingService service) {
     this.usertrackingService = service;
   }
@@ -116,7 +116,7 @@ public class UserTrackingRestService {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/impl/UserTrackingServiceImpl.java
+++ b/modules/usertracking-impl/src/main/java/org/opencastproject/usertracking/impl/UserTrackingServiceImpl.java
@@ -98,10 +98,7 @@ public class UserTrackingServiceImpl implements UserTrackingService, ManagedServ
   /** OSGi DI */
 
   /** OSGi DI */
-  @Reference(
-      name = "entityManagerFactory",
-      target = "(osgi.unit.name=org.opencastproject.usertracking)"
-  )
+  @Reference(target = "(osgi.unit.name=org.opencastproject.usertracking)")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/endpoint/VideoEditorServiceEndpoint.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/endpoint/VideoEditorServiceEndpoint.java
@@ -124,17 +124,17 @@ public class VideoEditorServiceEndpoint extends AbstractJobProducerEndpoint {
     return serviceRegistry;
   }
 
-  @Reference(name = "videoeditor-service")
+  @Reference
   public void setVideoEditorService(VideoEditorService videoEditorService) {
     this.videoEditorService = videoEditorService;
   }
 
-  @Reference(name = "service-registry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "smil-service")
+  @Reference
   public void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -479,37 +479,37 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
     jobload = LoadUtil.getConfiguredLoadValue(properties, JOB_LOAD_KEY, DEFAULT_JOB_LOAD, serviceRegistry);
   }
 
-  @Reference(name = "inspection-service")
+  @Reference
   public void setMediaInspectionService(MediaInspectionService inspectionService) {
     this.inspectionService = inspectionService;
   }
 
-  @Reference(name = "service-registry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "organization-directory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(name = "smil-service")
+  @Reference
   public void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }

--- a/modules/videoeditor-remote/src/main/java/org/opencastproject/videoeditor/remote/VideoEditorServiceRemote.java
+++ b/modules/videoeditor-remote/src/main/java/org/opencastproject/videoeditor/remote/VideoEditorServiceRemote.java
@@ -101,13 +101,13 @@ public class VideoEditorServiceRemote extends RemoteBase implements VideoEditorS
             + smil.getId() + " using a remote videoeditor service.");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/SilenceDetectionWorkflowOperationHandler.java
@@ -288,22 +288,22 @@ public class SilenceDetectionWorkflowOperationHandler extends AbstractWorkflowOp
     logger.info("Registering silence detection workflow operation handler");
   }
 
-  @Reference(name = "detectionService")
+  @Reference
   public void setDetectionService(SilenceDetectionService detectionService) {
     this.detetionService = detectionService;
   }
 
-  @Reference(name = "SmilService")
+  @Reference
   public void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }
 
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
+++ b/modules/videoeditor-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videoeditor/VideoEditorWorkflowOperationHandler.java
@@ -638,22 +638,22 @@ public class VideoEditorWorkflowOperationHandler extends ResumableWorkflowOperat
     return smilResponse.getSmil();
   }
 
-  @Reference(name = "smil-service")
+  @Reference
   public void setSmilService(SmilService smilService) {
     this.smilService = smilService;
   }
 
-  @Reference(name = "videoeditor-service")
+  @Reference
   public void setVideoEditorService(VideoEditorService editor) {
     videoEditorService = editor;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/videogrid-remote/src/main/java/org/opencastproject/videogrid/remote/VideoGridServiceRemoteImpl.java
+++ b/modules/videogrid-remote/src/main/java/org/opencastproject/videogrid/remote/VideoGridServiceRemoteImpl.java
@@ -103,13 +103,13 @@ public class VideoGridServiceRemoteImpl extends RemoteBase implements VideoGridS
     }
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/videogrid-service-impl/src/main/java/org/opencastproject/videogrid/endpoint/VideoGridServiceEndpoint.java
+++ b/modules/videogrid-service-impl/src/main/java/org/opencastproject/videogrid/endpoint/VideoGridServiceEndpoint.java
@@ -100,7 +100,7 @@ public class VideoGridServiceEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -111,7 +111,7 @@ public class VideoGridServiceEndpoint extends AbstractJobProducerEndpoint {
    * @param videoGridService
    *          the videoGridService
    */
-  @Reference(name = "VideoGridService")
+  @Reference
   public void setVideoGridService(VideoGridService videoGridService) {
     this.videoGridService = videoGridService;
   }

--- a/modules/videogrid-service-impl/src/main/java/org/opencastproject/videogrid/impl/VideoGridServiceImpl.java
+++ b/modules/videogrid-service-impl/src/main/java/org/opencastproject/videogrid/impl/VideoGridServiceImpl.java
@@ -295,27 +295,27 @@ public class VideoGridServiceImpl extends AbstractJobProducer implements VideoGr
     return organizationDirectoryService;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry jobManager) {
     this.serviceRegistry = jobManager;
   }
 
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "organization-directory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }

--- a/modules/videogrid-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videogrid/VideoGridWorkflowOperationHandler.java
+++ b/modules/videogrid-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videogrid/VideoGridWorkflowOperationHandler.java
@@ -137,23 +137,23 @@ public class VideoGridWorkflowOperationHandler extends AbstractWorkflowOperation
   private ComposerService composerService = null;
 
   /** Service Callbacks **/
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
-  @Reference(name = "VideoGridService")
+  @Reference
   public void setVideoGridService(VideoGridService videoGridService) {
     this.videoGridService = videoGridService;
   }
-  @Reference(name = "MediaInspectionService")
+  @Reference
   protected void setMediaInspectionService(MediaInspectionService inspectionService) {
     this.inspectionService = inspectionService;
   }
-  @Reference(name = "ComposerService")
+  @Reference
   public void setComposerService(ComposerService composerService) {
     this.composerService = composerService;
   }
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/VideoSegmenterServiceImpl.java
@@ -958,7 +958,7 @@ public class VideoSegmenterServiceImpl extends AbstractJobProducer implements
    * @param workspace
    *            an instance of the workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -981,7 +981,7 @@ public class VideoSegmenterServiceImpl extends AbstractJobProducer implements
    * @param serviceRegistry
    *            the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -1002,7 +1002,7 @@ public class VideoSegmenterServiceImpl extends AbstractJobProducer implements
    * @param securityService
    *            the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -1013,7 +1013,7 @@ public class VideoSegmenterServiceImpl extends AbstractJobProducer implements
    * @param userDirectoryService
    *            the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(
       UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
@@ -1025,7 +1025,7 @@ public class VideoSegmenterServiceImpl extends AbstractJobProducer implements
    * @param organizationDirectory
    *            the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(
       OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;

--- a/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/endpoint/VideoSegmenterRestEndpoint.java
+++ b/modules/videosegmenter-ffmpeg/src/main/java/org/opencastproject/videosegmenter/ffmpeg/endpoint/VideoSegmenterRestEndpoint.java
@@ -99,7 +99,7 @@ public class VideoSegmenterRestEndpoint extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -110,7 +110,7 @@ public class VideoSegmenterRestEndpoint extends AbstractJobProducerEndpoint {
    * @param videoSegmenter
    *          the segmenter
    */
-  @Reference(name = "segmenter")
+  @Reference
   protected void setVideoSegmenter(VideoSegmenterService videoSegmenter) {
     this.service = videoSegmenter;
   }

--- a/modules/videosegmenter-remote/src/main/java/org/opencastproject/videosegmenter/remote/VideoSegmenterRemoteImpl.java
+++ b/modules/videosegmenter-remote/src/main/java/org/opencastproject/videosegmenter/remote/VideoSegmenterRemoteImpl.java
@@ -88,13 +88,13 @@ public class VideoSegmenterRemoteImpl extends RemoteBase implements VideoSegment
     throw new VideoSegmenterException("Unable to analyze element '" + track + "' using a remote analysis service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/videosegmenter-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videosegmenter/VideoSegmenterWorkflowOperationHandler.java
+++ b/modules/videosegmenter-workflowoperation/src/main/java/org/opencastproject/workflow/handler/videosegmenter/VideoSegmenterWorkflowOperationHandler.java
@@ -176,7 +176,7 @@ public class VideoSegmenterWorkflowOperationHandler extends AbstractWorkflowOper
    * @param videosegmenter
    *          the video segmenter
    */
-  @Reference(name = "VideoSegmenterService")
+  @Reference
   protected void setVideoSegmenter(VideoSegmenterService videosegmenter) {
     this.videosegmenter = videosegmenter;
   }
@@ -188,12 +188,12 @@ public class VideoSegmenterWorkflowOperationHandler extends AbstractWorkflowOper
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/endpoint/WaveformServiceEndpoint.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/endpoint/WaveformServiceEndpoint.java
@@ -133,12 +133,12 @@ public class WaveformServiceEndpoint extends AbstractJobProducerEndpoint {
     return serviceRegistry;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "WaveformService")
+  @Reference
   public void setWaveformService(WaveformService waveformService) {
     this.waveformService = waveformService;
   }

--- a/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
+++ b/modules/waveform-ffmpeg/src/main/java/org/opencastproject/waveform/ffmpeg/WaveformServiceImpl.java
@@ -490,27 +490,27 @@ public class WaveformServiceImpl extends AbstractJobProducer implements Waveform
     return organizationDirectoryService;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
-  @Reference(name = "userDirectory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
 
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }
 
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/waveform-remote/src/main/java/org/opencastproject/waveform/remote/WaveformServiceRemote.java
+++ b/modules/waveform-remote/src/main/java/org/opencastproject/waveform/remote/WaveformServiceRemote.java
@@ -116,13 +116,13 @@ public class WaveformServiceRemote extends RemoteBase implements WaveformService
         "Unable to create waveform image from " + sourceTrack + " using a remote service");
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   @Override
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     super.setTrustedHttpClient(trustedHttpClient);
   }
 
-  @Reference(name = "remoteServiceManager")
+  @Reference
   @Override
   public void setRemoteServiceManager(ServiceRegistry serviceRegistry) {
     super.setRemoteServiceManager(serviceRegistry);

--- a/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
+++ b/modules/waveform-workflowoperation/src/main/java/org/opencastproject/workflow/handler/waveform/WaveformWorkflowOperationHandler.java
@@ -259,17 +259,17 @@ public class WaveformWorkflowOperationHandler extends AbstractWorkflowOperationH
     }
   }
 
-  @Reference(name = "WaveformService")
+  @Reference
   public void setWaveformService(WaveformService waveformService) {
     this.waveformService = waveformService;
   }
 
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
@@ -159,7 +159,7 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
    * @param serviceRegistry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -170,7 +170,7 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
    * @param service
    *          the workflow service instance
    */
-  @Reference(name = "service-impl")
+  @Reference
   public void setService(WorkflowService service) {
     this.service = service;
   }
@@ -181,7 +181,7 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowCleanupScanner.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowCleanupScanner.java
@@ -257,25 +257,25 @@ public class WorkflowCleanupScanner extends AbstractWorkflowBufferScanner implem
     }
   }
 
-  @Reference(name = "WorkflowService")
+  @Reference
   @Override
   public void bindWorkflowService(WorkflowService workflowService) {
     super.bindWorkflowService(workflowService);
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void bindServiceRegistry(ServiceRegistry serviceRegistry) {
     super.bindServiceRegistry(serviceRegistry);
   }
 
-  @Reference(name = "OrganizationDirectoryService")
+  @Reference
   @Override
   public void bindOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     super.bindOrganizationDirectoryService(organizationDirectoryService);
   }
 
-  @Reference(name = "SecurityService")
+  @Reference
   @Override
   public void bindSecurityService(SecurityService securityService) {
     super.bindSecurityService(securityService);

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
@@ -90,7 +90,7 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller {
 
   private OrganizationDirectoryService organizationDirectoryService;
 
-  @Reference(name = "index")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2005,7 +2005,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param unused
    *          the unused ReadinessIndicator
    */
-  @Reference(name = "profilesReadyIndicator", target = "(artifact=workflowdefinition)")
+  @Reference(target = "(artifact=workflowdefinition)")
   protected void setProfilesReadyIndicator(ReadinessIndicator unused) { }
 
   /**
@@ -2014,7 +2014,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -2025,7 +2025,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param registry
    *          the service registry
    */
-  @Reference(name = "serviceRegistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry registry) {
     this.serviceRegistry = registry;
   }
@@ -2040,7 +2040,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security-service")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -2051,7 +2051,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param authorizationService
    *          the authorizationService to set
    */
-  @Reference(name = "authorization")
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -2062,7 +2062,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param userDirectoryService
    *          the userDirectoryService to set
    */
-  @Reference(name = "user-directory")
+  @Reference
   public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
     this.userDirectoryService = userDirectoryService;
   }
@@ -2073,7 +2073,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param organizationDirectory
    *          the organization directory
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
     this.organizationDirectoryService = organizationDirectory;
   }
@@ -2084,7 +2084,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param index
    *          The search index
    */
-  @Reference(name = "index")
+  @Reference
   protected void setDao(WorkflowServiceIndex index) {
     this.index = index;
   }
@@ -2095,7 +2095,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param seriesService
    *          the seriesService to set
    */
-  @Reference(name = "series")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
@@ -2106,7 +2106,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param assetManager
    *          the assetManager to set
    */
-  @Reference(name = "assetManager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -2117,7 +2117,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param service
    *          the metadata service
    */
-  @Reference(name = "metadata", cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC, unbind = "removeMetadataService")
+  @Reference(cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC, unbind = "removeMetadataService")
   protected void addMetadataService(MediaPackageMetadataService service) {
     metadataServices.add(service);
   }
@@ -2138,7 +2138,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param scanner
    *          the workflow definition scanner
    */
-  @Reference(name = "scanner")
+  @Reference
   protected void addWorkflowDefinitionScanner(WorkflowDefinitionScanner scanner) {
     workflowDefinitionScanner = scanner;
   }
@@ -2149,7 +2149,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
    * @param index
    *          the admin UI index.
    */
-  @Reference(name = "elasticsearch-index")
+  @Reference
   public void setIndex(ElasticsearchIndex index) {
     this.elasticsearchIndex = index;
   }

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceSolrIndex.java
@@ -1107,7 +1107,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
    * @param registry
    *          the service registry
    */
-  @Reference(name = "serviceregistry")
+  @Reference
   protected void setServiceRegistry(ServiceRegistry registry) {
     this.serviceRegistry = registry;
   }
@@ -1118,7 +1118,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
    * @param orgDirectory
    *          the organization directory service
    */
-  @Reference(name = "orgDirectory")
+  @Reference
   protected void setOrgDirectory(OrganizationDirectoryService orgDirectory) {
     this.orgDirectory = orgDirectory;
   }
@@ -1129,7 +1129,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
    * @param authorizationService
    *          the authorizationService to set
    */
-  @Reference(name = "authorization")
+  @Reference
   protected void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -1140,7 +1140,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
    * @param securityService
    *          the securityService to set
    */
-  @Reference(name = "security")
+  @Reference
   protected void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -1151,7 +1151,7 @@ public class WorkflowServiceSolrIndex implements WorkflowServiceIndex {
    * @param assetManager
    *          the asset manager
    */
-  @Reference(name = "assetManager")
+  @Reference
   protected void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -101,7 +101,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
    * @param client
    */
   @Override
-  @Reference(name = "trustedHttpClient")
+  @Reference
   public void setTrustedHttpClient(TrustedHttpClient client) {
     super.setTrustedHttpClient(client);
   }
@@ -112,7 +112,7 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
    * @param remoteServiceManager
    */
   @Override
-  @Reference(name = "remoteServiceManager")
+  @Reference
   public void setRemoteServiceManager(ServiceRegistry remoteServiceManager) {
     this.remoteServiceManager = remoteServiceManager;
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/AddCatalogWorkflowOperationHandler.java
@@ -95,7 +95,7 @@ public class AddCatalogWorkflowOperationHandler extends AbstractWorkflowOperatio
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CleanupWorkflowOperationHandler.java
@@ -100,7 +100,7 @@ public class CleanupWorkflowOperationHandler extends AbstractWorkflowOperationHa
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -111,7 +111,7 @@ public class CleanupWorkflowOperationHandler extends AbstractWorkflowOperationHa
    * @param client
    *          the trusted http client
    */
-  @Reference(name = "trustedHttpClient")
+  @Reference
   public void setTrustedHttpClient(TrustedHttpClient client) {
     this.client = client;
   }
@@ -313,7 +313,7 @@ public class CleanupWorkflowOperationHandler extends AbstractWorkflowOperationHa
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CloneWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CloneWorkflowOperationHandler.java
@@ -89,7 +89,7 @@ public class CloneWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -204,7 +204,7 @@ public class CloneWorkflowOperationHandler extends AbstractWorkflowOperationHand
     return newElement;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConfigureByDublinCoreTermWOH.java
@@ -88,7 +88,7 @@ public class ConfigureByDublinCoreTermWOH extends ResumableWorkflowOperationHand
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CopyWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CopyWorkflowOperationHandler.java
@@ -92,7 +92,7 @@ public class CopyWorkflowOperationHandler extends AbstractWorkflowOperationHandl
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   protected void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -217,7 +217,7 @@ public class CopyWorkflowOperationHandler extends AbstractWorkflowOperationHandl
     logger.debug("Element {} copied to target {}.", sourceFile.getPath(), targetFile.getPath());
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandler.java
@@ -62,7 +62,7 @@ public class DefaultsWorkflowOperationHandler extends AbstractWorkflowOperationH
 
   private PresetProvider presetProvider;
 
-  @Reference(name = "PresetProvider")
+  @Reference
   void setPresetProvider(PresetProvider presetProvider) {
     this.presetProvider = presetProvider;
   }
@@ -127,7 +127,7 @@ public class DefaultsWorkflowOperationHandler extends AbstractWorkflowOperationH
     return createResult(workflowInstance.getMediaPackage(), properties, Action.CONTINUE, 0);
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DuplicateEventWorkflowOperationHandler.java
@@ -169,7 +169,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
    * OSGi setter
    * @param authorizationService
    */
-  @Reference(name = "authorization-service")
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -178,7 +178,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
    * OSGi setter
    * @param seriesService
    */
-  @Reference(name = "series-service")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
@@ -189,7 +189,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
    * @param assetManager
    *          the asset manager
    */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -200,7 +200,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -211,10 +211,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
    * @param distributionService
    *          the distributionService to set
    */
-  @Reference(
-      name = "distributionService",
-      target = "(distribution.channel=download)"
-  )
+  @Reference(target = "(distribution.channel=download)")
   public void setDistributionService(DistributionService distributionService) {
     this.distributionService = distributionService;
   }
@@ -577,7 +574,7 @@ public class DuplicateEventWorkflowOperationHandler extends AbstractWorkflowOper
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ErrorResolutionWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ErrorResolutionWorkflowOperationHandler.java
@@ -118,7 +118,7 @@ public class ErrorResolutionWorkflowOperationHandler extends ResumableWorkflowOp
     }
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
@@ -86,7 +86,7 @@ public class ExportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
   private Workspace workspace;
 
   /** OSGi DI */
-  @Reference(name = "Workspace")
+  @Reference
   void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/FailingWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/FailingWorkflowOperationHandler.java
@@ -57,7 +57,7 @@ public class FailingWorkflowOperationHandler extends AbstractWorkflowOperationHa
     throw new WorkflowOperationException("Test operation for failed ");
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
@@ -80,7 +80,7 @@ public class ImportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
   private Workspace workspace;
 
   /** OSGi DI */
-  @Reference(name = "Workspace")
+  @Reference
   void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/IncludeWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/IncludeWorkflowOperationHandler.java
@@ -128,12 +128,12 @@ public final class IncludeWorkflowOperationHandler extends AbstractWorkflowOpera
   /**
    * OSGi DI.
    */
-  @Reference(name = "workspace")
+  @Reference
   public void setWorkflowService(WorkflowService service) {
     this.workflowService = service;
   }
 
-  @Reference(name = "serviceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
@@ -132,7 +132,7 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
    * @param authorizationService
    *          the authorization service
    */
-  @Reference(name = "authorization")
+  @Reference
   protected void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -143,7 +143,7 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
    * @param seriesService
    *          the series service
    */
-  @Reference(name = "series")
+  @Reference
   public void setSeriesService(SeriesService seriesService) {
     this.seriesService = seriesService;
   }
@@ -154,7 +154,7 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -165,14 +165,13 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
    * @param securityService
    *          the securityService
    */
-  @Reference(name = "SecurityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
 
   /** OSGi callback to add {@link SeriesCatalogUIAdapter} instance. */
   @Reference(
-      name = "SeriesCatalogUIAdapter",
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
       unbind = "removeCatalogUIAdapter"
@@ -186,7 +185,7 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
     seriesCatalogUIAdapters.remove(catalogUIAdapter);
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandler.java
@@ -82,7 +82,7 @@ public class StartWorkflowWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param assetManager
    *          the asset manager
    */
-  @Reference(name = "asset-manager")
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -93,7 +93,7 @@ public class StartWorkflowWorkflowOperationHandler extends AbstractWorkflowOpera
    * @param workflowService
    *          the workflow service
    */
-  @Reference(name = "workflowService")
+  @Reference
   public void setWorkflowService(WorkflowService workflowService) {
     this.workflowService = workflowService;
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagByDublinCoreTermWOH.java
@@ -100,7 +100,7 @@ public class TagByDublinCoreTermWOH extends ResumableWorkflowOperationHandlerBas
    * @param workspace
    *          an instance of the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
@@ -175,7 +175,7 @@ public class TagWorkflowOperationHandler extends AbstractWorkflowOperationHandle
     return createResult(mediaPackage, Action.CONTINUE);
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TransferMetadataWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TransferMetadataWorkflowOperationHandler.java
@@ -236,7 +236,7 @@ public class TransferMetadataWorkflowOperationHandler extends AbstractWorkflowOp
   }
 
   /** OSGi callback to inject the workspace */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandler.java
@@ -130,12 +130,12 @@ public class ZipWorkflowOperationHandler extends AbstractWorkflowOperationHandle
    * @param workspace
    *          the workspace
    */
-  @Reference(name = "Workspace")
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
 
-  @Reference(name = "ServiceRegistry")
+  @Reference
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryRestEndpoint.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryRestEndpoint.java
@@ -128,13 +128,13 @@ public class WorkingFileRepositoryRestEndpoint extends WorkingFileRepositoryImpl
    * @param remoteServiceManager
    */
   @Override
-  @Reference(name = "remoteServiceManager")
+  @Reference
   public void setRemoteServiceManager(ServiceRegistry remoteServiceManager) {
     super.setRemoteServiceManager(remoteServiceManager);
   }
 
   @Override
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     super.setSecurityService(securityService);
   }

--- a/modules/working-file-repository-service-remote/src/main/java/org/opencastproject/workingfilerepository/remote/WorkingFileRepositoryRemoteImpl.java
+++ b/modules/working-file-repository-service-remote/src/main/java/org/opencastproject/workingfilerepository/remote/WorkingFileRepositoryRemoteImpl.java
@@ -79,7 +79,7 @@ public class WorkingFileRepositoryRemoteImpl extends RemoteBase implements Worki
    * @param client
    */
   @Override
-  @Reference(name = "trustedHttpClient")
+  @Reference
   public void setTrustedHttpClient(TrustedHttpClient client) {
     super.setTrustedHttpClient(client);
   }
@@ -90,7 +90,7 @@ public class WorkingFileRepositoryRemoteImpl extends RemoteBase implements Worki
    * @param remoteServiceManager
    */
   @Override
-  @Reference(name = "remoteServiceManager")
+  @Reference
   public void setRemoteServiceManager(ServiceRegistry remoteServiceManager) {
     super.setRemoteServiceManager(remoteServiceManager);
   }

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -875,7 +875,7 @@ public final class WorkspaceImpl implements Workspace {
     return wfr.getBaseUri();
   }
 
-  @Reference(name = "REPO")
+  @Reference
   public void setRepository(WorkingFileRepository repo) {
     this.wfr = repo;
     if (repo instanceof PathMappable) {
@@ -884,12 +884,12 @@ public final class WorkspaceImpl implements Workspace {
     }
   }
 
-  @Reference(name = "trustedHttpClient")
+  @Reference
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
     this.trustedHttpClient = trustedHttpClient;
   }
 
-  @Reference(name = "securityService")
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }


### PR DESCRIPTION
Follow up on PR #3255.

As mentioned by @gregorydlogan in PR #3255, some reference annotations have a custom name, and some do not.
Since a custom name has no value and removing them simplifies and unifies the codebase, this PR removes all reference names if possible.

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
