### PR TITLE
Added maximum line length configuration option to Azure Transcription Service

### DIFF
--- a/etc/org.opencastproject.transcription.microsoftazure.MicrosoftAzureTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.microsoftazure.MicrosoftAzureTranscriptionService.cfg
@@ -32,6 +32,17 @@ region=
 # Default: ANY
 #encoding.extension=ANY
 
+# Set this to true if you want to limit the maximum size of a line in the subtitle file.
+# Azure does not do this automatically, and sometimes produces very long lines.
+# Default: false
+split.text=false
+
+# The maximum amount of characters a single line in the subtitle file should contain.
+# Can go over the set number to avoid cutting words in half.
+# Only takes effect if "split.text" is set to true.
+# Default: 100
+split.text.line.size=100
+
 # Workflow to be executed when results are ready to be attached to media package.
 #workflow=microsoft-azure-attach-transcripts
 

--- a/etc/org.opencastproject.transcription.microsoftazure.MicrosoftAzureTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.microsoftazure.MicrosoftAzureTranscriptionService.cfg
@@ -35,13 +35,13 @@ region=
 # Set this to true if you want to limit the maximum size of a line in the subtitle file.
 # Azure does not do this automatically, and sometimes produces very long lines.
 # Default: false
-split.text=false
+#split.text=false
 
 # The maximum amount of characters a single line in the subtitle file should contain.
 # Can go over the set number to avoid cutting words in half.
 # Only takes effect if "split.text" is set to true.
 # Default: 100
-split.text.line.size=100
+#split.text.line.size=100
 
 # Workflow to be executed when results are ready to be attached to media package.
 #workflow=microsoft-azure-attach-transcripts

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
@@ -292,7 +292,6 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
     if (isSplitTextOpt.isSome()) {
       splitText = Boolean.valueOf(isSplitTextOpt.get());
     }
-    logger.info("Long text will be split at {} characters", splitText);
 
     // When splitting text into multiple cues, how many characters should each cue have at most
     Option<String> splitTextLineSizeOpt = OsgiUtil.getOptCfg(cc.getProperties(), SPLIT_TEXT_LINE_SIZE);
@@ -303,6 +302,10 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
         throw new ConfigurationException("Invalid configuration for split text line size. Please check your"
                 + "configuration");
       }
+    }
+
+    if (splitText) {
+      logger.info("Long text will be split at {} characters", splitTextLineSize);
     }
 
     // Workflow to execute when getting callback (optional, with default)

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
@@ -87,11 +87,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -178,6 +180,8 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
   public static final String NOTIFICATION_EMAIL_CONFIG = "notification.email";
   public static final String CLEANUP_RESULTS_DAYS_CONFIG = "cleanup.results.days";
   public static final String ENCODING_EXTENSION = "encoding.extension";
