### PR TITLE
Prioritization of jobs from older workflows

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -97,9 +97,6 @@ public class JobDispatcher {
   /** JPA persistence unit name */
   public static final String PERSISTENCE_UNIT = "org.opencastproject.common";
 
-  /** Identifier for the workflow service */
-  public static final String TYPE_WORKFLOW = "org.opencastproject.workflow";
-
   /** Configuration key for the dispatch interval, in seconds */
   protected static final String OPT_DISPATCHINTERVAL = "dispatch.interval";
 

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -656,9 +656,8 @@ public class JobDispatcher {
     public int compare(JpaJob jobA, JpaJob jobB) {
 
       //Prioritize jobs from older root jobs
-      if (jobA.getRootJob() != null && jobB.getRootJob() != null && jobA.getRootJob().getDateCreated() != null && jobB.getRootJob().getDateCreated() != null) {
+      if (jobA.getRootJob() != null && jobB.getRootJob() != null && jobA.getRootJob().getDateCreated() != null && jobB.getRootJob().getDateCreated() != null)
         return jobA.getRootJob().getDateCreated().compareTo(jobB.getRootJob().getDateCreated());
-      }
 
       // undecided
       return 0;

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -310,13 +310,13 @@ public class JobDispatcher {
           }
 
           //Prioritization of jobs from older workflows
-          dispatchableJobs.sort(new workflowPriorizationComparator());
+          dispatchableJobs.sort(new WorkflowPriorizationComparator());
           dispatchDispatchableJobs(em, dispatchableJobs);
         } while (jobsFound);
 
         if (!workflowJobs.isEmpty()) {
           //Prioritization of jobs from older workflows
-          workflowJobs.sort(new workflowPriorizationComparator());
+          workflowJobs.sort(new WorkflowPriorizationComparator());
           dispatchDispatchableJobs(em, workflowJobs);
         }
 
@@ -653,14 +653,14 @@ public class JobDispatcher {
   /**
    * Comparator that will sort jobs according to to the age of the workflows that evoked them. Jobs from older workflows are prioratized.
    */
-  static final class workflowPriorizationComparator implements Comparator<JpaJob> {
+  static final class WorkflowPriorizationComparator implements Comparator<JpaJob> {
 
     @Override
     public int compare(JpaJob jobA, JpaJob jobB) {
 
       //Prioritize jobs from older root jobs
-      if (jobA.getRootJob() != null && jobB.getRootJob() != null && jobA.getRootJob().getDateCreated() != null && jobB.getRootJob().getDateCreated() != null ) {
-        return jobA.getRootJob().getDateCreated().compareTo( jobB.getRootJob().getDateCreated());
+      if (jobA.getRootJob() != null && jobB.getRootJob() != null && jobA.getRootJob().getDateCreated() != null && jobB.getRootJob().getDateCreated() != null) {
+        return jobA.getRootJob().getDateCreated().compareTo(jobB.getRootJob().getDateCreated());
       }
 
       // undecided

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -567,6 +567,13 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       em.persist(jpaJob);
       tx.commit();
 
+      if (parentJob == null){
+        tx.begin();
+        jpaJob.setRootJob(jpaJob);
+        em.persist(jpaJob);
+        tx.commit();
+      }
+
       setJobUri(jpaJob);
       Job job = jpaJob.toJob();
       return job;

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -568,7 +568,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       tx.commit();
 
       //Jobs with out a parent are there own root. The Job ID is created at the time of persisting so this operation needs to be its own transaction
-      if (parentJob == null){
+      if (parentJob == null) {
         tx.begin();
         jpaJob.setRootJob(jpaJob);
         em.persist(jpaJob);

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -567,14 +567,6 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       em.persist(jpaJob);
       tx.commit();
 
-      //Jobs with out a parent are there own root. The Job ID is created at the time of persisting so this operation needs to be its own transaction
-      if (parentJob == null) {
-        tx.begin();
-        jpaJob.setRootJob(jpaJob);
-        em.persist(jpaJob);
-        tx.commit();
-      }
-
       setJobUri(jpaJob);
       Job job = jpaJob.toJob();
       return job;

--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/ServiceRegistryJpaImpl.java
@@ -567,6 +567,7 @@ public class ServiceRegistryJpaImpl implements ServiceRegistry, ManagedService {
       em.persist(jpaJob);
       tx.commit();
 
+      //Jobs with out a parent are there own root. The Job ID is created at the time of persisting so this operation needs to be its own transaction
       if (parentJob == null){
         tx.begin();
         jpaJob.setRootJob(jpaJob);

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -675,8 +675,14 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
 
     try {
       logger.info("Scheduling workflow %s for execution", workflow.getId());
-      Job job = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(),
-              Collections.singletonList(Long.toString(workflow.getId())), null, false, null, WORKFLOW_JOB_LOAD);
+      Job job = null;
+      if (serviceRegistry.getJob(workflow.getId()) != null) {
+        job = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(), Collections.singletonList(Long.toString(workflow.getId())), null, false,
+            serviceRegistry.getJob(workflow.getId()), WORKFLOW_JOB_LOAD);
+      } else {
+        job = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(), Collections.singletonList(Long.toString(workflow.getId())), null, false,
+            null, WORKFLOW_JOB_LOAD);
+      }
       operation.setId(job.getId());
       update(workflow);
       job.setStatus(Status.QUEUED);
@@ -784,8 +790,13 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
         case FAILING:
         case RUNNING:
           try {
-            job = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(),
-                    Collections.singletonList(Long.toString(workflow.getId())), null, false, null, WORKFLOW_JOB_LOAD);
+            if (serviceRegistry.getJob(workflow.getId()) != null){
+              job = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(),
+                  Collections.singletonList(Long.toString(workflow.getId())), null, false, serviceRegistry.getJob(workflow.getId()) , WORKFLOW_JOB_LOAD);
+            } else {
+              job = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(),
+                  Collections.singletonList(Long.toString(workflow.getId())), null, false, null , WORKFLOW_JOB_LOAD);
+            }
             currentOperation.setId(job.getId());
             update(workflow);
             job.setStatus(Status.QUEUED);
@@ -1041,8 +1052,13 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
     if (OperationState.INSTANTIATED.equals(currentOperation.getState())) {
       try {
         // the operation has its own job. Update that too.
-        Job operationJob = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(),
-                Collections.singletonList(Long.toString(workflowInstanceId)), null, false, null, WORKFLOW_JOB_LOAD);
+        Job operationJob = null;
+        if (serviceRegistry.getJob(workflowInstance.getId()) != null) {
+          operationJob = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(), Collections.singletonList(Long.toString(workflowInstance.getId())), null, false,
+              serviceRegistry.getJob(workflowInstance.getId()), WORKFLOW_JOB_LOAD);
+        } else {
+          operationJob = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(), Collections.singletonList(Long.toString(workflowInstanceId)), null, false, null, WORKFLOW_JOB_LOAD);
+        }
 
         // this method call is publicly visible, so it doesn't necessarily go through the accept method. Set the
         // workflow state manually.

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -790,7 +790,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
         case FAILING:
         case RUNNING:
           try {
-            if (serviceRegistry.getJob(workflow.getId()) != null){
+            if (serviceRegistry.getJob(workflow.getId()) != null) {
               job = serviceRegistry.createJob(JOB_TYPE, Operation.START_OPERATION.toString(),
                   Collections.singletonList(Long.toString(workflow.getId())), null, false, serviceRegistry.getJob(workflow.getId()) , WORKFLOW_JOB_LOAD);
             } else {


### PR DESCRIPTION
**This PR modifies the job dispatching to prioritize jobs from older workflows.**

### Technical explanation:
The job dispatcher uses three lists where the queued jobs are stored. 1) Restarted jobs 2) "normal" jobs 3) jobs from the workflow service. The lists are handled in this order.
This PR adds a comparator to order the last two lists by the time, when there related workflow has been started. By changing the order inside this lists the jobs from older workflows get handled earlier.

To be able to sort the jobs by the starting date of the related workflows, it's necessary to be able to match jobs against there related workflow. To achieve that the rootJob field every job object already has was used. Previously this field wasn't really set. To activate this field, the workflow service was modified in three places of job creation, to set this field.
The START_WORKFLOW job of each workflow is used as the rootJob for other jobs.
In cases, where a root job is missing the comparator leaves the order of the list untouched.


### TL;DR
The job queues are FIFO on a workflow level.