### PR TITLE
Update Opencast Studio to 2022-06-15 & Update Editor to Version 2022-06-15

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-03-22/oc-editor-2022-03-22.tar.gz</editor.url>
-    <editor.sha256>7966845ad71613e8b11d499cfb8e9c8a8e67a11522e66a5c9eee414a3e780e19</editor.sha256>
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-06-15/oc-editor-2022-06-15.tar.gz</editor.url>
+    <editor.sha256>91df2c409c31cb26b58cb817596ea39709155423d52d397668fa65455024e643</editor.sha256>
   </properties>
   <build>
     <plugins>

--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2022-02-16/oc-studio-2022-02-16-integrated.tar.gz</opencast.studio.url>
-    <opencast.studio.sha256>041f018fccf3ec13ffa50befd09a0d5bf6746b306e1a483328608948dc6c2afb</opencast.studio.sha256>
+    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2022-06-15/oc-studio-2022-06-15-integrated.tar.gz</opencast.studio.url>
+    <opencast.studio.sha256>757fa190cc8a63653fdf83ec83384b26c11235aa335c481e5ae72d45f96e90a0</opencast.studio.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Update Opencast Studio to 2022-06-15 & Update Editor to Version 2022-06-15

For the full release notes of Opencast Studio, please take a look at:
https://github.com/elan-ev/opencast-studio/releases/tag/2022-06-15

Added:
- Keyboard tab navigation opencast#921

Changed:
- Improved tooltips opencast#931
- Removed useless Tooltips opencast#933
- Updated browser support table in README.md opencast#935 and opencast#936
- Make CSS use more variable to make it more customizable opencast#902
- Updated dependencies

For the full release notes of the Editor, please take a look at:
https://github.com/opencast/opencast-editor/releases/tag/2022-06-15

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
