### PR TITLE
Always store ACE entries in JSON as array

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlParser.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlParser.java
@@ -223,20 +223,16 @@ public final class AccessControlParser {
     JSONObject json = new JSONObject();
     JSONObject jsonAcl = new JSONObject();
     List<AccessControlEntry> entries = acl.getEntries();
-    int numEntries = entries.size();
-    switch (numEntries) {
-      case 0:
-        break;
-      default:
-        JSONArray jsonEntryArray = new JSONArray();
-        jsonAcl.put(ACE, jsonEntryArray);
-        for (AccessControlEntry entry : entries) {
-          JSONObject jsonEntry = new JSONObject();
-          jsonEntry.put(ACTION, entry.getAction());
-          jsonEntry.put(ROLE, entry.getRole());
-          jsonEntry.put(ALLOW, entry.isAllow());
-          jsonEntryArray.add(jsonEntry);
-        }
+    if (entries.size() > 0) {
+      JSONArray jsonEntryArray = new JSONArray();
+      jsonAcl.put(ACE, jsonEntryArray);
+      for (AccessControlEntry entry : entries) {
+        JSONObject jsonEntry = new JSONObject();
+        jsonEntry.put(ACTION, entry.getAction());
+        jsonEntry.put(ROLE, entry.getRole());
+        jsonEntry.put(ALLOW, entry.isAllow());
+        jsonEntryArray.add(jsonEntry);
+      }
     }
     json.put(ACL, jsonAcl);
     return json.toJSONString();

--- a/modules/common/src/main/java/org/opencastproject/security/api/AccessControlParser.java
+++ b/modules/common/src/main/java/org/opencastproject/security/api/AccessControlParser.java
@@ -227,14 +227,6 @@ public final class AccessControlParser {
     switch (numEntries) {
       case 0:
         break;
-      case 1:
-        AccessControlEntry singleEntry = entries.get(0);
-        JSONObject singleJsonEntry = new JSONObject();
-        jsonAcl.put(ACE, singleJsonEntry);
-        singleJsonEntry.put(ACTION, singleEntry.getAction());
-        singleJsonEntry.put(ROLE, singleEntry.getRole());
-        singleJsonEntry.put(ALLOW, singleEntry.isAllow());
-        break;
       default:
         JSONArray jsonEntryArray = new JSONArray();
         jsonAcl.put(ACE, jsonEntryArray);


### PR DESCRIPTION
Removes an (imo) unnecessary special case when storing ACLs as JSON.

Resolves #3904.

When storing ACLs as JSON, it seems much nicer to always have an array instead of having a special case for single entries. This avoids problems like in the issue mentioned above, where the frontend code is only equipped to handle arrays.