### PR TITLE
Make deletion of live publication in case of capture errors configurable r/12.x

### DIFF
--- a/etc/org.opencastproject.liveschedule.message.SchedulerUpdateHandler.cfg
+++ b/etc/org.opencastproject.liveschedule.message.SchedulerUpdateHandler.cfg
@@ -1,0 +1,9 @@
+##############################################################################
+# Liveschedule Update Handler Configuration
+##############################################################################
+
+# This config option can be used to disable the deletion of live events when
+# the capturing has failed.
+#
+# Default: true
+#live.deleteOnCapureError = true


### PR DESCRIPTION
r/12.x version of #3681 

From the original pr:
Port of to the community edition.
This PR makes the deletion of a live publication in case of a capture error configurable.
