### PR TITLE
Silence npm autoupdate

### DIFF
--- a/.github/workflows/auto-update-npm-libraries.yml
+++ b/.github/workflows/auto-update-npm-libraries.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: modules/engage-ui
         run: |
           npm update --save --dev eslint eslint-plugin-header
-          npm audit fix
+          npm audit fix || true
           git add package.json package-lock.json
 
       - name: update all engage-theodul-* libraries (they only have tests)


### PR DESCRIPTION
Silencing output of npm auto update, lest it send me an email every single day

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
