### PR TITLE
Prevent Redirect When Going to Studio

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -49,7 +49,7 @@
         </div>
 
         <div class="nav-dd" title="Studio" with-role="ROLE_STUDIO">
-          <a href="/studio?return.label=Admin%20UI&return.target={{studioReturnUrl}}">
+          <a href="/studio/index.html?return.label=Admin%20UI&return.target={{studioReturnUrl}}">
             <span class="fa fa-video-camera"><!-- Opencast Studio --></span>
           </a>
         </div>


### PR DESCRIPTION
When clicking on the Studio icon in tha dmin interface, you go to a
location from which you will then be redirected again to yet another
place. This is completely unnecessary.

This closes #4011

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
