### PR TITLE
Fix Conductor OSGi Bindings

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/AssetManagerUpdatedEventHandler.java
@@ -50,6 +50,9 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FilenameUtils;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +62,15 @@ import java.net.URI;
 /**
  * Responds to series events by re-distributing metadata and security policy files to episodes.
  */
+@Component(
+    immediate = true,
+    service = {
+        AssetManagerUpdatedEventHandler.class
+    },
+    property = {
+        "service.description=AssetManagerUpdatedEventHandler"
+    }
+)
 public class AssetManagerUpdatedEventHandler {
 
   /** The logger */
@@ -91,6 +103,7 @@ public class AssetManagerUpdatedEventHandler {
    * @param bundleContext
    *          the OSGI bundle context
    */
+  @Activate
   protected void activate(BundleContext bundleContext) {
     this.systemAccount = bundleContext.getProperty("org.opencastproject.security.digest.user");
   }
@@ -99,6 +112,7 @@ public class AssetManagerUpdatedEventHandler {
    * @param workspace
    *          the workspace to set
    */
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -107,6 +121,7 @@ public class AssetManagerUpdatedEventHandler {
    * @param dublinCoreService
    *          the dublin core service to set
    */
+  @Reference
   public void setDublinCoreCatalogService(DublinCoreCatalogService dublinCoreService) {
     this.dublinCoreService = dublinCoreService;
   }
@@ -115,6 +130,7 @@ public class AssetManagerUpdatedEventHandler {
    * @param assetManager
    *          the asset manager to set
    */
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
@@ -123,6 +139,7 @@ public class AssetManagerUpdatedEventHandler {
    * @param securityService
    *          the securityService to set
    */
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -131,6 +148,7 @@ public class AssetManagerUpdatedEventHandler {
    * @param authorizationService
    *          the authorizationService to set
    */
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -139,6 +157,7 @@ public class AssetManagerUpdatedEventHandler {
    * @param organizationDirectoryService
    *          the organizationDirectoryService to set
    */
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingEpisodeUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingEpisodeUpdatedEventHandler.java
@@ -28,6 +28,10 @@ import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem;
 import org.opencastproject.security.api.SecurityService;
 
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +44,15 @@ import java.util.concurrent.FutureTask;
 /**
  * This handler listens for changes to episodes. Whenever a change is done, this is propagated to OAI-PMH.
  */
+@Component(
+    immediate = true,
+    service = {
+        ConductingEpisodeUpdatedEventHandler.class
+    },
+    property = {
+        "service.description=Conducting event handler for recording events",
+    }
+)
 public class ConductingEpisodeUpdatedEventHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(ConductingEpisodeUpdatedEventHandler.class);
@@ -54,12 +67,14 @@ public class ConductingEpisodeUpdatedEventHandler {
 
   private MessageWatcher messageWatcher;
 
+  @Activate
   public void activate(ComponentContext cc) {
     logger.info("Activating {}", ConductingEpisodeUpdatedEventHandler.class.getName());
     messageWatcher = new MessageWatcher();
     singleThreadExecutor.execute(messageWatcher);
   }
 
+  @Deactivate
   public void deactivate(ComponentContext cc) {
     logger.info("Deactivating {}", ConductingEpisodeUpdatedEventHandler.class.getName());
     if (messageWatcher != null) {
@@ -120,6 +135,7 @@ public class ConductingEpisodeUpdatedEventHandler {
   /**
    * OSGi DI callback.
    */
+  @Reference
   public void setOaiPmhUpdatedEventHandler(OaiPmhUpdatedEventHandler h) {
     this.oaiPmhUpdatedEventHandler = h;
   }
@@ -127,6 +143,7 @@ public class ConductingEpisodeUpdatedEventHandler {
   /**
    * OSGi DI callback.
    */
+  @Reference
   public void setMessageReceiver(MessageReceiver messageReceiver) {
     this.messageReceiver = messageReceiver;
   }
@@ -134,6 +151,7 @@ public class ConductingEpisodeUpdatedEventHandler {
   /**
    * OSGi DI callback.
    */
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingSeriesUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingSeriesUpdatedEventHandler.java
@@ -28,6 +28,10 @@ import org.opencastproject.message.broker.api.series.SeriesItem;
 import org.opencastproject.security.api.SecurityService;
 
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +46,15 @@ import java.util.concurrent.FutureTask;
  * Very simple approach to serialize the work of all three dependend update handlers. Todo: Merge all handlers into one
  * to avoid unnecessary distribution updates etc.
  */
+@Component(
+    immediate = true,
+    service = {
+        ConductingSeriesUpdatedEventHandler.class
+    },
+    property = {
+        "service.description=Conducting event handler for series events"
+    }
+)
 public class ConductingSeriesUpdatedEventHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(ConductingSeriesUpdatedEventHandler.class);
@@ -61,12 +74,14 @@ public class ConductingSeriesUpdatedEventHandler {
 
   private MessageWatcher messageWatcher;
 
+  @Activate
   public void activate(ComponentContext cc) {
     logger.info("Activating {}", ConductingSeriesUpdatedEventHandler.class.getName());
     messageWatcher = new MessageWatcher();
     singleThreadExecutor.execute(messageWatcher);
   }
 
+  @Deactivate
   public void deactivate(ComponentContext cc) {
     logger.info("Deactivating {}", ConductingSeriesUpdatedEventHandler.class.getName());
     if (messageWatcher != null) {
@@ -127,26 +142,31 @@ public class ConductingSeriesUpdatedEventHandler {
   }
 
   /** OSGi DI callback. */
+  @Reference
   public void setAssetManagerUpdatedEventHandler(AssetManagerUpdatedEventHandler h) {
     this.assetManagerUpdatedEventHandler = h;
   }
 
   /** OSGi DI callback. */
+  @Reference
   public void setSeriesUpdatedEventHandler(SeriesUpdatedEventHandler h) {
     this.seriesUpdatedEventHandler = h;
   }
 
   /** OSGi DI callback. */
+  @Reference
   public void setWorkflowPermissionsUpdatedEventHandler(WorkflowPermissionsUpdatedEventHandler h) {
     this.workflowPermissionsUpdatedEventHandler = h;
   }
 
   /** OSGi DI callback. */
+  @Reference
   public void setMessageReceiver(MessageReceiver messageReceiver) {
     this.messageReceiver = messageReceiver;
   }
 
   /** OSGi DI callback. */
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/OaiPmhUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/OaiPmhUpdatedEventHandler.java
@@ -49,6 +49,9 @@ import com.entwinemedia.fn.data.Opt;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +60,17 @@ import java.util.Dictionary;
 import java.util.HashSet;
 import java.util.Set;
 
+@Component(
+    immediate = true,
+    service = {
+        ManagedService.class,
+        OaiPmhUpdatedEventHandler.class
+    },
+    property = {
+        "service.description=OAI-PMH Updated Event Handler",
+        "service.pid=org.opencastproject.event.handler.OaiPmhUpdatedEventHandler"
+    }
+)
 public class OaiPmhUpdatedEventHandler implements ManagedService {
 
   /** The logger */
@@ -97,6 +111,7 @@ public class OaiPmhUpdatedEventHandler implements ManagedService {
    * @param bundleContext
    *          the OSGI bundle context
    */
+  @Activate
   protected void activate(BundleContext bundleContext) {
     this.systemAccount = bundleContext.getProperty("org.opencastproject.security.digest.user");
   }
@@ -188,18 +203,22 @@ public class OaiPmhUpdatedEventHandler implements ManagedService {
     }
   }
 
+  @Reference
   public void setAssetManager(AssetManager assetManager) {
     this.assetManager = assetManager;
   }
 
+  @Reference
   public void setOaiPmhPersistence(OaiPmhDatabase oaiPmhPersistence) {
     this.oaiPmhPersistence = oaiPmhPersistence;
   }
 
+  @Reference
   public void setOaiPmhPublicationService(OaiPmhPublicationService oaiPmhPublicationService) {
     this.oaiPmhPublicationService = oaiPmhPublicationService;
   }
 
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SeriesUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SeriesUpdatedEventHandler.java
@@ -62,6 +62,9 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FilenameUtils;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,6 +72,15 @@ import java.io.IOException;
 import java.net.URI;
 
 /** Responds to series events by re-distributing metadata and security policy files for published mediapackages. */
+@Component(
+    immediate = true,
+    service = {
+        SeriesUpdatedEventHandler.class
+    },
+    property = {
+        "service.description=Series Updated Event Handler"
+    }
+)
 public class SeriesUpdatedEventHandler {
 
   /** The logger */
@@ -107,6 +119,7 @@ public class SeriesUpdatedEventHandler {
    * @param bundleContext
    *          the OSGI bundle context
    */
+  @Activate
   protected void activate(BundleContext bundleContext) {
     this.systemAccount = bundleContext.getProperty("org.opencastproject.security.digest.user");
   }
@@ -115,6 +128,7 @@ public class SeriesUpdatedEventHandler {
    * @param serviceRegistry
    *          the serviceRegistry to set
    */
+  @Reference
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
@@ -123,6 +137,7 @@ public class SeriesUpdatedEventHandler {
    * @param workspace
    *          the workspace to set
    */
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -131,6 +146,7 @@ public class SeriesUpdatedEventHandler {
    * @param dublinCoreService
    *          the dublin core service to set
    */
+  @Reference
   public void setDublinCoreCatalogService(DublinCoreCatalogService dublinCoreService) {
     this.dublinCoreService = dublinCoreService;
   }
@@ -139,6 +155,7 @@ public class SeriesUpdatedEventHandler {
    * @param distributionService
    *          the distributionService to set
    */
+  @Reference
   public void setDistributionService(DistributionService distributionService) {
     this.distributionService = distributionService;
   }
@@ -147,6 +164,7 @@ public class SeriesUpdatedEventHandler {
    * @param searchService
    *          the searchService to set
    */
+  @Reference
   public void setSearchService(SearchService searchService) {
     this.searchService = searchService;
   }
@@ -155,6 +173,7 @@ public class SeriesUpdatedEventHandler {
    * @param securityService
    *          the securityService to set
    */
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -163,6 +182,7 @@ public class SeriesUpdatedEventHandler {
    * @param authorizationService
    *          the authorizationService to set
    */
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -171,6 +191,7 @@ public class SeriesUpdatedEventHandler {
    * @param organizationDirectoryService
    *          the organizationDirectoryService to set
    */
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/WorkflowPermissionsUpdatedEventHandler.java
@@ -48,6 +48,9 @@ import org.opencastproject.workspace.api.Workspace;
 
 import org.apache.commons.io.FilenameUtils;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +58,15 @@ import java.io.IOException;
 import java.net.URI;
 
 /** Responds to series events by re-distributing metadata and security policy files to workflows. */
+@Component(
+    immediate = true,
+    service = {
+        WorkflowPermissionsUpdatedEventHandler.class
+    },
+    property = {
+        "service.description=Workflow Permissions Updated Event Handler"
+    }
+)
 public class WorkflowPermissionsUpdatedEventHandler {
 
   /** The logger */
@@ -87,6 +99,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
    * @param bundleContext
    *          the OSGI bundle context
    */
+  @Activate
   protected void activate(BundleContext bundleContext) {
     this.systemAccount = bundleContext.getProperty("org.opencastproject.security.digest.user");
   }
@@ -95,6 +108,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
    * @param workspace
    *          the workspace to set
    */
+  @Reference
   public void setWorkspace(Workspace workspace) {
     this.workspace = workspace;
   }
@@ -103,6 +117,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
    * @param dublinCoreService
    *          the dublin core service to set
    */
+  @Reference
   public void setDublinCoreCatalogService(DublinCoreCatalogService dublinCoreService) {
     this.dublinCoreService = dublinCoreService;
   }
@@ -111,6 +126,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
    * @param workflowService
    *          the workflow service to set
    */
+  @Reference
   public void setWorkflowService(WorkflowService workflowService) {
     this.workflowService = workflowService;
   }
@@ -119,6 +135,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
    * @param securityService
    *          the securityService to set
    */
+  @Reference
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -127,6 +144,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
    * @param authorizationService
    *          the authorizationService to set
    */
+  @Reference
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -135,6 +153,7 @@ public class WorkflowPermissionsUpdatedEventHandler {
    * @param organizationDirectoryService
    *          the organizationDirectoryService to set
    */
+  @Reference
   public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
     this.organizationDirectoryService = organizationDirectoryService;
   }


### PR DESCRIPTION
This patch fixes the OSGi bindings of Opencast's conductor module which
were accidentally removed in pull request #3255.

  https://github.com/opencast/opencast/pull/3255/files#diff-6903fd0392932ec6f36f3e69d22808c75924bff91b26321b1a0b0d247370a2d7

With patch applied:

```
karaf@root()> bundle:list |grep conductor
 80 x Active   x  82 x 12.0.0.SNAPSHOT            x Opencast :: conductor
karaf@root()> bundle:services 80

Opencast :: conductor (80) provides:
------------------------------------
[org.osgi.service.cm.ManagedService]
[org.opencastproject.event.handler.AssetManagerUpdatedEventHandler]
[org.osgi.service.cm.ManagedService, org.opencastproject.event.handler.OaiPmhUpdatedEventHandler]
[org.opencastproject.event.handler.ConductingEpisodeUpdatedEventHandler]
[org.opencastproject.event.handler.WorkflowPermissionsUpdatedEventHandler]
[org.opencastproject.event.handler.SeriesUpdatedEventHandler]
[org.opencastproject.event.handler.ConductingSeriesUpdatedEventHandler]
karaf@root()>  
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
