### PR TITLE
Allow tags for ingesting attachments or catalogs via URL

### DIFF
--- a/modules/ingest-service-api/src/main/java/org/opencastproject/ingest/api/IngestService.java
+++ b/modules/ingest-service-api/src/main/java/org/opencastproject/ingest/api/IngestService.java
@@ -130,25 +130,6 @@ public interface IngestService extends JobProducer {
   MediaPackage createMediaPackage(String mediaPackageID) throws MediaPackageException, ConfigurationException,
           IOException, IngestException;
 
-
-  /**
-   * Add a media track to an existing MediaPackage in the repository
-   *
-   * @param uri
-   *          The URL of the file to add
-   * @param flavor
-   *          The flavor of the media that is being added
-   * @param mediaPackage
-   *          The specific Opencast MediaPackage to which Media is being added
-   * @return MediaPackageManifest The manifest of a specific Opencast MediaPackage element
-   * @throws MediaPackageException
-   * @throws IOException
-   * @throws IngestException
-   *           if an unexpected error occurs
-   */
-  MediaPackage addTrack(URI uri, MediaPackageElementFlavor flavor, MediaPackage mediaPackage)
-          throws MediaPackageException, IOException, IngestException;
-
     /**
    * Add a media track to an existing MediaPackage in the repository
    *

--- a/modules/ingest-service-api/src/main/java/org/opencastproject/ingest/api/IngestService.java
+++ b/modules/ingest-service-api/src/main/java/org/opencastproject/ingest/api/IngestService.java
@@ -256,6 +256,8 @@ public interface IngestService extends JobProducer {
    *          The URL of the file to add
    * @param flavor
    *          The flavor of the media that is being added
+   * @param tags
+   *           Tags to add to the catalog
    * @param mediaPackage
    *          The specific Opencast MediaPackage to which Media is being added
    * @return MediaPackage The updated Opencast MediaPackage element
@@ -264,7 +266,7 @@ public interface IngestService extends JobProducer {
    * @throws IngestException
    *           if an unexpected error occurs
    */
-  MediaPackage addCatalog(URI uri, MediaPackageElementFlavor flavor, MediaPackage mediaPackage)
+  MediaPackage addCatalog(URI uri, MediaPackageElementFlavor flavor, String[] tags, MediaPackage mediaPackage)
           throws MediaPackageException, IOException, IngestException;
 
   /**
@@ -313,6 +315,8 @@ public interface IngestService extends JobProducer {
    *          The URL of the file to add
    * @param flavor
    *          The flavor of the media that is being added
+   * @param tags
+   *           Tags to add to the attachment
    * @param mediaPackage
    *          The specific Opencast MediaPackage to which Media is being added
    * @return MediaPackage The updated Opencast MediaPackage element
@@ -321,7 +325,7 @@ public interface IngestService extends JobProducer {
    * @throws IngestException
    *           if an unexpected error occurs
    */
-  MediaPackage addAttachment(URI uri, MediaPackageElementFlavor flavor, MediaPackage mediaPackage)
+  MediaPackage addAttachment(URI uri, MediaPackageElementFlavor flavor, String[] tags, MediaPackage mediaPackage)
           throws MediaPackageException, IOException, IngestException;
 
   /**

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -658,20 +658,6 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
    * {@inheritDoc}
    *
    * @see org.opencastproject.ingest.api.IngestService#addTrack(java.net.URI,
-   *      org.opencastproject.mediapackage.MediaPackageElementFlavor, org.opencastproject.mediapackage.MediaPackage)
-   */
-  @Override
-  public MediaPackage addTrack(URI uri, MediaPackageElementFlavor flavor, MediaPackage mediaPackage)
-          throws IOException, IngestException {
-    String[] tags = null;
-    return this.addTrack(uri, flavor, tags, mediaPackage);
-
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * @see org.opencastproject.ingest.api.IngestService#addTrack(java.net.URI,
    *      org.opencastproject.mediapackage.MediaPackageElementFlavor, String[] ,
    *      org.opencastproject.mediapackage.MediaPackage)
    */

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -695,7 +695,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       if (tags != null && tags.length > 0) {
         MediaPackageElement trackElement = mp.getTrack(elementId);
         for (String tag : tags) {
-          logger.info("Adding Tag: " + tag + " to Element: " + elementId);
+          logger.info("Adding tag: " + tag + " to Element: " + elementId);
           trackElement.addTag(tag);
         }
       }
@@ -840,7 +840,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
    *      org.opencastproject.mediapackage.MediaPackageElementFlavor, org.opencastproject.mediapackage.MediaPackage)
    */
   @Override
