### PR TITLE
Add missing PRs to OC11 changelog

### DIFF
--- a/docs/guides/admin/docs/changelog.md
+++ b/docs/guides/admin/docs/changelog.md
@@ -196,6 +196,12 @@ Opencast 11
 
 *Released on December 15th, 2021*
 
+- [[#2949](https://github.com/opencast/opencast/pull/2949)] -
+  Encode username before useing it in CanvasUserRoleProvider
+- [[#2591](https://github.com/opencast/opencast/pull/2591)] -
+  Remove automatic handling of HLS bitrate ladder
+- [[#2559](https://github.com/opencast/opencast/pull/2559)] -
+  Allow proper mapping of tenant hostnames to URLs
 - [[#3263](https://github.com/opencast/opencast/pull/3263)] -
   Remove chinese traditional
 - [[#3264](https://github.com/opencast/opencast/pull/3264)] -


### PR DESCRIPTION
The following PRs are missing in the OC11 changelog:

- [[#2949](https://github.com/opencast/opencast/pull/2949)] -
  Encode username before useing it in CanvasUserRoleProvider
  Evidence: f8b19a7eb9eb5918623777562968f20ece514784
- [[#2591](https://github.com/opencast/opencast/pull/2591)] -
  Remove automatic handling of HLS bitrate ladder
  Evidence: ff9b21d9e2272fa8fb1675ef242d112384d7b5d8
- [[#2559](https://github.com/opencast/opencast/pull/2559)] -
  Allow proper mapping of tenant hostnames to URLs
  Evidence: 4d5e287cad5098dc684217c801c7178376802183

### Your pull request should…

* [x] have a concise title
*  [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
