### PR TITLE
Add basic auth support ingest download

### DIFF
--- a/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
+++ b/etc/org.opencastproject.ingest.impl.IngestServiceImpl.cfg
@@ -49,9 +49,13 @@
 # The credentials can be set for an external source (example: https://develop.opencast.org).
 # For example, this can be used to make Opencast download files from another Opencast.
 # The source is written as a regular expression.
+# auth.method can either be "Digest" or "Basic".
+# If auth.force_basic is true and method is Basic requests are always authenticated.
 # Example for two sources: (.*)//develop.opencast.org/(.*)|(.*)//stable.opencast.org/(.*)
 # Default: <empty>
 #org.opencastproject.download.source = http://localhost/.*
+#org.opencastproject.download.auth.method = Digest
+#org.opencastproject.download.auth.force_basic = false
 #org.opencastproject.download.user = opencast_system_account
 #org.opencastproject.download.password = CHANGE_ME
 

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -479,6 +479,7 @@
     <!-- CAS Auth:  Uncomment this if using CAS authentication -->
     <!-- <property name="userEntryPoint" ref="casEntryPoint" /> -->
     <property name="digestAuthenticationEntryPoint" ref="digestEntryPoint" />
+    <property name="basicAuthenticationEntryPoint" ref="basicEntryPoint" />
   </bean>
 
   <!-- Redirects unauthenticated requests to the login form -->

--- a/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
+++ b/modules/ingest-service-impl/src/test/java/org/opencastproject/ingest/impl/IngestServiceImplTest.java
@@ -467,6 +467,9 @@ public class IngestServiceImplTest {
 
     Dictionary<String, String> props = new Hashtable<>();
     props.put(IngestServiceImpl.DOWNLOAD_SOURCE, regex);
+    props.put(IngestServiceImpl.DOWNLOAD_USER, "user");
+    props.put(IngestServiceImpl.DOWNLOAD_PASSWORD, "password");
+
     service.updated(props);
 
     try {

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/DelegatingAuthenticationEntryPoint.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/DelegatingAuthenticationEntryPoint.java
@@ -23,6 +23,7 @@ package org.opencastproject.kernel.security;
 
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
 import org.springframework.security.web.authentication.www.DigestAuthenticationEntryPoint;
 
 import java.io.IOException;
@@ -38,10 +39,12 @@ import javax.servlet.http.HttpServletResponse;
 public class DelegatingAuthenticationEntryPoint implements AuthenticationEntryPoint {
   public static final String REQUESTED_AUTH_HEADER = "X-Requested-Auth";
   public static final String DIGEST_AUTH = "Digest";
+  public static final String BASIC_AUTH = "Basic";
   public static final String INITIAL_REQUEST_PATH = "initial_request_path";
 
   protected AuthenticationEntryPoint userEntryPoint;
   protected DigestAuthenticationEntryPoint digestAuthenticationEntryPoint;
+  private BasicAuthenticationEntryPoint basicAuthenticationEntryPoint;
 
   /**
    * {@inheritDoc}
@@ -54,6 +57,8 @@ public class DelegatingAuthenticationEntryPoint implements AuthenticationEntryPo
           throws IOException, ServletException {
     if (DIGEST_AUTH.equals(request.getHeader(REQUESTED_AUTH_HEADER))) {
       digestAuthenticationEntryPoint.commence(request, response, authException);
+    } else if (BASIC_AUTH.equals(request.getHeader(REQUESTED_AUTH_HEADER))) {
+      basicAuthenticationEntryPoint.commence(request, response, authException);
     } else {
       // if the user attempted to access a url other than /, store this in the session so we can forward the user there
       // after a successful login
@@ -86,5 +91,13 @@ public class DelegatingAuthenticationEntryPoint implements AuthenticationEntryPo
    */
   public void setDigestAuthenticationEntryPoint(DigestAuthenticationEntryPoint digestAuthenticationEntryPoint) {
     this.digestAuthenticationEntryPoint = digestAuthenticationEntryPoint;
+  }
+
+  /**
+   * @param basicAuthenticationEntryPoint
+   *          the basic auth entrypoint to set
+   */
+  public void setBasicAuthenticationEntryPoint(BasicAuthenticationEntryPoint basicAuthenticationEntryPoint) {
+    this.basicAuthenticationEntryPoint = basicAuthenticationEntryPoint;
   }
 }


### PR DESCRIPTION
The ingest service allows downloads from external HTTP servers. However, currently, only digest auth is supported. This introduces a new setting to switch this to basic authentication. By default, requests are only authenticated if the HTTP server requires this during a previous request attempt. An additional option allows forcing authenticating requests for basic auth.

Opencast allows forcing requests to be made with digest auth when setting the `X-Requested-Auth: Digest` header. This PR also allows the same for basic auth with `X-Requested-Auth: Basic`.

Also see #3915

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
