### PR TITLE
Generate more of the release notes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,7 +39,10 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: |
+          echo "::set-output name=VERSION::$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1.\2_'
+          echo "::set-output name=VERSION_MAIN::$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1_'
+          echo "::set-output name=VERSION_COMBINED::$GITHUB_REF" | sed 's_refs/tags/\([0-9]*\).\([0-9]*\)$_\1\2_'
 
       - name: create new release
         uses: softprops/action-gh-release@v1
@@ -49,8 +52,8 @@ jobs:
           fail_on_unmatched_files: true
           name: Opencast ${{ steps.get_version.outputs.VERSION }}
           body: |
-            This release …
+            This is an Opencast ${{ steps.get_version.outputs.VERSION_MAIN }} release.
             For further information, please take a look at:
 
-            - [Release notes](#)
-            - [Changelog](#)
+            - [Release notes](https://docs.opencast.org/r/${{ steps.get_version.outputs.VERSION_MAIN }}.x/admin/#releasenotes/#opencast-${{ steps.get_version.outputs.VERSION_COMBINED }})
+            - [Changelog](https://docs.opencast.org/r/${{ steps.get_version.outputs.VERSION_MAIN }}.x/admin/#changelog/#opencast-${{ steps.get_version.outputs.VERSION_COMBINED }})


### PR DESCRIPTION
This patch makes GitHub automatically generate more of the release notes so that release managers have less work to do.
This is #4091 cherry-picked to 12.x where I originally intended it to be.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
