### PR TITLE
Removing unnecessary workflow index data from rebuild

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIndexData.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIndexData.java
@@ -39,7 +39,7 @@ import javax.persistence.Table;
 @NamedNativeQueries({
         @NamedNativeQuery(
                 name = "WorkflowIndexData.getAll",
-                query = "SELECT id, state, mediapackage_id, organization_id FROM oc_workflow ORDER BY date_created ASC",
+                query = "SELECT id, state, mediapackage_id, organization_id FROM oc_workflow ORDER BY mediapackage_id, id DESC",
                 resultSetMapping = "DataResult"
         ),
 })
@@ -51,7 +51,7 @@ import javax.persistence.Table;
                         fields = {
                                   @FieldResult(name = "id",column = "id"),
                                   @FieldResult(name = "state", column = "state"),
-                                  @FieldResult(name = "mediaPackageId", column = "mediaPackage_id"),
+                                  @FieldResult(name = "mediaPackageId", column = "mediapackage_id"),
                                   @FieldResult(name = "organizationId", column = "organization_id")
                         }
                 )

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIndexData.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIndexData.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.api;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityResult;
+import javax.persistence.FieldResult;
+import javax.persistence.Id;
+import javax.persistence.NamedNativeQueries;
+import javax.persistence.NamedNativeQuery;
+import javax.persistence.SqlResultSetMapping;
+import javax.persistence.Table;
+
+/**
+ * Summary of the workflow stats necessary for index rebuild,
+ * for use in repopulate and update (immutable)
+ */
+@Table(name = "oc_workflow")
+@Entity
+@NamedNativeQueries({
+        @NamedNativeQuery(
+                name = "WorkflowIndexData.getAll",
+                query = "SELECT id, state, mediapackage_id, organization_id FROM oc_workflow ORDER BY date_created ASC",
+                resultSetMapping = "DataResult"
+        ),
+})
+@SqlResultSetMapping(
+        name = "DataResult",
+        entities = {
+                @EntityResult(
+                        entityClass = WorkflowIndexData.class,
+                        fields = {
+                                  @FieldResult(name = "id",column = "id"),
+                                  @FieldResult(name = "state", column = "state"),
+                                  @FieldResult(name = "mediaPackageId", column = "mediaPackage_id"),
+                                  @FieldResult(name = "organizationId", column = "organization_id")
+                        }
+                )
+})
+
+
+public class WorkflowIndexData {
+  @Id
+  private Long id;
+  private int state;
+  private String mediaPackageId;
+  private String organizationId;
+
+
+  /**
+   * Default constructor without any import.
+   */
+  public WorkflowIndexData() {
+
+  }
+
+  public WorkflowIndexData(Long id, int state, String mediaPackageId, String organizationId) {
+    this.id = id;
+    this.state = state;
+    this.mediaPackageId = mediaPackageId;
+    this.organizationId = organizationId;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public int getState() {
+    return state;
+  }
+
+  public String getMediaPackageId() {
+    return mediaPackageId;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+}

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -82,18 +82,6 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
                 name = "Workflow.findAll",
                 query = "select w from WorkflowInstance w where w.organizationId=:organizationId order by w.dateCreated"
         ),
-        // Finding the latest or active workflow for all events
-        @NamedQuery(
-                name = "Workflow.findLatest",
-                query = "SELECT w FROM WorkflowInstance w "
-                      + "WHERE "
-                      + "w.organizationId=:organizationId AND "
-                      + "w.dateCreated = (SELECT MAX(w2.dateCreated) "
-                      + "FROM WorkflowInstance w2 "
-                      + "WHERE w2.mediaPackageId = w.mediaPackageId AND "
-                      + "w2.workflowId>:startToken) "
-                      + "ORDER BY w.workflowId ASC"
-        ),
         @NamedQuery(
                 name = "Workflow.countLatest",
                 query = "SELECT COUNT(DISTINCT w.mediaPackageId) FROM WorkflowInstance w"

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
@@ -78,15 +78,19 @@ public interface WorkflowServiceDatabase {
    */
   long countWorkflows(WorkflowInstance.WorkflowState state) throws WorkflowDatabaseException;
 
-    /**
+  /**
    * Gets workflow index data for all events.
    * Selects only workflow id, state, mediapackage id and organization id
    *
-   * @return list of all {@link WorkflowIndexData}s
+   * @param limit
+   *          max number of data objects to be returned
+   * @param offset
+   *          only return data from this point onwards
+   * @return list of {@link WorkflowIndexData}s
    * @throws WorkflowDatabaseException
    *           if there is a problem communicating with the underlying data store
    */
-  List<WorkflowIndexData> getWorkflowIndexData() throws WorkflowDatabaseException;
+  List<WorkflowIndexData> getWorkflowIndexData(int limit, int offset) throws WorkflowDatabaseException;
 
   /**
    * Returns the number of events workflows have been run on.

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
@@ -78,19 +78,15 @@ public interface WorkflowServiceDatabase {
    */
   long countWorkflows(WorkflowInstance.WorkflowState state) throws WorkflowDatabaseException;
 
-  /**
-   * Gets latest workflow instances for all events.
-   * Selects workflows which haven't been finished (DateCompleted IS NULL) or greatest DateCompleted
+    /**
+   * Gets workflow index data for all events.
+   * Selects only workflow id, state, mediapackage id and organization id
    *
-   * @param limit
-   *          max number of workflows to be returned
-   * @param offset
-   *          only return workflows from this point onwards
-   * @return list of all {@link WorkflowInstance}s
+   * @return list of all {@link WorkflowIndexData}s
    * @throws WorkflowDatabaseException
    *           if there is a problem communicating with the underlying data store
    */
-  List<WorkflowInstance> getLatestWorkflowInstances(int limit, long token) throws WorkflowDatabaseException;
+  List<WorkflowIndexData> getWorkflowIndexData() throws WorkflowDatabaseException;
 
   /**
    * Returns the number of events workflows have been run on.

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
@@ -200,22 +200,15 @@ public class WorkflowServiceDatabaseImpl implements WorkflowServiceDatabase {
   /**
    * {@inheritDoc}
    *
-   * @see WorkflowServiceDatabase#getLatestWorkflowInstances(int limit, long token)
+   * @see WorkflowServiceDatabase#getWorkflowIndexData()
    */
-  public List<WorkflowInstance> getLatestWorkflowInstances(int limit, long token) throws WorkflowDatabaseException {
-
+  public List<WorkflowIndexData> getWorkflowIndexData() throws WorkflowDatabaseException {
     EntityManager em = null;
     try {
       em = emf.createEntityManager();
 
-      var query = em.createNamedQuery("Workflow.findLatest", WorkflowInstance.class);
-
-      String orgId = securityService.getOrganization().getId();
-      query.setParameter("organizationId", orgId);
-      query.setParameter("startToken", token);
-      query.setMaxResults(limit);
-      logger.debug("Requesting latest workflows using query: {}", query);
-      return query.getResultList();
+      var nativeQuery = em.createNamedQuery("WorkflowIndexData.getAll",WorkflowIndexData.class);
+      return nativeQuery.getResultList();
     } catch (Exception e) {
       throw new WorkflowDatabaseException(e);
     } finally {

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
@@ -200,14 +200,16 @@ public class WorkflowServiceDatabaseImpl implements WorkflowServiceDatabase {
   /**
    * {@inheritDoc}
    *
-   * @see WorkflowServiceDatabase#getWorkflowIndexData()
+   * @see WorkflowServiceDatabase#getWorkflowIndexData(int limit, int offset)
    */
-  public List<WorkflowIndexData> getWorkflowIndexData() throws WorkflowDatabaseException {
+  public List<WorkflowIndexData> getWorkflowIndexData(int limit, int offset) throws WorkflowDatabaseException {
     EntityManager em = null;
     try {
       em = emf.createEntityManager();
 
-      var nativeQuery = em.createNamedQuery("WorkflowIndexData.getAll",WorkflowIndexData.class);
+      var nativeQuery = em.createNamedQuery("WorkflowIndexData.getAll", WorkflowIndexData.class);
+      nativeQuery.setMaxResults(limit);
+      nativeQuery.setFirstResult(offset);
       return nativeQuery.getResultList();
     } catch (Exception e) {
       throw new WorkflowDatabaseException(e);

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -71,11 +71,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-dublincore</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.entwinemedia.common</groupId>
       <artifactId>functional</artifactId>
     </dependency>


### PR DESCRIPTION
Instead of reading the whole workflow instance from database when rebuilding the elasticsearch index only four attributes will be used:
- workflow id (long)
- state (int)
- mediapackage id (String)
- organization id (String

They are stored within a new entity object "WorkflowIndexData".

To reduce the database access time the WorkflowIndexData is only sorted by date_created and not filtered within the sql query.
The latest workflows are selected by mapping the date-sorted WorkflowIndexData with the mediapackage id as key value within the repopulate function.

Some attributes and function calls which added additional metadata while rebuilding the workflow index have been removed from the workflowServiceImpl.