### PR TITLE
Dont run gh actions on dbot multiple times

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -20,6 +20,8 @@ on:
 
 jobs:
   build:
+    # Don't run dependabot pull requests multiple times
+    if: ${{ !(github.event_name == 'push' && github.actor == 'dependabot[bot]')  }}
     strategy:
       matrix:
         java:


### PR DESCRIPTION
Aims to resolve #4171 by checking if the author is dependabot and if the event is a push. See #4171 for more details.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
