### PR TITLE
Do not run dependabot pushes multiple times

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -17,11 +17,11 @@ on:
       - 'docs/log4j/**'
       - 'assemblies/**'
       - '.github/**'
+    branches-ignore:    
+      - 'dependabot/**'  # Don't run dependabot branches, as they are already covered by pull requests
 
 jobs:
   build:
-    # Don't run dependabot pull requests multiple times
-    if: ${{ !(github.event_name == 'push' && github.actor == 'dependabot[bot]')  }}
     strategy:
       matrix:
         java:


### PR DESCRIPTION
We do not need to run tests on dependabot pushes, as they are already covered by its pull requests.

This is an alternative approach to #4187, filtering on the event level. Dependabot always creates branches under `dependabot/**`. According to [the docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore), there is a suitable filter:

> When using the `push` event, you can configure a workflow to run on
> specific branches or tags.
>
> Use the `branches` filter when you want to include branch name
> patterns or when you want to both include and exclude branch names
> patterns. Use the `branches-ignore` filter when you only want to
> exclude branch name patterns. You cannot use both the `branches` and
> `branches-ignore` filters for the same event in a workflow. 

Fixes: #4171

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
