### PR TITLE
Copy Mediapackage elements from the publication to mediapackage

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -74,6 +74,7 @@ The following table contains the workflow operations that are available in an ou
 |prepare-av          |Preparing audio and video work versions                        |[Documentation](prepareav-woh.md)|
 |probe-resolution    |Set workflow instance variables based on video resolution      |[Documentation](probe-resolution-woh.md)|
 |process-smil        |Edit and Encode media defined by a SMIL file                   |[Documentation](process-smil-woh.md)|
+|publication-to-workspace|Copy publication element to mediapackage in workspace       |[Documentation](publication-to-workspace-woh.md)|
 |publish-configure-aws|Distribute and publish media to the configured publication using Amazon S3 and Cloudfront|[Documentation](publish-configure-aws-woh.md)|
 |publish-configure   |Distribute and publish media to the configured publication     |[Documentation](publish-configure-woh.md)|
 |publish-engage-aws  |Distribute and publish media to the engage player using Amazon S3 and Cloudfront|[Documentation](publish-engage-aws-woh.md)|

--- a/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
@@ -1,8 +1,8 @@
 # PublicationToWorkspaceWorkflowOperationHandler
 
 ## Description
-The PublicationToWorkspaceWorkflowOperationHandler can be used to copy the content form publication channels to workspace.
-Wit this Workflow one can copy or maipulate published elements without reencoding.
+The PublicationToWorkspaceWorkflowOperationHandler can be used to copy the content from publication channels to workspace.
+With this workflow one can copy or manipulate published elements without re-encoding.
 ## Parameter Table
 
 |Configuration Key  |Example           |Description                                           |

--- a/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
@@ -8,9 +8,9 @@ With this workflow one can copy or manipulate published elements without re-enco
 |Configuration Key  |Example           |Description                                           |
 |-------------------|------------------|------------------------------------------------------|
 |publication-channel|engage-player     |the publication-channel for example interal or engage-player or oaipmh   |
-|source-flavors     |presenter/delivery|the "," seperatated source flavor list to move        |
-|source-tags        |engage-download   |the "," seperated source tag list to move             | 
-|target-tags        |archive           |the "," seperated of tags to add to the moved elements| 
+|source-flavors     |presenter/delivery|the "," separated source flavor list to move        |
+|source-tags        |engage-download   |the "," separated source tag list to move             | 
+|target-tags        |archive           |the "," separated list of tags to add to the moved elements| 
 
 
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
@@ -7,7 +7,7 @@ With this workflow one can copy or manipulate published elements without re-enco
 
 |Configuration Key  |Example           |Description                                           |
 |-------------------|------------------|------------------------------------------------------|
-|publication-channel|engage-player     |the publication-channel for example interal or engage-player or oaipmh   |
+|publication-channel|engage-player, internal, oaipmh    |the publication-channel |
 |source-flavors     |presenter/delivery|the "," separated source flavor list to move        |
 |source-tags        |engage-download   |the "," separated source tag list to move             | 
 |target-tags        |archive           |the "," separated list of tags to add to the moved elements| 

--- a/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
@@ -1,0 +1,36 @@
+# PublicationToWorkspaceWorkflowOperationHandler
+
+## Description
+The CopyWorkflowOperationHandler can be used to copy the content form publication channels to workspace.
+Wit this Workflow one can copy or maipulate published elements without reencoding.
+## Parameter Table
+
+|Configuration Key  |Example           |Description                                           |
+|-------------------|------------------|------------------------------------------------------|
+|publication-channel|engage-player     |the publication-channel interal,engage-player,oaipm   |
+|source-flavor      |presenter/delivery|the "," seperatated source flavor list to move        |
+|source-tag         |engage-download   |the "," seperated source tag list to move             | 
+|target-tags        |archive           |the "," seperated of tags to add to the moved elements| 
+
+
+\* mandatory configuration key
+
+Notes:
+
+This is working since opencast 11. When publication channel data is also stored in the elastic search index.
+
+
+## Operation Example
+
+    <operation id="publication-channel-to-workspace"
+             description="Copy publication channel to workspace"
+             fail-on-error="true"
+             exception-handler-workflow="partial-error">
+    <configurations>
+      <configuration key="source-channel">engage-player</configuration>
+      <configuration key="source-flavor">presenter-delivery,presentation-delivery</configuration>
+      <configuration key="source-tag">engage-download,engage-streaming</configuration>
+      <configuration key="target-tags">archive</configuration>
+    </configurations>
+  </operation>
+

--- a/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
@@ -1,36 +1,30 @@
 # PublicationToWorkspaceWorkflowOperationHandler
 
 ## Description
