### PR TITLE
fix cover-image-remote package import

### DIFF
--- a/modules/cover-image-remote/pom.xml
+++ b/modules/cover-image-remote/pom.xml
@@ -57,17 +57,6 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Import-Package>
-              org.apache.http,
-              org.apache.http.client.entity,
-              org.apache.http.client.methods,
-              org.apache.http.message,
-              org.apache.http.util,
-              org.opencastproject.coverimage;version=${project.version},
-              org.opencastproject.job.api;version=${project.version},
-              org.opencastproject.serviceregistry.api;version=${project.version},
-              org.slf4j
-            </Import-Package>
             <Export-Package>
               org.opencastproject.coverimage.remote;version=${project.version}
             </Export-Package>


### PR DESCRIPTION
The cover-image-remote bundle had a fixed import package list, which caused a class not found exception.

Closes #3692

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
