### PR TITLE
Make LtiServiceImpl read config file properly

### DIFF
--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -111,7 +111,8 @@ import java.util.stream.Collectors;
     immediate = true,
     service = { LtiService.class,ManagedService.class },
     property = {
-        "service.description=LTI Service"
+        "service.description=LTI Service",
+        "service.pid=org.opencastproject.lti.service.impl.LtiServiceImpl"
     }
 )
 public class LtiServiceImpl implements LtiService, ManagedService {


### PR DESCRIPTION
Opencast 12.x cannot properly read config from `etc/org.opencastproject.lti.service.impl.LtiServiceImpl.cfg`.

According to `LtiServiceImpl.java`, the config is expected be loaded in `updated` method. Yet, it seems the method never be invoked.

After some digging of the code, I added `service.pid` property to the `@Component` annotation and the config file can be loaded properly now. I'm not familiar with OSGi, but I guess may be there are some changes have been made to force explicitly define `service.pid` property.

This PR can make LtiServiceImpl read config file properly. But I guess there are some other components have the same problem and should be modified accordingly.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
