### PR TITLE
Clarify that #3715 was a fix in the release notes

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -99,11 +99,11 @@ Additional Notes about 11.7
       (cf. [[#3708](https://github.com/opencast/opencast/pull/3708)]).
     - Missing tags when encoding multiple qualities with the encode WOH
       (cf. [[#3639](https://github.com/opencast/opencast/pull/3639)]).
+    - The metadata in the video editor can now be changed and saved again
+      (cf. [[#3715](https://github.com/opencast/opencast/pull/3715)]).
 - New features and updates:
     - Check if user can be loaded before starting a workflow
       (cf. [[#3661](https://github.com/opencast/opencast/pull/3661)]).
-    - The metadata in the video editor can now be saved individually
-      (cf. [[#3715](https://github.com/opencast/opencast/pull/3715)]).
     - Make creation of default external API group configurable
       (cf. [[#3682](https://github.com/opencast/opencast/pull/3682)]).
 


### PR DESCRIPTION
#3715 was a bug fix, not a feature.
Sorry for the long PR discussion, which looks confusing but was
neccessary to find consensus on how to fix the unterlaying bug.
The bug itself was introduced when the metadata save button
first appeared.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
