### PR TITLE
Fix add punctuation and models support to google transcription

### DIFF
--- a/docs/guides/admin/docs/modules/googlespeechtranscripts.md
+++ b/docs/guides/admin/docs/modules/googlespeechtranscripts.md
@@ -103,6 +103,8 @@ Edit  _etc/org.opencastproject.transcription.googlespeech.GoogleSpeechTranscript
 * Use **_OAuth Client ID_**, **_OAuth Client secret_**, **_Refresh token_**, **_Token endpoint_** and **_storage bucket_** created above to respectively set _google.cloud.client.id_ , _google.cloud.client.secret_ , _google.cloud.refresh.token_ , _google.cloud.token.endpoint.url_ and _google.cloud.storage.bucket_
 * Enter the appropriate language in _google.speech.language_, default is (_en-US_). List of supported language: [https://cloud.google.com/speech-to-text/docs/languages](https://cloud.google.com/speech-to-text/docs/languages)
 * Remove profanity (bad language) from transcription by using _google.speech.profanity.filter_, default is (_false_), not removed by default
+* Set the transcription model using _google.speech.transcription.model_, default is (_default_). List of models: https://cloud.google.com/speech-to-text/docs/transcription-model
+* Enable punctuation for transcription result by setting _google.speech.transcription.punctuation_, to (_true_) default is (_false_)
 * In _workflow_, enter the workflow definition id of the workflow to be used to attach the generated transcripts/captions
 * Enter a _notification.email_ to get job failure notifications. If not entered, the email in _etc/custom.properties_ (org.opencastproject.admin.email) will be used.
 If no email address specified in either _notification.email_ or _org.opencastproject.admin.email_,
@@ -128,6 +130,13 @@ google.speech.language=
 
 # Filter out profanities from result. Default is false
 google.speech.profanity.filter=false
+
+# Enable punctuations for transcription. Default is false
+google.speech.transcription.punctuation=true
+
+# Transcription model to use
+# If empty, the "default" model will be used
+google.speech.transcription.model=default
 
 # Workflow to be executed when results are ready to be attached to media package.
 workflow=google-speech-attach-transcripts

--- a/etc/org.opencastproject.transcription.googlespeech.GoogleSpeechTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.googlespeech.GoogleSpeechTranscriptionService.cfg
@@ -25,6 +25,13 @@ google.cloud.storage.bucket=
 # List of languages with punctuation support: https://cloud.google.com/speech-to-text/docs/languages
 #google.speech.transcription.punctuation=false
 
+# Transcription model to use
+# If empty, the "default" model will be used
+# List of models: https://cloud.google.com/speech-to-text/docs/transcription-model
+# model "video" best for videos currently works with language set to en-US: 
+# https://cloud.google.com/speech-to-text/docs/languages
+#google.speech.transcription.model=default
+
 # Audio encoding extension.
 # The value will be used to store the audio file as [medidpackage_id].[extension] in the Google storage bucket
 # If empty the he default will be used (flac)

--- a/etc/org.opencastproject.transcription.googlespeech.GoogleSpeechTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.googlespeech.GoogleSpeechTranscriptionService.cfg
@@ -28,7 +28,7 @@ google.cloud.storage.bucket=
 # Transcription model to use
 # If empty, the "default" model will be used
 # List of models: https://cloud.google.com/speech-to-text/docs/transcription-model
-# model "video" best for videos currently works with language set to en-US: 
+# model "video" best for videos currently works with language set to en-US:
 # https://cloud.google.com/speech-to-text/docs/languages
 #google.speech.transcription.model=default
 

--- a/etc/org.opencastproject.transcription.googlespeech.GoogleSpeechTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.googlespeech.GoogleSpeechTranscriptionService.cfg
@@ -21,6 +21,10 @@ google.cloud.storage.bucket=
 # Filter out profanities from result. Default is false
 #google.speech.profanity.filter=false
 
+# Enable punctuations for transcription. Default is false
+# List of languages with punctuation support: https://cloud.google.com/speech-to-text/docs/languages
+#google.speech.transcription.punctuation=false
+
 # Audio encoding extension.
 # The value will be used to store the audio file as [medidpackage_id].[extension] in the Google storage bucket
 # If empty the he default will be used (flac)

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/GoogleSpeechCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/GoogleSpeechCaptionConverter.java
@@ -83,65 +83,67 @@ public class GoogleSpeechCaptionConverter implements CaptionConverter {
       for (int i = 0; i < resultsArray.size(); i++) {
         JSONObject resultElement = (JSONObject) resultsArray.get(i);
         JSONArray alternativesArray = (JSONArray) resultElement.get("alternatives");
-        if (alternativesArray != null && alternativesArray.size() > 0) {
-          JSONObject alternativeElement = (JSONObject) alternativesArray.get(0);
-          // remove trailing space in order to have correct transcript length
-          String transcript = ((String) alternativeElement.get("transcript")).trim();
-          if (transcript != null) {
-            JSONArray timestampsArray = (JSONArray) alternativeElement.get("words");
-            if (timestampsArray == null || timestampsArray.isEmpty()) {
-              logger.warn("Could not build caption object for job {}, result index {}: timestamp data not found",
-                      jobId, i);
-              continue;
-            }
-            // Force a maximum line size of transcriptionLineSize + one word
-            String[] words = transcript.split("\\s+");
-            StringBuffer line = new StringBuffer();
-            int indexFirst = -1;
-            int indexLast = -1;
-            for (int j = 0; j < words.length; j++) {
-              if (indexFirst == -1) {
-                indexFirst = j;
-              }
-              line.append(words[j]);
-              line.append(" ");
-              if (line.length() >= transcriptionLineSize || j == words.length - 1) {
-                indexLast = j;
-                // Create a caption
-                double start = -1;
-                double end = -1;
-                if (indexLast < timestampsArray.size()) {
-                  // Get start time of first element
-                  JSONObject wordTSList = (JSONObject) timestampsArray.get(indexFirst);
-                  if (wordTSList.size() == 3) {
-                    // Remove 's' at the end
-                    Number startNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("startTime").toString()), "s"));
-                    start = startNumber.doubleValue();
-                  }
-                  // Get end time of last element
-                  wordTSList = (JSONObject) timestampsArray.get(indexLast);
-                  if (wordTSList.size() == 3) {
-                    Number endNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("endTime").toString()), "s"));
-                    end = endNumber.doubleValue();
-                  }
-                }
-                if (start == -1 || end == -1) {
-                  logger.warn("Could not build caption object for job {}, result index {}: start/end times not found",
+            if (alternativesArray != null && alternativesArray.size() > 0) {
+              JSONObject alternativeElement = (JSONObject) alternativesArray.get(0);
+              if (!alternativeElement.isEmpty()) {
+              // remove trailing space in order to have correct transcript length
+              String transcript = ((String) alternativeElement.get("transcript")).trim();
+              if (transcript != null) {
+                JSONArray timestampsArray = (JSONArray) alternativeElement.get("words");
+                if (timestampsArray == null || timestampsArray.isEmpty()) {
+                  logger.warn("Could not build caption object for job {}, result index {}: timestamp data not found",
                           jobId, i);
-                  continue resultsLoop;
+                  continue;
                 }
+                // Force a maximum line size of transcriptionLineSize + one word
+                String[] words = transcript.split("\\s+");
+                StringBuffer line = new StringBuffer();
+                int indexFirst = -1;
+                int indexLast = -1;
+                for (int j = 0; j < words.length; j++) {
+                  if (indexFirst == -1) {
+                    indexFirst = j;
+                  }
+                  line.append(words[j]);
+                  line.append(" ");
+                  if (line.length() >= transcriptionLineSize || j == words.length - 1) {
+                    indexLast = j;
+                    // Create a caption
+                    double start = -1;
+                    double end = -1;
+                    if (indexLast < timestampsArray.size()) {
+                      // Get start time of first element
+                      JSONObject wordTSList = (JSONObject) timestampsArray.get(indexFirst);
+                      if (wordTSList.size() == 3) {
+                        // Remove 's' at the end
+                        Number startNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("startTime").toString()), "s"));
+                        start = startNumber.doubleValue();
+                      }
+                      // Get end time of last element
+                      wordTSList = (JSONObject) timestampsArray.get(indexLast);
+                      if (wordTSList.size() == 3) {
+                        Number endNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("endTime").toString()), "s"));
+                        end = endNumber.doubleValue();
+                      }
+                    }
+                    if (start == -1 || end == -1) {
+                      logger.warn("Could not build caption object for job {}, result index {}: start/end times not found",
+                              jobId, i);
+                      continue resultsLoop;
+                    }
 
-                String[] captionLines = new String[1];
-                captionLines[0] = line.toString().replace("%HESITATION", "...");
-                captionList.add(new CaptionImpl(buildTime((long) (start * 1000)), buildTime((long) (end * 1000)),
-                        captionLines));
-                indexFirst = -1;
-                indexLast = -1;
-                line.setLength(0);
+                    String[] captionLines = new String[1];
+                    captionLines[0] = line.toString().replace("%HESITATION", "...");
+                    captionList.add(new CaptionImpl(buildTime((long) (start * 1000)), buildTime((long) (end * 1000)),
+                            captionLines));
+                    indexFirst = -1;
+                    indexLast = -1;
+                    line.setLength(0);
+                  }
+                }
               }
             }
           }
