### PR TITLE
Automate the language selection in the transcription workflow of amberscript

### DIFF
--- a/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
@@ -8,6 +8,24 @@
 # Can be one of: nl, en, de, fr, da, sv, fi, no, es
 # language=en
 
+# Set to true if the transcription language should be taken from the dublincore catalog
+# If the dublincore catalog doesn't contain a language, the default process for determine
+# the language will be taken. Note, that the language field in the workflow operation
+# will be overwritten, in case the dublincore catalog has a language
+# Default=false
+#language.from.dublincore=false
+
+# Manual mapping for language codes
+# Here you can set which language spellings/codes from your system shall be
+# mapped to the corresponding amberscript language. In general the amberscript workflow
+# should figure it out by itself. Use this, if you have some special language strings and run into errors
+# You can map a language to the amberscript code with a Colon ':'
+# You can separate multiple mappings with a comma ','
+#example1=english:en
+#example2=german:de,french:fr,spanish:es
+#example3=SomeWeirdL4nguageC0de:en
+#language.code.map=
+
 # Default Job Type to use
 # You can override this within you workflow (see workflowoperationhandler amberscript-start-transcription).
 # Default: direct

--- a/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
@@ -21,9 +21,11 @@
 # should figure it out by itself. Use this, if you have some special language strings and run into errors
 # You can map a language to the amberscript code with a Colon ':'
 # You can separate multiple mappings with a comma ','
-#example1=english:en
-#example2=german:de,french:fr,spanish:es
-#example3=SomeWeirdL4nguageC0de:en
+# Examples:
+# language.code.map=english:en
+# language.code.map=german:de,french:fr,spanish:es
+# language.code.map=SomeWeirdL4nguageC0de:en
+# These are three different examples, please note that you can specify 'language.code.map' only once
 #language.code.map=
 
 # Default Job Type to use

