### PR TITLE
Workflow tests should no longer race

### DIFF
--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
@@ -210,10 +210,10 @@ public class CountWorkflowsTest {
     initialProps.put("testproperty", "foo");
     WorkflowInstance workflow1 = null;
     workflow1 = service.start(def, mp, initialProps);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(listener, 1);
     mp.setIdentifier(IdImpl.fromUUID());
     service.start(def, mp, initialProps);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(listener, 2);
     service.removeWorkflowListener(listener);
 
     // Test for two paused workflows in "op1"
@@ -225,7 +225,7 @@ public class CountWorkflowsTest {
     listener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(listener);
     service.resume(workflow1.getId());
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(listener, 1);
     service.removeWorkflowListener(listener);
 
     // Make sure one workflow is still on hold, the other is finished.

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
@@ -210,10 +210,10 @@ public class CountWorkflowsTest {
     initialProps.put("testproperty", "foo");
     WorkflowInstance workflow1 = null;
     workflow1 = service.start(def, mp, initialProps);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     mp.setIdentifier(IdImpl.fromUUID());
     service.start(def, mp, initialProps);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(listener);
 
     // Test for two paused workflows in "op1"
@@ -225,7 +225,7 @@ public class CountWorkflowsTest {
     listener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(listener);
     service.resume(workflow1.getId());
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(listener);
 
     // Make sure one workflow is still on hold, the other is finished.

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/CountWorkflowsTest.java
@@ -209,13 +209,11 @@ public class CountWorkflowsTest {
     Map<String, String> initialProps = new HashMap<String, String>();
     initialProps.put("testproperty", "foo");
     WorkflowInstance workflow1 = null;
-    synchronized (listener) {
-      workflow1 = service.start(def, mp, initialProps);
-      listener.wait();
-      mp.setIdentifier(IdImpl.fromUUID());
-      service.start(def, mp, initialProps);
-      listener.wait();
-    }
+    workflow1 = service.start(def, mp, initialProps);
+    Thread.sleep(100);
+    mp.setIdentifier(IdImpl.fromUUID());
+    service.start(def, mp, initialProps);
+    Thread.sleep(100);
     service.removeWorkflowListener(listener);
 
     // Test for two paused workflows in "op1"
@@ -226,10 +224,8 @@ public class CountWorkflowsTest {
     // Continue one of the two workflows, waiting for success
     listener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(listener);
-    synchronized (listener) {
-      service.resume(workflow1.getId());
-      listener.wait();
-    }
+    service.resume(workflow1.getId());
+    Thread.sleep(100);
     service.removeWorkflowListener(listener);
 
     // Make sure one workflow is still on hold, the other is finished.

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
@@ -221,7 +221,7 @@ public class HoldStateTest {
 
     Map<String, String> initialProps = Map.of("testproperty", "foo");
     workflow = service.start(def, mp, initialProps);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(pauseListener, 1);
     service.removeWorkflowListener(pauseListener);
 
     workflow = service.getWorkflowById(workflow.getId());
@@ -238,7 +238,7 @@ public class HoldStateTest {
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(succeedListener);
     service.resume(workflow.getId(), resumeProps);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(succeedListener, 1);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals("Workflow expected to succeed", 1, succeedListener.countStateChanges(WorkflowState.SUCCEEDED));
@@ -261,14 +261,14 @@ public class HoldStateTest {
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
     workflow = service.start(def, mp);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(pauseListener, 1);
 
     // Simulate a user resuming the workflow, but the handler still keeps the workflow in a hold state
     holdingOperationHandler.setResumeAction(Action.PAUSE);
 
     // Resume the workflow again. It should quickly reenter the paused state
     service.resume(workflow.getId());
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(pauseListener, 2);
 
     // remove the pause listener
     service.removeWorkflowListener(pauseListener);
@@ -282,7 +282,7 @@ public class HoldStateTest {
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED, WorkflowState.FAILED);
     service.addWorkflowListener(succeedListener);
     service.resume(workflow.getId());
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(succeedListener, 1);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals(WorkflowState.SUCCEEDED, service.getWorkflowById(workflow.getId()).getState());

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
@@ -221,7 +221,7 @@ public class HoldStateTest {
 
     Map<String, String> initialProps = Map.of("testproperty", "foo");
     workflow = service.start(def, mp, initialProps);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(pauseListener);
 
     workflow = service.getWorkflowById(workflow.getId());
@@ -238,7 +238,7 @@ public class HoldStateTest {
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(succeedListener);
     service.resume(workflow.getId(), resumeProps);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals("Workflow expected to succeed", 1, succeedListener.countStateChanges(WorkflowState.SUCCEEDED));
@@ -261,14 +261,14 @@ public class HoldStateTest {
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
     workflow = service.start(def, mp);
-    Thread.sleep(100);
+    Thread.sleep(1000);
 
     // Simulate a user resuming the workflow, but the handler still keeps the workflow in a hold state
     holdingOperationHandler.setResumeAction(Action.PAUSE);
 
     // Resume the workflow again. It should quickly reenter the paused state
     service.resume(workflow.getId());
-    Thread.sleep(100);
+    Thread.sleep(1000);
 
     // remove the pause listener
     service.removeWorkflowListener(pauseListener);
@@ -282,7 +282,7 @@ public class HoldStateTest {
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED, WorkflowState.FAILED);
     service.addWorkflowListener(succeedListener);
     service.resume(workflow.getId());
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals(WorkflowState.SUCCEEDED, service.getWorkflowById(workflow.getId()).getState());

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/HoldStateTest.java
@@ -220,10 +220,8 @@ public class HoldStateTest {
     service.addWorkflowListener(pauseListener);
 
     Map<String, String> initialProps = Map.of("testproperty", "foo");
-    synchronized (pauseListener) {
-      workflow = service.start(def, mp, initialProps);
-      pauseListener.wait();
-    }
+    workflow = service.start(def, mp, initialProps);
+    Thread.sleep(100);
     service.removeWorkflowListener(pauseListener);
 
     workflow = service.getWorkflowById(workflow.getId());
@@ -239,10 +237,8 @@ public class HoldStateTest {
 
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(succeedListener);
-    synchronized (succeedListener) {
-      service.resume(workflow.getId(), resumeProps);
-      succeedListener.wait();
-    }
+    service.resume(workflow.getId(), resumeProps);
+    Thread.sleep(100);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals("Workflow expected to succeed", 1, succeedListener.countStateChanges(WorkflowState.SUCCEEDED));
@@ -264,19 +260,15 @@ public class HoldStateTest {
 
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
-    synchronized (pauseListener) {
-      workflow = service.start(def, mp);
-      pauseListener.wait();
-    }
+    workflow = service.start(def, mp);
+    Thread.sleep(100);
 
     // Simulate a user resuming the workflow, but the handler still keeps the workflow in a hold state
     holdingOperationHandler.setResumeAction(Action.PAUSE);
 
     // Resume the workflow again. It should quickly reenter the paused state
-    synchronized (pauseListener) {
-      service.resume(workflow.getId());
-      pauseListener.wait();
-    }
+    service.resume(workflow.getId());
+    Thread.sleep(100);
 
     // remove the pause listener
     service.removeWorkflowListener(pauseListener);
@@ -289,10 +281,8 @@ public class HoldStateTest {
 
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED, WorkflowState.FAILED);
     service.addWorkflowListener(succeedListener);
-    synchronized (succeedListener) {
-      service.resume(workflow.getId());
-      succeedListener.wait();
-    }
+    service.resume(workflow.getId());
+    Thread.sleep(100);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals(WorkflowState.SUCCEEDED, service.getWorkflowById(workflow.getId()).getState());

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
@@ -185,10 +185,8 @@ public class PauseFinalOperationTest {
     // Start a new workflow, and wait for it to pause
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
-    synchronized (pauseListener) {
-      workflow = service.start(def, mp, null);
-      pauseListener.wait();
-    }
+    workflow = service.start(def, mp, null);
+    Thread.sleep(100);
     service.removeWorkflowListener(pauseListener);
 
     // Ensure that "start" was called on the first operation handler, but not resume
@@ -201,10 +199,8 @@ public class PauseFinalOperationTest {
     // Resume the workflow
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(succeedListener);
-    synchronized (succeedListener) {
-      service.resume(workflow.getId());
-      succeedListener.wait();
-    }
+    service.resume(workflow.getId());
+    Thread.sleep(100);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals(WorkflowState.SUCCEEDED, service.getWorkflowById(workflow.getId()).getState());

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
@@ -186,7 +186,7 @@ public class PauseFinalOperationTest {
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
     workflow = service.start(def, mp, null);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(pauseListener, 1);
     service.removeWorkflowListener(pauseListener);
 
     // Ensure that "start" was called on the first operation handler, but not resume
@@ -200,7 +200,7 @@ public class PauseFinalOperationTest {
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(succeedListener);
     service.resume(workflow.getId());
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(succeedListener, 1);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals(WorkflowState.SUCCEEDED, service.getWorkflowById(workflow.getId()).getState());

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseFinalOperationTest.java
@@ -186,7 +186,7 @@ public class PauseFinalOperationTest {
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
     workflow = service.start(def, mp, null);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(pauseListener);
 
     // Ensure that "start" was called on the first operation handler, but not resume
@@ -200,7 +200,7 @@ public class PauseFinalOperationTest {
     WorkflowStateListener succeedListener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(succeedListener);
     service.resume(workflow.getId());
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(succeedListener);
 
     Assert.assertEquals(WorkflowState.SUCCEEDED, service.getWorkflowById(workflow.getId()).getState());

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
@@ -191,10 +191,8 @@ public class PauseWorkflowTest {
     // Start a new workflow
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
-    synchronized (pauseListener) {
-      workflow = service.start(def, mp, null);
-      pauseListener.wait();
-    }
+    workflow = service.start(def, mp, null);
+    Thread.sleep(100);
 
     // Ensure that the first operation handler was called, but not the second
     Assert.assertTrue(firstHandler.isStarted());
@@ -208,10 +206,8 @@ public class PauseWorkflowTest {
     properties.put("key", "value");
 
     service.addWorkflowListener(pauseListener);
-    synchronized (pauseListener) {
-      service.resume(workflow.getId(), properties);
-      pauseListener.wait();
-    }
+    service.resume(workflow.getId(), properties);
+    Thread.sleep(100);
     service.removeWorkflowListener(pauseListener);
 
     // The handler should have picked up the properties

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
@@ -192,7 +192,7 @@ public class PauseWorkflowTest {
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
     workflow = service.start(def, mp, null);
-    Thread.sleep(100);
+    Thread.sleep(1000);
 
     // Ensure that the first operation handler was called, but not the second
     Assert.assertTrue(firstHandler.isStarted());
@@ -207,7 +207,7 @@ public class PauseWorkflowTest {
 
     service.addWorkflowListener(pauseListener);
     service.resume(workflow.getId(), properties);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(pauseListener);
 
     // The handler should have picked up the properties

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/PauseWorkflowTest.java
@@ -192,7 +192,7 @@ public class PauseWorkflowTest {
     WorkflowStateListener pauseListener = new WorkflowStateListener(WorkflowState.PAUSED);
     service.addWorkflowListener(pauseListener);
     workflow = service.start(def, mp, null);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(pauseListener, 1);
 
     // Ensure that the first operation handler was called, but not the second
     Assert.assertTrue(firstHandler.isStarted());
@@ -207,7 +207,7 @@ public class PauseWorkflowTest {
 
     service.addWorkflowListener(pauseListener);
     service.resume(workflow.getId(), properties);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(pauseListener, 3);
     service.removeWorkflowListener(pauseListener);
 
     // The handler should have picked up the properties

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingIntricateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingIntricateTest.java
@@ -252,7 +252,7 @@ public final class WorkflowOperationSkippingIntricateTest {
     service.addWorkflowListener(stateListener);
     WorkflowInstance instance;
     instance = service.start(definition, mp, properties);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(stateListener);
 
     return instance;

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingIntricateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingIntricateTest.java
@@ -252,7 +252,7 @@ public final class WorkflowOperationSkippingIntricateTest {
     service.addWorkflowListener(stateListener);
     WorkflowInstance instance;
     instance = service.start(definition, mp, properties);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(stateListener, 1);
     service.removeWorkflowListener(stateListener);
 
     return instance;

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingIntricateTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingIntricateTest.java
@@ -251,10 +251,8 @@ public final class WorkflowOperationSkippingIntricateTest {
     WorkflowStateListener stateListener = new WorkflowStateListener(WorkflowState.SUCCEEDED);
     service.addWorkflowListener(stateListener);
     WorkflowInstance instance;
-    synchronized (stateListener) {
-      instance = service.start(definition, mp, properties);
-      stateListener.wait();
-    }
+    instance = service.start(definition, mp, properties);
+    Thread.sleep(100);
     service.removeWorkflowListener(stateListener);
 
     return instance;

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
@@ -251,10 +251,8 @@ public class WorkflowOperationSkippingTest {
     WorkflowStateListener stateListener = new WorkflowStateListener(stateToWaitFor);
     service.addWorkflowListener(stateListener);
     WorkflowInstance instance = null;
-    synchronized (stateListener) {
-      instance = service.start(definition, mp, properties);
-      stateListener.wait();
-    }
+    instance = service.start(definition, mp, properties);
+    Thread.sleep(100);
     service.removeWorkflowListener(stateListener);
 
     return instance;

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
@@ -252,7 +252,7 @@ public class WorkflowOperationSkippingTest {
     service.addWorkflowListener(stateListener);
     WorkflowInstance instance = null;
     instance = service.start(definition, mp, properties);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(stateListener, 1);
     service.removeWorkflowListener(stateListener);
 
     return instance;

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowOperationSkippingTest.java
@@ -252,7 +252,7 @@ public class WorkflowOperationSkippingTest {
     service.addWorkflowListener(stateListener);
     WorkflowInstance instance = null;
     instance = service.start(definition, mp, properties);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(stateListener);
 
     return instance;

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -361,14 +361,12 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
     WorkflowStateListener stateListener = new WorkflowStateListener(stateToWaitFor);
     service.addWorkflowListener(stateListener);
     WorkflowInstance instance = null;
-    synchronized (stateListener) {
-      if (parentId == null) {
-        instance = service.start(definition, mp);
-      } else {
-        instance = service.start(definition, mp, parentId, Collections.emptyMap());
-      }
-      stateListener.wait();
+    if (parentId == null) {
+      instance = service.start(definition, mp);
+    } else {
+      instance = service.start(definition, mp, parentId, Collections.emptyMap());
     }
+    Thread.sleep(100);
     service.removeWorkflowListener(stateListener);
 
     return instance;
@@ -381,10 +379,8 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
     Map<String, String> props = new HashMap<String, String>();
     props.put("retryStrategy", retryStrategy);
     WorkflowInstance wfInstance = null;
-    synchronized (stateListener) {
-      wfInstance = service.resume(instance.getId(), props);
-      stateListener.wait();
-    }
+    wfInstance = service.resume(instance.getId(), props);
+    Thread.sleep(100);
     service.removeWorkflowListener(stateListener);
 
     return wfInstance;
@@ -617,9 +613,7 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
     }
 
     while (stateListener.countStateChanges() < count) {
-      synchronized (stateListener) {
-        stateListener.wait();
-      }
+      Thread.sleep(100);
     }
 
     Assert.assertEquals(count, service.countWorkflowInstances());

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -366,7 +366,7 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
     } else {
       instance = service.start(definition, mp, parentId, Collections.emptyMap());
     }
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(stateListener, 1);
     service.removeWorkflowListener(stateListener);
 
     return instance;
@@ -380,7 +380,7 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
     props.put("retryStrategy", retryStrategy);
     WorkflowInstance wfInstance = null;
     wfInstance = service.resume(instance.getId(), props);
-    Thread.sleep(1000);
+    WorkflowTestSupport.poll(stateListener, 1);
     service.removeWorkflowListener(stateListener);
 
     return wfInstance;
@@ -612,9 +612,7 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
       instances.add(service.start(workingDefinition, mp, Collections.emptyMap()));
     }
 
-    while (stateListener.countStateChanges() < count) {
-      Thread.sleep(1000);
-    }
+    WorkflowTestSupport.poll(stateListener, count);
 
     Assert.assertEquals(count, service.countWorkflowInstances());
     Assert.assertEquals(count, stateListener.countStateChanges(WorkflowState.SUCCEEDED));

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowServiceImplTest.java
@@ -366,7 +366,7 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
     } else {
       instance = service.start(definition, mp, parentId, Collections.emptyMap());
     }
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(stateListener);
 
     return instance;
@@ -380,7 +380,7 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
     props.put("retryStrategy", retryStrategy);
     WorkflowInstance wfInstance = null;
     wfInstance = service.resume(instance.getId(), props);
-    Thread.sleep(100);
+    Thread.sleep(1000);
     service.removeWorkflowListener(stateListener);
 
     return wfInstance;
@@ -613,7 +613,7 @@ protected WorkflowInstance startAndWait(WorkflowDefinition definition, MediaPack
     }
 
     while (stateListener.countStateChanges() < count) {
-      Thread.sleep(100);
+      Thread.sleep(1000);
     }
 
     Assert.assertEquals(count, service.countWorkflowInstances());

--- a/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowTestSupport.java
+++ b/modules/workflow-service-impl/src/test/java/org/opencastproject/workflow/impl/WorkflowTestSupport.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.impl;
+
+import org.opencastproject.workflow.api.WorkflowStateListener;
+
+public final class WorkflowTestSupport {
+
+  public static final int WAITTIME = 5; //ms
+
+  private WorkflowTestSupport() {
+    //pass
+  }
+
+  /*
+   * Wait up to 1000ms for the number of changes to be right
+   */
+  public static void poll(WorkflowStateListener listener, int changes) throws Exception {
+    int counter = 5000 / WAITTIME;
+    while (listener.countStateChanges() != changes && counter > 0) {
+      Thread.sleep(WAITTIME);
+      counter --;
+    }
+    if (listener.countStateChanges() != changes) {
+      throw new RuntimeException(String.format("Listener did not have the correct number (%s) of events inside of 1000ms, got %s instead", changes, listener.countStateChanges()));
+    }
+  }
+}


### PR DESCRIPTION
This pull request should fix the workflow implementation test deadlocks.

The tests were deadlocking on the `.wait()` calls, which were quite old.  I suspect that the previous workflow logic did enough stuff between a state change, and the `wait()` in the test that the wait happened *before* the state change (the expected behaviour).  With the newer implementation logic, the state change happens *after* the wait, and thus the wait deadlocks waiting on an event which has already happened.

Closes #3814

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
