### PR TITLE
Remove red check mark when editing metadata

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableBooleanValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableBooleanValue.html
@@ -1,4 +1,5 @@
-<div ng-form="innerForm">
+<div ng-form="innerForm"
+     ng-class="{ dirty: params.dirty }">
   <i class="edit fa fa-pencil-square"></i>
 
   <input type="checkbox"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableBooleanValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableBooleanValue.html
@@ -1,8 +1,9 @@
 <div ng-form="innerForm">
   <i class="edit fa fa-pencil-square"></i>
-  <i class="changed fa fa-check" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <input type="checkbox"
-         ng-model="params.value" ng-change="submit()"
-                                 ng-required="params.required" name="{{ params.name }}"/>
+         ng-model="params.value"
+         ng-change="submit()"
+         ng-required="params.required"
+         name="{{ params.name }}"/>
 </div>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableDateValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableDateValue.html
@@ -1,4 +1,7 @@
-<div ng-click="enterEditMode()" ng-form="innerForm">
+<div ng-click="enterEditMode()"
+     ng-form="innerForm"
+     ng-class="{ dirty: params.dirty }">
+
   &nbsp;<span ng-show="!editMode">{{ params.value | localizeDate:'dateTime'  }}</span>
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
 

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableDateValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableDateValue.html
@@ -1,9 +1,13 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
   &nbsp;<span ng-show="!editMode">{{ params.value | localizeDate:'dateTime'  }}</span>
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
-  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
-  <input ng-keyup="keyUp($event)" type="text" datetimepicker
-                                  ng-model="params.value" editMode="false" tabindex="{{ params.tabindex }}" select="submit()"
+  <input ng-keyup="keyUp($event)"
+         type="text"
+         datetimepicker
+         ng-model="params.value"
+         editMode="false"
+         tabindex="{{ params.tabindex }}"
+         select="submit()"
                                                                                                             ng-show="editMode" ng-required="params.required" name="{{ params.name }}"/>
 </div>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiSelect.html
@@ -6,7 +6,6 @@
   </ul>
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
-  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <div class="editable-select" ng-if="editMode">
     <input type="text" ng-blur="onBlur()" ng-required="params.required" tabindex="{{ params.tabindex }}"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiSelect.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiSelect.html
@@ -1,4 +1,7 @@
-<div ng-click="enterEditMode()" ng-form="innerForm">
+<div ng-click="enterEditMode()"
+     ng-form="innerForm"
+     ng-class="{ dirty: params.dirty }">
+
   &nbsp;<ul ng-show="!editMode">
     <li ng-repeat="value in params.value track by $index">
       <span ng-if="value">{{ getText(value).value | translate }}</span>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiValue.html
@@ -6,16 +6,16 @@
   </ul>
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()" tabindex="{{ params.tabindex }}"></i>
-  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <div class="editable-select" ng-if="editMode">
-    <input type="text" ng-model="data.value"
-                       ng-required="params.required"
-                       name="{{ params.name }}"
-                       tabindex="{{ params.tabindex }}"
-                       ng-blur="onBlur()"
-                       ng-keyup="keyUp($event)"
-                       placeholder="{{ 'EDITABLE.MULTI.PLACEHOLDER' | translate}}">
+    <input type="text"
+           ng-model="data.value"
+           ng-required="params.required"
+           name="{{ params.name }}"
+           tabindex="{{ params.tabindex }}"
+           ng-blur="onBlur()"
+           ng-keyup="keyUp($event)"
+           placeholder="{{ 'EDITABLE.MULTI.PLACEHOLDER' | translate}}">
   </div>
   <span ng-show="editMode" class="ng-multi-value"
                            ng-repeat="value in params.value track by $index">

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableMultiValue.html
@@ -1,4 +1,7 @@
-<div ng-click="enterEditMode()" ng-form="innerForm">
+<div ng-click="enterEditMode()"
+     ng-form="innerForm"
+     ng-class="{ dirty: params.dirty }">
+
   &nbsp;<ul ng-show="!editMode">
     <li ng-repeat="value in params.value track by $index">
       <span ng-if="value">{{ value | translate }}</span>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleSelect.html
