### PR TITLE
Fix single radio button in new-task UI

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/processing.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/processing.js
@@ -138,7 +138,7 @@ angular.module('adminNg.services')
         for (var i = 0; i < radios[radioId].length; i++) {
           radioValues.push(htmlFields[radios[radioId][i]]);
         }
-        if (allTheSame(radioValues)) {
+        if (allTheSame(radioValues) && radioValues.length > 1) {
           for (var j = 0; j < radios[radioId].length; j++) {
             htmlFields[radios[radioId][j]] = null;
           }


### PR DESCRIPTION
Previous behaviour caused the radio button's value to be reset to null,
which was displayed as a single "*" rather than the correct 'true' or
'false' in the summary screen, and was sent back as a straight null to
the endpoint.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
