### PR TITLE
Add navigation shortcuts in admin ui modals

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -218,6 +218,11 @@ prop.admin.shortcut.general.select_next_dashboard_filter=f
 prop.admin.shortcut.general.select_previous_dashboard_filter=F
 prop.admin.shortcut.general.main_menu=m
 
+# Shortcut definitions for admin UI add-event and add-series modals
+# Format: prop.admin.shortcut.add_media.<action>=<key(s)>
+prop.admin.shortcut.add_media.next_tab=alt+enter
+prop.admin.shortcut.add_media.previous_tab=alt+backspace
+
 # Default values for fields in the tab Source of the Add Event wizard
 #
 # Automatically populates fields in the tab Source of the Add Event wizard.

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/wizardDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/wizardDirective.js
@@ -22,7 +22,7 @@
 
 angular.module('adminNg.directives')
 .constant('EVENT_TAB_CHANGE', 'tab_change')
-.directive('adminNgWizard', ['EVENT_TAB_CHANGE', function (EVENT_TAB_CHANGE) {
+.directive('adminNgWizard', ['EVENT_TAB_CHANGE', 'HotkeysService', function (EVENT_TAB_CHANGE, HotkeysService) {
   function createWizard($scope) {
     var currentState = $scope.states[0], step, lookupIndex, lookupState, toTab,
         getCurrentState, getCurrentStateController, getPreviousState, getNextState,
@@ -113,14 +113,23 @@ angular.module('adminNg.directives')
       } catch (e) { }
     };
 
-    /* Will switch to the tab denoted in the data-modal-tab attribute of
+    /**
+     * Will switch to the tab denoted in the data-modal-tab attribute of
      * the anchor that was clicked.
      * Prerequisite: All previous steps of the wizard have been passed
      * successfully.
+     *
+     * @param {Event} $event event getting emitted when 'next' or 'previous' button is clicked.
+     *
+     * @param {string=} altTargetStepName (optional) 'next' or 'previous'. Needed by HotkeysService
+     *                                    because the emitted event and it's target are tied to an anchor
+     *                                    getting clicked - which does not happen when shortcuts are used.
+     *                                    Only used when $event.target.getAttribute('data-modal-tab)
+     *                                    returns 'undefined'.
      */
-    toTab = function ($event) {
+    toTab = function ($event, altTargetStepName) {
       var targetStepName, targetState;
-      targetStepName = $event.target.getAttribute('data-modal-tab');
+      targetStepName = $event.target.getAttribute('data-modal-tab') || altTargetStepName;
       if (targetStepName === 'previous') {
         targetState = getPreviousState();
       } else if (targetStepName === 'next') {
@@ -258,6 +267,19 @@ angular.module('adminNg.directives')
         }
       };
 
+      HotkeysService.activateHotkey(scope, 'add_media.next_tab', (event) => {
+        if (!scope.wizard.isLast()) {
+          scope.wizard.toTab(event, 'next');
+        } else {
+          scope.submit();
+        }
+        event.preventDefault();
+      });
+
+      HotkeysService.activateHotkey(scope, 'add_media.previous_tab', (event) => {
+        scope.wizard.toTab(event, 'previous');
+        event.preventDefault();
+      });
     }
   };
 }]);

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -2088,7 +2088,8 @@
        "GROUPS": {
            "GENERAL": "General",
            "PLAYER": "Player",
-           "EDITOR": "Editor"
+           "EDITOR": "Editor",
+           "ADD_MEDIA": "Create Event/Series"
        },
        "DESCRIPTIONS": {
            "GENERAL": {
@@ -2121,6 +2122,10 @@
                "CLEAR_LIST": "Clear segment",
                "PLAY_CURRENT_SEGMENT_WITH_PRE-ROLL": "Replay segment with pre-roll",
                "PLAY_ENDING_OF_CURRENT_SEGMENT": "End of segment"
+           },
+           "ADD_MEDIA": {
+               "NEXT_TAB": "Next tab/Create",
+               "PREVIOUS_TAB": "Previous tab"
            }
        }
    },


### PR DESCRIPTION
This adds key combinations to switch tabs in the new-event and new-series modals.

The combinations are: 
`alt + enter` for **next** or - if applicable - the **create** button,
and:
`alt + backspace` for the **previous** button.
(alt == option on macOS)

**Note**: Shortcuts will not be detected while `<input>` or `<select>` elements are focused. In most cases, you will need to press the `enter`key first. There might be a workaround/fix by adding the `mousetrap`class to those elements, but I am uncertain if this would disrupt any other functionality or if this is even an issue, so any feedback on that would be appreciated.

US translations for the hotkey cheatSheet are included and can be seen by pressing the `?`key while the modals are open.

This feature was originally requested by the ETH (closes eth-244).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
