### PR TITLE
Properly unregister OAI-PMH servlet

### DIFF
--- a/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiPmhServer.java
+++ b/modules/oaipmh/src/main/java/org/opencastproject/oaipmh/server/OaiPmhServer.java
@@ -41,6 +41,7 @@ import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -143,6 +144,11 @@ public final class OaiPmhServer extends HttpServlet implements OaiPmhServerInfo 
     updated(cc.getProperties());
   }
 
+  @Deactivate
+  public void deactivate() {
+    tryUnregisterServlet();
+  }
+
   /** Called by the ConfigurationAdmin service. This method actually sets up the server. */
   public synchronized void updated(Dictionary<String, ?> properties) throws ConfigurationException {
     // Because the OAI-PMH server implementation is technically not a REST service implemented
@@ -231,12 +237,6 @@ public final class OaiPmhServer extends HttpServlet implements OaiPmhServerInfo 
     res.setCharacterEncoding("UTF-8");
     res.setContentType("text/xml;charset=UTF-8");
     oai.generate(res.getOutputStream());
-  }
-
-  @Override
-  public void destroy() {
-    super.destroy();
-    tryUnregisterServlet();
   }
 
   private synchronized void tryUnregisterServlet() {


### PR DESCRIPTION
If you change the pax web config during runtime you provoke the error below.

In the stack trace, you can see that the `unregisterService` function is called two times. The whiteboard implementation takes care of unregistering a servlet if it gets destroyed.

This patch unregisters the servlet service only if the "parent" gets deactivated.

```
2022-05-30T09:13:37,856 | ERROR | (Main$1:328) - Bundle org.ops4j.pax.web.pax-web-extender-whiteboard [383] EventDispatcher: Error during dispatch. (java.lang.IllegalArgumentException: Alias [/oaipmh] was never registered)
java.lang.IllegalArgumentException: Alias [/oaipmh] was never registered
	at org.ops4j.pax.web.service.internal.HttpServiceStarted.unregister(HttpServiceStarted.java:324) ~[?:?]
	at org.ops4j.pax.web.service.internal.HttpServiceProxy.unregister(HttpServiceProxy.java:82) ~[?:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.element.ServletWebElement.unregister(ServletWebElement.java:127) ~[?:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.WebApplication.unregisterWebElement(WebApplication.java:417) ~[?:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.WebApplication.removeWebElement(WebApplication.java:214) ~[?:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.tracker.AbstractTracker.removedService(AbstractTracker.java:245) ~[?:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.tracker.AbstractTracker.removedService(AbstractTracker.java:46) ~[?:?]
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:967) ~[osgi.core-6.0.0.jar:?]
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:870) ~[osgi.core-6.0.0.jar:?]
	at org.osgi.util.tracker.AbstractTracked.untrack(AbstractTracked.java:341) ~[osgi.core-6.0.0.jar:?]
	at org.osgi.util.tracker.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:909) ~[osgi.core-6.0.0.jar:?]
	at org.apache.felix.framework.EventDispatcher.invokeServiceListenerCallback(EventDispatcher.java:990) ~[org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.EventDispatcher.fireEventImmediately(EventDispatcher.java:838) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.EventDispatcher.fireServiceEvent(EventDispatcher.java:545) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.Felix.fireServiceEvent(Felix.java:4595) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.Felix.access$000(Felix.java:106) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.Felix$1.serviceChanged(Felix.java:420) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.ServiceRegistry.unregisterService(ServiceRegistry.java:170) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.ServiceRegistrationImpl.unregister(ServiceRegistrationImpl.java:144) [org.apache.felix.framework-5.6.12.jar:?]
	at org.opencastproject.oaipmh.server.OaiPmhServer.tryUnregisterServlet(OaiPmhServer.java:244) [!/:?]
	at org.opencastproject.oaipmh.server.OaiPmhServer.destroy(OaiPmhServer.java:239) [!/:?]
	at org.eclipse.jetty.servlet.ServletHolder.destroyInstance(ServletHolder.java:455) [!/:9.4.43.v20210629]
	at org.eclipse.jetty.servlet.ServletHolder.doStop(ServletHolder.java:432) [!/:9.4.43.v20210629]
	at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:94) [!/:9.4.43.v20210629]
	at org.ops4j.pax.web.service.jetty.internal.JettyServerImpl$3.call(JettyServerImpl.java:496) [!/:?]
	at org.ops4j.pax.web.service.jetty.internal.JettyServerImpl$3.call(JettyServerImpl.java:492) [!/:?]
	at org.ops4j.pax.swissbox.core.ContextClassLoaderUtils.doWithClassLoader(ContextClassLoaderUtils.java:60) [!/:?]
	at org.ops4j.pax.web.service.jetty.internal.JettyServerImpl.removeServlet(JettyServerImpl.java:491) [!/:?]
	at org.ops4j.pax.web.service.jetty.internal.ServerControllerImpl$Started.removeServlet(ServerControllerImpl.java:322) [!/:?]
	at org.ops4j.pax.web.service.jetty.internal.ServerControllerImpl.removeServlet(ServerControllerImpl.java:127) [!/:?]
	at org.ops4j.pax.web.service.internal.HttpServiceStarted.unregister(HttpServiceStarted.java:330) [!/:?]
	at org.ops4j.pax.web.service.internal.HttpServiceProxy.unregister(HttpServiceProxy.java:82) [!/:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.element.ServletWebElement.unregister(ServletWebElement.java:127) [!/:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.WebApplication.unregisterWebElement(WebApplication.java:417) [!/:?]
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:807) [?:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.WebApplication.unregisterWebElements(WebApplication.java:407) [!/:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.WebApplication.serviceChanged(WebApplication.java:229) [!/:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.WebApplication.serviceChanged(WebApplication.java:68) [!/:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.util.tracker.ReplaceableService.bind(ReplaceableService.java:86) [!/:?]
	at org.ops4j.pax.web.extender.whiteboard.internal.util.tracker.ReplaceableService$Customizer.removedService(ReplaceableService.java:131) [!/:?]
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:967) [osgi.core-6.0.0.jar:?]
	at org.osgi.util.tracker.ServiceTracker$Tracked.customizerRemoved(ServiceTracker.java:870) [osgi.core-6.0.0.jar:?]
	at org.osgi.util.tracker.AbstractTracked.untrack(AbstractTracked.java:341) [osgi.core-6.0.0.jar:?]
	at org.osgi.util.tracker.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:909) [osgi.core-6.0.0.jar:?]
	at org.apache.felix.framework.EventDispatcher.invokeServiceListenerCallback(EventDispatcher.java:990) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.EventDispatcher.fireEventImmediately(EventDispatcher.java:838) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.EventDispatcher.fireServiceEvent(EventDispatcher.java:545) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.Felix.fireServiceEvent(Felix.java:4595) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.Felix.access$000(Felix.java:106) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.Felix$1.serviceChanged(Felix.java:420) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.ServiceRegistry.unregisterService(ServiceRegistry.java:170) [org.apache.felix.framework-5.6.12.jar:?]
	at org.apache.felix.framework.ServiceRegistrationImpl.unregister(ServiceRegistrationImpl.java:144) [org.apache.felix.framework-5.6.12.jar:?]
	at org.ops4j.pax.web.service.internal.Activator.updateController(Activator.java:340) [!/:?]
	at org.ops4j.pax.web.service.internal.Activator.lambda$scheduleUpdateConfig$0(Activator.java:290) [!/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
