### PR TITLE
Disable group removement upon missing group roles

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -306,6 +306,25 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
   }
 
   /**
+   * Removes a user from all groups
+   *
+   * @param userName
+   *          the username
+   * @param orgId
+   *          the user's organization
+   *
+   */
+  public void removeMemberFromAllGroups(String userName, String orgId) throws UnauthorizedException {
+    // List of the user's groups
+    List<JpaGroup> membership = UserDirectoryPersistenceUtil.findGroupsByUser(userName, orgId, emf);
+    for (JpaGroup group : membership) {
+      logger.debug("Removing user {} from group {}", userName, group.getRole());
+      group.getMembers().remove(userName);
+      addGroup(group);
+    }
+  }
+
+  /**
    * Loads a group from persistence
    *
    * @param groupId

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -314,13 +314,17 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
    *          the user's organization
    *
    */
-  public void removeMemberFromAllGroups(String userName, String orgId) throws UnauthorizedException {
+  public void removeMemberFromAllGroups(String userName, String orgId) {
     // List of the user's groups
     List<JpaGroup> membership = UserDirectoryPersistenceUtil.findGroupsByUser(userName, orgId, emf);
     for (JpaGroup group : membership) {
-      logger.debug("Removing user {} from group {}", userName, group.getRole());
-      group.getMembers().remove(userName);
-      addGroup(group);
+      try {
+        logger.debug("Removing user {} from group {}", userName, group.getRole());
+        group.getMembers().remove(userName);
+        addGroup(group);
+      } catch (UnauthorizedException e) {
+        logger.warn("Unauthorized to add or remove user {} from group {}", userName, group.getRole(), e);
+      }
     }
   }
 

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaGroupRoleProvider.java
@@ -267,9 +267,8 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
 
     logger.debug("updateGroupMembershipFromRoles({}, size={})", userName, roleList.size());
 
-    // The list of groups for this user represented by the roleList is considered authoritative,
-    // so remove the user from any groups which aren't represented in the roleList, and add the
-    // user to all groups which are in the roleList.
+    // Add the user to all groups which are in the roleList, but allow the user to be part of groups
+    // without having the group role
 
     Set<String> membershipRoles = new HashSet<String>();
 
@@ -280,18 +279,9 @@ public class JpaGroupRoleProvider implements AAIRoleProvider, GroupProvider, Gro
         //ignore groups of other providers
         continue;
       }
-      try {
-        if (roleList.contains(group.getRole())) {
-          // record this membership
-          membershipRoles.add(group.getRole());
-        } else {
-          // remove user from this group
-          logger.debug("Removing user {} from group {}", userName, group.getRole());
-          group.getMembers().remove(userName);
-          addGroup(group);
-        }
-      } catch (UnauthorizedException e) {
-        logger.warn("Unauthorized to add or remove user {} from group {}", userName, group.getRole(), e);
+      if (roleList.contains(group.getRole())) {
+        // record this membership
+        membershipRoles.add(group.getRole());
       }
     }
 

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserAndRoleProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserAndRoleProvider.java
@@ -493,7 +493,7 @@ public class JpaUserAndRoleProvider implements UserProvider, RoleProvider {
     }
 
     // Remove the user's group membership
