### PR TITLE
Add organization properties to mail template data

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -102,16 +102,16 @@ In your email template:
 
 ### Catalog fields
 
-Use `${catalogs['SUBTYPE']['FIELD']}`
+Use `${catalogs['FLAVOR']['FIELD']}`
 
 #### Examples
 
 |Field          |How To Get It|
 |---------------|-------------|
-|episode creator|${catalogs['episode']['creator']}|
-|episode title  |${catalogs['episode']['title']}|
-|series creator |${catalogs['series']['creator']}|
-|series title   |${catalogs['series']['title']}|
+|episode creator|${catalogs['dublincore/episode']['creator']}|
+|episode title  |${catalogs['dublincore/episode']['title']}|
+|series creator |${catalogs['dublincore/series']['creator']}|
+|series title   |${catalogs['dublincore/series']['title']}|
 
 
 Examples
@@ -149,9 +149,9 @@ To and subject are inline templates; the email body uses a template file named s
   <configurations>
     <!-- This is going to be replaced with the episode catalog publisher field, which in this example it is assumed
     it contains a notification email address -->
-    <configuration key="to">${catalogs['episode']['publisher']}</configuration>
+    <configuration key="to">${catalogs['dublincore/episode']['publisher']}</configuration>
     <!-- This is going to be replaced with the episode catalog title field -->
-    <configuration key="subject">${catalogs['episode']['title']} is ready for EDIT</configuration>
+    <configuration key="subject">${catalogs['dublincore/episode']['title']} is ready for EDIT</configuration>
     <!-- Email body is going to be built using the sample template found in <config_dir>/etc/email -->
     <configuration key="body-template-file">sample</configuration>
   </configurations>
@@ -164,9 +164,9 @@ The contents of the `…/etc/email/sample` email template:
 
 ```
 Event Details
-<#if catalogs['series']?has_content>
-Series Title: ${catalogs['series']['title']}
-Instructor: ${catalogs['series']['contributor']}
+<#if catalogs['dublincore/series']?has_content>
+Series Title: ${catalogs['dublincore/series']['title']}
+Instructor: ${catalogs['dublincore/series']['contributor']}
 </#if>
 Media Package Id: ${mediaPackage.identifier}
 Title: ${mediaPackage.title}
@@ -256,7 +256,7 @@ In error handling workflow (email-error):
   description="Sends email">
     <configurations>
     <!-- Note that you can use variable substitution in to, subject, body
-         e.g. ${(catalogs['episode']['FIELD']!'root@localhost'}  -->
+         e.g. ${(catalogs['dublincore/episode']['FIELD']!'root@localhost'}  -->
     <configuration key="to">root@localhost</configuration>
     <configuration key="subject">Failure processing a mediapackage</configuration>
     <configuration key="body-template-file">errorDetails</configuration>
@@ -271,11 +271,11 @@ The contents of the <config_dir>/etc/email/errorDetails email template:
 ```
 Error Details
 
-<#if catalogs['series']?has_content>
-Course: ${catalogs['series']['subject']!'series subject missing'}-${catalogs['series']['title']!'series title missing'}
-Instructor: ${catalogs['series']['contributor']!'instructor missing'}
+<#if catalogs['dublincore/series']?has_content>
+Course: ${catalogs['dublincore/series']['subject']!'series subject missing'}-${catalogs['dublincore/series']['title']!'series title missing'}
+Instructor: ${catalogs['dublincore/series']['contributor']!'instructor missing'}
 </#if>
-Title: ${catalogs['episode']['title']!'title missing'}
+Title: ${catalogs['dublincore/episode']['title']!'title missing'}
 Event Date: ${mediaPackage.date?datetime?iso_local}
 
 <#if failedOperation?has_content>
@@ -305,7 +305,7 @@ The user name is stored in the episode dublin core `contributor` field. There's 
       fail-on-error="false"
       description="Notify user associated to this recording that it is ready to be trimmed">
       <configurations>
-        <configuration key="to">${(catalogs['episode']['contributor'])}</configuration>
+        <configuration key="to">${(catalogs['dublincore/episode']['contributor'])}</configuration>
         <configuration key="subject">Recording is ready for EDIT</configuration>
         <configuration key="body-template-file">eventDetails</configuration>
       </configurations>

--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -113,6 +113,15 @@ Use `${catalogs['FLAVOR']['FIELD']}`
 |series creator |${catalogs['dublincore/series']['creator']}|
 |series title   |${catalogs['dublincore/series']['title']}|
 
+### Organization properties
+
+Use `${organization['PROPERTY']}`
+
+#### Examples
+
+|Property  |How To Get It|
+|----------|-------------|
+|Engage URL|${organization["org.opencastproject.engage.ui.url"]}|
 
 Examples
 --------

--- a/etc/email/errorDetails
+++ b/etc/email/errorDetails
@@ -1,10 +1,10 @@
 Error Details
 
