### PR TITLE
Indexing only latest workflows for all events

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -82,6 +82,22 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
                 name = "Workflow.findAll",
                 query = "select w from WorkflowInstance w where w.organizationId=:organizationId order by w.dateCreated"
         ),
+        // Finding the latest or active workflow for all events
+        @NamedQuery(
+                name = "Workflow.findLatest",
+                query = "SELECT w FROM WorkflowInstance w "
+                      + "WHERE "
+                      + "w.organizationId=:organizationId AND "
+                      + "w.dateCreated = (SELECT MAX(w2.dateCreated) "
+                      + "FROM WorkflowInstance w2 "
+                      + "WHERE w2.mediaPackageId = w.mediaPackageId AND "
+                      + "w2.workflowId>:startToken) "
+                      + "ORDER BY w.workflowId ASC"
+        ),
+        @NamedQuery(
+                name = "Workflow.countLatest",
+                query = "SELECT COUNT(DISTINCT mediapackage_id) FROM oc_workflow"
+        ),
         @NamedQuery(
                 name = "Workflow.findAllOrganizationIndependent",
                 query = "select w from WorkflowInstance w"
@@ -513,5 +529,3 @@ public class WorkflowInstance {
     }
   }
 }
-
-

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -96,7 +96,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
         ),
         @NamedQuery(
                 name = "Workflow.countLatest",
-                query = "SELECT COUNT(DISTINCT mediapackage_id) FROM oc_workflow"
+                query = "SELECT COUNT(DISTINCT w.mediaPackageId) FROM WorkflowInstance w"
         ),
         @NamedQuery(
                 name = "Workflow.findAllOrganizationIndependent",

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
@@ -79,6 +79,29 @@ public interface WorkflowServiceDatabase {
   long countWorkflows(WorkflowInstance.WorkflowState state) throws WorkflowDatabaseException;
 
   /**
+   * Gets latest workflow instances for all events.
+   * Selects workflows which haven't been finished (DateCompleted IS NULL) or greatest DateCompleted
+   *
+   * @param limit
+   *          max number of workflows to be returned
+   * @param offset
+   *          only return workflows from this point onwards
+   * @return list of all {@link WorkflowInstance}s
+   * @throws WorkflowDatabaseException
+   *           if there is a problem communicating with the underlying data store
+   */
+  List<WorkflowInstance> getLatestWorkflowInstances(int limit, long token) throws WorkflowDatabaseException;
+
+  /**
+   * Returns the number of events workflows have been run on.
+   *
+   * @return the number of latest workflows
+   * @throws WorkflowDatabaseException
+   *           if there is a problem communicating with the underlying data store
+   */
+  int countMediaPackages() throws WorkflowDatabaseException;
+
+  /**
    * Gets all workflow instances for a mediapackage.
    *
    * @param mediaPackageId

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
@@ -172,7 +172,7 @@ public class WorkflowServiceDatabaseImpl implements WorkflowServiceDatabase {
     }
   }
 
-  /**
+    /**
    * {@inheritDoc}
    *
    * @see WorkflowServiceDatabase#countWorkflows(WorkflowInstance.WorkflowState state)
@@ -191,6 +191,56 @@ public class WorkflowServiceDatabaseImpl implements WorkflowServiceDatabase {
       return query.getSingleResult();
     } catch (Exception e) {
       throw new WorkflowDatabaseException("Could not find number of workflows.", e);
+    } finally {
+      if (em != null)
+        em.close();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @see WorkflowServiceDatabase#getLatestWorkflowInstances(int limit, long token)
+   */
+  public List<WorkflowInstance> getLatestWorkflowInstances(int limit, long token) throws WorkflowDatabaseException {
+
+    EntityManager em = null;
+    try {
+      em = emf.createEntityManager();
+
+      var query = em.createNamedQuery("Workflow.findLatest", WorkflowInstance.class);
+
+      String orgId = securityService.getOrganization().getId();
+      query.setParameter("organizationId", orgId);
+      query.setParameter("startToken", token);
+      query.setMaxResults(limit);
+      logger.debug("Requesting latest workflows using query: {}", query);
+      return query.getResultList();
+    } catch (Exception e) {
+      throw new WorkflowDatabaseException(e);
+    } finally {
+      if (em != null)
+        em.close();
+    }
+  }
+
+    /**
+   * {@inheritDoc}
+   *
+   * @see WorkflowServiceDatabase#countMediaPackages()
+   */
+  public int countMediaPackages() throws WorkflowDatabaseException {
+
+    EntityManager em = null;
+    try {
+      em = emf.createEntityManager();
+
+      var query = em.createNamedQuery("Workflow.countLatest", Long.class);
+      logger.debug("Counting latest workflows using query: {}", query);
+      final Number countResult = query.getSingleResult();
+      return countResult.intValue();
+    } catch (Exception e) {
+      throw new WorkflowDatabaseException(e);
     } finally {
       if (em != null)
         em.close();

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
@@ -172,7 +172,7 @@ public class WorkflowServiceDatabaseImpl implements WorkflowServiceDatabase {
     }
   }
 
-    /**
+  /**
    * {@inheritDoc}
    *
    * @see WorkflowServiceDatabase#countWorkflows(WorkflowInstance.WorkflowState state)


### PR DESCRIPTION
Added 2 named queries and the corresponding methods within the workflowDatabaseService to count and read the latest/active workflows of each event.

Replaced the old list of the repopulate function within WorkflowServiceImpl containing all workflows with a new one containing only the active/latest workflows.

The rest of the indexing procedure remains the same.

This should save a lot of time when updating the elasticsearch index because we update only one elasticsearch doc per event instead of as many docs as workflows per event.