### PR TITLE
Fix filename dependency on locale

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -88,6 +88,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.IllegalFormatException;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -296,7 +297,7 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
    * Format a filename and make it "safe".
    */
   static String formatFileName(String format, double position, String suffix) {
-    return format(format, position, suffix);
+    return format(Locale.ROOT, format, position, suffix);
   }
 
 


### PR DESCRIPTION
The filename used for the image workflow operation depends on the used locale. This fixes the used locale to be `Locale.ROOT`

This bug is only visible due to #3960 and should not affect older Opencast versions.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
