### PR TITLE
Send waveform URIs to new editor

### DIFF
--- a/etc/org.opencastproject.editor.EditorServiceImpl.cfg
+++ b/etc/org.opencastproject.editor.EditorServiceImpl.cfg
@@ -30,6 +30,10 @@
 # Default: */silence
 #smil.silence.flavor=*/silence
 
+# Sets the flavor subtype of the waveform images
+# Default: waveform
+#waveform.subtype=waveform
+
 # Stream Security Configuration:
 
 # For further information please see:

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
@@ -45,9 +45,11 @@ public final class EditingData {
   private final SeriesData series;
   @SerializedName(WORKFLOW_ACTIVE)
   private final Boolean workflowActive;
+  private final List<String> waveformURIs;
 
   public EditingData(List<SegmentData> segments, List<TrackData> tracks, List<WorkflowData> workflows, Long duration,
-          String title, String recordingStartDate, String seriesId, String seriesName, Boolean workflowActive) {
+          String title, String recordingStartDate, String seriesId, String seriesName, Boolean workflowActive,
+          List<String> waveformURIs) {
     this.segments = segments;
     this.tracks = tracks;
     this.workflows = workflows;
@@ -56,6 +58,7 @@ public final class EditingData {
     this.date = recordingStartDate;
     this.series = new SeriesData(seriesId, seriesName);
     this.workflowActive = workflowActive;
+    this.waveformURIs = waveformURIs;
   }
 
   public static EditingData parse(String json) {

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -718,7 +718,7 @@ public class EditorServiceImpl implements EditorService {
       return new TrackData(track.getFlavor().getType(), track.getFlavor().getSubtype(), audio, video, uri,
                         track.getIdentifier());
     }).collect(Collectors.toList());
-    
+
     List<String> waveformList = Arrays.stream(internalPub.getAttachments())
             .filter(this::elementHasWaveformFlavor)
             .map(Attachment::getURI).map(this::signIfNecessary)

--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -44,6 +44,7 @@ import org.opencastproject.elasticsearch.index.objects.event.Event;
 import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.index.service.exception.IndexServiceException;
 import org.opencastproject.index.service.impl.util.EventUtils;
+import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
@@ -156,11 +157,13 @@ public class EditorServiceImpl implements EditorService {
   private String previewVideoSubtype;
   private String previewTag;
   private String previewSubtype;
+  private String waveformSubtype;
   private MediaPackageElementFlavor smilSilenceFlavor;
   private ElasticsearchIndex searchIndex;
 
   private static final String DEFAULT_PREVIEW_SUBTYPE = "prepared";
   private static final String DEFAULT_PREVIEW_TAG = "editor";
+  private static final String DEFAULT_WAVEFORM_SUBTYPE = "waveform";
   private static final String DEFAULT_SMIL_CATALOG_FLAVOR = "smil/cutting";
   private static final String DEFAULT_SMIL_CATALOG_TAGS = "archive";
   private static final String DEFAULT_SMIL_SILENCE_FLAVOR = "*/silence";
@@ -168,6 +171,7 @@ public class EditorServiceImpl implements EditorService {
 
   public static final String OPT_PREVIEW_SUBTYPE = "preview.subtype";
   public static final String OPT_PREVIEW_TAG = "preview.tag";
+  public static final String OPT_WAVEFORM_SUBTYPE = "waveform.subtype";
   public static final String OPT_SMIL_CATALOG_FLAVOR = "smil.catalog.flavor";
   public static final String OPT_SMIL_CATALOG_TAGS = "smil.catalog.tags";
   public static final String OPT_SMIL_SILENCE_FLAVOR = "smil.silence.flavor";
@@ -245,6 +249,10 @@ public class EditorServiceImpl implements EditorService {
     return previewTag;
   }
 
+  private String getWaveformSubtype() {
+    return waveformSubtype;
+  }
+
   @Activate
   @Modified
   public void activate(ComponentContext cc) {
@@ -262,6 +270,10 @@ public class EditorServiceImpl implements EditorService {
     // Preview subtype
     previewSubtype = Objects.toString(properties.get(OPT_PREVIEW_SUBTYPE), DEFAULT_PREVIEW_SUBTYPE);
     logger.debug("Preview subtype configuration set to '{}'", previewSubtype);
+
+    // Waveform subtype
+    waveformSubtype = Objects.toString(properties.get(OPT_WAVEFORM_SUBTYPE), DEFAULT_WAVEFORM_SUBTYPE);
+    logger.debug("Waveform subtype configuration set to '{}'", waveformSubtype);
 
     // SMIL catalog flavor
     smilCatalogFlavor = MediaPackageElementFlavor.parseFlavor(
@@ -294,6 +306,11 @@ public class EditorServiceImpl implements EditorService {
   private Boolean elementHasPreviewFlavor(MediaPackageElement element) {
     return element.getFlavor() != null
             && getPreviewSubtype().equals(element.getFlavor().getSubtype());
+  }
+
+  private Boolean elementHasWaveformFlavor(MediaPackageElement element) {
+    return element.getFlavor() != null
+            && getWaveformSubtype().equals(element.getFlavor().getSubtype());
   }
 
   private String signIfNecessary(final URI uri) {
@@ -701,9 +718,14 @@ public class EditorServiceImpl implements EditorService {
       return new TrackData(track.getFlavor().getType(), track.getFlavor().getSubtype(), audio, video, uri,
                         track.getIdentifier());
     }).collect(Collectors.toList());
+    
+    List<String> waveformList = Arrays.stream(internalPub.getAttachments())
+            .filter(this::elementHasWaveformFlavor)
+            .map(Attachment::getURI).map(this::signIfNecessary)
+            .collect(Collectors.toList());
 
     return new EditingData(segments, tracks, workflows, mp.getDuration(), mp.getTitle(), event.getRecordingStartDate(),
-            event.getSeriesId(), event.getSeriesName(), workflowActive);
+            event.getSeriesId(), event.getSeriesName(), workflowActive, waveformList);
   }
 
 


### PR DESCRIPTION
The automatic waveform generation in the new editor is plagued by various issues that can cause the whole editor to break. Until these issues can be fixed, this workaround sends pre-generated waveform images from Opencast to the new editor, like with the old editor.

This requires workflows to include the "Waveform" operation and add the generated file to the internal publication.

Also requires https://github.com/opencast/opencast-editor/pull/695 to be merged.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
