### PR TITLE
Revert try-catch in 12.x MariaDB upgrade script

### DIFF
--- a/docs/upgrade/11_to_12/workflows_mariadb.py
+++ b/docs/upgrade/11_to_12/workflows_mariadb.py
@@ -34,18 +34,14 @@ XML_DECLARATION = "<?xml version='1.0' encoding='UTF-8'?>"
 
 # DB functions
 def create_connection(host_name, user_name, user_password, db_name):
-    try:
-        connection = mysql.connector.connect(
-            host=host_name,
-            user=user_name,
-            passwd=user_password,
-            database=db_name
-        )
-        connection.row_factory = lambda cursor, row: row[0]
-        print("Connection to database successful")
-    except mysql.connector.errors.ProgrammingError:
-        print("Collation error found, try to use an older version of mysql_connector_python")
-        quit()
+    connection = mysql.connector.connect(
+        host=host_name,
+        user=user_name,
+        passwd=user_password,
+        database=db_name
+    )
+    connection.row_factory = lambda cursor, row: row[0]
+    print("Connection to database successful")
     return connection
 
 


### PR DESCRIPTION
Among other changes, pull request #4032 added a try-catch clause to the
migration script for migrating MariaDB-based Opencast 11 installations
to Opencast 12. This was later modified in pull request #4101 since it
completely broke the script.

Still, the remaining try-catch means that the script now works
differently than the PostgreSQL variant. It also means that for every
error you get the error message plus stack trace, except for one.

I think not hiding the stack trace is preferable to provide more
information and to assume that all caught `ProgrammingError` have the
same cause may not turn out to be correct.

Therefore, this pull request proposes to remove the try-catch entirely.

- This reverts commit 9b78c3362cea01c61ec94bbd3fd22e4256e0eeea.
- This reverts commit 9dd7823920813cf262571556215ebf9cf0daead9.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
