### PR TITLE
Force inject ChainingMediaPackageSerializer as MediaPackageSeriailzer

### DIFF
--- a/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
+++ b/modules/authorization-xacml/src/main/java/org/opencastproject/authorization/xacml/XACMLAuthorizationService.java
@@ -51,6 +51,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,9 +120,20 @@ public class XACMLAuthorizationService implements AuthorizationService {
     logger.debug("Merge mode set to {}", mergeMode);
   }
 
-  @Reference(cardinality = ReferenceCardinality.OPTIONAL)
+  @Reference(
+      cardinality = ReferenceCardinality.OPTIONAL,
+      policy = ReferencePolicy.DYNAMIC,
+      unbind = "unsetMediaPackageSerializer",
+      target = "(service.pid=org.opencastproject.mediapackage.ChainingMediaPackageSerializer)"
+  )
   public void setMediaPackageSerializer(MediaPackageSerializer serializer) {
     this.serializer = serializer;
+  }
+
+  protected void unsetMediaPackageSerializer(MediaPackageSerializer serializer) {
+    if (this.serializer == serializer) {
+      this.serializer = null;
+    }
   }
 
   @Override

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImpl.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/StaticMetadataServiceDublinCoreImpl.java
@@ -115,6 +115,7 @@ public class StaticMetadataServiceDublinCoreImpl implements StaticMetadataServic
   @Reference(
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
+      target = "(service.pid=org.opencastproject.mediapackage.ChainingMediaPackageSerializer)",
       unbind = "unsetMediaPackageSerializer"
   )
   public void setMediaPackageSerializer(MediaPackageSerializer serializer) {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
@@ -858,6 +858,7 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
   @Reference(
       cardinality = ReferenceCardinality.OPTIONAL,
       policy = ReferencePolicy.DYNAMIC,
+      target = "(service.pid=org.opencastproject.mediapackage.ChainingMediaPackageSerializer)",
       unbind = "unsetMediaPackageSerializer"
   )
   protected void setMediaPackageSerializer(MediaPackageSerializer serializer) {


### PR DESCRIPTION
### Background:
Recently, I try to upgrade Opencast 10 to Opencast 12 in my school, and find that the `PresignedUrlMediaPackageSerializer` cannot work properly as it was in Opencast 10. Actually, it would be invoked randomly.

### Cause:
There are three classes/components implement `org.opencastproject.mediapackage.MediaPackageSerializer` in the source:
* `org.opencastproject.distribution.aws.s3.PresignedUrlMediaPackageSerializer`
* `org.opencastproject.security.urlsigning.SigningMediaPackageSerializer`
* `org.opencastproject.mediapackage.ChainingMediaPackageSerializer`

It seems that during startup, Karaf will pick on of them randomly and inject it to any component require `MediaPackageSerializer`. 

### Solution:
This patch force `ChainingMediaPackageSerializer` be injected, and make sure that all serializers can be properly invoked.


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
