### PR TITLE
Publish Captions by Default

### DIFF
--- a/etc/workflows/fast.yaml
+++ b/etc/workflows/fast.yaml
@@ -105,7 +105,7 @@ operations:
     exception-handler-workflow: "partial-error"
     description: "Publishing to Engage"
     configurations:
-      - download-source-flavors: "dublincore/*,security/*"
+      - download-source-flavors: "dublincore/*,security/*,captions/*"
       - download-source-tags: "engage-download"
       - check-availability: false
 
@@ -114,7 +114,7 @@ operations:
     exception-handler-workflow: "partial-error"
     description: "Archiving"
     configurations:
-      - source-flavors: "*/source,dublincore/*,security/*"
+      - source-flavors: "*/source,dublincore/*,security/*,captions/*"
 
   - id: cleanup
     fail-on-error: "false"


### PR DESCRIPTION
This patch makes a minimal adjustment to the fast testing workflow, allowing it to publish and archive subtitles by default. This makes testing subtitles in the player much easier.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
