### PR TITLE
Deprecate Media Package Internal Metadata

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/ToolsEndpoint.java
@@ -508,7 +508,7 @@ public class ToolsEndpoint {
       .map(SourceTrackInfo::toJson)
       .collect(Collectors.toList());
 
-    return RestUtils.okJson(obj(f("title", v(mp.getTitle(), Jsons.BLANK)),
+    return RestUtils.okJson(obj(f("title", v(event.getTitle(), Jsons.BLANK)),
             f("date", v(event.getRecordingStartDate(), Jsons.BLANK)),
             f("series", obj(f("id", v(event.getSeriesId(), Jsons.BLANK)),
             f("title", v(event.getSeriesName(), Jsons.BLANK)))),

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackage.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackage.java
@@ -52,7 +52,10 @@ public interface MediaPackage extends Cloneable {
    * Returns the title for the associated series, if any.
    *
    * @return The series title
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   String getSeriesTitle();
 
   void setSeriesTitle(String seriesTitle);
@@ -61,7 +64,10 @@ public interface MediaPackage extends Cloneable {
    * Returns the title of the episode that this mediapackage represents.
    *
    * @return The episode title
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   String getTitle();
 
   void addCreator(String creator);
@@ -72,7 +78,10 @@ public interface MediaPackage extends Cloneable {
    * Returns the names of the institutions or people who created this mediapackage
    *
    * @return the creators of this mediapackage
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   String[] getCreators();
 
   void setSeries(String identifier);
@@ -90,7 +99,10 @@ public interface MediaPackage extends Cloneable {
    * The license for the content in this mediapackage
    *
    * @return the license
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   String getLicense();
 
   void addContributor(String contributor);
@@ -101,7 +113,10 @@ public interface MediaPackage extends Cloneable {
    * Returns the names of the institutions or people who contributed to the content within this mediapackage
    *
    * @return the contributors
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   String[] getContributors();
 
   void setLanguage(String language);
@@ -110,7 +125,10 @@ public interface MediaPackage extends Cloneable {
    * Returns the language written and/or spoken in the media content of this mediapackage
    *
    * @return the language
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   String getLanguage();
 
   void addSubject(String subject);
@@ -121,7 +139,10 @@ public interface MediaPackage extends Cloneable {
    * The keywords describing the subject(s) or categories describing the content of this mediapackage
    *
    * @return the subjects
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   String[] getSubjects();
 
   void setDate(Date date);
@@ -130,14 +151,20 @@ public interface MediaPackage extends Cloneable {
    * Returns the media package start time.
    *
    * @return the start time
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   Date getDate();
 
   /**
    * Returns the media package duration in milliseconds or <code>null</code> if no duration is available.
    *
    * @return the duration
+   *
+   * @deprecated This is not guaranteed to be correct. Use the metadata contained in the Dublin Core catalog instead.
    */
+  @Deprecated
   Long getDuration();
 
   /**
@@ -169,7 +196,7 @@ public interface MediaPackage extends Cloneable {
   Iterable<MediaPackageElement> elements();
 
   /**
-   * Returns all of the elements.
+   * Returns all the elements.
    *
    * @return the elements
    */
@@ -265,8 +292,8 @@ public interface MediaPackage extends Cloneable {
   boolean hasTracks();
 
   /**
-   * Returns the attachment identified by <code>attachmentId</code> or <code>null</code> if that attachment doesn't
-   * exists.
+   * Returns the attachment identified by <code>attachmentId</code> or <code>null</code> if that attachment does not
+   * exist.
    *
    * @param attachmentId
    *          the attachment identifier

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageSupport.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageSupport.java
@@ -21,7 +21,6 @@
 
 package org.opencastproject.mediapackage;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.opencastproject.util.IoSupport.withResource;
 import static org.opencastproject.util.data.Collections.list;
@@ -295,14 +294,6 @@ public final class MediaPackageSupport {
       }
     };
 
-    public static final Function<MediaPackageElement, Boolean> isEpisodeAcl = new Function<MediaPackageElement, Boolean>() {
-      @Override
-      public Boolean apply(MediaPackageElement mpe) {
-        // match is commutative
-        return MediaPackageElements.XACML_POLICY_EPISODE.matches(mpe.getFlavor());
-      }
-    };
-
     public static final Function<MediaPackageElement, Boolean> isEpisodeDublinCore = new Function<MediaPackageElement, Boolean>() {
       @Override
       public Boolean apply(MediaPackageElement mpe) {
@@ -345,17 +336,6 @@ public final class MediaPackageSupport {
                 return MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().loadFromXml(is);
               }
             });
-  }
-
-  /**
-   * Media package must have a title and contain tracks in order to be published.
-   *
-   * @param mp
-   *          the media package
-   * @return <code>true</code> if the media package can be published
-   */
-  public static boolean isPublishable(MediaPackage mp) {
-    return !isBlank(mp.getTitle()) && mp.hasTracks();
   }
 
   /**


### PR DESCRIPTION
This patch deprecates the media package methods for reading metadata
directly from the media package instead of getting them from the
metadata catalogs.

These fields are not guaranteed to be set (or set correctly) at any
given time and should usually be avoided. They pre-date the metadata
catalogs and were actually used at one time, but not anymore.

Take a [look at this review for an example of things going wrong](https://github.com/opencast/opencast/pull/3687#discussion_r854245988).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
