### PR TITLE
Matrix room description update fix

### DIFF
--- a/.github/workflows/update-matrix-room.yml
+++ b/.github/workflows/update-matrix-room.yml
@@ -17,7 +17,7 @@ jobs:
           URL_LOGOUT: 'https://matrix.org/_matrix/client/r0/logout'
           URL_TOPIC: 'https://matrix-client.matrix.org/_matrix/client/r0/rooms/!HBsLKoOIEEOkxAeQvC%3Amatrix.org/state/m.room.topic/'
         run: |
-          TAGS="$(curl https://api.github.com/repos/opencast/opencast/releases | jq -r '.[].tag_name')"
+          TAGS="$(curl https://api.github.com/repos/opencast/opencast/tags | jq -r '.[].name')"
           MAJOR="$(echo "$TAGS" | sed 's/\..*$//' | sort -h | tail -n1)"
           STABLE="$(echo "$TAGS" | sort -h | tail -n1)"
           LEGACY="$(echo "$TAGS" | grep -v "^${MAJOR}" | sort -h | tail -n1)"


### PR DESCRIPTION
The Matrix room description of the development team doesn't automatically update to the latest version in case of a new release. This should be fixed by using the 'tags' instead of the 'releases' list.