### PR TITLE
Use bulk inserts for all services during index rebuild

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -564,77 +564,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
   }
 
   /**
-<<<<<<< HEAD
    * Remove the event from the Elasticsearch index
-=======
-   * Update the events in the API index.
-   *
-   * @param snapshots
-   *         The latest snapshots of the events to update
-   * @param index
-   *         The API index to update
-   */
-  private void updateEventBundleInIndex(List<Snapshot> snapshots) {
-    final String organization = securityService.getOrganization().getId();
-    final User user = securityService.getUser();
-    List<String> eventIds = new ArrayList<>();
-    List<Function<Optional<Event>, Optional<Event>>> updateFunctions = new ArrayList<>();
-
-    for (Snapshot snapshot: snapshots) {
-      MediaPackage mp = snapshot.getMediaPackage();
-      String eventId = mp.getIdentifier().toString();
-      eventIds.add(eventId);
-      Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
-        Event event = eventOpt.orElse(new Event(eventId, organization));
-
-        AccessControlList acl = authorizationService.getActiveAcl(mp).getA();
-        List<ManagedAcl> acls = aclServiceFactory.serviceFor(securityService.getOrganization()).getAcls();
-        for (final ManagedAcl managedAcl : AccessInformationUtil.matchAcls(acls, acl)) {
-          event.setManagedAcl(managedAcl.getName());
-        }
-        event.setAccessPolicy(AccessControlParser.toJsonSilent(acl));
-        event.setArchiveVersion(Long.parseLong(snapshot.getVersion().toString()));
-        if (StringUtils.isBlank(event.getCreator())) {
-          event.setCreator(securityService.getUser().getName());
-        }
-        EventIndexUtils.updateEvent(event, mp);
-
-        for (Catalog catalog: mp.getCatalogs(MediaPackageElements.EPISODE)) {
-          try (InputStream in = workspace.read(catalog.getURI())) {
-            EventIndexUtils.updateEvent(event, DublinCores.read(in));
-          } catch (IOException | NotFoundException e) {
-            throw new IllegalStateException(String.format("Unable to load dublin core catalog for event '%s'",
-                    mp.getIdentifier()), e);
-          }
-        }
-
-        // Update series name if not already done
-        try {
-          EventIndexUtils.updateSeriesName(event, organization, user, index);
-        } catch (SearchIndexException e) {
-          logger.error("Error updating the series name of the event {} in the {} index.", eventId, index.getIndexName(),
-                  e);
-        }
-        return Optional.of(event);
-      };
-      updateFunctions.add(updateFunction);
-    }
-    // Persist the scheduling events
-    try {
-      index.addOrUpdateEventBundle(eventIds, updateFunctions, organization, user);
-      for (String eventId: eventIds) {
-        logger.debug("Event {} updated in the {} index.", eventId, index.getIndexName());
-      }
-    } catch (SearchIndexException e) {
-      for (String eventId: eventIds) {
-        logger.error("Error updating the event {} in the {} index.", eventId, index.getIndexName(), e);
-      }
-    }
-  }
-
-  /**
-   * Remove the event from the API index
->>>>>>> 6048653241 (Use bulk inserts for all services during index rebuild)
    *
    * @param eventId
    *         The id of the event to remove
@@ -1011,9 +941,10 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       final AQueryBuilder q = createQuery();
       final RichAResult r = enrich(q.select(q.snapshot()).where(q.version().isLatest()).run());
       final int total = r.countSnapshots();
+      logIndexRebuildBegin(logger, index.getIndexName(), total, "snapshot(s)");
       int current = 0;
       int n = 16;
-      logIndexRebuildBegin(logger, index.getIndexName(), total, "snapshot(s)");
+      var updatedEventRange = new ArrayList<Event>();
 
       final Map<String, List<Snapshot>> byOrg = r.getSnapshots().groupMulti(Snapshots.getOrganizationId);
       for (String orgId : byOrg.keySet()) {
@@ -1022,24 +953,22 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
           snapshotOrg = orgDir.getOrganization(orgId);
           securityService.setOrganization(snapshotOrg);
           securityService.setUser(SecurityUtil.createSystemUser(systemUserName, snapshotOrg));
-          List<Snapshot> snapshotBundle = new ArrayList<>();
           for (Snapshot snapshot : byOrg.get(orgId)) {
-            current += 1;
-            snapshotBundle.add(snapshot);
+            try {
+              current++;
 
-            if ((current % n) == 0 || current == byOrg.get(orgId).size()) {
-              try {
-                updateEventBundleInIndex(snapshotBundle);
-              } catch (Throwable t) {
-                for (Snapshot snap : snapshotBundle) {
-                  logSkippingElement(logger, "event", snap.getMediaPackage().getIdentifier().toString(), org, t);
-                }
+              var updatedEventData = index.getEvent(snapshot.getMediaPackage().getIdentifier().toString(), orgId, user);
+              updatedEventData = getEventUpdateFunction(snapshot, orgId, user).apply(updatedEventData);
+              updatedEventRange.add(updatedEventData.get());
+
+              if (updatedEventRange.size() >= n || current >= byOrg.get(orgId).size()) {
+                index.bulkEventUpdate(updatedEventRange);
+                logIndexRebuildProgress(logger, index.getIndexName(), total, current);
+                updatedEventRange.clear();
               }
-              for (int i = 1; i <= snapshotBundle.size(); i++) {
-                int logEntry = i + (current - snapshotBundle.size());
-                logIndexRebuildProgress(logger, index.getIndexName(), total, logEntry);
-              }
-              snapshotBundle.clear();
+            } catch (Throwable t) {
+              logSkippingElement(logger, "event", snapshot.getMediaPackage().getIdentifier().toString(),
+                      snapshotOrg, t);
             }
           }
         } catch (Throwable t) {
@@ -1615,5 +1544,51 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     protected ADeleteQueryDecorator mkDecorator(ADeleteQuery delegate) {
       return new ADeleteQueryWithMessaging(delegate);
     }
+  }
+
+  /**
+   * Get the function to update a commented event in the Elasticsearch index.
+   *
+   * @param eventId
+   *          The id of the current event
+   * @return the function to do the update
+   */
+  private Function<Optional<Event>, Optional<Event>> getEventUpdateFunction(Snapshot snapshot,
+          String orgId, User user) {
+    return (Optional<Event> eventOpt) -> {
+      MediaPackage mp = snapshot.getMediaPackage();
+      String eventId = mp.getIdentifier().toString();
+      Event event = eventOpt.orElse(new Event(eventId, orgId));
+
+      AccessControlList acl = authorizationService.getActiveAcl(mp).getA();
+      List<ManagedAcl> acls = aclServiceFactory.serviceFor(securityService.getOrganization()).getAcls();
+      for (final ManagedAcl managedAcl : AccessInformationUtil.matchAcls(acls, acl)) {
+        event.setManagedAcl(managedAcl.getName());
+      }
+      event.setAccessPolicy(AccessControlParser.toJsonSilent(acl));
+      event.setArchiveVersion(Long.parseLong(snapshot.getVersion().toString()));
+      if (StringUtils.isBlank(event.getCreator())) {
+        event.setCreator(securityService.getUser().getName());
+      }
+      EventIndexUtils.updateEvent(event, mp);
+
+      for (Catalog catalog: mp.getCatalogs(MediaPackageElements.EPISODE)) {
+        try (InputStream in = workspace.read(catalog.getURI())) {
+          EventIndexUtils.updateEvent(event, DublinCores.read(in));
+        } catch (IOException | NotFoundException e) {
+          throw new IllegalStateException(String.format("Unable to load dublin core catalog for event '%s'",
+                  mp.getIdentifier()), e);
+        }
+      }
+
+      // Update series name if not already done
+      try {
+        EventIndexUtils.updateSeriesName(event, orgId, user, index);
+      } catch (SearchIndexException e) {
+        logger.error("Error updating the series name of the event {} in the {} index.", eventId, index.getIndexName(),
+                e);
+      }
+      return Optional.of(event);
+    };
   }
 }