-  public MediaPackage addCatalog(URI uri, MediaPackageElementFlavor flavor, MediaPackage mediaPackage)
+  public MediaPackage addCatalog(URI uri, MediaPackageElementFlavor flavor, String[] tags, MediaPackage mediaPackage)
           throws IOException, IngestException {
     Job job = null;
     try {
@@ -857,6 +857,13 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       }
       MediaPackage mp = addContentToMediaPackage(mediaPackage, elementId, newUrl, MediaPackageElement.Type.Catalog,
               flavor);
+      if (tags != null && tags.length > 0) {
+        MediaPackageElement catalogElement = mp.getCatalog(elementId);
+        for (String tag : tags) {
+          logger.info("Adding tag: " + tag + " to Element: " + elementId);
+          catalogElement.addTag(tag);
+        }
+      }
       job.setStatus(Job.Status.FINISHED);
       logger.info("Successful added catalog {} on mediapackage {} at URL {}", elementId, mediaPackage, newUrl);
       return mp;
@@ -1008,7 +1015,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
    *      org.opencastproject.mediapackage.MediaPackageElementFlavor, org.opencastproject.mediapackage.MediaPackage)
    */
   @Override
-  public MediaPackage addAttachment(URI uri, MediaPackageElementFlavor flavor, MediaPackage mediaPackage)
+  public MediaPackage addAttachment(URI uri, MediaPackageElementFlavor flavor, String[] tags, MediaPackage mediaPackage)
           throws IOException, IngestException {
     Job job = null;
     try {
@@ -1022,6 +1029,13 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       URI newUrl = addContentToRepo(mediaPackage, elementId, uri);
       MediaPackage mp = addContentToMediaPackage(mediaPackage, elementId, newUrl, MediaPackageElement.Type.Attachment,
               flavor);
+      if (tags != null && tags.length > 0) {
+        MediaPackageElement attachmentElement = mp.getAttachment(elementId);
+        for (String tag : tags) {
+          logger.debug("Adding tag: " + tag + " to Element: " + elementId);
+          attachmentElement.addTag(tag);
+        }
+      }
       job.setStatus(Job.Status.FINISHED);
       logger.info("Successful added attachment {} on mediapackage {} at URL {}", elementId, mediaPackage, newUrl);
       return mp;
@@ -1056,7 +1070,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       if (tags != null && tags.length > 0) {
         MediaPackageElement trackElement = mp.getAttachment(elementId);
         for (String tag : tags) {
-          logger.info("Adding Tag: " + tag + " to Element: " + elementId);
+          logger.info("Adding tag: " + tag + " to Element: " + elementId);
           trackElement.addTag(tag);
         }
       }

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
@@ -94,7 +94,7 @@ public class IngestRestServiceTest {
             (MediaPackage) EasyMock.anyObject())).andReturn(MediaPackageBuilderFactory.newInstance()
         .newMediaPackageBuilder().createNew());
     EasyMock.expect(ingestService.addTrack((URI) EasyMock.anyObject(), (MediaPackageElementFlavor) EasyMock.anyObject(),
-            (MediaPackage) EasyMock.anyObject()))
+                    (String[]) EasyMock.anyObject(), (MediaPackage) EasyMock.anyObject()))
             .andReturn(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());
     EasyMock.expect(ingestService.addTrack((URI) EasyMock.anyObject(), (MediaPackageElementFlavor) EasyMock.anyObject(),
             (String[]) EasyMock.anyObject(), (MediaPackage) EasyMock.anyObject()))

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/endpoint/IngestRestServiceTest.java
@@ -86,11 +86,13 @@ public class IngestRestServiceTest {
             .andReturn(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder()
                     .createNew(new IdImpl("1a6f70ab-4262-4523-9f8e-babce22a1ea8")));
     EasyMock.expect(ingestService.addAttachment((URI) EasyMock.anyObject(),
-            (MediaPackageElementFlavor) EasyMock.anyObject(), (MediaPackage) EasyMock.anyObject()))
-            .andReturn(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());
+            (MediaPackageElementFlavor) EasyMock.anyObject(), EasyMock.anyObject(),
+            (MediaPackage) EasyMock.anyObject())).andReturn(MediaPackageBuilderFactory.newInstance()
+        .newMediaPackageBuilder().createNew());
     EasyMock.expect(ingestService.addCatalog((URI) EasyMock.anyObject(),
-            (MediaPackageElementFlavor) EasyMock.anyObject(), (MediaPackage) EasyMock.anyObject()))
-            .andReturn(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());
+            (MediaPackageElementFlavor) EasyMock.anyObject(), EasyMock.anyObject(),
+            (MediaPackage) EasyMock.anyObject())).andReturn(MediaPackageBuilderFactory.newInstance()
+        .newMediaPackageBuilder().createNew());
     EasyMock.expect(ingestService.addTrack((URI) EasyMock.anyObject(), (MediaPackageElementFlavor) EasyMock.anyObject(),
             (MediaPackage) EasyMock.anyObject()))
             .andReturn(MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew());
