### PR TITLE
Add optional key "skip-if-target-flavor-has-elements" to Image WOH

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/image-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/image-woh.md
@@ -24,7 +24,7 @@ Parameter Table
 |target-base-name-format-second|thumbnail\_%.0f%s|Used to control the target filenames for images extracted at absolute times. Mainly helpful when integrating third-party applications that prefer to use filename to distinguish individual images|
 |target-base-name-format-percent|thumbnail\_%.3f%s|Used to control the target filenames for images extracted at relative times. Mainly helpful when integrating third-party applications that prefer to use filename to distinguish individual images|
 |end-margin        |500|Safety margin at the end of the track. Sometimes, image extraction is critical at the end of the file. Using *end-margin* ensures, that no images are being extracted near the end of the video file to avoid problems with defective inputs.</br>(Default: 100)|
-|skip_if_target_flavor_has_elements|false|Does not run the operation if the target flavor already contains elements (Default: false)    |
+|skip-if-target-flavor-has-elements|false|Does not run the operation if the target flavor already contains elements (Default: false)    |
 
 Notes:
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/image-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/image-woh.md
@@ -24,6 +24,7 @@ Parameter Table
 |target-base-name-format-second|thumbnail\_%.0f%s|Used to control the target filenames for images extracted at absolute times. Mainly helpful when integrating third-party applications that prefer to use filename to distinguish individual images|
 |target-base-name-format-percent|thumbnail\_%.3f%s|Used to control the target filenames for images extracted at relative times. Mainly helpful when integrating third-party applications that prefer to use filename to distinguish individual images|
 |end-margin        |500|Safety margin at the end of the track. Sometimes, image extraction is critical at the end of the file. Using *end-margin* ensures, that no images are being extracted near the end of the video file to avoid problems with defective inputs.</br>(Default: 100)|
+|skip_if_target_flavor_has_elements|false|Does not run the operation if the target flavor already contains elements (Default: false)    |
 
 Notes:
 

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -115,7 +115,7 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
   public static final String OPT_TARGET_BASE_NAME_FORMAT_SECOND = "target-base-name-format-second";
   public static final String OPT_TARGET_BASE_NAME_FORMAT_PERCENT = "target-base-name-format-percent";
   public static final String OPT_END_MARGIN = "end-margin";
-  public static final String OPT_SKIP_IF_TARGET_FLAVOR_HAS_ELEMENTS = "skip_if_target_flavor_has_elements";
+  public static final String OPT_SKIP_IF_TARGET_FLAVOR_HAS_ELEMENTS = "skip-if-target-flavor-has-elements";
 
   private static final long END_MARGIN_DEFAULT = 100;
   public static final double SINGLE_FRAME_POS = 0.0;

--- a/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandlerTest.java
+++ b/modules/composer-workflowoperation/src/test/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandlerTest.java
@@ -30,7 +30,6 @@ import static org.opencastproject.workflow.handler.composer.ImageWorkflowOperati
 import static org.opencastproject.workflow.handler.composer.ImageWorkflowOperationHandler.validateTargetBaseNameFormat;
 
 import org.opencastproject.composer.api.EncodingProfile;
-import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.workflow.handler.composer.ImageWorkflowOperationHandler.Cfg;
 import org.opencastproject.workflow.handler.composer.ImageWorkflowOperationHandler.Extractor;
@@ -145,8 +144,8 @@ public class ImageWorkflowOperationHandlerTest {
 
   private Cfg cfg(Opt<String> targetBaseNamePatternSecond, Opt<String> targetBaseNamePatternPercent) {
     return new Cfg(l.<Track> nil(), l.<MediaPosition> nil(), l.<EncodingProfile> nil(),
-            l.<MediaPackageElementFlavor> nil(), l.<String> nil(), targetBaseNamePatternSecond,
-            targetBaseNamePatternPercent, 0);
+            null, l.<String> nil(), targetBaseNamePatternSecond,
+            targetBaseNamePatternPercent, 0, false);
   }
 
   private MediaPosition sec(double a) {


### PR DESCRIPTION
Adds an optional key to the image workflow operation handler that skips the operation if the specified target flavor contains at least one element. This can for example be useful if, for some events, you provide the images in some other form and don't want them to be overwritten by your image operation.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
