### PR TITLE
Add new config `list-all-jobs-in-series` to LtiServiceImpl

### DIFF
--- a/etc/org.opencastproject.lti.service.impl.LtiServiceImpl.cfg
+++ b/etc/org.opencastproject.lti.service.impl.LtiServiceImpl.cfg
@@ -5,3 +5,8 @@ workflow-configuration={"flagForCutting":"false","flagForReview":"false","publis
 # After deletion, events are retracted with this workflow
 retract-workflow-id=retract
 copy-workflow-id=copy-event-to-series
+
+# Whether list all jobs in series (include jobs created by other instructors).
+# Or, show jobs created by current user only.
+# default: false
+#list-all-jobs-in-series=false

--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -133,6 +133,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
   private String retractWorkflowId;
   private String copyWorkflowId;
   private final List<EventCatalogUIAdapter> catalogUIAdapters = new ArrayList<>();
+  private boolean listAllJobsInSeries;
 
   /** OSGi DI */
   @Reference
@@ -242,7 +243,10 @@ public class LtiServiceImpl implements LtiService, ManagedService {
   public List<LtiJob> listJobs(String seriesId) {
     final User user = securityService.getUser();
     final EventSearchQuery query = new EventSearchQuery(securityService.getOrganization().getId(), user)
-            .withCreator(user.getName()).withSeriesId(StringUtils.trimToNull(seriesId));
+            .withSeriesId(StringUtils.trimToNull(seriesId));
+    if (!listAllJobsInSeries) {
+      query.withCreator(user.getName());
+    }
     try {
       SearchResult<Event> results = this.searchIndex.getByQuery(query);
       ZonedDateTime startOfDay = ZonedDateTime.now().truncatedTo(ChronoUnit.DAYS);
@@ -561,5 +565,7 @@ public class LtiServiceImpl implements LtiService, ManagedService {
     } catch (JsonSyntaxException e) {
       throw new IllegalArgumentException("Invalid JSON specified for workflow configuration");
     }
+    String listAllJobsInSeriesStr = Objects.toString(properties.get("list-all-jobs-in-series"), "false");
+    this.listAllJobsInSeries = Boolean.parseBoolean(listAllJobsInSeriesStr);
   }
 }


### PR DESCRIPTION
### Backgroud

While using LTI tool, sometimes a series is created by admin or other instructors of the same course. The logic of LTI tool only show jobs while the corresponding series is created by the current user. This is not friendly enough for some users.

### Solution

This PR add a new config `list-all-jobs-in-series` to LtiServiceImpl, which allow users view jobs which in a series created by other instructor or admin in LTI tool.

To keep the current behavior as before, this config is set to `false` by default.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
