### PR TITLE
partial-publish workflow fix

### DIFF
--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -29,7 +29,6 @@
       <configurations>
         <configuration key="source-flavor">*/source</configuration>
         <configuration key="target-flavor">*/prepared</configuration>
-        <configuration key="target-tags">editor</configuration>
       </configurations>
     </operation>
 
@@ -40,7 +39,7 @@
       exception-handler-workflow="partial-error"
       description="Selecting audio/video streams for processing">
       <configurations>
-        <configuration key="source-flavor">*/source</configuration>
+        <configuration key="source-flavor">*/prepared</configuration>
         <configuration key="target-flavor">*/work</configuration>
         <configuration key="target-tags">-archive</configuration>
         <configuration key="audio-muxing">duplicate</configuration>


### PR DESCRIPTION
The fallback tracks will never been used as the following operation uses */source as input flavor.
The clone operation do not have a target-flavor option.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
