### PR TITLE
Simplify ldap user directory implementation

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -128,6 +128,7 @@
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-aai/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-lti/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-shibboleth/${project.version}</bundle>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-security-ldap/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-series-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-serviceregistry/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-static/${project.version}</bundle>

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -783,6 +783,12 @@
   -->
 
   <!--
+  <bean id="userDetailsMapper" class="org.opencastproject.security.ldap.OpencastUserDetailsMapper">
+    <constructor-arg ref="userDetailsService" />
+  </bean>
+  -->
+
+  <!--
   <bean id="ldapAuthProvider"
     class="org.springframework.security.ldap.authentication.LdapAuthenticationProvider">
     <constructor-arg>
@@ -810,8 +816,11 @@
         - - >
       </bean>
     </constructor-arg>
+    < ! - - Retrieve user and attributes from opencasts user details service - - >
+    <property name="userDetailsContextMapper" ref="userDetailsMapper"/>
     < ! - - Defines how the user attributes are converted to authorities (roles) - - >
-    <constructor-arg ref="authoritiesPopulator" />
+    < ! - - Output is ignored if used together with userDetailsMapper - - >
+    < ! - - constructor-arg ref="authoritiesPopulator" /- - >
   </bean>
   -->
 
@@ -833,7 +842,7 @@
   <osgi:reference id="userDirectoryService" cardinality="1..1"
                   interface="org.opencastproject.security.api.UserDirectoryService" />
 
-  <!-- Uncomment this to enable LDAP -->
+  <!-- Uncomment this as an alternative to the userDetailsMapper -->
   <!-- Make sure you provide the same instanceId you used in org.opencastproject.userdirectory.ldap-….cfg -->
   <!--
   <osgi:reference id="authoritiesPopulator" cardinality="1..1"

--- a/modules/security-ldap/pom.xml
+++ b/modules/security-ldap/pom.xml
@@ -14,6 +14,21 @@
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-ldap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.ldap</groupId>
+      <artifactId>spring-ldap-core</artifactId>
+      <version>1.3.1.RELEASE</version>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
@@ -29,6 +44,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
             <Import-Package>
+              org.springframework.ldap.core;version=1.3.1.RELEASE,
               org.springframework.security.ldap;version=${spring-security.version},
               org.springframework.security.ldap.authentication;version=${spring-security.version},
               org.springframework.security.ldap.ppolicy;version=${spring-security.version},
@@ -36,6 +52,9 @@
               org.springframework.security.ldap.server;version=${spring-security.version},
               org.springframework.security.ldap.userdetails;version=${spring-security.version}
             </Import-Package>
+            <Export-Package>
+              org.opencastproject.security.ldap,
+            </Export-Package>
             <Fragment-Host>opencast-kernel</Fragment-Host>
           </instructions>
         </configuration>

--- a/modules/security-ldap/src/main/java/org/opencastproject/security/ldap/OpencastUserDetailsMapper.java
+++ b/modules/security-ldap/src/main/java/org/opencastproject/security/ldap/OpencastUserDetailsMapper.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.security.ldap;
+
+import org.springframework.ldap.core.DirContextAdapter;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.ldap.userdetails.UserDetailsContextMapper;
+
+import java.util.Collection;
+
+
+public class OpencastUserDetailsMapper implements UserDetailsContextMapper {
+
+  private UserDetailsService userDetailsService;
+
+  /**
+   * Activate component
+   *
+   * @param userDetailsService Reference to the UserDetailsService.
+   * 
+   */
+  public OpencastUserDetailsMapper(UserDetailsService userDetailsService) {
+    this.userDetailsService = userDetailsService;
+  }
+
+  public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
+      Collection<? extends GrantedAuthority> authorities) {
+    return userDetailsService.loadUserByUsername(username);
+  }
+
+  public void mapUserToContext(UserDetails user, DirContextAdapter ctx) {
+    throw new UnsupportedOperationException("OpencastUserDetailsMapper only supports reading from a context. Please"
+        + "use a subclass if mapUserToContext() is required.");
+  }
+
+}

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
@@ -149,7 +149,7 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
   /** The key to indicate a comma-separated list of extra roles to add to the authenticated user */
   private static final String EXTRA_ROLES_KEY = "org.opencastproject.userdirectory.ldap.extra.roles";
 
