### PR TITLE
Make Workflow Operation Docs Look Alike

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/analyze-tracks-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/analyze-tracks-woh.md
@@ -1,11 +1,12 @@
-AnalyzeTracksWorkflowOperationHandler
-=====================================
+Analyze Tracks Workflow Operation
+=================================
 
+ID: `analyze-tracks`
 
 Description
 -----------
 
-The AnalyzeTracksWorkflowOperationHandler analyzes specified tracks in the mediapackage and sets workflow instance
+The analyze-tracks operation analyzes specified tracks in the mediapackage and sets workflow instance
 variables based on the tracks audio and video properties. These variables can then be used to control if workflow
 operations should be executed.
 
@@ -53,25 +54,27 @@ option, `…_aspect_snap` would be set to 4/3.
 Operation Example
 -----------------
 
-    <operation
-      id="analyze-tracks"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error"
-      description="Analyze tracks in media package and set control variables">
-      <configurations>
-        <configuration key="source-flavor">*/source</configuration>
-        <configuration key="aspect-ratio">4/3,16/9</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+    id="analyze-tracks"
+    description="Analyze tracks in media package and set control variables">
+  <configurations>
+    <configuration key="source-flavor">*/source</configuration>
+    <configuration key="aspect-ratio">4/3,16/9</configuration>
+  </configurations>
+</operation>
+```
 
 If a video track with a resolution of 1280x720 and an included audio stream is passed to this operation as
 `presentiation/source`, the resulting variables would be:
 
-    presentation_source_aspect=16/9
-    presentation_source_aspect_snap=16/9
-    presentation_source_audio=true
-    presentation_source_media=true
-    presentation_source_resolution_x=1280
-    presentation_source_resolution_y=720
-    presentation_source_video=true
-    presentation_source_framerate=30.0
+```properties
+presentation_source_aspect=16/9
+presentation_source_aspect_snap=16/9
+presentation_source_audio=true
+presentation_source_media=true
+presentation_source_resolution_x=1280
+presentation_source_resolution_y=720
+presentation_source_video=true
+presentation_source_framerate=30.0
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/comment-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/comment-woh.md
@@ -1,9 +1,15 @@
-# CommentWorkflowOperationHandler
+Comment Workflow Operation
+==========================
 
-## Description
-The CommentWorkflowOperationHandler can be used to create, resolve or delete comments for events within workflows.
+ID: `comment`
 
-## Parameter Table
+Description
+-----------
+
+The comment operation can be used to create, resolve or delete comments for events within workflows.
+
+Parameter Table
+---------------
 
 |Configuration Key|Example                         |Description                                       |
 |-----------------|--------------------------------|--------------------------------------------------|
@@ -20,28 +26,32 @@ Notes:
    or reason and description). If more than one comment matches the parameters, only the first matching comment will be
    resolved or deleted.
 
-## Operation Examples
+Operation Example
+-----------------
 
 Create a comment:
 
-    <operation
-      id="comment"
-      description="Mark the recording for cutting">
-      <configurations>
-        <configuration key="action">create</configuration>
-        <configuration key="reason">EVENTS.EVENTS.DETAILS.COMMENTS.REASONS.CUTTING</configuration>
-        <configuration key="description">Recording has not been cut yet.</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+    id="comment"
+    description="Mark the recording for cutting">
+  <configurations>
+    <configuration key="action">create</configuration>
+    <configuration key="reason">EVENTS.EVENTS.DETAILS.COMMENTS.REASONS.CUTTING</configuration>
+    <configuration key="description">Recording has not been cut yet.</configuration>
+  </configurations>
+</operation>
+```
 
 Resolve a comment:
 
-    <operation
-      id="comment"
-      description="Resolve the cutting flag">
-      <configurations>
-        <configuration key="action">resolve</configuration>
-        <configuration key="reason">EVENTS.EVENTS.DETAILS.COMMENTS.REASONS.CUTTING</configuration>
-      </configurations>
-    </operation>
-
+```xml
+<operation
+    id="comment"
+    description="Resolve the cutting flag">
+  <configurations>
+    <configuration key="action">resolve</configuration>
+    <configuration key="reason">EVENTS.EVENTS.DETAILS.COMMENTS.REASONS.CUTTING</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/copy-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/copy-woh.md
@@ -1,16 +1,21 @@
-# CopyWorkflowOperationHandler
+Copy Workflow Operation
+=======================
 
-## Description
-The CopyWorkflowOperationHandler can be used to copy media package elements to a given target directory.
+ID: `copy`
 
-## Parameter Table
+Description
+-----------
+The copy operation can be used to copy media package elements to a given target directory.
 
-|Configuration Key|Example           |Description                                       |
-|-----------------|------------------|--------------------------------------------------|
-|source-flavors    |presenter/source |Comma-separated list of source-flavors            |
-|source-tags       |archive          |Comma-separated list of source-tags               |
-|target-directory* |/mnt/mydisk      |The directory where the file is copied to         |
-|target-filename   |test             |The optional target filename. The file extension extract from the media package element URI will be appended|
+Parameter Table
+---------------
+
+|Configuration Key  |Example           |Description                                       |
+|-------------------|------------------|--------------------------------------------------|
+|source-flavors     |presenter/source |Comma-separated list of source-flavors             |
+|source-tags        |archive          |Comma-separated list of source-tags                |
+|target-directory\* |/mnt/mydisk      |The directory where the file is copied to          |
+|target-filename    |test             |The optional target filename. The file extension extract from the media package element URI will be appended|
 
 \* mandatory configuration key
 
@@ -21,22 +26,25 @@ Notes:
 * In case that neither *source-flavors* nor *source-tags* are specified, the operation will be skipped
 * In case no media package elements match *source-flavors* and *source-tags*, the operation will be skipped
 
-## Target Filenames
+Target Filenames
+----------------
+
 If *target-filename* is not specified, the filename for each media package element is extracted from the media package
 element URI. If *target-filename* is specified, the filename is the result of appending the file extension (extracted
 from the media package element URI) to *target-filename*. In case the *source-flavors* and *source-tags* match multiple
 media package elements, a sequentially increasing integer number (starting at 1) can be used within *target-filename* in
 Java string formatting manner to ensure unique filenames.
 
-## Operation Example
+Operation Example
+-----------------
 
-    <operation id="copy"
-             description="Copy sources to my disk"
-             fail-on-error="true"
-             exception-handler-workflow="partial-error">
-    <configurations>
-      <configuration key="source-flavors">presenter/source, presentation/source</configuration>
-      <configuration key="target-directory">/mnt/mydisk</configuration>
-    </configurations>
-  </operation>
-
+```xml
+<operation
+    id="copy"
+    description="Copy sources to my disk">
+  <configurations>
+    <configuration key="source-flavors">presenter/source, presentation/source</configuration>
+    <configuration key="target-directory">/mnt/mydisk</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/encode-woh.md
@@ -1,6 +1,8 @@
 Encode Workflow Operation Handler
 =================================
 
+ID: `encode`
+
 > Parallel FFmpeg encoding
 
 Description
@@ -43,10 +45,9 @@ Operation Example
 
 ```xml
 <operation
