### PR TITLE
Fix faulty validity check for access policies when creating an event/series

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
@@ -201,14 +201,12 @@ angular.module('adminNg.services')
             rulesValid = true;
 
         angular.forEach(me.ud.policies, function (policy) {
-          rulesValid = false;
-
           if (policy.read && policy.write) {
             hasRights = true;
           }
 
-          if ((policy.read || policy.write || policy.actions.value.length > 0) && !angular.isUndefined(policy.role)) {
-            rulesValid = true;
+          if (!(policy.read || policy.write || policy.actions.value.length > 0) || angular.isUndefined(policy.role)) {
+            rulesValid = false;
           }
         });
 

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/access.js
@@ -138,27 +138,17 @@ angular.module('adminNg.services')
             rulesValid = true;
 
         angular.forEach(me.ud.policies, function (policy) {
-          rulesValid = false;
-
           if (policy.read && policy.write) {
             hasRights = true;
           }
 
-          if ((policy.read || policy.write || policy.actions.value.length > 0) && !angular.isUndefined(policy.role)) {
-            rulesValid = true;
+          if (!(policy.read || policy.write || policy.actions.value.length > 0) || angular.isUndefined(policy.role)) {
+            rulesValid = false;
           }
         });
 
         me.unvalidRule = !rulesValid;
         me.hasRights = hasRights;
-
-        if (hasRights && angular.isDefined(aclNotification)) {
-          Notifications.remove(aclNotification, 'series-acl');
-        }
-
-        if (!hasRights && !angular.isDefined(aclNotification)) {
-          aclNotification = Notifications.add('warning', 'SERIES_ACL_MISSING_READWRITE_ROLE', 'series-acl', -1);
-        }
 
         return rulesValid && hasRights;
       };


### PR DESCRIPTION
The Admin UI for creating new events and series would allow invalid access policies, as long as the last one was valid. This fixes that

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
