### PR TITLE
Make initialization of new event ACL with series ACL in the Admin UI configurable

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -315,6 +315,12 @@ prop.admin.shortcut.general.main_menu=m
 # Default: optional
 #prop.admin.series.acl.event.update.mode=optional
 
+# Whether the ACL of a new event is initialized with the ACL of its series.
+#
+# Format: Boolean
+# Default: true
+#prop.admin.init.event.acl.with.series.acl=true
+
 # Default values for  trim segment in the editor.
 # Default: In milliseconds
 #

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
@@ -128,22 +128,32 @@ angular.module('adminNg.services')
       me.ud.policies = addUserRolePolicy(me.ud.policies);
       me.ud.baseAcl = {};
 
+      AuthService.getUser().$promise.then(function (user) {
+        var ADMIN_INIT_EVENT_ACL_WITH_SERIES_ACL = 'admin.init.event.acl.with.series.acl';
+        if (angular.isDefined(user.org.properties[ADMIN_INIT_EVENT_ACL_WITH_SERIES_ACL])) {
+          me.initEventAclWithSeriesAcl = user.org.properties[ADMIN_INIT_EVENT_ACL_WITH_SERIES_ACL] === 'true';
+        } else {
+          me.initEventAclWithSeriesAcl = true;
+        }
+      }).catch(angular.noop);
+
       this.setMetadata = function (metadata) {
         me.metadata = metadata;
-        me.loadSeriesAcl();
       };
 
       this.loadSeriesAcl = function () {
-        angular.forEach(me.metadata.getUserEntries(), function (m) {
-          if (m.id === 'isPartOf' && angular.isDefined(m.value) && m.value !== '') {
-            SeriesAccessResource.get({ id: m.value }, function (data) {
-              if (angular.isDefined(data.series_access)) {
-                var json = angular.fromJson(data.series_access.acl);
-                changePolicies(json.acl.ace, true);
-              }
-            });
-          }
-        });
+        if (me.initEventAclWithSeriesAcl) {
+          angular.forEach(me.metadata.getUserEntries(), function (m) {
+            if (m.id === 'isPartOf' && angular.isDefined(m.value) && m.value !== '') {
+              SeriesAccessResource.get({ id: m.value }, function (data) {
+                if (angular.isDefined(data.series_access)) {
+                  var json = angular.fromJson(data.series_access.acl);
+                  changePolicies(json.acl.ace, true);
+                }
+              });
+            }
+          });
+        }
       };
 
       this.changeBaseAcl = function () {


### PR DESCRIPTION
...because this will result in series rights lingering in the event ACL even once they have been removed from the series itself, which is impractical for adopters who use the ACL merge modes 'roles' or 'actions' and mostly manage rights for series instead of events.

Also remove one unnecessary method call because the metadata isn't even loaded from the backend at that point.

