### PR TITLE
Save button for event/series "Access policy"-tab

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -203,10 +203,6 @@ angular.module('adminNg.controllers')
           angular.forEach(newPolicies, function (policy) {
             $scope.policies.push(policy);
           });
-
-          if (!loading) {
-            $scope.accessSave();
-          }
         },
         checkForActiveTransactions = function () {
           EventTransactionResource.hasActiveTransaction({id: $scope.resourceId }, function (data) {
@@ -426,6 +422,7 @@ angular.module('adminNg.controllers')
             if (angular.isDefined(data.episode_access)) {
               var json = angular.fromJson(data.episode_access.acl);
               changePolicies(json.acl.ace, true);
+              getCurrentPolicies();
             }
           });
 
@@ -626,8 +623,6 @@ angular.module('adminNg.controllers')
       if (angular.isDefined(index)) {
         $scope.policies.splice(index, 1);
       }
-
-      $scope.accessSave();
     };
 
     $scope.getPreview = function (url) {
@@ -726,7 +721,8 @@ angular.module('adminNg.controllers')
 
     $scope.close = function() {
       if (($scope.unsavedChanges([$scope.commonMetadataCatalog]) === false
-           && $scope.unsavedChanges($scope.extendedMetadataCatalogs)  === false)
+           && $scope.unsavedChanges($scope.extendedMetadataCatalogs)  === false
+           && unsavedAccessChanges() === false)
           || confirmUnsaved()) {
         Modal.$scope.close();
       }
@@ -870,11 +866,6 @@ angular.module('adminNg.controllers')
       });
     };
 
-    $scope.accessChanged = function (role) {
-      if (!role) return;
-      $scope.accessSave();
-    };
-
     $scope.accessSave = function () {
       var ace = [],
           hasRights = false,
@@ -947,6 +938,46 @@ angular.module('adminNg.controllers')
           override: true
         }, me.accessSaved, me.accessNotSaved);
       }
+      getCurrentPolicies();
+    };
+
+    let oldPolicies = {}
+    
+    function getCurrentPolicies () {
+
+      oldPolicies = $scope.policies.map(policy => {
+        let newObject = {};
+        Object.keys(policy).forEach(propertyKey => {
+          newObject[propertyKey] = policy[propertyKey];
+        });
+        return newObject;
+      })
+
+      return oldPolicies
+    };
+
+    function unsavedAccessChanges () {
+      let hasChanges = false;
+
+      if (oldPolicies.length !== $scope.policies.length) {
+        hasChanges = true;
+        return hasChanges;
+      }
+
+      oldPolicies.forEach((oldPolicy, index) => {
+        const policy = $scope.policies[index]
+
+        if(oldPolicy.role !== policy.role) {
+          hasChanges = true;
+        }
+        else if (oldPolicy.read !== policy.read) {
+          hasChanges = true;
+        }
+        else if (oldPolicy.write !== policy.write) {
+          hasChanges = true;
+        }
+      });
+      return hasChanges
     };
 
     $scope.statisticsCsvFileName = function (statsTitle) {

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -941,8 +941,8 @@ angular.module('adminNg.controllers')
       getCurrentPolicies();
     };
 
-    let oldPolicies = {}
-    
+    let oldPolicies = {};
+
     function getCurrentPolicies () {
 
       oldPolicies = $scope.policies.map(policy => {
@@ -951,10 +951,10 @@ angular.module('adminNg.controllers')
           newObject[propertyKey] = policy[propertyKey];
         });
         return newObject;
-      })
+      });
 
-      return oldPolicies
-    };
+      return oldPolicies;
+    }
 
     function unsavedAccessChanges () {
       let hasChanges = false;
@@ -965,7 +965,7 @@ angular.module('adminNg.controllers')
       }
 
       oldPolicies.forEach((oldPolicy, index) => {
-        const policy = $scope.policies[index]
+        const policy = $scope.policies[index];
 
         if(oldPolicy.role !== policy.role) {
           hasChanges = true;
@@ -977,8 +977,8 @@ angular.module('adminNg.controllers')
           hasChanges = true;
         }
       });