-  id="encode"
-  exception-handler-workflow="partial-error"
-  description="encoding media files">
-    <configurations>
+    id="encode"
+    description="encoding media files">
+  <configurations>
     <configuration key="source-flavor">*/trimmed</configuration>
     <configuration key="target-flavor">*/delivery</configuration>
     <configuration key="target-tags">engage-download,engage-streaming</configuration>

--- a/docs/guides/admin/docs/workflowoperationhandlers/include-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/include-woh.md
@@ -1,7 +1,7 @@
 Include Workflow Operation
-===================================
+==========================
 
-```Id: include```
+ID: `include`
 
 Description
 -----------
@@ -19,11 +19,19 @@ Parameter Table
 Operation Example
 -----------------
 
-    <operation
-      id="include"
-      description="Remove temporary processing artifacts">
-      <configurations>
-        <configuration key="workflow-id">partial-cleanup</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+    id="include"
+    description="Remove temporary processing artifacts">
+  <configurations>
+    <configuration key="workflow-id">partial-cleanup</configuration>
+  </configurations>
+</operation>
+```
 
+```yml
+- id: include
+  description: Include clean-up workflow
+  configurations:
+    workflow-id: partial-cleanup
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/log-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/log-woh.md
@@ -1,12 +1,14 @@
-LoggingWorkflowOperationHandler
-===============================
+Logging Workflow Operation
+==========================
+
+ID: `log`
 
 
 Description
 -----------
 
-The LoggingWorkflowOperationHandler is primarily meant for testing and debugging purposes. It allows to log the current
-state of of a workflow and/or its media package.
+The `log` operation is primarily meant for testing and debugging purposes.
+It allows you to log the current state of of a workflow and/or its media package.
 
 |Name                |Default|Description                                                  |
 |--------------------|-------|-------------------------------------------------------------|
@@ -21,6 +23,11 @@ explicitly enabled will be logged.
 
 Operation Example
 -----------------
+
+```yml
+- id: log
+  description: Log to system logger
+```
 
 ```xml
 <operation

--- a/docs/guides/admin/docs/workflowoperationhandlers/microsoft-azure-start-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/microsoft-azure-start-transcription-woh.md
@@ -1,11 +1,16 @@
-# Microsoft Azure Start Transcription
+Microsoft Azure Start Transcription Workflow Operation
+======================================================
 
-## Description
+ID: `microsoft-azure-start-transcription`
+
+Description
+-----------
 
 Microsoft Azure Start Transcription invokes the Azure Speech-to-Text service by passing a file with an audio track
 to be translated to text.
 
-## Parameter Table
+Parameter Table
+---------------
 
 |configuration keys|description|default value|example|
 |------------------|-------|-----------|-------------|
@@ -16,20 +21,17 @@ to be translated to text.
 
 **One of source-flavor or source-tag must be specified.**
 
-## Example
+Example
+-------
 
 ```xml
-    <!-- Start Microsoft Azure transcription job -->
-    <operation
-        id="microsoft-azure-start-transcription"
-        fail-on-error="true"
-        exception-handler-workflow="partial-error"
-        description="Start Microsoft Azure transcription job">
-      <configurations>
-        <!--  Skip this operation if flavor already exists. Used for cases when mediapackage already has captions. -->
-        <configuration key="skip-if-flavor-exists">captions/vtt+de-DE</configuration>
-        <configuration key="language-code">de-DE</configuration>
-        <configuration key="source-flavor">presenter/prepared</configuration>
-      </configurations>
-    </operation>
+<operation
+    id="microsoft-azure-start-transcription"
+    description="Start Microsoft Azure transcription job">
+  <configurations>
+    <configuration key="skip-if-flavor-exists">captions/vtt+de-DE</configuration>
+    <configuration key="language-code">de-DE</configuration>
+    <configuration key="source-flavor">presenter/prepared</configuration>
+  </configurations>
+</operation>
 ```

--- a/docs/guides/admin/docs/workflowoperationhandlers/postmediapackage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/postmediapackage-woh.md
@@ -1,12 +1,17 @@
-# PostMediapackageWorkflowHandler
+Post Media Package Workflow Operation
+=====================================
 
-## Description
+ID: `post-mediapackage`
 
-This Workflow Operation Handler can be used to send a POST request containing an XML/JSON representation of the
-Mediapackage processed by the workflow to an external webservice. The service supports HTTP Basic and Digest
-Authentication.
+Description
+-----------
 
-## Parameter Table
+This workflow operation can be used to send a POST request containing an XML/JSON representation of the
+media package processed by the workflow to an external web service. the service supports HTTP Basic and Digest
+authentication.
+
+Parameter Table
+---------------
 
 |Configuration Keys |Description                                                                                   |
 |-------------------|----------------------------------------------------------------------------------------------|
@@ -19,21 +24,22 @@ Authentication.
 |auth.password      |password for authentication                                                                   |
 |+source_system     |fields with keys beginning with `+` will be added to the message body                         |
 
-## Operation Example
+Operation Example
+-----------------
 
-    <operation
-        id="post-mediapackage"
-        fail-on-error="false"
-        exception-handler-workflow="error"
-        description="Sending MediaPackage to Lernfunk3">
-        <configurations>
-            <configuration key="url">http://example.com:5000/</configuration>
-            <configuration key="format">xml</configuration>
-            <configuration key="debug">no</configuration>
-            <configuration key="mediapackage.type">search</configuration>
-            <configuration key="auth.enabled">yes</configuration>
-            <configuration key="auth.username">exportuser</configuration>
-            <configuration key="auth.password">secret</configuration>
-            <configuration key="+source_system">video.example.com</configuration>
-        </configurations>
-    </operation>
+```xml
+<operation
+    id="post-mediapackage"
+    description="Sending MediaPackage to Lernfunk3">
+  <configurations>
+    <configuration key="url">http://example.com:5000/</configuration>
+    <configuration key="format">xml</configuration>
+    <configuration key="debug">no</configuration>
+    <configuration key="mediapackage.type">search</configuration>
+    <configuration key="auth.enabled">yes</configuration>
+    <configuration key="auth.username">exportuser</configuration>
+    <configuration key="auth.password">secret</configuration>
+    <configuration key="+source_system">video.example.com</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/probe-resolution-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/probe-resolution-woh.md
@@ -1,11 +1,12 @@
-ProbeResolutionWorkflowOperationHandler
-=======================================
+Probe Resolution Workflow Operation
+===================================
 
+ID: `probe-resolution`
 
 Description
 -----------
 
-The ProbeResolutionWorkflowOperationHandler analyzes specified tracks in the mediapackage and sets workflow instance
+The probe-resolution operation analyzes specified tracks in the mediapackage and sets workflow instance
 variables based on the video resolution and the mapping set-up.
 
 
@@ -34,22 +35,24 @@ taken.
 Operation Example
 -----------------
 
