### PR TITLE
Do not update default player components on legacy branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,6 @@ updates:
   directory: "/modules/engage-paella-player"
   schedule:
     interval: daily
-  target-branch: "r/11.x"
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/engage-paella-player-7"


### PR DESCRIPTION
This patch removes the configuration that tells Dependabot to update components of Paella Player 6 – Opencast's default player – on legacy branches.

The reasoning is that we know that dependency update pull requests are often not well tested but get merged nonetheless. Doing so on `develop` gives us time to react if something breaks. Doing this on a release branch comes with a high risk of breaking the default player in a release. Doing so in a legacy branch even increases the risk since less people will test these.

There is usually no need for updating dependencies at all in the release branches unless it is a security update or the dependency is the Player itself, which should get proper attention and manual testing.

I don't mind auto-updating Paella Player 7, but only since that one is not the default and specifically marked as “beta”.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
