### PR TITLE
Fix snapshot moving

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -672,7 +672,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
   @Override
   public void moveSnapshotsByIdAndDate(final String mpId, final Date start, final Date end, final String targetStore)
           throws NotFoundException {
-    RichAResult results = getSnapshotsByDate(start, end);
+    RichAResult results = getSnapshotsByIdAndDate(mpId, start, end);
 
     if (results.getRecords().isEmpty()) {
       throw new NotFoundException("No media package with id " + mpId + " found between " + start + " and " + end);


### PR DESCRIPTION
This fixes two issues with the move snapshot function of the asset manager:

1. `moveSnapshotsByIdAndDate` previously used `getSnapshotsByDate` instead of `getSnapshotsByIdAndDate` to fetch lookup snapshots that should be moved.
2. `moveSnapshotsByDate` can potentially query a large set of snapshots as also snapshots already present in the target store are included in the query and only later on filtered out in Opencast. This could lead to memory overflows, e.g. in combination with `TimedMediaArchiver` that uses a start date of `new Date(0)`. Running `TimedMediaArchiver` regularly, a memory overflow should be unlikely if the query is reduced to snapshots not already present in the target store.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