-    <operation
-      id="probe-resolution"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error"
-      description="Set control variables based on video resolution">
-      <configurations>
-        <configuration key="source-flavor">*/source</configuration>
-        <configuration key="var:aspect">1280x720,1920x1080,2592x1080</configuration>
-        <configuration key="val:aspect">16/9</configuration>
-        <configuration key="var:is_720">1280x720</configuration>
-        <configuration key="var:is_1080">1920x1080,2592x1080</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+    id="probe-resolution"
+    description="Set control variables based on video resolution">
+  <configurations>
+    <configuration key="source-flavor">*/source</configuration>
+    <configuration key="var:aspect">1280x720,1920x1080,2592x1080</configuration>
+    <configuration key="val:aspect">16/9</configuration>
+    <configuration key="var:is_720">1280x720</configuration>
+    <configuration key="var:is_1080">1920x1080,2592x1080</configuration>
+  </configurations>
+</operation>
+```
 
 If a video track with a resolution of 1280x720 is passed to this operation as `presentation/source`, the resulting
 variables would be:
 
-    presentation_source_is_720=true
-    presentation_source_aspect=16/9
+```properties
+presentation_source_is_720=true
+presentation_source_aspect=16/9
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-youtube-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-youtube-woh.md
@@ -1,11 +1,13 @@
-PublishYoutubeWorkflowOperation
-===============================
+Publish YouTube Workflow Operation
+==================================
+
+ID: `publish-youtube`
 
 
 Description
 -----------
 
-The PublishYoutubeWorkflowOperation publishes a single stream to YouTube.  This stream must meet YouTube's format
+The publish YouTube operation publishes a single stream to YouTube.  This stream must meet YouTube's format
 requirements, and may consist of audio and/or video.  If you want to publish both your presenter and presentation
 streams we suggest using the [Composite](composite-woh.md) workflow operation handler to prepare a composite file
 with both streams inside of it.  The default Opencast workflow prepares a video using this method.
@@ -24,13 +26,11 @@ Operation Example
 -----------------
 
 ```xml
-    <operation
-      id="publish-youtube"
-      max-attempts="2"
-      exception-handler-workflow="ng-partial-error"
-      description="Publishing to YouTube">
-      <configurations>
-        <configuration key="source-tags">youtube</configuration>
-      </configurations>
-    </operation>
+<operation
+    id="publish-youtube"
+    description="Publishing to YouTube">
+  <configurations>
+    <configuration key="source-tags">youtube</configuration>
+  </configurations>
+</operation>
 ```

--- a/docs/guides/admin/docs/workflowoperationhandlers/retract-configure-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/retract-configure-woh.md
@@ -1,15 +1,19 @@
-# ConfigurableRetractWorkflowOperationHandler
+Configurable Retract Workflow Operation
+=======================================
 
+ID: `retract-configure`
 
-## Description
+Description
+-----------
 
-The ConfigurableRetractWorkflowOperationHandler retracts the published elements from a configured publication.
+The configurable retract operation retracts the published elements from a configured publication.
 
 If the elements have been added to the Publication using "with-published-elements", as in the case with the external
 api, they haven't actually been published so it is unnecessary to have a retract-configuration. Adding a retraction
 won't cause any errors, it will just skip those elements.
 
-## Parameters
+Parameters
+----------
 
 These are the keys that can be configured for the workflow operation in the workflow definition.  The `channel-id` is
 mandatory.
@@ -21,27 +25,30 @@ mandatory.
 
 Setting `retract-streaming` to true only makes sense if you've published streaming elements for this channel before.
 
-## Operation Examples
+Operation Example
+-----------------
 
-#### Retract from Internal Channel
-    <!-- Remove the internal publication if the mediapackage is being deleted. -->
-    <operation
-      id="retract-configure"
-      exception-handler-workflow="partial-error"
-      description="Retract from internal publication channel">
-      <configurations>
-        <configuration key="channel-id">internal</configuration>
-      </configurations>
-    </operation>
+Retract from internal channel:
 
-#### Retract from External API
+```xml
+<operation
+    id="retract-configure"
+    description="Retract from internal publication channel">
+  <configurations>
+    <configuration key="channel-id">internal</configuration>
+  </configurations>
+</operation>
+```
 
-    <operation
-      id="retract-configure"
-      exception-handler-workflow="partial-error"
-      description="Retract from external api publication channel">
-      <configurations>
-        <configuration key="channel-id">api</configuration>
-        <configuration key="retract-streaming">false</configuration>
-      </configurations>
-    </operation>
+Retract from external API:
+
+```xml
+<operation
+    id="retract-configure"
+    description="Retract from external api publication channel">
+  <configurations>
+    <configuration key="channel-id">api</configuration>
+    <configuration key="retract-streaming">false</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/retract-engage-aws-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/retract-engage-aws-woh.md
@@ -1,20 +1,20 @@
-# RetractEngageAWSS3WorkflowOperationHandler
+Retract Engage AWS S3 Workflow Operation
+========================================
 
+ID: `retract-engage-aws`
 
-## Description
+Description
+-----------
 
-The RetractEngageAWSS3WorkflowOperationHandler retracts the published elements from Amazon S3.
-
+The retract-engage AWS/S3 operation retracts the published elements from Amazon S3.
 There are no configuration keys at this time.
 
-## Operation Examples
+Operation Example
+-----------------
 
-#### Retract
-    <!-- Retract from AWS -->
-
-    <operation
-      id="retract-engage-aws"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error"
-      description="Retract recording from AWS">
-    </operation>
+```xml
+<operation
+  id="retract-engage-aws"
+  description="Retract recording from AWS">
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/retract-engage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/retract-engage-woh.md
@@ -1,20 +1,25 @@
-# RetractEngageWorkflowOperationHandler
+Retract Engage Workflow Operation
+=================================
 
+ID: `retract-engage`
 
-## Description
+Description
+-----------
 
-The RetractEngageWorkflowOperationHandler retracts the published elements from the local Opencast Media Module.
-
+The retract-engage operation retracts the published elements from the local Opencast Media Module.
 There are no configuration keys at this time.
 
-## Operation Examples
+Operation Example
+-----------------
 
-#### Retract
-    <!-- Retract from engage player -->
+```xml
+<operation
+  id="retract-engage"
+  description="Retract recording from Engage">
+</operation>
+```
 