-        }
       }
     } catch (Exception e) {
       logger.warn("Error when parsing Google transcriptions result: {}" + e.getMessage());

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/GoogleSpeechCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/GoogleSpeechCaptionConverter.java
@@ -83,67 +83,64 @@ public class GoogleSpeechCaptionConverter implements CaptionConverter {
       for (int i = 0; i < resultsArray.size(); i++) {
         JSONObject resultElement = (JSONObject) resultsArray.get(i);
         JSONArray alternativesArray = (JSONArray) resultElement.get("alternatives");
-            if (alternativesArray != null && alternativesArray.size() > 0) {
-              JSONObject alternativeElement = (JSONObject) alternativesArray.get(0);
-              if (!alternativeElement.isEmpty()) {
-              // remove trailing space in order to have correct transcript length
-              String transcript = ((String) alternativeElement.get("transcript")).trim();
-              if (transcript != null) {
-                JSONArray timestampsArray = (JSONArray) alternativeElement.get("words");
-                if (timestampsArray == null || timestampsArray.isEmpty()) {
-                  logger.warn("Could not build caption object for job {}, result index {}: timestamp data not found",
-                          jobId, i);
-                  continue;
+        if (alternativesArray != null && alternativesArray.size() > 0) {
+          JSONObject alternativeElement = (JSONObject) alternativesArray.get(0);
+          if (!alternativeElement.isEmpty()) {
+            // remove trailing space in order to have correct transcript length
+            String transcript = ((String) alternativeElement.get("transcript")).trim();
+            if (transcript != null) {
+              JSONArray timestampsArray = (JSONArray) alternativeElement.get("words");
+              if (timestampsArray == null || timestampsArray.isEmpty()) {
+                logger.warn("Could not build caption object for job {}, result index {}: timestamp data not found", jobId, i);
+                continue;
+              }
+              // Force a maximum line size of transcriptionLineSize + one word
+              String[] words = transcript.split("\\s+");
+              StringBuffer line = new StringBuffer();
+              int indexFirst = -1;
+              int indexLast = -1;
+              for (int j = 0; j < words.length; j++) {
+                if (indexFirst == -1) {
+                  indexFirst = j;
                 }
-                // Force a maximum line size of transcriptionLineSize + one word
-                String[] words = transcript.split("\\s+");
-                StringBuffer line = new StringBuffer();
-                int indexFirst = -1;
-                int indexLast = -1;
-                for (int j = 0; j < words.length; j++) {
-                  if (indexFirst == -1) {
-                    indexFirst = j;
+                line.append(words[j]);
+                line.append(" ");
+                if (line.length() >= transcriptionLineSize || j == words.length - 1) {
+                  indexLast = j;
+                  // Create a caption
+                  double start = -1;
+                  double end = -1;
+                  if (indexLast < timestampsArray.size()) {
+                    // Get start time of first element
+                    JSONObject wordTSList = (JSONObject) timestampsArray.get(indexFirst);
+                    if (wordTSList.size() == 3) {
+                      // Remove 's' at the end
+                      Number startNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("startTime").toString()), "s"));
+                      start = startNumber.doubleValue();
+                    }
+                    // Get end time of last element
+                    wordTSList = (JSONObject) timestampsArray.get(indexLast);
+                    if (wordTSList.size() == 3) {
+                      Number endNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("endTime").toString()), "s"));
+                      end = endNumber.doubleValue();
+                    }
                   }
-                  line.append(words[j]);
-                  line.append(" ");
-                  if (line.length() >= transcriptionLineSize || j == words.length - 1) {
-                    indexLast = j;
-                    // Create a caption
-                    double start = -1;
-                    double end = -1;
-                    if (indexLast < timestampsArray.size()) {
-                      // Get start time of first element
-                      JSONObject wordTSList = (JSONObject) timestampsArray.get(indexFirst);
-                      if (wordTSList.size() == 3) {
-                        // Remove 's' at the end
-                        Number startNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("startTime").toString()), "s"));
-                        start = startNumber.doubleValue();
-                      }
-                      // Get end time of last element
-                      wordTSList = (JSONObject) timestampsArray.get(indexLast);
-                      if (wordTSList.size() == 3) {
-                        Number endNumber = NumberFormat.getInstance(Locale.US).parse(removeEndCharacter((wordTSList.get("endTime").toString()), "s"));
-                        end = endNumber.doubleValue();
-                      }
-                    }
-                    if (start == -1 || end == -1) {
-                      logger.warn("Could not build caption object for job {}, result index {}: start/end times not found",
-                              jobId, i);
-                      continue resultsLoop;
-                    }
+                  if (start == -1 || end == -1) {
+                    logger.warn("Could not build caption object for job {}, result index {}: start/end times not found", jobId, i);
+                    continue resultsLoop;
+                  }
 
-                    String[] captionLines = new String[1];
-                    captionLines[0] = line.toString().replace("%HESITATION", "...");
-                    captionList.add(new CaptionImpl(buildTime((long) (start * 1000)), buildTime((long) (end * 1000)),
-                            captionLines));
-                    indexFirst = -1;
-                    indexLast = -1;
-                    line.setLength(0);
-                  }
+                  String[] captionLines = new String[1];
+                  captionLines[0] = line.toString().replace("%HESITATION", "...");
+                  captionList.add(new CaptionImpl(buildTime((long) (start * 1000)), buildTime((long) (end * 1000)), captionLines));
+                  indexFirst = -1;
+                  indexLast = -1;
+                  line.setLength(0);
                 }
               }
             }
           }
+        }
       }
     } catch (Exception e) {
       logger.warn("Error when parsing Google transcriptions result: {}" + e.getMessage());

--- a/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
+++ b/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
@@ -124,6 +124,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
   private static final int DEFAULT_CLEANUP_RESULTS_DAYS = 7;
   private static final boolean DEFAULT_PROFANITY_FILTER = false;
   private static final String DEFAULT_LANGUAGE = "en-US";
+  private static final boolean DEFAULT_ENABLE_PUNCTUATION = false;
   private static final String GOOGLE_SPEECH_URL = "https://speech.googleapis.com/v1";
   private static final String GOOGLE_AUTH2_URL = "https://www.googleapis.com/oauth2/v4/token";
   private static final String REQUEST_METHOD = "speech:longrunningrecognize";
@@ -162,6 +163,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
   public static final String ENABLED_CONFIG = "enabled";
   public static final String GOOGLE_SPEECH_LANGUAGE = "google.speech.language";
   public static final String PROFANITY_FILTER = "google.speech.profanity.filter";
+  public static final String ENABLE_PUNCTUATION = "google.speech.transcription.punctuation";
   public static final String WORKFLOW_CONFIG = "workflow";
   public static final String DISPATCH_WORKFLOW_INTERVAL_CONFIG = "workflow.dispatch.interval";
   public static final String COMPLETION_CHECK_BUFFER_CONFIG = "completion.check.buffer";
@@ -180,6 +182,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
    */
   private boolean enabled = false; // Disabled by default
   private boolean profanityFilter = DEFAULT_PROFANITY_FILTER;
+  private boolean enablePunctuation = DEFAULT_ENABLE_PUNCTUATION;
   private String defaultLanguage = DEFAULT_LANGUAGE;
   private String defaultEncoding = DEFAULT_ENCODING;
   private String workflowDefinitionId = DEFAULT_WF_DEF;
@@ -240,7 +243,14 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
     } else {
       logger.info("Default language will be used");
     }
