### PR TITLE
Reuse mediapackage object from workflow instance where possible

### DIFF
--- a/modules/comments-workflowoperation/src/main/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandler.java
+++ b/modules/comments-workflowoperation/src/main/java/org/opencastproject/workflow/handler/comments/CommentWorkflowOperationHandler.java
@@ -152,13 +152,12 @@ public class CommentWorkflowOperationHandler extends AbstractWorkflowOperationHa
    */
   private void createComment(WorkflowInstance workflowInstance, String reason, String description)
           throws EventCommentException {
-    Opt<EventComment> optComment = findComment(workflowInstance.getMediaPackage().getIdentifier().toString(), reason,
-            description);
+    String mpId = workflowInstance.getMediaPackage().getIdentifier().toString();
+    Opt<EventComment> optComment = findComment(mpId, reason, description);
     if (optComment.isNone()) {
       final User user = userDirectoryService.loadUser(workflowInstance.getCreatorName());
       EventComment comment = EventComment.create(
-          Option.none(),
-          workflowInstance.getMediaPackage().getIdentifier().toString(),
+          Option.none(), mpId,
           securityService.getOrganization().getId(), description, user, reason, false);
       eventCommentService.updateComment(comment);
     } else {
@@ -181,12 +180,12 @@ public class CommentWorkflowOperationHandler extends AbstractWorkflowOperationHa
    */
   private void resolveComment(WorkflowInstance workflowInstance, String reason, String description)
           throws EventCommentException {
-    Opt<EventComment> optComment = findComment(workflowInstance.getMediaPackage().getIdentifier().toString(), reason,
-            description);
+    String mpId = workflowInstance.getMediaPackage().getIdentifier().toString();
+    Opt<EventComment> optComment = findComment(mpId, reason, description);
     if (optComment.isSome()) {
       EventComment comment = EventComment.create(
           optComment.get().getId(),
-          workflowInstance.getMediaPackage().getIdentifier().toString(),
+          mpId,
           securityService.getOrganization().getId(), optComment.get().getText(),
           optComment.get().getAuthor(), optComment.get().getReason(), true, optComment.get().getCreationDate(),
           optComment.get().getModificationDate(), optComment.get().getReplies());
@@ -212,8 +211,8 @@ public class CommentWorkflowOperationHandler extends AbstractWorkflowOperationHa
    */
   private void deleteComment(WorkflowInstance workflowInstance, String reason, String description)
           throws EventCommentException, NotFoundException {
-    Opt<EventComment> optComment = findComment(workflowInstance.getMediaPackage().getIdentifier().toString(), reason,
-            description);
+    String mpId = workflowInstance.getMediaPackage().getIdentifier().toString();
+    Opt<EventComment> optComment = findComment(mpId, reason, description);
     if (optComment.isSome()) {
       try {
         eventCommentService.deleteComment(optComment.get().getId().get());

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -151,8 +151,9 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
           throws WorkflowOperationException {
     logger.debug("Running image workflow operation on {}", wi);
     try {
-      final Extractor e = new Extractor(this, configure(wi.getMediaPackage(), wi));
-      return e.main(MediaPackageSupport.copy(wi.getMediaPackage()));
+      MediaPackage mp = wi.getMediaPackage();
+      final Extractor e = new Extractor(this, configure(mp, wi));
+      return e.main(MediaPackageSupport.copy(mp));
     } catch (Exception e) {
       throw new WorkflowOperationException(e);
     }

--- a/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
+++ b/modules/mattermost-notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/mattermost/notification/MattermostNotificationWorkflowOperationHandler.java
@@ -27,6 +27,7 @@ import static org.apache.http.HttpStatus.SC_NO_CONTENT;
 import static org.apache.http.HttpStatus.SC_OK;
 
 import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -182,12 +183,13 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
     logger.debug("Request will be sent using the '{}' method", method);
 
     // Add event parameters as form parameters
+    MediaPackage mp = workflowInstance.getMediaPackage();
     try {
       List<BasicNameValuePair> params = new ArrayList<>();
 
       // Add the subject (if specified)
       if (notificationMessage != null) {
-        params.add(new BasicNameValuePair(HTTP_PARAM_PAYLOAD, makeJson(notificationMessage, workflowInstance)));
+        params.add(new BasicNameValuePair(HTTP_PARAM_PAYLOAD, makeJson(notificationMessage, workflowInstance, mp)));
       }
 
       request.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
@@ -200,7 +202,7 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
       throw new WorkflowOperationException(format("Notification could not be delivered to %s", urlPath));
     }
 
-    return createResult(workflowInstance.getMediaPackage(), Action.CONTINUE);
+    return createResult(mp, Action.CONTINUE);
   }
 
   /**
@@ -209,22 +211,23 @@ public class MattermostNotificationWorkflowOperationHandler extends AbstractWork
    *
    * @param s                The notification message to transform to Json-String
    * @param workflowInstance The workflowInstance which getting metadata from
+   * @param mediaPackage     The mediaPackage
    * @return JSON-String containing the information of the workflowInstance
    */
-  private String makeJson(String s, WorkflowInstance workflowInstance) {
+  private String makeJson(String s, WorkflowInstance workflowInstance, MediaPackage mediaPackage) {
     s = s.replace("%t", checkIfNull(workflowInstance.getTitle(), "Title"));
     s = s.replace("%i", String.valueOf(workflowInstance.getId()));
     s = s.replace("%s", String.valueOf(workflowInstance.getState()));
     s = s.replace("%o", String.valueOf(workflowInstance.getCurrentOperation().getId()));
-    s = s.replace("%I", checkIfNull(workflowInstance.getMediaPackage().getIdentifier(), "Mediapackage-ID"));
-    s = s.replace("%T", checkIfNull(workflowInstance.getMediaPackage().getTitle(), "Mediapackage-Title"));
-    s = s.replace("%c", checkIfNull(workflowInstance.getMediaPackage().getContributors(), "Contributors"));
-    s = s.replace("%C", checkIfNull(workflowInstance.getMediaPackage().getCreators(), "Creators"));
-    s = s.replace("%D", checkIfNull(workflowInstance.getMediaPackage().getDate(), "Date"));
-    s = s.replace("%d", checkIfNull(workflowInstance.getMediaPackage().getDuration(), "Duration"));
-    s = s.replace("%l", checkIfNull(workflowInstance.getMediaPackage().getLanguage(), "Language"));
-    s = s.replace("%L", checkIfNull(workflowInstance.getMediaPackage().getLicense(), "License"));
-    s = s.replace("%S", checkIfNull(workflowInstance.getMediaPackage().getSeriesTitle(), "Series-Title"));
+    s = s.replace("%I", checkIfNull(mediaPackage.getIdentifier(), "Mediapackage-ID"));
+    s = s.replace("%T", checkIfNull(mediaPackage.getTitle(), "Mediapackage-Title"));
+    s = s.replace("%c", checkIfNull(mediaPackage.getContributors(), "Contributors"));
+    s = s.replace("%C", checkIfNull(mediaPackage.getCreators(), "Creators"));
+    s = s.replace("%D", checkIfNull(mediaPackage.getDate(), "Date"));
+    s = s.replace("%d", checkIfNull(mediaPackage.getDuration(), "Duration"));
+    s = s.replace("%l", checkIfNull(mediaPackage.getLanguage(), "Language"));
+    s = s.replace("%L", checkIfNull(mediaPackage.getLicense(), "License"));
+    s = s.replace("%S", checkIfNull(mediaPackage.getSeriesTitle(), "Series-Title"));
 
     JsonObject json = new JsonObject();
     json.addProperty("text", s);

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -64,6 +64,7 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.Transient;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
@@ -156,6 +157,9 @@ public class WorkflowInstance {
   @Column(name = "mediapackage", length = 16777215)
   private String mediaPackage;
 
+  @Transient
+  private MediaPackage mediaPackageObj;
+
   @OneToMany(
           mappedBy = "instance",
           cascade = CascadeType.ALL,
@@ -233,6 +237,7 @@ public class WorkflowInstance {
     this.organizationId = organization != null ? organization.getId() : null;
     this.state = WorkflowState.INSTANTIATED;
     this.dateCreated = new Date();
+    this.mediaPackageObj = mediaPackage;
     this.mediaPackage = mediaPackage == null ? null : MediaPackageParser.getAsXml(mediaPackage);
     this.mediaPackageId = mediaPackage == null ? null : mediaPackage.getIdentifier().toString();
     this.seriesId = mediaPackage == null ? null : mediaPackage.getSeries();
@@ -270,6 +275,7 @@ public class WorkflowInstance {
     this.organizationId = organizationId;
     this.dateCreated = dateCreated;
     this.dateCompleted = dateCompleted;
+    this.mediaPackageObj = mediaPackage;
     this.mediaPackage = mediaPackage == null ? null : MediaPackageParser.getAsXml(mediaPackage);
     this.operations = operations;
     this.configurations = configurations;
@@ -355,8 +361,12 @@ public class WorkflowInstance {
 
   public MediaPackage getMediaPackage()  {
     try {
+      if (mediaPackageObj != null) {
+        return mediaPackageObj;
+      }
       if (mediaPackage != null) {
-        return MediaPackageParser.getFromXml(mediaPackage);
+        mediaPackageObj = MediaPackageParser.getFromXml(mediaPackage);
+        return mediaPackageObj;
       }
     } catch (MediaPackageException e) {
       logger.error("Error parsing media package in workflow instance", e);
@@ -365,6 +375,7 @@ public class WorkflowInstance {
   }
 
   public void setMediaPackage(MediaPackage mediaPackage) {
+    this.mediaPackageObj = mediaPackage;
     this.mediaPackage = mediaPackage == null ? null : MediaPackageParser.getAsXml(mediaPackage);
     this.mediaPackageId = mediaPackage == null ? null : mediaPackage.getIdentifier().toString();
     this.seriesId = mediaPackage == null ? null : mediaPackage.getSeries();

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -875,14 +875,15 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
   private void removeTempFiles(WorkflowInstance workflowInstance) {
     logger.info("Removing temporary files for workflow {}", workflowInstance);
-    if (null == workflowInstance.getMediaPackage()) {
+    MediaPackage mp = workflowInstance.getMediaPackage();
+    if (null == mp) {
       logger.warn("Workflow instance {} does not have an media package set", workflowInstance.getId());
       return;
     }
-    for (MediaPackageElement elem : workflowInstance.getMediaPackage().getElements()) {
+    for (MediaPackageElement elem : mp.getElements()) {
       if (null == elem.getURI()) {
         logger.warn("Mediapackage element {} from the media package {} does not have an URI set",
-                elem.getIdentifier(), workflowInstance.getMediaPackage().getIdentifier().toString());
+                elem.getIdentifier(), mp.getIdentifier().toString());
         continue;
       }
       try {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CloneWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CloneWorkflowOperationHandler.java
@@ -151,7 +151,7 @@ public class CloneWorkflowOperationHandler extends AbstractWorkflowOperationHand
     if (elements.size() == 0) {
       // If no one found, we skip the operation
       logger.debug("No matching elements found, skipping operation.");
-      return createResult(workflowInstance.getMediaPackage(), Action.SKIP);
+      return createResult(mediaPackage, Action.SKIP);
     } else {
       logger.debug("Copy " + elements.size() + " elements to new flavor: {}", targetFlavorOption);
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConditionalConfigWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ConditionalConfigWorkflowOperationHandler.java
@@ -22,6 +22,7 @@
 package org.opencastproject.workflow.handler.workflow;
 
 import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.WorkflowInstance;
 import org.opencastproject.workflow.api.WorkflowOperationException;
@@ -68,6 +69,7 @@ public class ConditionalConfigWorkflowOperationHandler extends AbstractWorkflowO
   public WorkflowOperationResult start(final WorkflowInstance workflowInstance, JobContext context)
           throws WorkflowOperationException {
     WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
+    MediaPackage mp = workflowInstance.getMediaPackage();
 
     Map<String, String> properties = new HashMap<>();
 
@@ -109,7 +111,7 @@ public class ConditionalConfigWorkflowOperationHandler extends AbstractWorkflowO
          // Replace workflow configuration, even if already set.
         properties.put(wfConfigName, value.trim());
         logger.debug("Configuration key '{}' of workflow {} is set to value '{}'", wfConfigName, id, value.trim());
-        return createResult(workflowInstance.getMediaPackage(), properties, Action.CONTINUE, 0);
+        return createResult(mp, properties, Action.CONTINUE, 0);
       }
     }
 
@@ -118,7 +120,7 @@ public class ConditionalConfigWorkflowOperationHandler extends AbstractWorkflowO
     if (StringUtils.isNotEmpty(NO_MATCH)) {
       properties.put(wfConfigName, noMatch);
       logger.debug("Configuration key '{}' of workflow {} is set to value '{}'", wfConfigName, id, noMatch);
-      return createResult(workflowInstance.getMediaPackage(), properties, Action.CONTINUE, 0);
+      return createResult(mp, properties, Action.CONTINUE, 0);
     }
     return createResult(Action.SKIP);
   }

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CopyWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/CopyWorkflowOperationHandler.java
@@ -157,7 +157,7 @@ public class CopyWorkflowOperationHandler extends AbstractWorkflowOperationHandl
     // Check the the number of element returned
     if (elements.size() == 0) {
       // If no one found, we skip the operation
-      return createResult(workflowInstance.getMediaPackage(), Action.SKIP);
+      return createResult(mediaPackage, Action.SKIP);
     } else if (elements.size() == 1) {
       for (MediaPackageElement element : elements) {
         logger.debug("Copy single element to: {}", targetDirectoryOption);
@@ -194,7 +194,7 @@ public class CopyWorkflowOperationHandler extends AbstractWorkflowOperationHandl
       }
     }
 
-    return createResult(workflowInstance.getMediaPackage(), Action.CONTINUE);
+    return createResult(mediaPackage, Action.CONTINUE);
   }
 
   private void copyElement(MediaPackageElement element, File targetFile) throws WorkflowOperationException {

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/DefaultsWorkflowOperationHandler.java
@@ -21,6 +21,7 @@
 package org.opencastproject.workflow.handler.workflow;
 
 import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.presets.api.PresetProvider;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.NotFoundException;
@@ -101,7 +102,8 @@ public class DefaultsWorkflowOperationHandler extends AbstractWorkflowOperationH
     WorkflowOperationInstance operation = workflowInstance.getCurrentOperation();
     Long id = workflowInstance.getId();
     String organizationId = workflowInstance.getOrganizationId();
-    String seriesID = workflowInstance.getMediaPackage().getSeries();
+    MediaPackage mp = workflowInstance.getMediaPackage();
+    String seriesID = mp.getSeries();
     // Iterate over all configuration keys
     Map<String, String> properties = new HashMap<>();
     logger.debug("Getting properties for {} {} {}", id, organizationId, seriesID);
@@ -124,7 +126,7 @@ public class DefaultsWorkflowOperationHandler extends AbstractWorkflowOperationH
         logger.debug("Configuration key '{}' of workflow {} is set to '{}' specified in event.", key, id, value);
       }
     }
-    return createResult(workflowInstance.getMediaPackage(), properties, Action.CONTINUE, 0);
+    return createResult(mp, properties, Action.CONTINUE, 0);
   }
 
   @Reference

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ExportWorkflowPropertiesWOH.java
@@ -108,7 +108,7 @@ public class ExportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
 
     // Read optional existing workflow properties from mediapackage
     Properties workflowProps = new Properties();
-    Opt<Attachment> existingPropsElem = loadPropertiesElementFromMediaPackage(targetFlavor, workflowInstance);
+    Opt<Attachment> existingPropsElem = loadPropertiesElementFromMediaPackage(targetFlavor, mediaPackage);
     if (existingPropsElem.isSome()) {
       workflowProps = loadPropertiesFromXml(workspace, existingPropsElem.get().getURI());
 

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ImportWorkflowPropertiesWOH.java
@@ -91,21 +91,21 @@ public class ImportWorkflowPropertiesWOH extends AbstractWorkflowOperationHandle
     ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(wi,
         Configuration.none, Configuration.one, Configuration.none, Configuration.none);
     final MediaPackageElementFlavor sourceFlavor = tagsAndFlavors.getSingleSrcFlavor();
+    MediaPackage mp = wi.getMediaPackage();
     Opt<Attachment> propertiesElem = loadPropertiesElementFromMediaPackage(
-            sourceFlavor, wi);
+            sourceFlavor, mp);
     if (propertiesElem.isSome()) {
       Properties properties = loadPropertiesFromXml(workspace, propertiesElem.get().getURI());
       final Set<String> keys = $(getOptConfig(wi, KEYS_PROPERTY)).bind(Strings.splitCsv).toSet();
-      return createResult(wi.getMediaPackage(), convertToWorkflowProperties(properties, keys), CONTINUE, 0);
+      return createResult(mp, convertToWorkflowProperties(properties, keys), CONTINUE, 0);
     } else {
       logger.info("No attachment with workflow properties found, skipping...");
-      return createResult(wi.getMediaPackage(), SKIP);
+      return createResult(mp, SKIP);
     }
   }
 
   static Opt<Attachment> loadPropertiesElementFromMediaPackage(MediaPackageElementFlavor sourceFlavor,
-          WorkflowInstance wi) throws WorkflowOperationException {
-    final MediaPackage mp = wi.getMediaPackage();
+      MediaPackage mp) throws WorkflowOperationException {
     final Attachment[] elements = mp.getAttachments(sourceFlavor);
 
     if (elements.length < 1) {


### PR DESCRIPTION
Some workflow operations assumed that the mediapackage object returned from the workflow instance stays the same. Instead with the new workflow implementation, the mediapackage is always parsed from the XML string.

This reuses the mediapackage object where possible and also caches the parsed object.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
