### PR TITLE
Out of video image extraction should not fail

### DIFF
--- a/etc/encoding/opencast.properties
+++ b/etc/encoding/opencast.properties
@@ -79,9 +79,9 @@ profile.player-preview.http.name = cover image for engage
 profile.player-preview.http.input = visual
 profile.player-preview.http.output = image
 profile.player-preview.http.suffix = -player.jpg
-profile.player-preview.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
-  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),fps=25,reverse,scale=-2:720 \
-  #{out.dir}/#{out.name}#{out.suffix}
+profile.player-preview.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
+  -vf "fps=1,scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:-1:-1 [in]; color=black:s=1280x720:r=1:d=1 [bg]; [bg][in] overlay=0:0 [out]" \
+  -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
 
 # Slide preview images as shown in the player
 profile.player-slides.http.name = slide preview image for engage
@@ -89,17 +89,17 @@ profile.player-slides.http.input = visual
 profile.player-slides.http.output = image
 profile.player-slides.http.suffix = .#{time}.jpg
 profile.player-slides.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
-  -r 1 -frames:v 1 -filter:v scale=160:-1 \
-  #{out.dir}/#{out.name}#{out.suffix}
+  -vf "fps=1,scale=160:90:force_original_aspect_ratio=decrease,pad=160:90:-1:-1 [in]; color=black:s=160x90:r=1:d=1 [bg]; [bg][in] overlay=0:0 [out]" \
+  -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
 
 # Cover image for search results
 profile.search-cover.http.name = cover image for engage
 profile.search-cover.http.input = visual
 profile.search-cover.http.output = image
 profile.search-cover.http.suffix = -search.jpg
-profile.search-cover.http.ffmpeg.command = -i #{in.video.path} -frames:v 1 \
-  -filter:v select=eq(n\\,1)+lt(t\\,#{time}),fps=25,reverse,scale=160:-2 \
-  #{out.dir}/#{out.name}#{out.suffix}
+profile.search-cover.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
+  -vf "fps=1,scale=160:90:force_original_aspect_ratio=decrease,pad=160:90:-1:-1 [in]; color=black:s=160x90:r=1:d=1 [bg]; [bg][in] overlay=0:0 [out]" \
+  -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
 
 profile.mp4-preview.http.name = preview video
 profile.mp4-preview.http.input = visual
@@ -138,8 +138,8 @@ profile.feed-cover.http.input = visual
 profile.feed-cover.http.output = image
 profile.feed-cover.http.suffix = -feed.jpg
 profile.feed-cover.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
-  -r 1 -frames:v 1 -filter:v scale=-1:54 \
-  #{out.dir}/#{out.name}#{out.suffix}
+  -vf "fps=1,scale=96:54:force_original_aspect_ratio=decrease,pad=96:54:-1:-1 [in]; color=black:s=96x54:r=1:d=1 [bg]; [bg][in] overlay=0:0 [out]" \
+  -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
 
 # Image to video
 profile.image-movie.work.name = image to video
@@ -158,8 +158,8 @@ profile.editor.tracks.preview.output = image
 profile.editor.tracks.preview.suffix = -preview.jpg
 profile.editor.tracks.preview.mimetype = image/jpeg
 profile.editor.tracks.preview.ffmpeg.command = -ss #{time} -i #{in.video.path} \
-  -r 1 -frames:v 1 -filter:v scale=320:-1 \
-  #{out.dir}/#{out.name}#{out.suffix}
+  -vf "fps=1,scale=320:180:force_original_aspect_ratio=decrease,pad=320:180:-1:-1 [in]; color=black:s=320x180:r=1:d=1 [bg]; [bg][in] overlay=0:0 [out]" \
+  -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}
 
 profile.composite.http.name = composite
 profile.composite.http.input = visual
@@ -245,5 +245,5 @@ profile.text-analysis.http.input = visual
 profile.text-analysis.http.output = image
 profile.text-analysis.http.suffix = .#{time}.png
 profile.text-analysis.http.ffmpeg.command = -ss #{time} -i #{in.video.path} \
-  -filter:v curves=preset=increase_contrast \
-  -frames:v 1 -pix_fmt:v gray -r 1 #{out.dir}/#{out.name}#{out.suffix}
+  -vf "fps=1,scale=1280:720:force_original_aspect_ratio=decrease,pad=1280:720:-1:-1 [in]; color=black:s=1280x720:r=1:d=1 [bg]; [bg][in] overlay=0:0 [mux]; [mux] curves=preset=increase_contrast,format=pix_fmts=gray [out]" \
+  -frames:v 1 #{out.dir}/#{out.name}#{out.suffix}


### PR DESCRIPTION
Some operations in Opencast make use of image extraction on given times in video, e.g. text analysis, seekbar preview. In some cases the video track is shorter then audio track (a few milliseconds to some seconds). In this case the image extraction will fail and the whole operation also fail. This patch will fix this by overlaying the video frame on a black background. If you try to extract a frame outside of the video track, you will get a black (background) image. The (positive) downside is the fixed size of resulting images.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