+  public static final String SPLIT_TEXT = "split.text";
+  public static final String SPLIT_TEXT_LINE_SIZE = "split.text.line.size";
 
   /**
    * Service configuration values
@@ -201,6 +205,8 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
   private List<String> phraseList = new ArrayList<>();
   private boolean useSubRipTextCaptionFormat = false;
   private String fileFormat = "vtt";
+  private boolean splitText = false;
+  private int splitTextLineSize = 100;
 
   public MicrosoftAzureTranscriptionService() {
     super(JOB_TYPE);
@@ -278,6 +284,24 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
       logger.info("Audio encoding configured as {}", compressedAudioFormat);
     } else {
       logger.info("Default '{}' audio encoding will be used", compressedAudioFormat);
+    }
+
+    // If text should be split into multiple cues
+    Option<String> isSplitTextOpt = OsgiUtil.getOptCfg(cc.getProperties(), SPLIT_TEXT);
+    if (isSplitTextOpt.isSome()) {
+      splitText = Boolean.valueOf(isSplitTextOpt.get());
+    }
+    logger.info("Long text will be split: {}", splitText);
+
+    // When splitting text into multiple cues, how many characters should each cue have at most
+    Option<String> splitTextLineSizeOpt = OsgiUtil.getOptCfg(cc.getProperties(), SPLIT_TEXT_LINE_SIZE);
+    if (splitTextLineSizeOpt.isSome()) {
+      try {
+        splitTextLineSize = Integer.parseInt(splitTextLineSizeOpt.get());
+      } catch (NumberFormatException e) {
+        // Use default
+        logger.warn("Invalid configuration for split text line size. Default used instead: {}", splitTextLineSize);
+      }
     }
 
     // Workflow to execute when getting callback (optional, with default)
@@ -520,12 +544,15 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
     speechRecognizer.recognized.addEventListener((s, e) -> {
       if (ResultReason.RecognizedSpeech == e.getResult().getReason() && e.getResult().getText().length() > 0) {
         sequenceNumber[0]++;
-        String text = captionFromSpeechRecognitionResult(sequenceNumber[0], e.getResult());
+        List<String> texts = captionFromSpeechRecognitionResult(sequenceNumber[0], e.getResult());
+        sequenceNumber[0] += texts.size() - 1;
 
-        try {
-          writeToTmpFile(text, jobId);
-        } catch (IOException ioException) {
-          logger.error(String.format("Could not write to tmp file: %s", text));
+        for (String text : texts) {
+          try {
+            writeToTmpFile(text, jobId);
+          } catch (IOException ioException) {
+            logger.error(String.format("Could not write to tmp file: %s", text));
+          }
         }
       }
       else if (ResultReason.NoMatch == e.getResult().getReason()) {
@@ -587,21 +614,108 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
     logger.debug(text);
   }
 
-  private String captionFromSpeechRecognitionResult(int sequenceNumber, SpeechRecognitionResult result) {
-    StringBuilder caption = new StringBuilder();
-    if (useSubRipTextCaptionFormat) {
-      caption.append(String.format("%d%s", sequenceNumber, System.lineSeparator()));
+  /**
+   * Creates a WebVTT cue string from the given result that can be directly appended to a WebVTT file.
+   * If splitText is enabled, will split a given result into multiple cues based on line size.
+   *
+   * @param sequenceNumber number of the cue. Used for SubRip.
+   * @param result A recognized text
+   * @return A list containing at least one WebVTT cue as it would be written in a file.
+   */
+  private List<String> captionFromSpeechRecognitionResult(int sequenceNumber, SpeechRecognitionResult result) {
+    List<String> lines;
+    List<BigInteger> offsets;
+    List<BigInteger> durations;
+
+    if (splitText) {
+      lines = splitText(result.getText());
+      Map<String, List<BigInteger>> offsetsAndDurations = splitTextTimes(lines, result.getOffset(),
+              result.getDuration());
+      offsets = offsetsAndDurations.get("offsets");
+      durations = offsetsAndDurations.get("durations");
+    } else {
+      lines = Collections.singletonList(result.getText());
+      offsets = Collections.singletonList(result.getOffset());
+      durations = Collections.singletonList(result.getDuration());
     }
-    caption.append(String.format("%s%s", timestampFromSpeechRecognitionResult(result), System.lineSeparator()));
-    caption.append(String.format("%s%s%s", result.getText(), System.lineSeparator(), System.lineSeparator()));
-    return caption.toString();
+
+    List<String> formattedLines = new ArrayList<>();
+    for (int i = 0; i < lines.size(); i++) {
+      StringBuilder caption = new StringBuilder();
+
+      if (useSubRipTextCaptionFormat) {
+        caption.append(String.format("%d%s", sequenceNumber + i, System.lineSeparator()));
+      }
+      caption.append(String.format("%s%s", timestampFromSpeechRecognitionResult(offsets.get(i), durations.get(i)),
+              System.lineSeparator()));
+      caption.append(String.format("%s%s%s", lines.get(i), System.lineSeparator(), System.lineSeparator()));
+
+      formattedLines.add(caption.toString());
+    }
+
+    return formattedLines;
   }
 