-    <operation
-      id="retract-engage"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error"
-      description="Retract recording from Engage">
-    </operation>
+```yml
+- id: retract-engage
+  description: Retract recording from Engage
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/retract-oaipmh-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/retract-oaipmh-woh.md
@@ -1,25 +1,29 @@
-# RetractOaiPmhWorkflowOperation
+Retract OAI-PMH Workflow Operation
+==================================
 
+ID: `retract-oaipmh`
 
-## Description
+Description
+-----------
 
-The Retract OAI-PMH workflow operation retracts the published elements from a OAI-PMH repository.
+The retract OAI-PMH operation retracts the published elements from a OAI-PMH repository.
 
-## Parameter Table
+Parameter Table
+---------------
 
 |Configuration Keys |Description                                                                                   |
 |-------------------|----------------------------------------------------------------------------------------------|
 |repository         |The name of the OAI-PMH repository where the media should be retracted from                   |
 
-## Operation Examples
+Operation Example
+-----------------
 
-
-    <operation
-        id="retract-oaipmh"
-        fail-on-error="true"
-        exception-handler-workflow="error"
-        description="Retract event from the OAI-PMH repository">
-        <configurations>
-            <configuration key="repository">default</configuration>
-        </configurations>
-    </operation>
+```xml
+<operation
+    id="retract-oaipmh"
+    description="Retract event from the OAI-PMH repository">
+  <configurations>
+    <configuration key="repository">default</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/retract-youtube-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/retract-youtube-woh.md
@@ -1,19 +1,20 @@
-# RetractYoutubeWorkflowOperation
+Retract Youtube Workflow Operation
+==================================
 
+ID: `retract-youtube`
 
-## Description
+Description
+-----------
 
-The RetractYoutubeWorkflowOperationHandler retracts the published elements from YouTube.
-
+The retract YouTube operation retracts the published elements from YouTube.
 There are no configuration keys at this time.
 
-## Operation Example
+Operation Example
+-----------------
 
 ```xml
-    <operation
-      id="retract-youtube"
-      fail-on-error="true"
-      exception-handler-workflow="ng-partial-error"
-      description="Retract recording from YouTube">
-    </operation>
+<operation
+  id="retract-youtube"
+  description="Retract recording from YouTube">
+</operation>
 ```

--- a/docs/guides/admin/docs/workflowoperationhandlers/sanitize-adaptive-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/sanitize-adaptive-woh.md
@@ -1,14 +1,20 @@
-# SanitizeAdaptiveWorkflowHandler
+Sanitize Adaptive Workflow Operation
+====================================
 
-## Description
-The SanitizeAdaptiveWorkflowHandler is used to fix references to media files in a playlist.
+ID: `sanitize-adaptive`
+
+Description
+-----------
+
+The sanitize adaptive operation is used to fix references to media files in a playlist.
 When files are ingested, they are put into system created and uniquely named directories.
 This code will attempt to match the referenced files by changing the references in the playlists.
 All the file names must be unique.
 This will allow the inspection to parse and inspect all the renditions in an adaptive playlist.
 Currently only HLS is supported
 
-## Parameter Table
+Parameter Table
+---------------
 
 |configuration keys|example             |description                                                                    |
 |------------------|--------------------|-------------------------------------------------------------------------------|
@@ -17,16 +23,17 @@ Currently only HLS is supported
 |target-tags       | sometag            | Specifies the tags of the new media                                           |
 
 
-## Operation Example
+Operation Example
+-----------------
 
-    <operation
-        id="sanitize-adaptive"
-        fail-on-error="true"
-        exception-handler-workflow="error"
-        description="Fix uploaded HLS files ">
-        <configurations>
-            <configuration key="source-flavor">presenter/ingested</configuration>
-            <configuration key="target-flavor">presenter/delivery</configuration>
-            <configuration key="target-tags">engage</configuration>
-        </configurations>
-    </operation>
+```xml
+<operation
+    id="sanitize-adaptive"
+    description="Fix uploaded HLS files ">
+  <configurations>
+    <configuration key="source-flavor">presenter/ingested</configuration>
+    <configuration key="target-flavor">presenter/delivery</configuration>
+    <configuration key="target-tags">engage</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/segmentpreviews-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/segmentpreviews-woh.md
@@ -1,10 +1,16 @@
-# SegmentpreviewsWorkflowOperation
+Segment Previews Workflo wOperation
+===================================
 
-## Description
-The SegmentpreviewsWorkflowOperation will extract still images from a video using FFmpeg, a given encoding profile and
+ID: `segmentpreviews`
+
+Description
+-----------
+
+The segment previews operation will extract still images from a video using FFmpeg, a given encoding profile and
 previous discovered segments.
 
-## Parameter Table
+Parameter Table
+---------------
 
 |configuration keys|example|description|
 |------------------|-------|-----------|
@@ -16,20 +22,21 @@ previous discovered segments.
 |reference-flavor    |presentation/work    |Flavor of the segments to use.     |
 |reference-tags    |engage    |Tags of the segments to use.     |
 
-## Operation Example
+Operation Example
+-----------------
 
-    <operation
-          id="segmentpreviews"
-          fail-on-error="false"
-          exception-handler-workflow="error"
-          description="Encoding presentation (screen) to segment preview image">
-          <configurations>
-                <configuration key="source-flavor">presentation/trimmed</configuration>
-                <configuration key="source-tags"></configuration>
-                <configuration key="target-flavor">presentation/segment+preview</configuration>
-                <configuration key="reference-flavor">presentation/delivery</configuration>
-                <configuration key="reference-tags">engage</configuration>
-                <configuration key="target-tags">engage</configuration>
-                <configuration key="encoding-profile">player-slides.http</configuration>
-          </configurations>
-    </operation>
+```xml
+<operation
+    id="segmentpreviews"
+    description="Encoding presentation (screen) to segment preview image">
+  <configurations>
+    <configuration key="source-flavor">presentation/trimmed</configuration>
+    <configuration key="source-tags"></configuration>
+    <configuration key="target-flavor">presentation/segment+preview</configuration>
+    <configuration key="reference-flavor">presentation/delivery</configuration>
+    <configuration key="reference-tags">engage</configuration>
+    <configuration key="target-tags">engage</configuration>
+    <configuration key="encoding-profile">player-slides.http</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/segmentvideo-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/segmentvideo-woh.md
@@ -1,27 +1,34 @@
-# SegmentVideoWorkflowOperation
+Segment Video Workflow Operation
+================================
 
-## Description
+ID: `segment-video`
+
+Description
+-----------
+
 The SegmentVideoWorkflowOperation will try to identify and mark different segments of a video. A new segment is created
 when a major change in the video occurs. This might be the case for example if the video is a screen recording and the
 slides which were shown change.
 If both tag and flavor are used, the the element will be chosen by tag AND flavor.
 
-## Parameter Table
+Parameter Table
+---------------
 
 |configuration keys|example|description|
 |------------------|-------|-----------|
 |source-flavor |presentation/trimmed|Specifies which media should be processed.|
 |source-tags |tag|Specifies which media should be processed by tag.|
 
-## Operation Example
+Operation Example
+-----------------
 
