### PR TITLE
Redowngrade Paella to 6.4.4

### DIFF
--- a/modules/engage-paella-player/gulpfile.js
+++ b/modules/engage-paella-player/gulpfile.js
@@ -29,7 +29,7 @@ var source = require('vinyl-source-stream');
 var gunzip = require('gulp-gunzip');
 var untar = require('gulp-untar');
 
-var PAELLA_VERSION = '6.5.5';
+var PAELLA_VERSION = '6.4.4';
 
 var buildPath = 'target/gulp',
     paellaSrc = 'src/main/paella-opencast',

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.descriptionPlugin/mh_description.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.descriptionPlugin/mh_description.js
@@ -33,9 +33,9 @@ paella.addPlugin(function() {
 
     getSubclass() { return 'showMHDescriptionTabBar'; }
     getName() { return 'es.upv.paella.opencast.descriptionPlugin'; }
-    getTabName() { return paella.utils.dictionary.translate('Description'); }
+    getTabName() { return paella.dictionary.translate('Description'); }
     getIndex() { return 10; }
-    getDefaultToolTip() { return paella.utils.dictionary.translate('Description'); }
+    getDefaultToolTip() { return paella.dictionary.translate('Description'); }
 
 
     checkEnabled(onSuccess) {
@@ -93,7 +93,7 @@ paella.addPlugin(function() {
         this.desc.date = sd.toLocaleString();
       }
 
-      paella.utils.ajax.get({url:'/usertracking/stats.json', params:{id:thisClass._episode.id}},
+      paella.ajax.get({url:'/usertracking/stats.json', params:{id:thisClass._episode.id}},
         function(data, contentType, returnCode) {
           thisClass.desc.views = data.stats.views;
           thisClass.insertDescription();
@@ -115,38 +115,38 @@ paella.addPlugin(function() {
       var divPresenter = document.createElement('div'); divPresenter.className = 'showMHDescriptionTabBarElement';
       var divDescription = document.createElement('div'); divDescription.className = 'showMHDescriptionTabBarElement';
 
-      divDate.innerHTML = paella.utils.dictionary.translate('Date')
+      divDate.innerHTML = paella.dictionary.translate('Date')
         + ': <span class="showMHDescriptionTabBarValue">' + paella.AntiXSS.htmlEscape(this.desc.date) + '</span>';
-      divContributor.innerHTML = paella.utils.dictionary.translate('Contributor')
+      divContributor.innerHTML = paella.dictionary.translate('Contributor')
         + ': <span class="showMHDescriptionTabBarValue">'
         + paella.AntiXSS.htmlEscape(this.desc.contributor) + '</span>';
-      divLanguage.innerHTML = paella.utils.dictionary.translate('Language')
+      divLanguage.innerHTML = paella.dictionary.translate('Language')
         + ': <span class="showMHDescriptionTabBarValue">' + paella.AntiXSS.htmlEscape(this.desc.language) + '</span>';
-      divViews.innerHTML = paella.utils.dictionary.translate('Views')
+      divViews.innerHTML = paella.dictionary.translate('Views')
         + ': <span class="showMHDescriptionTabBarValue">' + paella.AntiXSS.htmlEscape(this.desc.views) + '</span>';
-      divTitle.innerHTML = paella.utils.dictionary.translate('Title')
+      divTitle.innerHTML = paella.dictionary.translate('Title')
         + ': <span class="showMHDescriptionTabBarValue">' + paella.AntiXSS.htmlEscape(this.desc.title) + '</span>';
-      divSubject.innerHTML = paella.utils.dictionary.translate('Subject')
+      divSubject.innerHTML = paella.dictionary.translate('Subject')
         + ': <span class="showMHDescriptionTabBarValue">' + paella.AntiXSS.htmlEscape(this.desc.subject) + '</span>';
       if (this.desc.presenter == '') {
-        divPresenter.innerHTML = paella.utils.dictionary.translate('Presenter')
+        divPresenter.innerHTML = paella.dictionary.translate('Presenter')
           + ': <span class="showMHDescriptionTabBarValue"></span>';
       }
       else {
-        divPresenter.innerHTML = paella.utils.dictionary.translate('Presenter')
+        divPresenter.innerHTML = paella.dictionary.translate('Presenter')
           + ': <span class="showMHDescriptionTabBarValue"><a tabindex="4001" href="/engage/ui/index.html?q='
           + this.desc.presenter + '">' + paella.AntiXSS.htmlEscape(this.desc.presenter) + '</a></span>';
       }
       if (this.desc.serieId == '') {
-        divSeries.innerHTML = paella.utils.dictionary.translate('Series')
+        divSeries.innerHTML = paella.dictionary.translate('Series')
           + ': <span class="showMHDescriptionTabBarValue"></span>';
       }
       else {
-        divSeries.innerHTML = paella.utils.dictionary.translate('Series')
+        divSeries.innerHTML = paella.dictionary.translate('Series')
           + ': <span class="showMHDescriptionTabBarValue"><a tabindex="4002" href="/engage/ui/index.html?epFrom='
           + this.desc.serieId + '">' + paella.AntiXSS.htmlEscape(this.desc.serie) + '</a></span>';
       }
-      divDescription.innerHTML = paella.utils.dictionary.translate('Description')
+      divDescription.innerHTML = paella.dictionary.translate('Description')
         + ': <span class="showMHDescriptionTabBarValue">'
         + paella.AntiXSS.htmlEscape(this.desc.description) + '</span>';
 

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.downloadsButtonPlugin/mh_downloads.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.downloadsButtonPlugin/mh_downloads.js
@@ -25,7 +25,7 @@ class DownloadTrack {
       throw 'No audio and video';
     }
     this.flavor = ocTrack.type;
-    this.mimetype = paella.utils.dictionary.translate(ocTrack.mimetype);
+    this.mimetype = paella.dictionary.translate(ocTrack.mimetype);
     this.url = ocTrack.url;
     if (ocTrack.audio) {
       this.type = 'audio';
@@ -55,7 +55,7 @@ paella.addPlugin(function() {
     getSubclass() { return 'downloadsButton'; }
     getName() { return 'es.upv.paella.opencast.downloadsButtonPlugin'; }
     getIndex() { return 1000; }
-    getDefaultToolTip() { return paella.utils.dictionary.translate('Downloads'); }
+    getDefaultToolTip() { return paella.dictionary.translate('Downloads'); }
     getAlignment() { return 'right'; }
     getButtonType() { return paella.ButtonPlugin.type.popUpButton; }
     getIconClass() { return 'icon-folder-download'; }
@@ -91,7 +91,7 @@ paella.addPlugin(function() {
           onSuccess(true);
         })
         .catch(function(error) {
-          paella.log.error('opencast downloads button plugin disabled: ' + error);
+          base.log.error('opencast downloads button plugin disabled: ' + error);
           onSuccess(false);
         });
       }
@@ -155,7 +155,7 @@ paella.addPlugin(function() {
 
       if (self._episode === undefined || self._tracks.length < 1) {
         container.innerHTML = '<div class="downloadsItemContainer"><p class="noTracks">'
-                                + paella.utils.dictionary.translate('No downloads available') + '</p></div';
+                                + paella.dictionary.translate('No downloads available') + '</p></div';
       } else {
         let trackTypes = ['video', 'audio'];
         let flavors = new Set(self._tracks.map(track => track.flavor));
@@ -204,7 +204,7 @@ paella.addPlugin(function() {
                 if ('video' === track.type) {
                   let videoFormatElement = document.createElement('span');
                   videoFormatElement.className = 'downloadsButtonItemLinkSpanFormat';
-                  videoFormatElement.innerText = `[${paella.utils.dictionary.translate(mimetype)}]`;
+                  videoFormatElement.innerText = `[${paella.dictionary.translate(mimetype)}]`;
                   a.appendChild(videoFormatElement);
 
                   let videoResolutionElement = document.createElement('span');
@@ -214,7 +214,7 @@ paella.addPlugin(function() {
                 } else if ('audio' === track.type) {
                   let audioFormatElement = document.createElement('span');
                   audioFormatElement.className = 'downloadsButtonItemLinkSpanFormat';
-                  audioFormatElement.innerText = `[${paella.utils.dictionary.translate(mimetype)}]`;
+                  audioFormatElement.innerText = `[${paella.dictionary.translate(mimetype)}]`;
                   a.appendChild(audioFormatElement);
 
                   let audioBitrateElement = document.createElement('span');

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.downloadsPlugin/mh_downloads.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.downloadsPlugin/mh_downloads.js
@@ -22,9 +22,9 @@ paella.addPlugin(function() {
   return class DownloadsPlugin extends paella.TabBarPlugin {
     getSubclass() { return 'downloadsTabBar'; }
     getName() { return 'es.upv.paella.opencast.downloadsPlugin'; }
-    getTabName() { return paella.utils.dictionary.translate('Downloads'); }
+    getTabName() { return paella.dictionary.translate('Downloads'); }
     getIndex() { return 30; }
-    getDefaultToolTip() { return paella.utils.dictionary.translate('Downloads'); }
+    getDefaultToolTip() { return paella.dictionary.translate('Downloads'); }
 
 
     get domElement() { return this._domElement; }
@@ -73,7 +73,7 @@ paella.addPlugin(function() {
           }
         }
         if (download) {
-          paella.log.debug(track.type);
+          paella.debug.log(track.type);
           container.appendChild(this.createLink(track, i));
         }
       }
@@ -98,12 +98,10 @@ paella.addPlugin(function() {
       var text = '';
 
       if (track.video) {
-        text = '<span class="downloadLinkText TypeFile Video">'
-          + paella.utils.dictionary.translate('Video file') + '</span>';
+        text = '<span class="downloadLinkText TypeFile Video">' + paella.dictionary.translate('Video file') + '</span>';
       }
       else if (track.audio){
-        text = '<span class="downloadLinkText TypeFile Audio">'
-          + paella.utils.dictionary.translate('Audio file') + '</span>';
+        text = '<span class="downloadLinkText TypeFile Audio">' + paella.dictionary.translate('Audio file') + '</span>';
       }
       // track
       var trackText = '<span class="downloadLinkText Track">' + track.type + '</span>';
@@ -126,7 +124,7 @@ paella.addPlugin(function() {
       }
 
       if (mimetype)
-        text += ' <span class="downloadLinkText MIMEType">[' + paella.utils.dictionary.translate(mimetype) + ']</span>';
+        text += ' <span class="downloadLinkText MIMEType">[' + paella.dictionary.translate(mimetype) + ']</span>';
       text += ': ' + trackText;
       if (resolution)
         text += ' <span class="downloadLinkText Resolution">(' + resolution + ')</span>';

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/01_prerequisites.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/01_prerequisites.js
@@ -35,7 +35,7 @@ class Opencast {
         resolve(self._me);
       }
       else {
-        paella.utils.ajax.get({url:'/info/me.json'},
+        base.ajax.get({url:'/info/me.json'},
           function(data,contentType,code) {
             self._me = data;
             resolve(data);
@@ -54,7 +54,7 @@ class Opencast {
       }
       else {
         var episodeId = paella.utils.parameters.get('id');
-        paella.utils.ajax.get({url:'/search/episode.json', params:{'id': episodeId}},
+        base.ajax.get({url:'/search/episode.json', params:{'id': episodeId}},
           function(data, contentType, code) {
             if (data['search-results'].result) {
               self._episode = data['search-results'].result;
@@ -84,7 +84,7 @@ class Opencast {
         else {
           var serie = episode.mediapackage.series;
           if (serie != undefined) {
-            paella.utils.ajax.get({url:'/search/series.json', params:{'id': serie}},
+            base.ajax.get({url:'/search/series.json', params:{'id': serie}},
               function(data, contentType, code) {
                 if (data['search-results'].result) {
                   self._series = data['search-results'].result;
@@ -114,7 +114,7 @@ class Opencast {
       return new Promise((resolve, reject)=>{
         var serie = episode.mediapackage.series;
         if (serie != undefined) {
-          paella.utils.ajax.get({url:'/series/' + serie + '/acl.json'},
+          base.ajax.get({url:'/series/' + serie + '/acl.json'},
             function(data,contentType,code) {
               self._acl = data;
               resolve(self._acl);
@@ -133,7 +133,7 @@ class Opencast {
 }
 
 // Patch to work with MH jetty server.
-paella.utils.ajax.send = function(type,params,onSuccess,onFail) {
+base.ajax.send = function(type,params,onSuccess,onFail) {
   this.assertParams(params);
 
   var ajaxObj = jQuery.ajax({

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -32,7 +32,7 @@ class OpencastToPaellaConverter {
     var streams = this._config.streams || [];
     streams.some(function(curretStream){
       return curretStream.filter.system.some(function(currentFilter) {
-        if ((currentFilter == '*') || paella.utils.userAgent.system[currentFilter] ) {
+        if ((currentFilter == '*') || base.userAgent.system[currentFilter] ) {
           filterStream = curretStream;
           return true;
         }
@@ -83,7 +83,7 @@ class OpencastToPaellaConverter {
           sourceType = 'rtmp';
           break;
         default:
-          paella.log.debug(`OpencastToPaellaConverter: MimeType (${track.mimetype}) not supported!`);
+          paella.debug.log(`OpencastToPaellaConverter: MimeType (${track.mimetype}) not supported!`);
           break;
         }
         break;
@@ -108,12 +108,12 @@ class OpencastToPaellaConverter {
           sourceType = 'audio';
           break;
         default:
-          paella.log.debug(`OpencastToPaellaConverter: MimeType (${track.mimetype}) not supported!`);
+          paella.debug.log(`OpencastToPaellaConverter: MimeType (${track.mimetype}) not supported!`);
           break;
         }
         break;
       default:
-        paella.log.debug(`OpencastToPaellaConverter: Protocol (${protocol[1]}) not supported!`);
+        paella.debug.log(`OpencastToPaellaConverter: Protocol (${protocol[1]}) not supported!`);
         break;
       }
     }
@@ -222,7 +222,7 @@ class OpencastToPaellaConverter {
         let smask = atc[0].split('/');
 
         if (((smask[0] == '*') || (smask[0] == sflavor[0])) && ((smask[1] == '*') || (smask[1] == sflavor[1]))) {
-          audioTag = (atc[1] == '*') ? paella.utils.dictionary.currentLanguage() : atc[1];
+          audioTag = (atc[1] == '*') ? base.dictionary.currentLanguage() : atc[1];
           return true;
         }
       });
@@ -414,7 +414,7 @@ class OpencastToPaellaConverter {
           }
 
           let captions_label = captions_lang || 'unknown language';
-          //paella.utils.dictionary.translate("CAPTIONS_" + captions_lang);
+          //base.dictionary.translate("CAPTIONS_" + captions_lang);
 
           captions.push({
             id: currentAttachment.id,

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/04_datadelegates.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/04_datadelegates.js
@@ -26,29 +26,28 @@ class MHAnnotationServiceDefaultDataDelegate extends paella.DataDelegate {
 
   read(context,params,onSuccess) {
     var episodeId = params.id;
-    paella.utils.ajax.get({url: '/annotation/annotations.json',
-      params: {episode: episodeId, type: 'paella/' + context}},
-    function(data, contentType, returnCode) {
-      var annotations = data.annotations.annotation;
-      if (!(annotations instanceof Array)) { annotations = [annotations]; }
-      if (annotations.length > 0) {
-        if (annotations[0] && annotations[0].value !== undefined) {
-          var value = annotations[0].value;
-          try {
-            value = JSON.parse(value);
+    paella.ajax.get({url: '/annotation/annotations.json', params: {episode: episodeId, type: 'paella/' + context}},
+      function(data, contentType, returnCode) {
+        var annotations = data.annotations.annotation;
+        if (!(annotations instanceof Array)) { annotations = [annotations]; }
+        if (annotations.length > 0) {
+          if (annotations[0] && annotations[0].value !== undefined) {
+            var value = annotations[0].value;
+            try {
+              value = JSON.parse(value);
+            }
+            catch(err) {/**/}
+            if (onSuccess) onSuccess(value, true);
           }
-          catch(err) {/**/}
-          if (onSuccess) onSuccess(value, true);
+          else{
+            if (onSuccess) onSuccess(undefined, false);
+          }
         }
-        else{
+        else {
           if (onSuccess) onSuccess(undefined, false);
         }
-      }
-      else {
-        if (onSuccess) onSuccess(undefined, false);
-      }
-    },
-    function(data, contentType, returnCode) { onSuccess(undefined, false); }
+      },
+      function(data, contentType, returnCode) { onSuccess(undefined, false); }
     );
   }
 
@@ -57,68 +56,66 @@ class MHAnnotationServiceDefaultDataDelegate extends paella.DataDelegate {
     var episodeId = params.id;
     if (typeof(value) == 'object') value = JSON.stringify(value);
 
-    paella.utils.ajax.get({url: '/annotation/annotations.json',
-      params: {episode: episodeId, type: 'paella/' + context}},
-    function(data, contentType, returnCode) {
-      var annotations = data.annotations.annotation;
-      if (annotations == undefined) {annotations = [];}
-      if (!(annotations instanceof Array)) { annotations = [annotations]; }
+    paella.ajax.get({url: '/annotation/annotations.json', params: {episode: episodeId, type: 'paella/' + context}},
+      function(data, contentType, returnCode) {
+        var annotations = data.annotations.annotation;
+        if (annotations == undefined) {annotations = [];}
+        if (!(annotations instanceof Array)) { annotations = [annotations]; }
 
-      if (annotations.length == 0 ) {
-        paella.utils.ajax.put({ url: '/annotation/',
-          params: {
-            episode: episodeId,
-            type: 'paella/' + context,
-            value: value,
-            'in': 0
-          }},
-        function(data, contentType, returnCode) { onSuccess({}, true); },
-        function(data, contentType, returnCode) { onSuccess({}, false); }
-        );
-      }
-      else if (annotations.length == 1 ) {
-        var annotationId = annotations[0].annotationId;
-        paella.utils.ajax.put({ url: '/annotation/' + annotationId, params: { value: value }},
+        if (annotations.length == 0 ) {
+          paella.ajax.put({ url: '/annotation/',
+            params: {
+              episode: episodeId,
+              type: 'paella/' + context,
+              value: value,
+              'in': 0
+            }},
           function(data, contentType, returnCode) { onSuccess({}, true); },
           function(data, contentType, returnCode) { onSuccess({}, false); }
-        );
-      }
-      else if (annotations.length > 1 ) {
-        thisClass.remove(context, params, function(notUsed, removeOk){
-          if (removeOk){
-            thisClass.write(context, params, value, onSuccess);
-          }
-          else{
-            onSuccess({}, false);
-          }
-        });
-      }
-    },
-    function(data, contentType, returnCode) { onSuccess({}, false); }
+          );
+        }
+        else if (annotations.length == 1 ) {
+          var annotationId = annotations[0].annotationId;
+          paella.ajax.put({ url: '/annotation/' + annotationId, params: { value: value }},
+            function(data, contentType, returnCode) { onSuccess({}, true); },
+            function(data, contentType, returnCode) { onSuccess({}, false); }
+          );
+        }
+        else if (annotations.length > 1 ) {
+          thisClass.remove(context, params, function(notUsed, removeOk){
+            if (removeOk){
+              thisClass.write(context, params, value, onSuccess);
+            }
+            else{
+              onSuccess({}, false);
+            }
+          });
+        }
+      },
+      function(data, contentType, returnCode) { onSuccess({}, false); }
     );
   }
 
   remove(context,params,onSuccess) {
     var episodeId = params.id;
 
-    paella.utils.ajax.get({url: '/annotation/annotations.json',
-      params: {episode: episodeId, type: 'paella/' + context}},
-    function(data, contentType, returnCode) {
-      var annotations = data.annotations.annotation;
-      if(annotations) {
-        if (!(annotations instanceof Array)) { annotations = [annotations]; }
-        var asyncLoader = new paella.utils.AsyncLoader();
-        for (var i = 0; i < annotations.length; ++i) {
-          var annotationId = data.annotations.annotation.annotationId;
-          asyncLoader.addCallback(new paella.JSONCallback({url:'/annotation/' + annotationId}, 'DELETE'));
+    paella.ajax.get({url: '/annotation/annotations.json', params: {episode: episodeId, type: 'paella/' + context}},
+      function(data, contentType, returnCode) {
+        var annotations = data.annotations.annotation;
+        if(annotations) {
+          if (!(annotations instanceof Array)) { annotations = [annotations]; }
+          var asyncLoader = new paella.AsyncLoader();
+          for (var i = 0; i < annotations.length; ++i) {
+            var annotationId = data.annotations.annotation.annotationId;
+            asyncLoader.addCallback(new paella.JSONCallback({url:'/annotation/' + annotationId}, 'DELETE'));
+          }
+          asyncLoader.load(function(){ if (onSuccess) { onSuccess({}, true); } }, function() { onSuccess({}, false); });
         }
-        asyncLoader.load(function(){ if (onSuccess) { onSuccess({}, true); } }, function() { onSuccess({}, false); });
-      }
-      else {
-        if (onSuccess) { onSuccess({}, true); }
-      }
-    },
-    function(data, contentType, returnCode) { if (onSuccess) { onSuccess({}, false); } }
+        else {
+          if (onSuccess) { onSuccess({}, true); }
+        }
+      },
+      function(data, contentType, returnCode) { if (onSuccess) { onSuccess({}, false); } }
     );
   }
 }
@@ -158,7 +155,7 @@ class MHFootPrintsDataDelegate extends paella.DataDelegate {
   read(context,params,onSuccess) {
     var episodeId = params.id;
 
-    paella.utils.ajax.get({url: '/usertracking/footprint.json', params: {id: episodeId}},
+    paella.ajax.get({url: '/usertracking/footprint.json', params: {id: episodeId}},
       function(data, contentType, returnCode) {
         if ((returnCode == 200) && (contentType == 'application/json')) {
           var footPrintsData = data.footprints.footprint;
@@ -179,7 +176,7 @@ class MHFootPrintsDataDelegate extends paella.DataDelegate {
 
   write(context,params,value,onSuccess) {
     var episodeId = params.id;
-    paella.utils.ajax.put({url: '/usertracking/', params: {
+    paella.ajax.put({url: '/usertracking/', params: {
       id: episodeId,
       type:'FOOTPRINT',
       in:value.in,

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/05_loader.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/05_loader.js
@@ -57,7 +57,7 @@ function loadOpencastPaella(containerId) {
         window.location.href = oacl.getAuthenticationUrl();
       }
       else {
-        var errorMessage = paella.utils.dictionary
+        var errorMessage = paella.dictionary
           .translate('Error loading video {id}')
           .replace(/\{id\}/g, paella.utils.parameters.get('id') || '');
         paella.messageBox.showError(errorMessage);
@@ -74,8 +74,7 @@ function loadOpencastPaella(containerId) {
               var converter = new OpencastToPaellaConverter();
               var data = converter.convertToDataJson(episode);
               if (data.streams.length < 1) {
-                paella.messageBox.showError(paella.utils.dictionary.translate('Error loading video! \
-                No video tracks found'));
+                paella.messageBox.showError(paella.dictionary.translate('Error loading video! No video tracks found'));
               }
               else {
                 resolve(data);

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.logIn/log_in.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.logIn/log_in.js
@@ -32,7 +32,7 @@ paella.addPlugin(function() {
     getIconClass() { return 'icon-user'; }
     getAlignment() { return 'right'; }
     getIndex() {return 10;}
-    getDefaultToolTip() { return paella.utils.dictionary.translate('Log in'); }
+    getDefaultToolTip() { return base.dictionary.translate('Log in'); }
 
     checkEnabled(onSuccess) {
       paella.initDelegate.initParams.accessControl.userData()

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.searchPlugin/mh_search.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.searchPlugin/mh_search.js
@@ -38,9 +38,9 @@ paella.addPlugin(function() {
       else {
         var episodeId = paella.utils.parameters.get('id');
 
-        paella.utils.ajax.get({url:'/search/episode.json', params:{id:episodeId, q:text, limit:1000}},
+        paella.ajax.get({url:'/search/episode.json', params:{id:episodeId, q:text, limit:1000}},
           function(data, contentType, returnCode) {
-            paella.log.debug('Searching episode=' + episodeId + ' q=' + text);
+            paella.debug.log('Searching episode=' + episodeId + ' q=' + text);
             var segmentsAvailable = (data !== undefined) && (data['search-results'] !== undefined) &&
                         (data['search-results'].result !== undefined) &&
                         (data['search-results'].result.segments !== undefined) &&
@@ -67,7 +67,7 @@ paella.addPlugin(function() {
               next(false, searchResult);
             }
             else {
-              paella.log.debug('No Revelance');
+              paella.debug.log('No Revelance');
               next(false, []);
             }
           },

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.transcriptionTabBarPlugin/mh_transcription.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.transcriptionTabBarPlugin/mh_transcription.js
@@ -56,9 +56,9 @@ paella.addPlugin(function() {
 
     getSubclass() { return 'searchTabBar'; }
     getName() { return 'es.upv.paella.opencast.transcriptionTabBarPlugin'; }
-    getTabName() { return paella.utils.dictionary.translate('Transcription'); }
+    getTabName() { return paella.dictionary.translate('Transcription'); }
     getIndex() { return 20; }
-    getDefaultToolTip() { return paella.utils.dictionary.translate('Transcription'); }
+    getDefaultToolTip() { return paella.dictionary.translate('Transcription'); }
 
 
     checkEnabled(onSuccess) {
@@ -133,7 +133,7 @@ paella.addPlugin(function() {
       // -------  Left
       var inputElement = document.createElement('input');
       inputElement.type = 'text';
-      inputElement.value = paella.utils.dictionary.translate('Search in this event');
+      inputElement.value = paella.dictionary.translate('Search in this event');
       inputElement.setAttribute('size', '30');
       inputElement.setAttribute('dir','lrt');
       inputElement.setAttribute('spellcheck','true');
@@ -154,7 +154,7 @@ paella.addPlugin(function() {
       r3.className = 'lt70';
       r4.className = 'gt70';
 
-      r1.innerText = paella.utils.dictionary.translate('Search relevance:');
+      r1.innerText = paella.dictionary.translate('Search relevance:');
       r2.innerHTML = '&lt; 30%';
       r3.innerHTML = '&lt; 70%';
       r4.innerHTML = '&gt; 70%';
@@ -174,7 +174,7 @@ paella.addPlugin(function() {
       this.divResults.innerText = '';
 
       if (self._episode.segments === undefined) {
-        paella.log.debug('Segment Text data not available');
+        paella.debug.log('Segment Text data not available');
       }
       else {
         var segments = self._episode.segments;
@@ -233,9 +233,9 @@ paella.addPlugin(function() {
 
 
       var segmentsAvailable = false;
-      paella.utils.ajax.get({url:'/search/episode.json', params:{id:thisClass._episode.id, q:value, limit:1000}},
+      paella.ajax.get({url:'/search/episode.json', params:{id:thisClass._episode.id, q:value, limit:1000}},
         function(data, contentType, returnCode) {
-          paella.log.debug('Searching episode=' + thisClass._episode.id + ' q=' + value);
+          paella.debug.log('Searching episode=' + thisClass._episode.id + ' q=' + value);
 
           segmentsAvailable = (data !== undefined) && (data['search-results'] !== undefined) &&
                       (data['search-results'].result !== undefined) &&
@@ -260,7 +260,7 @@ paella.addPlugin(function() {
                 maxRelevance = parseInt(segment.relevance);
               }
             }
-            paella.log.debug('Search Max Revelance ' + maxRelevance);
+            paella.debug.log('Search Max Revelance ' + maxRelevance);
 
 
             for (i = 0; i < segments.segment.length; ++i){
@@ -290,7 +290,7 @@ paella.addPlugin(function() {
             thisClass.lastHit = value;
           }
           else {
-            paella.log.debug('No Revelance');
+            paella.debug.log('No Revelance');
             if (thisClass.foundAlready){
               thisClass.setNoActualResultAvailable(value);
             }
@@ -305,14 +305,13 @@ paella.addPlugin(function() {
 
 
     setNoActualResultAvailable(searchValue) {
-      this.divSearch.innerText = paella.utils.dictionary
+      this.divSearch.innerText = paella.dictionary
         .translate('Results for \'{0}\' (no actual results for \'{1}\' found)')
         .replace(/\{0\}/g,this.lastHit).replace(/\{1\}/g,searchValue);
     }
 
     setResultAvailable(searchValue) {
-      this.divSearch.innerText =
-        paella.utils.dictionary.translate('Results for \'{0}\'').replace(/\{0\}/g,searchValue);
+      this.divSearch.innerText =  paella.dictionary.translate('Results for \'{0}\'').replace(/\{0\}/g,searchValue);
     }
 
     setNotSearch() {

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.userTrackingSaverPlugIn/mh_usertracking_saver.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.userTrackingSaverPlugIn/mh_usertracking_saver.js
@@ -23,7 +23,7 @@ paella.addPlugin(function() {
     getName() { return 'es.upv.paella.opencast.userTrackingSaverPlugIn'; }
 
     checkEnabled(onSuccess) {
-      paella.utils.ajax.get({url:'/usertracking/detailenabled'},
+      paella.ajax.get({url:'/usertracking/detailenabled'},
         function(data, contentType, returnCode) {
           if (data == 'true') {
             onSuccess(true);
@@ -83,7 +83,7 @@ paella.addPlugin(function() {
           break;
         }
         opencastLog.type = opencastLog.type.substr(0, 128);
-        paella.utils.ajax.put( {url: '/usertracking/', params: opencastLog});
+        paella.ajax.put( {url: '/usertracking/', params: opencastLog});
       });
     }
   };

--- a/modules/engage-paella-player/src/main/paella-opencast/ui/embed.html
+++ b/modules/engage-paella-player/src/main/paella-opencast/ui/embed.html
@@ -6,6 +6,8 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Opencast Paella Player</title>
 	<script type="text/javascript" src="javascript/polyfill.min.js"></script>
+	<script type="text/javascript" src="javascript/swfobject.js"></script>
+	<script type="text/javascript" src="javascript/base.js"></script>
 	<script type="text/javascript" src="javascript/jquery.min.js"></script>
 	<script type="text/javascript" src="javascript/lunr.min.js"></script>
 	<script type="text/javascript" src="javascript/require.js"></script>

--- a/modules/engage-paella-player/src/main/paella-opencast/ui/watch.html
+++ b/modules/engage-paella-player/src/main/paella-opencast/ui/watch.html
@@ -6,6 +6,8 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Opencast Paella Player</title>
 	<script type="text/javascript" src="javascript/polyfill.min.js"></script>
+	<script type="text/javascript" src="javascript/swfobject.js"></script>
+	<script type="text/javascript" src="javascript/base.js"></script>
 	<script type="text/javascript" src="javascript/jquery.min.js"></script>
 	<script type="text/javascript" src="javascript/lunr.min.js"></script>
 	<script type="text/javascript" src="javascript/require.js"></script>


### PR DESCRIPTION
This commit re-downgrades Paella from 6.5.5 to 6.4.4 to fix slow/non loading HLS videos.
This PR reverts a revert which went into `r/11.x` but shouldn't have.  Original PR was #3531.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
