### PR TITLE
Update mariadb migration script to make aware of the mysql_connector_python error

### DIFF
--- a/docs/upgrade/11_to_12/workflows_mariadb.py
+++ b/docs/upgrade/11_to_12/workflows_mariadb.py
@@ -2,6 +2,11 @@
 # Requires Python3 to run
 # Required packages:
 #   $ pip install mysql-connector-python
+# NOTE: Please don't install version 8.0.30 of the mysql-connector-python module,
+# because the script runs into errors. Install a newer version if exists or
+# install the previous version 8.0.29 (in case newer versions are still running into errors).
+# You can install a specific version like this:
+#   $ pip install mysql_connector_python==8.0.29
 # Set vars to point to your database
 # Run on commandline: "python3 workflow_db_upgrade.py"
 # WARNING: THIS SCRIPT DELETES DATA. CREATE A BACKUP BEFORE RUNNING


### PR DESCRIPTION
I updated the docs in the mariadb migration script from 11 to 12. It makes aware of the mysql_connector_python error that currently occurs, when the version 8.0.30 is used.