### PR TITLE
Doc change: Maven build source command

### DIFF
--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -88,7 +88,7 @@ Building Opencast
 Automatically build all Opencast modules and assemble distributions for different server types:
 
     cd opencast-dir
-    mvn clean install
+    mvn clean install -T 1.0C -Pnone && cd assemblies && mvn install -T 1.0C && cd ..
 
 Deploy all-in-one distribution:
 

--- a/docs/guides/admin/docs/installation/source-macosx.md
+++ b/docs/guides/admin/docs/installation/source-macosx.md
@@ -117,7 +117,7 @@ Switch to the opencast folder. If you downloaded the tarball, this is the folder
 like `opencast-community-opencast-[…]`). If you chose to download via git, use `cd opencast`. You can proceed by
 building opencast (depending on the folder permissions, you might need to start the command with `sudo`):
 
-    mvn clean install -Pdev
+    mvn clean install -T 1.0C -Pnone && cd assemblies && mvn install -T 1.0C -Pdev && cd ..
 
 Please be patient, as building Opencast for the first time will take quite long.
 


### PR DESCRIPTION
This PR, changes the build command in the source install docs from `mvn clean install` to 
```
$ mvn clean install -T 1.0C -Pnone && cd assemblies && mvn install -T 1.0C -Pdev && cd ..

```
Because take advantage of the multithread capabilities of almost all the modern computers.

I've got results with my Machine (Intel i5 Macbook Pro 2020) up to 400% faster compared with the single `mvn clean install` single thread command.


PS: Thanks @mtneug for the tip!

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
