### PR TITLE
Fix duplicate dependency declaration

### DIFF
--- a/modules/cover-image-workflowoperation/pom.xml
+++ b/modules/cover-image-workflowoperation/pom.xml
@@ -69,10 +69,6 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
       <artifactId>osgi.cmpn</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
See https://github.com/opencast/opencast/pull/3798

> This pull request fixes this error, which was popping up right at the very beginning of every build
> 
> ```
> Some problems were encountered while building the effective model for org.opencastproject:opencast-cover-image-workflowoperation:bundle:13-SNAPSHOT
> Warning:  'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.osgi:org.osgi.core:jar -> duplicate declaration of version (?) @ line 78, column 17
> Warning:  
> Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
> Warning:  
> Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
> Warning:  
> ```

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