@@ -3,7 +3,6 @@
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode && collection.length != 0" ng-focus="enterEditMode()"
      tabindex="{{ collection.length != 0 ? params.tabindex : -1 }}"></i>
-  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
 
   <div class="editable-select" ng-if="editMode" ng-keyup="keyUp($event)" ng-mousedown="$event.stopPropagation()"
        ng-click="$event.stopPropagation()">

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleSelect.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleSelect.html
@@ -1,4 +1,8 @@
-<div ng-form="innerForm" ng-mousedown="enterEditMode($event)" ng-click="$event.stopPropagation()">
+<div ng-form="innerForm"
+     ng-mousedown="enterEditMode($event)"
+     ng-click="$event.stopPropagation()"
+     ng-class="{ dirty: params.dirty }">
+
   &nbsp;<span ng-show="!editMode" >{{ getLabel() | translate }}</span>
 
   <i class="edit fa fa-pencil-square" ng-show="!editMode && collection.length != 0" ng-focus="enterEditMode()"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleValue.html
@@ -1,9 +1,11 @@
 <div ng-click="enterEditMode()" ng-form="innerForm">
   &nbsp;<span ng-show="!editMode" class="preserve-newlines">{{ presentableValue | localizeDate:params.type:'short' }}</span>
 
-  <i class="edit fa fa-pencil-square" ng-show="!editMode" ng-focus="enterEditMode()"
-                                                          tabindex="{{ params.tabindex }}" focushere="{{ params.tabindex }}"></i>
-  <i class="changed fa fa-check" ng-show="!editMode" ng-class="{ saved: params.saved, dirty: params.dirty }"></i>
+  <i class="edit fa fa-pencil-square"
+     ng-show="!editMode"
+     ng-focus="enterEditMode()"
+     tabindex="{{ params.tabindex }}"
+     focushere="{{ params.tabindex }}"></i>
 
   <textarea ng-keydown="keyDown($event)"
             ng-keyup="keyUp($event)"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleValue.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/editableSingleValue.html
@@ -1,4 +1,7 @@
-<div ng-click="enterEditMode()" ng-form="innerForm">
+<div ng-click="enterEditMode()"
+     ng-form="innerForm"
+     ng-class="{ dirty: params.dirty }">
+
   &nbsp;<span ng-show="!editMode" class="preserve-newlines">{{ presentableValue | localizeDate:params.type:'short' }}</span>
 
   <i class="edit fa fa-pencil-square"

--- a/modules/admin-ui-frontend/app/styles/main.scss
+++ b/modules/admin-ui-frontend/app/styles/main.scss
@@ -516,27 +516,9 @@ table.main-tbl {
     display: none !important;
   }
 
-  td{
-    .fa-check {
-      float: right;
-      margin-top: 3px;
-      font-size: 18px;
-      opacity: 0;
-      visibility: hidden;
-      @include transition(all .2s);
-
-      &.saved {
-        opacity: 1;
-        visibility: visible;
-        color: $green;
-      }
-
-      &.dirty {
-        opacity: 1;
-        visibility: visible;
-        color: $red;
-      }
-    } // fa-check
+  .dirty {
+    border-right: 3px solid #333;
+    margin-right: -3px;
   }
 }
 


### PR DESCRIPTION
When editing meta data in the admin UI, a red check mark is shown on
changed (dirty/unwritten) fields. Red is not distinguishable from green
for some people, and the check mark as an indicator for unsaved changes
is not obvious.

Since the check marks do not mean anything anymore except that the user
finished their entry (which they should obviously know), this pull
request removes the check marks entirely.

If users try leaving the dialog with unsaved changes, a warning is
displayed anyway.

This fixes #3738

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
