### PR TITLE
Fix check if all workflows were loaded when using YAML

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowDefinitionScanner.java
@@ -124,7 +124,7 @@ public class WorkflowDefinitionScanner implements ArtifactInstaller, Organizatio
       }
 
       // Determine the number of available profiles
-      String[] filesInDirectory = artifact.getParentFile().list((arg0, name) -> name.endsWith(".xml"));
+      String[] filesInDirectory = artifact.getParentFile().list((arg0, name) -> name.matches(".*\\.(xml|yaml|yml)$"));
       if (filesInDirectory == null) {
         throw new RuntimeException("error retrieving files from directory \"" + artifact.getParentFile() + "\"");
       }


### PR DESCRIPTION
The `WorkflowDefinitionScanner` only checked for XML file when determining if all workflows where loaded. OC 12 also supports YAML files.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
