### PR TITLE
Update adopter registration code

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -258,6 +258,7 @@
     <script src="scripts/shared/resources/taskResource.js"></script>
     <script src="scripts/shared/resources/adopterRegistrationResource.js"></script>
     <script src="scripts/shared/resources/countryResource.js"></script>
+    <script src="scripts/shared/resources/termsOfUseResource.js"></script>
     <script src="scripts/shared/services/wizards/new-event/access.js"></script>
     <script src="scripts/shared/services/wizards/new-event/metadata.js"></script>
     <script src="scripts/shared/services/wizards/new-event/metadataExtended.js"></script>

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
@@ -58,6 +58,10 @@ angular.module('adminNg.controllers')
           return;
         }
       }
+      // NB: Deliberately choosing a different value to denote confirmation
+      if ($scope.state === 'delete_submit' && inputAction === 0) {
+        $scope.close();
+      }
 
       $scope.state = $scope.states[$scope.state]['nextState'][inputAction];
       if($scope.state === 'close'){

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
@@ -48,7 +48,7 @@ angular.module('adminNg.controllers')
       if (!angular.isDefined(adopter['termsVersionAgreed']) || $scope.tou['latest'] != adopter['termsVersionAgreed']) {
         $scope.adopter['agreedToPolicy'] = false;
         $scope.registered = false;
-        $scope.state = 'form';
+        $scope.state = 'information';
       }
     });
 

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
@@ -23,14 +23,15 @@
 // Controller for creating a new event. This is a wizard, so it implements a state machine design pattern.
 angular.module('adminNg.controllers')
 .controller('RegistrationCtrl', ['$scope', '$timeout', 'Table', 'AdopterRegistrationStates',
-  'AdopterRegistrationResource', 'CountryResource', 'NewEventStates', 'NewEventResource', 'EVENT_TAB_CHANGE',
-  'Notifications', 'Modal', 'AuthService',
-  function ($scope, $timeout, Table, AdopterRegistrationStates, AdopterRegistrationResource, CountryResource,
-    NewEventStates, NewEventResource, EVENT_TAB_CHANGE, Notifications, Modal, AuthService) {
+  'AdopterRegistrationResource', 'TermsOfUseResource', 'CountryResource', 'NewEventStates', 'NewEventResource',
+  'EVENT_TAB_CHANGE', 'Notifications', 'Modal', 'AuthService',
+  function ($scope, $timeout, Table, AdopterRegistrationStates, AdopterRegistrationResource, TermsOfUseResource,
+    CountryResource, NewEventStates, NewEventResource, EVENT_TAB_CHANGE, Notifications, Modal, AuthService) {
 
     $scope.state = AdopterRegistrationStates.getInitialState($scope.$parent.resourceId);
     $scope.states = AdopterRegistrationStates.get($scope.$parent.resourceId);
     $scope.countries = CountryResource.getCountries();
+    $scope.tou = TermsOfUseResource.get();
     $scope.adopter = new AdopterRegistrationResource();
 
     document.getElementById('help-dd').classList.remove('active');
@@ -43,6 +44,11 @@ angular.module('adminNg.controllers')
           continue;
         }
         $scope.adopter[field] = adopter[field];
+      }
+      if (!angular.isDefined(adopter['termsVersionAgreed']) || $scope.tou['latest'] != adopter['termsVersionAgreed']) {
+        $scope.adopter['agreedToPolicy'] = false;
+        $scope.registered = false;
+        $scope.state = 'form';
       }
     });
 

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
@@ -48,7 +48,6 @@ angular.module('adminNg.controllers')
       if (!angular.isDefined(adopter['termsVersionAgreed']) || $scope.tou['latest'] != adopter['termsVersionAgreed']) {
         $scope.adopter['agreedToPolicy'] = false;
         $scope.registered = false;
-        $scope.state = 'information';
       }
     });
 

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/partials/terms-of-use.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/partials/terms-of-use.html
@@ -4,18 +4,11 @@
 </h1>
 
 <p style="padding-bottom: 15px">
-  Thank you for using Opencast. We really appreciate your registration.
-  You can change the data you provided at any time. To do so, go to the “Opencast Registration”
-  in the menu “Help” of the administrative user interface. If you deleted your Opencast
-  installation, want to remove your account but cannot anymore, please write an email to
-  support@opencast.org.
-</p>
-
-<p style="padding-bottom: 15px">
-  Although Opencast is free, open-source software it is important for us,
-  to know how Opencast is used. For instance, hardware vendors want to know how
-  large the market is before they make their devices Opencast compatible. Even public
-  funding for further development relies on such data.
+  Opencast is free, open-source software - so why do we bother you with registration and feedback?
+  Well, data on the usage of Opencast is important for us.  When it comes to discussions with hardware vendors about
+  cooperation and compatibility they want to know how large the market is before they make any decision. Likewise,
+  public funding for further development relies on such data.  Finally, we also need the feedback to further develop
+  Opencast in line with its usage.
 </p>
 
 <p style="padding-bottom: 15px">
@@ -67,7 +60,7 @@
 </p>
 
 <p style="padding-bottom: 15px">
-  If provided, we will publish the name of your institution on opencast.org and set
+  If any data is provided, we will publish the name of your institution on opencast.org and set
   a geographical marker for your institution on the Opencast adopter’s map.
 </p>
 
@@ -76,7 +69,7 @@
 </p>
 
 <p style="padding-bottom: 15px">
-  This data is anonymized and will be stored without any relation to your organizational
+  This data itself is anonymized and will be stored without any relation to your organizational
   or personal data unless you allow us to link this information. The data will be sent in
    a regular interval. The data sent may include the following information:
 </p>
@@ -110,12 +103,12 @@
 </p>
 
 <p style="padding-bottom: 15px">
-  Error reports can be automatically sent so that we can monitor if there
+  Additionally, error reports can be automatically sent so that we can monitor if there
   are systematic errors within Opencast that were not detected in our QA.
 </p>
 
 <p style="padding-bottom: 15px">
-  Note that this data will be linked to your organization so that we are
+  Note that this specific data will be linked to your organization so that we are
   able to warn you in case we found a critical behavior. The error reports
   may also contain information about your content. This data will not be public.
   It will only be accessible to Opencast committers.
@@ -131,6 +124,13 @@
   <li>A timestamp when the error occurred</li>
   <li>The Opencast version</li>
 </ul>
+
+<p style="padding-bottom: 10px">
+  Finally, you can change the data you provided at any time. To do so, go to the “Opencast
+  Registration” in the menu “Help” of the administrative user interface. If you deleted your
+  Opencast installation, want to remove your account but cannot anymore, please write an
+  email to support@opencast.org
+</p>
 
 
 

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/partials/terms-of-use.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/partials/terms-of-use.html
@@ -23,7 +23,40 @@
   agree to sending data from all categories.
 </p>
 
