### PR TITLE
Fix bug with adding a series when a deleted one still lingers

### DIFF
--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -321,7 +321,8 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
         // If the series existed but is marked deleted, we completely delete it
         // here to make sure no remains of the old series linger.
         if (entity != null) {
-          this.deleteSeries(seriesId);
+          em.remove(entity);
+          em.flush();
         }
 
         // no series stored, create new entity


### PR DESCRIPTION
`this.deleteSeries` only marks the series as deleted again, not actually
removing it. This will clash if a series with the same ID is added again
as it will cause a unique constraint violation. Instead, we completely
remove it here. Unfortunately, without the `flush` it didn't work: the
unique violation was still triggered. Whether `flush` is the best
solution: 🤷, I hardly know stuff about JPA.

This was noticed by Katrin: https://github.com/opencast/opencast/pull/3076#discussion_r839548962

CC @KatrinIhler 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