-<#if catalogs['series']?has_content>
-Course: ${catalogs['series']['subject']!'series subject missing'} - ${catalogs['series']['title']!'series title missing'}
-Instructor: ${catalogs['series']['contributor']!'instructor missing'}
+<#if catalogs['dublincore/series']?has_content>
+Course: ${catalogs['dublincore/series']['subject']!'series subject missing'} - ${catalogs['dublincore/series']['title']!'series title missing'}
+Instructor: ${catalogs['dublincore/series']['contributor']!'instructor missing'}
 </#if>
-Title: ${catalogs['episode']['title']!'title missing'}
+Title: ${catalogs['dublincore/episode']['title']!'title missing'}
 Event Date: ${mediaPackage.date?datetime?iso_local}
 
 <#if failedOperation?has_content>

--- a/modules/email-template-service-impl/pom.xml
+++ b/modules/email-template-service-impl/pom.xml
@@ -49,12 +49,41 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-index-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.fileinstall</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-elasticsearch-index</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-series-service-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-ingest-service-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-list-providers-service</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -85,6 +114,10 @@
           <ignoredUnusedDeclaredDependencies>
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-elasticsearch-index</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-series-service-api</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-ingest-service-api</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-list-providers-service</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailData.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailData.java
@@ -48,6 +48,7 @@ public class EmailData extends DocData {
   private final HashMap<String, HashMap<String, String>> catalogs;
   private final WorkflowOperationInstance failed;
   private final List<Incident> incidents;
+  private final Map<String, String> orgProperties;
 
   /**
    * Create the base data object for populating email fields.
@@ -62,9 +63,11 @@ public class EmailData extends DocData {
    *          workflow operation that caused the workflow to fail
    * @param incidents
    *          incidents
+   * @param orgProperties
+   *          organization properties
    */
   public EmailData(String name, WorkflowInstance workflow, HashMap<String, HashMap<String, String>> catalogs,
-          WorkflowOperationInstance failed, List<Incident> incidents) {
+          WorkflowOperationInstance failed, List<Incident> incidents, Map<String, String> orgProperties) {
     super(name, null, null);
 
     this.workflow = workflow;
@@ -76,6 +79,7 @@ public class EmailData extends DocData {
     this.catalogs = catalogs;
     this.failed = failed;
     this.incidents = incidents;
+    this.orgProperties = orgProperties;
   }
 
   /**
@@ -100,6 +104,7 @@ public class EmailData extends DocData {
     m.put("catalogs", catalogs);
     m.put("failedOperation", failed); // Will be null if no errors
     m.put("incident", incidents); // Will be null if no incidents
+    m.put("organization", orgProperties);
     return m;
   }
 

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailData.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailData.java
@@ -43,8 +43,8 @@ public class EmailData extends DocData {
   private final Map<String, String> workflowConfig;
   private final MediaPackage mediaPackage;
   // The hash map below looks like this:
-  // "episode" --> { "creator": "John Harvard", "type": "L05", "isPartOf": "20140224038"... }
-  // "series" --> { "creator": "Harvard", "identifier": "20140224038"... }
+  // "dublincore/episode" --> { "creator": "John Harvard", "type": "L05", "isPartOf": "20140224038"... }
+  // "dublincore/series" --> { "creator": "Harvard", "identifier": "20140224038"... }
   private final HashMap<String, HashMap<String, String>> catalogs;
   private final WorkflowOperationInstance failed;
   private final List<Incident> incidents;

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
@@ -21,11 +21,14 @@
 package org.opencastproject.email.template.impl;
 
 import org.opencastproject.email.template.api.EmailTemplateService;
+import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.job.api.Incident;
 import org.opencastproject.job.api.IncidentTree;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.metadata.dublincore.CatalogUIAdapter;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCores;
@@ -47,10 +50,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 @Component(
     immediate = true,
@@ -72,6 +80,8 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
 
   /** The incident service (to list errors in email) */
   private IncidentService incidentService = null;
+
+  private IndexService indexService;
 
   @Activate
   protected void activate(ComponentContext context) {
@@ -130,11 +140,25 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
    */
   private HashMap<String, HashMap<String, String>> initCatalogs(MediaPackage mediaPackage, String delimiter) {
     HashMap<String, HashMap<String, String>> catalogs = new HashMap<String, HashMap<String, String>>();
-    Catalog[] dcs = mediaPackage.getCatalogs(DublinCoreCatalog.ANY_DUBLINCORE);
 
-    for (int i = 0; dcs != null && i < dcs.length; i++) {
+    Set<MediaPackageElementFlavor> catalogFlavors = new HashSet<>();
+    catalogFlavors.add(indexService.getCommonEventCatalogUIAdapter().getFlavor());
+    catalogFlavors.add(indexService.getCommonSeriesCatalogUIAdapter().getFlavor());
+    catalogFlavors.addAll(indexService.getEventCatalogUIAdapters().stream()
+        .map(CatalogUIAdapter::getFlavor)
+        .collect(Collectors.toSet()));
+    catalogFlavors.addAll(indexService.getSeriesCatalogUIAdapters().stream()
+        .map(CatalogUIAdapter::getFlavor)
+        .collect(Collectors.toSet()));
+
+    Set<Catalog> catalogElements = catalogFlavors.stream()
+        .flatMap(f -> Arrays.stream(mediaPackage.getCatalogs(f)))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+
+    for (Catalog c : catalogElements) {
       DublinCoreCatalog dc;
-      try (InputStream in = workspace.read(dcs[i].getURI())) {
+      try (InputStream in = workspace.read(c.getURI())) {
         dc = DublinCores.read(in);
       } catch (Exception e) {
         logger.warn("Error when populating catalog data", e);
@@ -142,13 +166,17 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
         continue;
       }
 
-      String catalogFlavor = dcs[i].getFlavor().getSubtype();
       HashMap<String, String> catalogHash = new HashMap<>();
       for (EName ename : dc.getProperties()) {
         String name = ename.getLocalName();
         catalogHash.put(name, dc.getAsText(ename, DublinCore.LANGUAGE_ANY, delimiter));
       }
-      catalogs.put(catalogFlavor, catalogHash);
+
+      catalogs.put(c.getFlavor().toString(), catalogHash);
+      // Backwards compatibility: use only subtype of the flavor as key
+      if (c.getFlavor().getType().equals("dublincore")) {
+        catalogs.put(c.getFlavor().getSubtype(), catalogHash);
+      }
     }
 
     return catalogs;
@@ -242,4 +270,8 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
     this.incidentService = incidentService;
   }
 
+  @Reference
+  public void setIndexService(IndexService indexService) {
+    this.indexService = indexService;
+  }
 }

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
@@ -32,6 +32,8 @@ import org.opencastproject.metadata.dublincore.CatalogUIAdapter;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCores;
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.serviceregistry.api.IncidentService;
 import org.opencastproject.util.doc.DocUtil;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -55,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -82,6 +85,8 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
   private IncidentService incidentService = null;
 
   private IndexService indexService;
+
+  private SecurityService securityService;
 
   @Activate
   protected void activate(ComponentContext context) {
@@ -131,8 +136,14 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
       }
     }
 
-    return DocUtil.generate(new EmailData(templateName, workflowInstance, catalogs, failed, incidentList),
-            templateContent);
+    Map<String, String> orgProperties = null;
+    Organization org = securityService.getOrganization();
+    if (org != null) {
+      orgProperties = org.getProperties();
+    }
+
+    return DocUtil.generate(new EmailData(templateName, workflowInstance, catalogs, failed, incidentList,
+            orgProperties), templateContent);
   }
 
   /**
@@ -273,5 +284,10 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
   @Reference
   public void setIndexService(IndexService indexService) {
     this.indexService = indexService;
+  }
+
+  @Reference
+  protected void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
   }
 }

--- a/modules/email-template-service-impl/src/test/java/org/opencastproject/email/template/impl/EmailDataTest.java
+++ b/modules/email-template-service-impl/src/test/java/org/opencastproject/email/template/impl/EmailDataTest.java
@@ -57,6 +57,7 @@ public class EmailDataTest {
   private Incident incident2;
   private List<Incident> incidents;
   private URI uriMP;
+  private Map<String, String> orgProperties;
 
   @Before
   public void setUp() throws Exception {
@@ -104,6 +105,9 @@ public class EmailDataTest {
 
     failedOperation = new WorkflowOperationInstance("operation1", OperationState.FAILED);
 
+    orgProperties = new HashMap<>();
+    orgProperties.put("org.opencastproject.engage.ui.url", "http://engage.my.edu");
+
     WorkflowOperationInstance operation = new WorkflowOperationInstance("email", OperationState.RUNNING);
     List<WorkflowOperationInstance> operationList = new ArrayList<>();
     operationList.add(failedOperation);
@@ -125,7 +129,7 @@ public class EmailDataTest {
 
   @Test
   public void testToMap() throws Exception {
-    EmailData emailData = new EmailData("data1", workflowInstance, catalogs, failedOperation, incidents);
+    EmailData emailData = new EmailData("data1", workflowInstance, catalogs, failedOperation, incidents, orgProperties);
 
     Map<String, Object> map = emailData.toMap();
 
@@ -169,6 +173,11 @@ public class EmailDataTest {
     Assert.assertEquals(2, ((List) inc).size());
     Assert.assertTrue(((List) inc).contains(incident1));
     Assert.assertTrue(((List) inc).contains(incident2));
+
+    Object orgProp = map.get("organization");
+    Assert.assertNotNull(orgProp);
+    Assert.assertTrue(orgProp instanceof Map);
+    Assert.assertEquals("http://engage.my.edu", ((Map) orgProp).get("org.opencastproject.engage.ui.url"));
   }
 
 }


### PR DESCRIPTION
This allows access to organization properties in mail templates.

This is based on #4376 to prevent merge conflicts.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
