### PR TITLE
Remove Entwine Functional Library from Execute Service

### DIFF
--- a/modules/execute-workflowoperation/pom.xml
+++ b/modules/execute-workflowoperation/pom.xml
@@ -17,10 +17,6 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>com.entwinemedia.common</groupId>
-      <artifactId>functional</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/modules/execute-workflowoperation/src/test/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandlerTest.java
+++ b/modules/execute-workflowoperation/src/test/java/org/opencastproject/execute/operation/handler/ExecuteOnceWorkflowOperationHandlerTest.java
@@ -40,9 +40,6 @@ import org.opencastproject.workflow.api.WorkflowOperationException;
 import org.opencastproject.workflow.api.WorkflowOperationInstance;
 import org.opencastproject.workspace.api.Workspace;
 
-import com.entwinemedia.fn.Fn2;
-import com.entwinemedia.fn.Stream;
-
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
@@ -123,14 +120,10 @@ public class ExecuteOnceWorkflowOperationHandlerTest {
     execOnceWOH = new ExecuteOnceWorkflowOperationHandler() {
       @Override
       protected Result waitForStatus(long timeout, Job... jobs) {
-        HashMap<Job, Status> map = Stream.mk(jobs).foldl(new HashMap<Job, Status>(),
-                new Fn2<HashMap<Job, Status>, Job, HashMap<Job, Status>>() {
-          @Override
-          public HashMap<Job, Status> apply(HashMap<Job, Status> a, Job b) {
-            a.put(b, Status.FINISHED);
-            return a;
-          }
-        });
+        var map = new HashMap<Job, Status>();
+        for (var job: jobs) {
+          map.put(job, Status.FINISHED);
+        }
         return new Result(map);
       }
     };


### PR DESCRIPTION
This patch is yet another step in the direction of removing the Entwine
functional library from the Opencast codebase.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