-The CopyWorkflowOperationHandler can be used to copy the content form publication channels to workspace.
+The PublicationToWorkspaceWorkflowOperationHandler can be used to copy the content form publication channels to workspace.
 Wit this Workflow one can copy or maipulate published elements without reencoding.
 ## Parameter Table
 
 |Configuration Key  |Example           |Description                                           |
 |-------------------|------------------|------------------------------------------------------|
-|publication-channel|engage-player     |the publication-channel interal,engage-player,oaipm   |
-|source-flavor      |presenter/delivery|the "," seperatated source flavor list to move        |
-|source-tag         |engage-download   |the "," seperated source tag list to move             | 
+|publication-channel|engage-player     |the publication-channel for example interal or engage-player or oaipmh   |
+|source-flavors     |presenter/delivery|the "," seperatated source flavor list to move        |
+|source-tags        |engage-download   |the "," seperated source tag list to move             | 
 |target-tags        |archive           |the "," seperated of tags to add to the moved elements| 
 
 
-\* mandatory configuration key
-
-Notes:
-
-This is working since opencast 11. When publication channel data is also stored in the elastic search index.
-
 
 ## Operation Example
-
-    <operation id="publication-channel-to-workspace"
-             description="Copy publication channel to workspace"
-             fail-on-error="true"
-             exception-handler-workflow="partial-error">
+```
+  <operation id="publication-channel-to-workspace"
+      description="Copy publication channel to workspace"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error">
     <configurations>
       <configuration key="source-channel">engage-player</configuration>
-      <configuration key="source-flavor">presenter-delivery,presentation-delivery</configuration>
-      <configuration key="source-tag">engage-download,engage-streaming</configuration>
+      <configuration key="source-flavors">presenter-delivery,presentation-delivery</configuration>
+      <configuration key="source-tags">engage-download,engage-streaming</configuration>
       <configuration key="target-tags">archive</configuration>
     </configurations>
   </operation>
-
+```

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -216,6 +216,7 @@ nav:
    - Prepare A/V: 'workflowoperationhandlers/prepareav-woh.md'
    - Probe Resolution: 'workflowoperationhandlers/probe-resolution-woh.md'
    - Process Smil: 'workflowoperationhandlers/process-smil-woh.md'
+   - Publication Workspace: 'workflowoperationhandlers/publication-to-workspace-woh.md'
    - Publish Configure AWS: 'workflowoperationhandlers/publish-configure-aws-woh.md'
    - Publish Configure: 'workflowoperationhandlers/publish-configure-woh.md'
    - Publish Engage AWS: 'workflowoperationhandlers/publish-engage-aws-woh.md'

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -216,7 +216,7 @@ nav:
    - Prepare A/V: 'workflowoperationhandlers/prepareav-woh.md'
    - Probe Resolution: 'workflowoperationhandlers/probe-resolution-woh.md'
    - Process Smil: 'workflowoperationhandlers/process-smil-woh.md'
