### PR TITLE
Remove ActiveMQ related steps from doc

### DIFF
--- a/docs/guides/admin/docs/configuration/firewall.md
+++ b/docs/guides/admin/docs/configuration/firewall.md
@@ -12,8 +12,7 @@ General rules are:
 - Users communicate with Opencast via HTTP(S)
 - Capture agents communicate with Opencast via HTTP(S)
 - Opencast nodes communicate among each other via HTTP(S)
-- Often Elasticsearch and ActiveMQ are run on the admin node since this node communicates with these services
-  exclusively
+- Often Elasticsearch runs on the admin node since this node communicates with these services exclusively
 - All servers should get access to the storage infrastructure
 - All Opencast nodes need database access
 

--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -93,7 +93,7 @@ Install Opencast
 
 For a basic installation (All-In-One) just run:
 
-    apt-get install opencast-{{ opencast_major_version() }}-allinone elasticsearch-oss activemq-dist
+    apt-get install opencast-{{ opencast_major_version() }}-allinone elasticsearch-oss
 
 This will install the default distribution of Opencast and all its dependencies, including the 3rd-Party-Tools.  Note
 that while the repository provides a packaged version of FFmpeg, your distribution may have a version which is
@@ -220,5 +220,5 @@ Troubleshooting
 ### Missing Dependencies
 
 This repository expects that the `stable` section is always available, regardless of which version of Opencast you have
-installed.  The 3rd party tools (ActiveMQ, FFmpeg) may or may not be in the other sections, but if they are there it is
+installed.  The 3rd party tools (e.g. FFmpeg) may or may not be in the other sections, but if they are there it is
 only during a testing period for a new version.  For day-to-day use, please install them from `stable`!

--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -53,7 +53,6 @@ Required:
 
 Required (not necessarily on the same machine):
 
-    ActiveMQ >= 5.10 (older versions untested)
     Elasticsearch 7.9.x
 
 Required for text extraction (recommended):

--- a/docs/guides/admin/docs/installation/source-macosx.md
+++ b/docs/guides/admin/docs/installation/source-macosx.md
@@ -59,7 +59,6 @@ Required:
 
 Required (not necessarily on the same machine):
 
-    ActiveMQ >= 5.10 (older versions untested)
     Elasticsearch 7.9.x
 
 Required for text extraction:

--- a/docs/guides/developer/docs/development-environment-docker.md
+++ b/docs/guides/developer/docs/development-environment-docker.md
@@ -6,7 +6,7 @@ because of Docker's isolation functionality, multiple environments can be operat
 
 ## Setting up a Docker build environment
 
-Two `docker-compose` files are provided to start up different development environments. You also need the ActiveMQ configuration
+Multiple `docker-compose` files are provided to start up different development environments
 (see "Testing Locally with Docker" guide in the administration documentation).
 
 

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -41,7 +41,6 @@ That is why patches may only be accepted into releases branches (`r/?.x`) if the
 
 * Patches must not modify existing database tables
 * Patches must not modify the indexes or otherwise cause re-indexing
-* Patches must not require a different ActiveMQ configuration
 * Patches must not modify existing translation keys
 * Patches must work with the same configuration within a major version
 

--- a/docs/guides/developer/docs/installation/source-linux.md
+++ b/docs/guides/developer/docs/installation/source-linux.md
@@ -77,7 +77,6 @@ Required:
 
 Required as a service for running Opencast:
 
-    ActiveMQ >= 5.10
     elasticsearch = 7.9.x
 
 Required for some services. Some tests may be skipped and some features


### PR DESCRIPTION
Since ActiveMQ is no longer needed since Opencast 12. Remove all ActiveMQ related words in the documentation.

P.S.
I also notice in `etc/workflows`, there are a lot of 
```xml
 <!-- ACLs are required again when working through ActiveMQ messages -->
```

I'm not sure these descriptions are still needed.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
