### PR TITLE
Fixes mysql upgrade script stop error

### DIFF
--- a/docs/upgrade/11_to_12/workflows_mariadb.py
+++ b/docs/upgrade/11_to_12/workflows_mariadb.py
@@ -45,7 +45,6 @@ def create_connection(host_name, user_name, user_password, db_name):
         print("Connection to database successful")
     except mysql.connector.errors.ProgrammingError:
         print("Collation error found, try to use an older version of mysql_connector_python")
-    finally:
         quit()
     return connection
 


### PR DESCRIPTION
Very little script fix. With #4032 I added a `finally` clause that made the script to stop executing and not doing any changes. This fixes that problem


* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
