### PR TITLE
Update Editor to Version 2022-07-08

### DIFF
--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-07-08/oc-editor-2022-07-08.tar.gz</editor.url>
-    <editor.sha256>adfa288476055fbfcafeb6ca2934ce3b98ba6bb1dfb79988c3e83dcde134a751</editor.sha256>
+    <editor.url>https://github.com/opencast/opencast-editor/releases/download/2022-07-08/oc-editor-2022-07-08.tar.gz</editor.url>
+    <editor.sha256>a1309c6b08ed3c3b383f7b59f95418c20d3c0d0d89460e15aefcd8df30952038</editor.sha256>
   </properties>
   <build>
     <plugins>

--- a/modules/editor/pom.xml
+++ b/modules/editor/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-06-15/oc-editor-2022-06-15.tar.gz</editor.url>
-    <editor.sha256>91df2c409c31cb26b58cb817596ea39709155423d52d397668fa65455024e643</editor.sha256>
+    <editor.url>https://github.com/elan-ev/opencast-editor/releases/download/2022-07-08/oc-editor-2022-07-08.tar.gz</editor.url>
+    <editor.sha256>adfa288476055fbfcafeb6ca2934ce3b98ba6bb1dfb79988c3e83dcde134a751</editor.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
This updates the editor to the release 2022-07-08. For the full release notes, please take a look at:

https://github.com/opencast/opencast-editor/releases/tag/2022-07-08