-      return hasChanges
-    };
+      return hasChanges;
+    }
 
     $scope.statisticsCsvFileName = function (statsTitle) {
       var sanitizedStatsTitle = statsTitle.replace(/[^0-9a-z]/gi, '_').toLowerCase();

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -489,8 +489,8 @@ angular.module('adminNg.controllers')
       return { ace, hasRights, rulesValid };
     };
 
-    let oldPolicies = {}
-    
+    let oldPolicies = {};
+
     function getCurrentPolicies () {
 
       oldPolicies = $scope.policies.map(policy => {
@@ -499,14 +499,14 @@ angular.module('adminNg.controllers')
           newObject[propertyKey] = policy[propertyKey];
         });
         return newObject;
-      })
+      });
 
       return oldPolicies;
-    };
-    
+    }
+
     $scope.saveChanges = function (override) {
       var access = $scope.accessSave(override);
-      
+
       var ace = access.ace;
       var hasRights = access.hasRights;
       var rulesValid = access.rulesValid;
@@ -526,7 +526,7 @@ angular.module('adminNg.controllers')
 
     $scope.updateEventPermissions = function (override) {
       var access = $scope.accessSave(override);
-      
+
       var ace = access.ace;
       var hasRights = access.hasRights;
       var rulesValid = access.rulesValid;
@@ -553,7 +553,7 @@ angular.module('adminNg.controllers')
       }
 
       oldPolicies.forEach((oldPolicy, index) => {
-        const policy = $scope.policies[index]
+        const policy = $scope.policies[index];
 
         if(oldPolicy.role !== policy.role) {
           hasChanges = true;
@@ -565,8 +565,8 @@ angular.module('adminNg.controllers')
           hasChanges = true;
         }
       });
-      return hasChanges
-    };
+      return hasChanges;
+    }
 
     $scope.themeSave = function () {
       var selectedThemeID = $scope.selectedTheme.id;

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -486,7 +486,7 @@ angular.module('adminNg.controllers')
         me.notificationRights = undefined;
       }
 
-      return { ace, hasRights, rulesValid };
+      return { ace, hasRights, rulesValid, override };
     };
 
     let oldPolicies = {};
@@ -530,6 +530,7 @@ angular.module('adminNg.controllers')
       var ace = access.ace;
       var hasRights = access.hasRights;
       var rulesValid = access.rulesValid;
