### PR TITLE
Fix Typo in Opencast 10 Upgrade Guide

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -63,11 +63,8 @@ The option affects the `org.opencastproject.userdirectory.ldap.roleattributes` a
 Opencast 9.2 came with a [completely new system for securing static file content](configuration/serving-static-files.md)
 which is now active by default in Opencast 10. If you are deferring the file access authorization to another system
 using Opencast's [security token mechanism](configuration/stream-security.md), you need to deactivate this protection
-in:
+in `etc/org.opencastproject.fsresources.StaticResourceServlet.cfg`.
 
-```
-etc/org.opencastproject.fsresources.StaticResourceServlet.cfg
-
-The [ILIAS plugin](https://github.com/fluxapps/OpenCast), for example, does not authenticate users against Opencast.     
-If you are using that plugin, this is why you probably want to disable this feature and make your media publically       
+The [ILIAS plugin](https://github.com/fluxapps/OpenCast), for example, does not authenticate users against Opencast.
+If you are using that plugin, this is why you probably want to disable this feature and make your media publically
 accessable.


### PR DESCRIPTION
This patch fixes a typo in the Opencast 10 upgrade guide which does not
close a code block.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
