### PR TITLE
Don't Fail on Missing Jobs

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CurrentJobFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CurrentJobFilter.java
@@ -23,6 +23,7 @@ package org.opencastproject.kernel.rest;
 
 import org.opencastproject.job.api.Job;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.util.NotFoundException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
@@ -121,6 +122,8 @@ public class CurrentJobFilter implements Filter {
         Job currentJob = serviceRegistry.getJob(Long.parseLong(currentJobId));
         serviceRegistry.setCurrentJob(currentJob);
       }
+    } catch (NotFoundException e) {
+      logger.debug("Unable to set non-existing current job {}: {}", currentJobId, e);
     } catch (Exception e) {
       logger.error("Unable to set the current job {}: {}", currentJobId, e);
       httpResponse.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Requesting data from Opencast may fail if the request includes a job
context. For example, if one Opencast requests data from another
Opencast. This should not happen. This patch now just does not add a
context if no such context exists.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
