### PR TITLE
Remove code which is not loading any roles

### DIFF
--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.entwinemedia.common</groupId>
       <artifactId>functional</artifactId>
     </dependency>

--- a/modules/userdirectory/src/main/resources/roles/system-admins
+++ b/modules/userdirectory/src/main/resources/roles/system-admins
@@ -1,2 +1,0 @@
-# Add default roles for the Admin User
-#ROLE_ADMIN


### PR DESCRIPTION
This patch removes some code which tries to load additional roles for
system users from a file which is hard-coded, does not contain any roles
and cannot be modified by users since it is compiled into the bundle.

In other words, this removes code doing absolutely nothing.

As a nice side-effect, this also removes the Entwine functional library
from this service ;-)

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