-    <operation
-          id="segment-video"
-          fail-on-error="false"
-          exception-handler-workflow="error"
-          description="Extracting segments from presentation">
-          <configurations>
-                <configuration key="source-tags">presentation-lowres</configuration>
-                <configuration key="source-flavor">presentation/trimmed</configuration>
-          </configurations>
-    </operation>
+```xml
+<operation
+    id="segment-video"
+    description="Extracting segments from presentation">
+  <configurations>
+    <configuration key="source-tags">presentation-lowres</configuration>
+    <configuration key="source-flavor">presentation/trimmed</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/select-streams-woh.md
@@ -1,11 +1,13 @@
-SelectTracksWorkflowOperationHandler
-====================================
+Select Tracks Workflow Operation
+================================
+
+ID: `select-tracks`
 
 
 Description
 -----------
 
-The SelectTracksWorkflowOperationHandler can be used in case not all source tracks should be processed. For example,
+The select-tracks operation can be used in case not all source tracks should be processed. For example,
 given a recording with a presenter and a presentation track, the final recording to be published should only include the
 video stream of the presenter track and the audio stream of the presentation track.
 
@@ -21,8 +23,8 @@ Parameter Table
 
 Configuration Key | Example   | Description
 :-----------------|:----------|:-----------
-source-flavor\*   | */source  | The flavor of the track(s) to use as a source input
-target-flavor\*   | */work    | The flavor of the target track(s)
+source-flavor\*   | \*/source | The flavor of the track(s) to use as a source input
+target-flavor\*   | \*/work   | The flavor of the target track(s)
 target-tags       | download  | The tags applied to all target tracks
 audio-muxing      | force     | Move single-audio media packages to a specific track (see below)
 force-target      | presenter     | Target track for the `force` setting for `audio-muxing`
@@ -47,12 +49,12 @@ Those properties are set by the Opencast video editor and can also be set using 
 
 
 Audio Muxing
------------------
+------------
 
 The optional `audio-muxing` parameter has three possible values: `none` (same as omitting the option), `force` and
 `duplicate`.
 
-### `none` ###
+### `none`
 
 If `none` is specified or the option is omitted, the audio stream is taken from the specified `source-flavor` track and is
 edited according to the selections in video editor’s “Tracks” panel. The resulting tracks are stored in the
@@ -61,7 +63,7 @@ corresponding `target-flavor` and `target-tags` are applied.
 Note: If your editing results in a single video and single audio (track/stream) they will be muxed together even if
 this option is set to `none`.
 
-### `force` ###
+### `force`
 
 The parameter value `force` only applies to media packages that have exactly one non-hidden audio stream. For media
 packages without an audio stream or with more than one audio stream, the behavior is the same as if the parameter were
@@ -69,14 +71,14 @@ omitted. The same applies to media packages for which there is only one audio st
 track with flavor type given by `force-target` (or `presenter` if that parameter is omitted).
 
 If, however, there is only one non-hidden audio stream and it does *not* belong to the track given by `force-target`,
-then the WOH will “move” the audio stream to this target track. Specifically, it will mux the video stream of
+then the operation will “move” the audio stream to this target track. Specifically, it will mux the video stream of
 `force-target` with the audio stream it found. Then, it removes the audio stream from the original track.
 
 For example, consider a media package with two tracks, *presenter* and *presentation*. Both of these tracks have
 audio components, however the *presenter* audio stream is hidden. This WOH will mux *presentations*'s audio stream
 with *presenter*'s video, and remove the audio track from *presentation*'s video.
 
-### `duplicate` ###
+### `duplicate`
 
 The parameter value `duplicate` only applies to media packages that have exactly one non-hidden audio stream and no
 hidden video streams. For these media packages, the WOH will mux the audio stream it found to all video streams in
@@ -99,14 +101,14 @@ Note that those encoding profiles are included in the default configuration of O
 Operation Example
 -----------------
 
-    <operation
-      id="select-tracks"
-      fail-on-error="true"
-      exception-handler-workflow="partial-error"
-      description="Select tracks for further processing">
-      <configurations>
-        <configuration key="source-flavor">*/source</configuration>
-        <configuration key="target-flavor">*/work</configuration>
-        <configuration key="audio-muxing">force</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+    id="select-tracks"
+    description="Select tracks for further processing">
+  <configurations>
+    <configuration key="source-flavor">*/source</configuration>
+    <configuration key="target-flavor">*/work</configuration>
+    <configuration key="audio-muxing">force</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/series-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/series-woh.md
@@ -1,10 +1,12 @@
-SeriesWorkflowOperationHandler
-==============================
+Series Workflow Operation
+=========================
+
+ID: `series`
 
 Description
 -----------
 
-The SeriesWorkflowOperation will apply a series to the mediapackage.
+The series operation will apply a series to the mediapackage.
 
 
 Parameter Table
@@ -62,10 +64,8 @@ Operation Examples
 
 ```XML
 <operation
-  id="series"
-  fail-on-error="true"
-  exception-handler-workflow="error"
-  description="Applying series to mediapackage">
+    id="series"
+    description="Applying series to mediapackage">
   <configurations>
     <configuration key="series">0d06537e-09d3-420c-8314-a21e45c5d032</configuration>
     <configuration key="attach">*</configuration>
@@ -76,10 +76,8 @@ Operation Examples
 
 ```XML
 <operation
-  id="series"
-  fail-on-error="true"
-  exception-handler-workflow="error"
-  description="Applying series to mediapackage">
+    id="series"
+    description="Applying series to mediapackage">
   <configurations>
     <configuration key="attach">*</configuration>
     <configuration key="apply-acl">false</configuration>
@@ -90,10 +88,8 @@ Operation Examples
 
 ```XML
 <operation
-  id="series"
-  fail-on-error="true"
-  exception-handler-workflow="error"
-  description="Applying series to mediapackage">
+    id="series"
+    description="Applying series to mediapackage">
   <configurations>
     <configuration key="attach">dublincore/*</configuration>
     <configuration key="apply-acl">false</configuration>

--- a/docs/guides/admin/docs/workflowoperationhandlers/silence-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/silence-woh.md
@@ -1,12 +1,15 @@
-SilenceDetectionWorkflowOperationHandler
-========================================
+Silence Detection Workflow Operation
+====================================
+
+ID: `silence`
 
 Description
 -----------
 
 The silence operation performs a silence detection on an audio-only input file.
 
-## Parameter Table
+Parameter Table
+---------------
 
 |configuration keys      |example    |description|default value|
 |------------------------|-----------|-----------|-------------|
@@ -26,22 +29,24 @@ The relation to the whole track length will be set with the workflow property na
 
 
 Example output for an 120 minutes long presenter/source track:
-```
+
+```properties
 presenter_source_active_audio_duration = 5400
 presenter_source_active_audio_duration_percent = 75
 ```
 
-
 Operation Example
 -----------------
 
-    <operation
-      id="silence"
-      description="Executing silence detection">
-      <configurations>
-        <configuration key="source-flavors">*/audio</configuration>
-        <configuration key="smil-flavor-subtype">smil</configuration>
-        <configuration key="reference-tracks-flavor">*/preview</configuration>
-        <configuration key="export-segments-duration">true</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+    id="silence"
+    description="Executing silence detection">
+  <configurations>
+    <configuration key="source-flavors">*/audio</configuration>
+    <configuration key="smil-flavor-subtype">smil</configuration>
+    <configuration key="reference-tracks-flavor">*/preview</configuration>
+    <configuration key="export-segments-duration">true</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/snapshot-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/snapshot-woh.md
@@ -1,5 +1,7 @@
-AssetManagerSnapshotWorkflowOperationHandler
-============================================
+Asset Manager Snapshot Workflow Operation
+=========================================
+
+ID: `snapshot`
 
 Description
 -----------
