### PR TITLE
Add missing elasticsearch dependencies to opencast-ingest feature

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -575,6 +575,9 @@
   <feature name="opencast-ingest" version="${project.version}">
     <feature start-level="80">opencast-core</feature>
 
+    <bundle start-level="82">mvn:org.opencastproject/opencast-elasticsearch-api/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-elasticsearch-impl/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-elasticsearch-index/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-scheduler-remote/${project.version}</bundle>


### PR DESCRIPTION
The ingest service has a dependency on the elastic search bundles, but the feature does not contain those. This PR adds the elastic search bundles to the opencast-ingest feature.

It would be the first time that a non-admin node uses the index. Can this have side effects?

```
Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=opencast-ingest; type=karaf.feature; version="[12.0.0,12.0.0]"; filter:="(&(osgi.identity=opencast-ingest)(type=karaf.feature)(version>=12.0.0)(version<=12.0.0))" [caused by: Unable to resolve opencast-ingest/12.0.0: missing requirement [opencast-ingest/12.0.0] osgi.identity; osgi.identity=opencast-ingest-service-impl; type=osgi.bundle; version="[12.0.0,12.0.0]"; resolution:=mandatory [caused by: Unable to resolve opencast-ingest-service-impl/12.0.0: missing requirement [opencast-ingest-service-impl/12.0.0] osgi.wiring.package; filter:="(&(osgi.wiring.package=org.opencastproject.elasticsearch.api)(version>=12.0.0)(!(version>=13.0.0)))"]]
```

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
