### PR TITLE
Warn About Removed Workflow Endpoint

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -81,8 +81,13 @@ Opencast 12.0
 
 ### API changes
 
-- Important: The endpoint for querying workflows has been removed from the
-  External API.
+<div class=warn>
+The endpoint for querying workflows has been completely removed from the External API.
+It was conflicting with our removal of Solr.
+We tried making sure that no one was using this, but if we missed you and you desperately need it, please reach out.
+We will then see what we can reasonaably do about this.
+</div>
+
 - [[#3204](https://github.com/opencast/opencast/pull/3204)] removes the fulltext
   search query from the series endpoint and adds it to the
   [External API](https://docs.opencast.org/r/12.x/developer/#api/series-api/).


### PR DESCRIPTION
This patch makes it very clear that a part of the external API has been
removed in Opencast 12.

![Screenshot from 2022-08-05 17-09-53](https://user-images.githubusercontent.com/1008395/183107097-c8a4d37e-1a59-43f5-b309-d450262e6d5b.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
