### PR TITLE
Extract JobDispatcher into its own class

### DIFF
--- a/assemblies/dist-admin/pom.xml
+++ b/assemblies/dist-admin/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
+    <enableJobDispatching>true</enableJobDispatching>
   </properties>
   <artifactId>opencast-dist-admin</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-adminpresentation/pom.xml
+++ b/assemblies/dist-adminpresentation/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
+    <enableJobDispatching>true</enableJobDispatching>
   </properties>
   <artifactId>opencast-dist-adminpresentation</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-allinone/pom.xml
+++ b/assemblies/dist-allinone/pom.xml
@@ -9,6 +9,7 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
+    <enableJobDispatching>true</enableJobDispatching>
   </properties>
   <artifactId>opencast-dist-allinone</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-develop/pom.xml
+++ b/assemblies/dist-develop/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <packaging.definition>${project.basedir}/target/classes/package.xml</packaging.definition>
+    <enableJobDispatching>true</enableJobDispatching>
   </properties>
   <artifactId>opencast-dist-develop</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-ingest/pom.xml
+++ b/assemblies/dist-ingest/pom.xml
@@ -9,7 +9,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <disableJobDispatching>true</disableJobDispatching>
   </properties>
   <artifactId>opencast-dist-ingest</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-presentation/pom.xml
+++ b/assemblies/dist-presentation/pom.xml
@@ -9,7 +9,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <disableJobDispatching>true</disableJobDispatching>
   </properties>
   <artifactId>opencast-dist-presentation</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/dist-worker/pom.xml
+++ b/assemblies/dist-worker/pom.xml
@@ -9,7 +9,6 @@
   </parent>
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
-    <disableJobDispatching>true</disableJobDispatching>
   </properties>
   <artifactId>opencast-dist-worker</artifactId>
   <packaging>karaf-assembly</packaging>

--- a/assemblies/resources/build.xml
+++ b/assemblies/resources/build.xml
@@ -44,8 +44,8 @@
     <echo>Enabling job dispatching</echo>
     <replaceregexp
       file="target/classes/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg"
-      match="^# dispatch.enabled=false$"
-      replace="dispatch.enabled=true"
+      match="^#dispatch.interval=0$"
+      replace="dispatch.interval=2"
       byline="true" />
   </target>
 </project>

--- a/assemblies/resources/build.xml
+++ b/assemblies/resources/build.xml
@@ -40,12 +40,12 @@
     </delete>
   </target>
 
-  <target if="disableJobDispatching" name="job dispatching">
-    <echo>Disabling job dispatching</echo>
+  <target if="enableJobDispatching" name="job dispatching">
+    <echo>Enabling job dispatching</echo>
     <replaceregexp
-      file="target/classes/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg"
-      match="^#dispatch.interval=2$"
-      replace="dispatch.interval=0"
+      file="target/classes/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg"
+      match="^# dispatch.enabled=false$"
+      replace="dispatch.enabled=true"
       byline="true" />
   </target>
 </project>

--- a/docs/guides/admin/docs/installation/multiple-servers.md
+++ b/docs/guides/admin/docs/installation/multiple-servers.md
@@ -185,8 +185,3 @@ set all servers to use the same URL (e.g. URL of the admin node).
 
     prop.org.opencastproject.file.repo.url=http://<ADMIN-URL>:8080
 
-### org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
-
-To ensure that jobs are not dispatched by non-admin nodes, on these you should also set:
-
-    dispatch.interval=0

--- a/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
@@ -1,13 +1,8 @@
 # Configuration for the job dispatcher
 
-# Enables dispatching from this node.  It is very important that only a single node be dispatching at once.
-# Usually you want to enable this on your admin node, but nowhere else.
-# Default: false
-# dispatch.enabled=false
-
 # The interval in seconds between two rounds of dispatching in the service registry. A minimum value of 1s is enforced
-# due to performance reasons. Set to 0 to disable dispatching from this service registry.
-# Service registry dispatching is automatically set to 0 on everything but admin or allinone nodes and should usually
-# not be activated on these nodes to avoid concurrency problems.
-# Default: 2
-#dispatch.interval=2
+# due to performance reasons. Set to 0 to disable dispatching from this service registry.  Default for the job dispatch
+# node is 2. Service registry dispatching is automatically set to 0 on everything but admin or allinone nodes and should
+# usually not be activated on these nodes to avoid concurrency problems.
+# Default: 0
+#dispatch.interval=0

--- a/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.JobDispatcher.cfg
@@ -1,0 +1,13 @@
+# Configuration for the job dispatcher
+
+# Enables dispatching from this node.  It is very important that only a single node be dispatching at once.
+# Usually you want to enable this on your admin node, but nowhere else.
+# Default: false
+# dispatch.enabled=false
+
+# The interval in seconds between two rounds of dispatching in the service registry. A minimum value of 1s is enforced
+# due to performance reasons. Set to 0 to disable dispatching from this service registry.
+# Service registry dispatching is automatically set to 0 on everything but admin or allinone nodes and should usually
+# not be activated on these nodes to avoid concurrency problems.
+# Default: 2
+#dispatch.interval=2

--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -8,13 +8,6 @@
 # Default: None
 #no.error.state.service.types=
 
-# The interval in seconds between two rounds of dispatching in the service registry. A minimum value of 1s is enforced
-# due to performance reasons. Set to 0 to disable dispatching from this service registry.
-# Service registry dispatching is automatically set to 0 on everything but admin or allinone nodes and should usually
-# not be activated on these nodes to avoid concurrency problems.
-# Default: 2
-#dispatch.interval=2
-
 # The interval in seconds between checking if the hosts in the service registry hosts are still alive.
 # Set to 0 to disable checking if hosts are still alive and able to be dispatched to.
 # Default: 60

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -79,10 +79,6 @@
       <artifactId>httpclient-osgi</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.entwinemedia.common</groupId>
