### PR TITLE
Ignore NoSuchFileException when cleaning directories

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/cleanup/RecursiveDirectoryCleaner.java
+++ b/modules/common/src/main/java/org/opencastproject/cleanup/RecursiveDirectoryCleaner.java
@@ -29,6 +29,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
@@ -74,7 +75,9 @@ public final class RecursiveDirectoryCleaner implements FileVisitor<Path> {
 
   @Override
   public FileVisitResult visitFileFailed(Path path, IOException e) throws IOException {
-    logger.warn("Visiting file {} failed with exception {}", path, e);
+    if (!(e instanceof NoSuchFileException)) {
+      logger.warn("Visiting file {} failed with exception {}", path, e);
+    }
     return FileVisitResult.CONTINUE;
   }
 


### PR DESCRIPTION
The `RecursiveDirectoryCleaner` is used to clean up the workspace and working file repository. If multiple Openacst instances run on a shared file system, one could delete files before the other, leading to a `NoSuchFileException`. These can be ignored as the file is already deleted.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
