### PR TITLE
Opencast 12.2 Release Notes

### DIFF
--- a/docs/guides/admin/docs/changelog.md
+++ b/docs/guides/admin/docs/changelog.md
@@ -38,8 +38,6 @@ Opencast 12
   Remove ActiveMQ related steps from doc
 - [[#4012](https://github.com/opencast/opencast/pull/4012)] -
   Prevent Redirect When Going to Studio
-- [[#4007](https://github.com/opencast/opencast/pull/4007)] -
-  Opencast 12.1 Release Notes
 - [[#4005](https://github.com/opencast/opencast/pull/4005)] -
   Allow Admins Access to Editor Interface
 - [[#4004](https://github.com/opencast/opencast/pull/4004)] -

--- a/docs/guides/admin/docs/changelog.md
+++ b/docs/guides/admin/docs/changelog.md
@@ -4,6 +4,50 @@ Changelog
 Opencast 12
 -----------
 
+### Opencast 12.2
+
+*Released on August 17th, 2022*
+
+- [[#4087](https://github.com/opencast/opencast/pull/4087)] -
+  Link the docs for the publication to workspace WOH
+- [[#4064](https://github.com/opencast/opencast/pull/4064)] -
+  Fallback for Event Title in Publication
+- [[#4063](https://github.com/opencast/opencast/pull/4063)] -
+  Warn About Removed Workflow Endpoint
+- [[#4059](https://github.com/opencast/opencast/pull/4059)] -
+  Bump mariadb-java-client from 3.0.6 to 3.0.7 in /modules/db
+- [[#4057](https://github.com/opencast/opencast/pull/4057)] -
+  Fixed OSGI annotation for OaiPmhServer
+- [[#4049](https://github.com/opencast/opencast/pull/4049)] -
+  Update Opencast Studio to 2022-08-03
+- [[#4048](https://github.com/opencast/opencast/pull/4048)] -
+  Don't Fail on Missing Jobs
+- [[#4032](https://github.com/opencast/opencast/pull/4032)] -
+  Clarify migration script dependencies and make aware of the mysql_connector_python error
+- [[#4031](https://github.com/opencast/opencast/pull/4031)] -
+  Remove ManagedService from LtiServiceImpl
+- [[#4030](https://github.com/opencast/opencast/pull/4030)] -
+  Removing remaining activemq docs
+- [[#4027](https://github.com/opencast/opencast/pull/4027)] -
+  Add new config `list-all-jobs-in-series` to LtiServiceImpl
+- [[#4025](https://github.com/opencast/opencast/pull/4025)] -
+  Update CAS docs
+- [[#4016](https://github.com/opencast/opencast/pull/4016)] -
+  Force inject ChainingMediaPackageSerializer as MediaPackageSeriailzer
+- [[#4015](https://github.com/opencast/opencast/pull/4015)] -
+  Remove ActiveMQ related steps from doc
+- [[#4012](https://github.com/opencast/opencast/pull/4012)] -
+  Prevent Redirect When Going to Studio
+- [[#4007](https://github.com/opencast/opencast/pull/4007)] -
+  Opencast 12.1 Release Notes
+- [[#4005](https://github.com/opencast/opencast/pull/4005)] -
+  Allow Admins Access to Editor Interface
+- [[#4004](https://github.com/opencast/opencast/pull/4004)] -
+  MariaDB Connector Bugfix Update
+- [[#3995](https://github.com/opencast/opencast/pull/3995)] -
+  Avoid GitHub Actions Scheduling Conflicts
+
+
 ### Opencast 12.1
 
 *Released on July 20th, 2022*

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -9,6 +9,11 @@ Notable changes:
 - New Opencast Studio version including dark mode feature
 - Fix OAI-PMH
 - Update CAS documentation
+- Bugfix update the MariaDB database driver (again)
+- Use an event title fallback from Dublin Core catalog while publishing to
+  Engage
+- Update the migration script installation instructions, which will otherwise
+  fail with newer versions of the MariaDB Python connector
 
 See [changelog](changelog.md) for a comprehensive list of changes.
 

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -1,5 +1,17 @@
 # Opencast 12: Release Notes
 
+Opencast 12.2
+-------------
+
+The second maintenance release of Opencast 12.
+Notable changes:
+
+- New Opencast Studio version including dark mode feature
+- Fix OAI-PMH
+- Update CAS documentation
+
+See [changelog](changelog.md) for a comprehensive list of changes.
+
 Opencast 12.1
 -------------
 


### PR DESCRIPTION
This patch adds the release notes for Opencast 12.2 which is to be
released on August 17, 2022.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
