### PR TITLE
Fix merge conflict

### DIFF
--- a/modules/rename-files-workflowoperation/pom.xml
+++ b/modules/rename-files-workflowoperation/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.compendium</artifactId>
+      <artifactId>osgi.cmpn</artifactId>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This patch fixes the problem of the OSGi compendium having been renamed
in newer versions. Since the rename-files operation was merged from
Opencast 10 and still used the old name, this caused a build failure.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
