### PR TITLE
Update PostegreSQL Driver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: maven
+  directory: /modules/db
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -49,6 +49,13 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <version>42.3.2</version>
+    </dependency>
+    <dependency>
+      <!-- runtime dependency for postgresql -->
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+      <version>3.21.2</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
@@ -69,6 +76,7 @@
             <ignoredUnusedDeclaredDependency>com.mchange:mchange-commons-java</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.mariadb.jdbc:mariadb-java-client</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.postgresql:postgresql</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.checkerframework:checker-qual</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>net.java.dev.jna:jna</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
@@ -89,6 +97,7 @@
               !org.apache.lucene.*,
               !org.hibernate.*,
               !org.jboss.resource.adapter.jdbc.*,
+              !software.amazon.awssdk.*,
               !waffle.*,
               org.w3c.dom;version=0,
               *
@@ -100,7 +109,8 @@
               mchange-commons-java;inline=true,
               mariadb-java-client;inline=true,
               jna,
-              postgresql;inline=true
+              postgresql;inline=true,
+              checker-qual;inline=true
             </Embed-Dependency>
             <Export-Package>
               org.opencastproject.db;version=${project.version}

--- a/pom.xml
+++ b/pom.xml
@@ -1287,11 +1287,6 @@
         <version>2.7.2</version>
       </dependency>
       <dependency>
-        <groupId>org.postgresql</groupId>
-        <artifactId>postgresql</artifactId>
-        <version>42.2.19.jre7</version>
-      </dependency>
-      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>${jackson.version}</version>


### PR DESCRIPTION
This patch updates the JDBC driver for PostgreSQL and enables automated
updates for the database libraries.

This also fixes CVE-2022-21724, which is nice to not have shouldn't be
of much relevance to Opencast. Hence, no need to push this to old
release branches.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
