### PR TITLE
Adds a config key to set the number of speakers for amberscript trans…

### DIFF
--- a/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
@@ -54,3 +54,11 @@ client.key=
 # How long to keep result files in the working file repository in days.
 # The default is 7 days.
 #cleanup.results.days=7
+
+# Configure which metadata field shall be considered when "counting" the
+# number of speakers. The "presenter" or the "contributor" field.
+# Note for developers: the "presenter" becomes the "creator" in the Operation Handler
+# possible values: presenter, contributor, both
+# Both means, that both list will be joined (Union)
+# The default is presenter
+#speaker.metadata.field=presenter


### PR DESCRIPTION
Amberscripts default value of "number of speakers" is 2. In some cases, amberscripts recognizes 2 speakers, although there is only one, which results in a bad transcription file (1 word per line).

This PR adds the possibility to configure the "number of speakers". The configured value will be added to the REST call of the amberscript api.