### PR TITLE
Check if user can be loaded before starting the workflow

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -585,11 +585,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
       // Get the current user
       User currentUser = securityService.getUser();
-      if (currentUser == null)
-        throw new SecurityException("Current user is unknown");
-
-      if (userDirectoryService.loadUser(currentUser.getUsername()) == null)
-        throw new SecurityException(String.format("Current user '%s' can not be loaded", currentUser.getUsername()));
+      validUserOrThrow(currentUser);
 
       // Get the current organization
       Organization organization = securityService.getOrganization();
@@ -948,6 +944,17 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     } finally {
       lock.unlock();
     }
+  }
+
+  /**
+   * Checks whether user is set and is known to the userDirectoryService
+   */
+  private void validUserOrThrow(User user) {
+      if (user == null)
+        throw new SecurityException("Current user is unknown");
+
+      if (userDirectoryService.loadUser(user.getUsername()) == null)
+        throw new SecurityException(String.format("Current user '%s' can not be loaded", user.getUsername()));
   }
 
   private void removeTempFiles(WorkflowInstance workflowInstance) {

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -588,6 +588,9 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
       if (currentUser == null)
         throw new SecurityException("Current user is unknown");
 
+      if (userDirectoryService.loadUser(currentUser.getUsername()) == null)
+        throw new SecurityException(String.format("Current user '%s' can not be loaded", currentUser.getUsername()));
+
       // Get the current organization
       Organization organization = securityService.getOrganization();
       if (organization == null)


### PR DESCRIPTION
Port to the opencast community edition.
This PR simply adds a small check before starting a workflow that ensures the workflow user can be loaded.
Seems like that the corresponding bug has already been fixed, but since this is just an additional check, there seems to be no real downside to adding this.