### PR TITLE
Authenticate user when viewing a protected video

### DIFF
--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -400,7 +400,7 @@ export function episodeToManifest(ocResponse, config) {
     return result;
   }
   else {
-    throw Error('No episode found');
+    return null;
   }
 }
 


### PR DESCRIPTION
When you play a protected video while not logged in, paella 7 returns an error instead of trying to authenticate the user.
Paella 7 should authenticate the user and try to view the video again.

### Your pull request should…

* [x] have a concise title
* [x] close #4338 
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
