### PR TITLE
Fixed azure transcription error message in case of Error

### DIFF
--- a/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
+++ b/modules/transcription-service-microsoft-azure/src/main/java/org/opencastproject/transcription/microsoftazure/MicrosoftAzureTranscriptionService.java
@@ -542,15 +542,14 @@ public class MicrosoftAzureTranscriptionService extends AbstractJobProducer impl
         return;
       }
       else if (CancellationReason.CancelledByUser == e.getReason()) {
-        errorMessage = String.format("User canceled request.%s", System.lineSeparator());
+        errorMessage = "User canceled request.";
       }
       else if (CancellationReason.Error == e.getReason()) {
-        errorMessage = String.format("Encountered error.%sError code: %d%sError details: %s%s",
-                System.lineSeparator(), e.getErrorCode(), e.getErrorDetails());
+        errorMessage = String.format("Encountered error.%sError code: %s%sError details: %s",
+                System.lineSeparator(), e.getErrorCode().name(), System.lineSeparator(), e.getErrorDetails());
       }
       else {
-        errorMessage = String.format("Request was cancelled for an unrecognized reason: %d.%s",
-                e.getReason(), System.lineSeparator());
+        errorMessage = String.format("Request was cancelled for an unrecognized reason: %d.", e.getReason());
       }
 
       errorCallback(errorMessage, speechRecognizer, jobId, mpId);


### PR DESCRIPTION
Formatting the error message failed due to type mismatching. Also removes some unnecessary newlines.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
