### PR TITLE
Update Live Publication in Archive on Capture Agent Change

### DIFF
--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -342,7 +342,6 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     MediaPackage tmpMp = (MediaPackage) snapshot.getMediaPackage().clone();
     setDurationForMediaPackage(tmpMp, episodeDC); // duration is used by live tracks
     Map<String, Track> liveTracks = addLiveTracksToMediaPackage(tmpMp, episodeDC);
-    createOrUpdatePublicationTracks(tmpMp, liveTracks);
 
     // if nothing changed, no need to do anything
     if (isSameMediaPackage(mpFromSearch, tmpMp)) {
@@ -360,6 +359,10 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     removeLivePublicationChannel(mpForSearch); // we don't need the live publication in search
     publishToSearch(mpForSearch);
     retractPreviousElements(mpFromSearch, mpForSearch); // cleanup
+
+    // update live publication in archive
+    MediaPackage updatedArchivedMp = updateLivePublication(snapshot.getMediaPackage(), liveTracks);
+    snapshotVersionCache.put(mpId, assetManager.takeSnapshot(updatedArchivedMp).getVersion());
     return true;
   }
 
@@ -376,13 +379,14 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
   }
 
-  private void createOrUpdatePublicationTracks(MediaPackage mediaPackage, Map<String, Track> generatedTracks) {
+  private MediaPackage updateLivePublication(MediaPackage mediaPackage, Map<String, Track> generatedTracks) {
     Publication[] publications = mediaPackage.getPublications();
     for (Publication publication : publications) {
       if (publication.getChannel().equals(CHANNEL_ID)) {
         createOrUpdatePublicationTracks(publication, generatedTracks);
       }
     }
+    return mediaPackage;
   }
 
   boolean retractLiveEvent(MediaPackage mp) throws LiveScheduleException {

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -291,7 +291,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       // Replace and distribute acl, this creates new mp
       MediaPackage newMp = replaceAndDistributeAcl(previousMp, acl);
       // Publish mp to engage search index
-      publish(newMp);
+      publishToSearch(newMp);
       // Don't leave garbage there!
       retractPreviousElements(previousMp, newMp);
       logger.info("Updated live acl for media package {}", newMp);
@@ -303,77 +303,63 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   boolean createLiveEvent(String mpId, DublinCoreCatalog episodeDC) throws LiveScheduleException {
     try {
       logger.info("Creating live media package {}", mpId);
-      // Get latest mp from the asset manager
-      Snapshot snapshot = getSnapshot(mpId);
-      // Temporary mp
-      MediaPackage tempMp = (MediaPackage) snapshot.getMediaPackage().clone();
-      // Set duration (used by live tracks)
-      setDuration(tempMp, episodeDC);
-      // Add live tracks to media package
-      Map<String, Track> generatedTracks = addLiveTracks(tempMp, episodeDC.getFirst(DublinCore.PROPERTY_SPATIAL));
-      // Add and distribute catalogs/acl, this creates a new mp object
-      MediaPackage mp = addAndDistributeElements(snapshot);
-      // Add tracks from tempMp
-      for (Track t : tempMp.getTracks()) {
-        mp.add(t);
+      Snapshot snapshot = getSnapshotFromArchive(mpId);
+
+      // generate live tracks
+      MediaPackage tmpMp = (MediaPackage) snapshot.getMediaPackage().clone();
+      setDurationForMediaPackage(tmpMp, episodeDC); // duration is used by live tracks
+      Map<String, Track> liveTracks = addLiveTracksToMediaPackage(tmpMp, episodeDC);
+
+      // publish to search
+      MediaPackage mpForSearch = distributeAclsAndCatalogs(snapshot);
+      for (Track t : tmpMp.getTracks()) {
+        mpForSearch.add(t);
       }
-      // Publish mp to engage search index
-      publish(mp);
-      // Add engage-live publication channel to archived mp
-      Organization currentOrg = null;
-      try {
-        currentOrg = organizationService.getOrganization(snapshot.getOrganizationId());
-      } catch (NotFoundException e) {
-        logger.warn("Organization in snapshot not found: {}", snapshot.getOrganizationId());
-      }
-      MediaPackage archivedMp = snapshot.getMediaPackage();
-      addLivePublicationChannel(currentOrg, archivedMp, generatedTracks);
-      // Take a snapshot with the publication added and put its version in our local cache
-      // so that we ignore notifications for this snapshot version.
-      snapshotVersionCache.put(mpId, assetManager.takeSnapshot(archivedMp).getVersion());
+      publishToSearch(mpForSearch);
+
+      // add live publication to archive
+      MediaPackage updatedArchivedMp = addLivePublicationToMediaPackage(snapshot, liveTracks);
+      snapshotVersionCache.put(mpId, assetManager.takeSnapshot(updatedArchivedMp).getVersion());
       return true;
     } catch (Exception e) {
       throw new LiveScheduleException(e);
     }
   }
 
-  boolean updateLiveEvent(MediaPackage previousMp, DublinCoreCatalog episodeDC) throws LiveScheduleException {
-    // Get latest mp from the asset manager
-    Snapshot snapshot = getSnapshot(previousMp.getIdentifier().toString());
+  boolean updateLiveEvent(MediaPackage mpFromSearch, DublinCoreCatalog episodeDC) throws LiveScheduleException {
+    String mpId = mpFromSearch.getIdentifier().toString();
+    Snapshot snapshot = getSnapshotFromArchive(mpId);
+
     // If the snapshot version is in our local cache, it means that this snapshot was created by us so
     // nothing to do. Note that this is just to save time; if the entry has already been deleted, the mp
     // will be compared below.
-    if (snapshot.getVersion().equals(snapshotVersionCache.getIfPresent(previousMp.getIdentifier().toString()))) {
+    if (snapshot.getVersion().equals(snapshotVersionCache.getIfPresent(mpId))) {
       logger.debug("Snapshot version {} was created by us so this change is ignored.", snapshot.getVersion());
       return false;
     }
-    // Temporary mp
-    MediaPackage tempMp = (MediaPackage) snapshot.getMediaPackage().clone();
-    // Set duration (used by live tracks)
-    setDuration(tempMp, episodeDC);
-    // Add live tracks to media package
-    Map<String, Track> generatedTracks = addLiveTracks(tempMp, episodeDC.getFirst(DublinCore.PROPERTY_SPATIAL));
-    // Update tracks in the publication
-    createOrUpdatePublicationTracks(tempMp, generatedTracks);
-    // If same mp, no need to do anything
-    if (isSameMediaPackage(previousMp, tempMp)) {
-      logger.debug("Live media package {} seems to be the same. Not updating.", previousMp);
+
+    // generate new live tracks
+    MediaPackage tmpMp = (MediaPackage) snapshot.getMediaPackage().clone();
+    setDurationForMediaPackage(tmpMp, episodeDC); // duration is used by live tracks
+    Map<String, Track> liveTracks = addLiveTracksToMediaPackage(tmpMp, episodeDC);
+    createOrUpdatePublicationTracks(tmpMp, liveTracks);
+
+    // if nothing changed, no need to do anything
+    if (isSameMediaPackage(mpFromSearch, tmpMp)) {
+      logger.debug("Live media package {} seems to be the same. Not updating.", mpFromSearch);
       return false;
     }
-    logger.info("Updating live media package {}", previousMp);
-    // Add and distribute catalogs/acl, this creates a new mp
-    MediaPackage mp = addAndDistributeElements(snapshot);
-    // Add tracks from tempMp
-    for (Track t : tempMp.getTracks()) {
-      mp.add(t);
+
+    logger.info("Updating live media package {}", mpFromSearch);
+
+    // update mp in search
+    MediaPackage mpForSearch = distributeAclsAndCatalogs(snapshot);
+    for (Track t : tmpMp.getTracks()) {
+      mpForSearch.add(t);
     }
-    // Remove publication element that came with the snapshot mp
-    removeLivePublicationChannel(mp);
-    // Publish mp to engage search index
-    publish(mp);
-    // Publication channel already there so no need to add
-    // Don't leave garbage there!
-    retractPreviousElements(previousMp, mp);
+    removeLivePublicationChannel(mpForSearch); // we don't need the live publication in search
+    publishToSearch(mpForSearch);
+    retractPreviousElements(mpFromSearch, mpForSearch); // cleanup
     return true;
   }
 
@@ -405,7 +391,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     // Get latest mp from the asset manager if there to remove the publication
     try {
       String mpId = mp.getIdentifier().toString();
-      Snapshot snapshot = getSnapshot(mpId);
+      Snapshot snapshot = getSnapshotFromArchive(mpId);
       MediaPackage archivedMp = snapshot.getMediaPackage();
       removeLivePublicationChannel(archivedMp);
       logger.debug("Removed live pub channel from archived media package {}", mp);
@@ -418,7 +404,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     return true;
   }
 
-  void publish(MediaPackage mp) throws LiveScheduleException {
+  void publishToSearch(MediaPackage mp) throws LiveScheduleException {
     try {
       // Add media package to the search index
       logger.info("Publishing LIVE media package {} to search index", mp);
@@ -494,7 +480,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
   }
 
-  void setDuration(MediaPackage mp, DublinCoreCatalog dc) {
+  void setDurationForMediaPackage(MediaPackage mp, DublinCoreCatalog dc) {
     DCMIPeriod period = EncodingSchemeUtils.decodeMandatoryPeriod(dc.getFirst(DublinCore.PROPERTY_TEMPORAL));
     long duration = period.getEnd().getTime() - period.getStart().getTime();
     mp.setDuration(duration);
@@ -502,8 +488,10 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
             mp.getDuration());
   }
 
-  Map<String, Track> addLiveTracks(MediaPackage mp, String caName) throws LiveScheduleException {
-    HashMap<String, Track> generatedTracks = new HashMap<String, Track>();
+  Map<String, Track> addLiveTracksToMediaPackage(MediaPackage mp, DublinCoreCatalog episodeDC)
+          throws LiveScheduleException {
+    String caName = episodeDC.getFirst(DublinCore.PROPERTY_SPATIAL);
+    HashMap<String, Track> generatedTracks = new HashMap<>();
     String mpId = mp.getIdentifier().toString();
     try {
       // If capture agent registered the properties:
@@ -638,7 +626,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     return barrier.waitForJobs();
   }
 
-  Snapshot getSnapshot(String mpId) throws LiveScheduleException {
+  Snapshot getSnapshotFromArchive(String mpId) throws LiveScheduleException {
     AQueryBuilder query = assetManager.createQuery();
     AResult result = query.select(query.snapshot()).where(query.mediaPackageId(mpId).and(query.version().isLatest()))
             .run();
@@ -654,11 +642,11 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     return record.get().getSnapshot().get();
   }
 
-  MediaPackage addAndDistributeElements(Snapshot snapshot) throws LiveScheduleException {
+  MediaPackage distributeAclsAndCatalogs(Snapshot snapshot) throws LiveScheduleException {
     try {
       MediaPackage mp = (MediaPackage) snapshot.getMediaPackage().clone();
 
-      Set<String> elementIds = new HashSet<String>();
+      Set<String> elementIds = new HashSet<>();
       // Then, add series catalog if needed
       if (StringUtils.isNotEmpty(mp.getSeries())) {
         DublinCoreCatalog catalog = seriesService.getSeries(mp.getSeries());
@@ -747,11 +735,17 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
   }
 
-  void addLivePublicationChannel(
-      Organization currentOrg,
-      MediaPackage mp,
-      Map<String, Track> generatedTracks
-  ) throws LiveScheduleException {
+  MediaPackage addLivePublicationToMediaPackage(Snapshot snapshot, Map<String, Track> generatedTracks)
+          throws LiveScheduleException {
+    MediaPackage mp = snapshot.getMediaPackage();
+
+    Organization currentOrg = null;
+    try {
+      currentOrg = organizationService.getOrganization(snapshot.getOrganizationId());
+    } catch (NotFoundException e) {
+      logger.warn("Organization in snapshot not found: {}", snapshot.getOrganizationId());
+    }
+
     logger.debug("Adding live channel publication element to media package {}", mp);
     String engageUrlString = null;
     if (currentOrg != null) {
@@ -771,6 +765,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
               MimeTypes.parseMimeType("text/html"));
       mp.add(publicationElement);
       createOrUpdatePublicationTracks(publicationElement, generatedTracks);
+      return mp;
     } catch (URISyntaxException e) {
       throw new LiveScheduleException(e);
     }

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -818,6 +818,14 @@ public class LiveScheduleServiceImplTest {
             EasyMock.anyObject(Set.class), EasyMock.anyBoolean())).andReturn(job);
     EasyMock.expect(serviceRegistry.getJob(1L)).andReturn(job).anyTimes();
 
+    Capture<MediaPackage> capturedSnapshotMp = Capture.newInstance();
+    Version v = EasyMock.createNiceMock(Version.class);
+    Snapshot s = EasyMock.createNiceMock(Snapshot.class);
+    EasyMock.expect(s.getVersion()).andReturn(v);
+    EasyMock.replay(s, v);
+    EasyMock.expect(
+            assetManager.takeSnapshot(EasyMock.capture(capturedSnapshotMp))).andReturn(s);
+
     Job jobPub = createJob(2L, "anything", "anything");
     Capture<MediaPackage> capturedMp = Capture.newInstance();
     EasyMock.expect(searchService.add(EasyMock.capture(capturedMp))).andReturn(jobPub);

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -51,7 +51,6 @@ import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
 import org.opencastproject.metadata.dublincore.DublinCoreValue;
 import org.opencastproject.metadata.dublincore.DublinCores;
-import org.opencastproject.search.api.SearchQuery;
 import org.opencastproject.search.api.SearchResult;
 import org.opencastproject.search.api.SearchResultImpl;
 import org.opencastproject.search.api.SearchService;
@@ -130,9 +129,16 @@ public class LiveScheduleServiceImplTest {
   private OrganizationDirectoryService organizationService;
   private SecurityService securityService;
 
+  private DublinCoreCatalog episodeDC;
+  private DublinCoreCatalog seriesDC;
+
   @Before
   public void setUp() throws Exception {
     mimeType = MimeTypes.parseMimeType(MIME_TYPE);
+    URI catalogURI = LiveScheduleServiceImplTest.class.getResource("/episode.xml").toURI();
+    episodeDC = DublinCores.read(catalogURI.toURL().openStream());
+    catalogURI = LiveScheduleServiceImplTest.class.getResource("/series.xml").toURI();
+    seriesDC = DublinCores.read(catalogURI.toURL().openStream());
 
     // Osgi Services
     serviceRegistry = EasyMock.createNiceMock(ServiceRegistry.class);
@@ -165,7 +171,7 @@ public class LiveScheduleServiceImplTest {
     // Live service configuration
     BundleContext bc = EasyMock.createNiceMock(BundleContext.class);
     EasyMock.expect(bc.getProperty(SecurityUtil.PROPERTY_KEY_SYS_USER)).andReturn("system-user");
-    Dictionary<String, Object> props = new Hashtable<String, Object>();
+    Dictionary<String, Object> props = new Hashtable<>();
     props.put(LiveScheduleServiceImpl.LIVE_STREAMING_URL, STREAMING_SERVER_URL);
     props.put(LiveScheduleServiceImpl.LIVE_STREAM_MIME_TYPE, "video/x-flv");
     props.put(LiveScheduleServiceImpl.LIVE_STREAM_NAME, STREAM_NAME);
@@ -206,7 +212,7 @@ public class LiveScheduleServiceImplTest {
     boolean[] presentationFound = new boolean[2];
     // Order may vary so that's why we loop
     for (Track track : liveTracks) {
-      if (track.getURI().toString().indexOf("presenter") > -1) {
+      if (track.getURI().toString().contains("presenter")) {
         if (((VideoStream) track.getStreams()[0]).getFrameHeight() == 270) {
           Assert.assertEquals(
                   STREAMING_SERVER_URL + "/" + MP_ID + "-" + caName + "-presenter-delivery-stream-960x270" + suffix,
@@ -254,7 +260,7 @@ public class LiveScheduleServiceImplTest {
 
   private Job createJob(long id, String elementId, String payload) {
     Job job = EasyMock.createNiceMock(Job.class);
-    List<String> args = new ArrayList<String>();
+    List<String> args = new ArrayList<>();
     args.add("anything");
     args.add("anything");
     args.add(elementId);
@@ -299,7 +305,7 @@ public class LiveScheduleServiceImplTest {
     mp.setIdentifier(new IdImpl(MP_ID));
     mp.setDuration(DURATION);
 
-    service.addLiveTracks(mp, CAPTURE_AGENT_NAME);
+    service.addLiveTracksToMediaPackage(mp, episodeDC);
     assertExpectedLiveTracks(mp.getTracks(), DURATION, CAPTURE_AGENT_NAME, "_suffix", false);
   }
 
@@ -319,14 +325,13 @@ public class LiveScheduleServiceImplTest {
     mp.setIdentifier(new IdImpl(MP_ID));
     mp.setDuration(DURATION);
 
-    service.addLiveTracks(mp, "another-capture-agent");
+    episodeDC.set(DublinCore.PROPERTY_SPATIAL, DublinCoreValue.mk("another-capture-agent"));
+    service.addLiveTracksToMediaPackage(mp, episodeDC);
     assertExpectedLiveTracks(mp.getTracks(), DURATION, "another-capture-agent", "_suffix_from_ca", false);
   }
 
   @Test
   public void testAddAndDistributeElements() throws Exception {
-    URI catalogURI = LiveScheduleServiceImplTest.class.getResource("/series.xml").toURI();
-    DublinCoreCatalog seriesDC = DublinCores.read(catalogURI.toURL().openStream());
     EasyMock.expect(seriesService.getSeries(SERIES_ID)).andReturn(seriesDC).anyTimes();
 
     Job job = createJob(1L, "anything", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
@@ -359,7 +364,7 @@ public class LiveScheduleServiceImplTest {
     EasyMock.replay(s);
     service.setDownloadDistributionService(downloadDistributionService);
 
-    MediaPackage mp1 = service.addAndDistributeElements(s);
+    MediaPackage mp1 = service.distributeAclsAndCatalogs(s);
 
     Catalog[] catalogs = mp1.getCatalogs(MediaPackageElements.EPISODE);
     Assert.assertNotNull(catalogs);
@@ -451,7 +456,7 @@ public class LiveScheduleServiceImplTest {
     setUpAssetManager(mp);
     replayServices();
 
-    Snapshot s = service.getSnapshot(MP_ID);
+    Snapshot s = service.getSnapshotFromArchive(MP_ID);
 
     Assert.assertNotNull(s);
     MediaPackage mp1 = s.getMediaPackage();
@@ -467,7 +472,7 @@ public class LiveScheduleServiceImplTest {
   public void testGetMediaPackageFromSearch() throws Exception {
     URI searchResultURI = LiveScheduleServiceImplTest.class.getResource("/search-result.xml").toURI();
     SearchResult searchResult = SearchResultImpl.valueOf(searchResultURI.toURL().openStream());
-    EasyMock.expect(searchService.getForAdministrativeRead((SearchQuery) EasyMock.anyObject())).andReturn(searchResult);
+    EasyMock.expect(searchService.getForAdministrativeRead(EasyMock.anyObject())).andReturn(searchResult);
     replayServices();
 
     MediaPackage mp = service.getMediaPackageFromSearch(MP_ID);
@@ -479,7 +484,7 @@ public class LiveScheduleServiceImplTest {
   public void testGetMediaPackageFromSearchNotFound() throws Exception {
     URI searchResultURI = LiveScheduleServiceImplTest.class.getResource("/search-result-empty.xml").toURI();
     SearchResult searchResult = SearchResultImpl.valueOf(searchResultURI.toURL().openStream());
-    EasyMock.expect(searchService.getForAdministrativeRead((SearchQuery) EasyMock.anyObject())).andReturn(searchResult);
+    EasyMock.expect(searchService.getForAdministrativeRead(EasyMock.anyObject())).andReturn(searchResult);
     replayServices();
 
     MediaPackage mp = service.getMediaPackageFromSearch(MP_ID);
@@ -494,12 +499,12 @@ public class LiveScheduleServiceImplTest {
     setUpAssetManager(mp);
     replayServices();
 
-    MediaPackage mp1 = (MediaPackage) service.getSnapshot(MP_ID).getMediaPackage().clone();
+    MediaPackage mp1 = (MediaPackage) service.getSnapshotFromArchive(MP_ID).getMediaPackage().clone();
     mp1.setDuration(DURATION);
-    service.addLiveTracks(mp1, CAPTURE_AGENT_NAME);
-    MediaPackage mp2 = (MediaPackage) service.getSnapshot(MP_ID).getMediaPackage().clone();
+    service.addLiveTracksToMediaPackage(mp1, episodeDC);
+    MediaPackage mp2 = (MediaPackage) service.getSnapshotFromArchive(MP_ID).getMediaPackage().clone();
     mp2.setDuration(DURATION);
-    service.addLiveTracks(mp2, CAPTURE_AGENT_NAME);
+    service.addLiveTracksToMediaPackage(mp2, episodeDC);
 
     Assert.assertTrue(service.isSameMediaPackage(mp1, mp2));
   }
@@ -512,12 +517,12 @@ public class LiveScheduleServiceImplTest {
     setUpAssetManager(mp);
     replayServices();
 
-    MediaPackage mp1 = (MediaPackage) service.getSnapshot(MP_ID).getMediaPackage().clone();
+    MediaPackage mp1 = (MediaPackage) service.getSnapshotFromArchive(MP_ID).getMediaPackage().clone();
     mp1.setDuration(DURATION);
-    service.addLiveTracks(mp1, CAPTURE_AGENT_NAME);
-    MediaPackage mp2 = (MediaPackage) service.getSnapshot(MP_ID).getMediaPackage().clone();
+    service.addLiveTracksToMediaPackage(mp1, episodeDC);
+    MediaPackage mp2 = (MediaPackage) service.getSnapshotFromArchive(MP_ID).getMediaPackage().clone();
     mp2.setDuration(DURATION);
-    service.addLiveTracks(mp2, CAPTURE_AGENT_NAME);
+    service.addLiveTracksToMediaPackage(mp2, episodeDC);
 
     // Change title
     String previous = mp2.getTitle();
@@ -589,7 +594,7 @@ public class LiveScheduleServiceImplTest {
 
     MediaPackage mp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
     mp.setIdentifier(new IdImpl(MP_ID));
-    service.publish(mp);
+    service.publishToSearch(mp);
     Assert.assertEquals(MP_ID, capturedMp.getValue().getIdentifier().toString());
   }
 
@@ -601,7 +606,12 @@ public class LiveScheduleServiceImplTest {
 
     replayServices();
 
-    service.addLivePublicationChannel(org, mp, new HashMap<String, Track>());
+    snapshot = EasyMock.createNiceMock(Snapshot.class);
+    EasyMock.expect(snapshot.getMediaPackage()).andReturn(mp).anyTimes();
+    EasyMock.expect(snapshot.getOrganizationId()).andReturn(ORG_ID).anyTimes();
+    EasyMock.replay(snapshot);
+
+    service.addLivePublicationToMediaPackage(snapshot, new HashMap<>());
     Publication[] publications = mp.getPublications();
     Assert.assertEquals(1, publications.length);
     Assert.assertEquals(LiveScheduleService.CHANNEL_ID, publications[0].getChannel());
@@ -682,11 +692,6 @@ public class LiveScheduleServiceImplTest {
             .loadFromXml(mpURI.toURL().openStream());
     setUpAssetManager(mp);
 
-    URI catalogURI = LiveScheduleServiceImplTest.class.getResource("/episode.xml").toURI();
-    DublinCoreCatalog episodeDC = DublinCores.read(catalogURI.toURL().openStream());
-
-    catalogURI = LiveScheduleServiceImplTest.class.getResource("/series.xml").toURI();
-    DublinCoreCatalog seriesDC = DublinCores.read(catalogURI.toURL().openStream());
     EasyMock.expect(seriesService.getSeries(SERIES_ID)).andReturn(seriesDC).anyTimes();
 
     Job job = createJob(1L, "anything", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
@@ -753,9 +758,6 @@ public class LiveScheduleServiceImplTest {
     MediaPackage previousMp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder()
             .loadFromXml(mpURI.toURL().openStream());
 
-    URI catalogURI = LiveScheduleServiceImplTest.class.getResource("/episode.xml").toURI();
-    DublinCoreCatalog episodeDC = DublinCores.read(catalogURI.toURL().openStream());
-
     replayServices();
 
     service.getSnapshotVersionCache().put(MP_ID, version);
@@ -767,22 +769,18 @@ public class LiveScheduleServiceImplTest {
   public void testCreateOuUpdateLiveEventAlreadyPast() throws Exception {
     URI searchResultURI = LiveScheduleServiceImplTest.class.getResource("/search-result-empty.xml").toURI();
     SearchResult searchResult = SearchResultImpl.valueOf(searchResultURI.toURL().openStream());
-    EasyMock.expect(searchService.getForAdministrativeRead((SearchQuery) EasyMock.anyObject())).andReturn(searchResult);
+    EasyMock.expect(searchService.getForAdministrativeRead(EasyMock.anyObject())).andReturn(searchResult);
     replayServices();
 
-    URI catalogURI = LiveScheduleServiceImplTest.class.getResource("/episode.xml").toURI();
-    DublinCoreCatalog episodeDC = DublinCores.read(catalogURI.toURL().openStream());
     Assert.assertFalse(service.createOrUpdateLiveEvent(MP_ID, episodeDC));
   }
 
   @Test
   public void testCreateOuUpdateLiveEventAlreadyPublished() throws Exception {
-    URI catalogURI = LiveScheduleServiceImplTest.class.getResource("/episode.xml").toURI();
-    DublinCoreCatalog episodeDC = DublinCores.read(catalogURI.toURL().openStream());
 
     URI searchResultURI = LiveScheduleServiceImplTest.class.getResource("/no-live-search-result.xml").toURI();
     SearchResult searchResult = SearchResultImpl.valueOf(searchResultURI.toURL().openStream());
-    EasyMock.expect(searchService.getForAdministrativeRead((SearchQuery) EasyMock.anyObject())).andReturn(searchResult);
+    EasyMock.expect(searchService.getForAdministrativeRead(EasyMock.anyObject())).andReturn(searchResult);
     replayServices();
 
     Assert.assertFalse(service.createOrUpdateLiveEvent(MP_ID, episodeDC));
@@ -799,11 +797,6 @@ public class LiveScheduleServiceImplTest {
     MediaPackage previousMp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder()
             .loadFromXml(mpURI.toURL().openStream());
 
-    URI catalogURI = LiveScheduleServiceImplTest.class.getResource("/episode.xml").toURI();
-    DublinCoreCatalog episodeDC = DublinCores.read(catalogURI.toURL().openStream());
-
-    catalogURI = LiveScheduleServiceImplTest.class.getResource("/series.xml").toURI();
-    DublinCoreCatalog seriesDC = DublinCores.read(catalogURI.toURL().openStream());
     EasyMock.expect(seriesService.getSeries(SERIES_ID)).andReturn(seriesDC).anyTimes();
 
     Job job = createJob(1L, "anything", "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
@@ -928,6 +921,6 @@ public class LiveScheduleServiceImplTest {
       return null;
     }
 
-  };
+  }
 
 }


### PR DESCRIPTION
Before I begin, I would like to apologize to whoever will review this, because you're now going to have to deal with this extremely complicated and messy code.

The problem this PR is trying to fix is the following: If someone changes the capture agent for a scheduled live event, the URLs of the live tracks (which usually contain the capture agent name) are updated for search, but not in the archive. This means that the External API still serves the old information, and the live stream cannot be played. Additionally, the URLs in the search service are only up-to-date temporarily, but can revert back to their old state on the next snapshot.

The reasons for this are two-fold:
1. The live schedule service reads the capture agent name from the episode Dublin Core spatial field, called location in the metadata. (This is IMO very questionable, because we might put other stuff in that metadata field aside from the capture agent id, and would not expect this to impact the live publication, but changing this was out of scope for this PR. One thing at a time...)
When changing the capture agent, the scheduler service actually writes the CA id into that metadata field. This information is then put into the Elasticsearch index and handed over to the live schedule service. It is not, however, actually archived. Which means that on the next snapshot (unless we change metadata in the Admin UI, which will send _all_ fields to the back-end on a change, including the location info from the index), that value is overwritten again.
2. The second problem is that the live schedule service updates the live tracks for search on a capture agent change, but doesn't actually update the live publication that the asset manager knows about.

So basically what I did here in both cases is to actually tell the asset manager what the hell is going on. Because I had a lot of problems understanding the code and was concerned that I could unintentionally break something, this also contains some refactoring. This is not supposed to change behavior, but simply make things clearer. I'm also fairly certain that there are more bugs in the affected code and that it could be simplified more, but this was out of scope for this work. I hope to be able to revisit this in the future, but for now, this will hopefully make things a little bit better.

Edit: I would also like to add that I still don't completely understand why the code does the things it does, so please don't ask me.