### PR TITLE
Faster Blend Effects on Cuts

### DIFF
--- a/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
+++ b/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
@@ -10,7 +10,7 @@ video.codec = libx264
 
 # ffmpeg general options for file quality
 # This is a temporary file, so it doesn't have to be generic, the default is ffmpeg only - lossless
-# ffmpeg.properties = -strict -2 -preset ultrafast -qp 0 -tune film
+# ffmpeg.properties = -preset ultrafast -qp 0 -tune film
 # DO NOT use filters here, it will conflict with -complex-filter in the editor
 ffmpeg.properties = -preset veryfast -crf 18 -tune film -map_metadata -1 -map_chapters -1 -sn -dn
 # preset can be: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow. Default is medium

--- a/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
+++ b/etc/org.opencastproject.videoeditor.impl.VideoEditorServiceImpl.cfg
@@ -1,8 +1,8 @@
 # The following options are used by the ffmpeg video editor
 
 # fade in/out time in seconds
-audio.fade = 2
-video.fade = 2
+audio.fade = 0.2
+video.fade = 0.2
 
 # if not specified, default codec is same as input file
 audio.codec = aac
@@ -12,7 +12,7 @@ video.codec = libx264
 # This is a temporary file, so it doesn't have to be generic, the default is ffmpeg only - lossless
 # ffmpeg.properties = -strict -2 -preset ultrafast -qp 0 -tune film
 # DO NOT use filters here, it will conflict with -complex-filter in the editor
-ffmpeg.properties = -strict -2 -preset veryfast -crf 18 -tune film -map_metadata -1 -map_chapters -1 -sn -dn
+ffmpeg.properties = -preset veryfast -crf 18 -tune film -map_metadata -1 -map_chapters -1 -sn -dn
 # preset can be: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow. Default is medium
 # faster = larger output file
 

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
@@ -53,9 +53,9 @@ public class FFmpegEdit {
   private static final String FFMPEG_BINARY_DEFAULT = "ffmpeg";
   private static final String CONFIG_FFMPEG_PATH = "org.opencastproject.composer.ffmpeg.path";
 
-  private static final String DEFAULT_FFMPEG_PROPERTIES = "-strict -2 -preset faster -crf 18";
-  private static final String DEFAULT_AUDIO_FADE = "2.0";
-  private static final String DEFAULT_VIDEO_FADE = "2.0";
+  private static final String DEFAULT_FFMPEG_PROPERTIES = "-preset faster -crf 18";
+  private static final String DEFAULT_AUDIO_FADE = "0.2";
+  private static final String DEFAULT_VIDEO_FADE = "0.2";
   private static String binary = FFMPEG_BINARY_DEFAULT;
 
   protected float vfade;


### PR DESCRIPTION
The blending effect (fading to black and back) is very slow in Opencast.
It is sometimes even hiding important information in the videos.

This patch changes the default configuration to have a much faster
fading effect for cuts from the video editor.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
