### PR TITLE
Respect system settings when sending adopter data

### DIFF
--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -59,6 +59,14 @@
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>jakarta.persistence</artifactId>
     </dependency>

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
@@ -21,6 +21,13 @@
 
 package org.opencastproject.adopter.statistic;
 
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +35,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
@@ -112,7 +117,7 @@ public class Sender {
    * @throws IOException General exception that can occur while processing the POST request.
    */
   private void send(String json, String urlSuffix) throws IOException {
-    send(json, urlSuffix, "GET");
+    send(json, urlSuffix, "POST");
   }
 
   /**
@@ -123,27 +128,22 @@ public class Sender {
    * @throws IOException General exception that can occur while processing the POST request.
    */
   private void send(String json, String urlSuffix, String method) throws IOException {
-    URL url = new URL(baseUrl + urlSuffix);
-    HttpURLConnection con = (HttpURLConnection) url.openConnection();
-    con.setRequestMethod(method);
-    con.setRequestProperty("Content-Type", "application/json; utf-8");
-    con.setRequestProperty("Accept", "application/json");
-    con.setDoOutput(true);
-
-    try (OutputStream os = con.getOutputStream()) {
-      byte[] input = json.getBytes(StandardCharsets.UTF_8);
-      os.write(input, 0, input.length);
-    }
-
-    String httpStatus = con.getResponseCode() + "";
-    boolean errorOccurred = !httpStatus.startsWith("2");
-    InputStream responseStream;
-
-    if (errorOccurred) {
-      responseStream = con.getErrorStream();
+    HttpClient client = HttpClientBuilder.create().useSystemProperties().build();
+    String url = new URL(baseUrl + urlSuffix).toString();
+    HttpRequestBase request = null;
+    if ("DELETE".equals(method)) {
+      request = new HttpDelete(url);
     } else {
-      responseStream = con.getInputStream();
+      request = new HttpPost(url);
+      request.addHeader("Content-Type", "application/json; utf-8");
+      request.addHeader("Accept", "application/json");
+      ((HttpPost) request).setEntity(new StringEntity(json));
     }
+
+    HttpResponse resp = client.execute(request);
+    int httpStatus = resp.getStatusLine().getStatusCode();
+    boolean errorOccurred = httpStatus < 200 || httpStatus > 299;
+    InputStream responseStream = resp.getEntity().getContent();
 
     try (BufferedReader br = new BufferedReader(new InputStreamReader(responseStream, StandardCharsets.UTF_8))) {
       StringBuilder response = new StringBuilder();


### PR DESCRIPTION
As reported on list, the adopter registration data is sent disregarding the system proxy settings.  This should resolve that, copying the methods from the version endpoint.

This also fixes [this](https://github.com/opencast/opencast/pull/4119/files#diff-8943442c01293b164d1c5ef7a1217b55208536757a3604d12040f21d10c0de17L115), which I'm 99% sure works even without this fix, but I'm not 100% sure since we haven't actually deployed the server side of this yet.  Hence the inclusion in `r/11.x`.