### PR TITLE
Matomo paella 7 plugin

### DIFF
--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -286,7 +286,7 @@
         },
 
         "org.opencast.paella.opencast.userTrackingDataPlugin" :{
-            "enabled": true,
+            "enabled": false,
             "context": [
                 "userTracking"
             ]

--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -293,7 +293,7 @@
         },
 
         "org.opencast.paella.opencast.matomoTrackingDataPlugin" :{
-            "enabled": true,
+            "enabled": false,
             "client_id": "Paella Player 7",
             "heartbeat": 30,
             "server": "https://demo.matomo.cloud/",

--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -294,10 +294,10 @@
 
         "org.opencast.paella.opencast.matomoTrackingDataPlugin" :{
             "enabled": true,
+            "client_id": "Paella Player 7",
+            "heartbeat": 30,
             "server": "https://demo.matomo.cloud/",
             "site_id": 2,
-            "heartbeat": 30,
-            "client_id": "Paella Player 7",
             "tracking_client": "matomo",
             "context": [
                 "userTracking"

--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -292,6 +292,18 @@
             ]
         },
 
+        "org.opencast.paella.opencast.matomoTrackingDataPlugin" :{
+            "enabled": true,
+            "server": "https://demo.matomo.cloud/",
+            "site_id": 2,
+            "heartbeat": 30,
+            "client_id": "Paella Player 7",
+            "tracking_client": "matomo",
+            "context": [
+                "userTracking"
+            ]
+        },
+
         "org.opencast.paella.breaksPlugin": {
             "enabled": true
         }

--- a/modules/engage-paella-player-7/.eslintrc.js
+++ b/modules/engage-paella-player-7/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
     },
     "globals": {
         "require": true,
+        "Matomo": true
     }
 };

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
@@ -23,16 +23,17 @@ import { DataPlugin, Events, bindEvent } from 'paella-core';
 export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
 
   async isEnabled() {
-    try {
-      const response = await fetch('/usertracking/detailenabled');
-      const data = await response.text();
-      const enabled = /true/i.test(data);
-
-      return enabled;
-    }
-    catch(e) {
-      return false;
-    }
+      // This is the CORRECT WAY to extend isEnabled() default behavior
+      if (!(await super.isEnabled())) {
+        return false;
+      }
+      else {
+        // Extend the isEnabled() funcionality
+        const response = await fetch('/usertracking/detailenabled');
+        const data = await response.text();
+        const enabled = /true/i.test(data);
+        return enabled;
+      }
   }
 
   async load(){

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
@@ -23,17 +23,15 @@ import { DataPlugin, Events, bindEvent } from 'paella-core';
 export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
 
   async isEnabled() {
-      // This is the CORRECT WAY to extend isEnabled() default behavior
-      if (!(await super.isEnabled())) {
-        return false;
-      }
-      else {
-        // Extend the isEnabled() funcionality
-        const response = await fetch('/usertracking/detailenabled');
-        const data = await response.text();
-        const enabled = /true/i.test(data);
-        return enabled;
-      }
+    if (!(await super.isEnabled())) {
+      return false;
+    }
+    else {
+      const response = await fetch('/usertracking/detailenabled');
+      const data = await response.text();
+      const enabled = /true/i.test(data);
+      return enabled;
+    }
   }
 
   async load(){

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
@@ -1,0 +1,117 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+import { DataPlugin, Events } from 'paella-core';
+
+export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
+
+  async isEnabled() {
+    try {
+      const response = await fetch('/usertracking/detailenabled');
+      const data = await response.text();
+      const enabled = /true/i.test(data);
+
+      return enabled;
+    }
+    catch(e) {
+      return false;
+    }
+  }
+
+  async load(){
+    var server = this.config.server;
+    const tracking_client = this.config.tracking_client;
+    const site_id = this.config.site_id;
+    
+    let Matomo;
+    let matomoPromise = null;
+    const matomoScript = (path) => {
+      if (!matomoPromise){
+        matomoPromise = new Promise((resolve) => {
+          const script = document.createElement('script');
+          script.type = 'text/javascript';
+          script.src = path;
+          let loaded = false;
+          script.onload = script.onreadystatechange = () => {
+            if (!loaded) {
+              loaded = true;
+              resolve();
+            }
+          };
+          document.head.appendChild(script);
+        });
+      }
+      return matomoPromise;
+    };
+
+    if (server.substr(-1) != '/') server += '/';
+    await matomoScript(server + tracking_client + '.js'); 
+    this.player.matomotracker = Matomo.getAsyncTracker( server + tracking_client + '.php', site_id );
+    this.player.log.debug('Matomo Analytics Initialized: ' + Matomo.initialized);
+  }
+
+  async write(context, { id }, data) {
+    const currentTime = await this.player.videoContainer.currentTime();
+    const playing = !(await this.player.videoContainer.paused());
+    this.player.log.debug(`Logging event for video id ${ id } at time: ${ currentTime }`);
+
+    const opencastLog = {
+      id,
+      type: data.event.substr(0,128),
+      in: Math.round(currentTime),
+      out: Math.round(currentTime),
+      playing
+    };
+
+    switch (data.event) {
+    case Events.PLAY:
+      opencastLog.type = 'PLAY';
+      break;
+    case Events.PAUSE:
+      opencastLog.type = 'PAUSE';
+      break;
+    case Events.SEEK:
+      opencastLog.type = 'SEEK';
+      opencastLog.in = Math.round(data.params.prevTime);
+      break;
+    case Events.FULLSCREEN_CHANGED:
+
+      break;
+    case Events.RESIZE_END:
+      opencastLog.type = `RESIZE-TO-${ data.params.size.w }x${ data.params.size.h }`;
+      break;
+    case Events.BUTTON_PRESS:
+      opencastLog.type += '-' + data.plugin;
+      break;
+    default:
+      opencastLog.type += params;
+    }
+
+    const params = (new URLSearchParams(opencastLog)).toString();
+    const requestUrl = `/usertracking/?_method=PUT&${ params }`;
+    const result = await fetch(requestUrl);
+    if (!result.ok) {
+      this.player.log.error('Error in user data log');
+    }
+    else {
+      this.player.log.debug(`Opencast Matomo user log event done: '${ opencastLog.type }'`);
+    }
+  }
+}

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
@@ -39,7 +39,7 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
     var server = this.config.server;
     const tracking_client = this.config.tracking_client;
     const site_id = this.config.site_id;
-    
+
 
     let matomoPromise = null;
     const matomoScript = (path) => {
@@ -62,7 +62,7 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
     };
 
     if (server.substr(-1) != '/') server += '/';
-    await matomoScript(server + tracking_client + '.js'); 
+    await matomoScript(server + tracking_client + '.js');
     this.player.matomotracker = Matomo.getAsyncTracker( server + tracking_client + '.php', site_id );
     this.player.log.debug('Matomo Analytics Initialized: ' + Matomo.initialized);
   }

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
@@ -18,7 +18,7 @@
  * the License.
  *
  */
