### PR TITLE
Auto-update JavaScript Test libraries

### DIFF
--- a/.github/workflows/auto-update-npm-libraries.yml
+++ b/.github/workflows/auto-update-npm-libraries.yml
@@ -1,0 +1,43 @@
+name: Auto-update npm libraries
+
+# Be carefuly for which modules you activate auto-updates.
+# Braking changes *MUST* be caught in the CI or they will cause errors.
+# Updating test libraries like eslint should be safe however.
+
+on:
+  schedule:
+  - cron: "0 5 * * *"
+
+jobs:
+  update-npm-libs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: prepare git
+        run: |
+          git config --global user.email 'update-bot@opencast.org'
+          git config --global user.name 'Update Bot'
+
+      - name: use node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: update all engage-theodul-core libraries (has only tests)
+        working-directory: modules/engage-theodul-core
+        run: |
+          rm package-lock.json
+          npm update --dev
+          npm audit fix
+          git add package.json package-lock.json
+
+      - name: make sure tests still work
+        working-directory: modules/engage-theodul-core
+        run: |
+          npm run eslint
+
+      - name: push changes
+        run: |
+          git commit -m 'Auto-update npm packages'
+          git push


### PR DESCRIPTION
This patch adds an auto-update for the JavaScript dependencies of
engage-theodul-core which are eslint and other test libraries.

This should mean that we will usually no longer need to manually merge
the Dependabot pull requests for these modules.

This is done *only* for test libraries. No libraries which will actually
end up in Opencast itself are updated.

If the tests and thus the workflow fail, let's say eslint introduced new
default rules we do not comply with, this will eventually be picked up
by Dependabot which will then still create a pull request for us to
handle manually.

This is intentionally done for one module only to check if this works
properly. If it does, we can extend it to other modules which handly
only tests via npm.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
