### PR TITLE
Fix frontend-no-prebuilt profile

### DIFF
--- a/modules/admin-ui-frontend/pom.xml
+++ b/modules/admin-ui-frontend/pom.xml
@@ -44,8 +44,9 @@
                 </goals>
                 <phase>initialize</phase>
                 <configuration>
-                  <executable>node_modules/.bin/bower</executable>
+                  <executable>npx</executable>
                   <arguments>
+                    <argument>bower</argument>
                     <argument>--allow-root</argument>
                     <argument>install</argument>
                   </arguments>
@@ -56,17 +57,18 @@
                 <goals>
                   <goal>exec</goal>
                 </goals>
-                <phase>compile</phase>
+                <phase>initialize</phase>
                 <configuration>
-                  <executable>node_modules/grunt-cli/bin/grunt</executable>
+                  <executable>npx</executable>
                   <arguments>
+                    <argument>grunt</argument>
                     <argument>build</argument>
                     <argument>--skipTests=${skipTests}</argument>
                   </arguments>
                 </configuration>
               </execution>
               <execution>
-                <id>esline</id>
+                <id>eslint</id>
                 <goals>
                   <goal>exec</goal>
                 </goals>

--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -37,11 +37,11 @@
                 </configuration>
               </execution>
               <execution>
-                <id>esline</id>
+                <id>eslint</id>
                 <goals>
                   <goal>exec</goal>
                 </goals>
-                <phase>validate</phase>
+                <phase>test</phase>
                 <configuration>
                   <executable>npm</executable>
                   <arguments>
@@ -55,10 +55,11 @@
                 <goals>
                   <goal>exec</goal>
                 </goals>
-                <phase>compile</phase>
+                <phase>generate-resources</phase>
                 <configuration>
-                  <executable>node_modules/gulp/bin/gulp.js</executable>
+                  <executable>npx</executable>
                   <arguments>
+                    <argument>gulp</argument>
                     <argument>paella-opencast:build</argument>
                   </arguments>
                 </configuration>

--- a/modules/lti/pom.xml
+++ b/modules/lti/pom.xml
@@ -97,31 +97,16 @@
               </execution>
 
               <execution>
-                <id>esline</id>
+                <id>build</id>
                 <goals>
                   <goal>exec</goal>
                 </goals>
-                <phase>test</phase>
+                <phase>compile</phase>
                 <configuration>
                   <executable>npm</executable>
                   <arguments>
                     <argument>run</argument>
-                    <argument>eslint</argument>
-                  </arguments>
-                </configuration>
-              </execution>
-
-              <execution>
-                <id>html-linter</id>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <phase>test</phase>
-                <configuration>
-                  <executable>npm</executable>
-                  <arguments>
-                    <argument>run</argument>
-                    <argument>html-linter</argument>
+                    <argument>build</argument>
                   </arguments>
                 </configuration>
               </execution>


### PR DESCRIPTION
This patch fixes the frontend-no-prebuilt maven profile which can be
used to have maven run the local npm version instead of downloading one.
That has the big advantage of not having to remove any `none*` folders
when you switch versions.

To try this, run:

```
❯ mvn clean install -Pdev,frontend-no-prebuilt
```

The profile did exist for a long time but was broken due to some tasks
being executed in the wrong order like trying to copy the frontend to
the target folder before actually building it.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