--- a/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
+++ b/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
@@ -42,6 +42,8 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetRequest;
@@ -285,6 +287,57 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
     } while (indexResponse == null);
 
     return indexResponse;
+  }
+
+  /**
+   * Posts the input documents to the search index.
+   *
+   * @param maxRetryAttempts
+   *          How often to retry update in case of ElasticsearchStatusException
+   * @param retryWaitingPeriod
+   *          How long to wait (in ms) between retries
+   * @param documents
+   *          The Elasticsearch documents
+   * @return the query response
+   *
+   * @throws IOException
+   *         If updating the index fails
+   * @throws InterruptedException
+   *         If waiting during retry is interrupted
+   */
+  protected BulkResponse bundleUpdate(int maxRetryAttempts, int retryWaitingPeriod,
+      List<ElasticsearchDocument> documents)
+          throws IOException, InterruptedException {
+    BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+    for (ElasticsearchDocument document: documents) {
+      bulkRequest.add(new IndexRequest(getSubIndexIdentifier(document.getType())).id(document.getUID())
+          .source(document));
+    }
+
+    BulkResponse bulkResponse = null;
+    int retryAttempts = 0;
+    do {
+      try {
+        bulkResponse = client.bulk(bulkRequest, RequestOptions.DEFAULT);
+      } catch (ElasticsearchStatusException e) {
+        retryAttempts++;
+
+        if (retryAttempts <= maxRetryAttempts) {
+          logger.warn("Could not update documents in index {} because of {}, retrying in {} ms.", getIndexName(),
+                  e.getMessage(), retryWaitingPeriod);
+          if (retryWaitingPeriod > 0) {
+            Thread.sleep(retryWaitingPeriod);
+          }
+        } else {
+          logger.error("Could not update documents in index {} because of {}, not retrying.", getIndexName(),
+                  e.getMessage());
+          throw e;
+        }
+      }
+    } while (bulkResponse == null);
+
+    return bulkResponse;
   }
 
   /**

--- a/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
+++ b/modules/elasticsearch-impl/src/main/java/org/opencastproject/elasticsearch/impl/AbstractElasticsearchIndex.java
@@ -273,15 +273,14 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
         retryAttempts++;
 
         if (retryAttempts <= maxRetryAttempts) {
-          logger.warn("Could not update documents in index {} because of {}, retrying in {} ms.", getIndexName(),
-                  e.getMessage(), retryWaitingPeriod);
+          logger.warn("Could not update documents in index {}, retrying in {} ms.", getIndexName(),
+                  e, retryWaitingPeriod);
           if (retryWaitingPeriod > 0) {
             Thread.sleep(retryWaitingPeriod);
           }
         } else {
-          logger.error("Could not update documents in index {} because of {}, not retrying.", getIndexName(),
-                  e.getMessage());
-          throw e;
+          logger.error("Could not update documents in index {}, not retrying.", getIndexName(),
+                  e);
         }
       }
     } while (indexResponse == null);
@@ -305,7 +304,7 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
    * @throws InterruptedException
    *         If waiting during retry is interrupted
    */