+      override = access.override;
 
       if (hasRights && rulesValid) {
         SeriesAccessResource.save({ id: $scope.resourceId }, {

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -625,7 +625,6 @@
                                       ng-disabled="((tab == 'access') && !$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT'))"
                                       data-width="'360px'"
                                       ng-model="policy.role"
-                                      ng-change="accessChanged(policy.role)"
                                       ng-options="role as role for role in roles"
                                       call-on-search="getMatchingRoles"
                                       placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
@@ -635,10 +634,10 @@
                             <td ng-show="transactions.read_only">
                               <p>{{policy.role}}</p>
                             </td>
-                            <td class="fit text-center"><input type="checkbox" ng-model="policy.read" ng-change="accessSave(policy)" ng-disabled="(transactions.read_only) || !$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT')"/></td>
-                            <td class="fit text-center"><input type="checkbox" ng-model="policy.write" ng-change="accessSave(policy)" ng-disabled="(transactions.read_only) || !$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT')"/></td>
+                            <td class="fit text-center"><input type="checkbox" ng-model="policy.read" ng-disabled="(transactions.read_only) || !$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT')"/></td>
+                            <td class="fit text-center"><input type="checkbox" ng-model="policy.write" ng-disabled="(transactions.read_only) || !$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT')"/></td>
                             <td class="fit editable" ng-if="hasActions">
-                              <div ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT') && !transactions.read_only" save="accessSave" admin-ng-editable-multi-select mixed="false" params="policy.actions" collection="actions"></div>
+                              <div ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT') && !transactions.read_only" admin-ng-editable-multi-select mixed="false" params="policy.actions" collection="actions"></div>
                               <div ng-if="((!$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT')) || transactions.read_only)" ng-repeat="customAction in policy.actions.value">{{ customAction }}</div>
                             </td>
                             <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT')" class="fit"><a ng-show="!transactions.read_only" ng-click="deletePolicy(policy)" class="remove"></a>
@@ -653,6 +652,12 @@
                     </div>
                   </div>
                 </div>
+                <footer>
+                  <a ng-click="accessSave(policy)"
+                    class="submit">
+                    {{ "SAVE" | translate}}
+                  </a>
+              </footer>
             </div>
           </li>
         </ul>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
@@ -227,7 +227,6 @@
                                     ng-disabled="(tab == 'permissions') && (!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT') || aclLocked)"
                                     data-width="'360px'"
                                     ng-model="policy.role"
-                                    ng-change="accessChanged(policy.role)"
                                     ng-options="role as role for role in roles"
                                     call-on-search="getMatchingRoles"
                                     placeholder-text-single="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
@@ -237,18 +236,15 @@
                           <td class="fit text-center">
                             <input type="checkbox"
                                    ng-model="policy.read"
-                                   ng-change="accessSave()"
                                    ng-disabled="!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT') || aclLocked"/>
                           </td>
                           <td class="fit text-center">
                             <input type="checkbox"
                                    ng-model="policy.write"
-                                   ng-change="accessSave()"
                                    ng-disabled="!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT') || aclLocked"/>
                           </td>
                           <td class="fit editable" ng-if="hasActions">
                             <div ng-if="$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT') && !aclLocked"
-                                 save="accessSave"
                                  admin-ng-editable-multi-select
                                  mixed="false"
                                  params="::policy.actions"
@@ -282,14 +278,22 @@
                 </div>
               </div>
               <footer ng-if="updateMode === 'optional'">
-                <!-- Button to remove all episode ACLs to ensure only the series ACL applies -->
-                <a ng-click="accessSave(true)"
-                   class="submit"
-                   ng-class="{disabled: !validAcl}"
-                   translate="EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.REPLACE_EVENT_ACLS"
-                   title="{{'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.REPLACE_EVENT_ACLS_HINT' | translate}}">
-                  <!-- Submit -->
-                </a>
+                <div style="float: right">
+                  <a ng-click="saveChanges(true)"
+                    class="submit" style="float: left"
+                    translate="EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.SAVE_SERIES_ACLS"
+                    title="{{'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.SAVE_SERIES_ACLS_HINT' | translate}}">
+                    <!-- Save -->
+                  </a>
+                  <!-- Button to remove all episode ACLs to ensure only the series ACL applies -->
+                  <a ng-click="updateEventPermissions(true)"
+                    class="submit"
+                    ng-class="{disabled: !validAcl}"
+                    translate="EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.REPLACE_EVENT_ACLS"
+                    title="{{'EVENTS.SERIES.DETAILS.ACCESS.ACCESS_POLICY.REPLACE_EVENT_ACLS_HINT' | translate}}">
+                    <!-- Submit -->
+                  </a>
+                </div>
               </footer>
             </div>
           </li>

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1165,8 +1165,10 @@
              "ACTION"      : "Actions",
              "NEW"         : "New policy",
              "DETAILS"     : "Details",
-             "REPLACE_EVENT_ACLS": "Update event permissions",
+             "REPLACE_EVENT_ACLS": "Save & update event permissions",
              "REPLACE_EVENT_ACLS_HINT": "Ensure all events of this series have these permissions in effect",
+             "SAVE_SERIES_ACLS": "Save",
+             "SAVE_SERIES_ACLS_HINT": "Apply permissions only to series",
              "LOAD_MORE_LIMIT": "policies shown.",
              "LOAD_MORE_LINK": "Load more"
            },

--- a/modules/admin-ui-frontend/test/test/unit/modules/events/controllers/serieControllerSpec.js
+++ b/modules/admin-ui-frontend/test/test/unit/modules/events/controllers/serieControllerSpec.js
@@ -272,7 +272,7 @@ describe('Serie controller', function () {
             };
 
             spyOn(SeriesAccessResource, 'save');
-            $scope.accessSave.call(this);
+            $scope.updateEventPermissions.call(this);
 
             expect(SeriesAccessResource.save).toHaveBeenCalledWith({ id: '73f9b7ab-1d8f-4c75-9da1-ceb06736d82c' },
                 {


### PR DESCRIPTION
- This should fix the problem with racecondition when editig acces rights in the admin-ui.
- Changes to roles can now be submitted all at once (with button "Save & update event permissions") and are no longer automatically submitted with each change
- User must now confirm unsaved changes (like in metadata-tab)
- Save-Button for saving changes (but not submitting)

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
