### PR TITLE
Fix Merge of JavaScript Auto-Updates

### DIFF
--- a/.github/workflows/auto-update-npm-libraries.yml
+++ b/.github/workflows/auto-update-npm-libraries.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: update engage-ui test libraries
+        working-directory: modules/engage-ui
+        run: |
+          npm update --save --dev eslint eslint-plugin-header
+          npm audit fix
+          git add package.json package-lock.json
+
       - name: update all engage-theodul-* libraries (they only have tests)
         working-directory: modules/
         run: |


### PR DESCRIPTION
This patch re-applies the code from pull request #3566 which was
overwritten when the Theodul auto-updates were merged [1] which had
conflicts with the Engage UI patch.

[1] https://github.com/opencast/opencast/commit/9c7511ae7ceda4f983c8c1abba480e2c0ae53510

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
