### PR TITLE
Add "Create new event with metadata from another event" button to Admin UI

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/newEventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/newEventController.js
@@ -22,14 +22,17 @@
 
 // Controller for creating a new event. This is a wizard, so it implements a state machine design pattern.
 angular.module('adminNg.controllers')
-.controller('NewEventCtrl', ['$scope', '$timeout', 'Table', 'NewEventStates', 'NewEventResource', 'EVENT_TAB_CHANGE',
-  'Notifications', 'Modal',
-  function ($scope, $timeout, Table, NewEventStates, NewEventResource, EVENT_TAB_CHANGE, Notifications, Modal) {
+.controller('NewEventCtrl', ['$scope', '$timeout', 'Table', 'NewEventStates', 'NewEventResource',
+  'EventMetadataResource', 'EVENT_TAB_CHANGE','Notifications', 'Modal',
+  function ($scope, $timeout, Table, NewEventStates, NewEventResource, EventMetadataResource, EVENT_TAB_CHANGE,
+    Notifications, Modal) {
     $scope.states = NewEventStates.get();
     // This is a hack, due to the fact that we need to read html from the server :(
     // Shall be banished ASAP
 
     var metadata,
+        extendedMetadata,
+        sourceController,
         accessController,
         // Reset all the wizard states
         resetStates = function () {
@@ -47,8 +50,25 @@ angular.module('adminNg.controllers')
         // MH-12854 get latest collections (series)
         state.stateController.reset({resetDefaults: true});
         metadata = state.stateController;
+      } else if (state.stateController.isMetadataExtendedState) {
+        state.stateController.reset({resetDefaults: true});
+        extendedMetadata = state.stateController;
+      } else if (state.stateController.isSourceState) {
+        state.stateController.reset({resetDefaults: true});
+        sourceController = state.stateController;
       }
     });
+
+    // Set template event Id
+    if (angular.isDefined(metadata)) {
+      metadata.setCopyEventId( $scope.resourceId );
+    }
+    if (angular.isDefined(extendedMetadata)) {
+      extendedMetadata.setCopyEventId( $scope.resourceId );
+    }
+    if (angular.isDefined(sourceController)) {
+      sourceController.setCopyEventId( $scope.resourceId );
+    }
 
     if (angular.isDefined(metadata) && angular.isDefined(accessController)) {
       accessController.setMetadata(metadata);

--- a/modules/admin-ui-frontend/app/scripts/modules/events/partials/eventActionsCell.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/partials/eventActionsCell.html
@@ -67,3 +67,11 @@
    title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.EMBEDDING_CODE' | translate }}"
    with-role="ROLE_UI_EVENTS_EMBEDDING_CODE_VIEW">
 </a>
+
+<!-- Copy metadata from exisiting event to new event modal -->
+<a data-open-modal="new-event-modal"
+   data-resource-id="{{ row.id }}"
+   class="fa fa-copy"
+   title="{{ 'EVENTS.EVENTS.TABLE.TOOLTIP.COPY_TO_NEW_EVENT' | translate }}"
+   with-role="ROLE_UI_EVENTS_CREATE">
+</a>

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/metadata.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/metadata.js
@@ -21,117 +21,165 @@
 'use strict';
 
 angular.module('adminNg.services')
-.factory('NewEventMetadata', ['NewEventMetadataResource', function (NewEventMetadataResource) {
-  var Metadata = function () {
-    var me = this, mainMetadataName = 'dublincore/episode', i;
-    me.ud = {};
-    me.isMetadataState = true;
+.factory('NewEventMetadata', ['NewEventMetadataResource', 'EventMetadataResource',
+  function (NewEventMetadataResource, EventMetadataResource) {
+    var Metadata = function () {
+      var me = this, mainMetadataName = 'dublincore/episode', i;
+      me.ud = {};
+      me.isMetadataState = true;
+      me.copyEventId = undefined;
 
-    this.requiredMetadata = {};
+      this.requiredMetadata = {};
 
-    this.updateRequiredMetadata = function(fieldId, value) {
-      if (angular.isDefined(value) && value.length > 0) {
-        me.requiredMetadata[fieldId] = true;
-      } else {
-        me.requiredMetadata[fieldId] = false;
-      }
-    };
+      this.updateRequiredMetadata = function(fieldId, value) {
+        if (angular.isDefined(value) && value.length > 0) {
+          me.requiredMetadata[fieldId] = true;
+        } else {
+          me.requiredMetadata[fieldId] = false;
+        }
+      };
 
-    // As soon as the required metadata fields arrive from the backend,
-    // we check which are mandatory.
-    // This information will be needed in ordert to tell if we can move
-    // on to the next page of the wizard.
-    this.findRequiredMetadata = function (data) {
-      var mainData = data[mainMetadataName];
-      // we go for the regular dublincore metadata here
-      me.ud[mainMetadataName] = mainData;
-      if (mainData && mainData.fields) {
-        for (i = 0; i < mainData.fields.length; i++) {
-          var field = mainData.fields[i];
-          // preserve default value, if set
-          if (Object.prototype.hasOwnProperty.call(field, 'value') && field.value) {
-            field.presentableValue = me.extractPresentableValue(field);
-            me.ud[mainMetadataName].fields[i] = field;
-          }
-          // just hooking the tab index up here, as this is already running through all elements
-          field.tabindex = i + 1;
-          if (field.required) {
-            me.updateRequiredMetadata(field.id, field.value);
-            if (field.type === 'boolean') {
-              // set all boolean fields to false by default
-              field.value = false;
-              me.requiredMetadata[field.id] = true;
+      // Set Id of the event used as a template for this new one
+      this.setCopyEventId = function(copyEventId) {
+        me.copyEventId = copyEventId;
+      };
+
+      // Fetch additional information if we've got a template event
+      this.findRequiredMetadata = function (data) {
+        if(me.copyEventId === undefined) {
+          me.setupRequiredMetadata(data);
+        } else {
+          EventMetadataResource.get({ id: me.copyEventId }, function (copyMetadata) {
+            var copyMainMetadata;
+            angular.forEach(copyMetadata.entries, function (catalog) {
+              if (catalog.flavor === mainMetadataName) {
+                copyMainMetadata = catalog;
+              }
+            });
+
+            // FIXME: Instead of assigning the fields from copyMetadata, it
+            //  would be cleaner to just set the values in default data.
+            //  But for whatever reason single value fields don't initially display
+            //  in the Admin UI when you do that (the values are there, they just
+            //  are not displayed).
+            // Filter superfluous fields (e.g. UID)
+            var fieldsFiltered = copyMainMetadata.fields.filter((el) => {
+              return data[mainMetadataName].fields.some((f) => {
+                return f.id === el.id;
+              });
+            });
+            // Set certain properties to their default value
+            angular.forEach(fieldsFiltered, function (fieldFiltered, i) {
+              // var fieldFiltered = fieldsFiltered[i];
+              var fieldDefault = data[mainMetadataName].fields.find(field => {
+                return field.id === fieldFiltered.id;
+              });
+              fieldsFiltered[i].readOnly = fieldDefault.readOnly;
+            });
+            // Overwrite defaults with the new fields
+            data[mainMetadataName].fields = fieldsFiltered;
+
+            me.setupRequiredMetadata(data);
+          });
+        }
+      };
+
+      // As soon as the required metadata fields arrive from the backend,
+      // we check which are mandatory.
+      // This information will be needed in ordert to tell if we can move
+      // on to the next page of the wizard.
+      this.setupRequiredMetadata = function(data) {
+        var mainData = data[mainMetadataName];
+        // we go for the regular dublincore metadata here
+        me.ud[mainMetadataName] = mainData;
+        if (mainData && mainData.fields) {
+          for (i = 0; i < mainData.fields.length; i++) {
+            var field = mainData.fields[i];
+            // preserve default value, if set
+            if (Object.prototype.hasOwnProperty.call(field, 'value') && field.value) {
+              field.presentableValue = me.extractPresentableValue(field);
+              me.ud[mainMetadataName].fields[i] = field;
+            }
+            // just hooking the tab index up here, as this is already running through all elements
+            field.tabindex = i + 1;
+            if (field.required) {
+              me.updateRequiredMetadata(field.id, field.value);
+              if (field.type === 'boolean') {
+                // set all boolean fields to false by default
+                field.value = false;
+                me.requiredMetadata[field.id] = true;
+              }
             }
           }
         }
-      }
-    };
+      };
 
-    this.metadata = NewEventMetadataResource.get(this.findRequiredMetadata);
+      this.metadata = NewEventMetadataResource.get(this.findRequiredMetadata);
 
-    // Checks if the current state of this wizard is valid and we are
-    // ready to move on.
-    this.isValid = function () {
-      var result = true;
-      //FIXME: The angular validation should rather be used,
-      // unfortunately it didn't work in this context.
-      angular.forEach(me.requiredMetadata, function (item) {
-        if (item === false) {
-          result = false;
-        }
-      });
-      return result;
-    };
-
-    this.extractPresentableValue = function (field) {
-      var presentableValue = '';
-      if (field.value !== undefined && field.value !== '' && field.value !== null) {
-        if (angular.isArray(field.value)) {
-          presentableValue = field.value.join(', ');
-        } else if (field.collection) {
-          // We need to lookup the presentable value in the collection
-          if (Object.prototype.hasOwnProperty.call(field.collection, field.value)) {
-            presentableValue = field.collection[field.value];
-          } else {
-            // This should work in older browsers, albeit looking clumsy
-            var matchingKey = Object.keys(field.collection)
-              .filter(function(key) {return field.collection[key] === field.value;})[0];
-            presentableValue = field.type === 'ordered_text'
-              ? JSON.parse(matchingKey)['label']
-              : matchingKey;
+      // Checks if the current state of this wizard is valid and we are
+      // ready to move on.
+      this.isValid = function () {
+        var result = true;
+        //FIXME: The angular validation should rather be used,
+        // unfortunately it didn't work in this context.
+        angular.forEach(me.requiredMetadata, function (item) {
+          if (item === false) {
+            result = false;
           }
-        } else {
-          presentableValue = field.value;
+        });
+        return result;
+      };
+
+      this.extractPresentableValue = function (field) {
+        var presentableValue = '';
+        if (field.value !== undefined && field.value !== '' && field.value !== null) {
+          if (angular.isArray(field.value)) {
+            presentableValue = field.value.join(', ');
+          } else if (field.collection) {
+            // We need to lookup the presentable value in the collection
+            if (Object.prototype.hasOwnProperty.call(field.collection, field.value)) {
+              presentableValue = field.collection[field.value];
+            } else {
+              // This should work in older browsers, albeit looking clumsy
+              var matchingKey = Object.keys(field.collection)
+                .filter(function(key) {return field.collection[key] === field.value;})[0];
+              presentableValue = field.type === 'ordered_text'
+                ? JSON.parse(matchingKey)['label']
+                : matchingKey;
+            }
+          } else {
+            presentableValue = field.value;
+          }
         }
-      }
-      return presentableValue;
+        return presentableValue;
+      };
+
+      this.save = function (scope) {
+        //FIXME: This should be nicer, rather propagate the id and values instead of looking for them
+        // in the parent scope.
+        var field = scope.$parent.params;
+        field.presentableValue = me.extractPresentableValue(field);
+
+        if (angular.isDefined(me.requiredMetadata[field.id])) {
+          me.updateRequiredMetadata(field.id, field.value);
+        }
+
+        me.ud[mainMetadataName].fields[field.tabindex - 1] = field;
+      };
+
+      this.reset = function () {
+        me.ud = {};
+        me.metadata = NewEventMetadataResource.get(this.findRequiredMetadata);
+      };
+
+      this.getUserEntries = function () {
+        if (angular.isDefined(me.ud[mainMetadataName])) {
+          return me.ud[mainMetadataName].fields;
+        } else {
+          return {};
+        }
+      };
     };
 
-    this.save = function (scope) {
-      //FIXME: This should be nicer, rather propagate the id and values instead of looking for them in the parent scope.
-      var field = scope.$parent.params;
-      field.presentableValue = me.extractPresentableValue(field);
-
-      if (angular.isDefined(me.requiredMetadata[field.id])) {
-        me.updateRequiredMetadata(field.id, field.value);
-      }
-
-      me.ud[mainMetadataName].fields[field.tabindex - 1] = field;
-    };
-
-    this.reset = function () {
-      me.ud = {};
-      me.metadata = NewEventMetadataResource.get(this.findRequiredMetadata);
-    };
-
-    this.getUserEntries = function () {
-      if (angular.isDefined(me.ud[mainMetadataName])) {
-        return me.ud[mainMetadataName].fields;
-      } else {
-        return {};
-      }
-    };
-  };
-
-  return new Metadata();
-}]);
+    return new Metadata();
+  }]);

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -638,7 +638,8 @@
            "EDITOR_NEEDS_CUTTING": "Open video Editor (a comment indicates that cutting the video has been requested)",
            "COMMENTS": "View comments",
            "PAUSED_WORKFLOW": "View paused workflow",
-           "PRESENTER": "Filter for this presenter"
+           "PRESENTER": "Filter for this presenter",
+           "COPY_TO_NEW_EVENT": "Copy metadata to new event"
          }
        },
        "STATUS": {


### PR DESCRIPTION
Adds a new button to the action column of the events table in the Admin UI. The button opens the "Create new event" modal and fills in information from the already existing event that is associated with the button. Fills in metadata, extended metadata and scheduling information.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
