### PR TITLE
Allow for more diverse exception throwing WorkflowService.start()

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/endpoint/IngestRestService.java
@@ -728,6 +728,7 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
       responses = {
           @RestResponse(description = "Ingest successful. Returns workflow instance as XML", responseCode = HttpServletResponse.SC_OK),
           @RestResponse(description = "Ingest failed due to invalid requests.", responseCode = HttpServletResponse.SC_BAD_REQUEST),
+          @RestResponse(description = "Ingest failed. A workflow is currently active on the media package", responseCode = HttpServletResponse.SC_CONFLICT),
           @RestResponse(description = "Ingest failed. Something went wrong internally. Please have a look at the log files",
               responseCode = HttpServletResponse.SC_INTERNAL_SERVER_ERROR) },
       returnDescription = "")
@@ -905,6 +906,8 @@ public class IngestRestService extends AbstractJobProducerEndpoint {
       return Response.serverError().status(Status.BAD_REQUEST).build();
     } catch (IllegalArgumentException e) {
       return badRequest(e.getMessage(), e);
+    } catch (IllegalStateException e) {
+      return Response.status(Status.CONFLICT).entity(e.getMessage()).build();
     } catch (Exception e) {
       logger.warn("Unable to add mediapackage", e);
       return Response.serverError().status(Status.INTERNAL_SERVER_ERROR).build();

--- a/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/Workflows.java
+++ b/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/Workflows.java
@@ -27,6 +27,7 @@ import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.assetmanager.api.Snapshot;
 import org.opencastproject.assetmanager.api.query.AQueryBuilder;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.workflow.api.ConfiguredWorkflow;
 import org.opencastproject.workflow.api.WorkflowDatabaseException;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -72,7 +73,7 @@ public class Workflows {
       @Override public Opt<WorkflowInstance> apply(MediaPackage mp) {
         try {
           return Opt.some(wfs.start(wf.getWorkflowDefinition(), mp, wf.getParameters()));
-        } catch (WorkflowDatabaseException | WorkflowParsingException e) {
+        } catch (WorkflowDatabaseException | WorkflowParsingException | UnauthorizedException e) {
           logger.error("Cannot start workflow on media package " + mp.getIdentifier().toString(), e);
           return Opt.none();
         }

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowService.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowService.java
@@ -103,7 +103,8 @@ public interface WorkflowService {
    *           if there is a problem parsing or serializing workflow entities
    */
   WorkflowInstance start(WorkflowDefinition workflowDefinition, MediaPackage mediaPackage,
-          Map<String, String> properties) throws WorkflowDatabaseException, WorkflowParsingException;
+          Map<String, String> properties) throws WorkflowDatabaseException, WorkflowParsingException,
+          UnauthorizedException;
 
   /**
    * Creates a new workflow instance and starts the workflow.
@@ -123,9 +124,15 @@ public interface WorkflowService {
    *           if there is a problem storing the workflow instance in persistence
    * @throws WorkflowParsingException
    *           if there is a problem parsing or serializing workflow entities
+   * @throws IllegalStateException
+   *           if there is currently a workflow active on the media package
+   * @throws UnauthorizedException
+   *           if the current user does not have {@link org.opencastproject.security.api.Permissions.Action#WRITE}
+   *           on the media package.
    */
   WorkflowInstance start(WorkflowDefinition workflowDefinition, MediaPackage mediaPackage, Long parentWorkflowId,
-          Map<String, String> properties) throws WorkflowDatabaseException, WorkflowParsingException, NotFoundException;
+          Map<String, String> properties) throws WorkflowDatabaseException, WorkflowParsingException,
+          UnauthorizedException, NotFoundException, IllegalStateException;
 
   /**
    * Creates a new workflow instance and starts the workflow.
@@ -141,7 +148,7 @@ public interface WorkflowService {
    *           if there is a problem parsing or serializing workflow entities
    */
   WorkflowInstance start(WorkflowDefinition workflowDefinition, MediaPackage mediaPackage)
-          throws WorkflowDatabaseException, WorkflowParsingException;
+          throws WorkflowDatabaseException, WorkflowParsingException, UnauthorizedException;
 
   /**
    * Gets the total number of workflows that have been created to date.
@@ -279,7 +286,7 @@ public interface WorkflowService {
    * @throws UnauthorizedException
    *           if the current user does not have read permissions on the workflow instance's mediapackage.
    */
-  void update(WorkflowInstance workflowInstance) throws WorkflowException, UnauthorizedException;
+  void update(WorkflowInstance workflowInstance) throws WorkflowDatabaseException, UnauthorizedException;
 
   /**
    * Gets the list of available workflow definitions. In order to be "available", a workflow definition must be

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/StartWorkflowWorkflowOperationHandler.java
@@ -27,6 +27,7 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import org.opencastproject.assetmanager.api.AssetManager;
 import org.opencastproject.job.api.JobContext;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowDatabaseException;
@@ -151,7 +152,7 @@ public class StartWorkflowWorkflowOperationHandler extends AbstractWorkflowOpera
         logger.info("Starting '{}' workflow for media package '{}'", configuredWorkflowDefinition,
                 mpId);
         workflowService.start(workflowDefinition, mp, properties);
-      } catch (WorkflowDatabaseException | WorkflowParsingException e) {
+      } catch (WorkflowDatabaseException | WorkflowParsingException | UnauthorizedException e) {
         if (failOnError) {
           throw new WorkflowOperationException(e);
         } else {


### PR DESCRIPTION
Resolves #2276.

Instead of catching all errors and exceptions and rethrowing them as WorkflowDatabaseExceptions, they are now simply rethrown. This allows us to give more precise return codes in i.e. the IngestService.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
