### PR TITLE
Add support for multiple common metadata catalogs

### DIFF
--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/CatalogUIAdapterFactory.java
@@ -141,10 +141,6 @@ public class CatalogUIAdapterFactory implements ManagedServiceFactory {
           ConfigurableEventDCCatalogUIAdapter adapter;
           String[] adapterClassesNames;
           if (isCommonMetadata) {
-            if (bundleContext.getServiceReference(CommonEventCatalogUIAdapter.class.getName()) != null)
-              throw new ConfigurationException(CONF_COMMON_METADATA_KEY, format(
-                      "Only one common metadata catalog adapter is allowed for the type '%s'", CATALOG_TYPE_EVENTS));
-
             adapter = new CommonEventCatalogUIAdapter();
             adapterClassesNames = new String[] { CommonEventCatalogUIAdapter.class.getName(),
                     EventCatalogUIAdapter.class.getName() };
@@ -173,10 +169,6 @@ public class CatalogUIAdapterFactory implements ManagedServiceFactory {
           ConfigurableSeriesDCCatalogUIAdapter adapter;
           String[] adapterClassesNames;
           if (isCommonMetadata) {
-            if (bundleContext.getServiceReference(CommonSeriesCatalogUIAdapter.class.getName()) != null)
-              throw new ConfigurationException(CONF_COMMON_METADATA_KEY, format(
-                      "Only one common metadata catalog adapter is allowed for the type '%s'", CATALOG_TYPE_SERIES));
-
             adapter = new CommonSeriesCatalogUIAdapter();
             adapterClassesNames = new String[] { CommonSeriesCatalogUIAdapter.class.getName(),
                     SeriesCatalogUIAdapter.class.getName() };

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -461,7 +461,7 @@ public class IndexServiceImpl implements IndexService {
 
     if (orgEventCatalogUIAdapter.isPresent()) {
       return orgEventCatalogUIAdapter.get();
-    } else if (organization != DEFAULT_ORGANIZATION_ID) {
+    } else if (!organization.equals(DEFAULT_ORGANIZATION_ID)) {
       return getCommonEventCatalogUIAdapter(DEFAULT_ORGANIZATION_ID);
     } else {
        throw new IllegalStateException("Common event metadata for " + DEFAULT_ORGANIZATION_ID + " needs to be "
@@ -477,7 +477,7 @@ public class IndexServiceImpl implements IndexService {
 
     if (orgSeriesCatalogUIAdapter.isPresent()) {
       return orgSeriesCatalogUIAdapter.get();
-    } else if (organization != DEFAULT_ORGANIZATION_ID) {
+    } else if (!organization.equals(DEFAULT_ORGANIZATION_ID)) {
       return getCommonSeriesCatalogUIAdapter(DEFAULT_ORGANIZATION_ID);
     } else {
       throw new IllegalStateException("Common series metadata for " + DEFAULT_ORGANIZATION_ID + " needs to be "


### PR DESCRIPTION
Previously there could only be a single common metadata catalog for all tenants. This change allows common metadata catalogs per tenant while falling back to mh_default_org if a tenant does not provide one. In this way the common metadata catalogs can differ between tenants (e.g. different required fields etc.).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