+<h1 style="font-size: x-large;margin: 15px 0">
+  Data Stewardship
+</h1>
 
+<p style="padding-bottom: 10px; font-weight: bold">
+  Location
+</p>
+<p style="padding-bottom: 15px">
+  This data will be stored within the European Union, and will be GDPR compliant.
+  The current location can be found <a href="https://docs.opencast.org/develop/developer/#infrastructure/">here</a>
+</p>
+
+<p style="padding-bottom: 10px; font-weight: bold">
+  Storage Duration
+</p>
+<p style="padding-bottom: 5px;">
+  Organizational Profile
+</p>
+<p style="padding-bottom: 10px">
+  Your organizational profile will be purged 6 months after its last update.
+</p>
+<p style="padding-bottom: 5px">
+  Usage statistics and technical data
+<p style="padding-bottom: 15px">
+  Your technical statistics will be purged 24 months after their last update
+</p>
+
+<p style="padding-bottom: 10px; font-weight: bold">
+  Access to Information
+</p>
+<p style="padding-bottom: 15px">
+  Acess to the raw data is restricted to the Opencast board, who can authorize release to commiters on a case-by-case basis.
+  Aggregated summaries of the data will be made available from time to time at locations of the board's choosing.
+</p>
 
 <h1 style="font-size: x-large;margin: 15px 0">
   What Happens With Your Data
@@ -44,26 +77,29 @@
 
 <p style="padding-bottom: 15px">
   This data is anonymized and will be stored without any relation to your organizational
-  or personal data. The data will be sent in a regular interval. The data sent may include
-  the following information:
+  or personal data unless you allow us to link this information. The data will be sent in
+   a regular interval. The data sent may include the following information:
 </p>
 
 <ul style="padding-left: 30px; list-style: disc; padding-bottom: 15px; color: #333">
   <li>A timestamp at which this data has been created</li>
-  <li>An identifier marking the data source but is impossible
-    to link to your personal or organizational data
-  </li>
+  <li>An optional identifier marking the data source to link your organizational data to your install</li>
   <li>The number and status of events in your Opencast system</li>
   <li>The total duration of all media in your Opencast system</li>
   <li>The number of series in your Opencast system</li>
