### PR TITLE
Usage of CPU load for job dispatching

### DIFF
--- a/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
+++ b/etc/org.opencastproject.serviceregistry.impl.ServiceRegistryJpaImpl.cfg
@@ -22,7 +22,6 @@
 # Default: 14
 #org.opencastproject.statistics.services.max_job_age = 14
 
-
 # Comma-separated list of encoding specialized worker nodes. Specified workers are preferred when dispatching encoding jobs.
 # Default: empty
 #org.opencastproject.encoding.workers=http://example.com, http://example1.com:8080
@@ -31,3 +30,13 @@
 # A value of 0.2 corresponds to a threshold of 20% worker load
 # Default: 0.0
 #org.opencastproject.encoding.workers.threshold=
+
+# Flag to enable dispatching by the servers hardware load.
+# When dispatching jobs, nodes with lower hardware utilization get preffered.
+# When a nodes hardware load exceeds its max.hardwareload it doesn't accept anymore jobs.
+#Default: false
+#hardware.load.enabled=false
+
+# The maximum hardware load on this server.
+# Default: number of cores
+# org.opencastproject.server.max.hardwareload=24

--- a/modules/common/src/main/java/org/opencastproject/job/api/AbstractJobProducer.java
+++ b/modules/common/src/main/java/org/opencastproject/job/api/AbstractJobProducer.java
@@ -178,6 +178,12 @@ public abstract class AbstractJobProducer implements JobProducer {
     // Add the current job load to compare below
     currentLoad += job.getJobLoad();
 
+    //if hardware load is enabled use the hardware load values instead
+    if (getServiceRegistry().isHardwareLoadEnabled()) {
+      currentLoad = (float)getServiceRegistry().getHardwareLoad();
+      maxload.setMaxLoad((float)getServiceRegistry().getMaxHardwareLoad());
+    }
+
     /* Note that this first clause looks at the *job's*, the other two look at the *node's* load
      * We're assuming that if this case is true, then we're also the most powerful node in the system for this service,
      * per the current job dispatching code in ServiceRegistryJpaImpl */

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistry.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistry.java
@@ -117,11 +117,32 @@ public interface ServiceRegistry {
   SystemLoad getCurrentHostLoads() throws ServiceRegistryException;
 
   /**
-   * Gets the load value for the current host (ie, the host this service registry lives on
+   * Gets the load value for the current host (ie, the host this service registry lives on)
    *
    * @return the load value for this host
    */
   float getOwnLoad() throws ServiceRegistryException;
+
+  /**
+   * Gets the hardware load value for the current host (ie, the host this service registry lives on)
+   *
+   * @return the hardware load value for this host
+   */
+  double getHardwareLoad() throws ServiceRegistryException;
+
+  /**
+   * Gets the maximum hardware load value for the current host (ie, the host this service registry lives on)
+   *
+   * @return the maximum hardware load value for this host
+   */
+  double getMaxHardwareLoad() throws ServiceRegistryException;
+
+  /**
+   * Returns true if the hardware load is enabled
+   *
+   * @return the maximum hardware load value for this host
+   */
+  boolean isHardwareLoadEnabled() throws ServiceRegistryException;
 
   /**
    * Registers a host to handle a specific type of job

--- a/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/serviceregistry/api/ServiceRegistryInMemoryImpl.java
@@ -1095,6 +1095,21 @@ public class ServiceRegistryInMemoryImpl implements ServiceRegistry {
   }
 
   @Override
+  public double getHardwareLoad() throws ServiceRegistryException {
+    return 0;
+  }
+
+  @Override
+  public double getMaxHardwareLoad() throws ServiceRegistryException {
+    return 0;
+  }
+
+  @Override
+  public boolean isHardwareLoadEnabled() throws ServiceRegistryException {
+    return false;
+  }
+
+  @Override
   public String getRegistryHostname() {
     return LOCALHOST;
   }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -68,7 +68,6 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.osgi.framework.BundleContext;

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/ServiceRegistryEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/ServiceRegistryEndpoint.java
@@ -688,6 +688,20 @@ public class ServiceRegistryEndpoint {
   }
 
   @GET
+  @Path("maxhardwareload")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(name = "maxhardwareload", description = "Returns the maximum hardware load this service registry can execute concurrently.",
+      returnDescription = "The  maximum hardware load this service registry can execute", restParameters = {},
+      responses = { @RestResponse(responseCode = SC_OK, description = "Maximum hardware load this service registry can execute.") })
+  public Response getMaxHardwareLoad() {
+    try {
+      return Response.ok(serviceRegistry.getMaxHardwareLoad()).build();
+    } catch (ServiceRegistryException e) {
+      throw new WebApplicationException(e);
+    }
+  }
+
+  @GET
   @Path("currentload")
   @Produces(MediaType.TEXT_XML)
   @RestQuery(name = "currentload", description = "Returns the current load on the servers in this service registry.  "
@@ -712,6 +726,20 @@ public class ServiceRegistryEndpoint {
   public Response getOwnLoad() {
     try {
       return Response.ok(serviceRegistry.getOwnLoad()).build();
+    } catch (ServiceRegistryException e) {
+      throw new WebApplicationException(e);
+    }
+  }
+
+  @GET
+  @Path("hardwareload")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(name = "hardwareload", description = "Returns the current hardware load on this service registry's node.",
+      returnDescription = "The current hardware load across the cluster", restParameters = {},
+      responses = { @RestResponse(responseCode = SC_OK, description = "Current hardware load for the cluster.") })
+  public Response getHardwareLoad() {
+    try {
+      return Response.ok(serviceRegistry.getHardwareLoad()).build();
     } catch (ServiceRegistryException e) {
       throw new WebApplicationException(e);
     }

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/ServiceRegistryEndpoint.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/endpoint/ServiceRegistryEndpoint.java
@@ -60,6 +60,7 @@ import org.opencastproject.util.doc.rest.RestService;
 
 import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -689,13 +690,17 @@ public class ServiceRegistryEndpoint {
 
   @GET
   @Path("maxhardwareload")
-  @Produces(MediaType.TEXT_PLAIN)
+  @Produces(MediaType.APPLICATION_JSON)
   @RestQuery(name = "maxhardwareload", description = "Returns the maximum hardware load this service registry can execute concurrently.",
       returnDescription = "The  maximum hardware load this service registry can execute", restParameters = {},
       responses = { @RestResponse(responseCode = SC_OK, description = "Maximum hardware load this service registry can execute.") })
   public Response getMaxHardwareLoad() {
     try {
-      return Response.ok(serviceRegistry.getMaxHardwareLoad()).build();
+      JSONArray list = new JSONArray();
+
+      list.add(serviceRegistry.getMaxHardwareLoad());
+
+      return Response.ok(list.toString()).build();
     } catch (ServiceRegistryException e) {
       throw new WebApplicationException(e);
     }
@@ -739,7 +744,12 @@ public class ServiceRegistryEndpoint {
       responses = { @RestResponse(responseCode = SC_OK, description = "Current hardware load for the cluster.") })
   public Response getHardwareLoad() {
     try {
-      return Response.ok(serviceRegistry.getHardwareLoad()).build();
+      JSONObject list = new JSONObject();
+
+      list.put("load",serviceRegistry.getHardwareLoad());
+      list.put("maxLoad",serviceRegistry.getMaxHardwareLoad());
+
+      return Response.ok(list.toString()).build();
     } catch (ServiceRegistryException e) {
       throw new WebApplicationException(e);
     }


### PR DESCRIPTION
This Pull Request adds the usage of the operating systems load value as metric for scheduling jobs. The hardware load values are a more realistic representation of a systems occupation then the current load values and there usage for managing loads promises more precise scheduling and better system usage.

The usage of hardware loads is an optional-in, disabled by default. If enabled the usage of hardware loads means two things:

1. When two nodes offer the the same service, the node with the lower system load is preferred

2. A maximum hardware load can be configured in the configuration file for each node. If a nodes maximum hardware load is reached this server stops accepting jobs till the nodes load gets below the maximum.

This mechanism is implemented by introducing two new configurable values managed in the service registry. A flag to enable the hardware load and a maximum hardware load value, defaulting to the number CPU of cores.
If the hardware load flag is set, the already existing logic of the service registry switches to using the hardware load values instead of the current load values. The existing logic uses the load values for two purposes:

1. Ordering the potential services a job could be dispatched to

2. Accepting a job on the service side, if the load doesn’t exceed the maximum load

The new load values are obtained from the OperatingSystemMXBean, if this bean is for some reasons not obtainable a log warning advices the user to switch to non hardware load scheduling.


Outlook:
With the usage of hardware loads nodes tend to decline jobs more reliable, if they are fully occupied. Together with an upcoming pull request, which introduces the preference of jobs from older workflows, this could stop Opencasts habit to try to work on all workflows at the same time under heavy loads.