### PR TITLE
Target to released branches Paella 6 and 7 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,11 +34,13 @@ updates:
   directory: "/modules/engage-paella-player"
   schedule:
     interval: daily
+  target-branch: "r/11.x"
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/engage-paella-player-7"
   schedule:
     interval: daily
+  target-branch: "r/12.x"
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/admin-ui-frontend"

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -88,8 +88,8 @@ Example on how to create the Opencast 7 release branch:
         git checkout develop
         git pull <remote> develop
 
-2. Modify the Paella target branch (For Paella 6.x and 7.x), found in the dependabot configuration file (`.github/dependabot.yml`) to target the 
-   latest supported version when this version will released.
+2. Modify the Paella target branch (For Paella 6.x and 7.x), found in the dependabot configuration file `.github/dependabot.yml` to target the 
+   latest supported version when this version will released. 
 
         Example:
         - package-ecosystem: npm
@@ -108,31 +108,33 @@ Example on how to create the Opencast 7 release branch:
           target-branch: "r/13.x"
           open-pull-requests-limit: 10
 
+  make a PR then merge this change to `develop` branch.
+
 
 
         
 
-4. Make sure you did not modify any files. If you did, stash those changes:
+3. Make sure you did not modify any files. If you did, stash those changes:
 
         git status   # check for modified files
         git stash    # stash them if necessary
 
-5. Create and push the new release branch:
+4. Create and push the new release branch:
 
         git checkout -b r/7.x
         git push <remote> r/7.x
 
-6. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
+5. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
 
         git checkout develop
         mvn versions:set -DnewVersion=8-SNAPSHOT versions:commit
 
-7. Have a look at the changes. Make sure that nothing else was modified:
+6. Have a look at the changes. Make sure that nothing else was modified:
 
         git diff
         git status | grep modified: | grep -v pom.xml   # this should have no output
 
-8. If everything looks fine, commit the changes and push it to the community repository:
+7. If everything looks fine, commit the changes and push it to the community repository:
 
         git add $(git status | grep 'modified:.*pom.xml' | awk '{print $2;}')
         git commit -s -m 'Bumping pom.xml Version Numbers'

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -88,27 +88,51 @@ Example on how to create the Opencast 7 release branch:
         git checkout develop
         git pull <remote> develop
 
-2. Make sure you did not modify any files. If you did, stash those changes:
+2. Modify the Paella target branch (For Paella 6.x and 7.x), found in the dependabot configuration file (`.github/dependabot.yml`) to target the 
+   latest supported version when this version will released.
+
+        Example:
+        - package-ecosystem: npm
+          directory: "/modules/engage-paella-player-7"
+          schedule:
+          interval: daily
+          target-branch: "r/12.x"
+          open-pull-requests-limit: 10
+        
+        to
+
+        - package-ecosystem: npm
+          directory: "/modules/engage-paella-player-7"
+          schedule:
+          interval: daily
+          target-branch: "r/13.x"
+          open-pull-requests-limit: 10
+
+
+
+        
+
+4. Make sure you did not modify any files. If you did, stash those changes:
 
         git status   # check for modified files
         git stash    # stash them if necessary
 
-3. Create and push the new release branch:
+5. Create and push the new release branch:
 
         git checkout -b r/7.x
         git push <remote> r/7.x
 
-4. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
+6. That is it for the release branch. Now update the versions in `develop` in preparation for the next release:
 
         git checkout develop
         mvn versions:set -DnewVersion=8-SNAPSHOT versions:commit
 
-5. Have a look at the changes. Make sure that nothing else was modified:
+7. Have a look at the changes. Make sure that nothing else was modified:
 
         git diff
         git status | grep modified: | grep -v pom.xml   # this should have no output
 
-6. If everything looks fine, commit the changes and push it to the community repository:
+8. If everything looks fine, commit the changes and push it to the community repository:
 
         git add $(git status | grep 'modified:.*pom.xml' | awk '{print $2;}')
         git commit -s -m 'Bumping pom.xml Version Numbers'

--- a/docs/guides/developer/docs/release-manager.md
+++ b/docs/guides/developer/docs/release-manager.md
@@ -88,8 +88,8 @@ Example on how to create the Opencast 7 release branch:
         git checkout develop
         git pull <remote> develop
 
-2. Modify the Paella target branch (For Paella 6.x and 7.x), found in the dependabot configuration file `.github/dependabot.yml` to target the 
-   latest supported version when this version will released. 
+2. Modify the Paella target branch (For Paella 6.x and 7.x), found in the dependabot configuration
+   file `.github/dependabot.yml` to target the latest supported version when this version will released.
 
         Example:
         - package-ecosystem: npm
@@ -109,10 +109,6 @@ Example on how to create the Opencast 7 release branch:
           open-pull-requests-limit: 10
 
   make a PR then merge this change to `develop` branch.
-
-
-
-        
 
 3. Make sure you did not modify any files. If you did, stash those changes:
 


### PR DESCRIPTION
This commit adds the rule to target Paella 6.x and 7.x updates to the legacy and production branches instead to develop.

This will avoid any backports to supported versions

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
