### PR TITLE
Clarify migration script dependencies and make aware of the mysql_connector_python error

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -49,10 +49,16 @@ You can do this in a virtual Python environment if you do not want to install th
 ```sh
 python3 -m venv venv
 . ./venv/bin/activate
+
 # you might need to have a MariaDB/PostgrSQL client installed
+
+# for PostgrSQL:
 pip install psycopg2-binary
-# or for MariaDB
-pip install mysql-connector-python
+
+# or for MariaDB:
+pip install mysql_connector_python==8.0.29
+# NOTE: please don't install version 8.0.30, because the migration
+# script runs into errors with this version. Newer versions also were not tested yet.
 ```
 
 Alternatively to using `pip`, use your system's package manager, e.g.:

--- a/docs/upgrade/11_to_12/workflows_mariadb.py
+++ b/docs/upgrade/11_to_12/workflows_mariadb.py
@@ -34,14 +34,19 @@ XML_DECLARATION = "<?xml version='1.0' encoding='UTF-8'?>"
 
 # DB functions
 def create_connection(host_name, user_name, user_password, db_name):
-    connection = mysql.connector.connect(
-        host=host_name,
-        user=user_name,
-        passwd=user_password,
-        database=db_name
-    )
-    connection.row_factory = lambda cursor, row: row[0]
-    print("Connection to database successful")
+    try:
+        connection = mysql.connector.connect(
+            host=host_name,
+            user=user_name,
+            passwd=user_password,
+            database=db_name
+        )
+        connection.row_factory = lambda cursor, row: row[0]
+        print("Connection to database successful")
+    except mysql.connector.errors.ProgrammingError:
+        print("Collation error found, try to use an older version of mysql_connector_python")
+    finally:
+        quit()
     return connection
 
 

--- a/docs/upgrade/11_to_12/workflows_mariadb.py
+++ b/docs/upgrade/11_to_12/workflows_mariadb.py
@@ -1,7 +1,9 @@
 # Upgrade script for MariaDB databases
 # Requires Python3 to run
 # Required packages:
-#   $ pip install mysql-connector-python
+#   $ pip install mysql_connector_python==8.0.29
+# NOTE: Please don't install version 8.0.30 of the mysql-connector-python module,
+# because the script runs into errors. Newer versions were not tested yet.
 # Set vars to point to your database
 # Run on commandline: "python3 workflow_db_upgrade.py"
 # WARNING: THIS SCRIPT DELETES DATA. CREATE A BACKUP BEFORE RUNNING


### PR DESCRIPTION
I updated the docs, so people hopefully don't run into the weird "UTF-8" error, when executing the 11-to-12 database migration script.