### PR TITLE
Add summary of sent data during registration

### DIFF
--- a/modules/admin-ui-frontend/app/index.html
+++ b/modules/admin-ui-frontend/app/index.html
@@ -258,6 +258,7 @@
     <script src="scripts/shared/resources/newThemeResource.js"></script>
     <script src="scripts/shared/resources/taskResource.js"></script>
     <script src="scripts/shared/resources/adopterRegistrationResource.js"></script>
+    <script src="scripts/shared/resources/adopterStatisticSummaryResource.js"></script>
     <script src="scripts/shared/resources/countryResource.js"></script>
     <script src="scripts/shared/resources/termsOfUseResource.js"></script>
     <script src="scripts/shared/services/wizards/new-event/access.js"></script>

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
@@ -24,15 +24,17 @@
 angular.module('adminNg.controllers')
 .controller('RegistrationCtrl', ['$scope', '$timeout', 'Table', 'AdopterRegistrationStates',
   'AdopterRegistrationResource', 'TermsOfUseResource', 'CountryResource', 'NewEventStates', 'NewEventResource',
-  'EVENT_TAB_CHANGE', 'Notifications', 'Modal', 'AuthService',
+  'AdopterStatisticSummaryResource', 'EVENT_TAB_CHANGE', 'Notifications', 'Modal', 'AuthService',
   function ($scope, $timeout, Table, AdopterRegistrationStates, AdopterRegistrationResource, TermsOfUseResource,
-    CountryResource, NewEventStates, NewEventResource, EVENT_TAB_CHANGE, Notifications, Modal, AuthService) {
+    CountryResource, NewEventStates, NewEventResource, AdopterStatisticSummaryResource, EVENT_TAB_CHANGE, Notifications,
+    Modal, AuthService) {
 
     $scope.state = AdopterRegistrationStates.getInitialState($scope.$parent.resourceId);
     $scope.states = AdopterRegistrationStates.get($scope.$parent.resourceId);
     $scope.countries = CountryResource.getCountries();
     $scope.tou = TermsOfUseResource.get();
     $scope.adopter = new AdopterRegistrationResource();
+    $scope.summary = AdopterStatisticSummaryResource.get();
 
     document.getElementById('help-dd').classList.remove('active');
 

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/controllers/registrationController.js
@@ -53,6 +53,9 @@ angular.module('adminNg.controllers')
       }
     });
 
