### PR TITLE
Add authentication entry point with redirect query parameter support

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -486,6 +486,13 @@
     <property name="loginFormUrl" value="/admin-ng/login.html" />
   </bean>
 
+  <!-- Redirect unauthenticated requests to custom login url with configurable redirect query parameter
+       Example: http://localhost/Shibboleth.sso/Login?target=<RELATIVE_REQUEST_URL> -->
+  <!--bean id="userEntryPoint" class="org.opencastproject.kernel.security.RedirectQueryParamAuthenticationEntryPoint">
+    <constructor-arg index="0" value="/Shibboleth.sso/Login" />
+    <constructor-arg index="1" value="target" />
+  </bean-->
+
   <!-- Returns a 401 request for authentication via digest auth -->
   <bean id="digestEntryPoint" class="org.springframework.security.web.authentication.www.DigestAuthenticationEntryPoint">
     <property name="realmName" value="Opencast" />

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/RedirectQueryParamAuthenticationEntryPoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/RedirectQueryParamAuthenticationEntryPoint.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.kernel.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.util.UrlUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.UriBuilder;
+
+/**
+ * An {@link AuthenticationEntryPoint} that redirects to a configured login URL with a specified return query parameter.
+ */
+public class RedirectQueryParamAuthenticationEntryPoint extends LoginUrlAuthenticationEntryPoint {
+
+  private String loginQueryParam;
+
+  public RedirectQueryParamAuthenticationEntryPoint(String loginFormUrl, String loginQueryParam) {
+    super(loginFormUrl);
+    if (loginQueryParam == null) {
+      throw new IllegalArgumentException("loginQueryParam cannot be null");
+    }
+    this.loginQueryParam = loginQueryParam;
+  }
+
+  @Override
+  protected String determineUrlToUseForThisRequest(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) {
+    return UriBuilder.fromPath(super.determineUrlToUseForThisRequest(request, response, exception))
+        .queryParam(loginQueryParam, UrlUtils.buildRequestUrl(request))
+        .build()
+        .toString();
+  }
+
+}


### PR DESCRIPTION
The idea behind this authentication entry point is to build the return URL when the access is denied by spring instead of relying on data saved in cookies or sessions, which only works under certain circumstances.

A usage example is using SAML2. You do not have to configure the URLs which are only allowed to access with a session and force the user to log in. Instead, you can rely on the spring security settings and spring to redirect the user to the login if they do not have a session.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
