### PR TITLE
Fix search service limit - update more than 10 events for a series change

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SeriesUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SeriesUpdatedEventHandler.java
@@ -186,7 +186,7 @@ public class SeriesUpdatedEventHandler {
     try {
       securityService.setUser(SecurityUtil.createSystemUser(systemAccount, prevOrg));
 
-      SearchQuery q = new SearchQuery().withSeriesId(seriesId);
+      SearchQuery q = new SearchQuery().withSeriesId(seriesId).withLimit(-1);
       SearchResult result = searchService.getForAdministrativeRead(q);
 
       for (SearchResultItem item : result.getItems()) {

--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchQuery.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchQuery.java
@@ -29,6 +29,9 @@ import java.util.Date;
  * Represents a query to find search results
  */
 public class SearchQuery {
+
+  public static final int DEFAULT_LIMIT = 100;
+
   protected boolean includeEpisode = true;
   protected boolean includeSeries = false;
   protected boolean includeDeleted = false;
@@ -36,7 +39,7 @@ public class SearchQuery {
   protected String seriesId;
   protected String text;
   protected String query;
-  protected int limit = 0;
+  protected int limit = DEFAULT_LIMIT;
   protected int offset = 0;
   protected String[] tags = null;
   protected MediaPackageElementFlavor[] flavors = null;

--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResult.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResult.java
@@ -22,8 +22,6 @@
 
 package org.opencastproject.search.api;
 
-import java.util.Optional;
-
 /**
  * A single result of searching.
  */
@@ -69,7 +67,7 @@ public interface SearchResult {
    *
    * @return The limit.
    */
-  Optional<Long> getLimit();
+  long getLimit();
 
   /**
    * Get the search time.

--- a/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultImpl.java
+++ b/modules/search-service-api/src/main/java/org/opencastproject/search/api/SearchResultImpl.java
@@ -22,6 +22,8 @@
 
 package org.opencastproject.search.api;
 
+import static org.opencastproject.search.api.SearchQuery.DEFAULT_LIMIT;
+
 import org.opencastproject.util.XmlSafeParser;
 
 import org.apache.commons.io.IOUtils;
@@ -31,7 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -50,7 +51,7 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(
     name = "search-results",
     namespace = "http://search.opencastproject.org",
-    propOrder = { "query", "resultSet", "limit" }
+    propOrder = { "query", "resultSet" }
 )
 @XmlRootElement(name = "search-results", namespace = "http://search.opencastproject.org")
 public class SearchResultImpl implements SearchResult {
@@ -98,9 +99,9 @@ public class SearchResultImpl implements SearchResult {
   @XmlAttribute
   private long offset = 0;
 
-  /** The pagination limit. Default is 10. */
-  @XmlElement
-  private Optional<Long> limit = Optional.of(10L);
+  /** The pagination limit. Default is 100. */
+  @XmlAttribute
+  private long limit = DEFAULT_LIMIT;
 
   /** The number of hits total, regardless of the limit */
   @XmlAttribute
@@ -195,7 +196,7 @@ public class SearchResultImpl implements SearchResult {
    *
    * @see org.opencastproject.search.api.SearchResult#getLimit()
    */
-  public Optional<Long> getLimit() {
+  public long getLimit() {
     return limit;
   }
 
@@ -205,7 +206,7 @@ public class SearchResultImpl implements SearchResult {
    * @param limit
    *          The limit.
    */
-  public void setLimit(Optional<Long> limit) {
+  public void setLimit(long limit) {
     this.limit = limit;
   }
 
@@ -253,8 +254,8 @@ public class SearchResultImpl implements SearchResult {
    * @see org.opencastproject.search.api.SearchResult#getPage()
    */
   public long getPage() {
-    if (limit.isPresent() && limit.get() != 0) {
-      return offset / limit.get();
+    if (limit != 0) {
+      return offset / limit;
     }
     return 0;
   }

--- a/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/SeriesFeedService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/feed/impl/SeriesFeedService.java
@@ -46,7 +46,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -226,7 +225,7 @@ public class SeriesFeedService extends AbstractFeedService implements FeedGenera
         SearchResultImpl artificialResult = new SearchResultImpl();
 
         // Response either finds the one series or nothing at all
-        artificialResult.setLimit(Optional.of(1L));
+        artificialResult.setLimit(1L);
         artificialResult.setOffset(0);
         artificialResult.setTotal(1);
 

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/endpoint/SearchRestService.java
@@ -272,8 +272,9 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               name = "limit",
               isRequired = false,
               type = RestParameter.Type.STRING,
-              defaultValue = "20",
-              description = "The maximum number of items to return per page."
+              defaultValue = "100",
+              description = "The maximum number of items to return per page. -1 translates to everything, however, "
+                      + "non-admin users will only ever get a maximum of 2000 results. 0 is equal to 100."
           ),
           @RestParameter(
               name = "offset",
@@ -413,8 +414,9 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               name = "limit",
               isRequired = false,
               type = RestParameter.Type.STRING,
-              defaultValue = "20",
-              description = "The maximum number of items to return per page."
+              defaultValue = "100",
+              description = "The maximum number of items to return per page. -1 translates to everything, however, "
+                      + "non-admin users will only ever get a maximum of 2000 results. 0 is equal to 100."
           ),
           @RestParameter(
               name = "offset",
@@ -594,8 +596,9 @@ public class SearchRestService extends AbstractJobProducerEndpoint {
               name = "limit",
               isRequired = false,
               type = RestParameter.Type.STRING,
-              defaultValue = "20",
-              description = "The maximum number of items to return per page."
+              defaultValue = "100",
+              description = "The maximum number of items to return per page. -1 translates to everything, however, "
+                      + "non-admin users will only ever get a maximum of 2000 results. 0 is equal to 100."
           ),
           @RestParameter(
               name = "offset",

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/solr/SolrRequester.java
@@ -70,7 +70,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -176,7 +175,7 @@ public class SolrRequester {
     final SearchResultImpl result = new SearchResultImpl(query.getQuery());
     result.setSearchTime(solrResponse.getQTime());
     result.setOffset(solrResponse.getResults().getStart());
-    result.setLimit(Optional.ofNullable(query.getRows()).map(i -> Long.valueOf(i)));
+    result.setLimit(query.getRows());
     result.setTotal(solrResponse.getResults().getNumFound());
 
     // Walk through response and create new items with title, creator, etc:


### PR DESCRIPTION
Okay, this is a bit of an obscure bug that requires some explanation.

The SeriesUpdatedEventHandler reacts to changes to a series, e.g. the ACL, and will update all events of that series accordingly (e.g. setting the new series ACL and making a snapshot). Or, that's the intention. Since #3119, this will only update the first 10 events. Why? Well...

1. The SeriesUpdatedEventHandler queries the search service without explicitely setting a limit.
2. In SeachQuery, the default limit is 0.
3. In SolrRequester, prior to the pull request linked above, that would default to QUERY_MAX_ROWS, which is 2000. (See #1092.) However, this was changed for admins in #3119, so they can query more than 2000 results. This unintentionally leads to no limit being set for admins if limit is <= 0.
4. Solr itself will default to 10 if no limit is set.

Setting reasonable limits is made difficult by the fact that the search endpoint is also used internally by the remote. Additionally, Solr will be removed soon, so I ~~didn't want to put too much thought into this~~ (this is a lie, I totally put too much thought into this). So I did the following:

1. In SolrRequester:
    1. Differentiate only between admins and non-Admins where the allowed max limit is concerned - non-admins: MAX_QUERY_ROWS = 2000, admins: None (no more setting limit to MAX_QUERY_ROWS if <= 0)
    2. If limit is 0, default to 100.
    3. Translate all negative values to MAX_INT to be similar to Elasticsearch (otherwise Solr will return 0 results) and so create a shorthand for 'give me everything you have'. Of course this will only work for admins, non-admins will get 2000 results max.
3. Use that shorthand in SeriesUpdatedEventHandler (set limit explicitly to -1).
4. In SearchQuery, set default limit of 100. This has the disadvantage that when coding, you have to remember to set limit to -1 to ensure you get everything, but the advantage that you can't query everything by accident by not setting limit when querying the endpoint. It's a trade-off...
5. Change default of limit for the search endpoint from 20 to 100 to be equal to that of SearchQuery.
5. Document all of this in the rest docs of the search endpoint to avoid confusion.

So basically:
- No limit -> 100 (
    - before: 20 in endpoint, 2000 for non-admins, 10 for admins
- 0 -> 100 
    - before: 2000 for non-admins, 10 for admins
- Negative limit -> endless when admin, otherwise 2000 
    - before: 2000 for non-admins, 10 for admins
- Limit > 2000 -> capped to 2000 for non-admins
    - same as before

This behavior is similar, but not identical to Elasticsearch (but that behavior is all over the place as well, soo...). All but the last point are new behaviors. A lot of this might be controversial, but I think there's not a perfect solution to be had here as long as Solr exists. At least now we don't have a hundred different default values?

However, the most important question is probably how much of these changes can go into a minor release. One could argue that this behavior is broken right now, however, I also didn't go back to the behavior as it was before, so this change could break other things. I checked the usage of search in Opencast, but I don't know how other projects might be affected by this, and what guarantees we currently make for the search API.

This will be probably discussed in the next Technical Meeting, so stay tuned. Now excuse me while I go wash my brain with bleach.

----------------------------------------------------------------------------------------------------------------------------------------------------------
EDIT:

There is actually a second bug introduced by #3119, which is that limit is returned as an empty string by the search endpoint because RequestBuilder can't handle the new Optional. Since we now, once again, always set a limit, we don't need the Optional anymore, so I created a second commit that undoes that change.