@@ -20,10 +22,12 @@ Parameter Table
 Operation Example
 -----------------
 
-    <operation
-      id="snapshot"
-      description="Archiving">
-      <configurations>
-        <configuration key="source-tags">archive</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+    id="snapshot"
+    description="Archiving">
+  <configurations>
+    <configuration key="source-tags">archive</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/start-watson-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/start-watson-transcription-woh.md
@@ -1,10 +1,16 @@
-# Start Watson Transcription
-## Description
+Start Watson Transcription Workflow Operation
+=============================================
 
-The Start Watson Transcription invokes the IBM Watson Speech-to-Text service, passing an audio file to be translated to
-text.
+ID: `start-watson-transcription`
 
-## Parameter Table
+Description
+-----------
+
+The start watson transcription operation invokes the IBM Watson Speech-to-Text service,
+passing an audio file to be translated to text.
+
+Parameter Table
+---------------
 
 |configuration keys|description|default value|example|
 |------------------|-------|-----------|-------------|
@@ -14,7 +20,9 @@ text.
 
 **One of source-flavor or source-tag must be specified.**
 
-## Example
+Example
+-------
+
 ```xml
 <!-- Extract audio from video in ogg/opus format -->
 
@@ -49,8 +57,9 @@ text.
 </operation>
 ```
 
-#### Encoding profile used in example above
-```
+### Encoding profile used in example above
+
+```properties
 profile.audio-opus.name = audio-opus
 profile.audio-opus.input = stream
 profile.audio-opus.output = audio

--- a/docs/guides/admin/docs/workflowoperationhandlers/start-workflow-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/start-workflow-woh.md
@@ -1,20 +1,26 @@
-# StartWorkflowWorkflowOperationHandler
+Start-Workflow Workflow Operation
+=================================
 
-## Description
+ID: `start-workflow`
 
-The StartWorkflowWorkflowOperationHandler can be used to start a new workflow for given media package and workflow definition.
+Description
+-----------
 
-## Parameter Table
+The `start-workflow` operationHandler can be used to start a new workflow for given media package and workflow definition.
+
+Parameter Table
+---------------
 
 |Configuration Key         |Example                              |Description                                     |
 |--------------------------|-------------------------------------|------------------------------------------------|
 |media-packages\*          |e72f2265-472a-49ae-bc04-8301d94b4b1a, a32e2265-472a-49ae-bc04-8351d94b4b1c |comma separated list of the media package ids that should be used |
 |workflow-definition\*     |fast                                 |The workflow definition that should be used     |
-|*configProperty*          |abc / false                          |Workflow configuration property                 |
+|configProperty            |abc / false                          |Workflow configuration property                 |
 
 \* mandatory configuration key
 
