### PR TITLE
Adopter wizard botton text repair

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
@@ -308,7 +308,7 @@
          ng-form="adopterRegistrationForm"
          ng-class="{inactive: !adopter.agreedToPolicy}"
          ng-click="nextState(1)"
-         translate="{{states[state]['buttons']['submitButtonText']}}"></a>
+         translate="{{!registered ? states[state]['buttons']['submitButtonText'] : 'WIZARD.UPDATE' }}"></a>
       <a ng-show="state != 'form' && state != 'delete_submit'"
          class="submit"
          ng-form="adopterRegistrationForm"


### PR DESCRIPTION
This PR fixes adopter wizard button text.  Updating your data now shows 'Update' rather than 'Create'

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
