### PR TITLE
fix #3602, Terminate state service, check that host is not in maintenance

### DIFF
--- a/modules/termination-state-aws/src/main/java/org/opencastproject/terminationstate/aws/AutoScalingTerminationStateService.java
+++ b/modules/termination-state-aws/src/main/java/org/opencastproject/terminationstate/aws/AutoScalingTerminationStateService.java
@@ -118,6 +118,14 @@ public final class AutoScalingTerminationStateService extends AbstractJobTermina
       return;
     }
 
+    // make sure host is not in maintenance due to previous termination handling
+    try {
+      String host = getServiceRegistry().getRegistryHostname();
+      getServiceRegistry().setMaintenanceStatus(host, false);
+    } catch (ServiceRegistryException | NotFoundException e) {
+      logger.error("Cannot take this host out of maintenance", e);
+    }
+
     if (accessKeyIdOpt.isNone() && accessKeySecretOpt.isNone()) {
       credentials = new DefaultAWSCredentialsProviderChain();
     } else {


### PR DESCRIPTION
Fixes #3602, Termination State Services leaves nodes in maintenance mode

Checks on startup, that the host is not in maintenance due to state of a previous instance.