-
+    // Enable punctuation or not
+    Option<String> punctuationOpt = OsgiUtil.getOptCfg(cc.getProperties(), ENABLE_PUNCTUATION);
+    if (punctuationOpt.isSome()) {
+      enablePunctuation = Boolean.parseBoolean(punctuationOpt.get());
+      logger.info("Enable punctuation is set to {}", enablePunctuation);
+    } else {
+      logger.info("Default punctuation setting will be used");
+    }
     // Encoding to be used
     Option<String> encodingOpt = OsgiUtil.getOptCfg(cc.getProperties(), ENCODING_EXTENSION);
     if (encodingOpt.isSome()) {
@@ -481,6 +491,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
     configValues.put("languageCode", languageCode);
     configValues.put("enableWordTimeOffsets", true);
     configValues.put("profanityFilter", profanityFilter);
+    configValues.put("enableAutomaticPunctuation", enablePunctuation);
     audioValues.put("uri", audioUrl);
     container.put("config", configValues);
     container.put("audio", audioValues);

--- a/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
+++ b/modules/transcription-service-google-speech-impl/src/main/java/org/opencastproject/transcription/googlespeech/GoogleSpeechTranscriptionService.java
@@ -125,6 +125,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
   private static final boolean DEFAULT_PROFANITY_FILTER = false;
   private static final String DEFAULT_LANGUAGE = "en-US";
   private static final boolean DEFAULT_ENABLE_PUNCTUATION = false;
+  private static final String DEFAULT_MODEL = "default";
   private static final String GOOGLE_SPEECH_URL = "https://speech.googleapis.com/v1";
   private static final String GOOGLE_AUTH2_URL = "https://www.googleapis.com/oauth2/v4/token";
   private static final String REQUEST_METHOD = "speech:longrunningrecognize";
@@ -164,6 +165,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
   public static final String GOOGLE_SPEECH_LANGUAGE = "google.speech.language";
   public static final String PROFANITY_FILTER = "google.speech.profanity.filter";
   public static final String ENABLE_PUNCTUATION = "google.speech.transcription.punctuation";
+  public static final String TRANSCRIPTION_MODEL = "google.speech.transcription.model";
   public static final String WORKFLOW_CONFIG = "workflow";
   public static final String DISPATCH_WORKFLOW_INTERVAL_CONFIG = "workflow.dispatch.interval";
   public static final String COMPLETION_CHECK_BUFFER_CONFIG = "completion.check.buffer";
@@ -183,6 +185,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
   private boolean enabled = false; // Disabled by default
   private boolean profanityFilter = DEFAULT_PROFANITY_FILTER;
   private boolean enablePunctuation = DEFAULT_ENABLE_PUNCTUATION;
+  private String model = DEFAULT_MODEL;
   private String defaultLanguage = DEFAULT_LANGUAGE;
   private String defaultEncoding = DEFAULT_ENCODING;
   private String workflowDefinitionId = DEFAULT_WF_DEF;
@@ -250,6 +253,14 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
       logger.info("Enable punctuation is set to {}", enablePunctuation);
     } else {
       logger.info("Default punctuation setting will be used");
+    }
+    // Transription model to be used
+    Option<String> transModel = OsgiUtil.getOptCfg(cc.getProperties(), TRANSCRIPTION_MODEL);
+    if (transModel.isSome()) {
+      model = transModel.get();
+      logger.info("Transcription model used is {}", model);
+    } else {
+      logger.info("Default Transcription model will be used");
     }
     // Encoding to be used
     Option<String> encodingOpt = OsgiUtil.getOptCfg(cc.getProperties(), ENCODING_EXTENSION);
