### PR TITLE
Move thumbnail preview generation to the client

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/subresources/controllers/toolsController.js
@@ -24,9 +24,9 @@
 angular.module('adminNg.controllers')
 .controller('ToolsCtrl', ['$scope', '$route', '$location', 'Storage', '$window',
   'ToolsResource', 'Notifications', 'EventHelperService', 'MetadataSaveService',
-  '$q',
+  'PlayerAdapter', '$q',
   function ($scope, $route, $location, Storage, $window, ToolsResource,
-    Notifications, EventHelperService, MetadataSaveService, $q) {
+    Notifications, EventHelperService, MetadataSaveService, PlayerAdapter, $q) {
 
     var thumbnailErrorMessageId = null;
     var trackErrorMessageId = null;
@@ -68,11 +68,54 @@ angular.module('adminNg.controllers')
       return undefined;
     };
 
-    $scope.changeThumbnail = function (file, track, position) {
+    $scope.changeThumbnailPreviewJump = function(track, position) {
+      $scope.player.adapter.addListener(PlayerAdapter.EVENTS.SEEKED, function() {
+        $scope.changeThumbnailPreview(track);
+      }, { once: true });
+      $scope.player.adapter.setCurrentTime(position);
+    };
+
+    $scope.changeThumbnailPreview = function (track) {
+      var position = $scope.player.adapter.getCurrentTime();
+
+      // generate preview image
+      var canvas = document.createElement('canvas');
+      var video = document.getElementById('player');
+      var vidWidth = video.videoWidth;
+      var vidHeight = video.videoHeight;
+      if (vidWidth > vidHeight) {
+        canvas.width = 640;
+        canvas.height = 640 * vidHeight / vidWidth;
+      } else {
+        canvas.height = 480;
+        canvas.width = 480 * vidWidth / vidHeight;
+      }
+      var ctx = canvas.getContext('2d');
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+      ctx.font = '80px Noto Sans';
+      ctx.fillStyle = 'gray';
+      ctx.textAlign = 'center';
+      ctx.fillText('@' + position.toFixed(2) , canvas.width / 2, canvas.height / 2);
+
+      var preview_data = canvas.toDataURL();
+      var preview_bin = atob(preview_data.split(',')[1]);
+      var preview_type = preview_data.split(':')[1].split(';')[0];
+      var preview_ab = new ArrayBuffer(preview_bin.length);
+      var preview_ia = new Uint8Array(preview_ab);
+      for (var i = 0; i < preview_bin.length; i++) {
+        preview_ia[i] = preview_bin.charCodeAt(i);
+      }
+      var preview_blob = new Blob([preview_ab], {type: preview_type});
+
+      $scope.changeThumbnail(undefined, track, position, preview_blob);
+    };
+
+    $scope.changeThumbnail = function (file, track, position, previewfile) {
       $scope.video.thumbnail.loading = true;
       ToolsResource.thumbnail(
         { id: $scope.id, tool: 'thumbnail' },
-        { file: file, track: $scope.getTrackFlavorType(track), position: position },
+        { file: file, track: $scope.getTrackFlavorType(track), position: position, previewfile: previewfile },
         function(response) {
           $scope.video.thumbnail = response.thumbnail;
           $scope.video.thumbnail.defaultThumbnailPositionChanged = false;

--- a/modules/admin-ui-frontend/app/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/subresources/partials/tools.html
@@ -135,7 +135,7 @@
                          ng-if="video.source_tracks.length === 1"
                          translate="VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_VIDEO.LABEL"
                          title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_VIDEO.TOOLTIP' |translate  }}"
-                         ng-click="changeThumbnail(undefined, 'single', player.adapter.getCurrentTime())"
+                         ng-click="changeThumbnailPreview('single')"
                          ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                         <!-- Extract -->
                       </a>
@@ -143,7 +143,7 @@
                          ng-if="video.source_tracks.length > 1"
                          translate="VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_LEFT_VIDEO.LABEL"
                          title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_LEFT_VIDEO.TOOLTIP' |translate  }}"
-                         ng-click="changeThumbnail(undefined, 'left', player.adapter.getCurrentTime())"
+                         ng-click="changeThumbnailPreview('left')"
                          ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                         <!-- Extract -->
                       </a>
@@ -151,7 +151,7 @@
                          ng-if="video.source_tracks.length > 1"
                          translate="VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_RIGHT_VIDEO.LABEL"
                          title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.EXTRACT.FROM_RIGHT_VIDEO.TOOLTIP' | translate }}"
-                         ng-click="changeThumbnail(undefined, 'right', player.adapter.getCurrentTime())"
+                         ng-click="changeThumbnailPreview('right')"
                          ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                         <!-- Extract from video -->
                       </a>
@@ -168,13 +168,13 @@
                           class="hidden"
                           type="file"
                           accept="image/*"
-                          onchange="angular.element(this).scope().changeThumbnail(this.files[0], undefined, undefined)"
+                          onchange="angular.element(this).scope().changeThumbnail(this.files[0], undefined, undefined, undefined)"
                           ng-disabled="video.thumbnail.loading"/>
                       </form>
                       <a class="use-default-thumbnail"
                          translate="VIDEO_TOOL.THUMBNAIL.ACTIONS.USE_DEFAULT.LABEL"
                          title="{{ 'VIDEO_TOOL.THUMBNAIL.ACTIONS.USE_DEFAULT.TOOLTIP' | translate }}"
-                         ng-click="changeThumbnail(undefined, 'DEFAULT', calculateDefaultThumbnailPosition())"
+                         ng-click="changeThumbnailPreviewJump('DEFAULT', calculateDefaultThumbnailPosition())"
                          ng-if="video.thumbnail.url && video.thumbnail.type !== 'DEFAULT'"
                          ng-class="{disabled: !video.thumbnail || video.thumbnail.loading || activeTransaction || activeSubmission}">
                         <!-- Use default thumbnail -->

--- a/modules/admin-ui-frontend/app/scripts/shared/resources/toolsResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/toolsResource.js
@@ -99,6 +99,7 @@ angular.module('adminNg.resources')
         if (data.file) fd.append('File', data.file);
         if (data.track) fd.append('Track', data.track);
         if (angular.isNumber(data.position)) fd.append('Position', data.position);
+        if(data.previewfile) fd.append('PreviewFile', data.previewfile);
         return fd;
       }
     },

--- a/modules/admin-ui-frontend/app/scripts/shared/services/playerAdapter.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/playerAdapter.js
@@ -48,6 +48,7 @@ angular.module('adminNg.services')
     PLAY: 'play',
     PAUSE: 'pause',
     SEEKING: 'seeking',
+    SEEKED: 'seeked',
     READY: 'ready',
     TIMEUPDATE: 'timeupdate',
     ERROR: 'error',

--- a/modules/admin-ui-frontend/app/scripts/shared/services/playerAdapterFactoryDefault.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/playerAdapterFactoryDefault.js
@@ -39,6 +39,7 @@ angular.module('adminNg.services')
                 .map(PlayerAdapter.EVENTS.PAUSE, 'pause')
                 .map(PlayerAdapter.EVENTS.PLAY, 'play')
                 .map(PlayerAdapter.EVENTS.READY, 'ready')
+                .map(PlayerAdapter.EVENTS.SEEKED, 'seeked')
                 .map(PlayerAdapter.EVENTS.TIMEUPDATE, 'timeupdate')
                 .map(PlayerAdapter.EVENTS.DURATION_CHANGE, 'durationchange')
                 .map(PlayerAdapter.EVENTS.CAN_PLAY, 'canplay')
@@ -140,8 +141,8 @@ angular.module('adminNg.services')
              * @param type
              * @param listener
              */
-      this.addListener = function (type, listener) {
-        targetElement.addEventListener(eventMapping.resolveNativeName(type), listener);
+      this.addListener = function (type, listener, configuration) {
+        targetElement.addEventListener(eventMapping.resolveNativeName(type), listener, configuration);
       };
 
       /**


### PR DESCRIPTION
This pullrequest allows for the editor to generate thumbnail previews on the client instead of generating the thumbnails on the opencast admin-node.
This reduces load on the admin-node, which previously was responsible for the preview generation.

Some smaller problems still exist, but overall this is probably much more usable than the current state.

Smaller problems:
- When cutting the default preview won't be refreshed (this is only really a problem if the default preview was already created, which only happens after generating another preview before switching back to the default preview).
- The text indicating a outdated preview is inaccurate and isn't shown in all cases.