--- a/modules/transcription-service-amberscript/pom.xml
+++ b/modules/transcription-service-amberscript/pom.xml
@@ -87,6 +87,11 @@
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-dublincore</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptLangUtil.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptLangUtil.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.transcription.amberscript;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Manages the available Amberscript languages and helps with finding the
+ * right code for a given language string.
+ */
+public final class AmberscriptLangUtil {
+
+  private static final Logger logger = LoggerFactory.getLogger(AmberscriptLangUtil.class);
+
+  /** Contains the available amberscript lang codes */
+  private List<String> availableAmberscriptLangs;
+
+  /** Contains different locale names and codes, that maps to the corresponding amberscript language */
+  private Map<String, String> langMap;
+
+  /** Singleton instance */
+  private static AmberscriptLangUtil amberscriptLangUtil;
+
+  /** Singleton method */
+  public static AmberscriptLangUtil getInstance() {
+    if (amberscriptLangUtil == null) {
+      amberscriptLangUtil = new AmberscriptLangUtil();
+    }
+    return amberscriptLangUtil;
+  }
+
+  /** Singleton constructor */
+  private AmberscriptLangUtil() {
+    populateLangMap();
+  }
+
+  /**
+   * Iterates through all available amberscript languages and finds the corresponding
+   * java locale object. After that a map will be created, that maps all possible
+   * spellings to the amberscript language code.
+   */
+  private void populateLangMap() {
+    langMap = new HashMap<>();
+    availableAmberscriptLangs = new LinkedList<>();
+    availableAmberscriptLangs.add("af-za");
+    availableAmberscriptLangs.add("sq-al");
+    availableAmberscriptLangs.add("am-et");
+    availableAmberscriptLangs.add("ar");
+    availableAmberscriptLangs.add("hy-am");
+    availableAmberscriptLangs.add("az-az");
+    availableAmberscriptLangs.add("id-id");
+    availableAmberscriptLangs.add("eu-es");
+    availableAmberscriptLangs.add("bn-bd");
+    availableAmberscriptLangs.add("bn-in");
+    availableAmberscriptLangs.add("bs-ba");
+    availableAmberscriptLangs.add("bg");
+    availableAmberscriptLangs.add("my-mm");
+    availableAmberscriptLangs.add("ca");
+    availableAmberscriptLangs.add("cmn");
+    availableAmberscriptLangs.add("hr");
+    availableAmberscriptLangs.add("cs");
+    availableAmberscriptLangs.add("da");
+    availableAmberscriptLangs.add("nl");
+    availableAmberscriptLangs.add("en-au");
+    availableAmberscriptLangs.add("en-uk");
+    availableAmberscriptLangs.add("en");
+    availableAmberscriptLangs.add("et-ee");
+    availableAmberscriptLangs.add("fa-ir");
+    availableAmberscriptLangs.add("fil-ph");
+    availableAmberscriptLangs.add("fi");
+    availableAmberscriptLangs.add("nl-be");
+    availableAmberscriptLangs.add("fr-ca");
+    availableAmberscriptLangs.add("fr");
+    availableAmberscriptLangs.add("gl-es");
+    availableAmberscriptLangs.add("ka-ge");
+    availableAmberscriptLangs.add("de-at");
+    availableAmberscriptLangs.add("de-ch");
+    availableAmberscriptLangs.add("de");
+    availableAmberscriptLangs.add("el");
+    availableAmberscriptLangs.add("gu-in");
+    availableAmberscriptLangs.add("iw-il");
+    availableAmberscriptLangs.add("hi");
+    availableAmberscriptLangs.add("hu");
+    availableAmberscriptLangs.add("is-is");
+    availableAmberscriptLangs.add("it");
+    availableAmberscriptLangs.add("ja");
+    availableAmberscriptLangs.add("jv-id");
+    availableAmberscriptLangs.add("kn-in");
+    availableAmberscriptLangs.add("km-kh");
+    availableAmberscriptLangs.add("ko");
+    availableAmberscriptLangs.add("lo-la");
+    availableAmberscriptLangs.add("lv");
+    availableAmberscriptLangs.add("lt");
+    availableAmberscriptLangs.add("mk-mk");
+    availableAmberscriptLangs.add("ms");
+    availableAmberscriptLangs.add("ml-in");
+    availableAmberscriptLangs.add("mr-in");
+    availableAmberscriptLangs.add("mn-mn");
+    availableAmberscriptLangs.add("ne-np");
+    availableAmberscriptLangs.add("no");
+    availableAmberscriptLangs.add("pl");
+    availableAmberscriptLangs.add("pt-br");
+    availableAmberscriptLangs.add("pt");
+    availableAmberscriptLangs.add("pa-guru-in");
+    availableAmberscriptLangs.add("ro");
+    availableAmberscriptLangs.add("ru");
+    availableAmberscriptLangs.add("sr-rs");
+    availableAmberscriptLangs.add("si-lk");
+    availableAmberscriptLangs.add("sk");
+    availableAmberscriptLangs.add("sl");
+    availableAmberscriptLangs.add("es");
+    availableAmberscriptLangs.add("su-id");
+    availableAmberscriptLangs.add("sw-ke");
+    availableAmberscriptLangs.add("sw-tz");
+    availableAmberscriptLangs.add("sv");
+    availableAmberscriptLangs.add("ta-in");
+    availableAmberscriptLangs.add("ta-my");
+    availableAmberscriptLangs.add("ta-sg");
+    availableAmberscriptLangs.add("ta-lk");
+    availableAmberscriptLangs.add("te-in");
+    availableAmberscriptLangs.add("th-th");
+    availableAmberscriptLangs.add("tr");
+    availableAmberscriptLangs.add("uk-ua");
+    availableAmberscriptLangs.add("ur-in");
+    availableAmberscriptLangs.add("ur-pk");
+    availableAmberscriptLangs.add("uz-uz");
+    availableAmberscriptLangs.add("vi-vn");
+    availableAmberscriptLangs.add("zu-za");
+
+    // it's important that we first put in the '-' languages,
+    // so the more general languages will overwrite the first ones
+    for (String amberLang : availableAmberscriptLangs)  {
+      if (amberLang.contains("-")) {
+        addAmberLangToMap(amberLang);
+      }
+    }
+    for (String amberLang : availableAmberscriptLangs)  {
+      if (!amberLang.contains("-")) {
+        addAmberLangToMap(amberLang);
+      }
+    }
+  }
+
+  /**
+   * Puts some different spellings of the java Local class into a map, with
+   * the corresponding Amberscript language code.
+   * @param amberLang the amberscript language code
+   */
+  private void addAmberLangToMap(String amberLang) {
+    Locale locale;
+    if (amberLang.contains("-")) {
+      locale = Locale.forLanguageTag(amberLang);
+    } else {
+      locale = Locale.forLanguageTag(amberLang + "-" + amberLang);
+    }
+    if (locale.getDisplayCountry().equals("")) {
+      logger.warn("Didn't found locale for code '{}'", amberLang);
+      return;
+    }
+    langMap.put(amberLang, amberLang);
+    langMap.put(locale.toString().toLowerCase(), amberLang);
+    langMap.put(locale.getDisplayLanguage().toLowerCase(), amberLang);
+    langMap.put(locale.getDisplayName().toLowerCase(), amberLang);
+    langMap.put(locale.getLanguage().toLowerCase(), amberLang);
+    langMap.put(locale.getISO3Language().toLowerCase(), amberLang);
+  }
+
+  /**
+   * Tries to determine which amberscript language code should be taken for a
+   * given language name or code.
+   * @return the amberscript language code or null if nothing was found.
+   */
+  public String getLanguageCodeOrNull(String languageWithRandomFormat) {
+    return langMap.get(languageWithRandomFormat.toLowerCase());
+  }
+
+  /**
+   * Adds a custom mapping entry. Can be configured in the amberscript config file.
+   * @param customKey The key
+   * @param amberscriptLangCode Amberscript Language Code
+   */
+  public void addCustomMapping(String customKey, String amberscriptLangCode) {
+    langMap.put(customKey, amberscriptLangCode);
+  }
+}

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptLangUtil.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptLangUtil.java
@@ -179,7 +179,7 @@ public final class AmberscriptLangUtil {
       locale = Locale.forLanguageTag(amberLang + "-" + amberLang);
     }
     if (locale.getDisplayCountry().equals("")) {
-      logger.warn("Didn't found locale for code '{}'", amberLang);
+      logger.warn("Locale not found for code '{}'", amberLang);
       return;
     }
     langMap.put(amberLang, amberLang);

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -270,10 +270,10 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
       try {
         languageFromDublinCore = Boolean.parseBoolean(languageFromDublinCoreOpt.get());
       } catch (Exception e) {
-        logger.warn("Configured '{}' is invalid. Set to 'false'.", LANGUAGE_FROM_DUBLINCORE);
+        logger.warn("Configuration value for '{}' is invalid, defaulting to false.", LANGUAGE_FROM_DUBLINCORE);
       }
     }
