### PR TITLE
Handle tracks with multiple videos in engage player

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -125,7 +125,7 @@ class OpencastToPaellaConverter {
     var res = new Array(0,0);
     // HLS-VOD
     if (track.video instanceof Object) {
-      if (!track.master) {
+      if (track.video.resolution) {
         res = track.video.resolution.split('x');
       }
       // HLS-VOD- parse sub-video data from the adaptive "master" tagged track


### PR DESCRIPTION
We have some events that have tracks with multiple videos, and those can't be played in the engage player (since track.video.resolution is undefined). This is a small change to make this work also for non-HLS-VOD.