-      <artifactId>functional</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -97,9 +97,6 @@ public class JobDispatcher {
   /** JPA persistence unit name */
   public static final String PERSISTENCE_UNIT = "org.opencastproject.common";
 
-  /** Configuration key to enable dispatch. */
-  protected  static final String OPT_DISPATCHENABLED = "dispatch.enabled";
-
   /** Configuration key for the dispatch interval, in seconds */
   protected static final String OPT_DISPATCHINTERVAL = "dispatch.interval";
 
@@ -107,7 +104,7 @@ public class JobDispatcher {
   static final long MIN_DISPATCH_INTERVAL = 1;
 
   /** Default delay between job dispatching attempts, in seconds */
-  static final long DEFAULT_DISPATCH_INTERVAL = 2;
+  static final long DEFAULT_DISPATCH_INTERVAL = 0;
 
   private static final Logger logger = LoggerFactory.getLogger(JobDispatcher.class);
 
@@ -192,9 +189,6 @@ public class JobDispatcher {
 
     logger.info("Updating job dipatcher properties");
 
-    // NB: Read the javadoc for Boolean.valueOf.  This basically defaults to false.
-    boolean enableDispatch = Boolean.valueOf(StringUtils.trimToNull((String) properties.get(OPT_DISPATCHENABLED)));
-
     long dispatchInterval = DEFAULT_DISPATCH_INTERVAL;
     String dispatchIntervalString = StringUtils.trimToNull((String) properties.get(OPT_DISPATCHINTERVAL));
     if (StringUtils.isNotBlank(dispatchIntervalString)) {
@@ -222,7 +216,7 @@ public class JobDispatcher {
     }
 
     // Schedule the job dispatching.
-    if (enableDispatch && dispatchInterval > 0) {
+    if (dispatchInterval > 0) {
       logger.info("Job dispatching is enabled");
       logger.debug("Starting job dispatching at a custom interval of {}s", dispatchInterval);
       jdfuture = scheduledExecutor.scheduleWithFixedDelay(getJobDispatcherRunnable(), dispatchDelay, dispatchInterval,

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -111,9 +111,6 @@ public class JobDispatcher {
   /** Default delay between job dispatching attempts, in seconds */
   static final long DEFAULT_DISPATCH_INTERVAL = 2;
 
-  /** Default delay before starting job dispatching, in seconds */
-  static final long DEFAULT_DISPATCH_START_DELAY = 60;
-
   private static final Logger logger = LoggerFactory.getLogger(JobDispatcher.class);
 
   private ServiceRegistryJpaImpl serviceRegistry;

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -1,0 +1,649 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.serviceregistry.impl;
+
+import static com.entwinemedia.fn.Stream.$;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.opencastproject.security.api.SecurityConstants.ORGANIZATION_HEADER;
+import static org.opencastproject.security.api.SecurityConstants.USER_HEADER;
+
+import org.opencastproject.job.api.Job;
+import org.opencastproject.job.jpa.JpaJob;
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.OrganizationDirectoryService;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.TrustedHttpClient;
+import org.opencastproject.security.api.TrustedHttpClientException;
+import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
+import org.opencastproject.serviceregistry.api.HostRegistration;
+import org.opencastproject.serviceregistry.api.ServiceRegistration;
+import org.opencastproject.serviceregistry.api.ServiceRegistryException;
+import org.opencastproject.serviceregistry.api.SystemLoad;
+import org.opencastproject.serviceregistry.impl.jpa.ServiceRegistrationJpaImpl;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.util.UrlSupport;
+
+import com.entwinemedia.fn.Fn;
+import com.entwinemedia.fn.Fn2;
+import com.entwinemedia.fn.Stream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.message.BasicNameValuePair;
+import org.osgi.service.cm.ConfigurationException;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Query;
+
+/**
+ * This dispatcher implementation will check for jobs in the QUEUED {@link Job.Status}. If
+ * new jobs are found, the dispatcher will attempt to dispatch each job to the least loaded service.
+ */
+@Component(
+    property = {
+        "service.description=Job Dispatcher"
+    },
+    immediate = true,
+    service = { JobDispatcher.class }
+)
+public class JobDispatcher {
+
+  /** JPA persistence unit name */
+  public static final String PERSISTENCE_UNIT = "org.opencastproject.common";
+
+  /** Configuration key to enable dispatch. */
+  protected  static final String OPT_DISPATCHENABLED = "dispatch.enabled";
+
+  /** Configuration key for the dispatch interval, in seconds */
+  protected static final String OPT_DISPATCHINTERVAL = "dispatch.interval";
+
+  /** Minimum delay between job dispatching attempts, in seconds */
+  static final long MIN_DISPATCH_INTERVAL = 1;
+
+  /** Default delay between job dispatching attempts, in seconds */
+  static final long DEFAULT_DISPATCH_INTERVAL = 2;
+
+  /** Default delay before starting job dispatching, in seconds */
+  static final long DEFAULT_DISPATCH_START_DELAY = 60;
+
+  private static final Logger logger = LoggerFactory.getLogger(JobDispatcher.class);
+
+  private ServiceRegistryJpaImpl serviceRegistry;
+
+  private OrganizationDirectoryService organizationDirectoryService;
+  private UserDirectoryService userDirectoryService;
+  private SecurityService securityService;
+  private TrustedHttpClient client;
+
+  /** The thread pool to use for dispatching. */
+  protected ScheduledThreadPoolExecutor scheduledExecutor = null;
+
+  /** The factory used to generate the entity manager */
+  private EntityManagerFactory emf = null;
+
+  private ScheduledFuture jdfuture = null;
+
+  /**
+   * A list with job types that cannot be dispatched in each interation
+   */
+  private List<String> undispatchableJobTypes = null;
+
+  /** The dispatcher priority list */
+  protected final Map<Long, String> dispatchPriorityList = new HashMap<>();
+
+  /** OSGi DI */
+  @Reference(target = "(osgi.unit.name=org.opencastproject.common)")
+  void setEntityManagerFactory(EntityManagerFactory emf) {
+    this.emf = emf;
+  }
+
+  /** OSGi DI */
+  @Reference()
+  void setServiceRegistry(ServiceRegistryJpaImpl sr) {
+    this.serviceRegistry = sr;
+  }
+
+  @Reference()
+  void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
+    this.organizationDirectoryService = organizationDirectoryService;
+  }
+
+  @Reference
+  void setUserDirectoryService(UserDirectoryService svc) {
+    this.userDirectoryService = svc;
+  }
+
+  @Reference
+  void setSecurityService(SecurityService sec) {
+    this.securityService = sec;
+  }
+
+  @Reference
+  void setTrustedHttpClient(TrustedHttpClient client) {
+    this.client = client;
+  }
+
+  @Activate
+  public void activate(ComponentContext cc) throws ConfigurationException  {
+    logger.info("Activate job dispatcher");
+    scheduledExecutor = (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1);
+    scheduledExecutor.setRemoveOnCancelPolicy(true);
+    logger.info("Activated");
+    updated(cc.getProperties());
+  }
+
+
+  @Modified
+  public void modified(ComponentContext cc) throws ConfigurationException {
+    logger.debug("Modified in job dispatcher");
+    updated(cc.getProperties());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see org.osgi.service.cm.ManagedService#updated(java.util.Dictionary)
+   */
+  @SuppressWarnings("rawtypes")
+  public void updated(Dictionary properties) {
+
+    logger.info("Updating job dipatcher properties");
+
+    // NB: Read the javadoc for Boolean.valueOf.  This basically defaults to false.
+    boolean enableDispatch = Boolean.valueOf(StringUtils.trimToNull((String) properties.get(OPT_DISPATCHENABLED)));
+
+    long dispatchInterval = DEFAULT_DISPATCH_INTERVAL;
+    String dispatchIntervalString = StringUtils.trimToNull((String) properties.get(OPT_DISPATCHINTERVAL));
+    if (StringUtils.isNotBlank(dispatchIntervalString)) {
+      try {
+        dispatchInterval = Long.parseLong(dispatchIntervalString);
+      } catch (Exception e) {
+        logger.warn("Dispatch interval '{}' is malformed, setting to {}", dispatchIntervalString, MIN_DISPATCH_INTERVAL);
+        dispatchInterval = MIN_DISPATCH_INTERVAL;
+      }
+      if (dispatchInterval == 0) {
+        logger.info("Dispatching disabled");
+      } else if (dispatchInterval < MIN_DISPATCH_INTERVAL) {
+        logger.warn("Dispatch interval {} ms too low, adjusting to {}", dispatchInterval, MIN_DISPATCH_INTERVAL);
+        dispatchInterval = MIN_DISPATCH_INTERVAL;
+      } else {
+        logger.info("Dispatch interval set to {} ms", dispatchInterval);
+      }
+    }
+
+    long dispatchDelay = dispatchInterval;
+
+    // Stop the current dispatch thread so we can configure a new one
+    if (jdfuture != null) {
+      jdfuture.cancel(true);
+    }
+
+    // Schedule the job dispatching.
+    if (enableDispatch && dispatchInterval > 0) {
+      logger.info("Job dispatching is enabled");
+      logger.debug("Starting job dispatching at a custom interval of {}s", dispatchInterval);
+      jdfuture = scheduledExecutor.scheduleWithFixedDelay(getJobDispatcherRunnable(), dispatchDelay, dispatchInterval,
+          TimeUnit.SECONDS);
+    } else {
+      logger.info("Job dispatching is disabled");
+    }
+  }
+
+  Runnable getJobDispatcherRunnable() {
+    return new JobDispatcherRunner();
+  }
+
+  public class JobDispatcherRunner implements Runnable {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see Thread#run()
+     */
+    @Override
+    public void run() {
+
+      logger.debug("Starting job dispatch");
+
+      undispatchableJobTypes = new ArrayList<String>();
+      EntityManager em = null;
+      try {
+        em = emf.createEntityManager();
+
+        //GDLGDL: move collectJobStats to the JD config, then this is reasonable
+        // FIXME: the stats are not currently used and the queries are very expensive in database time.
+        if (serviceRegistry.collectJobstats) {
+          serviceRegistry.updateStatisticsJobData();
+        }
+
+        if (!dispatchPriorityList.isEmpty()) {
+          logger.trace("Checking for outdated jobs in dispatchPriorityList's '{}' jobs", dispatchPriorityList.size());
+          // Remove outdated jobs from priority list
+          List<Long> jobIds = getDispatchableJobsWithIdFilter(em, dispatchPriorityList.keySet());
+          for (Long jobId : new HashSet<>(dispatchPriorityList.keySet())) {
+            if (!jobIds.contains(jobId)) {
+              logger.debug("Removing outdated dispatchPriorityList job '{}'", jobId);
+              dispatchPriorityList.remove(jobId);
+            }
+          }
+        }
+
+        int jobsOffset = 0;
+        List<JpaJob> dispatchableJobs = null;
+        List<JpaJob> workflowJobs = new ArrayList();
+        boolean jobsFound = false;
+        do {
+          // dispatch all dispatchable jobs with status restarted
+          dispatchableJobs = serviceRegistry.getDispatchableJobsWithStatus(em, jobsOffset, ServiceRegistryJpaImpl.DEFAULT_DISPATCH_JOBS_LIMIT, Job.Status.RESTART);
+          jobsOffset += ServiceRegistryJpaImpl.DEFAULT_DISPATCH_JOBS_LIMIT;
+          jobsFound = !dispatchableJobs.isEmpty();
+
+          // skip all jobs of type workflow, we will handle them next
+          for (JpaJob job : dispatchableJobs) {
+            if (ServiceRegistryJpaImpl.TYPE_WORKFLOW.equals(job.getJobType())) {
+              workflowJobs.add(job);
+            }
+          }
+          if (dispatchableJobs.removeAll(workflowJobs) && dispatchableJobs.isEmpty()) {
+            continue;
+          }
+
+          dispatchDispatchableJobs(em, dispatchableJobs);
+        } while (jobsFound);
+
+        jobsOffset = 0;
+        jobsFound = false;
+        do {
+          // dispatch all dispatchable jobs with status queued
+          dispatchableJobs = serviceRegistry.getDispatchableJobsWithStatus(em, jobsOffset, ServiceRegistryJpaImpl.DEFAULT_DISPATCH_JOBS_LIMIT, Job.Status.QUEUED);
+          jobsOffset += ServiceRegistryJpaImpl.DEFAULT_DISPATCH_JOBS_LIMIT;
+          jobsFound = !dispatchableJobs.isEmpty();
+
+          // skip all jobs of type workflow, we will handle them next
+          for (JpaJob job : dispatchableJobs) {
+            if (ServiceRegistryJpaImpl.TYPE_WORKFLOW.equals(job.getJobType())) {
+              workflowJobs.add(job);
+            }
+          }
+          if (dispatchableJobs.removeAll(workflowJobs) && dispatchableJobs.isEmpty()) {
+            continue;
+          }
+
+          dispatchDispatchableJobs(em, dispatchableJobs);
+        } while (jobsFound);
+
+        if (!workflowJobs.isEmpty()) {
+          dispatchDispatchableJobs(em, workflowJobs);
+        }
+
+      } catch (Throwable t) {
+        logger.warn("Error dispatching jobs", t);
+      } finally {
+        undispatchableJobTypes = null;
+        if (em != null) {
+          em.close();
+        }
+      }
+
+      logger.debug("Finished job dispatch");
+    }
+
+    /**
+     * Dispatch the given jobs.
+     *
+     * @param em             the entity manager
+     * @param jobsToDispatch list with dispatchable jobs to dispatch
+     */
+    private void dispatchDispatchableJobs(EntityManager em, List<JpaJob> jobsToDispatch) {
+      //Get the current system load
+      SystemLoad systemLoad = serviceRegistry.getHostLoads(em);
+
+      for (JpaJob job : jobsToDispatch) {
+
+        // Remember the job type
+        String jobType = job.getJobType();
+
+        // Skip jobs that we already know can't be dispatched except of jobs in the priority list
+        String jobSignature = new StringBuilder(jobType).append('@').append(job.getOperation()).toString();
+        if (undispatchableJobTypes.contains(jobSignature) && !dispatchPriorityList.keySet().contains(job.getId())) {
+          logger.trace("Skipping dispatching of {} with type '{}' for this round of dispatching", job, jobType);
+          continue;
+        }
+
+        // Set the job's user and organization prior to dispatching
+        String creator = job.getCreator();
+        String creatorOrganization = job.getOrganization();
+
+        // Try to load the organization.
+        Organization organization = null;
+        try {
+          organization = organizationDirectoryService.getOrganization(creatorOrganization);
+          securityService.setOrganization(organization);
+        } catch (NotFoundException e) {
+          logger.debug("Skipping dispatching of job for non-existing organization '{}'", creatorOrganization);
+          continue;
+        }
+
+        // Try to load the user
+        User user = userDirectoryService.loadUser(creator);
+        if (user == null) {
+          logger.warn("Unable to dispatch {}: creator '{}' is not available", job, creator);
+          continue;
+        }
+        securityService.setUser(user);
+
+        // Start dispatching
+        try {
+          List<ServiceRegistration> services = serviceRegistry.getServiceRegistrations(em);
+          List<HostRegistration> hosts = Stream.$(serviceRegistry.getHostRegistrations(em)).filter(filterOutPriorityHosts._2(job.getId())).toList();
+          List<ServiceRegistration> candidateServices = null;
+
+          // Depending on whether this running job is trying to reach out to other services or whether this is an
+          // attempt to execute the next operation in a workflow, choose either from a limited or from the full list
+          // of services
+          Job parentJob = null;
+          try {
+            if (job.getParentJob() != null) {
+              parentJob = serviceRegistry.getJob(job.getParentJob().getId());
+            }
+          } catch (NotFoundException e) {
+            // That's ok
+          }
+
+          // When a job A starts a series of child jobs, then those child jobs should only be dispatched at the
+          // same time if there is processing capacity available.
+          boolean parentHasRunningChildren = false;
+          if (parentJob != null) {
+            for (Job child : serviceRegistry.getChildJobs(parentJob.getId())) {
+              if (Job.Status.RUNNING.equals(child.getStatus())) {
+                parentHasRunningChildren = true;
+                break;
+              }
+            }
+          }
+
+          // If this is a root job (a new workflow or a new workflow operation), then only dispatch if there is
+          // capacity, i. e. the workflow service is ok dispatching the next workflow or the next workflow operation.
+          if (parentJob == null || ServiceRegistryJpaImpl.TYPE_WORKFLOW.equals(jobType) || parentHasRunningChildren) {
+            logger.trace("Using available capacity only for dispatching of {} to a service of type '{}'", job, jobType);
+            candidateServices = serviceRegistry.getServiceRegistrationsWithCapacity(jobType, services, hosts, systemLoad);
+          } else {
+            logger.trace("Using full list of services for dispatching of {} to a service of type '{}'", job, jobType);
+            candidateServices = serviceRegistry.getServiceRegistrationsByLoad(jobType, services, hosts, systemLoad);
+          }
+
+          // Try to dispatch the job
+          String hostAcceptingJob = null;
+          try {
+            hostAcceptingJob = dispatchJob(em, job, candidateServices);
+            try {
+              systemLoad.updateNodeLoad(hostAcceptingJob, job.getJobLoad());
+            } catch (NotFoundException e) {
+              logger.info("Host {} not found in load list, cannot dispatch {} to it", hostAcceptingJob, job);
+            }
+
+            dispatchPriorityList.remove(job.getId());
+          } catch (ServiceUnavailableException e) {
+            logger.debug("Jobs of type {} currently cannot be dispatched", job.getOperation());
+            // Don't mark workflow jobs as undispatchable to not impact worklfow operations
+            if (!ServiceRegistryJpaImpl.TYPE_WORKFLOW.equals(jobType)) {
+              undispatchableJobTypes.add(jobSignature);
+            }
+            continue;
+          } catch (UndispatchableJobException e) {
+            logger.debug("{} currently cannot be dispatched", job);
+            continue;
+          }
+
+          logger.debug("{} dispatched to {}", job, hostAcceptingJob);
+        } catch (ServiceRegistryException e) {
+          Throwable cause = (e.getCause() != null) ? e.getCause() : e;
+          logger.error("Error dispatching {}: {}", job, cause);
+        } finally {
+          securityService.setUser(null);
+          securityService.setOrganization(null);
+        }
+      }
+    }
+
+    /**
+     * Dispatches the job to the least loaded service that will accept the job, or throws a
+     * <code>ServiceUnavailableException</code> if there is no such service.
+     *
+     * @param em       the current entity manager
+     * @param job      the job to dispatch
+     * @param services a list of service registrations
+     * @return the host that accepted the dispatched job, or <code>null</code> if no services took the job.
+     * @throws ServiceRegistryException    if the service registrations are unavailable
+     * @throws ServiceUnavailableException if no service is available or if all available services refuse to take on more work
+     * @throws UndispatchableJobException  if the current job cannot be processed
+     */
+    private String dispatchJob(EntityManager em, JpaJob job, List<ServiceRegistration> services)
+        throws ServiceRegistryException, ServiceUnavailableException, UndispatchableJobException {
+
+      if (services.size() == 0) {
+        logger.debug("No service is currently available to handle jobs of type '" + job.getJobType() + "'");
+        throw new ServiceUnavailableException("No service of type " + job.getJobType() + " available");
+      }
+
+      // Try the service registrations, after the first one finished, we quit;
+      job.setStatus(Job.Status.DISPATCHING);
+
+      boolean triedDispatching = false;
+
+      boolean jobLoadExceedsMaximumLoads = false;
+      final Float highestMaxLoad = $(services).map(toHostRegistration).map(toMaxLoad).sort(sortFloatValuesDesc).head2();
+      if (job.getJobLoad() > highestMaxLoad) {
+        // None of the available hosts is able to accept the job because the largest max load value is less than this job's load value
+        jobLoadExceedsMaximumLoads = true;
+      }
+
+      for (ServiceRegistration registration : services) {
+        job.setProcessorServiceRegistration((ServiceRegistrationJpaImpl) registration);
+
+        // Skip registration of host with less max load than highest available max load
+        // Note: This service registration may or may not live on a node which is set to accept jobs exceeding its max load
+        if (jobLoadExceedsMaximumLoads && job.getProcessorServiceRegistration().getHostRegistration().getMaxLoad() != highestMaxLoad) {
+          continue;
+        }
+
+        try {
+          job = serviceRegistry.updateInternal(em, job);
+        } catch (Exception e) {
+          // In theory, we should catch javax.persistence.OptimisticLockException. Unfortunately, eclipselink throws
+          // org.eclipse.persistence.exceptions.OptimisticLockException. In order to avoid importing the implementation
+          // specific APIs, we just catch Exception.
+          logger.debug("Unable to dispatch {}.  This is likely caused by another service registry dispatching the job",
+              job);
+          throw new UndispatchableJobException(job + " is already being dispatched");
+        }
+
+        triedDispatching = true;
+
+        String serviceUrl = UrlSupport.concat(registration.getHost(), registration.getPath(), "dispatch");
+        HttpPost post = new HttpPost(serviceUrl);
+
+        // Add current organization and user so they can be used during execution at the remote end
+        post.addHeader(ORGANIZATION_HEADER, securityService.getOrganization().getId());
+        post.addHeader(USER_HEADER, securityService.getUser().getUsername());
+
+        List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
+        params.add(new BasicNameValuePair("id", Long.toString(job.getId())));
+        params.add(new BasicNameValuePair("operation", job.getOperation()));
+        post.setEntity(new UrlEncodedFormEntity(params, UTF_8));
+
+        // Post the request
+        HttpResponse response = null;
+        int responseStatusCode;
+        try {
+          logger.debug("Trying to dispatch {} type '{}' load {} to {}", job, job.getJobType(), job.getJobLoad(),
+              registration.getHost());
+          if (!ServiceRegistryJpaImpl.START_WORKFLOW.equals(job.getOperation())) {
+            serviceRegistry.setCurrentJob(job.toJob());
+          }
+          response = client.execute(post);
+          responseStatusCode = response.getStatusLine().getStatusCode();
+          if (responseStatusCode == HttpStatus.SC_NO_CONTENT) {
+            return registration.getHost();
+          } else if (responseStatusCode == HttpStatus.SC_SERVICE_UNAVAILABLE) {
+            logger.debug("Service {} is currently refusing to accept jobs of type {}", registration, job.getOperation());
+            continue;
+          } else if (responseStatusCode == HttpStatus.SC_PRECONDITION_FAILED) {
+            job.setStatus(Job.Status.FAILED);
+            job = serviceRegistry.updateJob(job);
+            logger.debug("Service {} refused to accept {}", registration, job);
+            throw new UndispatchableJobException(IOUtils.toString(response.getEntity().getContent()));
+          } else if (responseStatusCode == HttpStatus.SC_METHOD_NOT_ALLOWED) {
+            logger.debug("Service {} is not yet reachable", registration);
+            continue;
+          } else {
+            logger.warn("Service {} failed ({}) accepting {}", registration, responseStatusCode, job);
+            continue;
+          }
+        } catch (UndispatchableJobException e) {
+          throw e;
+        } catch (TrustedHttpClientException e) {
+          // Will try another node. If no other node, it will be re-queued
+          logger.warn("Unable to dispatch {}", job, e);
+          continue;
+        } catch (Exception e) {
+          logger.warn("Unable to dispatch {}", job, e);
+        } finally {
+          try {
+            client.close(response);
+          } catch (IOException e) {
+            // ignore
+          }
+          serviceRegistry.setCurrentJob(null);
+        }
+      }
+
+      // We've tried dispatching to every online service that can handle this type of job, with no luck.
+      if (triedDispatching) {
+        // Workflow type jobs are not set to priority list, because they handle accepting jobs not based on the job load
+        // If the system don't accepts jobs whose load exceeds the host's max load we can't make use of the priority
+        // list
+        if (serviceRegistry.acceptJobLoadsExeedingMaxLoad && !dispatchPriorityList.containsKey(job.getId()) && !ServiceRegistryJpaImpl.TYPE_WORKFLOW.equals(job.getJobType())
+            && job.getProcessorServiceRegistration() != null) {
+          String host = job.getProcessorServiceRegistration().getHost();
+          logger.debug("About to add {} to dispatchPriorityList with processor host {}", job, host);
+          dispatchPriorityList.put(job.getId(), host);
+        }
+
+        try {
+          job.setStatus(Job.Status.QUEUED);
+          job.setProcessorServiceRegistration(null);
+          job = serviceRegistry.updateJob(job);
+        } catch (Exception e) {
+          logger.error("Unable to put {} back into queue", job, e);
+        }
+      }
+
+      logger.debug("Unable to dispatch {}, no service is currently ready to accept the job", job);
+      throw new UndispatchableJobException(job + " is currently undispatchable");
+    }
+
+    /**
+     * Return dispatchable job ids, where the job status is RESTART or QUEUED and the job id is listed in the given set.
+     *
+     * @param em the entity manager
+     * @param jobIds set with job id's interested in
+     * @return list with dispatchable job id's from the given set, with job status RESTART or QUEUED
+     * @throws ServiceRegistryException if there is a problem communicating with the jobs database
+     */
+    private List<Long> getDispatchableJobsWithIdFilter(EntityManager em, Set<Long> jobIds)
+        throws ServiceRegistryException {
+      if (jobIds == null || jobIds.isEmpty())
+        return Collections.EMPTY_LIST;
+
+      Query query = null;
+      try {
+        query = em.createNamedQuery("Job.dispatchable.status.idfilter");
+        query.setParameter("jobids", dispatchPriorityList.keySet());
+        query.setParameter("statuses", Arrays.asList(Job.Status.RESTART.ordinal(), Job.Status.QUEUED.ordinal()));
+        return query.getResultList();
+      } catch (Exception e) {
+        throw new ServiceRegistryException(e);
+      }
+    }
+
+    private final Fn2<HostRegistration, Long, Boolean> filterOutPriorityHosts = new Fn2<HostRegistration, Long, Boolean>() {
+      @Override
+      public Boolean apply(HostRegistration host, Long jobId) {
+        if (dispatchPriorityList.values().contains(host.getBaseUrl()) && !host.getBaseUrl().equals(dispatchPriorityList.get(jobId))) {
+          return false;
+        }
+        return true;
+      }
+    };
+
+    private final Fn<ServiceRegistration, HostRegistration> toHostRegistration = new Fn<ServiceRegistration, HostRegistration>() {
+      @Override
+      public HostRegistration apply(ServiceRegistration s) {
+        return ((ServiceRegistrationJpaImpl) s).getHostRegistration();
+      }
+    };
+
+    private final Fn<HostRegistration, Float> toMaxLoad = new Fn<HostRegistration, Float>() {
+      @Override
+      public Float apply(HostRegistration h) {
+        return h.getMaxLoad();
+      }
+    };
+
+    private final Comparator<Float> sortFloatValuesDesc = new Comparator<Float>() {
+      @Override
+      public int compare(Float o1, Float o2) {
+        return o2.compareTo(o1);
+      }
+    };
+  }
+}

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.serviceregistry.impl;
 
-import static com.entwinemedia.fn.Stream.$;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.opencastproject.job.api.AbstractJobProducer.ACCEPT_JOB_LOADS_EXCEEDING_PROPERTY;
@@ -64,8 +63,6 @@ import org.opencastproject.util.UrlSupport;
 import org.opencastproject.util.data.functions.Strings;
 import org.opencastproject.util.jmx.JmxUtil;
 
-import com.entwinemedia.fn.Fn;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.http.HttpResponse;
@@ -104,6 +101,7 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.management.ObjectInstance;
@@ -2618,7 +2616,9 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
           List<ServiceRegistration> serviceRegistrations, List<HostRegistration> hostRegistrations,
           final SystemLoad systemLoad) {
 
-    final List<String> hostBaseUrls = $(hostRegistrations).map(toBaseUrl).toList();
+    final List<String> hostBaseUrls = hostRegistrations.stream()
+                                                       .map(toBaseUrl)
+                                                       .collect(Collectors.toUnmodifiableList());
     final List<ServiceRegistration> filteredList = new ArrayList<ServiceRegistration>();
 
     for (ServiceRegistration service : serviceRegistrations) {
@@ -2702,7 +2702,9 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
           List<ServiceRegistration> serviceRegistrations, List<HostRegistration> hostRegistrations,
           final SystemLoad systemLoad) {
 
-    final List<String> hostBaseUrls = $(hostRegistrations).map(toBaseUrl).toList();
+    final List<String> hostBaseUrls = hostRegistrations.stream()
+                                                       .map(toBaseUrl)
+                                                       .collect(Collectors.toUnmodifiableList());
     final List<ServiceRegistration> filteredList = new ArrayList<ServiceRegistration>();
 
     logger.debug("Finding services to dispatch job of type {}", jobType);
@@ -2790,7 +2792,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     }
   }
 
-  private final Fn<HostRegistration, String> toBaseUrl = new Fn<HostRegistration, String>() {
+  private final Function<HostRegistration, String> toBaseUrl = new Function<HostRegistration, String>() {
     @Override
     public String apply(HostRegistration h) {
       return h.getBaseUrl();

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -23,14 +23,11 @@ package org.opencastproject.serviceregistry.impl;
 
 import static com.entwinemedia.fn.Stream.$;
 import static java.lang.String.format;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.opencastproject.job.api.AbstractJobProducer.ACCEPT_JOB_LOADS_EXCEEDING_PROPERTY;
 import static org.opencastproject.job.api.AbstractJobProducer.DEFAULT_ACCEPT_JOB_LOADS_EXCEEDING;
 import static org.opencastproject.job.api.Job.FailureReason.DATA;
 import static org.opencastproject.job.api.Job.Status.FAILED;
-import static org.opencastproject.security.api.SecurityConstants.ORGANIZATION_HEADER;
-import static org.opencastproject.security.api.SecurityConstants.USER_HEADER;
 import static org.opencastproject.serviceregistry.api.ServiceState.ERROR;
 import static org.opencastproject.serviceregistry.api.ServiceState.NORMAL;
 import static org.opencastproject.serviceregistry.api.ServiceState.WARNING;
@@ -41,12 +38,10 @@ import org.opencastproject.job.api.Job.Status;
 import org.opencastproject.job.jpa.JpaJob;
 import org.opencastproject.rest.RestConstants;
 import org.opencastproject.security.api.Organization;
-import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.TrustedHttpClientException;
 import org.opencastproject.security.api.User;
-import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.serviceregistry.api.HostRegistration;
 import org.opencastproject.serviceregistry.api.HostStatistics;
 import org.opencastproject.serviceregistry.api.IncidentService;
@@ -70,17 +65,12 @@ import org.opencastproject.util.data.functions.Strings;
 import org.opencastproject.util.jmx.JmxUtil;
 
 import com.entwinemedia.fn.Fn;
-import com.entwinemedia.fn.Fn2;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.message.BasicNameValuePair;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -98,7 +88,6 @@ import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -109,11 +98,9 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -137,7 +124,7 @@ import javax.persistence.TypedQuery;
     "service.description=Service registry"
   },
   immediate = true,
-  service = { ManagedService.class, ServiceRegistry.class }
+  service = { ManagedService.class, ServiceRegistry.class, ServiceRegistryJpaImpl.class }
 )
 public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
 
@@ -185,9 +172,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** Configuration key for the maximum load */
   protected static final String OPT_MAXLOAD = "org.opencastproject.server.maxload";
 
-  /** Configuration key for the dispatch interval, in seconds */
-  protected static final String OPT_DISPATCHINTERVAL = "dispatch.interval";
-
   /** Configuration key for the interval to check whether the hosts in the service registry are still alive, in seconds */
   protected static final String OPT_HEARTBEATINTERVAL = "heartbeat.interval";
 
@@ -199,15 +183,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
 
   /** The http client to use when connecting to remote servers */
   protected TrustedHttpClient client = null;
-
-  /** Minimum delay between job dispatching attempts, in seconds */
-  static final long MIN_DISPATCH_INTERVAL = 1;
-
-  /** Default delay between job dispatching attempts, in seconds */
-  static final long DEFAULT_DISPATCH_INTERVAL = 2;
-
-  /** Default delay before starting job dispatching, in seconds */
-  static final long DEFAULT_DISPATCH_START_DELAY = 60;
 
   /** Default jobs limit during dispatching
    * (larger value will fetch more entries from the database at the same time and increase RAM usage) */
@@ -265,12 +240,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
   /** The security service */
   protected SecurityService securityService = null;
 
-  /** The user directory service */
-  protected UserDirectoryService userDirectoryService = null;
-
-  /** The organization directory service */
-  protected OrganizationDirectoryService organizationDirectoryService = null;
-
   protected Incidents incidents;
 
   /** Whether to collect detailed job statistics */
@@ -291,9 +260,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     JOB_STATUSES_INFLUENCING_LOAD_BALANCING = new ArrayList<Status>();
     JOB_STATUSES_INFLUENCING_LOAD_BALANCING.add(Status.RUNNING);
   }
-
-  /** The dispatcher priority list */
-  protected final Map<Long, String> dispatchPriorityList = new HashMap<>();
 
   /** Whether to accept a job whose load exceeds the host’s max load */
   protected Boolean acceptJobLoadsExeedingMaxLoad = true;
@@ -770,25 +736,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       }
     }
 
-    long dispatchInterval = DEFAULT_DISPATCH_INTERVAL;
-    String dispatchIntervalString = StringUtils.trimToNull((String) properties.get(OPT_DISPATCHINTERVAL));
-    if (StringUtils.isNotBlank(dispatchIntervalString)) {
-      try {
-        dispatchInterval = Long.parseLong(dispatchIntervalString);
-      } catch (Exception e) {
-        logger.warn("Dispatch interval '{}' is malformed, setting to {}", dispatchIntervalString, MIN_DISPATCH_INTERVAL);
-        dispatchInterval = MIN_DISPATCH_INTERVAL;
-      }
-      if (dispatchInterval == 0) {
-        logger.info("Dispatching disabled");
-      } else if (dispatchInterval < MIN_DISPATCH_INTERVAL) {
-        logger.warn("Dispatch interval {} ms too low, adjusting to {}", dispatchInterval, MIN_DISPATCH_INTERVAL);
-        dispatchInterval = MIN_DISPATCH_INTERVAL;
-      } else {
-        logger.info("Dispatch interval set to {} ms", dispatchInterval);
-      }
-    }
-
     long heartbeatInterval = DEFAULT_HEART_BEAT;
     String heartbeatIntervalString = StringUtils.trimToNull((String) properties.get(OPT_HEARTBEATINTERVAL));
     if (StringUtils.isNotBlank(heartbeatIntervalString)) {
@@ -830,27 +777,12 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       }
     }
 
-    long dispatchDelay = DEFAULT_DISPATCH_START_DELAY;
-
-    // Stop the current scheduled executors so we can configure new ones
-    if (scheduledExecutor != null) {
-      scheduledExecutor.shutdown();
-      dispatchDelay = dispatchInterval;
-    }
-
-    scheduledExecutor = Executors.newScheduledThreadPool(2);
+    scheduledExecutor = Executors.newScheduledThreadPool(1);
 
     // Schedule the service heartbeat if the interval is > 0
     if (heartbeatInterval > 0) {
       logger.debug("Starting service heartbeat at a custom interval of {}s", heartbeatInterval);
       scheduledExecutor.scheduleWithFixedDelay(new JobProducerHeartbeat(), heartbeatInterval, heartbeatInterval,
-              TimeUnit.SECONDS);
-    }
-
-    // Schedule the job dispatching.
-    if (dispatchInterval > 0) {
-      logger.debug("Starting job dispatching at a custom interval of {}s", dispatchInterval);
-      scheduledExecutor.scheduleWithFixedDelay(new JobDispatcher(), dispatchDelay, dispatchInterval,
               TimeUnit.SECONDS);
     }
   }
@@ -916,7 +848,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     currentJob.set(job);
   }
 
-  private JpaJob updateJob(JpaJob job) throws ServiceRegistryException {
+  JpaJob updateJob(JpaJob job) throws ServiceRegistryException {
     EntityManager em = null;
     try {
       em = emf.createEntityManager();
@@ -1037,6 +969,21 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
         tx.rollback();
       }
       throw e;
+    }
+  }
+
+  public void updateStatisticsJobData() {
+    EntityManager em = null;
+    try {
+      em = emf.createEntityManager();
+      jobsStatistics.updateAvg(getAvgOperations(em));
+      jobsStatistics.updateJobCount(getCountPerHostService(em));
+    } catch (ServiceRegistryException e) {
+      logger.warn("Unable to update job dispatch statistics data", e);
+    } finally {
+      if (null != em) {
+        em.close();
+      }
     }
   }
 
@@ -1958,30 +1905,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     }
   }
 