-    logger.info("Configuration '{}' set to '{}'.", LANGUAGE_FROM_DUBLINCORE, languageFromDublinCore);
+    logger.info("Configuration value for '{}' is set to '{}'.", LANGUAGE_FROM_DUBLINCORE, languageFromDublinCore);
 
     amberscriptLangUtil = AmberscriptLangUtil.getInstance();
     int customMapEntriesCount = 0;
@@ -324,14 +324,14 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
 
     if (languageFromDublinCore) {
       for (Catalog catalog : track.getMediaPackage().getCatalogs(MediaPackageElements.EPISODE)) {
-        if (language != null) {
-          break;
-        }
         try (InputStream in = workspace.read(catalog.getURI())) {
           DublinCoreCatalog dublinCatalog = DublinCores.read(in);
           String dublinCoreLang = dublinCatalog.getFirst(DublinCore.PROPERTY_LANGUAGE);
           if (dublinCoreLang != null) {
             language = amberscriptLangUtil.getLanguageCodeOrNull(dublinCoreLang);
+          }
+          if (language != null) {
+            break;
           }
         } catch (IOException | NotFoundException e) {
           logger.error(String.format("Unable to load dublin core catalog for event '%s'",

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -28,13 +28,18 @@ import org.opencastproject.assetmanager.util.Workflows;
 import org.opencastproject.job.api.AbstractJobProducer;
 import org.opencastproject.job.api.Job;
 import org.opencastproject.mediapackage.Attachment;
+import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageElementBuilder;
 import org.opencastproject.mediapackage.MediaPackageElementBuilderFactory;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
+import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.mediapackage.MediaPackageException;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.metadata.dublincore.DublinCore;
+import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
+import org.opencastproject.metadata.dublincore.DublinCores;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.OrganizationDirectoryService;
@@ -50,6 +55,7 @@ import org.opencastproject.transcription.persistence.TranscriptionDatabase;
 import org.opencastproject.transcription.persistence.TranscriptionDatabaseException;
 import org.opencastproject.transcription.persistence.TranscriptionJobControl;
 import org.opencastproject.transcription.persistence.TranscriptionProviderControl;
+import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.PathSupport;
 import org.opencastproject.util.data.Option;
@@ -86,6 +92,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Date;
@@ -154,6 +161,8 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
   private static final String DISPATCH_WORKFLOW_INTERVAL_CONFIG = "workflow.dispatch.interval";
   private static final String MAX_PROCESSING_TIME_CONFIG = "max.overdue.time";
   private static final String CLEANUP_RESULTS_DAYS_CONFIG = "cleanup.results.days";
+  private static final String LANGUAGE_FROM_DUBLINCORE = "language.from.dublincore";
+  private static final String LANGUAGE_CODE_MAP = "language.code.map";
 
   // service configuration default values
   private boolean enabled = false;
@@ -164,6 +173,15 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
   private long workflowDispatchIntervalSeconds = 60;
   private long maxProcessingSeconds = 8 * 24 * 60 * 60; // maximum runtime for jobType perfect is 8 days
   private int cleanupResultDays = 7;
+
+  /**
+   * Contains mappings from several possible ways of writing a language name/code to the
+   * corresponding amberscript language code
+   */
+  private AmberscriptLangUtil amberscriptLangUtil;
+
+  /** determines if the transcription language should be taken from the dublincore */
+  private boolean languageFromDublinCore;
 
   private String systemAccount;
 
@@ -247,6 +265,35 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
     }
     logger.info("Cleanup result files after {} days.", cleanupResultDays);
 
+    Option<String> languageFromDublinCoreOpt = OsgiUtil.getOptCfg(cc.getProperties(), LANGUAGE_FROM_DUBLINCORE);
+    if (languageFromDublinCoreOpt.isSome()) {
+      try {
+        languageFromDublinCore = Boolean.parseBoolean(languageFromDublinCoreOpt.get());
+      } catch (Exception e) {
+        logger.warn("Configured '{}' is invalid. Set to 'false'.", LANGUAGE_FROM_DUBLINCORE);
+      }
+    }
+    logger.info("Configuration '{}' set to '{}'.", LANGUAGE_FROM_DUBLINCORE, languageFromDublinCore);
+
+    amberscriptLangUtil = AmberscriptLangUtil.getInstance();
+    int customMapEntriesCount = 0;
+    Option<String> langCodeMapOpt = OsgiUtil.getOptCfg(cc.getProperties(), LANGUAGE_CODE_MAP);
+    if (langCodeMapOpt.isSome()) {
+      try {
+        String langCodeMapStr = langCodeMapOpt.get();
+        if (langCodeMapStr != null) {
+          for (String mapping : langCodeMapStr.split(",")) {
+            String[] mapEntries = mapping.split(":");
+            amberscriptLangUtil.addCustomMapping(mapEntries[0], mapEntries[1]);
+            customMapEntriesCount += 1;
+          }
+        }
+      } catch (Exception e) {
+        logger.warn("Configuration '{}' is invalid. Using just default mapping.", LANGUAGE_CODE_MAP);
+      }
+    }
+    logger.info("Language code map was set. Added '{}' additional entries.", customMapEntriesCount);
+
     systemAccount = OsgiUtil.getContextProperty(cc, OpencastConstants.DIGEST_USER_PROPERTY);
 
     scheduledExecutor = Executors.newScheduledThreadPool(2);
@@ -273,11 +320,32 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
 
   @Override
   public Job startTranscription(String mpId, Track track, String... args) throws TranscriptionServiceException {
-    String language;
-    if (args.length > 0 && StringUtils.isNotBlank(args[0])) {
-      language = args[0];
-    } else {
-      language = getLanguage();
+    String language = null;
+
+    if (languageFromDublinCore) {
+      for (Catalog catalog : track.getMediaPackage().getCatalogs(MediaPackageElements.EPISODE)) {
+        if (language != null) {
+          break;
+        }
+        try (InputStream in = workspace.read(catalog.getURI())) {
+          DublinCoreCatalog dublinCatalog = DublinCores.read(in);
+          String dublinCoreLang = dublinCatalog.getFirst(DublinCore.PROPERTY_LANGUAGE);
+          if (dublinCoreLang != null) {
+            language = amberscriptLangUtil.getLanguageCodeOrNull(dublinCoreLang);
+          }
+        } catch (IOException | NotFoundException e) {
+          logger.error(String.format("Unable to load dublin core catalog for event '%s'",
+              track.getMediaPackage().getIdentifier()), e);
+        }
+      }
+    }
+
+    if (language == null) {
+      if (args.length > 0 && StringUtils.isNotBlank(args[0])) {
+        language = args[0];
+      } else {
+        language = getLanguage();
+      }
     }
 
     String jobType;


### PR DESCRIPTION
Adds 2 new configurations for the amberscript transcription workflow. First, you can activate this feature, so the language for the transcription will be taken from the dublincore catalog. If no language is given or the feature is deactivated, the default process will be executed. 

A new class will handle the many ways a language can be represented. It takes the different fields of the java 'Locale' class and maps them to the corresponding amberscript language code. The second configuration variable allows someone to add custom mappings. If somebody knows, what language codes they are using internally, they can add these mappings manually. The custom mappings will overwrite existing mappings in case the key already exist.