-    groupRoleProvider.updateGroupMembershipFromRoles(username, orgId, new ArrayList<String>());
+    groupRoleProvider.removeMemberFromAllGroups(username, orgId);
 
     // Remove the user
     UserDirectoryPersistenceUtil.deleteUser(username, orgId, emf);

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
@@ -58,6 +58,9 @@ public class JpaGroupRoleProviderTest {
   public ExpectedException thrown = ExpectedException.none();
 
   private JpaGroupRoleProvider provider = null;
+
+  private JpaUserAndRoleProvider userProvider = null;
+
   private static JpaOrganization org1 = new JpaOrganization("org1", "org1", "localhost", 80, "admin", "anon", null);
   private static JpaOrganization org2 = new JpaOrganization("org2", "org2", "127.0.0.1", 80, "admin", "anon", null);
 
@@ -83,7 +86,6 @@ public class JpaGroupRoleProviderTest {
     provider.setSecurityService(securityService);
     provider.setEntityManagerFactory(newTestEntityManagerFactory(JpaUserAndRoleProvider.PERSISTENCE_UNIT));
     provider.activate(null);
-
   }
 
   @Test
@@ -278,4 +280,44 @@ public class JpaGroupRoleProviderTest {
     Assert.assertEquals(2, IteratorUtils.toList(provider.findRoles("%test%", Role.Target.ALL, 0, 2)).size());
   }
 
+  @Test
+  public void testRemoveUserFromAllGroups() throws UnauthorizedException {
+
+    Set<String> members = new HashSet<String>();
+    members.add("user");
+
+    JpaGroup group1 = new JpaGroup("test1", org1, "Test1", "Test 1 group",
+            new HashSet<JpaRole>(), members);
+    JpaGroup group2 = new JpaGroup("test2", org1, "Test2", "Test 2 group",
+            new HashSet<JpaRole>(), members);
+    JpaGroup group3 = new JpaGroup("test3", org1, "Test3", "Test 3 group",
+            new HashSet<JpaRole>(), members);
+
+    provider.addGroup(group1);
+    provider.addGroup(group2);
+    provider.addGroup(group3);
+
+    List<Role> groupRoles = provider.getRolesForUser("user");
+    Assert.assertEquals("There should be three groupRoles added to the user",3, groupRoles.size());
+    Assert.assertTrue("GroupRole for group1 should be added", groupRoles.contains(new JpaRole(group1.getRole(), org1)));
+    Assert.assertTrue("GroupRole for group2 should be added", groupRoles.contains(new JpaRole(group2.getRole(), org1)));
+    Assert.assertTrue("GroupRole for group3 should be added", groupRoles.contains(new JpaRole(group3.getRole(), org1)));
+
+    provider.removeMemberFromAllGroups("user", "org1");
+
+    groupRoles = provider.getRolesForUser("user");
+    Assert.assertEquals("There should be no more groupRoles for the user",0, groupRoles.size());
+    Assert.assertFalse("GroupRole for group1 should be removed",
+            groupRoles.contains(new JpaRole(group1.getRole(), org1)));
+    Assert.assertFalse("GroupRole for group2 should be removed",
+            groupRoles.contains(new JpaRole(group2.getRole(), org1)));
+    Assert.assertFalse("GroupRole for group3 should be removed",
+            groupRoles.contains(new JpaRole(group3.getRole(), org1)));
+
+    provider.removeMemberFromAllGroups("user", "org1");
+
+    groupRoles = provider.getRolesForUser("user");
+    Assert.assertEquals("Make sure there is no issue with users that are not part of any group",
+            0, groupRoles.size());
+  }
 }

--- a/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
+++ b/modules/userdirectory/src/test/java/org/opencastproject/userdirectory/JpaGroupRoleProviderTest.java
@@ -58,9 +58,6 @@ public class JpaGroupRoleProviderTest {
   public ExpectedException thrown = ExpectedException.none();
 
   private JpaGroupRoleProvider provider = null;
-
-  private JpaUserAndRoleProvider userProvider = null;
-
   private static JpaOrganization org1 = new JpaOrganization("org1", "org1", "localhost", 80, "admin", "anon", null);
   private static JpaOrganization org2 = new JpaOrganization("org2", "org2", "127.0.0.1", 80, "admin", "anon", null);
 
@@ -86,6 +83,7 @@ public class JpaGroupRoleProviderTest {
     provider.setSecurityService(securityService);
     provider.setEntityManagerFactory(newTestEntityManagerFactory(JpaUserAndRoleProvider.PERSISTENCE_UNIT));
     provider.activate(null);
+
   }
 
   @Test


### PR DESCRIPTION
This PR addresses #3509 . When logging in via Shibboleth there is currently a check which matches all the primary group roles of a user with its corresponding group memberships. If a primary group role is not present, but the user is part of the corresponding group, the user gets removed from the group. 

The problem is that when adding a new user to a group, the user will get saved in the database, but won't get the primary group role and therefore will be removed from the group after the next login. 

I do not really see a reason for making it a hard constraint that the primary group role must be present in the users role list in order to be part of that group. It should be sufficient to rely on the `oc_group_member` database table to track all group memberships. 
For that reason I removed the part in the code which was responsible for the removement of group memberships when checking the primary group roles.

I would need someone with a Shibboleth system to test, if this fixes the problem, since I do not have a suitable local setup to test this. 

I would also appreciate feedback if the removal of group memberships served any special purpose which I might have missed.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
