### PR TITLE
No Elasticsearch Use In Ingest

### DIFF
--- a/docs/guides/admin/docs/releasenotes/auto-generated-capture-agent-series.txt
+++ b/docs/guides/admin/docs/releasenotes/auto-generated-capture-agent-series.txt
@@ -1,0 +1,2 @@
+Identifiers for auto-generated capture series are now generated slightly different. This may cause new series to be
+generated for capture agents in some cases.

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -61,16 +61,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-elasticsearch-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-elasticsearch-index</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>


### PR DESCRIPTION
The ingest service searches for series titles starting with pull
request #3586.  This causes trouble when combined with the removal of
the Solr index which now makes this code fall back to the Elasticsearch
index instead.

Unfortunately, the Elasticsearch modules are not included in the ingest
distribution (#3797) which will cause the distribution to fail.

Simply including it works in theory, but causes trouble since our
infrastructure documentation states that Elasticsearch may be available
on the admin only and can thus, for example, be run with no encryption
or authentication to make deployments easier. All this would need to
change, making this quite messy.

This patch fixes the issue by using a generated series identifier for
which we need to full text search instead.

This closes #3797

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