-  /**
-   * Return dispatchable job ids, where the job status is RESTART or QUEUED and the job id is listed in the given set.
-   *
-   * @param em the entity manager
-   * @param jobIds set with job id's interested in
-   * @return list with dispatchable job id's from the given set, with job status RESTART or QUEUED
-   * @throws ServiceRegistryException if there is a problem communicating with the jobs database
-   */
-  protected List<Long> getDispatchableJobsWithIdFilter(EntityManager em, Set<Long> jobIds)
-          throws ServiceRegistryException {
-    if (jobIds == null || jobIds.isEmpty())
-      return Collections.EMPTY_LIST;
-
-    Query query = null;
-    try {
-      query = em.createNamedQuery("Job.dispatchable.status.idfilter");
-      query.setParameter("jobids", dispatchPriorityList.keySet());
-      query.setParameter("statuses", Arrays.asList(Status.RESTART.ordinal(), Status.QUEUED.ordinal()));
-      return query.getResultList();
-    } catch (Exception e) {
-      throw new ServiceRegistryException(e);
-    }
-  }
-
   @SuppressWarnings("unchecked")
   protected List<Object[]> getAvgOperations(EntityManager em) throws ServiceRegistryException {
     Query query = null;
@@ -2464,28 +2387,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
     this.securityService = securityService;
   }
 