@@ -434,14 +436,14 @@ public class IngestRestServiceTest {
 
   @Test
   public void testAddMediaPackageCatalog() throws Exception {
-    Response response = restService.addMediaPackageCatalog("http://foo/dc.xml", "dublincore/episode",
+    Response response = restService.addMediaPackageCatalog("http://foo/dc.xml", "dublincore/episode", null,
             MediaPackageParser.getAsXml(((MediaPackage) restService.createMediaPackage().getEntity())));
     Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
 
   @Test
   public void testAddMediaPackageAttachment() throws Exception {
-    Response response = restService.addMediaPackageAttachment("http://foo/cover.png", "image/cover",
+    Response response = restService.addMediaPackageAttachment("http://foo/cover.png", "image/cover", null,
             MediaPackageParser.getAsXml(((MediaPackage) restService.createMediaPackage().getEntity())));
     Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
@@ -361,8 +361,9 @@ public class IngestServiceImplTest {
 
     mediaPackage = service.createMediaPackage();
     mediaPackage = service.addTrack(urlTrack, MediaPackageElements.PRESENTATION_SOURCE, mediaPackage);
-    mediaPackage = service.addCatalog(urlCatalog1, MediaPackageElements.EPISODE, mediaPackage);
-    mediaPackage = service.addAttachment(urlAttachment, MediaPackageElements.MEDIAPACKAGE_COVER_FLAVOR, mediaPackage);
+    mediaPackage = service.addCatalog(urlCatalog1, MediaPackageElements.EPISODE, null, mediaPackage);
+    mediaPackage = service.addAttachment(urlAttachment, MediaPackageElements.MEDIAPACKAGE_COVER_FLAVOR, null,
+        mediaPackage);
     WorkflowInstance instance = service.ingest(mediaPackage);
     Assert.assertEquals(1, mediaPackage.getTracks().length);
     Assert.assertEquals(1, mediaPackage.getCatalogs().length);

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
@@ -360,7 +360,7 @@ public class IngestServiceImplTest {
     service.updated(properties);
 
     mediaPackage = service.createMediaPackage();
-    mediaPackage = service.addTrack(urlTrack, MediaPackageElements.PRESENTATION_SOURCE, mediaPackage);
+    mediaPackage = service.addTrack(urlTrack, MediaPackageElements.PRESENTATION_SOURCE, null, mediaPackage);
     mediaPackage = service.addCatalog(urlCatalog1, MediaPackageElements.EPISODE, null, mediaPackage);
     mediaPackage = service.addAttachment(urlAttachment, MediaPackageElements.MEDIAPACKAGE_COVER_FLAVOR, null,
         mediaPackage);
@@ -419,13 +419,13 @@ public class IngestServiceImplTest {
 
     mediaPackage = service.createMediaPackage();
     try {
-      mediaPackage = service.addTrack(URI.create("http://www.test.com/testfile"), null, mediaPackage);
+      mediaPackage = service.addTrack(URI.create("http://www.test.com/testfile"), null, null, mediaPackage);
     } catch (Exception e) {
       Assert.fail("Unable to read content dispostion filename: " + e.getMessage());
     }
 
     try {
-      mediaPackage = service.addTrack(urlTrackNoFilename, null, mediaPackage);
+      mediaPackage = service.addTrack(urlTrackNoFilename, null, null, mediaPackage);
       Assert.fail("Allowed adding content without filename!");
     } catch (Exception e) {
       Assert.assertNotNull(e);
@@ -471,7 +471,7 @@ public class IngestServiceImplTest {
     service.updated(props);
 
     try {
-      service.addTrack(URI.create(url), null, mediaPackage);
+      service.addTrack(URI.create(url), null, null, mediaPackage);
     } catch (IOException e) {
       if (!shouldFail) {
         Assert.fail("Should not have failed!");
@@ -714,11 +714,11 @@ public class IngestServiceImplTest {
   public void testFailedJobs() throws Exception {
     Assert.assertEquals(0, serviceRegistry.getJobs(IngestServiceImpl.JOB_TYPE, Job.Status.FINISHED).size());
     Assert.assertEquals(0, serviceRegistry.getJobs(IngestServiceImpl.JOB_TYPE, Job.Status.FAILED).size());
-    service.addTrack(urlTrack, MediaPackageElements.PRESENTATION_SOURCE, service.createMediaPackage());
+    service.addTrack(urlTrack, MediaPackageElements.PRESENTATION_SOURCE, null, service.createMediaPackage());
     Assert.assertEquals(1, serviceRegistry.getJobs(IngestServiceImpl.JOB_TYPE, Job.Status.FINISHED).size());
     Assert.assertEquals(0, serviceRegistry.getJobs(IngestServiceImpl.JOB_TYPE, Job.Status.FAILED).size());
     try {
-      service.addTrack(URI.create("file//baduri"), MediaPackageElements.PRESENTATION_SOURCE,
+      service.addTrack(URI.create("file//baduri"), MediaPackageElements.PRESENTATION_SOURCE, null,
               service.createMediaPackage());
     } catch (Exception e) {
       // Ignore exception


### PR DESCRIPTION
Adding tags when ingesting a track via URL already works, so I added the same for catalogs and attachments since I needed this for a migration script. Mostly copy-and-paste, I also removed a wrapper method that was only used by the tests to clean up the interface a bit.

Adding tags when ingesting the files directly already worked, but wasn't included in the rest docs for attachments and catalogs, so I added that. Also some minor fixes in the descriptions.