@@ -492,6 +503,7 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
     configValues.put("enableWordTimeOffsets", true);
     configValues.put("profanityFilter", profanityFilter);
     configValues.put("enableAutomaticPunctuation", enablePunctuation);
+    configValues.put("model", model);
     audioValues.put("uri", audioUrl);
     container.put("config", configValues);
     container.put("audio", audioValues);
@@ -1042,9 +1054,9 @@ public class GoogleSpeechTranscriptionService extends AbstractJobProducer implem
           // If the job in progress, check if it should already have finished.
           if (TranscriptionJobControl.Status.InProgress.name().equals(j.getStatus())) {
             // If job should already have been completed, try to get the results. Consider a buffer factor so that we
-            // don't try it too early. Results normally should be ready half of the time of the track duration.
+            // don't try it too early. Results normally should be ready 1/3 of the time of the track duration.
             // The completionCheckBuffer can be used to delay results check.
-            if (j.getDateCreated().getTime() + (j.getTrackDuration() / 2) + completionCheckBuffer * 1000 < System
+            if (j.getDateCreated().getTime() + (j.getTrackDuration() / 3) + completionCheckBuffer * 1000 < System
                     .currentTimeMillis()) {
               try {
                 if (!getAndSaveJobResults(jobId)) {


### PR DESCRIPTION
Fix add punctuation and models support to google transcription #2147 #2148
Google has added support for punctuation and different transcription model to their API. 
With this update you can now enable or disable support for punctuation. In addition, you can set the transcription model such as `video` or `phone_call` or just leave the default. For more info about transcription models: https://cloud.google.com/speech-to-text/docs/transcription-model. 
These new changes will not affect users who decide to keep their current settings.
Also transcription time has been reduced from 1/2 of track time to 1/3 since Google has improved its services and return the transcription result file much quicker.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