-  /**
-   * Callback for setting the user directory service.
-   *
-   * @param userDirectoryService
-   *          the userDirectoryService to set
-   */
-  @Reference
-  public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
-    this.userDirectoryService = userDirectoryService;
-  }
-
-  /**
-   * Sets a reference to the organization directory service.
-   *
-   * @param organizationDirectory
-   *          the organization directory
-   */
-  @Reference
-  public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectory) {
-    this.organizationDirectoryService = organizationDirectory;
-  }
-
   /** OSGi DI. */
   @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy =  ReferencePolicy.DYNAMIC, unbind = "unsetIncidentService")
   public void setIncidentService(IncidentService incidentService) {
@@ -2895,402 +2796,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       return h.getBaseUrl();
     }
   };
-
-  /**
-   * This dispatcher implementation will check for jobs in the QUEUED {@link Status}. If
-   * new jobs are found, the dispatcher will attempt to dispatch each job to the least loaded service.
-   */
-  class JobDispatcher implements Runnable {
-
-    /** A list with job types that cannot be dispatched in each interation */
-    private List<String> undispatchableJobTypes = null;
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see java.lang.Thread#run()
-     */
-    @Override
-    public void run() {
-
-      logger.debug("Starting job dispatching");
-
-      undispatchableJobTypes = new ArrayList<String>();
-      EntityManager em = null;
-      try {
-        em = emf.createEntityManager();
-
-        // FIXME: the stats are not currently used and the queries are very
-        // expense in database time.
-        if (collectJobstats) {
-          jobsStatistics.updateAvg(getAvgOperations(em));
-          jobsStatistics.updateJobCount(getCountPerHostService(em));
-        }
-
-        if (!dispatchPriorityList.isEmpty()) {
-          logger.trace("Checking for outdated jobs in dispatchPriorityList's '{}' jobs", dispatchPriorityList.size());
-          // Remove outdated jobs from priority list
-          List<Long> jobIds = getDispatchableJobsWithIdFilter(em, dispatchPriorityList.keySet());
-          for (Long jobId : new HashSet<>(dispatchPriorityList.keySet())) {
-            if (!jobIds.contains(jobId)) {
-              logger.debug("Removing outdated dispatchPriorityList job '{}'", jobId);
-              dispatchPriorityList.remove(jobId);
-            }
-          }
-        }
-
-        int jobsOffset = 0;
-        List<JpaJob> dispatchableJobs = null;
-        List<JpaJob> workflowJobs = new ArrayList();
-        boolean jobsFound = false;
-        do {
-          // dispatch all dispatchable jobs with status restarted
-          dispatchableJobs = getDispatchableJobsWithStatus(em, jobsOffset, DEFAULT_DISPATCH_JOBS_LIMIT, Status.RESTART);
-          jobsOffset += DEFAULT_DISPATCH_JOBS_LIMIT;
-          jobsFound = !dispatchableJobs.isEmpty();
-
-          // skip all jobs of type workflow, we will handle them next
-          for (JpaJob job : dispatchableJobs) {
-            if (TYPE_WORKFLOW.equals(job.getJobType())) {
-              workflowJobs.add(job);
-            }
-          }
-          if (dispatchableJobs.removeAll(workflowJobs) && dispatchableJobs.isEmpty())
-            continue;
-
-          dispatchDispatchableJobs(em, dispatchableJobs);
-        } while (jobsFound);
-
-        jobsOffset = 0;
-        jobsFound = false;
-        do {
-          // dispatch all dispatchable jobs with status queued
-          dispatchableJobs = getDispatchableJobsWithStatus(em, jobsOffset, DEFAULT_DISPATCH_JOBS_LIMIT, Status.QUEUED);
-          jobsOffset += DEFAULT_DISPATCH_JOBS_LIMIT;
-          jobsFound = !dispatchableJobs.isEmpty();
-
-          // skip all jobs of type workflow, we will handle them next
-          for (JpaJob job : dispatchableJobs) {
-            if (TYPE_WORKFLOW.equals(job.getJobType())) {
-              workflowJobs.add(job);
-            }
-          }
-          if (dispatchableJobs.removeAll(workflowJobs) && dispatchableJobs.isEmpty())
-            continue;
-
-          dispatchDispatchableJobs(em, dispatchableJobs);
-        } while (jobsFound);
-
-        if (!workflowJobs.isEmpty())
-          dispatchDispatchableJobs(em, workflowJobs);
-
-      } catch (Throwable t) {
-        logger.warn("Error dispatching jobs", t);
-      } finally {
-        undispatchableJobTypes = null;
-        if (em != null)
-          em.close();
-      }
-
-      logger.debug("Finished job dispatching");
-    }
-
-    /**
-     * Dispatch the given jobs.
-     *
-     * @param em the entity manager
-     * @param jobsToDispatch list with dispatchable jobs to dispatch
-     */
-    private void dispatchDispatchableJobs(EntityManager em, List<JpaJob> jobsToDispatch) {
-      //Get the current system load
-      SystemLoad systemLoad = getHostLoads(em);
-
-      for (JpaJob job : jobsToDispatch) {
-
-        // Remember the job type
-        String jobType = job.getJobType();
-
-        // Skip jobs that we already know can't be dispatched except of jobs in the priority list
-        String jobSignature = new StringBuilder(jobType).append('@').append(job.getOperation()).toString();
-        if (undispatchableJobTypes.contains(jobSignature) && !dispatchPriorityList.keySet().contains(job.getId())) {
-          logger.trace("Skipping dispatching of {} with type '{}' for this round of dispatching", job,
-                  jobType);
-          continue;
-        }
-
-        // Set the job's user and organization prior to dispatching
-        String creator = job.getCreator();
-        String creatorOrganization = job.getOrganization();
-
-        // Try to load the organization.
-        Organization organization = null;
-        try {
-          organization = organizationDirectoryService.getOrganization(creatorOrganization);
-          securityService.setOrganization(organization);
-        } catch (NotFoundException e) {
-          logger.debug("Skipping dispatching of job for non-existing organization '{}'", creatorOrganization);
-          continue;
-        }
-
-        // Try to load the user
-        User user = userDirectoryService.loadUser(creator);
-        if (user == null) {
-          logger.warn("Unable to dispatch {}: creator '{}' is not available", job, creator);
-          continue;
-        }
-        securityService.setUser(user);
-
-        // Start dispatching
-        try {
-          List<ServiceRegistration> services = getServiceRegistrations(em);
-          List<HostRegistration> hosts = $(getHostRegistrations(em)).filter(filterOutPriorityHosts._2(job.getId()))
-                  .toList();
-          List<ServiceRegistration> candidateServices = null;
-
-          // Depending on whether this running job is trying to reach out to other services or whether this is an
-          // attempt to execute the next operation in a workflow, choose either from a limited or from the full list
-          // of services
-          Job parentJob = null;
-          try {
-            if (job.getParentJob() != null)
-              parentJob = getJob(job.getParentJob().getId());
-          } catch (NotFoundException e) {
-            // That's ok
-          }
-
-          // When a job A starts a series of child jobs, then those child jobs should only be dispatched at the
-          // same time if there is processing capacity available.
-          boolean parentHasRunningChildren = false;
-          if (parentJob != null) {
-            for (Job child : getChildJobs(parentJob.getId())) {
-              if (Status.RUNNING.equals(child.getStatus())) {
-                parentHasRunningChildren = true;
-                break;
-              }
-            }
-          }
-
-          // If this is a root job (a new workflow or a new workflow operation), then only dispatch if there is
-          // capacity, i. e. the workflow service is ok dispatching the next workflow or the next workflow operation.
-          if (parentJob == null || TYPE_WORKFLOW.equals(jobType) || parentHasRunningChildren) {
-            logger.trace("Using available capacity only for dispatching of {} to a service of type '{}'", job,
-                    jobType);
-            candidateServices = getServiceRegistrationsWithCapacity(jobType, services, hosts, systemLoad);
-          } else {
-            logger.trace("Using full list of services for dispatching of {} to a service of type '{}'", job, jobType);
-            candidateServices = getServiceRegistrationsByLoad(jobType, services, hosts, systemLoad);
-          }
-
-          // Try to dispatch the job
-          String hostAcceptingJob = null;
-          try {
-            hostAcceptingJob = dispatchJob(em, job, candidateServices);
-            try {
-              systemLoad.updateNodeLoad(hostAcceptingJob, job.getJobLoad());
-            } catch (NotFoundException e) {
-              logger.info("Host {} not found in load list, cannot dispatch {} to it", hostAcceptingJob, job);
-            }
-
-            dispatchPriorityList.remove(job.getId());
-          } catch (ServiceUnavailableException e) {
-            logger.debug("Jobs of type {} currently cannot be dispatched", job.getOperation());
-            // Don't mark workflow jobs as undispatchable to not impact worklfow operations
-            if (!TYPE_WORKFLOW.equals(jobType))
-              undispatchableJobTypes.add(jobSignature);
-            continue;
-          } catch (UndispatchableJobException e) {
-            logger.debug("{} currently cannot be dispatched", job);
-            continue;
-          }
-
-          logger.debug("{} dispatched to {}", job, hostAcceptingJob);
-        } catch (ServiceRegistryException e) {
-          Throwable cause = (e.getCause() != null) ? e.getCause() : e;
-          logger.error("Error dispatching {}: {}", job, cause);
-        } finally {
-          securityService.setUser(null);
-          securityService.setOrganization(null);
-        }
-      }
-    }
-
-    /**
-     * Dispatches the job to the least loaded service that will accept the job, or throws a
-     * <code>ServiceUnavailableException</code> if there is no such service.
-     *
-     * @param em
-     *          the current entity manager
-     * @param job
-     *          the job to dispatch
-     * @param services
-     *          a list of service registrations
-     * @return the host that accepted the dispatched job, or <code>null</code> if no services took the job.
-     * @throws ServiceRegistryException
-     *           if the service registrations are unavailable
-     * @throws ServiceUnavailableException
-     *           if no service is available or if all available services refuse to take on more work
-     * @throws UndispatchableJobException
-     *           if the current job cannot be processed
-     */
-    protected String dispatchJob(EntityManager em, JpaJob job, List<ServiceRegistration> services)
-            throws ServiceRegistryException, ServiceUnavailableException, UndispatchableJobException {
-
-      if (services.size() == 0) {
-        logger.debug("No service is currently available to handle jobs of type '" + job.getJobType() + "'");
-        throw new ServiceUnavailableException("No service of type " + job.getJobType() + " available");
-      }
-
-      // Try the service registrations, after the first one finished, we quit;
-      job.setStatus(Status.DISPATCHING);
-
-      boolean triedDispatching = false;
-
-      boolean jobLoadExceedsMaximumLoads = false;
-      final Float highestMaxLoad = $(services).map(toHostRegistration).map(toMaxLoad).sort(sortFloatValuesDesc).head2();
-      if (job.getJobLoad() > highestMaxLoad) {
-        // None of the available hosts is able to accept the job because the largest max load value is less than this job's load value
-        jobLoadExceedsMaximumLoads = true;
-      }
-
-      for (ServiceRegistration registration : services) {
-        job.setProcessorServiceRegistration((ServiceRegistrationJpaImpl) registration);
-
-        // Skip registration of host with less max load than highest available max load
-        // Note: This service registration may or may not live on a node which is set to accept jobs exceeding its max load
-        if (jobLoadExceedsMaximumLoads
-                && job.getProcessorServiceRegistration().getHostRegistration().getMaxLoad() != highestMaxLoad) {
-          continue;
-        }
-
-        try {
-          job = updateInternal(em, job);
-        } catch (Exception e) {
-          // In theory, we should catch javax.persistence.OptimisticLockException. Unfortunately, eclipselink throws
-          // org.eclipse.persistence.exceptions.OptimisticLockException. In order to avoid importing the implementation
-          // specific APIs, we just catch Exception.
-          logger.debug("Unable to dispatch {}.  This is likely caused by another service registry dispatching the job",
-                  job);
-          throw new UndispatchableJobException(job + " is already being dispatched");
-        }
-
-        triedDispatching = true;
-
-        String serviceUrl = UrlSupport.concat(registration.getHost(), registration.getPath(), "dispatch");
-        HttpPost post = new HttpPost(serviceUrl);
-
-        // Add current organization and user so they can be used during execution at the remote end
-        post.addHeader(ORGANIZATION_HEADER, securityService.getOrganization().getId());
-        post.addHeader(USER_HEADER, securityService.getUser().getUsername());
-
-        List<BasicNameValuePair> params = new ArrayList<BasicNameValuePair>();
-        params.add(new BasicNameValuePair("id", Long.toString(job.getId())));
-        params.add(new BasicNameValuePair("operation", job.getOperation()));
-        post.setEntity(new UrlEncodedFormEntity(params, UTF_8));
-
-        // Post the request
-        HttpResponse response = null;
-        int responseStatusCode;
-        try {
-          logger.debug("Trying to dispatch {} type '{}' load {} to {}",
-                  job, job.getJobType(), job.getJobLoad(), registration.getHost());
-          if (!START_WORKFLOW.equals(job.getOperation()))
-            setCurrentJob(job.toJob());
-          response = client.execute(post);
-          responseStatusCode = response.getStatusLine().getStatusCode();
-          if (responseStatusCode == HttpStatus.SC_NO_CONTENT) {
-            return registration.getHost();
-          } else if (responseStatusCode == HttpStatus.SC_SERVICE_UNAVAILABLE) {
-            logger.debug("Service {} is currently refusing to accept jobs of type {}", registration,
-                    job.getOperation());
-            continue;
-          } else if (responseStatusCode == HttpStatus.SC_PRECONDITION_FAILED) {
-            job.setStatus(Status.FAILED);
-            job = updateJob(job);
-            logger.debug("Service {} refused to accept {}", registration, job);
-            throw new UndispatchableJobException(IOUtils.toString(response.getEntity().getContent()));
-          } else if (responseStatusCode == HttpStatus.SC_METHOD_NOT_ALLOWED) {
-            logger.debug("Service {} is not yet reachable", registration);
-            continue;
-          } else {
-            logger.warn("Service {} failed ({}) accepting {}", registration, responseStatusCode, job);
-            continue;
-          }
-        } catch (UndispatchableJobException e) {
-          throw e;
-        } catch (TrustedHttpClientException e) {
-          // Will try another node. If no other node, it will be re-queued
-          logger.warn("Unable to dispatch {}", job, e);
-          continue;
-        } catch (Exception e) {
-          logger.warn("Unable to dispatch {}", job, e);
-        } finally {
-          try {
-            client.close(response);
-          } catch (IOException e) {
-            // ignore
-          }
-          setCurrentJob(null);
-        }
-      }
-
-      // We've tried dispatching to every online service that can handle this type of job, with no luck.
-      if (triedDispatching) {
-        // Workflow type jobs are not set to priority list, because they handle accepting jobs not based on the job load
-        // If the system don't accepts jobs whose load exceeds the host's max load we can't make use of the priority
-        // list
-        if (acceptJobLoadsExeedingMaxLoad && !dispatchPriorityList.containsKey(job.getId())
-                && !TYPE_WORKFLOW.equals(job.getJobType()) && job.getProcessorServiceRegistration() != null) {
-          String host = job.getProcessorServiceRegistration().getHost();
-          logger.debug("About to add {} to dispatchPriorityList with processor host {}", job, host);
-          dispatchPriorityList.put(job.getId(), host);
-        }
-
-        try {
-          job.setStatus(Status.QUEUED);
-          job.setProcessorServiceRegistration(null);
-          job = updateJob(job);
-        } catch (Exception e) {
-          logger.error("Unable to put {} back into queue", job, e);
-        }
-      }
-
-      logger.debug("Unable to dispatch {}, no service is currently ready to accept the job", job);
-      throw new UndispatchableJobException(job + " is currently undispatchable");
-    }
-
-    private final Fn2<HostRegistration, Long, Boolean> filterOutPriorityHosts = new Fn2<HostRegistration, Long, Boolean>() {
-      @Override
-      public Boolean apply(HostRegistration host, Long jobId) {
-        if (dispatchPriorityList.values().contains(host.getBaseUrl())
-                && !host.getBaseUrl().equals(dispatchPriorityList.get(jobId))) {
-          return false;
-        }
-        return true;
-      }
-    };
-
-    private final Fn<ServiceRegistration, HostRegistration> toHostRegistration = new Fn<ServiceRegistration, HostRegistration>() {
-      @Override
-      public HostRegistration apply(ServiceRegistration s) {
-        return ((ServiceRegistrationJpaImpl) s).getHostRegistration();
-      }
-    };
-
-    private final Fn<HostRegistration, Float> toMaxLoad = new Fn<HostRegistration, Float>() {
-      @Override
-      public Float apply(HostRegistration h) {
-        return h.getMaxLoad();
-      }
-    };
-
-    private final Comparator<Float> sortFloatValuesDesc = new Comparator<Float>() {
-      @Override
-      public int compare(Float o1, Float o2) {
-        return o2.compareTo(o1);
-      }
-    };
-
-  }
 
   /** A periodic check on each service registration to ensure that it is still alive. */
   class JobProducerHeartbeat implements Runnable {

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/JobTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/JobTest.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.serviceregistry.impl;
 
-import static com.entwinemedia.fn.Stream.$;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.opencastproject.util.data.Arrays.mkString;
@@ -55,9 +54,6 @@ import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Monadics;
 import org.opencastproject.util.persistence.PersistenceEnv;
 
-import com.entwinemedia.fn.Fn;
-import com.entwinemedia.fn.Stream;
-
 import org.apache.commons.lang3.StringUtils;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -68,6 +64,7 @@ import org.junit.Test;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -241,29 +238,29 @@ public class JobTest {
     job5 = serviceRegistry.updateJob(job5);
 
     // Search children by root job
-    final Stream<Job> rootChildren = $(serviceRegistry.getChildJobs(rootJob.getId()));
-    assertEquals(6, rootChildren.getSizeHint());
-    assertTrue(rootChildren.exists(matchesId(job)));
-    assertTrue(rootChildren.exists(matchesId(job1)));
-    assertTrue(rootChildren.exists(matchesId(job2)));
-    assertTrue(rootChildren.exists(matchesId(job3)));
-    assertTrue(rootChildren.exists(matchesId(job4)));
-    assertTrue(rootChildren.exists(matchesId(job5)));
+    final List<Job> rootChildren = serviceRegistry.getChildJobs(rootJob.getId());
+    assertEquals(6, rootChildren.size());
+    assertTrue(rootChildren.stream().anyMatch(matchesId(job)));
+    assertTrue(rootChildren.stream().anyMatch(matchesId(job1)));
+    assertTrue(rootChildren.stream().anyMatch(matchesId(job2)));
+    assertTrue(rootChildren.stream().anyMatch(matchesId(job3)));
+    assertTrue(rootChildren.stream().anyMatch(matchesId(job4)));
+    assertTrue(rootChildren.stream().anyMatch(matchesId(job5)));
 
     // Search children
-    final Stream<Job> jobChildren = $(serviceRegistry.getChildJobs(job.getId()));
-    assertEquals(5, jobChildren.getSizeHint());
-    assertTrue(jobChildren.exists(matchesId(job1)));
-    assertTrue(jobChildren.exists(matchesId(job2)));
-    assertTrue(jobChildren.exists(matchesId(job3)));
-    assertTrue(jobChildren.exists(matchesId(job4)));
-    assertTrue(jobChildren.exists(matchesId(job5)));
+    final List<Job> jobChildren = serviceRegistry.getChildJobs(job.getId());
+    assertEquals(5, jobChildren.size());
+    assertTrue(jobChildren.stream().anyMatch(matchesId(job1)));
+    assertTrue(jobChildren.stream().anyMatch(matchesId(job2)));
+    assertTrue(jobChildren.stream().anyMatch(matchesId(job3)));
+    assertTrue(jobChildren.stream().anyMatch(matchesId(job4)));
+    assertTrue(jobChildren.stream().anyMatch(matchesId(job5)));
   }
 
-  private static Fn<Job, Boolean> matchesId(final Job j) {
-    return new Fn<Job, Boolean>() {
+  private static Predicate<Job> matchesId(final Job j) {
+    return new Predicate<Job>() {
       @Override
-      public Boolean apply(Job job) {
+      public boolean test(Job job) {
         return job.getId() == j.getId();
       }
     };

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/JobTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/JobTest.java
@@ -104,7 +104,6 @@ public class JobTest {
     EasyMock.expect(organizationDirectoryService.getOrganization((String) EasyMock.anyObject()))
     .andReturn(organization).anyTimes();
     EasyMock.replay(organizationDirectoryService);
-    serviceRegistry.setOrganizationDirectoryService(organizationDirectoryService);
 
     JaxbOrganization jaxbOrganization = JaxbOrganization.fromOrganization(organization);
     User anonymous = new JaxbUser("anonymous", "test", jaxbOrganization, new JaxbRole(

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistrationTest.java
@@ -79,7 +79,6 @@ public class ServiceRegistrationTest {
     OrganizationDirectoryService organizationDirectoryService = EasyMock.createMock(OrganizationDirectoryService.class);
     expect(organizationDirectoryService.getOrganization((String) anyObject())).andReturn(organization).anyTimes();
     EasyMock.replay(organizationDirectoryService);
-    serviceRegistry.setOrganizationDirectoryService(organizationDirectoryService);
 
     JaxbOrganization jaxbOrganization = JaxbOrganization.fromOrganization(organization);
     User anonymous = new JaxbUser("anonymous", "test", jaxbOrganization, new JaxbRole(

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -243,8 +243,7 @@ public class ServiceRegistryJpaImplTest {
     // Setup the job dispatcher
     ComponentContext cc = EasyMock.createNiceMock(ComponentContext.class);
     Dictionary<String, Object> jdProps = new Hashtable<>();
-    //jdProps.setProperty(JobDispatcher.OPT_DISPATCHINTERVAL, ""+DISPATCH_START_DELAY);
-    jdProps.put(JobDispatcher.OPT_DISPATCHENABLED, "false");
+    jdProps.put(JobDispatcher.OPT_DISPATCHINTERVAL, "0");
     EasyMock.expect(cc.getProperties()).andReturn(jdProps).anyTimes();
     EasyMock.replay(cc);
     jobDispatcher = new JobDispatcher();

--- a/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
+++ b/modules/serviceregistry/src/test/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImplTest.java
@@ -42,7 +42,6 @@ import org.opencastproject.serviceregistry.api.ServiceRegistration;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.serviceregistry.api.ServiceState;
 import org.opencastproject.serviceregistry.api.SystemLoad;
-import org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.JobDispatcher;
 import org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.JobProducerHeartbeat;
 import org.opencastproject.systems.OpencastConstants;
 import org.opencastproject.util.NotFoundException;
@@ -97,6 +96,8 @@ public class ServiceRegistryJpaImplTest {
   private static BundleContext bundleContext = null;
   private static ComponentContext cc = null;
   private static ServiceRegistryJpaImpl serviceRegistryJpaImpl = null;
+  private static JobDispatcher jobDispatcher = null;
+
 
   private static final String TEST_SERVICE = "ingest";
   private static final String TEST_SERVICE_2 = "compose";
@@ -140,11 +141,6 @@ public class ServiceRegistryJpaImplTest {
     // reset the scheduledExecutor
     if (serviceRegistryJpaImpl.scheduledExecutor != null)
       serviceRegistryJpaImpl.scheduledExecutor.shutdown();
-    if (!serviceRegistryJpaImpl.dispatchPriorityList.isEmpty()) {
-      for (Long key : serviceRegistryJpaImpl.dispatchPriorityList.keySet()) {
-        serviceRegistryJpaImpl.dispatchPriorityList.remove(key);
-      }
-    }
     if (!serviceRegistryJpaImpl.getActiveJobs().isEmpty()) {
       List<Long> jobIds = new ArrayList();
       for (Job job : serviceRegistryJpaImpl.getActiveJobs()) {
@@ -206,7 +202,6 @@ public class ServiceRegistryJpaImplTest {
             .anyTimes();
 
     EasyMock.replay(organizationDirectoryService);
-    serviceRegistryJpaImpl.setOrganizationDirectoryService(organizationDirectoryService);
 
     JaxbOrganization jaxbOrganization = JaxbOrganization.fromOrganization(organization);
     User anonymous = new JaxbUser("anonymous", "test", jaxbOrganization,
@@ -220,7 +215,6 @@ public class ServiceRegistryJpaImplTest {
     UserDirectoryService userDirectoryService = EasyMock.createNiceMock(UserDirectoryService.class);
     EasyMock.expect(userDirectoryService.loadUser(EasyMock.anyString())).andReturn(anonymous).anyTimes();
     EasyMock.replay(userDirectoryService);
-    serviceRegistryJpaImpl.setUserDirectoryService(userDirectoryService);
 
     final Capture<HttpUriRequest> request = EasyMock.newCapture();
     final BasicHttpResponse successResponse = new BasicHttpResponse(
@@ -245,6 +239,26 @@ public class ServiceRegistryJpaImplTest {
     }).anyTimes();
     EasyMock.replay(trustedHttpClient);
     serviceRegistryJpaImpl.setTrustedHttpClient(trustedHttpClient);
+
+    // Setup the job dispatcher
+    ComponentContext cc = EasyMock.createNiceMock(ComponentContext.class);
+    Dictionary<String, Object> jdProps = new Hashtable<>();
+    //jdProps.setProperty(JobDispatcher.OPT_DISPATCHINTERVAL, ""+DISPATCH_START_DELAY);
+    jdProps.put(JobDispatcher.OPT_DISPATCHENABLED, "false");
+    EasyMock.expect(cc.getProperties()).andReturn(jdProps).anyTimes();
+    EasyMock.replay(cc);
+    jobDispatcher = new JobDispatcher();
+    jobDispatcher.setEntityManagerFactory(emf);
+    jobDispatcher.setServiceRegistry(serviceRegistryJpaImpl);
+    jobDispatcher.setSecurityService(securityService);
+    jobDispatcher.setOrganizationDirectoryService(organizationDirectoryService);
+    jobDispatcher.setUserDirectoryService(userDirectoryService);
+    jobDispatcher.setTrustedHttpClient(trustedHttpClient);
+    try {
+      jobDispatcher.activate(cc);
+    } catch (ConfigurationException e) {
+      Assert.fail("Job dispatcher activation failed" + e);
+    }
   }
 
   private void unregisterTestHostAndServices() {
@@ -283,7 +297,6 @@ public class ServiceRegistryJpaImplTest {
     EasyMock.expect(bundleContext.getProperty(ServiceRegistryJpaImpl.OPT_MAXLOAD)).andReturn("");
     EasyMock.expect(bundleContext.createFilter((String) EasyMock.anyObject()))
             .andReturn(EasyMock.createNiceMock(Filter.class));
-    EasyMock.expect(bundleContext.getProperty(ServiceRegistryJpaImpl.OPT_DISPATCHINTERVAL)).andReturn("0");
   }
 
   private static void setupComponentContext() {
@@ -300,8 +313,7 @@ public class ServiceRegistryJpaImplTest {
       serviceRegistryJpaImpl.scheduledExecutor.shutdown();
     }
     serviceRegistryJpaImpl.scheduledExecutor = Executors.newScheduledThreadPool(1);
-    JobDispatcher jd = serviceRegistryJpaImpl.new JobDispatcher();
-    serviceRegistryJpaImpl.scheduledExecutor.schedule(jd, DISPATCH_START_DELAY, TimeUnit.MILLISECONDS);
+    jobDispatcher.scheduledExecutor.schedule(jobDispatcher.getJobDispatcherRunnable(), DISPATCH_START_DELAY, TimeUnit.MILLISECONDS);
 
     if (withProducerHeartBeat) {
       JobProducerHeartbeat jph = serviceRegistryJpaImpl.new JobProducerHeartbeat();
@@ -347,7 +359,7 @@ public class ServiceRegistryJpaImplTest {
       barrier.waitForJobs(JOB_BARRIER_TIMEOUT);
       Assert.fail("Did not receive a timeout exception");
     } catch (Exception e) {
-      Assert.assertEquals(1, serviceRegistryJpaImpl.dispatchPriorityList.size());
+      Assert.assertEquals(1, jobDispatcher.dispatchPriorityList.size());
     }
   }
 
@@ -361,7 +373,7 @@ public class ServiceRegistryJpaImplTest {
       barrier.waitForJobs(JOB_BARRIER_TIMEOUT);
       Assert.fail("Did not receive a timeout exception");
     } catch (Exception e) {
-      Assert.assertEquals(0, serviceRegistryJpaImpl.dispatchPriorityList.size());
+      Assert.assertEquals(0, jobDispatcher.dispatchPriorityList.size());
     } finally {
       // extra clean up
       serviceRegistryJpaImpl.unRegisterService(TEST_SERVICE_3, TEST_HOST);
@@ -370,7 +382,7 @@ public class ServiceRegistryJpaImplTest {
 
   @Test
   public void testHostsBeingRemovedFromPriorityList() throws Exception {
-    serviceRegistryJpaImpl.dispatchPriorityList.put(0L, TEST_HOST);
+    jobDispatcher.dispatchPriorityList.put(0L, TEST_HOST);
     Job testJob = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE_2, TEST_OPERATION, null, null, true, null);
     JobBarrier barrier = new JobBarrier(null, serviceRegistryJpaImpl, testJob);
     launchDispatcherOnce(false);
@@ -378,7 +390,7 @@ public class ServiceRegistryJpaImplTest {
       barrier.waitForJobs(JOB_BARRIER_TIMEOUT);
       Assert.fail("Did not receive a timeout exception");
     } catch (Exception e) {
-      Assert.assertEquals(0, serviceRegistryJpaImpl.dispatchPriorityList.size());
+      Assert.assertEquals(0, jobDispatcher.dispatchPriorityList.size());
     } finally {
       logger.debug("end testHostsBeingRemovedFromPriorityList");
     }
@@ -388,7 +400,7 @@ public class ServiceRegistryJpaImplTest {
   public void testIgnoreHostsInPriorityList() throws Exception {
     Job testJob = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE_2, TEST_OPERATION, null, null, true, null);
     Job testJob2 = serviceRegistryJpaImpl.createJob(TEST_HOST, TEST_SERVICE, TEST_OPERATION, null, null, true, null);
-    serviceRegistryJpaImpl.dispatchPriorityList.put(testJob2.getId(), TEST_HOST);
+    jobDispatcher.dispatchPriorityList.put(testJob2.getId(), TEST_HOST);
     JobBarrier barrier = new JobBarrier(null, serviceRegistryJpaImpl, testJob, testJob2);
     launchDispatcherOnce(false);
     try {
@@ -397,8 +409,8 @@ public class ServiceRegistryJpaImplTest {
     } catch (Exception e) {
       logger.debug("job1: '{}'", serviceRegistryJpaImpl.getJob(testJob.getId()));
       logger.debug("job2: '{}'", serviceRegistryJpaImpl.getJob(testJob2.getId()));
-      for (Long jobId :serviceRegistryJpaImpl.dispatchPriorityList.keySet()) {
-        logger.debug("job in priority queue: {}, {}", jobId, serviceRegistryJpaImpl.dispatchPriorityList.get(jobId));
+      for (Long jobId :jobDispatcher.dispatchPriorityList.keySet()) {
+        logger.debug("job in priority queue: {}, {}", jobId, jobDispatcher.dispatchPriorityList.get(jobId));
       }
       // Mock http client always returns 503 for this path so it won't be dispatched anyway
       testJob = serviceRegistryJpaImpl.getJob(testJob.getId());
@@ -411,8 +423,8 @@ public class ServiceRegistryJpaImplTest {
       Assert.assertTrue("Second job should not have a processing host", StringUtils.isBlank(testJob2.getProcessingHost()));
       Assert.assertEquals("Second job is queued", Job.Status.QUEUED, testJob2.getStatus());
 
-      Assert.assertEquals(1, serviceRegistryJpaImpl.dispatchPriorityList.size());
-      String blockingHost = serviceRegistryJpaImpl.dispatchPriorityList.get(testJob2.getId());
+      Assert.assertEquals(1, jobDispatcher.dispatchPriorityList.size());
+      String blockingHost = jobDispatcher.dispatchPriorityList.get(testJob2.getId());
       Assert.assertEquals(TEST_HOST, blockingHost);
     } finally {
       logger.debug("end testIgnoreHostsInPriorityList");
@@ -600,5 +612,4 @@ public class ServiceRegistryJpaImplTest {
     Assert.assertEquals(dateCompleted, updatedJob.getDateCompleted());
     Assert.assertEquals(runTime, updatedJob.getRunTime());
   }
-
 }


### PR DESCRIPTION
This pull request:
 - Extracts the JobDispatcher from inside the ServiceRegistry into its own class
 - Make the JobDispatcher a configurable OSGi service, such that dispatching can be enabled or disabled during runtime
 - Changes the *default* job dispatch behaviour to not dispatch jobs, and alters the node profiles to enable it by default on the expected nodes

This should *not* change current job dispatcher behaviour, aside from being able to enable or disable job dispatch on the fly.
Further work would likely use some kind of database locking strategy to negotiate between (surviving) nodes in a failover situation for who should be doing job dispatching.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
