### PR TITLE
Add catalog ui adapter organization wildcard support

### DIFF
--- a/docs/guides/admin/docs/configuration/metadata.md
+++ b/docs/guides/admin/docs/configuration/metadata.md
@@ -50,12 +50,12 @@ The metadata configuration file format can be logically split up into different 
 
 ### Part 1: General catalog information
 
-|Configuration key|Example                  |Description                                                               |
-|-----------------|-------------------------|--------------------------------------------------------------------------|
-|type             |events                   |Two different types of catalog UI adapters may be configured, such for events and others for series.|
-|organization     |mh_default_org           |A custom catalog definition is mapped 1:1 to an organization and is available to this one organization only.|
-|flavor           |mycompany/episode        |The catalog must be of a certain flavor. For a events catalog, the flavor consists of the form type/subtype whereas for series you only need to define the subtype. Attention: For series catalogs, the type (the part before the slash '/') is used as element type.|
-|title            |My Personal Catalog Name |This is the title that is displayed in the UI. It should be something that is readable by humans.|
+|Configuration key|Example                  | Description                                                                                                                                                                                                                                                           |
+|-----------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|type             |events                   | Two different types of catalog UI adapters may be configured, such for events and others for series.                                                                                                                                                                  |
+|organization     |mh_default_org           | A custom catalog definition is mapped to an organization (1:1) or all organizations (1:n). To map a catalog to all organizations, use a wildcard as the organization name (`organization=*`). Else, the catalog is only available to the specified organization.      |
+|flavor           |mycompany/episode        | The catalog must be of a certain flavor. For a events catalog, the flavor consists of the form type/subtype whereas for series you only need to define the subtype. Attention: For series catalogs, the type (the part before the slash '/') is used as element type. |
+|title            |My Personal Catalog Name | This is the title that is displayed in the UI. It should be something that is readable by humans.                                                                                                                                                                     |
 
 ### Part 2: XML serialization information
 

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
@@ -1,5 +1,5 @@
 type=events
-organization=mh_default_org
+organization=*
 flavor=dublincore/episode
 title=EVENTS.EVENTS.DETAILS.CATALOG.EPISODE
 common-metadata=true

--- a/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-series-common.cfg
+++ b/etc/org.opencastproject.ui.metadata.CatalogUIAdapterFactory-series-common.cfg
@@ -1,5 +1,5 @@
 type=series
