### PR TITLE
Make Delete Dialog Look Alike

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/confirm-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/confirm-modal.html
@@ -4,17 +4,14 @@
     <h2 translate="CONFIRMATIONS.ACTIONS.CONFIRMATION"><!-- Confirm --></h2>
   </header>
 
-  <div>
+  <div class=dialog>
     <p><span translate="CONFIRMATIONS.METADATA.NOTICE.{{type}}"><!-- The following element will be deleted --></span>:</p>
     <p class="delete">{{name}}</p>
+    <p translate="CONFIRMATIONS.CONTINUE_ACTION"><!-- Are you sure you want to continue? --></p>
   </div>
-  <p class="warning" translate="CONFIRMATIONS.WARNINGS.EVENT_WILL_BE_GONE" ng-show="type=='EVENT'">
-    <!-- If you continue, the event will be irrevocably gone. -->
-  </p>
-  <p translate="CONFIRMATIONS.CONTINUE_ACTION"><!-- Are you sure you want to continue? --></p>
 
   <div class="btn-container">
     <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()"><i><!--- Cancel --></i></a>
-    <a translate="CONFIRM" class="danger-btn" ng-click="confirm()"><i><!-- Confirm --></i></a>
+    <a translate="WIZARD.DELETE" class="danger-btn" ng-click="confirm()"><i><!-- Confirm --></i></a>
   </div>
 </section>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/delete-single-series-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/delete-single-series-modal.html
@@ -36,7 +36,7 @@
       <a translate="CANCEL" class="cancel-btn close-modal" ng-click="close()">
         <!--- Cancel -->
       </a>
-      <a translate="CONFIRM" class="danger-btn" ng-click="confirm()">
+      <a translate="WIZARD.DELETE" class="danger-btn" ng-click="confirm()">
         <!-- Confirm -->
       </a>
     </div>

--- a/modules/admin-ui-frontend/app/styles/views/modals/_modal-dialog.scss
+++ b/modules/admin-ui-frontend/app/styles/views/modals/_modal-dialog.scss
@@ -30,22 +30,19 @@
 
         top: 35%;
 
-        p {
+        .dialog {
+            padding: 20px;
             text-align: center;
-            margin:20px auto 20px;
-        }
 
-        .delete {
-            font-weight: bold;
-        }
-
-        .warning {
-            color: $red;
+            .delete {
+                font-weight: bold;
+                padding: 20px;
+            }
         }
 
         .btn-container {
-            margin: 20px auto;
             text-align: center;
+            margin-bottom: 20px;
 
             a {
                 padding: 12px 30px;


### PR DESCRIPTION
This patch fixes the issue that all three of Opencast's delete dialog
(event, series, batch) do not look alike.

This patch mostly adjust the event delete dialog to look like the series
dialog. It now has one warning less, but the simpler structure adopted
for visual clarity makes it hopefully clearer what is going on and easier
to understand.

Additionally, all three dialog now use a red “Delete” button to confirm
the process, instead of using “Confirm” at some places.

![Screenshot from 2022-06-13 23-57-36](https://user-images.githubusercontent.com/1008395/173453727-47a0daea-569a-405a-bc8d-229a32312562.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
