### PR TITLE
Rework the userdirectory-brightspace module

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -124,6 +124,7 @@
               <feature>opencast-moodle</feature>
               <feature>opencast-sakai</feature>
               <feature>opencast-canvas</feature>
+              <feature>opencast-brightspace</feature>
             </installedFeatures>
           </configuration>
         </plugin>

--- a/etc/org.opencastproject.userdirectory.brightspace-default.cfg.template
+++ b/etc/org.opencastproject.userdirectory.brightspace-default.cfg.template
@@ -19,6 +19,11 @@ org.opencastproject.userdirectory.brightspace.application.key=application-key
 # The maximum number of minutes to cache a user
 #org.opencastproject.userdirectory.brightspace.cache.expiration=60
 
+# Optional comma-separated list of Brightspace roles which are mapped to Instructor role suffix in Opencast
+# default: TEACHER
+#org.opencastproject.userdirectory.brightspace.instructor.roles=TEACHER
 
-
+# Optional comma-separated list of usernames, which opencast wouldn't ask Brightspace for user's detail.
+# default: admin,anonymous
+#org.opencastproject.userdirectory.brightspace.ignored.usernames=admin,anonymous
 

--- a/modules/userdirectory-brightspace/pom.xml
+++ b/modules/userdirectory-brightspace/pom.xml
@@ -48,10 +48,6 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>

