### PR TITLE
Fix smil marshalling for mediapackage tracks typed as SmilMediaReferenceImpl

### DIFF
--- a/modules/smil-impl/src/main/java/org/opencastproject/smil/entity/media/element/SmilMediaElementImpl.java
+++ b/modules/smil-impl/src/main/java/org/opencastproject/smil/entity/media/element/SmilMediaElementImpl.java
@@ -42,7 +42,7 @@ import javax.xml.bind.annotation.XmlSeeAlso;
 /**
  * {@code SmilMediaElemnt} implementation.
  */
-@XmlSeeAlso({SmilMediaAudioImpl.class, SmilMediaVideoImpl.class})
+@XmlSeeAlso({SmilMediaAudioImpl.class, SmilMediaVideoImpl.class, SmilMediaReferenceImpl.class})
 public abstract class SmilMediaElementImpl extends SmilMediaObjectImpl implements SmilMediaElement {
 
   /**


### PR DESCRIPTION
When creating a new SmilImpl, tracks might be represented by SmilMediaAudioImpl, SmilMediaVideoImpl or SmilMediaReferenceImpl (e.g. subtitle tracks or other non-video/non-audio tracks). However, marshalling the SmilImpl does not work if it contains SmilMediaReferenceImpl. This for example breaks saving in the new editor if the event contains any tracks of type SmilMediaReferenceImpl. This fixes that.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