-  /** The key to setup a LDAP connection ID as an OSGI service property */
+  /** The key to setup an LDAP connection ID as an OSGI service property */
   private static final String INSTANCE_ID_SERVICE_PROPERTY_KEY = "instanceId";
 
   /** A map of pid to ldap user provider instance */
@@ -375,11 +375,6 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
     dict.put(INSTANCE_ID_SERVICE_PROPERTY_KEY, instanceId);
 
     // Instantiate this LDAP instance and register it as such
-    LdapUserProviderInstance provider = new LdapUserProviderInstance(pid, org, searchBase, searchFilter, url, userDn,
-            password, roleAttributes, rolePrefix, extraRoles, excludePrefixes, convertToUppercase, cacheSize,
-            cacheExpiration, securityService);
-
-    providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
 
     OpencastLdapAuthoritiesPopulator authoritiesPopulator = new OpencastLdapAuthoritiesPopulator(roleAttributes,
             rolePrefix, excludePrefixes, groupCheckPrefix, applyRoleattributesAsRoles, applyRoleattributesAsGroups,
@@ -389,6 +384,13 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
     // Also, register this instance as LdapAuthoritiesPopulator so that it can be used within the security.xml file
     authoritiesPopulatorRegistrations.put(pid,
             bundleContext.registerService(LdapAuthoritiesPopulator.class.getName(), authoritiesPopulator, dict));
+
+    LdapUserProviderInstance provider = new LdapUserProviderInstance(pid, org, searchBase, searchFilter, url, userDn,
+        password, roleAttributes, cacheSize,
+        cacheExpiration, securityService, authoritiesPopulator);
+
+    providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
+
   }
 
   /**

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderInstance.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderInstance.java
@@ -38,25 +38,21 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.ldap.DefaultSpringSecurityContextSource;
 import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
-import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
 import org.springframework.security.ldap.userdetails.LdapUserDetailsService;
 
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -73,7 +69,7 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
   public static final String PROVIDER_NAME = "ldap";
 
   /** The spring ldap userdetails service delegate */
-  private LdapUserDetailsService delegate = null;
+  private final LdapUserDetailsService delegate;
 
   /** The organization id */
   private Organization organization = null;
@@ -91,16 +87,7 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
   protected Object nullToken = new Object();
 
   /** Opencast's security service */