+    $scope.refreshSummary = function() {
+      $scope.summary = AdopterStatisticSummaryResource.get();
+    };
 
     $scope.nextState = function (inputAction) {
       if ($scope.state === 'form' && (inputAction === 1 || inputAction === 3)) { // 1:Save, 3:Update
@@ -83,14 +86,16 @@ angular.module('adminNg.controllers')
     $scope.save = function () {
       if($scope.adopterRegistrationForm.$valid) {
         AuthService.getUser().$promise.then(function() {
-          $scope.adopter.registered = true;
           AdopterRegistrationResource.create({}, $scope.adopter,
             function ($response, header) {
               // success callback
               $scope.nextState(0);
+              $scope.adopter.registered = true;
+              $scope.refreshSummary();
             }, function(error) {
               // error callback
               $scope.nextState(1);
+              $scope.refreshSummary();
             });
         }).catch(angular.noop);
       }
@@ -99,7 +104,7 @@ angular.module('adminNg.controllers')
 
     $scope.notNow = function () {
       AuthService.getUser().$promise.then(function() {
-        $scope.registered = false;
+        $scope.adopter.registered = false;
         AdopterRegistrationResource.create({}, $scope.adopter,
           function ($response, header) {
             // success callback

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/services/states.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/services/states.js
@@ -29,7 +29,7 @@ angular.module('adminNg.services')
           'information': {
             'nextState': {
               0: 'close',
-              1: 'summary',
+              1: 'form',
               2: 'skip'
             },
             'buttons': {
@@ -40,28 +40,14 @@ angular.module('adminNg.services')
               'submitButtonText': 'WIZARD.NEXT_STEP'
             }
           },
-          'summary': {
-            'nextState': {
-              0: 'close',
-              1: 'form',
-              5: 'information'
-            },
-            'buttons': {
-              'submit': true,
-              'back': true,
-              'skip': false,
-              'close': true,
-              'submitButtonText': 'WIZARD.NEXT_STEP'
-            }
-          },
           'form': {
             'nextState': {
               0: 'close',
               1: 'save',
               2: 'legal_info',
-              3: 'update',
+              //3: 'update', unused
               4: 'delete_submit',
-              5: 'summary'
+              5: 'information'
             },
             'buttons': {
               'submit': true,
@@ -74,7 +60,7 @@ angular.module('adminNg.services')
           },
           'save': {
             'nextState': {
-              0: 'thank_you',
+              0: 'summary',
               1: 'error'
             },
             'buttons': {
@@ -83,6 +69,20 @@ angular.module('adminNg.services')
               'skip': false,
               'close': false,
               'submitButtonText': null
+            }
+          },
+          'summary': {
+            'nextState': {
+              0: 'close',
+              1: 'thank_you',
+              5: 'form'
+            },
+            'buttons': {
+              'submit': true,
+              'back': true,
+              'skip': false,
+              'close': true,
+              'submitButtonText': 'WIZARD.NEXT_STEP'
             }
           },
           'update': {

--- a/modules/admin-ui-frontend/app/scripts/modules/registration/services/states.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/registration/services/states.js
@@ -29,13 +29,27 @@ angular.module('adminNg.services')
           'information': {
             'nextState': {
               0: 'close',
-              1: 'form',
+              1: 'summary',
               2: 'skip'
             },
             'buttons': {
               'submit': true,
               'back': false,
               'skip': true,
+              'close': true,
+              'submitButtonText': 'WIZARD.NEXT_STEP'
+            }
+          },
+          'summary': {
+            'nextState': {
+              0: 'close',
+              1: 'form',
+              5: 'information'
+            },
+            'buttons': {
+              'submit': true,
+              'back': true,
+              'skip': false,
               'close': true,
               'submitButtonText': 'WIZARD.NEXT_STEP'
             }
@@ -47,7 +61,7 @@ angular.module('adminNg.services')
               2: 'legal_info',
               3: 'update',
               4: 'delete_submit',
-              5: 'information'
+              5: 'summary'
             },
             'buttons': {
               'submit': true,

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
@@ -320,7 +320,7 @@
     <div class="pull-right" ng-show="states[state]['buttons']['submit']">
       <a ng-show="state == 'delete_submit'"
          class="danger"
-         ng-click="nextState(0)"
+         ng-click="nextState(1)"
          translate="{{states[state]['buttons']['submitButtonText']}}"></a>
       <a ng-show="state == 'form'"
          class="submit inactive"
@@ -340,7 +340,9 @@
          class="cancel"
          ng-click="nextState(5)"
          translate="ADOPTER_REGISTRATION.MODAL.BACK"></a>
-      <a ng-show="state == 'form' && registered"
+      <!-- Agreeing to the policy happens the second the checkbox is ticked, but registering only happens once you go to
+           the next page.  We need both to happen prior to showing the delete button -->
+      <a ng-show="state == 'form' && adopter.agreedToPolicy && adopter.registered"
          class="danger"
          ng-click="nextState(4)"
          translate="WIZARD.DELETE"></a>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
@@ -34,10 +34,12 @@
         <div class="scrollbox">
           <pre>{{ summary.general | json:2}}</pre>
         </div>
-        <p translate="ADOPTER_REGISTRATION.MODAL.SUMMARY_STATE.STATS_HEADER"></p>
-        <div class="scrollbox">
+        <br/>
+        <p ng-show="adopter.allowsStatistics" translate="ADOPTER_REGISTRATION.MODAL.SUMMARY_STATE.STATS_HEADER"></p>
+        <div ng-show="adopter.allowsStatistics" class="scrollbox">
           <pre>{{ summary.statistics | json:2}}</pre>
         </div>
+        <p ng-show="!adopter.allowsStatistics">No statistics data will be shared</p>
       </div>
     </div>
   </div>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/registration-modal.html
@@ -25,6 +25,23 @@
     </div>
   </div>
 
+  <div ng-show="state == 'summary'" class="modal-content"
+       style="display: block;">
+    <div class="modal-body">
+      <div class="row">
+        <p translate="ADOPTER_REGISTRATION.MODAL.SUMMARY_STATE.HEADER"></p>
+        <p translate="ADOPTER_REGISTRATION.MODAL.SUMMARY_STATE.GENERAL_HEADER"></p>
+        <div class="scrollbox">
+          <pre>{{ summary.general | json:2}}</pre>
+        </div>
+        <p translate="ADOPTER_REGISTRATION.MODAL.SUMMARY_STATE.STATS_HEADER"></p>
+        <div class="scrollbox">
+          <pre>{{ summary.statistics | json:2}}</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div ng-show="state == 'legal_info'" class="modal-content"
     style="display: block;">
     <div class="modal-body">

--- a/modules/admin-ui-frontend/app/scripts/shared/resources/adopterStatisticSummaryResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/adopterStatisticSummaryResource.js
@@ -28,10 +28,10 @@ angular.module('adminNg.resources')
       headers: {'Content-Type': 'application/json'},
       transformResponse: function (data) {
         data = JSON.parse(data);
-        for (var host in data['statistics']['hosts']) {
+        /*for (var host in data['statistics']['hosts']) {
           var shortenedServices = data['statistics']['hosts'][host]['services'].substring(0, 50) + '[...]';
           data['statistics']['hosts'][host]['services'] = shortenedServices;
-        }
+        }*/
         return {'general': data['general'], 'statistics': data['statistics']};
       }
     }

--- a/modules/admin-ui-frontend/app/scripts/shared/resources/adopterStatisticSummaryResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/adopterStatisticSummaryResource.js
@@ -1,0 +1,39 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+'use strict';
+
+angular.module('adminNg.resources')
+.factory('AdopterStatisticSummaryResource', ['$resource', function ($resource) {
+  return $resource('/admin-ng/adopter/summary', {}, {
+    get: {
+      method: 'GET',
+      headers: {'Content-Type': 'application/json'},
+      transformResponse: function (data) {
+        data = JSON.parse(data);
+        for (var host in data['statistics']['hosts']) {
+          var shortenedServices = data['statistics']['hosts'][host]['services'].substring(0, 50) + '[...]';
+          data['statistics']['hosts'][host]['services'] = shortenedServices;
+        }
+        return {'general': data['general'], 'statistics': data['statistics']};
+      }
+    }
+  });
+}]);

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -414,6 +414,11 @@
          "LEGAL_INFO_STATE": {
            "HEADER": "Terms of Service and Privacy Policy"
          },
+         "SUMMARY_STATE": {
+           "HEADER": "This is a JSON summary of exactly what would be sent to Opencast's servers",
+           "GENERAL_HEADER": "Adopter Information",
+           "STATS_HEADER": "Statistical Information"
+         },
          "INFORMATION_STATE": {
            "HEADER": "Thank you for using Opencast!",
            "INFORMATION_PARAGRAPH_1": "Our developers are constantly working to provide you the best possible user experience. For that, we need to know more about who uses Opencast and how it is used. You can help us with a quick registration.",

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/registration/Form.java
@@ -374,6 +374,21 @@ public class Form implements IForm {
 
   public void delete() {
     this.deleteMe = true;
+    this.organisationName = null;
+    this.departmentName = null;
+    this.firstName = null;
+    this.lastName = null;
+    this.email = null;
+    this.country = null;
+    this.postalCode = null;
+    this.city = null;
+    this.street = null;
+    this.streetNo = null;
+    this.contactMe = false;
+    this.allowsStatistics = false;
+    this.allowsErrorReports = false;
+    this.dateModified = new Date();
+    this.agreedToPolicy = false;
   }
 
   public boolean shouldDelete() {

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -236,7 +236,12 @@ public class ScheduledDataCollector extends TimerTask {
   public String getRegistrationDataAsString() throws Exception {
     Form adopter = (Form) adopterFormService.retrieveFormData();
     String generalJson = collectGeneralData(adopter);
-    String statsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
+    String statsJson;
+    if (adopter.allowsStatistics()) {
+      statsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
+    } else {
+      statsJson = "{}";
+    }
     //It's not stupid if it works!
     return "{ \"general\":" + generalJson + ", \"statistics\":" + statsJson + "}";
   }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -233,6 +233,14 @@ public class ScheduledDataCollector extends TimerTask {
     }
   }
 
+  public String getRegistrationDataAsString() throws Exception {
+    Form adopter = (Form) adopterFormService.retrieveFormData();
+    String generalJson = collectGeneralData(adopter);
+    String statsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
+    //It's not stupid if it works!
+    return "{ \"general\":" + generalJson + ", \"statistics\":" + statsJson + "}";
+  }
+
 
   //================================================================================
   // Data collecting methods


### PR DESCRIPTION
This pull request adds a summary screen of the data sent to our registration server.  ~It pulls the current data, only shortening the services list on the nodes.~
While I was in there, I also fixed a few UI shortcomings, and upgrading the data deletion workflow to properly reflect what is going on.

Fixes #4254

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
