### PR TITLE
Avoid rewriteUrls being invoked twice while loading mediapackage.

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageBuilderImpl.java
@@ -104,10 +104,6 @@ public class MediaPackageBuilderImpl implements MediaPackageBuilder {
   public MediaPackage loadFromXml(InputStream is) throws MediaPackageException {
     try {
       Document xml = XmlSafeParser.parse(is);
-      if (serializer != null) {
-        //Convert InputStream to XML document to rewrite the URLs
-        rewriteUrls(xml, serializer);
-      }
       return loadFromXml(xml);
     } catch (Exception e) {
       throw new MediaPackageException("Error deserializing paths in media package", e);


### PR DESCRIPTION
This PR is related to #3058 , which add `rewriteUrls` to `loadFromXml(InputStream is)`, and with a `loadFromXml(Node xml)` as return value.

Yet, another `rewriteUrls` is also exist in `loadFromXml(Node xml)`. So, while invoking  `loadFromXml(InputStream is)`, `rewriteUrls` will be called twice. That means, URLs in mediapackage will be rewrited twice, and cause an unexpected result.

For example, I use `PresignedUrlMediaPackageSerializer` to generate s3 presigned URL, and the current logic will return an unexpected presigned presigned URL.

Solution: remove the invoke of `rewriteUrls` in `loadFromXml(InputStream is)`.
All 3 `loadFromXml` method will eventually invoke `rewriteUrls` in  `loadFromXml(Node xml)` only once.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
