### PR TITLE
Fix Encoding Profile Type Handling in Encode WOH

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
@@ -188,12 +188,12 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
       // Encode the track with all profiles
       for (EncodingProfile profile : profiles) {
 
-        // Check if the track supports the output type of the profile
-        MediaType outputType = profile.getOutputType();
-        if (outputType.equals(MediaType.Audio) && !track.hasAudio()) {
+        // Check if the track supports the input type of the profile
+        MediaType inputType = profile.getApplicableMediaType();
+        if (inputType.equals(MediaType.Audio) && !track.hasAudio()) {
           logger.info("Skipping encoding of '{}', since it lacks an audio stream", track);
           continue;
-        } else if (outputType.equals(MediaType.Visual) && !track.hasVideo()) {
+        } else if (inputType.equals(MediaType.Visual) && !track.hasVideo()) {
           logger.info("Skipping encoding of '{}', since it lacks a video stream", track);
           continue;
         }

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/EncodeWorkflowOperationHandler.java
@@ -139,8 +139,8 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
 
     // Make sure either one of tags or flavors are provided
     if (sourceTagsOption.isEmpty() && sourceFlavorsOption.isEmpty()) {
-      logger.info("No source tags or flavors have been specified, not matching anything");
-      return createResult(mediaPackage, Action.CONTINUE);
+      logger.warn("No source tags or flavors have been specified, not matching anything");
+      return createResult(mediaPackage, Action.SKIP);
     }
 
     // Select the source flavors
@@ -207,7 +207,7 @@ public class EncodeWorkflowOperationHandler extends AbstractWorkflowOperationHan
 
     if (encodingJobs.isEmpty()) {
       logger.info("No matching tracks found");
-      return createResult(mediaPackage, Action.CONTINUE);
+      return createResult(mediaPackage, Action.SKIP);
     }
 
     // Wait for the jobs to return


### PR DESCRIPTION
@pthien1 stumbled over this  bug when trying to write an encoding profile to transform an audio file to a video file: The encode operation will be skipped unless output type is set to audio, which... isn't true. This is because the source tracks were compared to the output type of the encoding profile when they should be compared to the input type.

Additionally, in this case the workflow operation is still marked as Succeeded, even though nothing was actually encoded. 

This PR fixes #4218 as well as the underlying error.