-import { DataPlugin, Events } from 'paella-core';
+import { DataPlugin, Events, bindEvent } from 'paella-core';
 
 export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
 
@@ -36,9 +36,12 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
   }
 
   async load(){
-    var server = this.config.server;
+    const client_id = this.config.client_id;
+    const heartbeat = this.config.heartbeat;
     const tracking_client = this.config.tracking_client;
+    const server = this.config.server;
     const site_id = this.config.site_id;
+    
 
 
     let matomoPromise = null;
@@ -64,7 +67,16 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
     if (server.substr(-1) != '/') server += '/';
     await matomoScript(server + tracking_client + '.js');
     this.player.matomotracker = Matomo.getAsyncTracker( server + tracking_client + '.php', site_id );
-    this.player.log.debug('Matomo Analytics Initialized: ' + Matomo.initialized);
+    //this.player.log.debug('Matomo Analytics Initialized: ' + Matomo.initialized);
+    this.player.matomotracker.client_id = client_id;
+    if (heartbeat && heartbeat > 0) this.player.matomotracker.enableHeartBeatTimer(heartbeat);
+    if (Matomo && Matomo.MediaAnalytics) {
+      bindEvent(this.player, 
+        Events.PLAYER_LOADED,
+        () => {
+          Matomo.MediaAnalytics.scanForMedia();
+        });
+    }
   }
 
   async write(context, { id }, data) {
@@ -114,4 +126,24 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
       this.player.log.debug(`Opencast Matomo user log event done: '${ opencastLog.type }'`);
     }
   }
+  
+  registerVisit() {
+    var opencastData,
+        title,
+        event_id,
+        series_title,
+        series_id,
+        presenter,
+        view_mode;
+    
+        opencastData = this.player.videoManifest.metadata;
+        
+
+    
+    
+
+
+
+  }
+
 }

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
@@ -39,9 +39,9 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
     const client_id = this.config.client_id;
     const heartbeat = this.config.heartbeat;
     const tracking_client = this.config.tracking_client;
-    const server = this.config.server;
+    var server = this.config.server;
     const site_id = this.config.site_id;
-    
+
 
 
     let matomoPromise = null;
@@ -71,7 +71,7 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
     this.player.matomotracker.client_id = client_id;
     if (heartbeat && heartbeat > 0) this.player.matomotracker.enableHeartBeatTimer(heartbeat);
     if (Matomo && Matomo.MediaAnalytics) {
-      bindEvent(this.player, 
+      bindEvent(this.player,
         Events.PLAYER_LOADED,
         () => {
           Matomo.MediaAnalytics.scanForMedia();
@@ -126,24 +126,17 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
       this.player.log.debug(`Opencast Matomo user log event done: '${ opencastLog.type }'`);
     }
   }
-  
-  registerVisit() {
-    var opencastData,
-        title,
-        event_id,
-        series_title,
-        series_id,
-        presenter,
-        view_mode;
-    
-        opencastData = this.player.videoManifest.metadata;
-        
 
-    
-    
+  // registerVisit() {
+  //   var opencastData,
+  //       title,
+  //       event_id,
+  //       series_title,
+  //       series_id,
+  //       presenter,
+  //       view_mode;
 
-
-
-  }
+  //       opencastData = this.player.videoManifest.metadata;
+  //  }
 
 }

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.opencast.matomoTrackingDataPlugin.js
@@ -40,7 +40,7 @@ export default class OpencastMatomoTrackingDataPlugin extends DataPlugin {
     const tracking_client = this.config.tracking_client;
     const site_id = this.config.site_id;
     
-    let Matomo;
+
     let matomoPromise = null;
     const matomoScript = (path) => {
       if (!matomoPromise){


### PR DESCRIPTION
This is the implementation to support Matomo in Paella 7. 

The plugin is configurable through the `config.json` file found in the `ui-config` folder for paella 7.

I want to say thanks to @miesgre and @ferserc1 for helping with tips and tutorials to make it possible.

This PR only enables Matomo without asking the user, it will come a new PR that will add the cookie consent like in the plugin for Paella 6.


* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