+  <li>The number of Opencast users (does not collect info from external user providers</li>
   <li>The number of capture agents connected to your Opencast system</li>
+  <li>The number of jobs in your Opencast system</li>
+  <li>The number of tenants in your Opencast system</li>
   <li>The version of your Opencast system</li>
   <li>Technical data regarding servers in your Opencast system
     <ul style="padding-left: 80px; list-style: circle">
       <li>A unique anonymous identifier for each server</li>
+      <li>The hostname for each server</li>
       <li>The number of CPU cores of each server</li>
       <li>The system memory of each server</li>
       <li>The disk space of each server</li>
+      <li>The maximum load value for each server </li>
       <li>The Opencast services running on each server</li>
     </ul>
   </li>

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/services/states.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/services/states.js
@@ -37,7 +37,7 @@ angular.module('adminNg.services')
               'back': false,
               'skip': true,
               'close': true,
-              'submitButtonText': 'ADOPTER_REGISTRATION.MODAL.CONTINUE'
+              'submitButtonText': 'WIZARD.NEXT_STEP'
             }
           },
           'form': {
@@ -55,7 +55,7 @@ angular.module('adminNg.services')
               'skip': false,
               'close': true,
               'delete': false,
-              'submitButtonText': 'SUBMIT'
+              'submitButtonText': 'WIZARD.CREATE'
             }
           },
           'save': {
@@ -95,7 +95,7 @@ angular.module('adminNg.services')
               'back': true,
               'skip': false,
               'close': true,
-              'submitButtonText': 'CONFIRM'
+              'submitButtonText': 'WIZARD.DELETE'
             }
           },
           'delete': {
@@ -108,7 +108,7 @@ angular.module('adminNg.services')
               'back': false,
               'skip': false,
               'close': false,
-              'submitButtonText': null
+              'submitButtonText': 'WIZARD.DELETE'
             }
           },
           'thank_you': {

--- a/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/controllers/applicationController.js
@@ -23,10 +23,10 @@
 // The main controller that all other scopes inherit from (except isolated scopes).
 angular.module('adminNg.controllers')
 .controller('ApplicationCtrl', ['$scope', '$rootScope', '$location', '$window', 'AuthService', 'Notifications',
-  'ResourceModal', 'VersionResource', 'HotkeysService', '$interval', 'RestServiceMonitor',
+  'ResourceModal', 'VersionResource', 'TermsOfUseResource', 'HotkeysService', '$interval', 'RestServiceMonitor',
   'AdopterRegistrationResource',
   function ($scope, $rootScope, $location, $window, AuthService, Notifications, ResourceModal,
-    VersionResource, HotkeysService, $interval, RestServiceMonitor, AdopterRegistrationResource){
+    VersionResource, TermsOfUseResource, HotkeysService, $interval, RestServiceMonitor, AdopterRegistrationResource){
 
     $scope.adopter = new AdopterRegistrationResource();
 
@@ -49,6 +49,7 @@ angular.module('adminNg.controllers')
     $scope.$on('$locationChangeSuccess', function($event, newUrl) {
       $scope.studioReturnUrl = encodeURIComponent(newUrl);
     });
+    $scope.tou = TermsOfUseResource.get();
 
     AuthService.getUser().$promise.then(function (user) {
       $scope.currentUser = user;
@@ -117,15 +118,17 @@ angular.module('adminNg.controllers')
     AdopterRegistrationResource.get({}, function(adopter) {
       // We exclude localhost to not show this to developers all the time.
       // We wouldn't get proper data from such instances anyway.
-      if(adopter.dateModified == null && window.location.hostname != 'localhost') {
+      if (adopter.dateModified == null && window.location.hostname != 'localhost') {
         ResourceModal.show('registration-modal');
         return;
       }
-      if(adopter.registered === false) {
+      if (adopter.registered === false ||
+          !angular.isDefined(adopter['termsVersionAgreed']) ||
+          $scope.tou['latest'] != adopter['termsVersionAgreed']) {
         var now = new Date();
         var lastModified = new Date(adopter.dateModified);
         var numberOfDaysPassed = Math.ceil((now - lastModified) / 8.64e7);
-        if(numberOfDaysPassed > 30) {
+        if (numberOfDaysPassed > 30) {
           ResourceModal.show('registration-modal');
         }
       }

--- a/modules/admin-ui-frontend/app/scripts/shared/controllers/navigationController.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/controllers/navigationController.js
@@ -41,7 +41,7 @@ angular.module('adminNg.controllers')
     };
 
     $scope.showAdopterRegistrationModal = function () {
-      ResourceModal.show('registration-modal', 'slim');
+      ResourceModal.show('registration-modal', '');
     };
 
     $rootScope.$on('language-changed', function () {

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
@@ -299,9 +299,9 @@
 
   <footer>
     <div class="pull-right" ng-show="states[state]['buttons']['submit']">
-      <a ng-hide="state == 'form'"
-         class="continue-registration"
-         ng-click="nextState(1)"
+      <a ng-show="state == 'delete_submit'"
+         class="danger"
+         ng-click="nextState(0)"
          translate="{{states[state]['buttons']['submitButtonText']}}"></a>
       <a ng-show="state == 'form'"
          class="submit inactive"
@@ -309,11 +309,18 @@
          ng-class="{inactive: !adopter.agreedToPolicy}"
          ng-click="nextState(1)"
          translate="{{states[state]['buttons']['submitButtonText']}}"></a>
+      <a ng-show="state != 'form' && state != 'delete_submit'"
+         class="submit"
+         ng-form="adopterRegistrationForm"
+         ng-click="nextState(1)"
+         translate="{{states[state]['buttons']['submitButtonText']}}"></a>
     </div>
 
     <div class="pull-left">
-      <a ng-show="states[state]['buttons']['back']" class="cancel"
-         ng-click="nextState(5)" translate="ADOPTER_REGISTRATION.MODAL.BACK"></a>
+      <a ng-show="states[state]['buttons']['back']"
+         class="cancel"
+         ng-click="nextState(5)"
+         translate="ADOPTER_REGISTRATION.MODAL.BACK"></a>
       <a ng-show="state == 'form' && registered"
          class="danger"
          ng-click="nextState(4)"

--- a/modules/admin-ui-frontend/app/scripts/shared/resources/termsOfUseResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/termsOfUseResource.js
@@ -1,0 +1,34 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.resources')
+.factory('TermsOfUseResource', ['$resource', function ($resource) {
+  return $resource('/admin-ng/adopter/latestToU', {}, {
+    get: {
+      method: 'GET',
+      headers: {'Content-Type': 'text/plain'},
+      transformResponse: function (data) {
+        return {'latest': data};
+      }
+    }
+  });
+}]);

--- a/modules/admin-ui-frontend/test/test/unit/shared/controllers/applicationControllerSpec.js
+++ b/modules/admin-ui-frontend/test/test/unit/shared/controllers/applicationControllerSpec.js
@@ -46,6 +46,7 @@ describe('Application controller', function () {
                    });
         $httpBackend.whenGET('/services/health.json').respond('{}');
         $httpBackend.whenGET('modules/events/partials/index.html').respond('');
+        $httpBackend.whenGET('/admin-ng/adopter/latestToU').respond('test');
         $httpBackend.whenGET('shared/partials/modals/registration-modal.html').respond('');
 
         $scope = $rootScope.$new();

--- a/modules/adopter-registration-api/src/main/java/org/opencastproject/adopter/registration/Service.java
+++ b/modules/adopter-registration-api/src/main/java/org/opencastproject/adopter/registration/Service.java
@@ -38,7 +38,9 @@ public interface Service {
    */
   IForm retrieveFormData();
 
-  /** Deletes the registration form of the adopter. */
-  void deleteFormData();
+  /** Marks the adopter registration for deletion */
+  void markForDeletion();
 
+  /** Deletes teh local copy of the registration data */
+  void deleteRegistration();
 }

--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -41,6 +41,16 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-capture-admin-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-search-service-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/AdopterRegistrationServiceImpl.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/AdopterRegistrationServiceImpl.java
@@ -60,7 +60,13 @@ public class AdopterRegistrationServiceImpl implements Service {
   }
 
   @Override
-  public void deleteFormData() {
+  public void markForDeletion() {
+    Form form = ((Form) formRepository.getForm());
+    form.delete();
+    formRepository.save(form);
+  }
+
+  public void deleteRegistration() {
     formRepository.delete();
   }
 

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
@@ -183,6 +183,14 @@ public class Controller {
 
 
   @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  @Path("latestToU")
+  public String getLatestTermsofUse() {
+    return Form.getLatestTermsOfUse().name();
+  }
+
+
+  @GET
   @Produces(MediaType.TEXT_HTML)
   @Path("docs")
   public String getDocs() {

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
@@ -150,7 +150,7 @@ public class Controller {
     logger.debug("Saving adopter registration data.");
 
     Form form = new Form(organisationName, departmentName, firstName, lastName, email, country, postalCode, city,
-            street, streetNo, contactMe, agreedToPolicy, allowsErrorReports, allowsStatistics, registered
+            street, streetNo, contactMe, allowsStatistics, allowsErrorReports, agreedToPolicy, registered
     );
     try {
       registrationService.saveFormData(form);

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Controller.java
@@ -173,7 +173,7 @@ public class Controller {
   public Response deleteRegistrationData() {
     logger.debug("Deleting adopter registration data.");
     try {
-      registrationService.deleteFormData();
+      registrationService.markForDeletion();
       return ok();
     } catch (Exception e) {
       logger.error("Error while deleting adopter registration data.", e);

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -132,7 +132,7 @@ public class Form implements IForm {
 
   // If this is true, then the next stats send pass should delete the registration, then delete this object.
   @Column(name = "delete_me")
-  private transient boolean deleteMe = false;
+  private boolean deleteMe = false;
 
 
   //================================================================================
@@ -190,6 +190,7 @@ public class Form implements IForm {
       this.registered = f.registered;
     }
     this.dateModified = new Date();
+    this.deleteMe = f.deleteMe;
   }
 
   @Override

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -367,12 +367,4 @@ public class Form implements IForm {
     return Objects.requireNonNullElse(termsVersionAgreed, TERMSOFUSEVERSION.PRE_2022);
   }
 
-  public void setTermsVersionAgreed(TERMSOFUSEVERSION version) {
-    if (version == null) {
-      this.termsVersionAgreed = TERMSOFUSEVERSION.PRE_2022;
-    } else {
-      this.termsVersionAgreed = version;
-    }
-  }
-
 }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -49,6 +49,14 @@ import javax.persistence.TemporalType;
 })
 public class Form implements IForm {
 
+  public enum TERMSOFUSEVERSION {
+    PRE_2022, APRIL_2022
+  };
+
+  public static final TERMSOFUSEVERSION getLatestTermsOfUse() {
+    return TERMSOFUSEVERSION.APRIL_2022;
+  }
+
 
   //================================================================================
   // Properties
@@ -114,6 +122,13 @@ public class Form implements IForm {
   @Column(name = "registered")
   private boolean registered;
 
+  // The default here is the original terms of use.
+  // Note that this object doesn't get instanciated unless you've agreed to the terms *at some point*
+  // so assuming a default of PRE_2022 is reasonable.  Either no agreement -> no db object at all, or
+  // agreement -> PRE_2022 default
+  @Column(name = "terms_version_agreed")
+  private TERMSOFUSEVERSION termsVersionAgreed = TERMSOFUSEVERSION.PRE_2022;
+
 
   //================================================================================
   // Constructor and Methods
@@ -141,6 +156,9 @@ public class Form implements IForm {
     this.allowsStatistics = allowsStatistics;
     this.allowsErrorReports = allowsErrorReports;
     this.agreedToPolicy = agreedToPolicy;
+    if (this.agreedToPolicy) {
+      this.termsVersionAgreed = getLatestTermsOfUse();
+    }
     this.registered = registered;
   }
 
@@ -160,6 +178,7 @@ public class Form implements IForm {
     this.allowsStatistics = f.allowsStatistics;
     this.allowsErrorReports = f.allowsErrorReports;
     this.agreedToPolicy = f.agreedToPolicy;
+    this.termsVersionAgreed = f.termsVersionAgreed;
     if (!this.registered) {
       // overwrite this field only when an adopter isn't registered yet
       // once an adopter is registered, he stays registered
@@ -341,6 +360,18 @@ public class Form implements IForm {
 
   public void setRegistered(boolean registered) {
     this.registered = registered;
+  }
+
+  public TERMSOFUSEVERSION getTermsVersionAgreed() {
+    return null == termsVersionAgreed ? termsVersionAgreed : TERMSOFUSEVERSION.PRE_2022;
+  }
+
+  public void setTermsVersionAgreed(TERMSOFUSEVERSION version) {
+    if (version == null) {
+      this.termsVersionAgreed = TERMSOFUSEVERSION.PRE_2022;
+    } else {
+      this.termsVersionAgreed = version;
+    }
   }
 
 }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -130,6 +130,10 @@ public class Form implements IForm {
   @Column(name = "terms_version_agreed")
   private TERMSOFUSEVERSION termsVersionAgreed = TERMSOFUSEVERSION.PRE_2022;
 
+  // If this is true, then the next stats send pass should delete the registration, then delete this object.
+  @Column(name = "delete_me")
+  private transient boolean deleteMe = false;
+
 
   //================================================================================
   // Constructor and Methods
@@ -367,4 +371,11 @@ public class Form implements IForm {
     return Objects.requireNonNullElse(termsVersionAgreed, TERMSOFUSEVERSION.PRE_2022);
   }
 
+  public void delete() {
+    this.deleteMe = true;
+  }
+
+  public boolean shouldDelete() {
+    return this.deleteMe;
+  }
 }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -25,6 +25,7 @@ import org.opencastproject.security.api.Organization;
 import org.opencastproject.util.EqualsUtil;
 
 import java.util.Date;
+import java.util.Objects;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -363,7 +364,7 @@ public class Form implements IForm {
   }
 
   public TERMSOFUSEVERSION getTermsVersionAgreed() {
-    return null == termsVersionAgreed ? termsVersionAgreed : TERMSOFUSEVERSION.PRE_2022;
+    return Objects.requireNonNullElse(termsVersionAgreed, TERMSOFUSEVERSION.PRE_2022);
   }
 
   public void setTermsVersionAgreed(TERMSOFUSEVERSION version) {

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -180,8 +180,7 @@ public class ScheduledDataCollector extends TimerTask {
     // so rather than burning time turning various things off (after figuring out what needs to be turned off)
     // we just don't send anything.  By the time we need to update the ToU again this whole thing would need reworking
     // anyway, so we'll run with this for now.
-    if (adopter.isRegistered() && adopter.agreedToPolicy()
-        && adopter.getTermsVersionAgreed() == Form.TERMSOFUSEVERSION.APRIL_2022) {
+    if (adopter.isRegistered() && adopter.getTermsVersionAgreed() == Form.TERMSOFUSEVERSION.APRIL_2022) {
       try {
         String generalDataAsJson = collectGeneralData(adopter);
         sender.sendGeneralData(generalDataAsJson);

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -175,7 +175,13 @@ public class ScheduledDataCollector extends TimerTask {
       return;
     }
 
-    if (adopter.isRegistered() && adopter.agreedToPolicy()) {
+    // Don't send data unless they've agreed to the latest (at time of writing) terms.
+    // Pre April 2022 doesn't allow collection of a bunch of things, and doens't allow linking stat data to org
+    // so rather than burning time turning various things off (after figuring out what needs to be turned off)
+    // we just don't send anything.  By the time we need to update the ToU again this whole thing would need reworking
+    // anyway, so we'll run with this for now.
+    if (adopter.isRegistered() && adopter.agreedToPolicy()
+        && adopter.getTermsVersionAgreed() == Form.TERMSOFUSEVERSION.APRIL_2022) {
       try {
         String generalDataAsJson = collectGeneralData(adopter);
         sender.sendGeneralData(generalDataAsJson);

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -29,13 +29,23 @@ import org.opencastproject.adopter.statistic.dto.StatisticData;
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.query.AQueryBuilder;
 import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.capture.admin.api.CaptureAgentStateService;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.search.api.SearchQuery;
+import org.opencastproject.search.api.SearchResult;
+import org.opencastproject.search.api.SearchResultItem;
+import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.userdirectory.JpaUserAndRoleProvider;
 
 import org.osgi.framework.BundleContext;
@@ -43,9 +53,12 @@ import org.osgi.framework.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.stream.Collectors;
 
 /**
  * It collects and sends statistic data of an registered adopter.
@@ -71,11 +84,19 @@ public class ScheduledDataCollector extends TimerTask {
   /** Provides access to job and host information */
   private ServiceRegistry serviceRegistry;
 
+  /** Provides access to CA counts */
+  private CaptureAgentStateService caStateService;
+
+  private OrganizationDirectoryService organizationDirectoryService;
+
   /** Provides access to recording information */
   private AssetManager assetManager;
 
   /** Provides access to series information */
   private SeriesService seriesService;
+
+  /** Provides access to search information */
+  private SearchService searchService;
 
   /** User and role provider */
   protected JpaUserAndRoleProvider userAndRoleProvider;
@@ -99,6 +120,9 @@ public class ScheduledDataCollector extends TimerTask {
 
   /** The Opencast version this is running in */
   private String version;
+
+  /** The timer for shutdown uses */
+  private Timer t;
 
   //================================================================================
   // Scheduler methods
@@ -127,7 +151,12 @@ public class ScheduledDataCollector extends TimerTask {
     this.sender = new Sender(Objects.toString(serverBaseUrl, DEFAULT_STATISTIC_SERVER_ADDRESS));
 
     // Send data now. Repeat every 24h.
-    new Timer().schedule(this, 0, ONE_DAY_IN_MILLISECONDS);
+    t = new Timer();
+    t.schedule(this, 0, ONE_DAY_IN_MILLISECONDS);
+  }
+
+  public void deactivate() {
+    t.cancel();
   }
 
   /**
@@ -156,7 +185,7 @@ public class ScheduledDataCollector extends TimerTask {
 
       if (adopter.allowsStatistics()) {
         try {
-          String statisticDataAsJson = collectStatisticData(adopter.getStatisticKey());
+          String statisticDataAsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
           sender.sendStatistics(statisticDataAsJson);
         } catch (Exception e) {
           logger.error("Error occurred while processing adopter statistic data.", e);
@@ -186,9 +215,22 @@ public class ScheduledDataCollector extends TimerTask {
    * @return The statistic data as JSON string.
    * @throws Exception General exception that can occur while gathering data.
    */
-  private String collectStatisticData(String statisticKey) throws Exception {
+  private String collectStatisticData(String adopterKey, String statisticKey) throws Exception {
     StatisticData statisticData = new StatisticData(statisticKey);
-    serviceRegistry.getHostRegistrations().forEach(host -> statisticData.addHost(new Host(host)));
+    statisticData.setAdopterKey(adopterKey);
+    serviceRegistry.getHostRegistrations().forEach(host -> {
+      Host h = new Host(host);
+      try {
+        String services = serviceRegistry.getServiceRegistrationsByHost(host.getBaseUrl())
+            .stream()
+            .map(sr -> sr.getServiceType())
+            .collect(Collectors.joining(",\n"));
+        h.setServices(services);
+      } catch (ServiceRegistryException e) {
+        logger.warn("Error gathering services for {}", host.getBaseUrl(), e);
+      }
+      statisticData.addHost(h);
+    });
     statisticData.setJobCount(serviceRegistry.count(null, null));
 
     AQueryBuilder q = assetManager.createQuery();
@@ -199,6 +241,42 @@ public class ScheduledDataCollector extends TimerTask {
 
     statisticData.setSeriesCount(seriesService.getSeriesCount());
     statisticData.setUserCount(userAndRoleProvider.countAllUsers());
+
+    SearchQuery sq = new SearchQuery();
+    sq.withId("");
+    sq.withElementTags(new String[0]);
+    sq.withElementFlavors(new MediaPackageElementFlavor[0]);
+    sq.signURLs(false);
+    sq.includeEpisodes(true);
+    sq.includeSeries(false);
+
+    List<Organization> orgs = organizationDirectoryService.getOrganizations();
+    statisticData.setTenantCount(orgs.size());
+
+    for (Organization org : orgs) {
+      SecurityUtil.runAs(securityService, org, systemAdminUser, () -> {
+        //Calculate the number of attached CAs for this org, add it to the total
+        long current = statisticData.getCACount();
+        int orgCAs = caStateService.getKnownAgents(systemAdminUser, org).size();
+        statisticData.setCACount(current + orgCAs);
+
+        //Calculate the total number of minutes for this org, add it to the total
+        current = statisticData.getTotalMinutes();
+        long orgDuration = 0L;
+        try {
+          SearchResult sr = searchService.getForAdministrativeRead(sq);
+          orgDuration = Arrays.stream(sr.getItems())
+                                     .map(SearchResultItem::getMediaPackage)
+                                     .map(MediaPackage::getDuration)
+                                     .mapToLong(Long::valueOf)
+                                     .sum() / 1000L;
+        } catch (UnauthorizedException e) {
+          //This should never happen, but...
+          logger.warn("Unable to calculate total minutes, unauthorized");
+        }
+        statisticData.setTotalMinutes(current + orgDuration);
+      });
+    }
     statisticData.setVersion(version);
     return statisticData.jsonify();
   }
@@ -218,6 +296,10 @@ public class ScheduledDataCollector extends TimerTask {
     this.serviceRegistry = serviceRegistry;
   }
 
+  public void setCaptureAdminService(CaptureAgentStateService stateService) {
+    this.caStateService = stateService;
+  }
+
   /** OSGi setter for the asset manager. */
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
@@ -228,6 +310,10 @@ public class ScheduledDataCollector extends TimerTask {
     this.seriesService = seriesService;
   }
 
+  public void setSearchService(SearchService searchService) {
+    this.searchService = searchService;
+  }
+
   /** OSGi setter for the user provider. */
   public void setUserAndRoleProvider(JpaUserAndRoleProvider userAndRoleProvider) {
     this.userAndRoleProvider = userAndRoleProvider;
@@ -236,6 +322,11 @@ public class ScheduledDataCollector extends TimerTask {
   /** OSGi callback for setting the security service. */
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
+  }
+
+  /** OSGi callback for setting the org directory service. */
+  public void setOrganizationDirectoryService(OrganizationDirectoryService orgDirServ) {
+    this.organizationDirectoryService = orgDirServ;
   }
 
 }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -122,7 +122,7 @@ public class ScheduledDataCollector extends TimerTask {
   private String version;
 
   /** The timer for shutdown uses */
-  private Timer t;
+  private Timer timer;
 
   //================================================================================
   // Scheduler methods
@@ -151,12 +151,12 @@ public class ScheduledDataCollector extends TimerTask {
     this.sender = new Sender(Objects.toString(serverBaseUrl, DEFAULT_STATISTIC_SERVER_ADDRESS));
 
     // Send data now. Repeat every 24h.
-    t = new Timer();
-    t.schedule(this, 0, ONE_DAY_IN_MILLISECONDS);
+    timer = new Timer();
+    timer.schedule(this, 0, ONE_DAY_IN_MILLISECONDS);
   }
 
   public void deactivate() {
-    t.cancel();
+    timer.cancel();
   }
 
   /**

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -74,6 +74,9 @@ public class ScheduledDataCollector extends TimerTask {
 
   private static final int ONE_DAY_IN_MILLISECONDS = 1000 * 60 * 60 * 24;
 
+  /* How many records to get from the search index at once */
+  private static final int SEARCH_ITERATION_SIZE = 100;
+
   //================================================================================
   // OSGi properties
   //================================================================================
@@ -254,7 +257,7 @@ public class ScheduledDataCollector extends TimerTask {
     sq.signURLs(false);
     sq.includeEpisodes(true);
     sq.includeSeries(false);
-    sq.withLimit(10);
+    sq.withLimit(SEARCH_ITERATION_SIZE);
 
     List<Organization> orgs = organizationDirectoryService.getOrganizations();
     statisticData.setTenantCount(orgs.size());
@@ -275,14 +278,14 @@ public class ScheduledDataCollector extends TimerTask {
           do {
             sq.withOffset(offset);
             SearchResult sr = searchService.getForAdministrativeRead(sq);
-            offset += 10;
+            offset += SEARCH_ITERATION_SIZE;
             total = sr.getTotalSize();
             orgDuration = Arrays.stream(sr.getItems())
                                        .map(SearchResultItem::getMediaPackage)
                                        .map(MediaPackage::getDuration)
                                        .mapToLong(Long::valueOf)
                                        .sum() / 1000L;
-          } while (offset + 10 <= total);
+          } while (false); //offset + SEARCH_ITERATION_SIZE <= total);
         } catch (UnauthorizedException e) {
           //This should never happen, but...
           logger.warn("Unable to calculate total minutes, unauthorized");

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -262,7 +262,7 @@ public class ScheduledDataCollector extends TimerTask {
       SecurityUtil.runAs(securityService, org, systemAdminUser, () -> {
         //Calculate the number of attached CAs for this org, add it to the total
         long current = statisticData.getCACount();
-        int orgCAs = caStateService.getKnownAgents(systemAdminUser, org).size();
+        int orgCAs = caStateService.getKnownAgents().size();
         statisticData.setCACount(current + orgCAs);
 
         //Calculate the total number of minutes for this org, add it to the total

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
@@ -125,7 +125,7 @@ public class Sender {
   private void send(String json, String urlSuffix, String method) throws IOException {
     URL url = new URL(baseUrl + urlSuffix);
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
-    con.setRequestMethod("POST");
+    con.setRequestMethod(method);
     con.setRequestProperty("Content-Type", "application/json; utf-8");
     con.setRequestProperty("Accept", "application/json");
     con.setDoOutput(true);

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
@@ -25,10 +25,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -71,67 +71,90 @@ public class Sender {
   /**
    * Executes the 'send' method with the proper REST URL suffix.
    * @param json The data which shall be sent.
-   * @throws Exception General exception that can occur while sending the data.
+   * @throws IOException General exception that can occur while sending the data.
    */
-  public void sendGeneralData(String json) throws Exception {
+  public void sendGeneralData(String json) throws IOException  {
     send(json, GENERAL_DATA_URL_SUFFIX);
+  }
+
+  /**
+   * Deletes the adopter data
+   * @param json The data which shall be sent.
+   * @throws IOException General exception that can occur while sending the data.
+   */
+  public void deleteGeneralData(String json) throws IOException  {
+    send(json, GENERAL_DATA_URL_SUFFIX, "DELETE");
   }
 
   /**
    * Executes the 'send' method with the proper REST URL suffix.
    * @param json The data which shall be sent.
-   * @throws Exception General exception that can occur while sending the data.
+   * @throws IOException General exception that can occur while sending the data.
    */
-  public void sendStatistics(String json) throws Exception {
+  public void sendStatistics(String json) throws IOException {
     send(json, STATISTIC_URL_SUFFIX);
+  }
+
+  /**
+   * Deletes the statistics data
+   * @param json The data which shall be sent.
+   * @throws IOException General exception that can occur while sending the data.
+   */
+  public void deleteStatistics(String json) throws IOException {
+    send(json, STATISTIC_URL_SUFFIX, "DELETE");
+  }
+
+
+  /**
+   * Sends the JSON string via post request.
+   * @param json The JSON string that has to be send.
+   * @param urlSuffix The url suffix determines to which rest endpoint the data will be send.
+   * @throws IOException General exception that can occur while processing the POST request.
+   */
+  private void send(String json, String urlSuffix) throws IOException {
+    send(json, urlSuffix, "GET");
   }
 
   /**
    * Sends the JSON string via post request.
    * @param json The JSON string that has to be send.
    * @param urlSuffix The url suffix determines to which rest endpoint the data will be send.
-   * @throws Exception General exception that can occur while processing the POST request.
+   * @param method The HTTP method to send to the server with.  Hint: Try DELETE
+   * @throws IOException General exception that can occur while processing the POST request.
    */
-  private void send(String json, String urlSuffix) throws Exception {
-    try {
-      URL url = new URL(baseUrl + urlSuffix);
-      HttpURLConnection con = (HttpURLConnection) url.openConnection();
-      con.setRequestMethod("POST");
-      con.setRequestProperty("Content-Type", "application/json; utf-8");
-      con.setRequestProperty("Accept", "application/json");
-      con.setDoOutput(true);
+  private void send(String json, String urlSuffix, String method) throws IOException {
+    URL url = new URL(baseUrl + urlSuffix);
+    HttpURLConnection con = (HttpURLConnection) url.openConnection();
+    con.setRequestMethod("POST");
+    con.setRequestProperty("Content-Type", "application/json; utf-8");
+    con.setRequestProperty("Accept", "application/json");
+    con.setDoOutput(true);
 
-      try (OutputStream os = con.getOutputStream()) {
-        byte[] input = json.getBytes(StandardCharsets.UTF_8);
-        os.write(input, 0, input.length);
+    try (OutputStream os = con.getOutputStream()) {
+      byte[] input = json.getBytes(StandardCharsets.UTF_8);
+      os.write(input, 0, input.length);
+    }
+
+    String httpStatus = con.getResponseCode() + "";
+    boolean errorOccurred = !httpStatus.startsWith("2");
+    InputStream responseStream;
+
+    if (errorOccurred) {
+      responseStream = con.getErrorStream();
+    } else {
+      responseStream = con.getInputStream();
+    }
+
+    try (BufferedReader br = new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8))) {
+      StringBuilder response = new StringBuilder();
+      String responseLine;
+      while ((responseLine = br.readLine()) != null) {
+        response.append(responseLine.trim());
       }
-
-      String httpStatus = con.getResponseCode() + "";
-      boolean errorOccurred = !httpStatus.startsWith("2");
-      InputStream responseStream;
-
       if (errorOccurred) {
-        responseStream = con.getErrorStream();
-      } else {
-        responseStream = con.getInputStream();
+        String errorMessage = String.format("HttpStatus: %s, HttpResponse: %s", httpStatus, response);
+        throw new RuntimeException(errorMessage);
       }
-
-      try (BufferedReader br = new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8))) {
-        StringBuilder response = new StringBuilder();
-        String responseLine;
-        while ((responseLine = br.readLine()) != null) {
-          response.append(responseLine.trim());
-        }
-        if (errorOccurred) {
-          String errorMessage = String.format("HttpStatus: %s, HttpResponse: %s", httpStatus, response);
-          throw new RuntimeException(errorMessage);
-        }
-      }
-    } catch (ConnectException e) {
-      logger.debug("Unable to connect to {}, being quiet to prevent annoying adopters", baseUrl);
-    } catch (Exception e) {
-      logger.error("Error while sending JSON via POST request. The json string: {}", json, e);
-      throw e;
     }
   }
 

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
@@ -28,6 +28,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -115,8 +116,7 @@ public class Sender {
         responseStream = con.getInputStream();
       }
 
-      try (BufferedReader br = new BufferedReader(
-              new InputStreamReader(responseStream, StandardCharsets.UTF_8))) {
+      try (BufferedReader br = new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8))) {
         StringBuilder response = new StringBuilder();
         String responseLine;
         while ((responseLine = br.readLine()) != null) {
@@ -127,7 +127,8 @@ public class Sender {
           throw new RuntimeException(errorMessage);
         }
       }
-
+    } catch (ConnectException e) {
+      logger.debug("Unable to connect to {}, being quiet to prevent annoying adopters", baseUrl);
     } catch (Exception e) {
       logger.error("Error while sending JSON via POST request. The json string: {}", json, e);
       throw e;

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/GeneralData.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/GeneralData.java
@@ -40,7 +40,7 @@ public class GeneralData {
 
   /** The unique identification key for an adopter. */
   @SerializedName("adopter_key")
-  private final String adopterKey;
+  private String adopterKey;
 
   /** The organisation of the adopter. */
   @SerializedName("organisation_name")
@@ -127,6 +127,10 @@ public class GeneralData {
 
   public String getAdopterKey() {
     return adopterKey;
+  }
+
+  public void setAdopterKey(String key) {
+    this.adopterKey = key;
   }
 
   public String getOrganisationName() {

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/GeneralData.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/GeneralData.java
@@ -78,6 +78,18 @@ public class GeneralData {
   /** The E-Mail address of the adopter. */
   private final String email;
 
+  /** Whether we can contact the adopter */
+  @SerializedName("contact_me")
+  private final boolean allowContact;
+
+  /** Whether we can send error reports */
+  @SerializedName("send_errors")
+  private final boolean allowErrorReports;
+
+  /** Whether we can contact statistics */
+  @SerializedName("send_usage")
+  private final boolean allowStatistics;
+
 
   //================================================================================
   // Constructor and Methods
@@ -95,6 +107,9 @@ public class GeneralData {
     this.street = adopterRegistrationForm.getStreet();
     this.streetNo = adopterRegistrationForm.getStreetNo();
     this.email = adopterRegistrationForm.getEmail();
+    this.allowContact = adopterRegistrationForm.allowsContacting();
+    this.allowErrorReports = adopterRegistrationForm.allowsErrorReports();
+    this.allowStatistics = adopterRegistrationForm.allowsStatistics();
   }
 
   /**
@@ -152,5 +167,17 @@ public class GeneralData {
 
   public String getEmail() {
     return email;
+  }
+
+  public String getContactMe() {
+    return Boolean.toString(allowContact);
+  }
+
+  public String getErrorReports() {
+    return Boolean.toString(allowErrorReports);
+  }
+
+  public String getStatisticss() {
+    return Boolean.toString(allowStatistics);
   }
 }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/Host.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/Host.java
@@ -23,6 +23,8 @@ package org.opencastproject.adopter.statistic.dto;
 
 import org.opencastproject.serviceregistry.api.HostRegistration;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * DTO that contains information about a host machine of an adopter. It's a simplified version
  * of the HostRegistration class {@link org.opencastproject.serviceregistry.api.HostRegistration}.
@@ -33,16 +35,26 @@ public class Host {
   private int cores;
 
   /** The maximum load this host can run. */
+  @SerializedName("max_load")
   private float maxLoad;
 
   /** The allocated memory of this host. */
   private long memory;
 
+  /** The hostname of this node. */
+  private String hostname;
+
+  @SerializedName("disk_space")
+  private long diskspace;
+
+  private String services;
 
   public Host(HostRegistration host) {
     this.cores = host.getCores();
     this.maxLoad = host.getMaxLoad();
     this.memory = host.getMemory();
+    this.hostname = host.getNodeName();
+    //FIXME: Need disk space
   }
 
 
@@ -72,6 +84,22 @@ public class Host {
 
   public void setMemory(long memory) {
     this.memory = memory;
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+  public void setHostname(String hostname) {
+    this.hostname = hostname;
+  }
+
+  public String getServices() {
+    return this.services;
+  }
+
+  public void setServices(String services) {
+    this.services = services;
   }
 
 }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/StatisticData.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/dto/StatisticData.java
@@ -51,6 +51,9 @@ public class StatisticData {
   @SerializedName("statistic_key")
   private String statisticKey;
 
+  @SerializedName("adopter_key")
+  private String adopterKey;
+
   /** The total number of jobs. */
   @SerializedName("job_count")
   private long jobCount;
@@ -66,6 +69,15 @@ public class StatisticData {
   /** The total number of users. */
   @SerializedName("user_count")
   private long userCount;
+
+  @SerializedName("ca_count")
+  private long caCount;
+
+  @SerializedName("total_minutes")
+  private long totalMinutes;
+
+  @SerializedName("tenant_count")
+  private int tenantCount;
 
   /** The hosts of an adopter.*/
   private List<Host> hosts;
@@ -106,6 +118,14 @@ public class StatisticData {
     this.statisticKey = statisticKey;
   }
 
+  public String getAdopterKey() {
+    return adopterKey;
+  }
+
+  public void setAdopterKey(String adopterKey) {
+    this.adopterKey = adopterKey;
+  }
+
   public long getJobCount() {
     return jobCount;
   }
@@ -138,12 +158,36 @@ public class StatisticData {
     this.userCount = userCount;
   }
 
+  public long getCACount() {
+    return caCount;
+  }
+
+  public void setCACount(long caCount) {
+    this.caCount = caCount;
+  }
+
+  public long getTotalMinutes() {
+    return totalMinutes;
+  }
+
+  public void setTotalMinutes(long totalMinutes) {
+    this.totalMinutes = totalMinutes;
+  }
+
   public List<Host> getHosts() {
     return hosts;
   }
 
   public void setHosts(List<Host> hosts) {
     this.hosts = hosts;
+  }
+
+  public int getTenantCount() {
+    return tenantCount;
+  }
+
+  public void setTenantCount(int tenantCount) {
+    this.tenantCount = tenantCount;
   }
 
   public void addHost(Host host) {

--- a/modules/adopter-registration-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/adopter-registration-impl/src/main/resources/META-INF/persistence.xml
@@ -11,7 +11,7 @@
     <class>org.opencastproject.adopter.registration.Form</class>
     <shared-cache-mode>NONE</shared-cache-mode>
     <properties>
-      <property name="eclipselink.ddl-generation" value="create-tables" />
+      <property name="eclipselink.ddl-generation" value="create-or-extend-tables" />
       <property name="eclipselink.logging.logger" value="JavaLogger" />
       <property name="eclipselink.create-ddl-jdbc-file-name" value="create-kernel-jpa.jdbc"/>
       <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-kernel-jpa.jdbc"/>

--- a/modules/adopter-registration-impl/src/main/resources/OSGI-INF/adopter-scheduler.xml
+++ b/modules/adopter-registration-impl/src/main/resources/OSGI-INF/adopter-scheduler.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true"
-               name="org.opencastproject.adopter.statistic.ScheduledDataCollector">
+               name="org.opencastproject.adopter.statistic.ScheduledDataCollector"
+               activate="activate" deactivate="deactivate">
 
   <implementation class="org.opencastproject.adopter.statistic.ScheduledDataCollector"/>
 
@@ -19,6 +20,10 @@
              interface="org.opencastproject.serviceregistry.api.ServiceRegistry"
              bind="setServiceRegistry"/>
 
+  <reference name="capture-agent-service"
+             interface="org.opencastproject.capture.admin.api.CaptureAgentStateService"
+             bind="setCaptureAdminService"/>
+
   <reference name="asset-manager"
              interface="org.opencastproject.assetmanager.api.AssetManager"
              bind="setAssetManager"/>
@@ -27,12 +32,20 @@
              interface="org.opencastproject.series.api.SeriesService"
              bind="setSeriesService"/>
 
-  <reference name="user-and-role-rrovider"
+  <reference name="search-service"
+             interface="org.opencastproject.search.api.SearchService"
+             bind="setSearchService"/>
+
+  <reference name="user-and-role-provider"
              interface="org.opencastproject.userdirectory.JpaUserAndRoleProvider"
              bind="setUserAndRoleProvider"/>
 
   <reference name="security-service"
              interface="org.opencastproject.security.api.SecurityService"
              bind="setSecurityService"/>
+
+  <reference name="org-directory"
+             interface="org.opencastproject.security.api.OrganizationDirectoryService"
+             bind="setOrganizationDirectoryService"/>
 
 </scr:component>

--- a/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/CaptureAgentStateService.java
+++ b/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/CaptureAgentStateService.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.capture.admin.api;
 
-import org.opencastproject.security.api.Organization;
-import org.opencastproject.security.api.User;
 import org.opencastproject.util.NotFoundException;
 
 import java.util.Map;

--- a/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/CaptureAgentStateService.java
+++ b/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/CaptureAgentStateService.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.capture.admin.api;
 
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.User;
 import org.opencastproject.util.NotFoundException;
 
 import java.util.Map;
@@ -92,6 +94,13 @@ public interface CaptureAgentStateService {
    * @return A {@link java.util.Map} of name-agent pairs.
    */
   Map<String, Agent> getKnownAgents();
+
+  /**
+   * Returns the list of known agents that a given user and organization is authorized to schedule
+   *
+   * @return A {@link java.util.Map} of name-agent pairs.
+   */
+  Map<String, Agent> getKnownAgents(User u, Organization o);
 
   /**
    * Returns the list of known agent capabilities.

--- a/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/CaptureAgentStateService.java
+++ b/modules/capture-admin-service-api/src/main/java/org/opencastproject/capture/admin/api/CaptureAgentStateService.java
@@ -96,13 +96,6 @@ public interface CaptureAgentStateService {
   Map<String, Agent> getKnownAgents();
 
   /**
-   * Returns the list of known agents that a given user and organization is authorized to schedule
-   *
-   * @return A {@link java.util.Map} of name-agent pairs.
-   */
-  Map<String, Agent> getKnownAgents(User u, Organization o);
-
-  /**
    * Returns the list of known agent capabilities.
    *
    * @return A {@link java.util.Properties} of name-value capability pairs.

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
@@ -373,10 +373,21 @@ public class CaptureAgentStateServiceImpl implements CaptureAgentStateService, M
    */
   @Override
   public Map<String, Agent> getKnownAgents() {
+    return getKnownAgents(null, null);
+  }
+
+  public Map<String, Agent> getKnownAgents(User u, Organization o) {
     agentCache.cleanUp();
     EntityManager em = null;
-    User user = securityService.getUser();
-    Organization org = securityService.getOrganization();
+    User user = u;
+    Organization org = o;
+    if (null == u) {
+      user = securityService.getUser();
+    }
+    if (null == o) {
+      org = securityService.getOrganization();
+    }
+
     String orgAdmin = org.getAdminRole();
     Set<Role> roles = user.getRoles();
     try {

--- a/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
+++ b/modules/capture-admin-service-impl/src/main/java/org/opencastproject/capture/admin/impl/CaptureAgentStateServiceImpl.java
@@ -373,20 +373,10 @@ public class CaptureAgentStateServiceImpl implements CaptureAgentStateService, M
    */
   @Override
   public Map<String, Agent> getKnownAgents() {
-    return getKnownAgents(null, null);
-  }
-
-  public Map<String, Agent> getKnownAgents(User u, Organization o) {
     agentCache.cleanUp();
     EntityManager em = null;
-    User user = u;
-    Organization org = o;
-    if (null == u) {
-      user = securityService.getUser();
-    }
-    if (null == o) {
-      org = securityService.getOrganization();
-    }
+    User user = securityService.getUser();
+    Organization org = securityService.getOrganization();
 
     String orgAdmin = org.getAdminRole();
     Set<Role> roles = user.getRoles();


### PR DESCRIPTION
This pull request updates the adopter registration bits to:
 - Work properly
 - Log more things
 - Update the Terms of Service

Open questions:
 - Do we care about available disk space?  We would have to pull the data dir out of the config, then find the space from there since otherwise we get the node's root disk.  This data is likely not useful IMO.
 - Services are logged as a ",\n" delimited string.  I'm not sure how better to do this - creating a database entry for each service on each node seems excessive, but the string is a particularly dumb (and potentially problematic, due to field lengths) way of doing it.
 - This needs unit tests, although realistically integration tests would be useful too.

This goes hand-in-hand with https://github.com/opencast/adopter-registration-server/pull/17

---

To test this, set something like `org.opencastproject.adopter.registration.server.url=http://localhost:5000/` in `custom.properties`.

---

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