-  private SecurityService securityService;
-
-  /** The general role prefix, to be added to all the LDAP roles that do not start by one of the exclude prefixes */
-  private String rolePrefix;
-
-  /** A Set of roles to be added to all the users authenticated using this LDAP instance */
-  private Set<GrantedAuthority> setExtraRoles = new HashSet<>();
-
-  /** A Set of prefixes. When a role starts with any of these, the role prefix defined above will not be prepended */
-  private Set<String> setExcludePrefixes = new HashSet<>();
+  private final SecurityService securityService;
 
   /**
    * Constructs an ldap user provider with the needed settings.
@@ -121,8 +108,6 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
    *          the user credentials
    * @param roleAttributesGlob
    *          the comma separate list of ldap attributes to treat as roles or to consider for the ldapAssignmentRoleMap
-   * @param convertToUppercase
-   *          whether or not the role names will be converted to uppercase
    * @param cacheSize
    *          the number of users to cache
    * @param cacheExpiration
@@ -140,13 +125,10 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
       String userDn,
       String password,
       String roleAttributesGlob,
-      String rolePrefix,
-      String[] extraRoles,
-      String[] excludePrefixes,
-      boolean convertToUppercase,
       int cacheSize,
       int cacheExpiration,
-      SecurityService securityService
+      SecurityService securityService,
+      OpencastLdapAuthoritiesPopulator authoritiesPopulator
   ) {
     // CHECKSTYLE:ON
     this.organization = organization;
@@ -172,74 +154,7 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
     }
     FilterBasedLdapUserSearch userSearch = new FilterBasedLdapUserSearch(searchBase, searchFilter, contextSource);
     userSearch.setReturningAttributes(roleAttributesGlob.split(","));
-    delegate = new LdapUserDetailsService(userSearch);
-
-    if (StringUtils.isNotBlank(roleAttributesGlob)) {
-      LdapUserDetailsMapper mapper = new LdapUserDetailsMapper();
-
-      mapper.setConvertToUpperCase(convertToUppercase);
-
-      mapper.setRoleAttributes(roleAttributesGlob.split(","));
-
-      if (convertToUppercase) {
-        this.rolePrefix = StringUtils.trimToEmpty(rolePrefix).toUpperCase();
-      }
-      else {
-        this.rolePrefix = StringUtils.trimToEmpty(rolePrefix);
-      }
-
-      logger.debug("Role prefix set to: \"{}\"", this.rolePrefix);
-
-      // The default prefix value is "ROLE_", so we must explicitly set it to "" by default
-      // Because of the parameters extraRoles and excludePrefixes, we must add the prefix manually
-      mapper.setRolePrefix("");
-      delegate.setUserDetailsMapper(mapper);
-
-      // Process the excludePrefixes if needed
-      if (!this.rolePrefix.isEmpty()) {
-        if (excludePrefixes != null) {
-          // "Clean" the list of exclude prefixes
-          for (String excludePrefix : excludePrefixes) {
-            String cleanPrefix = excludePrefix.trim();
-            if (!cleanPrefix.isEmpty()) {
-              if (convertToUppercase) {
-                setExcludePrefixes.add(cleanPrefix.toUpperCase());
-              }
-              else {
-                setExcludePrefixes.add(cleanPrefix);
-              }
-            }
-          }
-
-          if (logger.isDebugEnabled()) {
-            if (setExcludePrefixes.size() > 0) {
-              logger.debug("Exclude prefixes set to:");
-              for (String prefix : excludePrefixes) {
-                logger.debug("\t* {}", prefix);
-              }
-            } else {
-              logger.debug("No exclude prefixes defined");
-            }
-          }
-        }
-      }
-    }
-
-    // Process extra roles
-    if (extraRoles != null) {
-      for (String extraRole : extraRoles) {
-        String finalRole = StringUtils.trimToEmpty(extraRole);
-        if (!finalRole.isEmpty()) {
-          if (convertToUppercase) {
-            setExtraRoles.add(new SimpleGrantedAuthority(finalRole.toUpperCase()));
-          } else {
-            setExtraRoles.add(new SimpleGrantedAuthority(finalRole));
-          }
-        }
-      }
-    }
-
-
+    delegate = new LdapUserDetailsService(userSearch, authoritiesPopulator);
 
     // Setup the caches
     cache = CacheBuilder.newBuilder().maximumSize(cacheSize).expireAfterWrite(cacheExpiration, TimeUnit.MINUTES)
@@ -339,43 +254,12 @@ public class LdapUserProviderInstance implements UserProvider, CachingUserProvid
         cache.put(userName, nullToken);
         return null;
       }
-
       JaxbOrganization jaxbOrganization = JaxbOrganization.fromOrganization(organization);
 
-      // Get the roles and add the extra roles
-      Collection<GrantedAuthority> authorities = new HashSet<>();
-      authorities.addAll(userDetails.getAuthorities());
-      authorities.addAll(setExtraRoles);
-
-      Set<JaxbRole> roles = new HashSet<>();
-      /*
-       * Please note the prefix logic for roles:
-       *
-       * - Roles that start with any of the "exclude prefixes" are left intact
-       * - In any other case, the "role prefix" is prepended to the roles read from LDAP
-       *
-       * This only applies to the prefix addition. The conversion to uppercase is independent from these
-       * considerations
-       */
-      for (GrantedAuthority authority : authorities) {
-        String strAuthority = authority.getAuthority();
-
-        boolean hasExcludePrefix = false;
-        for (String excludePrefix : setExcludePrefixes) {
-          if (strAuthority.startsWith(excludePrefix)) {
-            hasExcludePrefix = true;
-            break;
-          }
-        }
-        if (!hasExcludePrefix) {
-          strAuthority = rolePrefix + strAuthority;
-        }
-
-        logger.debug("Adding role " + strAuthority + " for user " + userName);
-
-        // Finally, add the role itself
-        roles.add(new JaxbRole(strAuthority, jaxbOrganization));
-      }
+      Set<JaxbRole> roles = userDetails.getAuthorities()
+          .stream()
+          .map(a -> new JaxbRole(a.getAuthority(), jaxbOrganization))
+          .collect(Collectors.toUnmodifiableSet());
 
       User user = new JaxbUser(userDetails.getUsername(), PROVIDER_NAME, jaxbOrganization, roles);
       cache.put(userName, user);

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulator.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulator.java
@@ -20,9 +20,6 @@
  */
 package org.opencastproject.userdirectory.ldap;
 
-import org.opencastproject.security.api.JaxbOrganization;
-import org.opencastproject.security.api.JaxbRole;
-import org.opencastproject.security.api.JaxbUser;
 import org.opencastproject.security.api.Organization;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.SecurityService;
