### PR TITLE
Rerun Failed Tests

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           mvn clean install -Pnone \
             --batch-mode \
+            -Dsurefire.rerunFailingTestsCount=2 \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
             -Dhttp.keepAlive=false \
             -Dmaven.wagon.http.pool=false \
@@ -79,6 +80,7 @@ jobs:
         run: |
           mvn clean install -Pallinone  \
             --batch-mode \
+            -Dsurefire.rerunFailingTestsCount=2 \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
             -Dhttp.keepAlive=false \
             -Dmaven.wagon.http.pool=false \


### PR DESCRIPTION
To circumvent the weird networking problems we sometimes see on GitHub
Actions, this pull request allows failing tests to be automatically
rerun before twice Maven counts the build as failing.

This is not ideal, but it hopefully means a lot less manual restarting
tests.

This patch only affects Surefire tests. Anything else failing will still
cause an instant test failure.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
