### PR TITLE
Speech to text language fallback and placeholder

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/speech-to-text-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/speech-to-text-woh.md
@@ -49,4 +49,15 @@ for the `language-code` field.
     <configuration key="language-code">eng</configuration>
   </configurations>
 </operation>
+
+<operation
+    id="speechtotext"
+    description="Generates subtitles for video and audio files, derive language-code from metadata">
+    <configurations>
+      <configuration key="source-flavor">*/source</configuration>
+      <configuration key="target-flavor">captions/vtt+#{lang}</configuration>
+      <configuration key="target-element">attachment</configuration>
+      <configuration key="target-tags">archive,subtitle,engage-download</configuration>
+    </configurations>
+</operation>
 ```

--- a/docs/guides/admin/docs/workflowoperationhandlers/speech-to-text-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/speech-to-text-woh.md
@@ -13,13 +13,14 @@ only [Vosk](https://alphacephei.com/vosk/) available as STT Engine. The subtitle
 Parameter Table
 ---------------
 
-|configuration keys|required|description                                                                      |
-|------------------|--------|---------------------------------------------------------------------------------|
-|source-flavor     |yes     |The source media package to use                                                  |
-|target-flavor     |yes     |Flavor of the produced subtitle file                                             |
-|target-element    |no      |Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment'. The default is "attachment".|
-|language-code     |no      |The language of the video or audio source (default is "eng). It has to match the name of the language model directory. See 'vosk-cli'.|
-|target-tags       |no      |Tags for the subtitle file                                                       |
+|configuration keys|required| description                                                                                                                             |
+|------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------|
+|source-flavor     |yes     | The source media package to use                                                                                                         |
+|target-flavor     |yes     | Flavor of the produced subtitle file. The subflavor supports the language-code placeholder `#{lang}`                                    |
+|target-element    |no      | Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment'. The default is "attachment".          |
+|language-code     |no      | The language of the video or audio source (default is "eng"). It has to match the name of the language model directory. See 'vosk-cli'. |
+|language-fallback |no      | The fallback value if the dublin core/media package language field is not present. (default is "eng")                                   |
+|target-tags       |no      | Tags for the subtitle file                                                                                                              |
 
 
 Requirements

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -77,6 +77,9 @@ public class SpeechToTextWorkflowOperationHandler extends AbstractWorkflowOperat
   /** Speech to Text language configuration property name. */
   private static final String LANGUAGE_CODE = "language-code";
 
+  /** Speech to Text language fallback configuration property name. */
+  private static final String LANGUAGE_FALLBACK = "language-fallback";
+
   /** Property name for configuring the place where the subtitles shall be appended. */
   private static final String TARGET_ELEMENT = "target-element";
 
@@ -281,7 +284,7 @@ public class SpeechToTextWorkflowOperationHandler extends AbstractWorkflowOperat
 
     if (language.isEmpty()) {
       // default value when nothing worked
-      language = "eng";
+      language = StringUtils.defaultIfBlank(operation.getConfiguration(LANGUAGE_FALLBACK), "eng");
     }
 
     return language;

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -83,6 +83,9 @@ public class SpeechToTextWorkflowOperationHandler extends AbstractWorkflowOperat
   /** Property name for configuring the place where the subtitles shall be appended. */
   private static final String TARGET_ELEMENT = "target-element";
 
+  /** Language placeholder */
+  private static final String PLACEHOLDER_LANG = "#{lang}";
+
   private enum AppendSubtitleAs {
     attachment, track
   }
@@ -200,6 +203,10 @@ public class SpeechToTextWorkflowOperationHandler extends AbstractWorkflowOperat
         subtitleMediaPackageElement.setURI(uri);
       }
       MediaPackageElementFlavor targetFlavor = tagsAndFlavors.getSingleTargetFlavor().applyTo(track.getFlavor());
+      targetFlavor = new MediaPackageElementFlavor(
+          targetFlavor.getType(),
+          targetFlavor.getSubtype().replace(PLACEHOLDER_LANG, languageCode)
+      );
       subtitleMediaPackageElement.setFlavor(targetFlavor);
 
       List<String> targetTags = tagsAndFlavors.getTargetTags();


### PR DESCRIPTION
This PR allows configuring the fallback language via a workflow operation configuration key (`language-fallback`).

In addition, it adds a language code placeholder which allows setting the target sub flavor based on the language code the speech to text operation used. If the language-code configuration key is empty, the workflow operation tries to determine the language based on dublin core/media package metadata.

```
    <operation
      id="speechtotext"
      description="Generates subtitles for video and audio files, derive language-code from metadata">
      <configurations>
        <configuration key="source-flavor">*/source</configuration>
        <configuration key="target-flavor">captions/vtt+#{lang}</configuration>
        <configuration key="target-element">track</configuration>
	<configuration key="target-tags">archive,subtitle,engage-download</configuration>
	<configuration key="language-fallback">deu</configuration>
      </configurations>
    </operation>
```

This fixes #3712

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
