### PR TITLE
Correctly identify the master playlist in the Tobira harvest

### DIFF
--- a/docs/guides/admin/docs/releasenotes/master-playlist-in-tobira-harvest.txt
+++ b/docs/guides/admin/docs/releasenotes/master-playlist-in-tobira-harvest.txt
@@ -1,0 +1,5 @@
+The Tobira harvesting API now identifies the master playlist of events with multiple HLS streams.
+This is needed for example when you are using the `multiencode` operation;
+without this information, the quality selection in Paella can't work in Tobira.
+(See also [elan-ev/tobira#573](https://github.com/elan-ev/tobira/issues/573).)
+If this affects you, you need to resync your Tobira instance.

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/Item.java
@@ -235,7 +235,8 @@ class Item {
               Jsons.p("uri", track.getURI().toString()),
               Jsons.p("mimetype", track.getMimeType().toString()),
               Jsons.p("flavor", track.getFlavor().toString()),
-              Jsons.p("resolution", resolution)
+              Jsons.p("resolution", resolution),
+              Jsons.p("isMaster", track.isMaster())
           );
         })
         .collect(Collectors.toCollection(ArrayList::new));


### PR DESCRIPTION
Some events in Opencast (for example those processed by the `multiencode` operation) have multiple HLS streams in their media package. These represent different levels of quality as far
as I understand. In this case there will be one among them marked as "master," which refers to the others.

Paella (7 at least) only ever expects and works with one (the first) HLS stream, so for quality switching to work in the above situation we have to make sure to pass said "master track." However, Tobira currently has no clue which one that is.

This patch exposes the required information in Tobira's harvesting API, allowing us to make the required distinction in a follow up PR on the Tobira side.

This change is not breaking in any way: Existing Tobiras will just ignore the information. Without it, they will however exhibit elan-ev/tobira#573.

### Your pull request should…

* [x] have a concise title
* [x] ~~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~~include migration scripts and documentation, if appropriate~~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
