### PR TITLE
Add missing tags in encode WOH

### DIFF
--- a/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/ComposerServiceTest.java
+++ b/modules/composer-ffmpeg/src/test/java/org/opencastproject/composer/impl/ComposerServiceTest.java
@@ -216,7 +216,7 @@ public class ComposerServiceTest {
     // Create and populate the composer service
     composerService = new ComposerServiceImpl() {
       @Override
-      protected List<Track> inspect(Job job, List<URI> uris) throws EncoderException {
+      protected List<Track> inspect(Job job, List<URI> uris, List<List<String>> tags) throws EncoderException {
         final var result = new ArrayList<Track>(uris.size());
         for (URI uri: uris) {
           result.add(inspectedTrack);


### PR DESCRIPTION
Tags for different output files were missing in encode WOH, because
the comparison of the output file name to a specified suffix stopped
working after 19c0940c.
The reason for this is that the files were renamed not including
the specified suffix, and comparison for the suffix as a condition
for adding a tag is used.
Fixes the issue by remembering the original file name from encoding.

Resolves #3639

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)

I might add additional test coverage in a separate PR against develop (as it doesn't seem to be covered yet, in spite of being documented).