-  protected BulkResponse bundleUpdate(int maxRetryAttempts, int retryWaitingPeriod,
+  protected BulkResponse bulkUpdate(int maxRetryAttempts, int retryWaitingPeriod,
       List<ElasticsearchDocument> documents)
           throws IOException, InterruptedException {
     BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
@@ -330,9 +329,8 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
             Thread.sleep(retryWaitingPeriod);
           }
         } else {
-          logger.error("Could not update documents in index {} because of {}, not retrying.", getIndexName(),
-                  e.getMessage());
-          throw e;
+          logger.error("Could not update documents in index {}, not retrying.", getIndexName(),
+                  e);
         }
       }
     } while (bulkResponse == null);
@@ -374,9 +372,8 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
             Thread.sleep(retryWaitingPeriod);
           }
         } else {
-          logger.error("Could not remove documents from index {} because of {}, not retrying.", getIndexName(),
-                  e.getMessage());
-          throw e;
+          logger.error("Could not remove documents from index {}, not retrying.", getIndexName(),
+                  e);
         }
       }
     } while (deleteResponse == null);
@@ -669,9 +666,8 @@ public abstract class AbstractElasticsearchIndex implements SearchIndex {
             Thread.sleep(retryWaitingPeriod);
           }
         } else {
-          logger.error("Could not query documents from index {} because of {}, not retrying.", getIndexName(),
-                  e.getMessage());
-          throw e;
+          logger.error("Could not query documents from index {}, not retrying.", getIndexName(),
+                  e);
         }
       }
     } while (searchResponse == null);

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -58,6 +58,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -417,6 +418,85 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
   }
 
   /**
+   * Adds or updates the events in the search index. Uses a locking mechanism to avoid issues like Lost Update.
+   *
+   * @param ids
+   *          The ids of the event to update
+   * @param updateFunctionBundle
+   *          The functions that do the actual updating
+   * @param orgId
+   *          The organization the events belong to
+   * @param user
+   *          The user
+   *
+   * @throws SearchIndexException
+   *          Thrown if unable to update the event.
+   */
+  public List<Optional<Event>> addOrUpdateEventBundle(List<String> ids,
+      List<Function<Optional<Event>, Optional<Event>>> updateFunctionBundle,
+      String orgId, User user) throws SearchIndexException {
+    List<Lock> lockBundle = new ArrayList<>();
+    for (String id: ids) {
+      lockBundle.add(this.locks.get(id));
+      lockBundle.get(lockBundle.size() - 1).lock();
+      logger.debug("Locked event '{}'", id);
+    }
+    try {
+      List<Optional<Event>> updatedEventOptBundle = new ArrayList<>();
+      List<Event> updatedEventBundle = new ArrayList<>();
+      boolean allPresent = true;
+      for (int i = 0; i < ids.size(); i++) {
+        Optional<Event> eventOpt = getEvent(ids.get(i), orgId, user,
+                maxRetryAttemptsUpdate, retryWaitingPeriodUpdate);
+        updatedEventOptBundle.add(updateFunctionBundle.get(i).apply(eventOpt));
+        if (!updatedEventOptBundle.get(updatedEventOptBundle.size() - 1).isPresent()) {
+          allPresent = false;
+        }
+      }
+      for (int i = 0; i < ids.size(); i++) {
+        updatedEventBundle.add(updatedEventOptBundle.get(i).get());
+      }
+      if (allPresent) {
+        bundleEventUpdate(updatedEventBundle);
+      }
+      return updatedEventOptBundle;
+    } finally {
+      for (int i = 0; i < ids.size(); i++) {
+        lockBundle.get(i).unlock();
+        logger.debug("Released locked event '{}'", ids.get(i));
+      }
+    }
+  }
+
+  /**
+   * Adds the recording events to the search index or updates it accordingly if it is there.
+   *
+   * @param eventList
+   *          The events to update
+   *
+   * @throws SearchIndexException
+   *          If the events cannot be added or updated
+   */
+  private void bundleEventUpdate(List<Event> eventList) throws SearchIndexException {
+    List<ElasticsearchDocument> docs = new ArrayList<>();
+    for (Event event: eventList) {
+      logger.debug("Adding event {} to search index", event.getIdentifier());
+      // Add the resource to the index
+      SearchMetadataCollection inputDocument = EventIndexUtils.toSearchMetadata(event);
+      List<SearchMetadata<?>> resourceMetadata = inputDocument.getMetadata();
+      docs.add(new ElasticsearchDocument(inputDocument.getIdentifier(),
+              inputDocument.getDocumentType(), resourceMetadata));
+    }
+    try {
+      bundleUpdate(maxRetryAttemptsUpdate, retryWaitingPeriodUpdate, docs);
+    } catch (Throwable t) {
+      for (Event event: eventList) {
+        throw new SearchIndexException("Cannot write event " + event + " to index", t);
+      }
+    }
+  }
+
+  /**
    * Adds or updates the series in the search index. Uses a locking mechanism to avoid issues like Lost Update.
    *
    * @param id
@@ -476,6 +556,85 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
   }
 
   /**
+   * Adds or updates the series in the search index. Uses a locking mechanism to avoid issues like Lost Update.
+   *
+   * @param ids
+   *          The ids of the series to add
+   * @param updateFunctionBundle
+   *          The functions that do the actual updating
+   * @param orgId
+   *          The organization the series belongs to
+   * @param user
+   *          The user
+   *
+   * @throws SearchIndexException
+   *          Thrown if unable to add or update the series.
+   */
+  public List<Optional<Series>> addOrUpdateSeriesBundle(List<String> ids,
+          List<Function<Optional<Series>, Optional<Series>>> updateFunctionBundle,
+          String orgId, User user) throws SearchIndexException {
+    List<Lock> lockBundle = new ArrayList<>();
+    for (String id: ids) {
+      lockBundle.add(this.locks.get(id));
+      lockBundle.get(lockBundle.size() - 1).lock();
+      logger.debug("Locked series '{}'", id);
+    }
+    try {
+      List<Optional<Series>> updatedSeriesOptBundle = new ArrayList<>();
+      List<Series> updatedSeriesBundle = new ArrayList<>();
+      boolean allPresent = true;
+      for (int i = 0; i < ids.size(); i++) {
+        Optional<Series> seriesOpt = getSeries(ids.get(i), orgId, user,
+                maxRetryAttemptsUpdate, retryWaitingPeriodUpdate);
+        updatedSeriesOptBundle.add(updateFunctionBundle.get(i).apply(seriesOpt));
+        if (!updatedSeriesOptBundle.get(updatedSeriesOptBundle.size() - 1).isPresent()) {
+          allPresent = false;
+        }
+      }
+      for (int i = 0; i < ids.size(); i++) {
+        updatedSeriesBundle.add(updatedSeriesOptBundle.get(i).get());
+      }
+      if (allPresent) {
+        bundleSeriesUpdate(updatedSeriesBundle);
+      }
+      return updatedSeriesOptBundle;
+    } finally {
+      for (int i = 0; i < ids.size(); i++) {
+        lockBundle.get(i).unlock();
+        logger.debug("Released locked series '{}'", ids.get(i));
+      }
+    }
+  }
+
+    /**
+   * Add or update a bundle of series in the search index.
+   *
+   * @param seriesList
+   *          The series to update
+   *
+   * @throws SearchIndexException
+   *          If the series cannot be added or updated
+   */
+  private void bundleSeriesUpdate(List<Series> seriesList) throws SearchIndexException {
+    List<ElasticsearchDocument> docs = new ArrayList<>();
+    for (Series series: seriesList) {
+      logger.debug("Adding series {} to search index", series.getIdentifier());
+      // Add the resource to the index
+      SearchMetadataCollection inputDocument = SeriesIndexUtils.toSearchMetadata(series);
+      List<SearchMetadata<?>> resourceMetadata = inputDocument.getMetadata();
+      docs.add(new ElasticsearchDocument(inputDocument.getIdentifier(),
+              inputDocument.getDocumentType(), resourceMetadata));
+    }
+    try {
+      bundleUpdate(maxRetryAttemptsUpdate, retryWaitingPeriodUpdate, docs);
+    } catch (Throwable t) {
+      for (Series series: seriesList) {
+        throw new SearchIndexException("Cannot write series " + series + " to index", t);
+      }
+    }
+  }
+
+  /**
    * Adds or updates the theme in the search index. Uses a locking mechanism to avoid issues like Lost Update.
    *
    * @param id
@@ -531,6 +690,85 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
       update(maxRetryAttemptsUpdate, retryWaitingPeriodUpdate, doc);
     } catch (Throwable t) {
       throw new SearchIndexException("Cannot write theme " + theme + " to index", t);
+    }
+  }
+
+  /**
+   * Adds or updates the themes in the search index. Uses a locking mechanism to avoid issues like Lost Update.
+   *
+   * @param ids
+   *          The ids of the themes to update
+   * @param updateFunctions
+   *          The functions that do the actual updating
+   * @param orgId
+   *          The organization the themes belong to
+   * @param user
+   *          The user
+   *
+   * @throws SearchIndexException
+   *          Thrown if unable to update the themes.
+   */
+  public List<Optional<IndexTheme>> addOrUpdateThemeBundle(List<Long> ids, List<Function<Optional<IndexTheme>,
+          Optional<IndexTheme>>> updateFunctions, String orgId, User user) throws SearchIndexException {
+    List<Lock> lockBundle = new ArrayList<>();
+    for (Long id: ids) {
+      lockBundle.add(this.locks.get(id));
+      lockBundle.get(lockBundle.size() - 1).lock();
+      logger.debug("Locked theme '{}'", id);
+    }
+
+    try {
+      List<Optional<IndexTheme>> updatedThemeOptBundle = new ArrayList<>();
+      List<IndexTheme> updatedThemeBundle = new ArrayList<>();
+      boolean allPresent = true;
+
+      for (int i = 0; i < ids.size(); i++) {
+        Optional<IndexTheme> themeOpt = getTheme(ids.get(i), orgId, user, maxRetryAttemptsUpdate,
+                retryWaitingPeriodUpdate);
+        updatedThemeOptBundle.add(updateFunctions.get(i).apply(themeOpt));
+        if (!updatedThemeOptBundle.get(updatedThemeOptBundle.size() - 1).isPresent()) {
+          allPresent = false;
+        }
+        updatedThemeBundle.add(updatedThemeOptBundle.get(i).get());
+      }
+      if (allPresent) {
+        bundleThemeUpdate(updatedThemeBundle);
+      }
+      return updatedThemeOptBundle;
+    } finally {
+      for (int i = 0; i < ids.size(); i++) {
+        lockBundle.get(i).unlock();
+        logger.debug("Released locked theme '{}'", ids.get(i));
+      }
+    }
+  }
+
+  /**
+   * Adds or updates the themes in the search index.
+   *
+   * @param themeList
+   *          The themes to update
+   *
+   * @throws SearchIndexException
+   *          Thrown if unable to add or update the themes.
+   */
+  private void bundleThemeUpdate(List<IndexTheme> themeList) throws SearchIndexException {
+    List<ElasticsearchDocument> docs = new ArrayList<>();
+    for (IndexTheme theme: themeList) {
+      logger.debug("Adding theme {} to search index", theme.getIdentifier());
+
+      // Add the resource to the index
+      SearchMetadataCollection inputDocument = theme.toSearchMetadata();
+      List<SearchMetadata<?>> resourceMetadata = inputDocument.getMetadata();
+      docs.add(new ElasticsearchDocument(inputDocument.getIdentifier(),
+              inputDocument.getDocumentType(), resourceMetadata));
+    }
+    try {
+      bundleUpdate(maxRetryAttemptsUpdate, retryWaitingPeriodUpdate, docs);
+    } catch (Throwable t) {
+      for (IndexTheme theme: themeList) {
+        throw new SearchIndexException("Cannot write theme " + theme + " to index", t);
+      }
     }
   }
 

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -443,6 +443,58 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
     }
   }
 
