### PR TITLE
Give internal opencast editor a unique external URL for Shibboleth

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -182,6 +182,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-streaming-wowza/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-workflowoperation/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-editor-external-url/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-email-template-service-api/${project.version}</bundle>
@@ -293,6 +294,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-streaming-remote/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-workflowoperation/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-editor-external-url/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-email-template-service-api/${project.version}</bundle>

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -97,6 +97,7 @@
     <sec:intercept-url pattern="/admin-ng/themes/*/usage.json" method="GET" access="ROLE_ADMIN, ROLE_UI_THEMES_DETAILS_VIEW" />
     <sec:intercept-url pattern="/admin-ng/themes/*.json" method="GET" access="ROLE_ADMIN, ROLE_UI_THEMES_DETAILS_VIEW" />
     <sec:intercept-url pattern="/admin-ng/tools/*/editor.json" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_EDITOR_VIEW" />
+    <sec:intercept-url pattern="/admin-ng/editor/*" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/admin-ng/tools/*/thumbnail.json" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_EDITOR_VIEW" />
     <sec:intercept-url pattern="/admin-ng/tools/*.json" method="GET" access="ROLE_ADMIN, ROLE_UI_EVENTS_EDITOR_VIEW" />
     <sec:intercept-url pattern="/admin-ng/users/users.json" method="GET" access="ROLE_ADMIN, ROLE_UI_USERS_VIEW" />
@@ -161,6 +162,7 @@
     <sec:intercept-url pattern="/admin-ng/tasks/new" method="POST" access="ROLE_ADMIN, ROLE_UI_TASKS_CREATE" />
     <sec:intercept-url pattern="/admin-ng/themes" method="POST" access="ROLE_ADMIN, ROLE_UI_THEMES_CREATE" />
     <sec:intercept-url pattern="/admin-ng/tools/*/editor.json" method="POST" access="ROLE_ADMIN, ROLE_UI_EVENTS_EDITOR_EDIT" />
+    <sec:intercept-url pattern="/admin-ng/editor/*" method="GET" access="ROLE_ANONYMOUS" />
     <sec:intercept-url pattern="/admin-ng/tools/*/thumbnail.json" method="POST" access="ROLE_ADMIN, ROLE_UI_EVENTS_EDITOR_EDIT" />
     <sec:intercept-url pattern="/admin-ng/users" method="POST" access="ROLE_ADMIN, ROLE_UI_USERS_CREATE" />
     <sec:intercept-url pattern="/admin-ng/user-settings/signature" method="POST" access="ROLE_ADMIN, ROLE_ADMIN_UI" />

--- a/modules/editor-external-url/pom.xml
+++ b/modules/editor-external-url/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>opencast-editor-external-url</artifactId>
+  <packaging>bundle</packaging>
+  <name>Opencast :: editor-external-url</name>
+  <parent>
+    <groupId>org.opencastproject</groupId>
+    <artifactId>base</artifactId>
+    <version>11-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <properties>
+    <opencast.basedir>${project.basedir}/../..</opencast.basedir>
+    <checkstyle.skip>false</checkstyle.skip>
+  </properties>
+  <dependencies>
+    <!-- osgi support -->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.cmpn</artifactId>
+    </dependency>
+    <!-- opencast -->
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- other -->
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Build-Number>${buildNumber}</Build-Number>
+            <Import-Package>
+              javax.ws.rs;version=2.0.1,
+              javax.ws.rs.core;version=2.0.1,
+              *
+            </Import-Package>
+            <Export-Package>
+            </Export-Package>
+            <Service-Component>
+            </Service-Component>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/modules/editor-external-url/src/main/java/org/opencastproject/editor/external/url/EditorExternalUrlEndpoint.java
+++ b/modules/editor-external-url/src/main/java/org/opencastproject/editor/external/url/EditorExternalUrlEndpoint.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.editor.external.url;
+
+import static javax.servlet.http.HttpServletResponse.SC_SEE_OTHER;
+
+import org.opencastproject.util.doc.rest.RestParameter;
+import org.opencastproject.util.doc.rest.RestParameter.Type;
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
+import org.opencastproject.util.doc.rest.RestService;
+
+import org.osgi.service.component.annotations.Component;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * External URL for the internal Opencast editor.
+ */
+@Path("/")
+@RestService(name = "EditorExternalUrlEndpoint",
+    title = "Editor External URL Endpoint",
+    abstractText = "External URL Endpoint",
+    notes = {
+        "This provides an external URL for the internal Opencast editor e.g. for use with Shibboleth."
+    }
+)
+@Component(
+    immediate = true,
+    service = EditorExternalUrlEndpoint.class,
+    property = {
+        "service.description=External URL for internal Opencast editor",
+        "opencast.service.type=org.opencastproject.editor.external.url.EditorExternalUrlEndpoint",
+        "opencast.service.path=/admin-ng/editor",
+    }
+)
+public class EditorExternalUrlEndpoint {
+
+  @GET
+  @Path("{eventId}")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(
+      name = "editor",
+      description = "An external URL for the internal Opencast editor",
+      pathParameters = {
+          @RestParameter(name = "eventId", isRequired = true, type = Type.STRING, description = "Event ID")
+      },
+      responses = {
+          @RestResponse(description = "Redirect", responseCode = SC_SEE_OTHER)
+      },
+      returnDescription = "Redirects to the internal Opencast editor.")
+  public Response editorExternalURL(@PathParam("eventId") String eventId) {
+    Response.ResponseBuilder builder = Response.status(Response.Status.SEE_OTHER);
+    builder.header("Location", "/admin-ng/index.html#!/events/events/" + eventId + "/tools/editor");
+    return builder.build();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,8 @@
     <module>modules/distribution-service-streaming-wowza</module>
     <module>modules/distribution-workflowoperation</module>
     <module>modules/dublincore</module>
+    <module>modules/editor-external-url</module>
+    <module>modules/editor-service</module>
     <module>modules/editor-service-api</module>
     <module>modules/editor-service-remote</module>
     <module>modules/editor-service</module>


### PR DESCRIPTION
I'm not entirely sure if this will be helpful, but I thought I'd at least put it out there.

So what we're trying to do is link to the internal Opencast editor (_not_ the new editor) in Ilias. That URL is protected by Shibboleth, so you will be prompted to log in if you haven't already. However, after login, you will be redirected to the Admin UI, not the editor UI. This is because the part that's telling Opencast we want to go the editor is only in the query string, and this information gets lost. (If you have an idea about how to get this to work with Shibboleth and Nginx, I'd love to hear it, I currently don't think it's possible.)
So we stole an idea from SWITCH, which is to create a new endpoint under a unique URL that simply redirects to the internal one.

Ideally this would probably be part of Opencast, but not active by default, because most people will never need it, but I'm too tired to understand how this is currently done for other modules (e.g. the ones for Shibboleth). It looks complicated?
On the other hand... it's an endpoint.

Just tell me what you think. ;)