### PR TITLE
fix admin-ui endpoint crash, when a series without title exists

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1189,7 +1189,7 @@ public abstract class AbstractEventEndpoint {
 
     // Remove null keys
     Map<String, String> seriesCollection = seriesField.getCollection();
-    while (seriesCollection.remove(null) != null) { }
+    seriesCollection.remove(null);
     seriesField.setCollection(seriesCollection);
 
     return;

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1172,6 +1172,29 @@ public abstract class AbstractEventEndpoint {
     }
   }
 
+  /**
+   * Removes emtpy series titles from the collection of the isPartOf Field
+   * @param ml the list to modify
+   */
+  private void removeSeriesWithNullTitlesFromFieldCollection(MetadataList ml) {
+    // get Series MetadataField from MetadataList
+    MetadataField seriesField = Optional.ofNullable(ml.getMetadataList().get("dublincore/episode"))
+            .flatMap(titledMetadataCollection -> Optional.ofNullable(titledMetadataCollection.getCollection()))
+            .flatMap(dcMetadataCollection -> Optional.ofNullable(dcMetadataCollection.getOutputFields()))
+            .flatMap(metadataFields -> Optional.ofNullable(metadataFields.get("isPartOf")))
+            .orElse(null);
+    if (seriesField == null || seriesField.getCollection() == null) {
+      return;
+    }
+
+    // Remove null keys
+    Map<String, String> seriesCollection = seriesField.getCollection();
+    while (seriesCollection.remove(null) != null) { }
+    seriesField.setCollection(seriesCollection);
+
+    return;
+  }
+
   @GET
   @Path("{eventId}/metadata.json")
   @Produces(MediaType.APPLICATION_JSON)
@@ -1214,6 +1237,9 @@ public abstract class AbstractEventEndpoint {
     DublinCoreMetadataCollection metadataCollection = eventCatalogUiAdapter.getRawFields(getCollectionQueryOverrides());
     EventUtils.setEventMetadataValues(event, metadataCollection);
     metadataList.add(eventCatalogUiAdapter, metadataCollection);
+
+    // remove series with empty titles from the collection of the isPartOf field as these can't be converted to json
+    removeSeriesWithNullTitlesFromFieldCollection(metadataList);
 
     // lock metadata?
     final String wfState = event.getWorkflowState();
@@ -2145,6 +2171,9 @@ public abstract class AbstractEventEndpoint {
     }
 
     metadataList.add(commonCatalogUiAdapter, commonMetadata);
+
+    // remove series with empty titles from the collection of the isPartOf field as these can't be converted to json
+    removeSeriesWithNullTitlesFromFieldCollection(metadataList);
 
     return okJson(MetadataJson.listToJson(metadataList, true));
   }


### PR DESCRIPTION
The metadata tab would break, when there is a series without title (see #1374 ).
This pullrequest fixes the endpoint, that causes this behavior, by simple removing series with empty titles. Meaning the metadata tab loads again, but series with empty titles are not selectable (other series work fine).

Not sure if this should close the issue, as this only fixes a major symptom, but not the underlying problem. Empty series titles still cause small problems in other areas (e.g. attributes of series with empty titles sometimes can't be modified) and can still be created over the rest api.