@@ -270,22 +267,6 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
     }
 
     // Update the user in the security service if it matches the user whose authorities are being returned
-    if ((securityService.getOrganization().equals(organization))
-            && ((securityService.getUser() == null) || (securityService.getUser().getUsername().equals(username)))) {
-      Set<JaxbRole> roles = new HashSet<>();
-      // Get the current roles
-      for (Role existingRole : securityService.getUser().getRoles()) {
-        authorities.add(new SimpleGrantedAuthority(existingRole.getName()));
-      }
-      // Convert GrantedAuthority's into JaxbRole's
-      for (GrantedAuthority authority : authorities) {
-        roles.add(new JaxbRole(authority.getAuthority(), JaxbOrganization.fromOrganization(organization)));
-      }
-      JaxbUser user = new JaxbUser(username, LdapUserProviderInstance.PROVIDER_NAME,
-              JaxbOrganization.fromOrganization(organization), roles.toArray(new JaxbRole[0]));
-
-      securityService.setUser(user);
-    }
 
     return authorities;
   }

--- a/modules/userdirectory-ldap/src/test/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulatorTest.java
+++ b/modules/userdirectory-ldap/src/test/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulatorTest.java
@@ -607,11 +607,6 @@ public class OpencastLdapAuthoritiesPopulatorTest {
       }
     }
 
-    // Add the internal roles
-    for (Role role : DEFAULT_INTERNAL_ROLES) {
-      expectedResult.add(new SimpleGrantedAuthority(role.getName()));
-    }
-
     // Add the additional authorities
     // no prefix for roles added this way (prefix = "")
     // no group resolve for roles added this way (groupRoleProvider = null)


### PR DESCRIPTION
The previous user directory implementation was reimplementing parts of the OpencastLdapAuthoritiesPopulator.
This PR removes the same logic from the user directory and uses the OpencastLdapAuthoritiesPopulator instead.

We only use LDAP for authorization, so I could only test it with Shibboleth for authentication. The behavior did not change for us.

This PR supersede #4377

**Follow up:**

Reusing the implementation throws an IllegalStateException caused by a recursive load under certain circumstances. This is caused by enriching the LDAP roles with opencast-managed roles.
`AuthoritiesPopulator.getGrantedAuthorities->SecurityService.getUser->UserAndRoleDirectory.loadUser->AuthortitiesPopulator.getGrantedAuthorities`

```
Caused by: java.lang.IllegalStateException: Recursive load of: (mh_default_org,test)
        at com.google.common.base.Preconditions.checkState(Preconditions.java:591) ~[!/:?]
        at com.google.common.cache.LocalCache$Segment.waitForLoadingValue(LocalCache.java:2172) ~[!/:?]
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2162) ~[!/:?]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[!/:?]
        at com.google.common.cache.LocalCache.get(LocalCache.java:3962) ~[!/:?]
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3985) ~[!/:?]
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4946) ~[!/:?]
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4952) ~[!/:?]
        at org.opencastproject.userdirectory.UserAndRoleDirectoryServiceImpl.loadUser(UserAndRoleDirectoryServiceImpl.java:265) ~[?:?]
        at org.opencastproject.kernel.security.SecurityServiceSpringImpl.getUser(SecurityServiceSpringImpl.java:127) ~[?:?]
        at org.opencastproject.userdirectory.ldap.OpencastLdapAuthoritiesPopulator.getGrantedAuthorities(OpencastLdapAuthoritiesPopulator.java:274) ~[?:?]
        at org.springframework.security.ldap.userdetails.LdapUserDetailsService.loadUserByUsername(LdapUserDetailsService.java:40) ~[?:?]
        at org.opencastproject.userdirectory.ldap.LdapUserProviderInstance.loadUserFromLdap(LdapUserProviderInstance.java:252) ~[?:?]
        at org.opencastproject.userdirectory.ldap.LdapUserProviderInstance$1.load(LdapUserProviderInstance.java:164) ~[?:?]
        at org.opencastproject.userdirectory.ldap.LdapUserProviderInstance$1.load(LdapUserProviderInstance.java:161) ~[?:?]
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[!/:?]
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278) ~[!/:?]
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155) ~[!/:?]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[!/:?]
        ... 121 more

```
A solution is to implement an UserDetailsContextMapper and return the UserDetails object retrieved via the UserDetailsService.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
Closes  #4377