### PR TITLE
Check if encoding profile exist for imageToVideo Operation

### DIFF
--- a/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
+++ b/modules/composer-ffmpeg/src/main/java/org/opencastproject/composer/impl/ComposerServiceImpl.java
@@ -996,6 +996,9 @@ public class ComposerServiceImpl extends AbstractJobProducer implements Composer
           MediaPackageException {
     try {
       final EncodingProfile profile = profileScanner.getProfile(profileId);
+      if (profile == null) {
+        throw new MediaPackageException(String.format("Encoding profile %s not found", profileId));
+      }
       return serviceRegistry.createJob(JOB_TYPE, Operation.ImageToVideo.toString(), Arrays.asList(
               profileId, MediaPackageElementParser.getAsXml(sourceImageAttachment), Double.toString(time)),
               profile.getJobLoad());


### PR DESCRIPTION
This Pullrequest log a proper ERROR if the Encoding Profile is missing in imageToVideo Operation.

This fixes #3465

### Your pull request should…

* [ x] have a concise title
* [ x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ x] pass automated tests
* [ x] have a clean commit history
* [ x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
