### PR TITLE
Replace DownloadDistributionService target filter with aws version

### DIFF
--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PartialRetractEngageAWSS3WorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/PartialRetractEngageAWSS3WorkflowOperationHandler.java
@@ -49,7 +49,7 @@ public class PartialRetractEngageAWSS3WorkflowOperationHandler extends PartialRe
    * @param downloadDistributionService
    *          the download distribution service
    */
-  @Reference(target = "(distribution.channel=download)")
+  @Reference(target = "(distribution.channel=aws.s3)")
   public void setDownloadDistributionService(DownloadDistributionService downloadDistributionService) {
     super.setDownloadDistributionService(downloadDistributionService);
   }


### PR DESCRIPTION
This PR changes the target service filter to the AWS.S3 version instead of the default download distribution service.

Old XML OSGi definition: https://github.com/opencast/opencast/blob/11.10/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/retract-partial-aws.xml

https://github.com/opencast/opencast/blob/9ab206ce2ff7e318ef0117261b8b3f5a5876bbee/modules/distribution-workflowoperation/src/main/resources/OSGI-INF/operations/retract-partial-aws.xml#L13

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
