### PR TITLE
Specify Units in Video Clips

### DIFF
--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/ffmpeg/FFmpegEdit.java
@@ -205,8 +205,8 @@ public class FFmpegEdit {
       // get clip and add fades to each clip
       VideoClip vclip = clips.get(i);
       int fileindx = vclip.getSrc();   // get source file by index
-      double inpt = vclip.getStart();     // get in points
-      double duration = vclip.getDuration();
+      double inpt = vclip.getStartInSeconds();     // get in points
+      double duration = vclip.getDurationInSeconds();
 
       String clip = "";
       if (hasVideo) {

--- a/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoClip.java
+++ b/modules/videoeditor-ffmpeg-impl/src/main/java/org/opencastproject/videoeditor/impl/VideoClip.java
@@ -23,20 +23,32 @@ package org.opencastproject.videoeditor.impl;
 
 public class VideoClip {
   private final int srcId;
-  private final double start;
-  private double end;
+  private final long start;
+  private long end;
   // if layout regions are supported, it will be resolved and stored here,
   // defaults to root layout
   private String region;
 
-  public VideoClip(int indx, double start, double end) {
-    this.srcId = indx;
+  /**
+   * Video clip constructor.
+   *
+   * @param id Source identifier of the video clip
+   * @param start Start time in milliseconds
+   * @param end End time in milliseconds
+   */
+  public VideoClip(int id, long start, long end) {
+    this.srcId = id;
     this.start = start;
     this.end = end;
   }
 
-  void setEnd(double newend) {
-    this.end = newend;
+  /**
+   * Update the video clip's end time.
+   *
+   * @param end New end time in milliseconds.
+   */
+  void setEnd(long end) {
+    this.end = end;
   }
 
   void setRegion(String region) { // Regions are relative to root-layout,
@@ -46,17 +58,63 @@ public class VideoClip {
   public int getSrc() {
     return srcId;
   }
-  public double getStart() {
+
+  /**
+   * Get the video clip's start time in milliseconds.
+   *
+   * @return Start time in milliseconds.
+   */
+  public long getStartInMilliseconds() {
     return start;
   }
-  public double getEnd() {
+
+  /**
+   * Get the video clip's start time in fractions of seconds.
+   *
+   * @return Start time in seconds.
+   */
+  public double getStartInSeconds() {
+    return start / 1000.0;
+  }
+
+  /**
+   * Get the video clip's end time in milliseconds.
+   *
+   * @return End time in milliseconds.
+   */
+  public long getEndInMilliseconds() {
     return end;
   }
+
+  /**
+   * Get the video clip's end time in fractions of seconds.
+   *
+   * @return End time in seconds.
+   */
+  public double getEndInSeconds() {
+    return end / 1000.0;
+  }
+
   public String getRegion() {
     return region;
   }
-  public double getDuration() {
+
+  /**
+   * Get the video clip's duration in milliseconds.
+   *
+   * @return Duration in milliseconds.
+   */
+  public long getDurationInMilliseconds() {
     return end - start;
+  }
+
+  /**
+   * Get the video clip's duration in fractions of seconds.
+   *
+   * @return Duration in seconds.
+   */
+  public double getDurationInSeconds() {
+    return (end - start) / 1000.0;
   }
 
 }

--- a/modules/videoeditor-ffmpeg-impl/src/test/java/org/opencastproject/videoeditor/ffmpeg/FFmpegTest.java
+++ b/modules/videoeditor-ffmpeg-impl/src/test/java/org/opencastproject/videoeditor/ffmpeg/FFmpegTest.java
@@ -23,6 +23,7 @@ package org.opencastproject.videoeditor.ffmpeg;
 
 import org.opencastproject.videoeditor.impl.VideoClip;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -31,8 +32,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-
-import junit.framework.Assert;
 
 /**
  * Tests the ffmpeg concatenation service
@@ -85,10 +84,10 @@ public class FFmpegTest {
     if (!ffmpegInstalled) {
       return;
     }
-    ArrayList<String> input = new ArrayList<String>();
-    ArrayList<VideoClip> clips = new ArrayList<VideoClip>();
-    clips.add(new VideoClip(0, 0.0, 10.0));
-    clips.add(new VideoClip(0, 25.0, 44.0));
+    ArrayList<String> input = new ArrayList<>();
+    ArrayList<VideoClip> clips = new ArrayList<>();
+    clips.add(new VideoClip(0, 0, 10000));
+    clips.add(new VideoClip(0, 25000, 44000));
     input.add(inputFilePath);
     FFmpegEdit fmp = new FFmpegEdit();
     fmp.processEdits(input, outputFilePath, null, clips);
@@ -108,10 +107,10 @@ public class FFmpegTest {
     if (!ffmpegInstalled) {
       return;
     }
-    ArrayList<String> input = new ArrayList<String>();
-    ArrayList<VideoClip> clips = new ArrayList<VideoClip>();
-    clips.add(new VideoClip(0, 0.0, 10.0));
-    clips.add(new VideoClip(1, 25.0, 44.0));
+    ArrayList<String> input = new ArrayList<>();
+    ArrayList<VideoClip> clips = new ArrayList<>();
+    clips.add(new VideoClip(0, 0, 10000));
+    clips.add(new VideoClip(1, 25000, 44000));
     input.add(inputFilePath);
     input.add(inputFilePath);
     FFmpegEdit fmp = new FFmpegEdit();


### PR DESCRIPTION
The `VideoClip` class stores a begin and an end value but does not specify the unit these values are stored in. This lead to code storing the values in seconds while in the next line code would store milliseconds. That is really confusing.

This patch now makes it clear that all input values are in milliseconds since that is what our code uses anyway and we have specific functions to get these vales either as seconds or as milliseconds.

This hopefully makes the code less confusing to read.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
