### PR TITLE
Update Editor to 2022-03-22

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-12-10/oc-editor-2021-12-10.tar.gz</editor.url>
-    <editor.sha256>0691936bcfc835b1823aabc9ee89281a7b166b690fbfda6c4e20383156e9d723</editor.sha256>
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-03-22/oc-editor-2022-03-22.tar.gz</editor.url>
+    <editor.sha256>7966845ad71613e8b11d499cfb8e9c8a8e67a11522e66a5c9eee414a3e780e19</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
This patch updates the stand-alone video editor to release 2022-03-22.
For more details and the full change logs, take a look at the [release
notes](https://github.com/opencast/opencast-editor/releases/tag/2022-03-22).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
