### PR TITLE
Make creation of default External API group configurable

### DIFF
--- a/etc/org.opencastproject.external.userdirectory.ExternalGroupLoader.cfg
+++ b/etc/org.opencastproject.external.userdirectory.ExternalGroupLoader.cfg
@@ -1,0 +1,9 @@
+##############################################################################
+# External Group Loader Configuration
+##############################################################################
+
+# This configuration lets you deactivate the creation of default groups for
+# the external api.
+#
+# Default: true
+#create_default_groups = true

--- a/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalGroupLoader.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/userdirectory/ExternalGroupLoader.java
@@ -36,13 +36,16 @@ import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.UrlSupport;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Dictionary;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -53,6 +56,9 @@ public class ExternalGroupLoader {
 
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(ExternalGroupLoader.class);
+
+  /** The config key, which specifies whether default groups should be created */
+  public static final String SHOULD_CREATE_DEFAULT_GROUPS_CONFIG_KEY = "create_default_groups";
 
   /** The external applications group suffix */
   public static final String EXTERNAL_GROUP_SUFFIX = "_EXTERNAL_APPLICATIONS";
@@ -101,7 +107,14 @@ public class ExternalGroupLoader {
   public void activate(ComponentContext cc) throws Exception {
     logger.debug("Activate external group loader");
 
-    createDefaultGroups(cc);
+    Dictionary properties = cc.getProperties();
+    boolean shouldCreateDefaultGroups = BooleanUtils.toBoolean(Objects.toString(properties.get(SHOULD_CREATE_DEFAULT_GROUPS_CONFIG_KEY), "true"));
+
+    if (shouldCreateDefaultGroups) {
+      createDefaultGroups(cc);
+    } else {
+      logger.info("Disabled generation of External Application group");
+    }
   }
 
   /**


### PR DESCRIPTION
This PR makes the default group creation of the external api configurable.