### PR TITLE
Fix NullPointerException when editor does not send subtitles

### DIFF
--- a/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
+++ b/modules/editor-service/src/main/java/org/opencastproject/editor/EditorServiceImpl.java
@@ -1051,7 +1051,9 @@ public class EditorServiceImpl implements EditorService {
     }
 
     try {
-      addSubtitleTrack(mediaPackage, editingData.getSubtitles());
+      if (editingData.getSubtitles() != null) {
+        addSubtitleTrack(mediaPackage, editingData.getSubtitles());
+      }
     } catch (IOException e) {
       errorExit("Unable to add subtitle track to archive", mediaPackageId, ErrorStatus.UNKNOWN, e);
     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Does not try to add subtitles to the mediapackage if the post request did not contain any.