### PR TITLE
Skip check if user has global admin role

### DIFF
--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventSearchQuery.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/event/EventSearchQuery.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.elasticsearch.index.objects.event;
 
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
+
 import org.opencastproject.elasticsearch.impl.AbstractSearchQuery;
 import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.Permissions.Action;
@@ -93,8 +95,10 @@ public class EventSearchQuery extends AbstractSearchQuery {
     this.organization = organization;
     this.user = user;
     this.actions.add(Permissions.Action.READ.toString());
-    if (!user.getOrganization().getId().equals(organization)) {
-      throw new IllegalStateException("User's organization must match search organization");
+    if (!user.hasRole(GLOBAL_ADMIN_ROLE)) {
+      if (!user.getOrganization().getId().equals(organization)) {
+        throw new IllegalStateException("User's organization must match search organization");
+      }
     }
   }
 

--- a/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
+++ b/modules/index-service/src/test/java/org/opencastproject/index/service/impl/IndexServiceImplTest.java
@@ -199,6 +199,7 @@ public class IndexServiceImplTest {
     User user = EasyMock.createMock(User.class);
     EasyMock.expect(user.getOrganization()).andReturn(organization).anyTimes();
     EasyMock.expect(user.getUsername()).andReturn(username);
+    EasyMock.expect(user.hasRole(EasyMock.anyString())).andReturn(false);
     EasyMock.replay(user);
 
     SecurityService securityService = EasyMock.createMock(SecurityService.class);


### PR DESCRIPTION
When reindexing the current user could belong to a different organization. This user usually has the global admin role and should thus still be able to query the event index.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
