### PR TITLE
Admin UI Node Version

### DIFF
--- a/.github/workflows/test-admin-interface-frontend.yml
+++ b/.github/workflows/test-admin-interface-frontend.yml
@@ -17,14 +17,14 @@ jobs:
         browser:
           - chrome
           - firefox
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 
     - name: use node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 16.x
 
     - name: install dependencies
       run: |


### PR DESCRIPTION
This patch fixes the admin interface tests which should use the same
version of node.js which Opencast uses for building the module.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
