### PR TITLE
Allow setting explicit id for themes

### DIFF
--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestThemesEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestThemesEndpoint.java
@@ -76,7 +76,7 @@ public class TestThemesEndpoint extends ThemesEndpoint {
   }
 
   private void addData() throws ThemesServiceDatabaseException {
-    Theme theme = new Theme(Option.some(theme1Id), creationDate, true, user, "The Theme name", "The Theme description",
+    Theme theme = new Theme(Option.none(), creationDate, true, user, "The Theme name", "The Theme description",
             true, "bumper-file", true, "trailer-file", true, "title,room,date", "title-background-file", true,
             "license-background-file", "The license description", true, "watermark-file", "top-left");
     themesServiceDatabaseImpl.updateTheme(theme);

--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
@@ -219,6 +219,9 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
   }
 
   private void updateTheme(Theme theme, ThemeDto themeDto) {
+    if (theme.getId().isSome()) {
+      themeDto.setId(theme.getId().get());
+    }
     themeDto.setUsername(theme.getCreator().getUsername());
     themeDto.setCreationDate(theme.getCreationDate());
     themeDto.setDefault(theme.isDefault());


### PR DESCRIPTION
This allows to explicitly set the identifier of a theme on creation or update. Currently Opencast does not do this, but you could use this via the Admin UI endpoint to faithfully recreate themes during a migration. In that case, keeping the id is important since the series have a reference to their theme via the id.