### PR TITLE
Document broken MariaDB upgrade script

### DIFF
--- a/docs/guides/admin/docs/upgrade.md
+++ b/docs/guides/admin/docs/upgrade.md
@@ -18,6 +18,12 @@ please refer to [older release notes](https://docs.opencast.org).
 Database Migration
 ------------------
 
+<div class=warn>
+Bug in 12.2:
+Please use the latest version of the upgrade script linked below.
+Version 12.2 of the MariaDB variant contained a bug which would make the script exit successfully while doing nothing.
+</div>
+
 Upgrading to Opencast 12 requires a database migration as some tables have changed.
 Migration scripts can be found in
 [`doc/upgrade/11_to_12/`](https://github.com/opencast/opencast/tree/r/12.x/docs/upgrade/11_to_12).


### PR DESCRIPTION
This patch adds a warning to the upgrade documentation, ensuring that
users are aware of a broken variant of the MariaDB script having been
released with 12.2.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
