### PR TITLE
Fallback for Event Title in Publication

### DIFF
--- a/modules/distribution-workflowoperation/pom.xml
+++ b/modules/distribution-workflowoperation/pom.xml
@@ -53,6 +53,16 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-dublincore</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-workspace-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
     </dependency>


### PR DESCRIPTION
The engage publication workflow operation will check in the media
package if a title is set, failing if it is not. This is true, even if
the event has a title set in its main metadata catalog.

The reason for this is that metadata are duplicated at some places and
are not kept in sync properly.

This patch mitigates the issue by looking up the title in the Dublin
Core catalog during publication if non is set in the media package, thus
avoiding a critical failure in this operation.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
