### PR TITLE
Join index rebuild of scheduler to assetmanager

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
@@ -50,7 +50,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -352,6 +354,21 @@ public class Database implements EntityPaths {
           .singleResult(Full.select);
       return Opt.nul(result).map(Full.fromTuple);
     });
+  }
+
+  /**
+   * Gets Scheduler index data for all events.
+   * Selects only mediapackage id, capture agent id, recording state, presenters, start date and end date
+   *
+   * @return list of {@link SchedulerIndexData}s
+   */
+  public Map<String, SchedulerIndexData> getSchedulerIndexData() {
+    var result = db.exec(namedQuery.findAll(
+            "SchedulerIndexData.getAll",
+            SchedulerIndexData.class
+    ));
+    return result.stream().collect(
+            Collectors.toMap(data -> data.getMediaPackageId(), data -> data));
   }
 
   //

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/Database.java
@@ -49,12 +49,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import javax.persistence.PersistenceException;
 
 /**
  * Data access object.
@@ -363,12 +365,14 @@ public class Database implements EntityPaths {
    * @return list of {@link SchedulerIndexData}s
    */
   public Map<String, SchedulerIndexData> getSchedulerIndexData() {
-    var result = db.exec(namedQuery.findAll(
-            "SchedulerIndexData.getAll",
-            SchedulerIndexData.class
-    ));
-    return result.stream().collect(
-            Collectors.toMap(data -> data.getMediaPackageId(), data -> data));
+    try {
+      var result = db.exec(namedQuery.findAll("SchedulerIndexData.getAll", SchedulerIndexData.class));
+      return result.stream().collect(Collectors.toMap(data -> data.getMediaPackageId(), data -> data));
+    } catch (PersistenceException e) {
+      // Should only ever happen if the scheduler table does not exist yet
+      logger.warn(e.getMessage());
+      return new HashMap<>();
+    }
   }
 
   //

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SchedulerIndexData.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SchedulerIndexData.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.assetmanager.impl.persistence;
+
+import java.util.Date;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityResult;
+import javax.persistence.FieldResult;
+import javax.persistence.Id;
+import javax.persistence.NamedNativeQueries;
+import javax.persistence.NamedNativeQuery;
+import javax.persistence.SqlResultSetMapping;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * Summary of the scheduler stats necessary for index rebuild, for use in repopulate
+ */
+@Entity
+@NamedNativeQueries({
+    @NamedNativeQuery(
+          name = "SchedulerIndexData.getAll",
+          query = "SELECT mediapackage_id, capture_agent_id, recording_state, presenters, start_date, end_date "
+                  + "FROM oc_scheduled_extended_event",
+          resultSetMapping = "DataResult"
+    ),
+})
+@SqlResultSetMapping(
+        name = "DataResult",
+        entities = {
+                @EntityResult(
+                        entityClass = SchedulerIndexData.class,
+                        fields = {
+                                  @FieldResult(name = "mediaPackageId", column = "mediapackage_id"),
+                                  @FieldResult(name = "captureAgentId", column = "capture_agent_id"),
+                                  @FieldResult(name = "recordingState", column = "recording_state"),
+                                  @FieldResult(name = "presenters", column = "presenters"),
+                                  @FieldResult(name = "startDate", column = "start_date"),
+                                  @FieldResult(name = "endDate", column = "end_date")
+                        }
+                )
+})
+
+
+public class SchedulerIndexData {
+
+  @Id
+  private String mediaPackageId;
+  private String captureAgentId;
+  private String recordingState;
+  private String presenters;
+
+  @Temporal(TemporalType.TIMESTAMP)
+  private Date startDate;
+  @Temporal(TemporalType.TIMESTAMP)
+  private Date endDate;
+
+  /**
+   * Default constructor without any import.
+   */
+  public SchedulerIndexData() {
+  }
+
+  public String getMediaPackageId() {
+    return mediaPackageId;
+  }
+
+  public String getCaptureAgentId() {
+    return captureAgentId;
+  }
+
+  public Date getStartDate() {
+    return startDate;
+  }
+
+  public Date getEndDate() {
+    return endDate;
+  }
+
+  public String getRecordingState() {
+    return recordingState;
+  }
+
+  public String getPresenters() {
+    return presenters;
+  }
+}

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/endpoint/IndexEndpoint.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/endpoint/IndexEndpoint.java
@@ -127,7 +127,7 @@ public class IndexEndpoint {
       description = "Repopulates the Index from an specific service",
       returnDescription = "OK if repopulation has started", pathParameters = {
       @RestParameter(name = "service", isRequired = true, description = "The service to recreate index from. "
-        + "The available services are: Themes, Series, Scheduler, Workflow, AssetManager and Comments. "
+        + "The available services are: Themes, Series, Workflow, AssetManager and Comments. "
         + "The service order (see above) is very important! Make sure, you do not run index rebuild for more than one "
         + "service at a time!",
         type = RestParameter.Type.STRING) }, responses = {
@@ -174,7 +174,7 @@ public class IndexEndpoint {
           returnDescription = "OK if repopulation has started", pathParameters = {
           @RestParameter(name = "service", isRequired = true, description = "The service to start recreating the index "
                   + "from. "
-                  + "The available services are: Themes, Series, Scheduler, Workflow, AssetManager and Comments. "
+                  + "The available services are: Themes, Series, Workflow, AssetManager and Comments. "
                   + "All services that come after the specified service in the order above will also run.",
                   type = RestParameter.Type.STRING) }, responses = {
           @RestResponse(description = "OK if repopulation has started", responseCode = HttpServletResponse.SC_OK) })

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/IndexRebuildService.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/rebuild/IndexRebuildService.java
@@ -64,7 +64,7 @@ public class IndexRebuildService implements BundleActivator {
    * Attention: The order is relevant for the index rebuild and should not be changed!
    */
   public enum Service {
-    Themes, Series, Scheduler, Workflow, AssetManager, Comments
+    Themes, Series, Workflow, AssetManager, Comments
   }
 
   private static final Logger logger = LoggerFactory.getLogger(IndexRebuildService.class);

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -57,11 +57,6 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-authorization-xacml</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -158,7 +153,6 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-asset-manager-impl</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -50,10 +50,6 @@ import org.opencastproject.elasticsearch.api.SearchIndexException;
 import org.opencastproject.elasticsearch.index.ElasticsearchIndex;
 import org.opencastproject.elasticsearch.index.objects.event.Event;
 import org.opencastproject.elasticsearch.index.objects.event.EventIndexUtils;
-import org.opencastproject.elasticsearch.index.rebuild.AbstractIndexProducer;
-import org.opencastproject.elasticsearch.index.rebuild.IndexProducer;
-import org.opencastproject.elasticsearch.index.rebuild.IndexRebuildException;
-import org.opencastproject.elasticsearch.index.rebuild.IndexRebuildService;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
@@ -166,12 +162,12 @@ import java.util.stream.Collectors;
  */
 @Component(
     immediate = true,
-    service = { ManagedService.class, SchedulerService.class, IndexProducer.class },
+    service = { ManagedService.class, SchedulerService.class },
     property = {
         "service.description=Scheduler Service"
     }
 )
-public class SchedulerServiceImpl extends AbstractIndexProducer implements SchedulerService, ManagedService {
+public class SchedulerServiceImpl implements SchedulerService, ManagedService {
 
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(SchedulerServiceImpl.class);
@@ -1713,137 +1709,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
             .filter(isNotEpisodeDublinCore).toList();
   }
 
-  @Override
-  public void repopulate() throws IndexRebuildException {
-    try {
-      final int total;
-      try {
-        total = persistence.countEvents();
-      } catch (SchedulerServiceDatabaseException e) {
-        logIndexRebuildError(logger, index.getIndexName(), e);
-        throw new IndexRebuildException(index.getIndexName(), getService(), e);
-      }
-      logIndexRebuildBegin(logger, index.getIndexName(), total, "scheduled events");
-      final int[] current = {0};
-      int n = 16;
-      var updatedEventRange = new ArrayList<Event>();
-
-      for (Organization organization: orgDirectoryService.getOrganizations()) {
-        final User user = SecurityUtil.createSystemUser(systemUserName, organization);
-        SecurityUtil.runAs(securityService, organization, user,
-                () -> {
-                  final List<ExtendedEventDto> events;
-                  try {
-                    events = persistence.getEvents();
-                  } catch (SchedulerServiceDatabaseException e) {
-                    logIndexRebuildError(logger, index.getIndexName(), e, organization);
-                    return;
-                  }
-
-                  for (ExtendedEventDto event : events) {
-                    try {
-                      current[0]++;
-
-                      var updatedEventData = Optional.of(new Event(event.getMediaPackageId(), organization.getId()));
-                      updatedEventData = getEventUpdateFunction(event, organization.getId(),
-                                  securityService.getUser()).apply(updatedEventData);
-                      updatedEventRange.add(updatedEventData.get());
-
-                      if (updatedEventRange.size() >= n || current[0] >= events.size()) {
-                        index.bulkEventUpdate(updatedEventRange);
-                        logIndexRebuildProgress(logger, index.getIndexName(), total, current[0]);
-                        updatedEventRange.clear();
-                      }
-                    } catch (SearchIndexException e) {
-                      logger.error("Error while updating event '{}' from search index:", event.getMediaPackageId(), e);
-                    }
-                  }
-               });
-      }
-    } catch (Exception e) {
-      logIndexRebuildError(logger, index.getIndexName(), e);
-      throw new IndexRebuildException(index.getIndexName(), getService(), e);
-    }
-  }
-
-  @Override
-  public IndexRebuildService.Service getService() {
-    return IndexRebuildService.Service.Scheduler;
-  }
-
   public SecurityService getSecurityService() {
     return securityService;
-  }
-  /**
-   * Get the function to update a scheduled event in the Elasticsearch index.
-   *
-   * @param scheduledEvent
-   *          The theme to update
-   * @param orgId
-   *          The id of the current organization
-   * @param user
-   *          The user
-   * @return the function to do the update
-   */
-  private Function<Optional<Event>, Optional<Event>> getEventUpdateFunction(ExtendedEventDto scheduledEvent,
-          String orgId, User user) {
-    return (Optional<Event> eventOpt) -> {
-      Event event = eventOpt.orElse(new Event(scheduledEvent.getMediaPackageId(), orgId));
-      final Set<String> presenters = getPresenters(Opt.nul(scheduledEvent.getPresenters()).getOr(""));
-      final Map<String, String> caMetadata = deserializeExtendedEventProperties(scheduledEvent.
-              getCaptureAgentProperties());
-      AQueryBuilder query = assetManager.createQuery();
-      final AResult result = query.select(query.snapshot())
-              .where(query.mediaPackageId(scheduledEvent.getMediaPackageId()).and(query.version().isLatest())).run();
-      final Snapshot snapshot = result.getRecords().head().get().getSnapshot().get();
-
-      Opt<AccessControlList> acl = Opt.some(authorizationService.getActiveAcl(snapshot.getMediaPackage()).getA());
-      Opt<DublinCoreCatalog> dublinCore = loadEpisodeDublinCoreFromAsset(snapshot);
-      Opt<Date> startTime = Opt.some(scheduledEvent.getStartDate());
-      Opt<Date> endTime = Opt.some(scheduledEvent.getEndDate());
-      Opt<Set<String>> presentersOpt = Opt.some(presenters);
-      Opt<String> agentId = Opt.some(scheduledEvent.getCaptureAgentId());
-      Opt<Map<String, String>> properties = Opt.some(caMetadata);
-      Opt<String> recordingStatus = Opt.nul(scheduledEvent.getRecordingState());
-
-      if (acl.isSome()) {
-        event.setAccessPolicy(AccessControlParser.toJsonSilent(acl.get()));
-      }
-      if (dublinCore.isSome()) {
-        EventIndexUtils.updateEvent(event, dublinCore.get());
-        if (isBlank(event.getCreator()))
-          event.setCreator(getSecurityService().getUser().getName());
-
-        // Update series name if not already done
-        try {
-          EventIndexUtils.updateSeriesName(event, orgId, user, index);
-        } catch (SearchIndexException e) {
-          logger.error("Error updating the series name of the event {} in the {} index.",
-                  scheduledEvent.getMediaPackageId(), index.getIndexName(), e);
-        }
-      }
-      if (presentersOpt.isSome()) {
-        event.setTechnicalPresenters(new ArrayList<>(presentersOpt.get()));
-      }
-      if (agentId.isSome()) {
-        event.setAgentId(agentId.get());
-      }
-      if (recordingStatus.isSome() && !recordingStatus.get().equals(RecordingState.UNKNOWN)) {
-        event.setRecordingStatus(recordingStatus.get());
-      }
-      if (properties.isSome()) {
-        event.setAgentConfiguration(properties.get());
-      }
-      if (startTime.isSome()) {
-        String startTimeStr = startTime == null ? null : DateTimeSupport.toUTC(startTime.get().getTime());
-        event.setTechnicalStartTime(startTimeStr);
-      }
-      if (endTime.isSome()) {
-        String endTimeStr = endTime == null ? null : DateTimeSupport.toUTC(endTime.get().getTime());
-        event.setTechnicalEndTime(endTimeStr);
-      }
-
-      return Optional.of(event);
-    };
   }
 }


### PR DESCRIPTION
Builds on PR #4120

- The repopulate function from the scheduler service has been removed.
- The index rebuild of scheduled events will now be proceessed as a part of the asset manager rebuild.
- A new SchedulerIndexData object will be created, selecting the relevant data from the scheduler database table.
- Within the rebuild of the assetmanager the scheduler data is checked for the given mediapackage id.
- If the event is a scheduled event it will by extended by the scheduler data, if not it will be processed as before.