### PR TITLE
Fix MariaDB Database Driver

### DIFF
--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.mariadb.jdbc</groupId>
       <artifactId>mariadb-java-client</artifactId>
-      <version>3.0.4</version>
+      <version>3.0.5</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>


### PR DESCRIPTION
This updates the MariaDB Connector/J to fix a problem where getting some
data from the Opencast database, for example extended series metadata,
will currently result in a ClassCastException.

This fixes #3914

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
