### PR TITLE
Fully Automated Release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -41,6 +41,14 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
+      - name: Get the major version
+        id: get_major_version
+        run: echo ::set-output name=MAJOR_VERSION::${VERSION//.*/}
+
+      - name: Get the minor version
+        id: get_minor_version
+        run: echo ::set-output name=MINOR_VERSION::${VERSION//*./}
+
       - name: create new release
         uses: softprops/action-gh-release@v1
         with:
@@ -52,5 +60,5 @@ jobs:
             This release …
             For further information, please take a look at:
 
-            - [Release notes](#)
-            - [Changelog](#)
+            - [Release notes](https://docs.opencast.org/r/${{ steps.get_major_version.outputs.MAJOR_VERSION }}.x/admin/#releasenotes/#additional-notes-about-${{ steps.get_major_version.outputs.MAJOR_VERSION }}${{ steps.get_minor_version.outputs.MINOR_VERSION }})
+            - [Changelog](https://docs.opencast.org/r/${{ steps.get_major_version.outputs.MAJOR_VERSION }}.x/admin/#changelog/#opencast-${{ steps.get_major_version.outputs.MAJOR_VERSION }}${{ steps.get_minor_version.outputs.MINOR_VERSION }})


### PR DESCRIPTION
In theory this should work, however...
- I have not tested that the calculatings for the major and minor versions actually work the way I think they do
- The text of the release is not properly set.  We probably want logic to do different release text depending on if it's a major release, or a minor.
  - In the case of a major we (IMO) have something very vague and ensure the RMs come back and update that text
  - In the case of a minor we (IMO) have something static like "This is a maintenance release for X.y", and the RMs can come back to update it if they feel like they need to.
- The release is still set to be a draft.  Before this goes in we should remove that.

Any other issues or objections people can see?

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
