### PR TITLE
Update Editor to 2022-03-22 and OC Studio to 2022-02-16 for OC 10.x

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2021-12-10/oc-editor-2021-12-10.tar.gz</editor.url>
-    <editor.sha256>0691936bcfc835b1823aabc9ee89281a7b166b690fbfda6c4e20383156e9d723</editor.sha256>
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-03-22/oc-editor-2022-03-22022-03-22editor.url>2022-03-22
+    <editor.sha256>7966845ad71613e8b11d499cfb8e9c8a8e67a11522e66a5c9eee414a3e780e19</editor.sha256>
   </properties>
   <build>
     <plugins>

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-03-22/oc-editor-2022-03-22022-03-22editor.url>2022-03-22
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-03-22/oc-editor-2022-03-22.tar.gz</editor.url>
     <editor.sha256>7966845ad71613e8b11d499cfb8e9c8a8e67a11522e66a5c9eee414a3e780e19</editor.sha256>
   </properties>
   <build>

--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2022-02-16/2022-02-16-integrated.tar.gz</opencast.studio.url>
+    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2022-02-16/oc-studio-2022-02-16-integrated.tar.gz</opencast.studio.url>
     <opencast.studio.sha256>041f018fccf3ec13ffa50befd09a0d5bf6746b306e1a483328608948dc6c2afb</opencast.studio.sha256>
   </properties>
   <build>

--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2021-06-11/oc-studio-2021-06-11-integrated.tar.gz</opencast.studio.url>
-    <opencast.studio.sha256>0a31de152502394e477b02c98b26c3af9aad1b4702be2eda571ff4d91022cf5f</opencast.studio.sha256>
+    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2022-02-16/2022-02-16-integrated.tar.gz</opencast.studio.url>
+    <opencast.studio.sha256>041f018fccf3ec13ffa50befd09a0d5bf6746b306e1a483328608948dc6c2afb</opencast.studio.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
This patch updates the stand alone Editor to 2022-03-22 for OC 10.x

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
