### PR TITLE
Add thumbnail support to new editor backend

### DIFF
--- a/etc/org.opencastproject.editor.EditorServiceImpl.cfg
+++ b/etc/org.opencastproject.editor.EditorServiceImpl.cfg
@@ -49,3 +49,18 @@
 # If this property is true then signed URLs for editing / previewing, such as videos accessed by the preview or editor
 # player will be limited to the IP address of the client making the original request.
 # url.signing.use.client.ip=true
+
+# The subtype of thumbnail images. Should match the subtype you are using in your workflows.
+# thumbnail.subtype=player+preview
+
+# If thumbnails are added from the editor, a workflow property will be set
+# The workflow property will look like "flavor.type/thumbnail.workflow.property"
+# thumbnail.workflow.property=thumbnail_edited
+
+# In Opencast workflows, one track is often used as the primary flavor for thumbnail generations, while other
+# tracks/flavors are used as fallbacks. Here you can specify a priority list to tell the editor frontend which
+# flavors are most important. The first flavor in the list will be the primary flavor, the second the secondary flavor
+# and so forth.
+# Flavors need to be fully qualified, separated by comma.
+# Example: thumbnail.priority.flavor=presenter/preview,presentation/preview
+#thumbnail.priority.flavor=

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/TrackData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/TrackData.java
@@ -37,6 +37,8 @@ public final class TrackData {
   private final MediaPackageElementFlavor flavor;
   private final String uri;
   private final String id;
+  private final String thumbnailUri;
+  private final int thumbnailPriority;
 
   public MediaPackageElementFlavor getFlavor() {
     if (flavor == null) {
@@ -46,12 +48,14 @@ public final class TrackData {
   }
 
   public TrackData(final String flavorType, final String flavorSubtype, final TrackSubData audio,
-          final TrackSubData video, String uri, String id) {
+          final TrackSubData video, String uri, String id, String thumbnailUri, int thumbnailPriority) {
     this.flavor = new MediaPackageElementFlavor(flavorType, flavorSubtype);
     this.audio = audio;
     this.video = video;
     this.uri = uri;
     this.id = id;
+    this.thumbnailUri = thumbnailUri;
+    this.thumbnailPriority = thumbnailPriority;
   }
 
   public TrackSubData getAudio() {
@@ -65,4 +69,7 @@ public final class TrackData {
   public String getId() {
     return this.id;
   }
+
+  public String getThumbnailURI() {
+    return this.thumbnailUri; }
 }


### PR DESCRIPTION
Modifies the editor-service to support thumbnails.

The editor service sends exisiting thumbnails to the frontend, and gets newly generated thumbnails from the frontend to save in the archive. It does not do any thumbnail generation itself.

As of now, thumbnails received from the frontend are not added to any publication (maybe they should?), just the archive. When using the thumbnail editor, Opencast workflows will need to be modified in such a way that they do not accidentally overwrite thumbnails.

Related editor PR: https://github.com/opencast/opencast-editor/pull/760

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
