### PR TITLE
Fix Publication to Workspace Operation Documentation

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publication-to-workspace-woh.md
@@ -1,30 +1,32 @@
-# PublicationToWorkspaceWorkflowOperationHandler
+# Publication to Workspace Workflow Operation
+
+ID: `publication-channel-to-workspace`
 
 ## Description
-The PublicationToWorkspaceWorkflowOperationHandler can be used to copy the content from publication channels to workspace.
+
+The Publication to Workspace operation can be used to copy content from publication channels to the workspace.
 With this workflow one can copy or manipulate published elements without re-encoding.
+
 ## Parameter Table
 
 |Configuration Key  |Example           |Description                                           |
 |-------------------|------------------|------------------------------------------------------|
-|publication-channel|engage-player, internal, oaipmh    |the publication-channel |
-|source-flavors     |presenter/delivery|the "," separated source flavor list to move        |
-|source-tags        |engage-download   |the "," separated source tag list to move             | 
-|target-tags        |archive           |the "," separated list of tags to add to the moved elements| 
-
+|publication-channel|engage-player     |The publication-channel |
+|source-flavors     |presenter/delivery|Comma-separated list of flavors identifying elements to copy|
+|source-tags        |engage-download   |Comma-separated list of tags identifying elements to copy|
+|target-tags        |archive           |Comma-separated list of tags to add to copied elements|
 
 
 ## Operation Example
-```
-  <operation id="publication-channel-to-workspace"
-      description="Copy publication channel to workspace"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error">
-    <configurations>
-      <configuration key="source-channel">engage-player</configuration>
-      <configuration key="source-flavors">presenter-delivery,presentation-delivery</configuration>
-      <configuration key="source-tags">engage-download,engage-streaming</configuration>
-      <configuration key="target-tags">archive</configuration>
-    </configurations>
-  </operation>
+
+```xml
+<operation id="publication-channel-to-workspace"
+           description="Copy publication channel to workspace">
+  <configurations>
+    <configuration key="source-channel">engage-player</configuration>
+    <configuration key="source-flavors">presenter/delivery,presentation/delivery</configuration>
+    <configuration key="source-tags">engage-download,engage-streaming</configuration>
+    <configuration key="target-tags">archive</configuration>
+  </configurations>
+</operation>
 ```


### PR DESCRIPTION
This patch fixes a few minor issues in the documentation of the
Publication to Workspace workflow operation handler.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
