### PR TITLE
Fix seriesname solver when ID is shorter than 7 characters

### DIFF
--- a/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/ListProvidersServiceImpl.java
+++ b/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/ListProvidersServiceImpl.java
@@ -144,9 +144,14 @@ public class ListProvidersServiceImpl implements ListProvidersService {
       for (Map.Entry<String,String> entry : list.entrySet()) {
         int repeated = Collections.frequency(list.values(), entry.getValue());
         if (repeated > 1) {
+          String newSeriesName = null;
           //If a series name is repeated, will add the first 7 characters of the series ID to the display name on the
           //admin-ui
-          String newSeriesName = entry.getValue() + " " + "(ID: " + entry.getKey().substring(0, 7) + "...)";
+          try {
+            newSeriesName = entry.getValue() + " " + "(ID: " + entry.getKey().substring(0, 7) + "...)";
+          } catch (StringIndexOutOfBoundsException e) {
+            newSeriesName = entry.getValue() + " " + "(ID: " + entry.getKey() + ")";
+          }
           logger.debug(String.format("Repeated series title \"%s\" found, changing to \"%s\" for admin-ui display",
               entry.getValue(), newSeriesName));
           list.put(entry.getKey(), newSeriesName);


### PR DESCRIPTION
This fixes #3895 (Improving #3650), when there are two series with the same name and at the same time one of them have an ID shorter than 7 characters triggers a `StringIndexOutOfBoundsException`.

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
