### PR TITLE
Split url parameter on first equal sign

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/ui/auth.html
+++ b/modules/engage-paella-player/src/main/paella-opencast/ui/auth.html
@@ -12,7 +12,7 @@
 
 			var search = {};
 			window.location.search.slice(1).split("&").forEach(function (x) {
-				var p = x.split("=");
+				var p = x.split(/=(.*)/);
 				search[p[0]] = p[1];
 			});
 


### PR DESCRIPTION
The parameter parser only worked if all special characters that are significant in an URL were escaped.

It was failing on URLs such as:
https://example.org/paella/ui/auth.html?redirect=https://example.org/paella/ui/watch.html?id=Changed-the-Way-You-Kiss-Me

Resulting in a redirect to https://example.org/paella/ui/watch.html?id

Steps to reproduce:

- Working: https://stable.opencast.org/paella/ui/auth.html?redirect=https%3A%2F%2Fstable.opencast.org%2Fpaella%2Fui%2Fwatch.html%3Fid%3DID-westerberg
- Broken: https://stable.opencast.org/paella/ui/auth.html?redirect=https://stable.opencast.org/paella/ui/watch.html?id=ID-westerberg

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
