### PR TITLE
Fail early on missing encoding profile

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/MultiEncodeWorkflowOperationHandler.java
@@ -150,9 +150,12 @@ public class MultiEncodeWorkflowOperationHandler extends AbstractWorkflowOperati
       List<String> profilelist = asList(profiles);
       for (String profile : profilelist) {
         EncodingProfile encodingprofile = composerService.getProfile(profile);
-        if (encodingprofile != null)
+        if (encodingprofile != null) {
           encodingProfiles.add(encodingprofile.getIdentifier());
-        encodingProfileList.add(encodingprofile);
+          encodingProfileList.add(encodingprofile);
+        } else {
+          throw new IllegalArgumentException("Encoding profile " + profile + " not found.");
+        }
       }
     }
 


### PR DESCRIPTION
If the encoding profile is missing on a remote node (opencast-worker), the workflow failed with a misleading exception. This PR introduces an exception and fails early instead of ignoring a missing profile and failing later.

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