-   - Publication Workspace: 'workflowoperationhandlers/publication-to-workspace-woh.md'
+   - Publication to Workspace: 'workflowoperationhandlers/publication-to-workspace-woh.md'
    - Publish Configure AWS: 'workflowoperationhandlers/publish-configure-aws-woh.md'
    - Publish Configure: 'workflowoperationhandlers/publish-configure-woh.md'
    - Publish Engage AWS: 'workflowoperationhandlers/publish-engage-aws-woh.md'

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/PublicationChannelToWorkspace.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/PublicationChannelToWorkspace.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.workflow.handler.workflow;
+
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.Publication;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Workflow operation handler to move elements from publication channel to workspace
+ */
+@Component(
+    immediate = true,
+    service = WorkflowOperationHandler.class,
+    property = {
+        "service.description=move publication elements to workspace",
+        "workflow.operation=publication-channel-to-workspace"
+    }
+)
+
+public class PublicationChannelToWorkspace extends AbstractWorkflowOperationHandler {
+
+  /** Configuration key for the "source-channel" to use as a source input */
+  static final String OPT_SOURCE_PUBLICATION_CHANNEL = "source-channel";
+
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory
+          .getLogger(PublicationChannelToWorkspace.class);
+
+  @Override
+  public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
+      throws WorkflowOperationException {
+
+    logger.info("Running get Publicationchannel to workspace for medipackage {}", workflowInstance.getId());
+    final MediaPackage mediaPackage = workflowInstance.getMediaPackage();
+
+    WorkflowOperationInstance currentOperation = workflowInstance.getCurrentOperation();
+
+    ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance, Configuration.many,
+        Configuration.many, Configuration.many, Configuration.many);
+    List<MediaPackageElementFlavor> configuredSourceFlavors = tagsAndFlavors.getSrcFlavors();
+    List<String> configuredSourceTags = tagsAndFlavors.getSrcTags();
+    List <String> configuredTargetTags = tagsAndFlavors.getTargetTags();
+    String publicationChannel = StringUtils
+        .trimToEmpty(currentOperation.getConfiguration(OPT_SOURCE_PUBLICATION_CHANNEL));
+    String configuredTargetTagsAsString =  String.join(",", configuredTargetTags);
+
+    if (publicationChannel.isEmpty()) {
+      logger.error("No source publication-channel set. Operation will be skipped.");
+      return createResult(mediaPackage, Action.SKIP);
+    }
+    if (configuredSourceFlavors.isEmpty()) {
+      logger.error("No source flavor set. Operation will be skipped.");
+      return createResult(mediaPackage, Action.SKIP);
+    }
+    if (configuredSourceTags.isEmpty()) {
+      logger.error("No source Tag set. Operation will be skipped.");
+      return createResult(mediaPackage, Action.SKIP);
+    }
+
+    Optional<Publication> publication = Arrays.stream(mediaPackage.getPublications())
+        .filter(channel -> channel.getChannel().equals(publicationChannel)).findFirst();
+    if (publication.get().getTracks().length >= 0) {
+
+      Collection<MediaPackageElement> tracks =  new ArrayList<MediaPackageElement>();
+
+      Arrays.stream(publication.get().getTracks())
+          .filter(element -> element.containsTag(configuredSourceTags))
+          .filter(Objects::nonNull)
+          .forEach(element -> tracks.add(element));
+      Arrays.stream(publication.get().getTracks())
+          .filter(element -> configuredSourceFlavors.contains(element.getFlavor()))
+          .filter(Objects::nonNull)
+          .forEach(element -> tracks.add(element));
+
+      tracks.stream().forEach(element -> element.addTag(configuredTargetTagsAsString));
+      tracks.stream().forEach(mediaPackageElement -> mediaPackage.add(mediaPackageElement));
+    }
+
+    if (publication.get().getAttachments().length >= 0) {
+      Collection<MediaPackageElement> attachments = new ArrayList<MediaPackageElement>();
+      Arrays.stream(publication.get().getAttachments())
+          .filter(element -> element.containsTag(configuredSourceTags))
+          .filter(Objects::nonNull)
+          .forEach(element -> attachments.add(element));
+      Arrays.stream(publication.get().getAttachments())
+          .filter(element -> configuredSourceFlavors.contains(element.getFlavor()))
+          .filter(Objects::nonNull)
+          .forEach(element -> attachments.add(element));
+
+      attachments.stream().forEach(element -> element.addTag(configuredTargetTagsAsString));
+      attachments.stream().forEach(mediaPackageElement -> mediaPackage.add(mediaPackageElement));
+    }
+
+    if (publication.get().getCatalogs().length >= 0) {
+      Collection<MediaPackageElement> catalogs = new ArrayList<MediaPackageElement>();
+      Arrays.stream(publication.get().getCatalogs())
+          .filter(element -> element.containsTag(configuredSourceTags))
+          .filter(Objects::nonNull)
+          .forEach(element -> catalogs.add(element));
+      Arrays.stream(publication.get().getCatalogs())
+          .filter(element -> configuredSourceFlavors.contains(element.getFlavor()))
+          .filter(Objects::nonNull)
+          .forEach(element -> catalogs.add(element));
+
+      catalogs.stream().forEach(mediaPackageElement -> mediaPackageElement.addTag(configuredTargetTagsAsString));
+      catalogs.stream().forEach(mediaPackageElement -> mediaPackage.add(mediaPackageElement));
+    }
+
+    return createResult(mediaPackage, Action.CONTINUE, 0);
+  }
+
+}


### PR DESCRIPTION
Since OC11 all publicationchannel metadata ist also stored in the mediapackage.
With this pr it is possible to copy this information from a selected
publication channel to the mediapackage in the workspace.

So it is possible to pull Publication elements to the archive.
You can clone/export/manipulate plublished material without reencoding.

Steps to do in the Workflow for example:
- woh publication-to-workspace
  -> select elements by tags or flavors 
  -> tag elements as archive
- ingest-download 
  -> download these elements to workspace 
- snapshot
  -> archive the elements

What is not implemented 
 - wildcards for selection
 - tests
Im not sure, when i would have time to do this last steps.
If someone want`s it in as it is, feel free to merge.


* [x] have a concise title
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