--- a/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/BrightspaceUserProviderFactory.java
+++ b/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/BrightspaceUserProviderFactory.java
@@ -44,7 +44,9 @@ import java.lang.management.ManagementFactory;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Dictionary;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.management.MalformedObjectNameException;
@@ -54,6 +56,9 @@ public class BrightspaceUserProviderFactory implements ManagedServiceFactory {
 
   private static final Logger logger = LoggerFactory.getLogger(BrightspaceUserProviderFactory.class);
 
+  private static final String LTI_LEARNER_ROLE = "Learner";
+  private static final String LTI_INSTRUCTOR_ROLE = "Instructor";
+
   private static final String ORGANIZATION_KEY = "org.opencastproject.userdirectory.brightspace.org";
   private static final String BRIGHTSPACE_USER_ID = "org.opencastproject.userdirectory.brightspace.systemuser.id";
   private static final String BRIGHTSPACE_USER_KEY = "org.opencastproject.userdirectory.brightspace.systemuser.key";
@@ -61,15 +66,25 @@ public class BrightspaceUserProviderFactory implements ManagedServiceFactory {
   private static final String BRIGHTSPACE_APP_ID = "org.opencastproject.userdirectory.brightspace.application.id";
   private static final String BRIGHTSPACE_APP_KEY = "org.opencastproject.userdirectory.brightspace.application.key";
 
-  private static final String CACHE_SIZE = "org.opencastproject.userdirectory.brightspace.cache.size";
-  private static final String CACHE_EXPIRATION = "org.opencastproject.userdirectory.brightspace.cache.expiration";
+  private static final String CACHE_SIZE_KEY = "org.opencastproject.userdirectory.brightspace.cache.size";
+  private static final String CACHE_EXPIRATION_KEY = "org.opencastproject.userdirectory.brightspace.cache.expiration";
   private static final String BRIGHTSPACE_NAME = "org.opencastproject.userdirectory.brightspace";
   private static final int DEFAULT_CACHE_SIZE_VALUE = 1000;
   private static final int DEFAULT_CACHE_EXPIRATION_VALUE = 60;
 
+  /** The keys to look up which roles in Brightspace should be considered as instructor roles */
+  private static final String BRIGHTSPACE_INSTRUCTOR_ROLES_KEY =
+                                "org.opencastproject.userdirectory.brightspace.instructor.roles";
+  private static final String DEFAULT_BRIGHTSPACE_INSTRUCTOR_ROLES = "teacher,ta";
+  /** The keys to look up which users should be ignored */
+  private static final String IGNORED_USERNAMES_KEY = "org.opencastproject.userdirectory.brightspace.ignored.usernames";
+  private static final String DEFAULT_IGNORED_USERNAMES = "admin,anonymous";
+
   protected BundleContext bundleContext;
   private Map<String, ServiceRegistration> providerRegistrations = new ConcurrentHashMap<>();
   private OrganizationDirectoryService orgDirectory;
+  private int cacheSize;
+  private int cacheExpiration;
 
   /**
    * Builds a JMX object name for a given PID
@@ -127,8 +142,34 @@ public class BrightspaceUserProviderFactory implements ManagedServiceFactory {
     final String applicationId = (String) properties.get(BRIGHTSPACE_APP_ID);
     final String applicationKey = (String) properties.get(BRIGHTSPACE_APP_KEY);
 
-    int cacheSize = parseCacheSizeProperty(properties);
-    int cacheExpiration = parseCacheExpirationProperty(properties);
+    String cacheSizeStr = (String) properties.get(CACHE_SIZE_KEY);
+    if (StringUtils.isBlank(cacheSizeStr)) {
+      int cacheSize = DEFAULT_CACHE_SIZE_VALUE;
+    } else {
+      int cacheSize = NumberUtils.toInt(cacheSizeStr);
+    }
+
+
+    String cacheExpirationStr = (String) properties.get(CACHE_EXPIRATION_KEY);
+    if (StringUtils.isBlank(cacheExpirationStr)) {
+      int cacheExpiration = DEFAULT_CACHE_EXPIRATION_VALUE;
+    } else {
+      int cacheExpiration = NumberUtils.toInt(cacheExpirationStr);
+    }
+
+    String rolesStr = (String) properties.get(BRIGHTSPACE_INSTRUCTOR_ROLES_KEY);
+    if (StringUtils.isBlank(rolesStr)) {
+      rolesStr = DEFAULT_BRIGHTSPACE_INSTRUCTOR_ROLES;
+    }
+    Set instructorRoles = parsePropertyLineAsSet(rolesStr);
+    logger.debug("Brightspace instructor roles: {}", instructorRoles);
+
+    String ignoredUsersStr = (String) properties.get(IGNORED_USERNAMES_KEY);
+    if (StringUtils.isBlank(ignoredUsersStr)) {
+      ignoredUsersStr = DEFAULT_IGNORED_USERNAMES;
+    }
+    Set ignoredUsernames = parsePropertyLineAsSet(ignoredUsersStr);
+    logger.debug("Ignored users: {}", ignoredUsernames);
 
     validateUrl(urlStr);
     validateConfigurationKey(ORGANIZATION_KEY, organization);
@@ -155,7 +196,8 @@ public class BrightspaceUserProviderFactory implements ManagedServiceFactory {
     BrightspaceClientImpl clientImpl
         = new BrightspaceClientImpl(urlStr, applicationId, applicationKey, systemUserId, systemUserKey);
     BrightspaceUserProviderInstance provider
-        = new BrightspaceUserProviderInstance(pid, clientImpl, org, cacheSize, cacheExpiration, adminUserName);
+        = new BrightspaceUserProviderInstance(pid, clientImpl, org, cacheSize, cacheExpiration  ,
+            instructorRoles, ignoredUsernames);
     this.providerRegistrations
         .put(pid, this.bundleContext.registerService(UserProvider.class.getName(), provider, null));
     this.providerRegistrations
@@ -182,14 +224,6 @@ public class BrightspaceUserProviderFactory implements ManagedServiceFactory {
     }
   }
 
-  private int parseCacheExpirationProperty(Dictionary properties) {
-    return NumberUtils.toInt(properties.get(CACHE_EXPIRATION). toString(), DEFAULT_CACHE_EXPIRATION_VALUE);
-  }
-
-  private int parseCacheSizeProperty(Dictionary properties) {
-    return NumberUtils.toInt(properties.get(CACHE_SIZE). toString(), DEFAULT_CACHE_SIZE_VALUE);
-  }
-
   private void validateConfigurationKey(String key, String value) throws ConfigurationException {
     if (StringUtils.isBlank(value)) {
       throw new ConfigurationException(key, "is not set");
@@ -206,6 +240,15 @@ public class BrightspaceUserProviderFactory implements ManagedServiceFactory {
         throw new ConfigurationException(BRIGHTSPACE_URL, "not a URL");
       }
     }
+  }
+
+  private Set<String> parsePropertyLineAsSet(String configLine) {
+    Set<String> set = new HashSet<>();
+    String[] configs = configLine.split(",");
+    for (String config: configs) {
+      set.add(config.trim());
+    }
+    return set;
   }
 
 }

--- a/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/client/BrightspaceClient.java
+++ b/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/client/BrightspaceClient.java
@@ -31,7 +31,7 @@ public interface BrightspaceClient {
 
   BrightspaceUser findUser(String username) throws BrightspaceClientException;
 
-  Set<String> findCourseIds(String brightspaceUserId) throws BrightspaceClientException;
+  List<String> getRolesFromBrightspace(String username, Set<String> instructorRoles) throws BrightspaceClientException;
 
   List<BrightspaceUser> findAllUsers() throws BrightspaceClientException;
 

--- a/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/client/BrightspaceClientImpl.java
+++ b/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/client/BrightspaceClientImpl.java
@@ -22,11 +22,11 @@
 package org.opencastproject.userdirectory.brightspace.client;
 
 import org.opencastproject.userdirectory.brightspace.client.api.BrightspaceUser;
+import org.opencastproject.userdirectory.brightspace.client.api.OrgUnitItem;
 import org.opencastproject.userdirectory.brightspace.client.api.OrgUnitResponse;
 import org.opencastproject.userdirectory.brightspace.client.api.PagingInfo;
 import org.opencastproject.userdirectory.brightspace.client.api.UsersResponse;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
@@ -40,10 +40,9 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -55,13 +54,14 @@ public class BrightspaceClientImpl implements BrightspaceClient {
 
   private static final Logger logger = LoggerFactory.getLogger(BrightspaceClientImpl.class);
 
-  private static final String GET_USER_BY_USERNAME = "/d2l/api/lp/1.0/users/?orgDefinedId=";
-  private static final String GET_ALL_USERS = "/d2l/api/lp/1.0/users/";
+  private static final String GET_USER_BY_USERNAME = "/d2l/api/lp/1.31/users/?UserName=";
+  private static final String GET_ALL_USERS = "/d2l/api/lp/1.31/users/";
   private static final String GET_COURSES_BY_BRIGHTSPACE_USER_ID
-      = "/d2l/api/lp/1.0/enrollments/users/{brightspace-userid}/orgUnits/";
+      = "/d2l/api/lp/1.31/enrollments/users/{brightspace-userid}/orgUnits/?orgUnitTypeId=3";
   private static final String UNEXPECTED_JSON_RESPONSE = "The brightspace API returned a unexpected json response";
   private static final String SUPER_ADMIN = "Super Administrator";
-
+  private static final String LTI_LEARNER_ROLE = "Learner";
+  private static final String LTI_INSTRUCTOR_ROLE = "Instructor";
 
   private final String url;
   private final String applicationId;
@@ -85,43 +85,54 @@ public class BrightspaceClientImpl implements BrightspaceClient {
   public BrightspaceUser findUser(String userName) throws BrightspaceClientException {
     String request = GET_USER_BY_USERNAME + userName;
     String response = httpGetRequest(request);
+    logger.debug(response);
 
     try {
-      List<BrightspaceUser> brightspaceUserList = objectMapper
-              .readValue(response, new TypeReference<List<BrightspaceUser>>() {
-              });
-      return brightspaceUserList.stream().findFirst().orElse(null);
+      BrightspaceUser brightspaceUser = objectMapper
+              .readerFor(BrightspaceUser.class)
+              .readValue(response);
+      return brightspaceUser;
     } catch (IOException e) {
+      logger.debug(e.toString());
       throw new BrightspaceClientException(UNEXPECTED_JSON_RESPONSE, e);
     }
   }
 
-  @Override
-  public Set<String> findCourseIds(String brightspaceUserId) throws BrightspaceClientException {
-    Set<String> courseIds = new HashSet<>();
+  @Override public List<String> getRolesFromBrightspace(String userid, Set<String> instructorRoles)
+                            throws BrightspaceClientException {
+    logger.debug("Retrieving subscribed courses for user: {}", userid);
+
     boolean hasMoreItems;
     String bookmark = null;
-    do {
-      String request = composePagedUrl(bookmark, brightspaceUserId);
-      OrgUnitResponse orgUnitPage = findOrgUnitPage(request);
-      if (SUPER_ADMIN.equals(orgUnitPage.getItems().get(0).getRole().getName())) {
-        courseIds.add("BRIGHTSPACE_ADMIN");
-        return courseIds;
-      }
+    List<String> roleList = new ArrayList<>();
+    try {
+      do {
+        String request = composePagedUrl(bookmark, userid);
+        OrgUnitResponse orgUnitPage = findOrgUnitPage(request);
+        if (SUPER_ADMIN.equals(orgUnitPage.getItems().get(0).getRole().getName())) {
+          roleList.add("BRIGHTSPACE_ADMIN");
+          return roleList;
+        }
 
-      Set<String> pagedCourseIds = orgUnitPage.getItems()
-              .stream()
-              .map(orgUnitItem -> orgUnitItem.getOrgUnit().getCode())
-              .collect(Collectors.toSet());
-      courseIds.addAll(pagedCourseIds);
+        for (OrgUnitItem course: orgUnitPage.getItems()) {
+          String brightspaceRole = course.getRole().getName();
+          String ltiRole = instructorRoles.contains(brightspaceRole) ? LTI_INSTRUCTOR_ROLE : LTI_LEARNER_ROLE;
+          String opencastRole = String.format("%s_%s", course.getOrgUnit().getId(), ltiRole);
+          roleList.add(opencastRole);
+        }
 
-      PagingInfo pagingInfo = orgUnitPage.getPagingInfo();
-      hasMoreItems = pagingInfo.hasMoreItems();
-      bookmark = pagingInfo.getBookmark();
+        PagingInfo pagingInfo = orgUnitPage.getPagingInfo();
+        hasMoreItems = pagingInfo.hasMoreItems();
+        bookmark = pagingInfo.getBookmark();
 
-    } while (hasMoreItems);
+      } while (hasMoreItems);
 
-    return courseIds;
+      return roleList;
+    } catch (BrightspaceClientException e) {
+      logger.warn("Exception getting site/role membership for brightspace user {}: {}", userid, e);
+      throw new BrightspaceClientException(UNEXPECTED_JSON_RESPONSE, e);
+    }
+
   }
 
   @Override
@@ -131,7 +142,7 @@ public class BrightspaceClientImpl implements BrightspaceClient {
       UsersResponse usersResponse = objectMapper.readValue(response, UsersResponse.class);
       return usersResponse.getItems();
     } catch (IOException e) {
-      throw new BrightspaceClientException(UNEXPECTED_JSON_RESPONSE);
+      throw new BrightspaceClientException(UNEXPECTED_JSON_RESPONSE, e);
     }
 
   }

--- a/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/client/api/BrightspaceUser.java
+++ b/modules/userdirectory-brightspace/src/main/java/org/opencastproject/userdirectory/brightspace/client/api/BrightspaceUser.java
@@ -37,6 +37,8 @@ public class BrightspaceUser {
   private String uniqueIdentifier;
   private Activation activation;
   private String displayName;
+  private String lastAccessedDate;
+  private String pronouns;
 
   @JsonCreator
   public BrightspaceUser(
@@ -50,7 +52,9 @@ public class BrightspaceUser {
       @JsonProperty("OrgDefinedId") String orgDefinedId,
       @JsonProperty("UniqueIdentifier") String uniqueIdentifier,
       @JsonProperty("Activation") Activation activation,
-      @JsonProperty("DisplayName") String displayName
+      @JsonProperty("DisplayName") String displayName,
+      @JsonProperty("LastAccessedDate") String lastAccessedDate,
+      @JsonProperty("Pronouns") String pronouns
   ) {
     this.orgId = orgId;
     this.userId = userId;
@@ -63,6 +67,9 @@ public class BrightspaceUser {
     this.uniqueIdentifier = uniqueIdentifier;
     this.activation = activation;
     this.displayName = displayName;
+    this.lastAccessedDate = lastAccessedDate;
+    this.pronouns = pronouns;
+
   }
 
   public String getOrgId() {
@@ -107,6 +114,14 @@ public class BrightspaceUser {
 
   public String getDisplayName() {
     return this.displayName;
+  }
+
+  public String getLastAccessedDate() {
+    return this.lastAccessedDate;
+  }
+
+  public String getPronouns() {
+    return this.pronouns;
   }
 
   public String getFullName() {


### PR DESCRIPTION
This fixes the userdirectory module to work with the latest version of the brightspace api, reworks the way it works ( identical to the canvas userprovider ) so you retrieve the user roles in an identical fashion to the roles you get via LTI.