### PR TITLE
Make deletion of live publication in case of capture errors configurable

### DIFF
--- a/etc/org.opencastproject.liveschedule.message.SchedulerUpdateHandler.cfg
+++ b/etc/org.opencastproject.liveschedule.message.SchedulerUpdateHandler.cfg
@@ -1,0 +1,9 @@
+##############################################################################
+# Liveschedule Update Handler Configuration
+##############################################################################
+
+# This config option can be used to disable the deletion of live events when
+# the capturing has failed.
+#
+# Default: true
+#live.deleteOnCapureError = true


### PR DESCRIPTION
Port of to the community edition.
This PR makes the deletion of a live publication in case of a capture error configurable.