### PR TITLE
Use Local Index References

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -414,7 +414,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
           snapshot.getMediaPackage().getIdentifier(), snapshot.getVersion());
       fireEventHandlers(mkTakeSnapshotMessage(snapshot));
 
-      updateEventInIndex(snapshot, index);
+      updateEventInIndex(snapshot);
 
       return snapshot;
     }
@@ -480,7 +480,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
    * @param index
    *         The API index to update
    */
-  private void updateEventInIndex(Snapshot snapshot, ElasticsearchIndex index) {
+  private void updateEventInIndex(Snapshot snapshot) {
     final MediaPackage mp = snapshot.getMediaPackage();
     String eventId = mp.getIdentifier().toString();
     final String organization = securityService.getOrganization().getId();
@@ -538,13 +538,13 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
    * @param index
    *         The API index to update
    */
-  private void removeArchivedVersionFromIndex(String eventId, ElasticsearchIndex index) {
+  private void removeArchivedVersionFromIndex(String eventId) {
     final String orgId = securityService.getOrganization().getId();
     final User user = securityService.getUser();
     logger.debug("Received AssetManager delete episode message {}", eventId);
 
     Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
-      if (!eventOpt.isPresent()) {
+      if (eventOpt.isEmpty()) {
         logger.warn("Event {} not found for deletion", eventId);
         return Optional.empty();
       }
@@ -876,7 +876,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     logger.info("Firing event handlers for event {}", mpId);
     fireEventHandlers(AssetManagerItem.deleteEpisode(mpId, new Date()));
 
-    removeArchivedVersionFromIndex(mpId, index);
+    removeArchivedVersionFromIndex(mpId);
   }
 
   /**
@@ -889,7 +889,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
   }
 
   @Override
-  public void repopulate(final ElasticsearchIndex index) throws IndexRebuildException {
+  public void repopulate() throws IndexRebuildException {
     final Organization org = securityService.getOrganization();
     final User user = (org != null ? securityService.getUser() : null);
     try {
@@ -915,7 +915,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
           for (Snapshot snapshot : byOrg.get(orgId)) {
             current += 1;
             try {
-              updateEventInIndex(snapshot, index);
+              updateEventInIndex(snapshot);
             } catch (Throwable t) {
               logSkippingElement(logger, "event", snapshot.getMediaPackage().getIdentifier().toString(), org, t);
             }

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/IndexProducer.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/IndexProducer.java
@@ -21,8 +21,6 @@
 
 package org.opencastproject.elasticsearch.index.rebuild;
 
-import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
-
 /**
  * This service handles data that's added to an ElasticSearch index.
  */
@@ -30,11 +28,8 @@ public interface IndexProducer {
 
   /**
    * Re-add all data of this service to the index.
-   *
-   * @param index
-   *           The index to repopulate.
    */
-  void repopulate(ElasticsearchIndex index) throws IndexRebuildException;
+  void repopulate() throws IndexRebuildException;
 
   /**
    * Get the service that implements IndexProducer.

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/IndexRebuildService.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/IndexRebuildService.java
@@ -193,7 +193,7 @@ public class IndexRebuildService implements BundleActivator {
 
     IndexProducer indexProducer = indexProducers.get(service);
     logger.info("Starting to rebuild the {} index from service '{}'", index.getIndexName(), service);
-    indexProducer.repopulate(index);
+    indexProducer.repopulate();
     logger.info("Finished to rebuild the {} index from service '{}'", index.getIndexName(), service);
   }
 

--- a/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
+++ b/modules/scheduler-impl/src/test/java/org/opencastproject/scheduler/impl/SchedulerServiceImplTest.java
@@ -1492,8 +1492,9 @@ public class SchedulerServiceImplTest {
     EasyMock.expect(index.addOrUpdateEvent(EasyMock.anyString(), EasyMock.anyObject(java.util.function.Function.class),
             EasyMock.anyString(), EasyMock.anyObject(User.class))).andReturn(Optional.empty()).times(orgList.size());
     EasyMock.replay(index, result);
+    schedSvc.setIndex(index);
 
-    schedSvc.repopulate(index);
+    schedSvc.repopulate();
   }
 
   private String addDublinCore(Opt<String> id, MediaPackage mediaPackage, final DublinCoreCatalog initalEvent)

--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
@@ -219,7 +219,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
       // update the elasticsearch indices
       String orgId = securityService.getOrganization().getId();
       User user = securityService.getUser();
-      updateThemeInIndex(theme, index, orgId, user);
+      updateThemeInIndex(theme, orgId, user);
 
       return theme;
     } catch (Exception e) {
@@ -274,12 +274,12 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
 
       // update the elasticsearch indices
       String organization = securityService.getOrganization().getId();
-      removeThemeFromIndex(id, index, organization);
+      removeThemeFromIndex(id, organization);
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
       logger.error("Could not delete theme '{}'", id, e);
-      if (tx.isActive()) {
+      if (tx != null && tx.isActive()) {
         tx.rollback();
       }
       throw new ThemesServiceDatabaseException(e);
@@ -329,12 +329,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
   }
 
   @Override
-  public void repopulate(final ElasticsearchIndex index) {
-    if (index.getIndexName() != this.index.getIndexName()) {
-      logger.info("Themes are currently not part of the {} index, no re-indexing necessary.");
-      return;
-    }
-
+  public void repopulate() {
     for (final Organization organization : organizationDirectoryService.getOrganizations()) {
       User systemUser = SecurityUtil.createSystemUser(cc, organization);
       SecurityUtil.runAs(securityService, organization, systemUser, () -> {
@@ -344,7 +339,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
           int current = 1;
           logIndexRebuildBegin(logger, index.getIndexName(), total, "themes", organization);
           for (Theme theme : themes) {
-            updateThemeInIndex(theme, index, organization.getId(), systemUser);
+            updateThemeInIndex(theme, organization.getId(), systemUser);
             logIndexRebuildProgress(logger, index.getIndexName(), total, current);
             current++;
           }
@@ -371,7 +366,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
    * @param orgId
    *           the organization the theme belongs to
    */
-  private void removeThemeFromIndex(long themeId, ElasticsearchIndex index, String orgId) {
+  private void removeThemeFromIndex(long themeId, String orgId) {
     logger.debug("Removing theme {} from the {} index.", themeId, index.getIndexName());
 
     try {
@@ -392,7 +387,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
    *           the organization the theme belongs to
    * @param user
    */
-  private void updateThemeInIndex(Theme theme, ElasticsearchIndex index, String orgId,
+  private void updateThemeInIndex(Theme theme, String orgId,
           User user) {
     logger.debug("Updating the theme with id '{}', name '{}', description '{}', organization '{}' in the {} index.",
             theme.getId(), theme.getName(), theme.getDescription(),
@@ -406,11 +401,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
       // the function to do the actual updating
       Function<Optional<IndexTheme>, Optional<IndexTheme>> updateFunction = (Optional<IndexTheme> indexThemeOpt) -> {
         IndexTheme indexTheme;
-        if (indexThemeOpt.isPresent()) {
-          indexTheme = indexThemeOpt.get();
-        } else {
-          indexTheme = new IndexTheme(id, orgId);
-        }
+        indexTheme = indexThemeOpt.orElseGet(() -> new IndexTheme(id, orgId));
         String creator = StringUtils.isNotBlank(theme.getCreator().getName())
                 ? theme.getCreator().getName() : theme.getCreator().getUsername();
 


### PR DESCRIPTION
Services now track their index on their own and use it to push updates
into the index if things change. For example, when a new workflow is
started.

For reindexing, an external index was still passed to the service
though. That's pretty weird since that could mean that the same service
would write to completely different indexes in different situations,
but expecting that the data would end up at the same place.

In practice this did not really matter since the same index was passed
to the `repopulate()` method which was tracked internally anyway. Still,
it makes more sense to always use the tracked index.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
