### PR TITLE
Fail on configuration error

### DIFF
--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
@@ -84,19 +84,9 @@ public class FFmpegEdit {
    */
   public FFmpegEdit(Properties properties) {
     String fade = properties.getProperty(VideoEditorProperties.AUDIO_FADE, DEFAULT_AUDIO_FADE);
-    try {
-      this.afade = Float.parseFloat(fade);
-    } catch (Exception e) {
-      logger.error("Unable to parse audio fade duration {}. Falling back to default value.", DEFAULT_AUDIO_FADE);
-      this.afade = Float.parseFloat(DEFAULT_AUDIO_FADE);
-    }
+    this.afade = Float.parseFloat(fade);
     fade = properties.getProperty(VideoEditorProperties.VIDEO_FADE, DEFAULT_VIDEO_FADE);
-    try {
-      this.vfade = Float.parseFloat(fade);
-    } catch (Exception e) {
-      logger.error("Unable to parse video fade duration {}. Falling back to default value.", DEFAULT_VIDEO_FADE);
-      this.vfade = Float.parseFloat(DEFAULT_VIDEO_FADE);
-    }
+    this.vfade = Float.parseFloat(fade);
     this.ffmpegProperties = properties.getProperty(VideoEditorProperties.FFMPEG_PROPERTIES, DEFAULT_FFMPEG_PROPERTIES);
     this.ffmpegScaleFilter = properties.getProperty(VideoEditorProperties.FFMPEG_SCALE_FILTER, null);
     this.videoCodec = properties.getProperty(VideoEditorProperties.VIDEO_CODEC, null);

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoEditorServiceImpl.java
@@ -284,7 +284,7 @@ public class VideoEditorServiceImpl extends AbstractJobProducer implements Video
       String outputResolution = "";    //TODO: fetch the largest output resolution from SMIL.head.layout.root-layout
       // When outputResolution is set to WxH, all clips are scaled to that size in the output video.
       // TODO: Each clips could have a region id, relative to the root-layout
-      // Then each clip is zoomed/panned/padded to WxH befor concatenation
+      // Then each clip is zoomed/panned/padded to WxH before concatenation
       FFmpegEdit ffmpeg = new FFmpegEdit(properties);
       error = ffmpeg.processEdits(inputfile, outputPath.getAbsolutePath(), outputResolution, cleanclips,
               sourceTrack.hasAudio(), sourceTrack.hasVideo());


### PR DESCRIPTION
This patch lets the video editor fail on configuration errors instead of
silently using a different configurations. If adopters change the
configuration, they want a specific effect and if they mess up, they
should be able to notice that right away and not only several videos are
processed and someone accidentally notices that the setting they made
aren't actually applied.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
