### PR TITLE
Deprecated junit import

### DIFF
--- a/modules/caption-impl/src/test/java/org/opencastproject/caption/converters/DFXPConverterTest.java
+++ b/modules/caption-impl/src/test/java/org/opencastproject/caption/converters/DFXPConverterTest.java
@@ -26,6 +26,7 @@ import org.opencastproject.caption.api.Caption;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,8 +34,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-
-import junit.framework.Assert;
 
 /**
  *

--- a/modules/caption-impl/src/test/java/org/opencastproject/caption/converters/Mpeg7ConverterTest.java
+++ b/modules/caption-impl/src/test/java/org/opencastproject/caption/converters/Mpeg7ConverterTest.java
@@ -30,6 +30,7 @@ import org.opencastproject.caption.impl.TimeImpl;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,8 +39,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-
-import junit.framework.Assert;
 
 /**
  * Test class for Mpeg7 format.

--- a/modules/caption-impl/src/test/java/org/opencastproject/caption/converters/SubRipConverterTest.java
+++ b/modules/caption-impl/src/test/java/org/opencastproject/caption/converters/SubRipConverterTest.java
@@ -26,6 +26,7 @@ import org.opencastproject.caption.api.Caption;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,8 +34,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-
-import junit.framework.Assert;
 
 
 /**

--- a/modules/capture-admin-service-impl/src/test/java/org/opencastproject/capture/admin/impl/AgentStateUpdateTest.java
+++ b/modules/capture-admin-service-impl/src/test/java/org/opencastproject/capture/admin/impl/AgentStateUpdateTest.java
@@ -28,10 +28,9 @@ import org.opencastproject.capture.admin.api.AgentStateUpdate;
 import org.opencastproject.security.api.DefaultOrganization;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import junit.framework.Assert;
 
 public class AgentStateUpdateTest {
 

--- a/modules/capture-admin-service-impl/src/test/java/org/opencastproject/capture/admin/impl/AgentTest.java
+++ b/modules/capture-admin-service-impl/src/test/java/org/opencastproject/capture/admin/impl/AgentTest.java
@@ -28,10 +28,9 @@ import org.opencastproject.capture.admin.api.Agent;
 import org.opencastproject.security.api.DefaultOrganization;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import junit.framework.Assert;
 
 public class AgentTest {
   private Agent agent = null;

--- a/modules/common/src/test/java/org/opencastproject/mediapackage/identifier/IdTest.java
+++ b/modules/common/src/test/java/org/opencastproject/mediapackage/identifier/IdTest.java
@@ -21,9 +21,9 @@
 
 package org.opencastproject.mediapackage.identifier;
 
+import org.junit.Assert;
 import org.junit.Test;
 
-import junit.framework.Assert;
 
 /**
  * Tests non-handle Identifiers

--- a/modules/common/src/test/java/org/opencastproject/mediapackage/track/TrackSupportTest.java
+++ b/modules/common/src/test/java/org/opencastproject/mediapackage/track/TrackSupportTest.java
@@ -30,11 +30,10 @@ import org.opencastproject.util.Checksum;
 import org.opencastproject.util.ChecksumType;
 import org.opencastproject.util.MimeTypes;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URI;
-
-import junit.framework.Assert;
 
 public class TrackSupportTest {
   @Test

--- a/modules/common/src/test/java/org/opencastproject/security/api/AccessControlParserTest.java
+++ b/modules/common/src/test/java/org/opencastproject/security/api/AccessControlParserTest.java
@@ -22,12 +22,11 @@
 package org.opencastproject.security.api;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
-
-import junit.framework.Assert;
 
 
 /**

--- a/modules/common/src/test/java/org/opencastproject/security/api/OrganizationParsingTest.java
+++ b/modules/common/src/test/java/org/opencastproject/security/api/OrganizationParsingTest.java
@@ -21,8 +21,8 @@
 
 package org.opencastproject.security.api;
 
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/modules/common/src/test/java/org/opencastproject/util/JsonsTest.java
+++ b/modules/common/src/test/java/org/opencastproject/util/JsonsTest.java
@@ -21,11 +21,11 @@
 
 package org.opencastproject.util;
 
-import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.opencastproject.util.Jsons.NULL;
 import static org.opencastproject.util.Jsons.ZERO_ARR;
 import static org.opencastproject.util.Jsons.ZERO_OBJ;

--- a/modules/inspection-service-ffmpeg/src/test/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImplTest.java
+++ b/modules/inspection-service-ffmpeg/src/test/java/org/opencastproject/inspection/ffmpeg/MediaInspectionServiceImplTest.java
@@ -21,10 +21,10 @@
 
 package org.opencastproject.inspection.ffmpeg;
 
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.opencastproject.util.MimeType.mimeType;
 import static org.opencastproject.util.data.Option.none;

--- a/modules/kernel/src/test/java/org/opencastproject/kernel/security/TrustedAnonymousAthenticationFilterTest.java
+++ b/modules/kernel/src/test/java/org/opencastproject/kernel/security/TrustedAnonymousAthenticationFilterTest.java
@@ -29,12 +29,11 @@ import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.User;
 
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
-
-import junit.framework.Assert;
 
 /**
  * Tests the {@link TrustedAnonymousAuthenticationFilter}

--- a/modules/search-service-impl/src/test/java/org/opencastproject/feed/impl/FeedImplTest.java
+++ b/modules/search-service-impl/src/test/java/org/opencastproject/feed/impl/FeedImplTest.java
@@ -33,6 +33,7 @@ import org.opencastproject.feed.api.Person;
 
 import org.easymock.EasyMock;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -42,8 +43,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
-
-import junit.framework.Assert;
 
 public class FeedImplTest {
   private static final Logger logger = LoggerFactory.getLogger(FeedImplTest.class);

--- a/modules/videoeditor-ffmpeg-impl/src/test/java/org/opencastproject/videoeditor/ffmpeg/FFmpegTest.java
+++ b/modules/videoeditor-ffmpeg-impl/src/test/java/org/opencastproject/videoeditor/ffmpeg/FFmpegTest.java
@@ -23,6 +23,7 @@ package org.opencastproject.videoeditor.ffmpeg;
 
 import org.opencastproject.videoeditor.impl.VideoClip;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -31,8 +32,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-
-import junit.framework.Assert;
 
 /**
  * Tests the ffmpeg concatenation service

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ZipWorkflowOperationHandlerTest.java
@@ -32,6 +32,7 @@ import org.opencastproject.workflow.api.WorkflowOperationResult;
 import org.opencastproject.workspace.api.Workspace;
 
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,8 +41,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-
-import junit.framework.Assert;
 
 /**
  * Test class for {@link ZipWorkflowOperationHandler}

--- a/modules/working-file-repository-service-impl/src/test/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryTest.java
+++ b/modules/working-file-repository-service-impl/src/test/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryTest.java
@@ -34,6 +34,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.easymock.EasyMock;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,8 +43,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
-import junit.framework.Assert;
 
 public class WorkingFileRepositoryTest {
 


### PR DESCRIPTION
Several of Opencast's classes still use the old deprecated `import junit.framework.Assert` for importing JUnit classes, while they should use the new `import org.junit.Assert` instead.

This fixes #4325 

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
