### PR TITLE
Improve trigger on Dependabot Batcher for Paella7

### DIFF
--- a/.github/workflows/dependabot-batcher.yml
+++ b/.github/workflows/dependabot-batcher.yml
@@ -6,10 +6,10 @@ name: 'Dependabot Batcher for Paella 7'
 on:
   pull_request:
     paths:
-      - '/modules/engage-paella-player-7/**'
+      - 'modules/engage-paella-player-7/**'
   push:
     paths:
-      - '/modules/engage-paella-player-7/**'
+      - 'modules/engage-paella-player-7/**'
 
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/dependabot-batcher.yml
+++ b/.github/workflows/dependabot-batcher.yml
@@ -15,6 +15,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   dependabot-batcher-paella-7:
     name: 'Combine dependabot PRs'


### PR DESCRIPTION
After the set in action of the new GitHub action to group all automatic PRs for Paella 7, we notice that they are not being triggered.

After looking into another actions, I notice that the trigger path doesn't start with a `/` at the beginning of each path. This PR amends that.

Closes #4279 

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [X] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