-  private String timestampFromSpeechRecognitionResult(SpeechRecognitionResult result) {
+  // Split text into multiple lines if too long
+  private List<String> splitText(String text) {
+    int previousSplitLength = 0;
+    int nextSplitLength = splitTextLineSize;
+    List<String> lines = new ArrayList();
+
+    do {
+      // Search ahead to next whitespace or end of text
+      int index;
+      for (index = nextSplitLength; index < text.length(); index++) {
+        if (text.charAt(index) == ' ') {
+          break;
+        }
+      }
+
+      if (index >= text.length()) {
+        index = text.length() - 1;
+      }
+
+      lines.add(text.substring(previousSplitLength, index).trim());
+
+      previousSplitLength = index;
+      nextSplitLength = index + splitTextLineSize;
+    } while (text.length() > previousSplitLength + 1);
+
+    return lines;
+  }
+
+  // If text was split into multiple lines, divide time between them
+  private Map<String, List<BigInteger>> splitTextTimes(List<String> lines, BigInteger offset, BigInteger duration) {
+    List<BigInteger> offsets = new ArrayList<>();
+    List<BigInteger> durations = new ArrayList<>();
+    BigInteger percentage = BigInteger.ZERO;
+    int lengthOfAllLines = lines.stream()
+            .mapToInt(l -> l.length())
+            .sum();
+
+    for (int i = 0; i < lines.size(); i++) {
+      BigInteger previousDurations = durations.stream().reduce(BigInteger.ZERO, BigInteger::add);
+      offsets.add(offset.add(previousDurations));
+
+      // Divide total duration fairly between lines, based on char count
+      percentage = BigDecimal.valueOf((double) lines.get(i).length() / lengthOfAllLines)
+              .multiply(new BigDecimal(duration))
+              .toBigInteger();
+
+      durations.add(percentage);
+    }
+
+    Map<String,List<BigInteger>> map = new HashMap();
+    map.put("offsets", offsets);
+    map.put("durations", durations);
+    return map;
+  }
+
+  private String timestampFromSpeechRecognitionResult(BigInteger offset, BigInteger duration) {
     final BigInteger ticksPerMillisecond = BigInteger.valueOf(10000);
-    final Date startTime = new Date(result.getOffset().divide(ticksPerMillisecond).longValue());
-    final Date endTime = new Date((result.getOffset()
-            .add(result.getDuration())).divide(ticksPerMillisecond).longValue());
+    final Date startTime = new Date(offset.divide(ticksPerMillisecond).longValue());
+    final Date endTime = new Date((offset
+            .add(duration)).divide(ticksPerMillisecond).longValue());
 
     String format = "";
     if (useSubRipTextCaptionFormat) {

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
@@ -51,6 +51,7 @@ import org.opencastproject.transcription.persistence.TranscriptionDatabase;
 import org.opencastproject.transcription.persistence.TranscriptionDatabaseException;
 import org.opencastproject.transcription.persistence.TranscriptionJobControl;
 import org.opencastproject.transcription.persistence.TranscriptionProviderControl;
+import org.opencastproject.util.ConfigurationException;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.data.Option;
@@ -299,8 +300,8 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
       try {
         splitTextLineSize = Integer.parseInt(splitTextLineSizeOpt.get());
       } catch (NumberFormatException e) {
-        // Use default
-        logger.warn("Invalid configuration for split text line size. Default used instead: {}", splitTextLineSize);
+        throw new ConfigurationException("Invalid configuration for split text line size. Please check your"
+                + "configuration");
       }
     }
 

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
@@ -292,7 +292,7 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
     if (isSplitTextOpt.isSome()) {
       splitText = Boolean.valueOf(isSplitTextOpt.get());
     }
-    logger.info("Long text will be split: {}", splitText);
+    logger.info("Long text will be split at {} characters", splitText);
 
     // When splitting text into multiple cues, how many characters should each cue have at most
     Option<String> splitTextLineSizeOpt = OsgiUtil.getOptCfg(cc.getProperties(), SPLIT_TEXT_LINE_SIZE);

--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
@@ -532,7 +532,7 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
           try {
             writeToTmpFile(String.format("WEBVTT%s%s", System.lineSeparator(), System.lineSeparator()), jobId);
           } catch (IOException ioException) {
-            logger.error(String.format("Could not write header to tmp file"));
+            logger.error("Could not write header to tmp file");
           }
         }
       } catch (TranscriptionDatabaseException ex) {
@@ -552,7 +552,7 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
           try {
             writeToTmpFile(text, jobId);
           } catch (IOException ioException) {
-            logger.error(String.format("Could not write to tmp file: %s", text));
+            logger.error("Could not write to tmp file: {}", text);
           }
         }
       }
@@ -1003,7 +1003,7 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
         return true;
       }
     } catch (Exception e) {
-      logger.error(String.format("ERROR while calculating transcription request expiration for job: %s", jobId), e);
+      logger.error("ERROR while calculating transcription request expiration for job: %s", jobId, e);
       // to avoid perpetual non-expired state, transcription is set as expired
       return true;
     }
@@ -1034,7 +1034,7 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
 
       sendEmail("Transcription ERROR", String.format("%s(media package %s, job id %s).", message, mpId, jobId));
     } catch (Exception e) {
-      logger.error(String.format("ERROR while deleting transcription job: %s", jobId), e);
+      logger.error("ERROR while deleting transcription job: %s", jobId, e);
     }
   }
 


### PR DESCRIPTION
In the Azure Transcription service, the text received from a recognized event can be rather long, longer than a subtitle line should reasonably be. This PR adds new config options to the service that allow you to limit the size of a line to a number of characters. Post processing in the service will then try to adhere to limit by splitting long lines into multiple shorter ones (i.e. without breaking up words), and dividing the display times between them evenly.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
