### PR TITLE
Update MariaDB Driver

### DIFF
--- a/docs/guides/admin/docs/configuration/database.md
+++ b/docs/guides/admin/docs/configuration/database.md
@@ -1,11 +1,17 @@
 Database Configuration
 ======================
 
-Opencast ships with embedded JDBC drivers for the H2, MySQL, MariaDB and PostgreSQL databases.
+Opencast ships with embedded H2, MariaDB and PostgreSQL JDBC drivers.
 The built-in H2 database is used by default and needs no configuration,
 but is not suited for production.
 
-> __H2__ is not supported for updates or distributed systems. Use it for testing only!
+The MariaDB driver also supports connecting to MySQL.
+But this may need additional setting and it not part of Opencast's documentation.
+We also do not test this, and hence do not guarantee that this will work.
+
+<div class=warn>
+  __H2__ is not supported for updates or distributed systems. Use it for testing only!
+</div>
 
 
 ### Requirements
@@ -26,7 +32,6 @@ Other database engines are not tested and specific issues will likely not be add
 
 - __MariaDB__ is the recommended database engine.
   It is used by most adopters and is well tested.
-- __MySQL__ is supported but tested less than MariaDB.
 - __PostgreSQL__ support is experimental.
 - __H2__ is not suitable for anything but testing and development.
   It cannot be used in distributed environments.
@@ -123,20 +128,20 @@ Step 4: Configure Opencast
 --------------------------
 
 The following changes must be made in `etc/custom.properties`.
-Examples are provided for MariaDB/MySQL and PostgreSQL.
+Examples are provided for MariaDB and PostgreSQL.
 
 1. Configure Opencast to use the JDBC driver for MariaDB or PostgreSQL.
    The MariaDB driver will also work for MySQL.
 
-        # MariaDB/MySQL
+        # MariaDB
         org.opencastproject.db.jdbc.driver=org.mariadb.jdbc.Driver
         # PostgreSQL
         org.opencastproject.db.jdbc.driver=org.postgresql.Driver
 
 2. Configure the host where Opencast will find the database (`127.0.0.1`) and the database name (`opencast`).
 
-        # MariaDB/MySQL
-        org.opencastproject.db.jdbc.url=jdbc:mysql://127.0.0.1/opencast?useMysqlMetadata=true
+        # MariaDB
+        org.opencastproject.db.jdbc.url=jdbc:mariadb://127.0.0.1/opencast?useMysqlMetadata=true
         # PostgreSQL
         org.opencastproject.db.jdbc.url=jdbc:postgresql://127.0.0.1/opencast
 

--- a/docs/guides/admin/docs/releasenotes/dropping-mysql-support.txt
+++ b/docs/guides/admin/docs/releasenotes/dropping-mysql-support.txt
@@ -1,0 +1,9 @@
+Dropping MySQL Support
+----------------------
+
+Due to the lack of usage and thus testing, we decided to drop the official support of Opencast for MySQL databases.
+Please use MariaDB or PostegreSQL instead.
+
+This does not mean that Opencast will stop working with MySQL immediately,
+but we like to highlight that developers are not spending any time on testing this,
+nor do we provide any configuration examples or support if additional steps may be necessary.

--- a/docs/guides/admin/docs/releasenotes/mariadb-connection-configuration.txt
+++ b/docs/guides/admin/docs/releasenotes/mariadb-connection-configuration.txt
@@ -1,0 +1,9 @@
+MariaDB Connection Configuration
+--------------------------------
+
+The syntax oof the JDBC coonnection configuration for MariaDB has slightly changed to an update of the MariaDB
+Connector/J. in `etc/custom.properties`, please use `jdbc:mariadb:` instead of `jdbc:mysql:`:
+
+```properties
+org.opencastproject.db.jdbc.url=jdbc:mariadb://localhost/opencast?useMysqlMetadata=true
+```

--- a/docs/guides/developer/docs/proposal-log.md
+++ b/docs/guides/developer/docs/proposal-log.md
@@ -9,6 +9,37 @@ The following list contains a list of passed proposals for reference.
 Passed Proposals
 ----------------
 
+### Drop official MySQL support
+Proposed by Lars Kiesow <lkiesow@uos.de>, passed on Wed, February 16 2022
+
+```no-highlight
+Hi everyone,
+since I'm testing database things once again, I noticed that more and
+more our infrastructure is set-up to test with MariaDB (or now
+PostegreSQL) and no longer with MySQL. We have MySQL left in none of our
+deployments and I feel like something could break compatibility at any
+moment right now and no one would notice during a release cycle.
+
+Overall, the situation is similar to back when we decided to no longer
+officially support PostgreSQL. It technically works and should continue
+to work, but no developers actually test against it and it could easily
+break without someone noticing.
+
+
+That is why, similar to the old decision, I would like to #propose to:
+
+- officially mark MySQL it as unsupported
+- explain that it should technically work, but we do not test it
+- explain that the set-up should be similar to MariaDB but may differ
+  slightly and we have no documentation for that
+
+
+Of course, also similar to PostgreSQL, we can always decide to support
+it again later, if interest picks up and the database landscape changes.
+
+–Lars
+```
+
 ### PR and release process changes
 Proposed by Greg Logan <gregorydlogan@gmail.com>, passed on Thu, 17 Jun 2021
 

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -120,7 +120,7 @@ org.opencastproject.download.directory=${org.opencastproject.storage.dir}/downlo
 #  .url=jdbc:h2:${org.opencastproject.storage.dir}/db
 #  .user=sa
 #  .pass=sa
-#org.opencastproject.db.jdbc.url=jdbc:mysql://localhost/opencast?useMysqlMetadata=true
+#org.opencastproject.db.jdbc.url=jdbc:mariadb://localhost/opencast?useMysqlMetadata=true
 #org.opencastproject.db.jdbc.user=opencast
 #org.opencastproject.db.jdbc.pass=dbpassword
 

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -59,6 +59,7 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1282,11 +1282,6 @@
         <version>${gson.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.mariadb.jdbc</groupId>
-        <artifactId>mariadb-java-client</artifactId>
-        <version>2.7.2</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>${jackson.version}</version>


### PR DESCRIPTION
This patch updates the MariaDB driver and marks MySQL as unsupported.
The new driver requires slight changes to the JDBC connection URL.

I've tested this with MariaDB, MySQL 5 and MySQL 8. MySQL 8 requires
additional authentication configuration since it changed it's default
authentication mechanism.

This patch assumes that the proposal to drop official support for MySQL
passes and should oviously not be merged before it actually does.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
