### PR TITLE
Fully Automate GitHub Release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -48,7 +48,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: build/opencast-dist-*.tar.gz
-          draft: true
           fail_on_unmatched_files: true
           name: Opencast ${{ steps.get_version.outputs.VERSION }}
           body: |


### PR DESCRIPTION
This seems to work well and I could just release the draft created by this with no further changes. So, why not directly create the release. Less work for release managers.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
