### PR TITLE
Keyboard shortcut permission

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
@@ -134,7 +134,7 @@ angular.module('adminNg.controllers')
     const checkPermission = (rolesWithPermission) => {
       let roles = AuthService.getRoles();
       return rolesWithPermission.some(i => roles.includes(i));
-    }
+    };
 
     HotkeysService.activateUniversalHotkey('general.event_view', function (event) {
       event.preventDefault();
@@ -147,7 +147,7 @@ angular.module('adminNg.controllers')
     });
 
     HotkeysService.activateUniversalHotkey('general.new_event', function (event) {
-      let rolesWithPermission = ["ROLE_UI_EVENTS_CREATE", "ROLE_ADMIN"];
+      let rolesWithPermission = ['ROLE_UI_EVENTS_CREATE', 'ROLE_ADMIN'];
       if (checkPermission(rolesWithPermission)) {
         event.preventDefault();
         ResourceModal.show('new-event-modal');
@@ -155,7 +155,7 @@ angular.module('adminNg.controllers')
     });
 
     HotkeysService.activateUniversalHotkey('general.new_series', function (event) {
-      let rolesWithPermission = ["ROLE_UI_SERIES_CREATE", "ROLE_ADMIN"];
+      let rolesWithPermission = ['ROLE_UI_SERIES_CREATE', 'ROLE_ADMIN'];
       if (checkPermission(rolesWithPermission)) {
         event.preventDefault();
         ResourceModal.show('new-series-modal');

--- a/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
@@ -148,6 +148,7 @@ angular.module('adminNg.controllers')
 
     HotkeysService.activateUniversalHotkey('general.new_event', function (event) {
       let rolesWithPermission = ['ROLE_UI_EVENTS_CREATE', 'ROLE_ADMIN'];
+      // only useres with above roles can trigger the modal
       if (checkPermission(rolesWithPermission)) {
         event.preventDefault();
         ResourceModal.show('new-event-modal');
@@ -156,6 +157,7 @@ angular.module('adminNg.controllers')
 
     HotkeysService.activateUniversalHotkey('general.new_series', function (event) {
       let rolesWithPermission = ['ROLE_UI_SERIES_CREATE', 'ROLE_ADMIN'];
+      // only useres with above roles can trigger the modal
       if (checkPermission(rolesWithPermission)) {
         event.preventDefault();
         ResourceModal.show('new-series-modal');

--- a/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
@@ -131,6 +131,11 @@ angular.module('adminNg.controllers')
       }
     });
 
+    const checkPermission = (rolesWithPermission) => {
+      let roles = AuthService.getRoles();
+      return rolesWithPermission.some(i => roles.includes(i));
+    }
+
     HotkeysService.activateUniversalHotkey('general.event_view', function (event) {
       event.preventDefault();
       $location.path('/events/events').replace();
@@ -142,13 +147,19 @@ angular.module('adminNg.controllers')
     });
 
     HotkeysService.activateUniversalHotkey('general.new_event', function (event) {
-      event.preventDefault();
-      ResourceModal.show('new-event-modal');
+      let rolesWithPermission = ["ROLE_UI_EVENTS_CREATE", "ROLE_ADMIN"];
+      if (checkPermission(rolesWithPermission)) {
+        event.preventDefault();
+        ResourceModal.show('new-event-modal');
+      }
     });
 
     HotkeysService.activateUniversalHotkey('general.new_series', function (event) {
-      event.preventDefault();
-      ResourceModal.show('new-series-modal');
+      let rolesWithPermission = ["ROLE_UI_SERIES_CREATE", "ROLE_ADMIN"];
+      if (checkPermission(rolesWithPermission)) {
+        event.preventDefault();
+        ResourceModal.show('new-series-modal');
+      }
     });
   }
 ]);

--- a/modules/admin-ui-frontend/app/scripts/shared/services/authService.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/authService.js
@@ -63,6 +63,10 @@ angular.module('adminNg.services')
       return identity;
     };
 
+    this.getRoles = function () {
+      return me.user.roles;
+    }
+
     this.getUserRole = function () {
       return userRole;
     };

--- a/modules/admin-ui-frontend/app/scripts/shared/services/authService.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/authService.js
@@ -65,7 +65,7 @@ angular.module('adminNg.services')
 
     this.getRoles = function () {
       return me.user.roles;
-    }
+    };
 
     this.getUserRole = function () {
       return userRole;


### PR DESCRIPTION
This fixes #2407
If the shortcut "n" or "N" is triggered without role permission, the modal is not displayed anymore.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