+  private void updateBundleIndex(List<String> eventIds, List<Boolean> hasCommentsList,
+          List<Boolean> hasOpenCommentsList, List<List<EventComment>> commentsList, List<Boolean> needsCuttingList,
+          String organization, User user) {
+    List<Function<Optional<Event>, Optional<Event>>> updateFunctions = new ArrayList<>();
+    for (int i = 0; i < eventIds.size(); i++) {
+      List<EventComment> comments = commentsList.get(i);
+      String eventId = eventIds.get(i);
+      Boolean hasComments = hasCommentsList.get(i);
+      Boolean hasOpenComments = hasOpenCommentsList.get(i);
+      Boolean needsCutting = needsCuttingList.get(i);
+      logger.debug("Updating comment status of event {} in the {} index.", eventId, index.getIndexName());
+      if (!hasComments && hasOpenComments) {
+        throw new IllegalStateException(
+                "Invalid comment update request: You can't have open comments without having any comments!");
+      }
+      if (!hasOpenComments && needsCutting) {
+        throw new IllegalStateException(
+                "Invalid comment update request: You can't have an needs cutting comment without having any open "
+                        + "comments!");
+      }
+
+      Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
+        if (eventOpt.isEmpty()) {
+          logger.debug("Event {} not found for comment status updating", eventId);
+          return Optional.empty();
+        }
+        Event event = eventOpt.get();
+        event.setHasComments(hasComments);
+        event.setHasOpenComments(hasOpenComments);
+        List<Comment> indexComments = new ArrayList<Comment>();
+        for (EventComment comment : comments) {
+          indexComments.add(new Comment(
+                  comment.getId().get().toString(), comment.getReason(), comment.getText(), comment.isResolvedStatus()
+          ));
+          // Do we want to include replies? Maybe not, no good reason to filter for them?
+        }
+        event.setComments(indexComments);
+        event.setNeedsCutting(needsCutting);
+        return Optional.of(event);
+      };
+      updateFunctions.add(updateFunction);
+    }
+
+    try {
+      index.addOrUpdateEventBundle(eventIds, updateFunctions, organization, user);
+    } catch (SearchIndexException e) {
+      for (String eventId: eventIds) {
+        logger.error("Error updating comment status of event {} in the {} index:", eventId, index.getIndexName(), e);
+      }
+    }
+  }
+
   private static final Fn<EventComment, Boolean> filterOpenComments = new Fn<EventComment, Boolean>() {
     @Override
     public Boolean apply(EventComment comment) {
@@ -463,7 +515,13 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
       final int total = countComments();
       final int[] current = new int[1];
       current[0] = 0;
+      int n = 16;
       logIndexRebuildBegin(logger, index.getIndexName(), total, "events with comment");
+      List<String> eventIds = new ArrayList<>();
+      List<Boolean> hasCommentsList = new ArrayList<>();
+      List<Boolean> hasOpenCommentsList = new ArrayList<>();
+      List<Boolean> needsCuttingList = new ArrayList<>();
+      List<List<EventComment>> commentsList = new ArrayList<>();
       final Map<String, List<String>> eventsWithComments = getEventsWithComments();
       for (String orgId : eventsWithComments.keySet()) {
         Organization organization = organizationDirectoryService.getOrganization(orgId);
@@ -473,15 +531,30 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
                   for (String eventId : eventsWithComments.get(orgId)) {
                     try {
                       List<EventComment> comments = getComments(eventId);
-                      boolean hasOpenComments = !Stream.$(comments).filter(filterOpenComments).toList().isEmpty();
-                      boolean needsCutting = !Stream.$(comments).filter(filterNeedsCuttingComment).toList().isEmpty();
+                      commentsList.add(comments);
+                      eventIds.add(eventId);
+                      hasCommentsList.add(!comments.isEmpty());
+                      hasOpenCommentsList.add(!Stream.$(comments).filter(filterOpenComments).toList().isEmpty());
+                      needsCuttingList.add(!Stream.$(comments).filter(filterNeedsCuttingComment).toList().isEmpty());
 
-                      updateIndex(eventId, !comments.isEmpty(), hasOpenComments, comments, needsCutting, orgId,
-                              systemUser);
                       current[0] += comments.size();
-                      logIndexRebuildProgress(logger, index.getIndexName(), total, current[0]);
+                      if ((current[0] % n) == 0 || current[0] == eventsWithComments.get(orgId).size()) {
+                        updateBundleIndex(eventIds, hasCommentsList, hasOpenCommentsList, commentsList,
+                                needsCuttingList, orgId, systemUser);
+                        for (int i = 1; i <= eventIds.size(); i++) {
+                          int logEntry = i + (current[0] - eventIds.size());
+                          logIndexRebuildProgress(logger, index.getIndexName(), total, logEntry);
+                        }
+                        commentsList.clear();
+                        eventIds.clear();
+                        hasCommentsList.clear();
+                        hasOpenCommentsList.clear();
+                        needsCuttingList.clear();
+                      }
                     } catch (Throwable t) {
-                      logSkippingElement(logger, "comment of event", eventId, organization, t);
+                      for (String event: eventIds) {
+                        logSkippingElement(logger, "comment of event", event, organization, t);
+                      }
                     }
                   }
                 });

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -514,88 +514,73 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       List<SeriesEntity> databaseSeries = persistence.getAllSeries();
       final int total = databaseSeries.size();
       logIndexRebuildBegin(logger, index.getIndexName(), total, "series");
-      if (total > 0) {
-        String lastOrg = databaseSeries.get(0).getOrganization();
-        int current = 0;
-        int n = 16;
-        while (current < total) {
-          List<SeriesEntity> seriesBundle = new ArrayList<>();
-          for (int i = 0; i < n; i++) {
-            if (current + i >= total) {
-              break;
-            }
-            String currentOrg = databaseSeries.get(current + i).getOrganization();
-            if (currentOrg.equals(lastOrg)) {
-              seriesBundle.add(databaseSeries.get(current + i));
-            } else {
-              lastOrg = currentOrg;
-              break;
-            }
-          }
-          current += seriesBundle.size();
+      int current = 0;
+      int n = 16;
+      var updatedSeriesRange = new ArrayList<Series>();
 
-          Organization organization = orgDirectory.getOrganization(seriesBundle.get(0).getOrganization());
-          User systemUser = SecurityUtil.createSystemUser(systemUserName, organization);
-          SecurityUtil.runAs(securityService, organization, systemUser,
-                  () -> {
-                    List<String> seriesIds = new ArrayList<>();
-                    List<Function<Optional<Series>, Optional<Series>>[]> updateFunctionBundle = new ArrayList<>();
-                    for (SeriesEntity series: seriesBundle) {
-                      String seriesId = series.getSeriesId();
-                      seriesIds.add(seriesId);
-                      logger.trace("Adding series {} for organization {} to the {} index.", seriesId,
-                              series.getOrganization(), index.getIndexName());
-                      List<Function<Optional<Series>, Optional<Series>>> updateFunctions = new ArrayList<>();
-                      try {
-                        DublinCoreCatalog catalog = DublinCoreXmlFormat.read(series.getDublinCoreXML());
-                        updateFunctions.add(getMetadataUpdateFunction(seriesId, catalog, organization.getId()));
-                      } catch (IOException | ParserConfigurationException | SAXException e) {
-                        logger.error("Could not read dublin core XML of series {}.", seriesId, e);
-                        return;
-                      }
+      for (SeriesEntity series: databaseSeries) {
+        String seriesId = series.getSeriesId();
+        logger.trace("Adding series {} for organization {} to the {} index.", seriesId,
+                series.getOrganization(), index.getIndexName());
+        Organization organization = orgDirectory.getOrganization(series.getOrganization());
+        User systemUser = SecurityUtil.createSystemUser(systemUserName, organization);
+        current++;
 
-                      // remove all extended metadata catalogs first so we get rid of old data
-                      updateFunctions.add(getResetExtendedMetadataFunction());
-                      for (Map.Entry<String, byte[]> entry: series.getElements().entrySet()) {
-                        try {
-                          DublinCoreCatalog dc = DublinCoreByteFormat.read(entry.getValue());
-                          updateFunctions.add(getExtendedMetadataUpdateFunction(seriesId, dc, entry.getKey(),
-                                  organization.getId()));
-                        } catch (IOException | ParseException | ParserConfigurationException | SAXException e) {
-                          logger.error("Could not parse series element {} of series {} as a dublin core catalog, skipping.",
-                                  entry.getKey(), seriesId, e);
-                        }
-                      }
+        SecurityUtil.runAs(securityService, organization, systemUser,
+              () -> {
+                var updatedSeriesData = Optional.of(new Series(seriesId, organization.getId()));
+                try {
+                  DublinCoreCatalog catalog = DublinCoreXmlFormat.read(series.getDublinCoreXML());
+                  updatedSeriesData = getMetadataUpdateFunction(seriesId, catalog, organization.getId())
+                      .apply(updatedSeriesData);
+                } catch (IOException | ParserConfigurationException | SAXException e) {
+                  logger.error("Could not read dublincore XML of series {}.", seriesId, e);
+                  return;
+                }
 
-                      String aclStr = series.getAccessControl();
-                      if (StringUtils.isNotBlank(aclStr)) {
-                        try {
-                          AccessControlList acl = AccessControlParser.parseAcl(aclStr);
-                          updateFunctions.add(getAclUpdateFunction(seriesId, acl, organization.getId()));
-                        } catch (Exception ex) {
-                          logger.error("Unable to parse ACL of series {}.", seriesId, ex);
-                        }
-                      }
+                // remove all extended metadata catalogs first so we get rid of old data
+                updatedSeriesData = getResetExtendedMetadataFunction().apply(updatedSeriesData);
+                for (Map.Entry<String, byte[]> entry: series.getElements().entrySet()) {
+                  try {
+                    DublinCoreCatalog dc = DublinCoreByteFormat.read(entry.getValue());
 
-                      try {
-                        Map<String, String> properties = persistence.getSeriesProperties(seriesId);
-                        updateFunctions.add(getThemePropertyUpdateFunction(seriesId,
-                                Optional.ofNullable(properties.get(THEME_PROPERTY_NAME)), organization.getId()));
-                      } catch (NotFoundException | SeriesServiceDatabaseException e) {
-                        logger.error("Error reading properties of series {}", seriesId, e);
-                      }
-                      updateFunctionBundle.add(updateFunctions.toArray(new Function[0]));
-                    }
+                    updatedSeriesData = getExtendedMetadataUpdateFunction(seriesId, dc, entry.getKey(),
+                            organization.getId()).apply(updatedSeriesData);
 
-                    // do the actual index update
-                    updateSeriesBundleInIndex(seriesIds, organization.getId(),
-                            updateFunctionBundle);
+                  } catch (IOException | ParseException | ParserConfigurationException | SAXException e) {
+                    logger.error("Could not parse series element {} of series {} as a dublin core catalog, skipping.",
+                            entry.getKey(), seriesId, e);
+                  }
+                }
 
-                  });
-          for (int i = 1; i <= seriesBundle.size(); i++) {
-            int logEntry = i + (current - seriesBundle.size());
-            logIndexRebuildProgress(logger, index.getIndexName(), total, logEntry);
-          }
+                String aclStr = series.getAccessControl();
+                if (StringUtils.isNotBlank(aclStr)) {
+                  try {
+                    AccessControlList acl = AccessControlParser.parseAcl(aclStr);
+                    updatedSeriesData = getAclUpdateFunction(seriesId, acl, organization.getId())
+                        .apply(updatedSeriesData);
+                  } catch (Exception ex) {
+                    logger.error("Unable to parse ACL of series {}.", seriesId, ex);
+                  }
+                }
+
+                try {
+                  Map<String, String> properties = persistence.getSeriesProperties(seriesId);
+                  updatedSeriesData = getThemePropertyUpdateFunction(seriesId,
+                          Optional.ofNullable(properties.get(THEME_PROPERTY_NAME)), organization.getId())
+                      .apply(updatedSeriesData);
+                } catch (NotFoundException | SeriesServiceDatabaseException e) {
+                  logger.error("Error reading properties of series {}", seriesId, e);
+                }
+                updatedSeriesRange.add(updatedSeriesData.get());
+
+              });
+
+        if (updatedSeriesRange.size() >= n || current >= databaseSeries.size()) {
+          // do the actual index update
+          index.bulkSeriesUpdate(updatedSeriesRange);
+          logIndexRebuildProgress(logger, index.getIndexName(), total, current);
+          updatedSeriesRange.clear();
         }
       }
     } catch (Exception e) {
@@ -892,42 +877,6 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
     } catch (SearchIndexException e) {
       logger.error("Series {} couldn't be updated in the {} index.", seriesId, index.getIndexName(), e);
       return Optional.empty();
-    }
-  }
-
-  /**
-   * Update a bundle of series in an API index.
-   *
-   * @param seriesIds
-   *          The series ids
-   * @param updateFunctionBundle
-   *          The functions to do the actual updating
-   * @param orgId
-   *          The id of the current organization
-   * @return the updated series (optional)
-   */
-  private  List<Optional<Series>> updateSeriesBundleInIndex(List<String> seriesIds, String orgId,
-          List<Function<Optional<Series>, Optional<Series>>[]> updateFunctionBundle) {
-    User user = securityService.getUser();
-    List<Function<Optional<Series>, Optional<Series>>> updateFunctions = new ArrayList<>();
-
-    for (int i = 0; i < seriesIds.size(); i++) {
-      Function<Optional<Series>, Optional<Series>> updateFunction =
-              Arrays.stream(updateFunctionBundle.get(i)).reduce(Function.identity(), Function::andThen);
-      updateFunctions.add(updateFunction);
-    }
-
-    try {
-      List<Optional<Series>> seriesOptBundle = index.addOrUpdateSeriesBundle(seriesIds, updateFunctions, orgId, user);
-      for (String seriesId: seriesIds) {
-        logger.debug("Series {} updated in the {} index", seriesId, index.getIndexName());
-      }
-      return seriesOptBundle;
-    } catch (SearchIndexException e) {
-      for (String seriesId: seriesIds) {
-        logger.error("Series {} couldn't be updated in the {} index.", seriesId, index.getIndexName(), e);
-      }
-      return new ArrayList<>();
     }
   }
 }


### PR DESCRIPTION
Instead of rebuilding the elastic search index entries with single index requests, now a configurable number of index request are summarized to a bulk request.
Therefor the repopulate functions of all services group multiple documents to a list now and new bundle update functions have been added to the corresponding services and to the elastic search service.
