### PR TITLE
Handle process stdout and stderr

### DIFF
--- a/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
+++ b/modules/crop-ffmpeg/src/main/java/org/opencastproject/crop/impl/CropServiceImpl.java
@@ -319,8 +319,11 @@ public class CropServiceImpl extends AbstractJobProducer implements CropService,
     logger.info("Running {}", cropCommandline);
 
     try {
-      pbuilder = new ProcessBuilder(cropCommandline.split(" "));
-      Process process = pbuilder.start();
+      Process process = new ProcessBuilder(cropCommandline.split(" "))
+          .redirectError(ProcessBuilder.Redirect.DISCARD)
+          .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+          .start();
+
       //wait until the task is finished
       exitCode = process.waitFor();
     } catch (InterruptedException | IOException e) {

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
@@ -365,7 +365,10 @@ public class Ingestor implements Runnable {
       String output;
       Process process = null;
       try {
-        process = new ProcessBuilder(command).start();
+        process = new ProcessBuilder(command)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start();
+
         try (InputStream in = process.getInputStream()) {
           output = IOUtils.toString(in, StandardCharsets.UTF_8);
         }

--- a/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/FFmpegAnalyzer.java
+++ b/modules/inspection-service-ffmpeg/src/main/java/org/opencastproject/inspection/ffmpeg/FFmpegAnalyzer.java
@@ -104,9 +104,9 @@ public class FFmpegAnalyzer implements MediaAnalyzer {
     final StringBuilder sb = new StringBuilder();
     Process encoderProcess = null;
     try {
-      ProcessBuilder processBuilder = new ProcessBuilder(command);
-      processBuilder.redirectErrorStream(false);
-      encoderProcess = processBuilder.start();
+      encoderProcess = new ProcessBuilder(command)
+          .redirectError(ProcessBuilder.Redirect.DISCARD)
+          .start();
 
       // tell encoder listeners about output
       try (var in = new BufferedReader(new InputStreamReader(encoderProcess.getInputStream()))) {


### PR DESCRIPTION
If the buffer allocated for standard output/error is full,
the started process will wait forever if the buffer's content is never consumed.
On Linux-based systems, the pipe has a buffer size of 65,536 bytes.

We encountered the error in the inspect FFmpegAnalyzer step. It was caused by ffprobe which was complaining on stderr about skipping HLS tags. The m3u8 file contained enough of those tags to fill up the buffer.
`[hls @ 0x33c4900] Skip ('#EXT-X-PROGRAM-DATE-TIME:2022-07-05T17:32:43.386+0200')`

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
