### PR TITLE
Replace fallback element identifiers with UUIDs

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageImpl.java
@@ -1090,13 +1090,8 @@ public final class MediaPackageImpl implements MediaPackage {
   }
 
   /**
-   * Returns a media package element identifier with the given prefix and the given number or a higher one as the
-   * suffix. The identifier will be unique within the media package.
+   * Returns a unique media package element identifier.
    *
-   * @param prefix
-   *          the identifier prefix
-   * @param count
-   *          the number
    * @return the element identifier
    */
   private String createElementIdentifier() {
@@ -1490,30 +1485,18 @@ public final class MediaPackageImpl implements MediaPackage {
   private void addInternal(MediaPackageElement element) {
     if (element == null)
       throw new IllegalArgumentException("Media package element must not be null");
-    String id = null;
-    if (elements.add(element)) {
-      if (element instanceof Track) {
-        tracks++;
-        id = "track-" + tracks;
-        recalculateDuration();
-      } else if (element instanceof Attachment) {
-        attachments++;
-        id = "attachment-" + attachments;
-      } else if (element instanceof Catalog) {
-        catalogs++;
-        id = "catalog-" + catalogs;
-      } else {
-        others++;
-        id = "unknown-" + others;
-      }
+
+    elements.add(element);
+    if (element instanceof Track) {
+      recalculateDuration();
     }
 
     // Check if element has an id
     if (element.getIdentifier() == null) {
       if (element instanceof AbstractMediaPackageElement) {
-        element.setIdentifier(id);
+        element.setIdentifier(createElementIdentifier());
       } else
-        throw new UnsupportedElementException(element, "Found unkown element without id");
+        throw new UnsupportedElementException(element, "Found unknown element without id");
     }
   }
 
@@ -1526,16 +1509,9 @@ public final class MediaPackageImpl implements MediaPackage {
   void removeInternal(MediaPackageElement element) {
     if (element == null)
       throw new IllegalArgumentException("Media package element must not be null");
-    if (elements.remove(element)) {
-      if (element instanceof Track) {
-        tracks--;
-        recalculateDuration();
-      } else if (element instanceof Attachment)
-        attachments--;
-      else if (element instanceof Catalog)
-        catalogs--;
-      else
-        others--;
+
+    if (elements.remove(element) && element instanceof Track) {
+      recalculateDuration();
     }
   }
 


### PR DESCRIPTION
MediaPackageElement identifiers are almost exclusively UUIDs, except if the identifier is missing.

Based on the element type, the MediaPackage Implementation creates identifiers that contain the type name and the number of elements of that type. (e.g., track-N, attachment-N, catalog-N,unknown-N)

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
