### PR TITLE
Enforce Workflow Operation Documentation Style

### DIFF
--- a/docs/checkstyle/check-docs.sh
+++ b/docs/checkstyle/check-docs.sh
@@ -32,4 +32,21 @@ if ! npm test; then
   ret=1
 fi
 
+echo checking workflow operation docs
+cd admin/docs/workflowoperationhandlers
+# Check page titles all end identical.
+# Should all end on " Workflow Operation"
+if test "$(head -n 1 -q *woh.md | awk '{print $(NF-1) $NF}' | uniq | wc -l)" -ne 1; then
+  echo 'ERROR: All workflow operation page titlesshould end with " Workflow Operation"'
+  head -n 1 -q *woh.md | awk '{print $(NF-1) " " $NF}' | uniq
+  ret=1
+fi
+# Check all docs list the operation identifier
+if test "$(grep -L 'ID: `' *-woh.md | wc -l)" -ne 0; then
+  echo 'ERROR: All workflow operation pages should list the operation identifier'
+  grep -L 'ID: `' *-woh.md
+  ret=1
+fi
+cd -
+
 exit $ret


### PR DESCRIPTION
This patch enforces a minimal style requirement on all workflow operation hander documentation pages:

- The pages must have a title ending in "Operation Handler"
- The page must list the operations identifier in the form:
  - ID: `identifier`

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
