### PR TITLE
Amberscript configuration fix

### DIFF
--- a/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
@@ -17,9 +17,9 @@
 # AmberScript API key
 client.key=
 
-# Workflow to be executed when results are ready to be attached to media package
-# Defaults: amberscript-attach-transcripts.xml
-#workflow=amberscript-attach-transcripts.xml
+# Workflow to be executed when results are ready to be attached to media package (workflow-id)
+# Defaults: amberscript-attach-transcripts
+#workflow=amberscript-attach-transcripts
 
 # Interval the workflow dispatcher runs to start workflows to attach transcripts to the media package
 # after the transcription job is completed.


### PR DESCRIPTION
The configuration is set to the workflow filename but the id is needed by the code.

Change configured workflow filename to id in the configuration.

