### PR TITLE
Fix submitter not being displayed in the event workflow details

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -27,16 +27,16 @@ angular.module('adminNg.controllers')
   'EventAssetCatalogsResource', 'CommentResource', 'EventWorkflowsResource', 'EventWorkflowActionResource',
   'EventWorkflowDetailsResource', 'ResourcesListResource', 'RolesResource', 'EventAccessResource',
   'EventPublicationsResource', 'EventSchedulingResource','NewEventProcessingResource', 'CaptureAgentsResource',
-  'ConflictCheckResource', 'Language', 'JsHelper', '$sce', '$timeout', 'EventHelperService', 'UploadAssetOptions',
-  'EventUploadAssetResource', 'Table', 'SchedulingHelperService', 'StatisticsReusable', 'Modal', '$translate',
-  'MetadataSaveService',
+  'ConflictCheckResource', 'UserResource', 'Language', 'JsHelper', '$sce', '$timeout', 'EventHelperService',
+  'UploadAssetOptions', 'EventUploadAssetResource', 'Table', 'SchedulingHelperService', 'StatisticsReusable', 'Modal',
+  '$translate', 'MetadataSaveService',
   function ($scope, Notifications, EventTransactionResource, EventMetadataResource, EventAssetsResource,
     EventAssetCatalogsResource, CommentResource, EventWorkflowsResource, EventWorkflowActionResource,
     EventWorkflowDetailsResource, ResourcesListResource, RolesResource, EventAccessResource,
     EventPublicationsResource, EventSchedulingResource, NewEventProcessingResource, CaptureAgentsResource,
-    ConflictCheckResource, Language, JsHelper, $sce, $timeout, EventHelperService, UploadAssetOptions,
-    EventUploadAssetResource, Table, SchedulingHelperService, StatisticsReusable, Modal, $translate,
-    MetadataSaveService) {
+    ConflictCheckResource, UserResource, Language, JsHelper, $sce, $timeout, EventHelperService,
+    UploadAssetOptions, EventUploadAssetResource, Table, SchedulingHelperService, StatisticsReusable, Modal,
+    $translate, MetadataSaveService) {
 
     var metadataChangedFns = {},
         me = this,
@@ -1031,6 +1031,17 @@ angular.module('adminNg.controllers')
       var currentWorkflow = $scope.workflows.entries[$scope.workflows.entries.length - 1];
       return currentWorkflow.id === workflowId;
     };
+
+    // Fetch additional user information
+    $scope.getUserDetails = function (username) {
+      if (username && ! $scope.creator) {
+        $scope.creator = UserResource.get({ username: username });
+        return $scope.creator
+      }
+      if ($scope.creator) {
+        return $scope.creator
+      }
+    }
 
     $scope.$on('$destroy', function () {
       cleanupScopeResources();

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -27,16 +27,16 @@ angular.module('adminNg.controllers')
   'EventAssetCatalogsResource', 'CommentResource', 'EventWorkflowsResource', 'EventWorkflowActionResource',
   'EventWorkflowDetailsResource', 'ResourcesListResource', 'RolesResource', 'EventAccessResource',
   'EventPublicationsResource', 'EventSchedulingResource','NewEventProcessingResource', 'CaptureAgentsResource',
-  'ConflictCheckResource', 'UserResource', 'Language', 'JsHelper', '$sce', '$timeout', 'EventHelperService',
-  'UploadAssetOptions', 'EventUploadAssetResource', 'Table', 'SchedulingHelperService', 'StatisticsReusable', 'Modal',
-  '$translate', 'MetadataSaveService',
+  'ConflictCheckResource', 'Language', 'JsHelper', '$sce', '$timeout', 'EventHelperService', 'UploadAssetOptions',
+  'EventUploadAssetResource', 'Table', 'SchedulingHelperService', 'StatisticsReusable', 'Modal', '$translate',
+  'MetadataSaveService',
   function ($scope, Notifications, EventTransactionResource, EventMetadataResource, EventAssetsResource,
     EventAssetCatalogsResource, CommentResource, EventWorkflowsResource, EventWorkflowActionResource,
     EventWorkflowDetailsResource, ResourcesListResource, RolesResource, EventAccessResource,
     EventPublicationsResource, EventSchedulingResource, NewEventProcessingResource, CaptureAgentsResource,
-    ConflictCheckResource, UserResource, Language, JsHelper, $sce, $timeout, EventHelperService,
-    UploadAssetOptions, EventUploadAssetResource, Table, SchedulingHelperService, StatisticsReusable, Modal,
-    $translate, MetadataSaveService) {
+    ConflictCheckResource, Language, JsHelper, $sce, $timeout, EventHelperService, UploadAssetOptions,
+    EventUploadAssetResource, Table, SchedulingHelperService, StatisticsReusable, Modal, $translate,
+    MetadataSaveService) {
 
     var metadataChangedFns = {},
         me = this,
@@ -1030,17 +1030,6 @@ angular.module('adminNg.controllers')
     $scope.isCurrentWorkflow = function (workflowId) {
       var currentWorkflow = $scope.workflows.entries[$scope.workflows.entries.length - 1];
       return currentWorkflow.id === workflowId;
-    };
-
-    // Fetch additional user information
-    $scope.getUserDetails = function (username) {
-      if (username && ! $scope.creator) {
-        $scope.creator = UserResource.get({ username: username });
-        return $scope.creator;
-      }
-      if ($scope.creator) {
-        return $scope.creator;
-      }
     };
 
     $scope.$on('$destroy', function () {

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -1036,12 +1036,12 @@ angular.module('adminNg.controllers')
     $scope.getUserDetails = function (username) {
       if (username && ! $scope.creator) {
         $scope.creator = UserResource.get({ username: username });
-        return $scope.creator
+        return $scope.creator;
       }
       if ($scope.creator) {
-        return $scope.creator
+        return $scope.creator;
       }
-    }
+    };
 
     $scope.$on('$destroy', function () {
       cleanupScopeResources();

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -1517,8 +1517,8 @@
               <tr>
                 <td translate="EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTER"><!-- Submitter--></td>
                 <td>
-                  {{ subNavData.creator.name }}
-                  <span ng-if="subNavData.creator.email">{{'&lt;' + subNavData.creator.email + '&gt;' }}</span>
+                  {{ getUserDetails(subNavData.creator).name }}
+                  <span ng-if="getUserDetails(subNavData.creator).email">{{'&lt;' + getUserDetails(subNavData.creator).email + '&gt;' }}</span>
                 </td>
               </tr>
               <tr>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -1517,8 +1517,7 @@
               <tr>
                 <td translate="EVENTS.EVENTS.DETAILS.WORKFLOWS.SUBMITTER"><!-- Submitter--></td>
                 <td>
-                  {{ getUserDetails(subNavData.creator).name }}
-                  <span ng-if="getUserDetails(subNavData.creator).email">{{'&lt;' + getUserDetails(subNavData.creator).email + '&gt;' }}</span>
+                  {{ subNavData.creator }}
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
Resolves #3831.

The change to workflow storage introduced with OC 12 caused workflow instances to only store the username of a user instead of the full user object. This caused a display error in the event workflow details. This PR fetches the additional user information based on the available username.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
