### PR TITLE
PoC: Karaf shell opencast:plugin* commands

### DIFF
--- a/modules/plugin-manager/pom.xml
+++ b/modules/plugin-manager/pom.xml
@@ -27,6 +27,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.karaf.shell</groupId>
+      <artifactId>org.apache.karaf.shell.core</artifactId>
+      <version>${karaf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.cmpn</artifactId>
       <scope>provided</scope>
@@ -34,6 +40,11 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.karaf.config</groupId>
+      <artifactId>org.apache.karaf.config.core</artifactId>
+      <version>${karaf.version}</version>
     </dependency>
   </dependencies>
   <build>
@@ -51,6 +62,7 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
+            <Karaf-Commands>*</Karaf-Commands>
           </instructions>
         </configuration>
       </plugin>

--- a/modules/plugin-manager/src/main/java/org/opencastproject/plugin/PluginManager.java
+++ b/modules/plugin-manager/src/main/java/org/opencastproject/plugin/PluginManager.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.plugin;
+
+import java.util.Set;
+
+public interface PluginManager {
+
+  Set<String> listAvailablePlugins();
+
+  Set<String> listInstalledPlugins();
+}

--- a/modules/plugin-manager/src/main/java/org/opencastproject/plugin/command/PluginDisable.java
+++ b/modules/plugin-manager/src/main/java/org/opencastproject/plugin/command/PluginDisable.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.plugin.command;
+
+import org.opencastproject.plugin.PluginManager;
+import org.opencastproject.plugin.command.completers.PluginNameCompleter;
+import org.opencastproject.plugin.impl.PluginManagerImpl;
+
+import org.apache.karaf.config.core.ConfigRepository;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Completion;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.osgi.service.cm.Configuration;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Command(scope = "opencast", name = "plugin-disable", description = "Disable a plugin with the specified name")
+public class PluginDisable implements Action {
+
+  @Reference
+  private ConfigRepository configRepository;
+
+  @Reference
+  private PluginManager pluginManager;
+
+  @Argument(name = "plugins", description = "The name of the plugin to disable.", required = true, multiValued = true)
+  @Completion(PluginNameCompleter.class)
+  private List<String> plugins;
+
+  @Option(name = "--persist", description = "Persist changes", required = false, multiValued = false)
+  private boolean persist = false;
+
+  @Override
+  public Object execute() throws Exception {
+    var properties = configRepository.getConfigAdmin()
+        .getConfiguration(PluginManagerImpl.class.getName()).getProperties();
+
+    Set<String> available = pluginManager.listAvailablePlugins();
+    for (String plugin : plugins) {
+      if (!available.contains(plugin)) {
+        throw new IllegalArgumentException("Plugin " + plugin + " is invalid");
+      } else {
+        properties.put(plugin, "off");
+      }
+    }
+
+    if (persist) {
+      Map<String, Object> propertiesMap = Collections.list(properties.keys())
+          .stream()
+          .collect(Collectors.toMap(Function.identity(), properties::get));
+      configRepository.update(PluginManagerImpl.class.getName(), propertiesMap);
+    } else {
+      Configuration c = configRepository.getConfigAdmin().getConfiguration(PluginManagerImpl.class.getName());
+      c.update(properties);
+    }
+    return null;
+  }
+}

--- a/modules/plugin-manager/src/main/java/org/opencastproject/plugin/command/PluginEnable.java
+++ b/modules/plugin-manager/src/main/java/org/opencastproject/plugin/command/PluginEnable.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.plugin.command;
+
+import org.opencastproject.plugin.PluginManager;
+import org.opencastproject.plugin.command.completers.PluginNameCompleter;
+import org.opencastproject.plugin.impl.PluginManagerImpl;
+
+import org.apache.karaf.config.core.ConfigRepository;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Argument;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Completion;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.osgi.service.cm.Configuration;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Command(scope = "opencast", name = "plugin-enable", description = "Enable a plugin with the specified name")
+public class PluginEnable implements Action {
+
+  @Reference
+  private ConfigRepository configRepository;
+
+  @Reference
+  private PluginManager pluginManager;
+
+  @Argument(name = "plugins", description = "The name of the plugin to enable.", required = true, multiValued = true)
+  @Completion(PluginNameCompleter.class)
+  private List<String> plugins;
+
+  @Option(name = "--persist", description = "Persist changes", required = false, multiValued = false)
+  private boolean persist = false;
+
+  @Override
+  public Object execute() throws Exception {
+    var properties = configRepository.getConfigAdmin()
+        .getConfiguration(PluginManagerImpl.class.getName()).getProperties();
+
+    Set<String> available = pluginManager.listAvailablePlugins();
+    for (String plugin : plugins) {
+      if (!available.contains(plugin)) {
+        throw new IllegalArgumentException("Plugin " + plugin + " is invalid");
+      } else {
+        properties.put(plugin, "on");
+      }
+    }
+
+    if (persist) {
+      Map<String, Object> propertiesMap = Collections.list(properties.keys())
+          .stream()
+          .collect(Collectors.toMap(Function.identity(), properties::get));
+      configRepository.update(PluginManagerImpl.class.getName(), propertiesMap);
+    } else {
+      Configuration c = configRepository.getConfigAdmin().getConfiguration(PluginManagerImpl.class.getName());
+      c.update(properties);
+    }
+    return null;
+  }
+}

--- a/modules/plugin-manager/src/main/java/org/opencastproject/plugin/command/PluginList.java
+++ b/modules/plugin-manager/src/main/java/org/opencastproject/plugin/command/PluginList.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.plugin.command;
+
+
+import org.opencastproject.plugin.PluginManager;
+
+import org.apache.karaf.features.FeaturesService;
+import org.apache.karaf.shell.api.action.Action;
+import org.apache.karaf.shell.api.action.Command;
+import org.apache.karaf.shell.api.action.Option;
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.support.table.Row;
+import org.apache.karaf.shell.support.table.ShellTable;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+@Service
+@Command(scope = "opencast", name = "plugin-list", description = "List available plugins")
+public class PluginList implements Action {
+
+  @Reference
+  private FeaturesService featuresService;
+
+  @Reference
+  private PluginManager pluginManager;
+
+  @Option(name = "--installed", description = "Show only installed plugins", required = false, multiValued = false)
+  private boolean installed;
+
+  @Option(name = "--no-format", description = "Disable table rendered output", required = false, multiValued = false)
+  private boolean noFormat;
+
+  @Override
+  public Object execute() throws Exception {
+    ShellTable table = new ShellTable();
+    table.column("ID");
+    table.column("State");
+
+    Set<String> plugins;
+    if (installed) {
+      plugins = pluginManager.listInstalledPlugins();
+    } else {
+      plugins = pluginManager.listAvailablePlugins();
+    }
+
+    for (String plugin: plugins) {
+      ArrayList<Object> rowData = new ArrayList<>();
+      rowData.add(plugin);
+      rowData.add(featuresService.getState(featuresService.getFeature(plugin).getId()));
+      Row row = table.addRow();
+      row.addContent(rowData);
+    }
+    table.print(System.out, !noFormat);
+    return null;
+  }
+
+}

--- a/modules/plugin-manager/src/main/java/org/opencastproject/plugin/command/completers/PluginNameCompleter.java
+++ b/modules/plugin-manager/src/main/java/org/opencastproject/plugin/command/completers/PluginNameCompleter.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.plugin.command.completers;
+
+import org.opencastproject.plugin.PluginManager;
+
+import org.apache.karaf.shell.api.action.lifecycle.Reference;
+import org.apache.karaf.shell.api.action.lifecycle.Service;
+import org.apache.karaf.shell.api.console.CommandLine;
+import org.apache.karaf.shell.api.console.Completer;
+import org.apache.karaf.shell.api.console.Session;
+import org.apache.karaf.shell.support.completers.StringsCompleter;
+
+import java.util.List;
+
+@Service
+public class PluginNameCompleter implements Completer {
+
+  @Reference
+  private PluginManager pluginManager;
+
+  @Override
+  public int complete(Session session, CommandLine commandLine, List<String> candidates) {
+    StringsCompleter completer = new StringsCompleter();
+    pluginManager.listAvailablePlugins().forEach(completer.getStrings()::add);
+    return completer.complete(session, commandLine, candidates);
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -711,6 +711,20 @@
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.apache.karaf.tooling</groupId>
+          <artifactId>karaf-services-maven-plugin</artifactId>
+          <version>${karaf.version}</version>
+          <executions>
+            <execution>
+              <id>service-metadata-generate</id>
+              <phase>process-classes</phase>
+              <goals>
+                <goal>service-metadata-generate</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
This PR adds three Karaf shell commands with auto-completion to be able to manage opencast plugins at runtime in a convenient way. This could either be just temporary or with the option to persist the configuration changes.

Added commands opencast:
- `opencast:plugin-list [--no-format] [--installed]`
- `opencast:plugin-enable [--persist] opencast-plugin-... opencast-plugin-...`
- `opencast:plugin-disable [--persist] opencast-plugin-...`

Its lacking documentation. I will add one if someone else likes the idea of having shell commands.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
