### PR TITLE
Use bulk inserts for series index rebuild

### DIFF
--- a/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
+++ b/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
@@ -42,6 +42,8 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetRequest;
@@ -282,6 +284,57 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
     } while (indexResponse == null);
 
     return indexResponse;
+  }
+
+  /**
+   * Posts the input document to the search index.
+   *
+   * @param maxRetryAttempts
+   *          How often to retry update in case of ElasticsearchStatusException
+   * @param retryWaitingPeriod
+   *          How long to wait (in ms) between retries
+   * @param documents
+   *          The Elasticsearch documents
+   * @return the query response
+   *
+   * @throws IOException
+   *         If updating the index fails
+   * @throws InterruptedException
+   *         If waiting during retry is interrupted
+   */
+  protected BulkResponse bundleUpdate(int maxRetryAttempts, int retryWaitingPeriod,
+      List<ElasticsearchDocument> documents)
+          throws IOException, InterruptedException {
+    BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+    for (ElasticsearchDocument document: documents) {
+      bulkRequest.add(new IndexRequest(getSubIndexIdentifier(document.getType())).id(document.getUID())
+          .source(document));
+    }
+
+    BulkResponse bulkResponse = null;
+    int retryAttempts = 0;
+    do {
+      try {
+        bulkResponse = client.bulk(bulkRequest, RequestOptions.DEFAULT);
+      } catch (ElasticsearchStatusException e) {
+        retryAttempts++;
+
+        if (retryAttempts <= maxRetryAttempts) {
+          logger.warn("Could not update documents in index {} because of {}, retrying in {} ms.", getIndexName(),
+                  e.getMessage(), retryWaitingPeriod);
+          if (retryWaitingPeriod > 0) {
+            Thread.sleep(retryWaitingPeriod);
+          }
+        } else {
+          logger.error("Could not update documents in index {} because of {}, not retrying.", getIndexName(),
+                  e.getMessage());
+          throw e;
+        }
+      }
+    } while (bulkResponse == null);
+
+    return bulkResponse;
   }
 
   /**

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -504,53 +504,75 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     try {
       List<SeriesEntity> databaseSeries = persistence.getAllSeries();
       final int total = databaseSeries.size();
-      int current = 1;
       logIndexRebuildBegin(logger, index.getIndexName(), total, "series");
+      if (total > 0) {
+        String lastOrg = databaseSeries.get(0).getOrganization();
+        int current = 0;
+        int n = 16;
+        while (current < total) {
+          List<SeriesEntity> seriesBundle = new ArrayList<>();
+          for (int i = 0; i < n; i++) {
+            if (current + i >= total) {
+              break;
+            }
+            String currentOrg = databaseSeries.get(current + i).getOrganization();
+            if (currentOrg.equals(lastOrg)) {
+              seriesBundle.add(databaseSeries.get(current + i));
+            } else {
+              lastOrg = currentOrg;
+              break;
+            }
+          }
+          current += seriesBundle.size();
 
-      for (SeriesEntity series: databaseSeries) {
-        Organization organization = orgDirectory.getOrganization(series.getOrganization());
-        User systemUser = SecurityUtil.createSystemUser(systemUserName, organization);
-        SecurityUtil.runAs(securityService, organization, systemUser,
-                () -> {
-                  String seriesId = series.getSeriesId();
-                  logger.trace("Adding series {} for organization {} to the {} index.", seriesId,
-                          series.getOrganization(), index.getIndexName());
-                  List<Function<Optional<Series>, Optional<Series>>> updateFunctions = new ArrayList<>();
+          Organization organization = orgDirectory.getOrganization(seriesBundle.get(0).getOrganization());
+          User systemUser = SecurityUtil.createSystemUser(systemUserName, organization);
+          SecurityUtil.runAs(securityService, organization, systemUser,
+                  () -> {
+                    List<String> seriesIds = new ArrayList<>();
+                    List<Function<Optional<Series>, Optional<Series>>[]> updateFunctionBundle = new ArrayList<>();
+                    for (SeriesEntity series: seriesBundle) {
+                      String seriesId = series.getSeriesId();
+                      seriesIds.add(seriesId);
+                      logger.trace("Adding series {} for organization {} to the {} index.", seriesId,
+                              series.getOrganization(), index.getIndexName());
+                      List<Function<Optional<Series>, Optional<Series>>> updateFunctions = new ArrayList<>();
+                      DublinCoreCatalog catalog;
+                      try {
+                        catalog = DublinCoreXmlFormat.read(series.getDublinCoreXML());
+                        updateFunctions.add(getMetadataUpdateFunction(seriesId, catalog, organization.getId()));
+                      } catch (IOException | ParserConfigurationException | SAXException e) {
+                        logger.error("Could not read dublincore XML of series {}.", seriesId, e);
+                        return;
+                      }
 
-                  DublinCoreCatalog catalog;
-                  try {
-                    catalog = DublinCoreXmlFormat.read(series.getDublinCoreXML());
-                    updateFunctions.add(getMetadataUpdateFunction(seriesId, catalog, organization.getId()));
-                  } catch (IOException | ParserConfigurationException | SAXException e) {
-                    logger.error("Could not read dublincore XML of series {}.", seriesId, e);
-                    return;
-                  }
+                      String aclStr = series.getAccessControl();
+                      if (StringUtils.isNotBlank(aclStr)) {
+                        try {
+                          AccessControlList acl = AccessControlParser.parseAcl(aclStr);
+                          updateFunctions.add(getAclUpdateFunction(seriesId, acl, organization.getId()));
+                        } catch (Exception ex) {
+                          logger.error("Unable to parse ACL of series {}.", seriesId, ex);
+                        }
+                      }
 
-                  String aclStr = series.getAccessControl();
-                  if (StringUtils.isNotBlank(aclStr)) {
-                    try {
-                      AccessControlList acl = AccessControlParser.parseAcl(aclStr);
-                      updateFunctions.add(getAclUpdateFunction(seriesId, acl, organization.getId()));
-                    } catch (Exception ex) {
-                      logger.error("Unable to parse ACL of series {}.", seriesId, ex);
+                      try {
+                        Map<String, String> properties = persistence.getSeriesProperties(seriesId);
+                        updateFunctions.add(getThemePropertyUpdateFunction(seriesId,
+                                Optional.ofNullable(properties.get(THEME_PROPERTY_NAME)), organization.getId()));
+                      } catch (NotFoundException | SeriesServiceDatabaseException e) {
+                        logger.error("Error reading properties of series {}", seriesId, e);
+                      }
+                      updateFunctionBundle.add(updateFunctions.toArray(new Function[0]));
                     }
-                  }
 
-                  try {
-                    Map<String, String> properties = persistence.getSeriesProperties(seriesId);
-                    updateFunctions.add(getThemePropertyUpdateFunction(seriesId,
-                            Optional.ofNullable(properties.get(THEME_PROPERTY_NAME)), organization.getId()));
-                  } catch (NotFoundException | SeriesServiceDatabaseException e) {
-                    logger.error("Error reading properties of series {}", seriesId, e);
-                  }
+                    // do the actual index update
+                    updateSeriesBundleInIndex(seriesIds, organization.getId(),
+                            updateFunctionBundle);
 
-                  // do the actual index update
-                  updateSeriesInIndex(seriesId, organization.getId(),
-                          updateFunctions.toArray(new Function[0]));
-
-                });
-        logIndexRebuildProgress(logger, index.getIndexName(), total, current);
-        current++;
+                  });
+          logIndexRebuildProgress(logger, index.getIndexName(), total, current);
+        }
       }
     } catch (Exception e) {
       logIndexRebuildError(logger, index.getIndexName(), e);
@@ -763,6 +785,42 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     } catch (SearchIndexException e) {
       logger.error("Series {} couldn't be updated in the {} index.", seriesId, index.getIndexName(), e);
       return Optional.empty();
+    }
+  }
+
+  /**
+   * Update a bundle of series in an API index.
+   *
+   * @param seriesIds
+   *          The series ids
+   * @param updateFunctionBundle
+   *          The functions to do the actual updating
+   * @param orgId
+   *          The id of the current organization
+   * @return the updated series (optional)
+   */
+  private  List<Optional<Series>> updateSeriesBundleInIndex(List<String> seriesIds, String orgId,
+          List<Function<Optional<Series>, Optional<Series>>[]> updateFunctionBundle) {
+    User user = securityService.getUser();
+    List<Function<Optional<Series>, Optional<Series>>> updateFunctions = new ArrayList<>();
+
+    for (int i = 0; i < seriesIds.size(); i++) {
+      Function<Optional<Series>, Optional<Series>> updateFunction =
+              Arrays.stream(updateFunctionBundle.get(i)).reduce(Function.identity(), Function::andThen);
+      updateFunctions.add(updateFunction);
+    }
+
+    try {
+      List<Optional<Series>> seriesOptBundle = index.addOrUpdateSeriesBundle(seriesIds, updateFunctions, orgId, user);
+      for (String seriesId: seriesIds) {
+        logger.debug("Series {} updated in the {} index", seriesId, index.getIndexName());
+      }
+      return seriesOptBundle;
+    } catch (SearchIndexException e) {
+      for (String seriesId: seriesIds) {
+        logger.error("Series {} couldn't be updated in the {} index.", seriesId, index.getIndexName(), e);
+      }
+      return new ArrayList<>();
     }
   }
 }


### PR DESCRIPTION
Instead of rebuilding the series index entries with single index requests, now a configurable number of index request are summarized to a bulk request.
Therefor the repopulate function of the series service groups multiple series objects to a list now and new bundle update functions have been added to the series and the elastic search services.