### PR TITLE
Automate Release Process

### DIFF
--- a/.github/make-release
+++ b/.github/make-release
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+set -eux
+
+# fail if we are not on a release branch
+git rev-parse --abbrev-ref HEAD | grep -e 'r/[0-9]*\.x'
+
+# make sure we have all tags
+git fetch --tags
+
+# determine the version we want to release
+MAJOR="$(git rev-parse --abbrev-ref HEAD | sed 's_r/\([0-9]*\)\.x_\1_')"
+LATEST_MINOR="$(git tag | grep "^${MAJOR}" | cut -d. -f2 | sort -n | tail -n1)"
+if [ -z $LATEST_MINOR ]; then
+  LATEST_MINOR=-1
+fi
+MINOR="$((LATEST_MINOR + 1))"
+VERSION="${MAJOR}.${MINOR}"
+
+# fail if any files are modified
+git status | grep modified: && exit 1
+
+# update pom.xml versions
+mvn versions:set -DnewVersion="${VERSION}" versions:commit
+
+# build opencast
+mvn clean install \
+  -Pdev \
+  -DskipTests \
+  -Dcheckstyle.skip=true \
+  --batch-mode \
+  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+  -Dhttp.keepAlive=false \
+  -Dmaven.wagon.http.pool=false \
+  -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
+# prepare dependencies
+cd docs/scripts/devel-dependency-containers
+docker-compose up -d
+cd -
+curl -fisS --retry 30 --retry-delay 5 --retry-all-errors http://localhost:9200/
+
+# run opencast
+"./build/opencast-dist-develop-${VERSION}/bin/start-opencast" daemon &
+
+# check opencast starts up and build is consistent
+curl -fsS --retry 30 --retry-delay 10 --retry-all-errors "http://127.0.0.1:8080/sysinfo/bundles/version" -o version.json
+test "$(jq .consistent < version.json)" = "true"
+
+# commit changes
+git add pom.xml modules/*/pom.xml
+git commit -m "Opencast ${VERSION}"
+git tag "${VERSION}" -m "Opencast ${VERSION}"
+
+# push new tag
+git push origin "${VERSION}:${VERSION}"

--- a/.github/workflows/cut-release-tag.yml
+++ b/.github/workflows/cut-release-tag.yml
@@ -1,0 +1,19 @@
+name: Cut Release Tag
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cut-release-tag:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: prepare git
+        run: |
+          git config --global user.email 'cloud@opencast.org'
+          git config --global user.name 'Release Bot'
+
+      - name: make release
+        run: |
+          ./.github/make-release


### PR DESCRIPTION
Right now, cutting a new release is mostly just copy and pasting commands from the developer documentation, hoping that you aren't so bored that you miss changing a version number in those commands.

This patch completely automates the release process. To cut a new release, a release manager can now go to GitHub Actions and trigger the “Cut Release Tag” workflow.

The GitHub Actions user interface will ask for a branch to run this on and the release manager would select the release branch, e.g. `r/13.x`. The workflow will check this and automatically fail on non-release branches.

Based on the release branch, the workflow will then extract the major version and based on existing tags automatically determine the next version in line.

For example, selecting `r/13.x`, with no 13.x versions tagged right now, the workflow will determine that the 13.0 release needs to be cut.

The workflow will then update the `pom.xml` versions, build Opencast and check it starts up properly, commit the changes, create a git tag and finally push the tag to GitHub. In other words, it does all the annoying stuff a release manager would usually have to do manually.

![Screenshot from 2022-10-20 17-55-44](https://user-images.githubusercontent.com/1008395/197000678-84c353d6-d00a-4742-962d-a289075dce34.png)
*Selecting the branch to run the workflow on*


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
