### PR TITLE
Actually Retract Live Publication

### DIFF
--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/SchedulerUpdateHandler.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/SchedulerUpdateHandler.java
@@ -20,6 +20,8 @@
  */
 package org.opencastproject.liveschedule.message;
 
+import static org.opencastproject.scheduler.api.SchedulerService.WORKFLOW_CONFIG_PREFIX;
+
 import org.opencastproject.message.broker.api.MessageItem;
 import org.opencastproject.message.broker.api.scheduler.SchedulerItem;
 import org.opencastproject.message.broker.api.scheduler.SchedulerItemList;
@@ -73,7 +75,7 @@ public class SchedulerUpdateHandler extends UpdateHandler {
           break;
         case UpdateProperties:
           // Workflow properties may have been updated (publishLive configuration)
-          String publishLive = schedulerItem.getProperties().get(PUBLISH_LIVE_PROPERTY);
+          String publishLive = schedulerItem.getProperties().get(WORKFLOW_CONFIG_PREFIX.concat(PUBLISH_LIVE_PROPERTY));
           if (publishLive == null) {
             // Not specified so we do nothing. We don't want to delete if we got incomplete props.
             return;

--- a/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
+++ b/modules/scheduler-api/src/main/java/org/opencastproject/scheduler/api/SchedulerService.java
@@ -49,6 +49,9 @@ public interface SchedulerService {
    */
   String JOB_TYPE = "org.opencastproject.scheduler";
 
+  /** The workflow configuration prefix */
+  String WORKFLOW_CONFIG_PREFIX = "org.opencastproject.workflow.config.";
+
   /**
    * Creates new event using specified mediapackage, workflow configuration and capture agent configuration. The
    * mediapackage id is used as the event's identifier.

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -175,9 +175,6 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
   /** The Etag for an empty calendar */
   private static final String EMPTY_CALENDAR_ETAG = "mod0";
 
-  /** The workflow configuration prefix */
-  public static final String WORKFLOW_CONFIG_PREFIX = "org.opencastproject.workflow.config.";
-
   private static final String SNAPSHOT_OWNER = SchedulerService.JOB_TYPE;
 
   private static final Gson gson = new Gson();


### PR DESCRIPTION
The retraction of the live publication by changing the workflow config of a scheduled event wasn't working because Opencast wasn't looking for the correct key in said config - when handing the config over to the update handler, the workflow config prefix has already been added by the scheduler service.