### PR TITLE
Do not add roleprefix to extra roles

### DIFF
--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderInstance.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderInstance.java
@@ -345,7 +345,6 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
       // Get the roles and add the extra roles
       Collection<GrantedAuthority> authorities = new HashSet<>();
       authorities.addAll(userDetails.getAuthorities());
-      authorities.addAll(setExtraRoles);
 
       Set<JaxbRole> roles = new HashSet<>();
       /*
@@ -376,6 +375,9 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
         // Finally, add the role itself
         roles.add(new JaxbRole(strAuthority, jaxbOrganization));
       }
+
+      // Add extra roles afterwards
+      setExtraRoles.forEach(r ->roles.add(new JaxbRole(r.getAuthority(), jaxbOrganization)));
 
       User user = new JaxbUser(userDetails.getUsername(), PROVIDER_NAME, jaxbOrganization, roles);
       cache.put(userName, user);


### PR DESCRIPTION
This PR fixes the ldap extra roles behavior to match the configuration file documentation. Currently, the `roleprefix` is applied to the defined extra roles.

```
However, the 'roleprefix' setting does not affect them
## -i.e. they will not be further modified even if 'roleprefix' is set.
## Defaut: <empty>
#org.opencastproject.userdirectory.ldap.extra.roles=
```

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
