### PR TITLE
Fix Vosk Concurrency Problem

### DIFF
--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -309,6 +309,7 @@ public final class WorkspaceImpl implements Workspace {
     staticCollections.add("inbox");
     staticCollections.add("ocrtext");
     staticCollections.add("sox");
+    staticCollections.add("subtitles");
     staticCollections.add("uploaded");
     staticCollections.add("videoeditor");
     staticCollections.add("videosegments");


### PR DESCRIPTION
This patch fixes a concurrency problem with the Vosk based speech to
text engine which might fail due to parallel removal of directories in
the workspace which may make the Vosk command fail.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
