### PR TITLE
Auto update engage-ui test libraries

### DIFF
--- a/.github/workflows/auto-update-npm-libraries.yml
+++ b/.github/workflows/auto-update-npm-libraries.yml
@@ -24,6 +24,14 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: update engage-ui test libraries
+        working-directory: modules/engage-ui
+        run: |
+          npm update --save --dev eslint eslint-plugin-header
+          npm audit fix
+          git add package.json package-lock.json
+
+
       - name: update all engage-theodul-core libraries (has only tests)
         working-directory: modules/engage-theodul-core
         run: |


### PR DESCRIPTION
Like the other auto-updates, this automatically updates the test
libraries for the `engage-ui` module. Though unlike the other modules,
`engage-ui` contains more than test libraries and we have to limit what
we update.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