-## Operation Example
+Operation Example
+-----------------
 
 ```xml
 <operation id="start-workflow">

--- a/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/tag-by-dcterm-woh.md
@@ -1,17 +1,24 @@
-# TagByDCTermWorkflowOperationHandler
+Tag-By-DC-Term Workflow Operation
+=================================
 
-## Description
-With the TagByDCTermWorkflowOperationHandler it's possible to select various media package elements and then modify
+ID: `tag-by-dcterm`
+
+Description
+-----------
+
+With the `tag-by-dcterm` opweation it's possible to select various media package elements and then modify
 their tag set and / or set their flavor according to whether a Dublin Core term in a catalog has a specific value.
 
 So for example it's possible to pick elements like the Dublin Core catalogs that have been added to the media package
 at the beginning of the workflow and tag them, so they can be picked up by operations later on or even an application
 that harvests the mediapackage from a publication channel.
 
-In combination with [ConfigureByDCTermWorkflowOperationHandler](configure-by-dcterm-woh.md) workflows can be controlled
+In combination with [`configure-by-dcterm` operation](configure-by-dcterm-woh.md) workflows can be controlled
 by the metadata contained within the Dublin core catalogs.
 
-## Parameter Table
+Parameter Table
+---------------
+
 Tags and flavors can be used in combination.
 
 |configuration keys|example|description|default value|
@@ -26,38 +33,43 @@ Tags and flavors can be used in combination.
 |target-flavor     |"presentation/tagged"     |Apply these flavor to any media package elements|EMPTY|
 |copy              |"true" or "false"         |Indicates if matching elements will be cloned before tagging is applied or whether tagging is applied to the original element. Set to "true" to create a copy first, "false" otherwise.|FALSE|
 
-Note: see [TagWorkflowOperationHandler](tag-woh.md) for further explanation of the source/target-flavor/tags
+Note: see [`tag` operation](tag-woh.md) for further explanation of the source/target-flavor/tags
 
 ### dccatalog
+
 The type of Dublin Core catalog in which to look for the `dcterm`. This will usually be `episode` or `series`.
 
 ### dcterm
+
 The name of the Dublin Core term to look for in the `dccatalog`. This could be one of the terms set by Opencast or an
 additional term adding to the catalog.
 
 ### match-value
+
 The value of the `dcterm` which to match against. The comparison is case sensitive.
 
 ### default-value
+
 If `default-value` is used when the `dcterm` is not found in the catalog. If not specified the operation will treat the
 match as false and not tag anything. If `default-value` is specified the operation will compare the `match-value` to
 the `default-value` and apply the tags if they match. This allows an implied value to be explicitly and clearly
 defined. For example if you have mediapackages that were created before additional metadata was added to the episode
 catalog you may want to imply that the `audience` term has a value of `all-enrolled`.
 
-## Operation Example
-    <operation
-      id="tag-by-dcterm"
-      max-attempts="2"
-      fail-on-error="true"
-      exception-handler-workflow="error"
-      description="Tagging media package elements according to dcterm">
-      <configurations>
-        <configuration key="source-flavors">dublincore/*,security/*</configuration>
-        <configuration key="dccatalog">episode</configuration>
-        <configuration key="dcterm">audience</configuration>
-        <configuration key="match-value">learning-difficulties</configuration>
-        <configuration key="default-value">all-enrolled</confiuration>
-        <configuration key="target-tags">+publishBeforeEditing</configuration>
-      </configurations>
-    </operation>
+Operation Example
+-----------------
+
+```xml
+<operation
+    id="tag-by-dcterm"
+    description="Tagging media package elements according to dcterm">
+  <configurations>
+    <configuration key="source-flavors">dublincore/*,security/*</configuration>
+    <configuration key="dccatalog">episode</configuration>
+    <configuration key="dcterm">audience</configuration>
+    <configuration key="match-value">learning-difficulties</configuration>
+    <configuration key="default-value">all-enrolled</confiuration>
+    <configuration key="target-tags">+publishBeforeEditing</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/theme-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/theme-woh.md
@@ -1,7 +1,12 @@
-# ThemeWorkflowOperationHandler
+Theme Workflow Operation
+========================
 
-## Description
-The ThemeWorkflowOperation loads workflow properties and adds elements to the media package if available.
+ID: `theme`
+
+Description
+-----------
+
+The theme operation loads workflow properties and adds elements to the media package if available.
 This information can be used within workflow definitions to actually implement themes.
 
 **Bumpers**
@@ -23,60 +28,61 @@ the background image is added to the media package with the flavor *title-slide-
 
 **Watermark**
 
-The property *theme_watermark_active* indicates whether the theme defines a watermark. If true, the watermark image
-is added to the media package with the flavor **watermark-flavor* and/or tags *watermark-tags*.
-Additionally, a watermark layout compatible to the CompositeWorkflowOperation is added as property
-*watermark_layout_variable*.
+The property `theme_watermark_active` indicates whether the theme defines a watermark.
+If true, the watermark is added to the media package with the flavor `watermark-flavor` and/or tags `watermark-tags`.
+Additionally, a watermark layout compatible to the composite operation is added as property `watermark_layout_variable`.
 
-## Workflow Properties
+Workflow Properties
+-------------------
 
 The ThemeWorkflowOperation will set the following workflow properties:
 
-|Property Name             |Description                                                          |
-|--------------------------|---------------------------------------------------------------------|
-|theme_active              |true if the theme has active settings, false or undefined otherwise  |
-|theme_bumper_active       |true if the theme has an active bumper video, false otherwise        |
-|theme_trailer_active      |true if the theme has an active trailer video, false otherwise       |
-|theme_title_slide_active  |true if the theme has an active title slide, false otherwise         |
-|theme_title_slide_uploaded|true if the theme come with an uploaded title slide, false otherwise |
-|theme_watermark_active    |true if the theme has an active watermark, false otherwise           |
+|Property Name                |Description                                                          |
+|-----------------------------|---------------------------------------------------------------------|
+|theme\_active                |true if the theme has active settings, false or undefined otherwise  |
+|theme\_bumper\_active        |true if the theme has an active bumper video, false otherwise        |
+|theme\_trailer\_active       |true if the theme has an active trailer video, false otherwise       |
+|theme\_title\_slide\_active  |true if the theme has an active title slide, false otherwise         |
+|theme\_title\_slide\_uploaded|true if the theme come with an uploaded title slide, false otherwise |
+|theme\_watermark\_active     |true if the theme has an active watermark, false otherwise           |
 
-Note: The property *theme_active* can be used to test whether a theme has any active settings, i.e.
-at least one of the properties *theme_\*_active* is true.
+Note: The property `theme_active` can be used to test whether a theme has any active settings,
+i.e. at least one of the properties `theme_*_active` is true.
 
-## Parameter Table
+Parameter Table
+---------------
 
-|Configuration Keys         |Example                |Description                                  |
-|---------------------------|-----------------------|---------------------------------------------|
-|*bumper-flavor             |branding/bumper        |Flavor of the bumper video                   |
-|*bumper-tags               |bumper                 |Tags of of the bumper video                  |
-|*trailer-flavor            |branding/trailer       |Flavor of the trailer video                  |
-|*trailer-tags              |trailer                |Tags of the trailer video                    |
-|*title-slide-flavor        |branding/titleslide    |Flavor of the title slide image              |
-|*title-slide-tags          |titleslide             |Tags of the title slide image                |
-|*watermark-flavor          |branding/watermark     |Flavor of the watermark image                |
-|*watermark-tags            |watermark              |Tags of the watermark image                  |
-|*watermark-layout-variable |theme_watermark_layout |Variable that will hold the watermark layout |
+|Configuration Keys          |Example                |Description                                  |
+|----------------------------|-----------------------|---------------------------------------------|
+|\*bumper-flavor             |branding/bumper        |Flavor of the bumper video                   |
+|\*bumper-tags               |bumper                 |Tags of of the bumper video                  |
+|\*trailer-flavor            |branding/trailer       |Flavor of the trailer video                  |
+|\*trailer-tags              |trailer                |Tags of the trailer video                    |
+|\*title-slide-flavor        |branding/titleslide    |Flavor of the title slide image              |
+|\*title-slide-tags          |titleslide             |Tags of the title slide image                |
+|\*watermark-flavor          |branding/watermark     |Flavor of the watermark image                |
+|\*watermark-tags            |watermark              |Tags of the watermark image                  |
+|\*watermark-layout-variable |theme_watermark_layout |Variable that will hold the watermark layout |
 
 \* Mandatory configuration key (in case the feature is active)
 
-## Operation Example
+Operation Example
+-----------------
 
-    <operation
-      id="theme"
-      exception-handler-workflow="partial-error"
-      description="Apply the theme">
-      <configurations>
-        <configuration key="bumper-flavor">branding/bumper</configuration>
-        <configuration key="bumper-tags">archive</configuration>
-        <configuration key="trailer-flavor">branding/trailer</configuration>
-        <configuration key="trailer-tags">archive</configuration>
-        <configuration key="title-slide-flavor">branding/titleslide</configuration>
-        <configuration key="title-slide-tags">archive</configuration>
-        <configuration key="watermark-flavor">branding/titleslide</configuration>
-        <configuration key="watermark-tags">archive</configuration>
-        <configuration key="watermark-layout-variable">theme_watermark_layout</configuration>
-      </configurations>
-    </operation>
-
-
+```xml
+<operation
+    id="theme"
+    description="Apply the theme">
+  <configurations>
+    <configuration key="bumper-flavor">branding/bumper</configuration>
+    <configuration key="bumper-tags">archive</configuration>
+    <configuration key="trailer-flavor">branding/trailer</configuration>
+    <configuration key="trailer-tags">archive</configuration>
+    <configuration key="title-slide-flavor">branding/titleslide</configuration>
+    <configuration key="title-slide-tags">archive</configuration>
+    <configuration key="watermark-flavor">branding/titleslide</configuration>
+    <configuration key="watermark-tags">archive</configuration>
+    <configuration key="watermark-layout-variable">theme_watermark_layout</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/timelinepreviews-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/timelinepreviews-woh.md
@@ -1,5 +1,7 @@
-TimelinePreviewsWorkflowOperationHandler
-========================================
+Timeline Previews Workflow Operation
+====================================
+
+ID: `timelinepreviews`
 
 Description
 -----------
@@ -27,8 +29,8 @@ Operation Example
 
 ```xml
 <operation
-  id="timelinepreviews"
-  description="Creating presentation timeline preview images">
+    id="timelinepreviews"
+    description="Creating presentation timeline preview images">
   <configurations>
     <configuration key="source-flavor">*/trimmed</configuration>
     <configuration key="target-flavor">*/timeline+preview</configuration>

--- a/docs/guides/admin/docs/workflowoperationhandlers/transfer-metadata-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/transfer-metadata-woh.md
@@ -1,6 +1,8 @@
 Transfer Metadata Workflow Operation
 ====================================
 
+ID: `transfer-metadata`
+
 Description
 -----------
 
