### PR TITLE
Fix Pom Version of Azure Transcription Service

### DIFF
--- a/modules/transcription-service-microsoft-azure/pom.xml
+++ b/modules/transcription-service-microsoft-azure/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencastproject</groupId>
     <artifactId>base</artifactId>
-    <version>12-SNAPSHOT</version>
+    <version>13-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <properties>


### PR DESCRIPTION
The new Azure based transcription service got merged into `develop`
without updating the pom version which breaks the build process. This
patch fixes the issue.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
