### PR TITLE
Document that you cannot run Opencast in a sub-path

### DIFF
--- a/docs/guides/admin/docs/configuration/basic.md
+++ b/docs/guides/admin/docs/configuration/basic.md
@@ -18,6 +18,10 @@ The value must be set to the URL from which the server can be accessed later.
 
     org.opencastproject.server.url=https://example.opencast.org
 
+It is not supported for Opencast to be hosted in a subpath.
+Opencast needs to be served from the root path element.
+The RFC 3986 URI path component needs to be empty.
+
 *Note:* This value will be written to all generated media packages and thus cannot be changed easily for already
 processed media. Please think about this setting carefully.
 

--- a/docs/guides/admin/docs/configuration/multi.tenancy.md
+++ b/docs/guides/admin/docs/configuration/multi.tenancy.md
@@ -77,6 +77,10 @@ do not support multitenancy.
 Note that if you are running Apache httpd with mod\_proxy in front of the Opencast installation, the port number will be
 -1 in both files.
 
+It is not supported for Opencast tenants to be hosted in a subpath.
+Opencast tenants needs to be served from the root path element.
+The RFC 3986 URI path component needs to be empty.
+
 ### Step 2: Security Configuration
 
 Create a file called tenant1.xml in /etc/security. This file specifies access rules for individual URLs that specify

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -12,6 +12,10 @@
 # Also note that if this felix installation is proxied behind an Apache HTTPD reverse proxy, and communication is meant
 # to go through that proxy, then server.url should point to the proxy's port (usually 80).
 # Related options (like listening addresses) are located in etc/org.ops4j.pax.web.cfg
+#
+# It is not supported for Opencast or it's tenants to be hosted in a subpath.  Opencast or the tenants need to be served
+# from the root path element. The RFC 3986 URI path component needs to be empty.
+
 org.opencastproject.server.url=http://localhost:8080
 
 # The environment specified below will show up in the email subject when sending a notification about transcription


### PR DESCRIPTION
This patch makes it clear that Opencast does not support being run in a
sub-path of a domain (e.g. `example.org/opencast`) but needs to be run
in the root of that domain. You can, of course, use a subdomain (e.g.
`opencast.example.com`).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