@@ -45,8 +47,8 @@ Operation Example
 
 ```xml
 <operation
-  id="transfer-metadata"
-  description="Transfer dcterms:creator to myterms:owner">
+    id="transfer-metadata"
+    description="Transfer dcterms:creator to myterms:owner">
   <configurations>
     <configuration key="source-flavor">dublincore/episode</configuration>
     <configuration key="target-flavor">myterms/episode</configuration>

--- a/docs/guides/admin/docs/workflowoperationhandlers/video-grid-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/video-grid-woh.md
@@ -1,12 +1,15 @@
-# VideoGridWorkflowOperationHandler
+Video Grid Workflow Operation
+=============================
 
-## Description
+ID: `video-grid`
 
-The VideoGridWorkflowOperationHandler offers a way to combine several, partially simultaneously
-playing videos into a single video file. For example, the webcam feeds during a video conference
-can be combined by this WOH. The resulting video puts each input video on a grid that dynamically
-resizes based on the number of inputs videos currently active. Which input video is active when
-is defined through a SMIL catalogue from e.g. a partial ingest.
+Description
+-----------
+
+The `video-grid` operation offers a way to combine several, partially simultaneously playing videos into a single video
+file. For example, the webcam feeds during a video conference can be combined by this WOH. The resulting video puts each
+input video on a grid that dynamically resizes based on the number of inputs videos currently active. Which input video
+is active when is defined through a SMIL catalogue from e.g. a partial ingest.
 
 If the SMIL defines a section where there are no videos active, the background color will be shown
 instead for the duration of the section. This also holds true for potentially empty beginning and end 
@@ -33,7 +36,8 @@ a single output file.
 
 \* **required keys**
 
-## Example
+Example
+-------
 
 For this example, let us assume that our source-flavor contains three videos. The SMIL file from our
 source-smil-flavor defines the duration for the final video as 3 (units of time). It also defines the start
@@ -49,13 +53,13 @@ how the videos from our source-flavor are arranged in each section.
 
 Finally, the videos for each section are combined into one final, single video file.
 
-## Operation Example
+Operation Example
+-----------------
+
 ```xml
 <operation
     id="video-grid"
-    description="Generate sections of the final video"
-    fail-on-error="true"
-    exception-handler-workflow="partial-error">
+    description="Generate sections of the final video">
   <configurations>
     <configuration key="source-flavor">presenter/source</configuration>
     <configuration key="source-smil-flavor">smil/source+partial</configuration>
@@ -65,10 +69,12 @@ Finally, the videos for each section are combined into one final, single video f
 </operation>
 ```
 
-## Encoding Profiles
+Encoding Profiles
+-----------------
 
 Although not necessary, it is recommended to use a concat encoding profile that makes use of concat demuxing. This helps with reducing working memory usage.
-```
+
+```properties
 # Concat - lossless concat
 # Source files must be of the same dimension and codecs and they will be used in the target
 # It uses ffmpeg concat demuxer

--- a/docs/guides/admin/docs/workflowoperationhandlers/waveform-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/waveform-woh.md
@@ -1,10 +1,12 @@
-WaveformWorkflowOperationHandler
-================================
+Waveform Workflow Operation
+===========================
+
+ID: `waveform`
 
 Description
 -----------
 
-The waveform operation creates an image showing the temporal audio activity within the recording like this:
+The `waveform` operation creates an image showing the temporal audio activity within the recording like this:
 
 ![waveform](waveform.png)
 
@@ -26,6 +28,7 @@ min-width         |10000       |Minimum width of waveform image in pixels       
 max-width         |30000       |Maximum width of waveform image in pixels                       |20000
 height            |60          |Height of waveform image in pixels                              |500
 color             |black       |Color of waveform image, see [ffmpeg.org/ffmpeg-all.html#Color](https://www.ffmpeg.org/ffmpeg-all.html#Color) |black
+
 Additional notes:
 
 - All media, that match either source-flavors or source tags will be processed.
@@ -35,17 +38,19 @@ Additional notes:
 Operation Example
 -----------------
 
-    <operation
-      id="waveform"
-      description="Generating waveform">
-      <configurations>
-        <configuration key="source-flavor">*/audio</configuration>
-        <configuration key="target-flavor">*/waveform</configuration>
-        <configuration key="target-tags">preview</configuration>
-        <configuration key="pixels-per-minute">200</configuration>
-        <configuration key="min-width">5000</configuration>
-        <configuration key="max-width">20000</configuration>
-        <configuration key="height">60</configuration>
-        <configuration key="color">black</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+    id="waveform"
+    description="Generating waveform">
+  <configurations>
+    <configuration key="source-flavor">*/audio</configuration>
+    <configuration key="target-flavor">*/waveform</configuration>
+    <configuration key="target-tags">preview</configuration>
+    <configuration key="pixels-per-minute">200</configuration>
+    <configuration key="min-width">5000</configuration>
+    <configuration key="max-width">20000</configuration>
+    <configuration key="height">60</configuration>
+    <configuration key="color">black</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/zip-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/zip-woh.md
@@ -1,12 +1,14 @@
-ZipWorkflowOperation
-====================
+Zip Workflow Operation
+======================
+
+ID: `zip`
 
 Description
 -----------
 
-The ZipWorkflowOperationHandler creates a zip archive including all elements of the current media package that are
-specified in the operation configuration. It then adds the archive to the media package as an attachment with the given
-flavor and tags and by default stores the zip file in the working file repository's "zip" collection.
+The `zip` oeration creates a zip archive including all elements of the current media package that are specified in the
+operation configuration. It then adds the archive to the media package as an attachment with the given flavor and tags
+and by default stores the zip file in the working file repository's "zip" collection.
 
 
 Parameter Table
@@ -31,13 +33,25 @@ Additional notes:
 Operation Example
 -----------------
 
-    <operation
-      id="zip"
-      description="Creating zipped recording archive">
-      <configurations>
-        <configuration key="zip-collection">failed.zips</configuration>
-        <configuration key="include-flavors">*/source,dublincore/*</configuration>
-        <configuration key="target-flavor">all/zip</configuration>
-        <configuration key="compression">false</configuration>
-      </configurations>
-    </operation>
+```xml
+<operation
+  id="zip"
+  description="Creating zipped recording archive">
+  <configurations>
+    <configuration key="zip-collection">failed.zips</configuration>
+    <configuration key="include-flavors">*/source,dublincore/*</configuration>
+    <configuration key="target-flavor">all/zip</configuration>
+    <configuration key="compression">false</configuration>
+  </configurations>
+</operation>
+```
+
+```yml
+- id: zip
+  description: Creating zipped recording archive
+  configurations:
+    - zip-collection: failed.zips
+    - include-flavors: */source,dublincore/*
+    - target-flavor: all/zip
+    - compression: false
+```


### PR DESCRIPTION
This patch starts adjusting the workflow operation handler documentation to always use a similar template, starting with the operations name and it's identifier and, not using the Java class name and ending with an example in a similar format with syntax highlighting enabled.

This does not yet update all workflow operation handler docs.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
