### PR TITLE
Changed inbox behaviour for additional files for scheduled events

### DIFF
--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -166,6 +166,11 @@
       <version>${project.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workspace-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/InboxScannerService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/InboxScannerService.java
@@ -33,6 +33,7 @@ import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.security.util.SecurityContext;
 import org.opencastproject.series.api.SeriesService;
+import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.BooleanUtils;
@@ -134,6 +135,7 @@ public class InboxScannerService implements ArtifactInstaller, ManagedService {
   private OrganizationDirectoryService orgDir;
   private SeriesService seriesService;
   private SchedulerService schedulerService;
+  protected Workspace workspace;
 
   private ComponentContext cc;
 
@@ -222,7 +224,8 @@ public class InboxScannerService implements ArtifactInstaller, ManagedService {
     // create new scanner
     this.ingestor = new Ingestor(ingestService, securityContext.get(), workflowDefinition,
             workflowConfig, mediaFlavor, inbox, maxThreads, seriesService, maxTries, secondsBetweenTries,
-            metadataPattern, dateFormatter, schedulerService, ffprobe, matchSchedule, matchThreshold);
+            metadataPattern, dateFormatter, schedulerService, ffprobe, matchSchedule, matchThreshold,
+            workspace);
     new Thread(ingestor).start();
     logger.info("Now watching inbox {}", inbox.getAbsolutePath());
   }
@@ -360,5 +363,10 @@ public class InboxScannerService implements ArtifactInstaller, ManagedService {
   @Reference
   public void setSchedulerService(SchedulerService schedulerService) {
     this.schedulerService = schedulerService;
+  }
+
+  @Reference
+  public void setWorkspace(Workspace workspace) {
+    this.workspace = workspace;
   }
 }

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
@@ -25,19 +25,27 @@ import static java.lang.String.format;
 import static org.opencastproject.scheduler.api.RecordingState.UPLOAD_FINISHED;
 
 import org.opencastproject.ingest.api.IngestService;
+import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElements;
+import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.identifier.Id;
+import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
+import org.opencastproject.metadata.dublincore.DublinCoreUtil;
 import org.opencastproject.metadata.dublincore.DublinCores;
 import org.opencastproject.metadata.dublincore.EncodingSchemeUtils;
 import org.opencastproject.metadata.dublincore.Precision;
+import org.opencastproject.scheduler.api.Recording;
 import org.opencastproject.scheduler.api.SchedulerService;
 import org.opencastproject.security.util.SecurityContext;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.util.IoSupport;
+import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workspace.api.Workspace;
 
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.gson.Gson;
@@ -57,6 +65,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -101,6 +110,7 @@ public class Ingestor implements Runnable {
 
   private final SeriesService seriesService;
   private final SchedulerService schedulerService;
+  private final Workspace workspace;
 
   private final int maxTries;
 
@@ -239,6 +249,31 @@ public class Ingestor implements Runnable {
                   mediaPackage = mediaPackages.get(0);
                   var id = mediaPackage.getIdentifier().toString();
                   var eventConfiguration = schedulerService.getCaptureAgentConfiguration(id);
+
+                  // Check if the scheduled event already has a recording associated with it
+                  // If so, ingest the file as a new event
+                  try {
+                    Recording recordingState = schedulerService.getRecordingState(id);
+                    if (recordingState.getState().equals(UPLOAD_FINISHED)) {
+                      mediaPackage = (MediaPackage) mediaPackage.clone();
+                      Id newId = IdImpl.fromUUID();
+                      mediaPackage.setIdentifier(newId);
+
+                      // Update dublincore title
+                      try {
+                        String newTitle = mediaPackage.getTitle() + " - " + newId;
+                        DublinCoreCatalog dc = DublinCoreUtil.loadEpisodeDublinCore(workspace, mediaPackage).get();
+                        dc.set(DublinCore.PROPERTY_TITLE, newTitle);
+                        mediaPackage = updateDublincCoreCatalog(mediaPackage, dc);
+                        mediaPackage.setTitle(newTitle);
+                      } catch (Exception e) {
+                        // Don't fail the ingest if we could not set the title for some reason
+                      }
+                    }
+                  } catch (NotFoundException e) {
+                    // Occurs if a scheduled event has not started yet
+                  }
+
                   currentWorkflowDefinition = eventConfiguration.getOrDefault(
                           "org.opencastproject.workflow.definition",
                           workflowDefinition);
@@ -415,7 +450,7 @@ public class Ingestor implements Runnable {
           String workflowDefinition, Map<String, String> workflowConfig, String mediaFlavor, File inbox, int maxThreads,
           SeriesService seriesService, int maxTries, int secondsBetweenTries, Optional<Pattern> metadataPattern,
           DateTimeFormatter dateFormatter, SchedulerService schedulerService, String ffprobe, boolean matchSchedule,
-          float matchThreshold) {
+          float matchThreshold, Workspace workspace) {
     this.ingestService = ingestService;
     this.secCtx = secCtx;
     this.workflowDefinition = workflowDefinition;
@@ -433,6 +468,7 @@ public class Ingestor implements Runnable {
     this.ffprobe = ffprobe;
     this.matchSchedule = matchSchedule;
     this.matchThreshold = matchThreshold;
+    this.workspace = workspace;
   }
 
   /**
@@ -475,6 +511,36 @@ public class Ingestor implements Runnable {
     } catch (Exception e) {
       logger.error("Unable to cleanup inbox for the artifact {}", artifact, e);
     }
+  }
+
+  /**
+   *
+   * @param mp
+   *          the mediapackage to update
+   * @param dc
+   *          the dublincore metadata to use to update the mediapackage
+   * @return the updated mediapackage
+   * @throws IOException
+   *           Thrown if an IO error occurred adding the dc catalog file
+   * @throws MediaPackageException
+   *           Thrown if an error occurred updating the mediapackage or the mediapackage does not contain a catalog
+   */
+  private MediaPackage updateDublincCoreCatalog(MediaPackage mp, DublinCoreCatalog dc)
+          throws IOException, MediaPackageException {
+    try (InputStream inputStream = IOUtils.toInputStream(dc.toXmlString(), "UTF-8")) {
+      // Update dublincore catalog
+      Catalog[] catalogs = mp.getCatalogs(MediaPackageElements.EPISODE);
+      if (catalogs.length > 0) {
+        Catalog catalog = catalogs[0];
+        URI uri = workspace.put(mp.getIdentifier().toString(), catalog.getIdentifier(), "dublincore.xml", inputStream);
+        catalog.setURI(uri);
+        // setting the URI to a new source so the checksum will most like be invalid
+        catalog.setChecksum(null);
+      } else {
+        throw new MediaPackageException("Unable to find catalog");
+      }
+    }
+    return mp;
   }
 
   public String myInfo() {


### PR DESCRIPTION
Resolves #3649

Previously, additional files for a scheduled event to the inbox would overwrite the previous event or cause an exception in case a workflow was currently running on the scheduled event. Now, new events are created for additional files instead.

Unfortunately I did not find a (reasonably easy) way to number the new events as requested in the linked issue. For now, new events are named after the pattern "originalTitle - newEventId". 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
