### PR TITLE
Adds the bibliographic presenter filter back to the Admin UI

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/resources/list/query/EventListQuery.java
@@ -90,6 +90,7 @@ public class EventListQuery extends ResourceListQueryImpl {
   public EventListQuery() {
     super();
     this.availableFilters.add(createSeriesFilter(Option.none()));
+    this.availableFilters.add(createPresentersFilter(Option.none()));
     this.availableFilters.add(createLocationFilter(Option.none()));
     this.availableFilters.add(createAgentFilter(Option.none()));
     this.availableFilters.add(createStartDateFilter(Option.none()));


### PR DESCRIPTION
Resolves (the very detailed and nicely written) issue #3768.

Does what is described in the title.

@KatrinIhler, you removed the presenter filter (among others) some months ago for performance reasons I think. Would you be opposed to adding it back in? I'd argue that it makes sense to have it, since it's effectively still usable (by clicking on a presenter name in the events table) and it is confusing to not have the filter pop up in the filter box in that case. Or do you think it be better to remove the ability to click on presenters in the events table?