### PR TITLE
Fix workflow config handover from ingest to scheduler service

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -1239,6 +1239,10 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
         agentProperties.put(key, properties.get(key));
       }
     }
+
+    // Remove workflow configuration prefixes from the workflow properties
+    workflowProperties = removePrefixFromProperties(workflowProperties);
+
     try {
       schedulerService.addEvent(period.getStart(), period.getEnd(), captureAgent, new HashSet<>(), mediaPackage,
               workflowProperties, agentProperties, Opt.none());


### PR DESCRIPTION
When scheduling via the ingest service, the workflow config is not handed over correctly. This will result in the config keys either having the workflow config prefix ("org.opencastproject.workflow.config") twice or not at all in the scheduler config. Neither of that will work obviously. :D 
Stripping the prefix already happens in other parts of the ingest service, it was just forgotten here.