### PR TITLE
Change default resolution of live schedule impl to standard 16:9

### DIFF
--- a/etc/org.opencastproject.liveschedule.impl.LiveScheduleServiceImpl.cfg
+++ b/etc/org.opencastproject.liveschedule.impl.LiveScheduleServiceImpl.cfg
@@ -9,8 +9,13 @@
 # The base URL that the player will use to play the live stream
 #live.streamingUrl=http://streaming.server/hls/
 
-# If a comma-separated list is provided, several resolutions will be generated for each flavor
-live.resolution=1920x540,960x270
+# If a comma-separated list is provided, several resolutions will be generated for each flavor.
+#
+# The default resolution is 16:9, a very typical aspect ratio nowadays. If your
+# capture agent's default is to stream two 16:9 images stitched together, as an
+# extra wide presenter and presentation video, parted later in an Opencast
+# workflow, it may help to set the resolution to 32:9: 1920x540,960x270.
+live.resolution=1920x1080,1280x720
 
 # Possible variable substitutions:
 # #{id} = media package id


### PR DESCRIPTION
I'm not sure why this default was set to a suuper-widescreen resolution. I think
it makes sense to change that as many Opencast installations don't change 
this, resulting in potentially weird effects (e.g. wrong player aspect ratio).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
