### PR TITLE
Fix sched event deletion - recordings endpoint

### DIFF
--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1523,6 +1523,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
 
     try {
       index.addOrUpdateEvent(mediaPackageId, updateFunction, orgId, user);
+      index.deleteEvent(mediaPackageId, orgId);
       logger.debug("Scheduling information of event {} removed from the {} index.", mediaPackageId,
               index.getIndexName());
     } catch (SearchIndexException e) {

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1508,21 +1508,8 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
    */
   private void removeSchedulingInfoFromIndex(String mediaPackageId) {
     String orgId = getSecurityService().getOrganization().getId();
-    User user = getSecurityService().getUser();
-
-    Function<Optional<Event>, Optional<Event>> updateFunction = (Optional<Event> eventOpt) -> {
-      if (eventOpt.isEmpty()) {
-        logger.warn("Scheduled recording {} not found for deletion from the {} index.", mediaPackageId,
-                index.getIndexName());
-        return Optional.empty();
-      }
-      Event event = eventOpt.get();
-      event.setAgentId(null);
-      return Optional.of(event);
-    };
 
     try {
-      index.addOrUpdateEvent(mediaPackageId, updateFunction, orgId, user);
       index.deleteEvent(mediaPackageId, orgId);
       logger.debug("Scheduling information of event {} removed from the {} index.", mediaPackageId,
               index.getIndexName());


### PR DESCRIPTION
Scheduled events will be completly deleted instead of just removing the capture agent ID when using the DELETE /recordings/ endpoint. This fixes #4273 

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
