### PR TITLE
Fix bug: Editor sometimes doesn't skip deactivated sections on Safari Browser

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/playerAdapterFactoryDefault.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/playerAdapterFactoryDefault.js
@@ -118,6 +118,12 @@ angular.module('adminNg.services')
           me.state.status = PlayerAdapter.STATUS.SEEKING;
         });
 
+        targetElement.addEventListener('seeked', function () {
+          if (me.state.status == PlayerAdapter.STATUS.SEEKING) {
+            me.state.status = me.state.oldStatus;
+          }
+        });
+
         targetElement.addEventListener('error', function () {
           me.state.status = PlayerAdapter.STATUS.ERROR_NETWORK;
         });


### PR DESCRIPTION
Under some circumstances the Safari Browser doesn't skip deactivated Sections in the Editor. For Example when using the
"Play Transition"-Button. This PR fixes this problem.

Reason for the Bug: Safari doesn't trigger a "Playing"-Event on finishing the seek (in contrast to firefox/chrome). This Event would
restore the Playback-State in the Editor. Instead the Editor remains in the Seeking-State, resulting in faulty behavior.

This fix additionally listens on the "Seeked"-Event, which is triggered by Safari (and some other Browsers), when
the seek is finished and restores the State.