### PR TITLE
Lower JWT error logging to debug level

### DIFF
--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/DynamicLoginHandler.java
@@ -171,7 +171,7 @@ public class DynamicLoginHandler implements InitializingBean, JWTLoginHandler {
         return cachedJwt.getUsername();
       }
     } catch (JWTVerificationException | JwkException exception) {
-      logger.error(exception.getMessage());
+      logger.debug(exception.getMessage());
     }
 
     return null;


### PR DESCRIPTION
Currently, all logins resulting in errors are logged with error level for the JWT handler. This could result in a log of noise. This lowers the level to debug.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
