### PR TITLE
Fix missing OSGI annotation for Caption service converters

### DIFF
--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/DFXPCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/DFXPCaptionConverter.java
@@ -34,6 +34,7 @@ import org.opencastproject.mediapackage.MediaPackageElement.Type;
 import org.opencastproject.util.XmlSafeParser;
 
 import org.apache.commons.io.IOUtils;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -67,6 +68,14 @@ import javax.xml.transform.stream.StreamResult;
  * This is converter for DFXP, XML based caption format. DOM parser is used for both caption importing and exporting,
  * while SAX parser is used for determining which languages are present (DFXP can contain multiple languages).
  */
+@Component(
+    immediate = true,
+    service = { CaptionConverter.class },
+    property = {
+        "service.description=DFXP caption converter",
+        "caption.format=dfxp"
+    }
+)
 public class DFXPCaptionConverter implements CaptionConverter {
 
   /** logging utility */

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/GoogleSpeechCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/GoogleSpeechCaptionConverter.java
@@ -33,6 +33,7 @@ import org.opencastproject.mediapackage.MediaPackageElement.Type;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +46,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+@Component(
+    immediate = true,
+    service = { CaptionConverter.class },
+    property = {
+        "service.description=Google speech caption converter",
+        "caption.format=google-speech"
+    }
+)
 public class GoogleSpeechCaptionConverter implements CaptionConverter {
 
   /**

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/IBMWatsonCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/IBMWatsonCaptionConverter.java
@@ -33,6 +33,7 @@ import org.opencastproject.mediapackage.MediaPackageElement.Type;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +46,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+@Component(
+    immediate = true,
+    service = { CaptionConverter.class },
+    property = {
+        "service.description=IBM Watson caption converter",
+        "caption.format=ibm-watson"
+    }
+)
 public class IBMWatsonCaptionConverter implements CaptionConverter {
 
   /** The logger */

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/Mpeg7CaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/Mpeg7CaptionConverter.java
@@ -44,6 +44,7 @@ import org.opencastproject.metadata.mpeg7.TemporalDecomposition;
 import org.opencastproject.metadata.mpeg7.TextAnnotation;
 import org.opencastproject.util.XmlSafeParser;
 
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +70,14 @@ import javax.xml.transform.stream.StreamResult;
 /**
  * This is converter for Mpeg7 caption format.
  */
+@Component(
+    immediate = true,
+    service = { CaptionConverter.class },
+    property = {
+        "service.description=Mpeg7 caption converter",
+        "caption.format=mpeg7"
+    }
+)
 public class Mpeg7CaptionConverter implements CaptionConverter {
 
   /** File extension for mpeg 7 catalogs */

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/SubRipCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/SubRipCaptionConverter.java
@@ -32,6 +32,7 @@ import org.opencastproject.caption.util.TimeUtil;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElement.Type;
 
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,14 @@ import java.util.Scanner;
  * annotations). Advanced format will be parsed but all annotations will be stripped off.
  *
  */
+@Component(
+    immediate = true,
+    service = { CaptionConverter.class },
+    property = {
+        "service.description=SubRip caption converter",
+        "caption.format=subrip"
+    }
+)
 public class SubRipCaptionConverter implements CaptionConverter {
 
   /** Logging utility */

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
@@ -27,6 +27,7 @@ import org.opencastproject.caption.util.TimeUtil;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElement.Type;
 
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,14 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.List;
 
+@Component(
+    immediate = true,
+    service = { CaptionConverter.class },
+    property = {
+        "service.description=WebVTT caption converter",
+        "caption.format=webvtt"
+    }
+)
 public class WebVttCaptionConverter implements CaptionConverter {
 
   /** Logging utility */

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
@@ -43,7 +43,7 @@ import java.util.List;
     service = { CaptionConverter.class },
     property = {
         "service.description=WebVTT caption converter",
-        "caption.format=webvtt"
+        "caption.format=vtt"
     }
 )
 public class WebVttCaptionConverter implements CaptionConverter {


### PR DESCRIPTION
Fix missing annotation for all caption converters #3625
With the move to OSGI annotation, it looks like all caption converters have been missed in the process. 
Hence this fix to get transcription service working again.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