-organization=mh_default_org
+organization=*
 title=Series Metadata
 flavor=dublincore/series
 common-metadata=true

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/CatalogUIAdapter.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/CatalogUIAdapter.java
@@ -32,12 +32,24 @@ import java.util.Map;
 public interface CatalogUIAdapter {
 
   /**
-   * Returns the name of the organization (tenant) this catalog UI adapter belongs to or {@code Opt.none()} if this is a
+   * Wildcard to specify tenant-agnostic catalog UI adaptors.
+   */
+  String ORGANIZATION_WILDCARD = "*";
+
+  /**
+   * Returns the name of the organization (tenant) this catalog UI adapter belongs to or {@value #ORGANIZATION_WILDCARD} if this is a
    * tenant-agnostic adapter.
    *
-   * @return The organization name or {@code Opt.none()}
+   * @return The organization name or {@value #ORGANIZATION_WILDCARD}
    */
   String getOrganization();
+
+  /**
+   * Check if the catalog UI adapter belongs to a tenant.
+   *
+   * @return true if adapter belongs to tenant.
+   */
+  boolean handlesOrganization(String organization);
 
   /**
    * Returns the media type of catalogs managed by this catalog UI adapter.

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -320,7 +320,7 @@ public class EventsEndpoint implements ManagedService {
   public List<EventCatalogUIAdapter> getEventCatalogUIAdapters(String organization) {
     List<EventCatalogUIAdapter> adapters = new ArrayList<>();
     for (EventCatalogUIAdapter adapter : catalogUIAdapters) {
-      if (organization.equals(adapter.getOrganization())) {
+      if (adapter.handlesOrganization(organization)) {
         adapters.add(adapter);
       }
     }

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestEventsEndpoint.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestEventsEndpoint.java
@@ -121,6 +121,7 @@ public class TestEventsEndpoint extends EventsEndpoint {
             .anyTimes();
     DublinCoreMetadataCollection collectionMock = EasyMock.createNiceMock(DublinCoreMetadataCollection.class);
     EasyMock.expect(deleteAdapter.getOrganization()).andReturn(defaultOrg.getId()).anyTimes();
+    EasyMock.expect(deleteAdapter.handlesOrganization(EasyMock.eq(defaultOrg.getId()))).andReturn(true).anyTimes();
     EasyMock.expect(deleteAdapter.getFields(EasyMock.anyObject(MediaPackage.class))).andReturn(null).anyTimes();
     EasyMock.expect(deleteAdapter.getUITitle()).andReturn(null).anyTimes();
     EasyMock.replay(deleteAdapter);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/ConfigurableDCCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/ConfigurableDCCatalogUIAdapter.java
@@ -201,6 +201,11 @@ public abstract class ConfigurableDCCatalogUIAdapter implements CatalogUIAdapter
   }
 
   @Override
+  public boolean handlesOrganization(String organization) {
+    return ORGANIZATION_WILDCARD.equals(this.organization) || organization.equals(this.organization);
+  }
+
+  @Override
   public MediaPackageElementFlavor getFlavor() {
     return flavor;
   }

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -440,7 +440,7 @@ public class IndexServiceImpl implements IndexService {
   }
 
   public List<EventCatalogUIAdapter> getEventCatalogUIAdapters(String organization) {
-    return eventCatalogUIAdapters.stream().filter(a -> organization.equals(a.getOrganization()))
+    return eventCatalogUIAdapters.stream().filter(a -> a.handlesOrganization(organization))
             .collect(Collectors.toList());
   }
 
@@ -450,14 +450,14 @@ public class IndexServiceImpl implements IndexService {
    * @return A {@link List} of {@link SeriesCatalogUIAdapter} that provide the metadata to the front end.
    */
   public List<SeriesCatalogUIAdapter> getSeriesCatalogUIAdapters(String organization) {
-    return seriesCatalogUIAdapters.stream().filter(a -> organization.equals(a.getOrganization()))
+    return seriesCatalogUIAdapters.stream().filter(a -> a.handlesOrganization(organization))
             .collect(Collectors.toList());
   }
 
   public EventCatalogUIAdapter getCommonEventCatalogUIAdapter(String organization) {
     Optional<EventCatalogUIAdapter> orgEventCatalogUIAdapter = eventCatalogUIAdapters.stream()
             .filter(a -> a instanceof CommonEventCatalogUIAdapter)
-            .filter(a -> organization.equals(a.getOrganization()))
+            .filter(a -> a.handlesOrganization(organization))
             .findFirst();
 
     if (orgEventCatalogUIAdapter.isPresent()) {
@@ -473,7 +473,7 @@ public class IndexServiceImpl implements IndexService {
   public SeriesCatalogUIAdapter getCommonSeriesCatalogUIAdapter(String organization) {
     Optional<SeriesCatalogUIAdapter> orgSeriesCatalogUIAdapter = seriesCatalogUIAdapters.stream()
             .filter(a -> a instanceof CommonSeriesCatalogUIAdapter)
-            .filter(a -> organization.equals(a.getOrganization()))
+            .filter(a -> a.handlesOrganization(organization))
             .findFirst();
 
     if (orgSeriesCatalogUIAdapter.isPresent()) {
@@ -495,7 +495,7 @@ public class IndexServiceImpl implements IndexService {
   public List<EventCatalogUIAdapter> getExtendedEventCatalogUIAdapters() {
     String organization = securityService.getOrganization().getId();
     return eventCatalogUIAdapters.stream().filter(a -> !(a instanceof CommonEventCatalogUIAdapter))
-            .filter(a -> organization.equals(a.getOrganization())).collect(Collectors.toList());
+            .filter(a -> a.handlesOrganization(organization)).collect(Collectors.toList());
   }
 
   @Override

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -92,6 +92,7 @@ import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.message.broker.api.update.AssetManagerUpdateHandler;
 import org.opencastproject.message.broker.api.update.SchedulerUpdateHandler;
+import org.opencastproject.metadata.dublincore.CatalogUIAdapter;
 import org.opencastproject.metadata.dublincore.DCMIPeriod;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCores;
@@ -153,6 +154,7 @@ import net.fortuna.ical4j.model.property.RRule;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.After;
@@ -250,11 +252,16 @@ public class SchedulerServiceImplTest {
     EasyMock.expect(episodeAdapter.getFlavor()).andReturn(new MediaPackageElementFlavor("dublincore", "episode"))
             .anyTimes();
     EasyMock.expect(episodeAdapter.getOrganization()).andReturn(new DefaultOrganization().getId()).anyTimes();
+    final Capture<String> stringCapture = EasyMock.newCapture();
+    EasyMock.expect(episodeAdapter.handlesOrganization(EasyMock.capture(stringCapture)))
+        .andAnswer(() -> DefaultOrganization.DEFAULT_ORGANIZATION_ID.equals(stringCapture.getValue())).anyTimes();
 
     EventCatalogUIAdapter extendedAdapter = EasyMock.createMock(EventCatalogUIAdapter.class);
     EasyMock.expect(extendedAdapter.getFlavor()).andReturn(new MediaPackageElementFlavor("extended", "episode"))
             .anyTimes();
     EasyMock.expect(extendedAdapter.getOrganization()).andReturn(new DefaultOrganization().getId()).anyTimes();
+    EasyMock.expect(extendedAdapter.handlesOrganization(EasyMock.capture(stringCapture)))
+        .andAnswer(() -> DefaultOrganization.DEFAULT_ORGANIZATION_ID.equals(stringCapture.getValue())).anyTimes();
 
     BundleContext bundleContext = EasyMock.createNiceMock(BundleContext.class);
     EasyMock.expect(bundleContext.getProperty(EasyMock.anyString())).andReturn("adminuser").anyTimes();
@@ -1464,7 +1471,8 @@ public class SchedulerServiceImplTest {
 
     EventCatalogUIAdapter episodeAdapter = EasyMock.createMock(EventCatalogUIAdapter.class);
     EasyMock.expect(episodeAdapter.getFlavor()).andReturn(MediaPackageElements.EPISODE).anyTimes();
-    EasyMock.expect(episodeAdapter.getOrganization()).andAnswer(() -> { return currentOrg.getId(); }).anyTimes();
+    EasyMock.expect(episodeAdapter.getOrganization()).andReturn(CatalogUIAdapter.ORGANIZATION_WILDCARD).anyTimes();
+    EasyMock.expect(episodeAdapter.handlesOrganization(EasyMock.anyString())).andReturn(true).anyTimes();
     EasyMock.replay(episodeAdapter);
     schedSvc.addCatalogUIAdapter(episodeAdapter);
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandler.java
@@ -374,7 +374,7 @@ public class SeriesWorkflowOperationHandler extends AbstractWorkflowOperationHan
   private static final Fn2<SeriesCatalogUIAdapter, String, Boolean> seriesOrganizationFilter = new Fn2<SeriesCatalogUIAdapter, String, Boolean>() {
     @Override
     public Boolean apply(SeriesCatalogUIAdapter catalogUIAdapter, String organization) {
-      return catalogUIAdapter.getOrganization().equals(organization);
+      return catalogUIAdapter.handlesOrganization(organization);
     }
   };
 

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/SeriesWorkflowOperationHandlerTest.java
@@ -107,12 +107,14 @@ public class SeriesWorkflowOperationHandlerTest {
 
     SeriesCatalogUIAdapter adapter = EasyMock.createNiceMock(SeriesCatalogUIAdapter.class);
     EasyMock.expect(adapter.getOrganization()).andReturn(new DefaultOrganization().getId()).anyTimes();
+    EasyMock.expect(adapter.handlesOrganization(EasyMock.eq(DefaultOrganization.DEFAULT_ORGANIZATION_ID))).andReturn(true).anyTimes();
     EasyMock.expect(adapter.getFlavor()).andReturn(MediaPackageElementFlavor.parseFlavor("creativecommons/series"))
             .anyTimes();
     EasyMock.replay(adapter);
 
     SeriesCatalogUIAdapter seriesAdapter = EasyMock.createNiceMock(SeriesCatalogUIAdapter.class);
     EasyMock.expect(seriesAdapter.getOrganization()).andReturn(new DefaultOrganization().getId()).anyTimes();
+    EasyMock.expect(seriesAdapter.handlesOrganization(EasyMock.eq(DefaultOrganization.DEFAULT_ORGANIZATION_ID))).andReturn(true).anyTimes();
     EasyMock.expect(seriesAdapter.getFlavor()).andReturn(MediaPackageElementFlavor.parseFlavor("dublincore/series"))
             .anyTimes();
     EasyMock.replay(seriesAdapter);


### PR DESCRIPTION
This patch adds wildcard support to catalog UI adapters which allows a specific catalog to be used for all organizations. 

Closes #2564

PS: I am not happy with the `handlesOrganization` function name, but I have no better idea.

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
