### PR TITLE
Don't store invalid ACLs submitted to api-endpoint

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -968,7 +968,7 @@ public class SeriesEndpoint {
     }
 
     if (!accessControlList.isValid()) {
-      logger.error("POST api/series/{}/access: Invalid series ACL detected", seriesId);
+      logger.debug("POST api/series/{}/access: Invalid series ACL detected", seriesId);
       return badRequest();
     }
 

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/SeriesEndpoint.java
@@ -967,6 +967,11 @@ public class SeriesEndpoint {
       return badRequest();
     }
 
+    if (!accessControlList.isValid()) {
+      logger.error("POST api/series/{}/access: Invalid series ACL detected", seriesId);
+      return badRequest();
+    }
+
     Opt<Series> series = indexService.getSeries(seriesId, searchIndex);
     if (series.isNone())
       return notFound("Cannot find a series with id {}", seriesId);

--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlEntry.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlEntry.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.security.api;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -84,6 +86,10 @@ public final class AccessControlEntry {
    */
   public boolean isAllow() {
     return allow;
+  }
+
+  public boolean isValid() {
+    return StringUtils.isNotBlank(role) && StringUtils.isNotBlank(action);
   }
 
   /**

--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlList.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlList.java
@@ -68,6 +68,13 @@ public final class AccessControlList {
     return entries;
   }
 
+  public boolean isValid() {
+    for (AccessControlEntry entry : entries) {
+      if (!entry.isValid()) return false;
+    }
+    return true;
+  }
+
   /**
    * {@inheritDoc}
    *

--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlList.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlList.java
@@ -69,10 +69,7 @@ public final class AccessControlList {
   }
 
   public boolean isValid() {
-    for (AccessControlEntry entry : entries) {
-      if (!entry.isValid()) return false;
-    }
-    return true;
+    return entries.stream().allMatch(AccessControlEntry::isValid);
   }
 
   /**


### PR DESCRIPTION
Port of an old bugfix to the community edition.
From the original commit:
```
This is a workaround for the following problem: When the user navigates
through series in the series details modal, the admin ui attempts to
store an invalid intermediate state of the series ACLs.
```

The mentioned bug in the admin ui has seemingly been fixed, but it is still possible to submit ACLs to the api that have an empty role or action.
The commit fixes this, but I am unsure if this is still wanted/needed as the original problem no longer exists.
Feel free to close this PR if you feel that this change is unnecessary.