### PR TITLE
Add captions to Tobira harvest API (plus: avoid using deprecated method for creators.)

### DIFF
--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -94,7 +94,7 @@ public class TobiraEndpoint {
   // adding new JSON fields is a non-breaking change. You should also consider whether Tobira needs
   // to resynchronize, i.e. to get new data.
   private static final int VERSION_MAJOR = 1;
-  private static final int VERSION_MINOR = 0;
+  private static final int VERSION_MINOR = 1;
   private static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR;
 
   private SearchService searchService;


### PR DESCRIPTION
See both commits! The main goal of this PR is to expose caption/subtitle information so that Tobira can show those in the player. Unfortunately, there are no strict rules how to attach captions to events, so this current code just checks multiple sources and takes all captions it can find. This is not optimal and it would be better if there were established best practices or even rules. This code is a bit flying blind. However, this harvest API does not guarantee any stability, so we can just improve the logic in the future.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
