### PR TITLE
Fix ingest of series catalog via external URL

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -853,7 +853,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       logger.info("Start adding catalog {} from URL {} on mediapackage {}", elementId, uri, mediaPackage);
       URI newUrl = addContentToRepo(mediaPackage, elementId, uri);
       if (MediaPackageElements.SERIES.equals(flavor)) {
-        updateSeries(uri);
+        updateSeries(newUrl);
       }
       MediaPackage mp = addContentToMediaPackage(mediaPackage, elementId, newUrl, MediaPackageElement.Type.Catalog,
               flavor);


### PR DESCRIPTION
Ingesting a series catalog via an external URL didn't work if that URL needs authentication. This was because we would try to use the external URL to update the series instead of the new internal URL we had just created. Since we didn't authenticate us for this, the request would be denied. Using the new internal URL, which we create prior to this by authenticating ourselves and then downloading the file into our workspace, works now.

Note that this error will also occur if updating existing series from an ingested series catalog is turned off (as is the default). This is because we need to read the catalog first to find out the series id so we can check if the series exists.
