### PR TITLE
Add support for multipart mails using text and HTML

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -102,16 +102,16 @@ In your email template:
 
 ### Catalog fields
 
-Use `${catalogs['SUBTYPE']['FIELD']}`
+Use `${catalogs['FLAVOR']['FIELD']}`
 
 #### Examples
 
 |Field          |How To Get It|
 |---------------|-------------|
-|episode creator|${catalogs['episode']['creator']}|
-|episode title  |${catalogs['episode']['title']}|
-|series creator |${catalogs['series']['creator']}|
-|series title   |${catalogs['series']['title']}|
+|episode creator|${catalogs['dublincore/episode']['creator']}|
+|episode title  |${catalogs['dublincore/episode']['title']}|
+|series creator |${catalogs['dublincore/series']['creator']}|
+|series title   |${catalogs['dublincore/series']['title']}|
 
 
 Examples
@@ -149,9 +149,9 @@ To and subject are inline templates; the email body uses a template file named s
   <configurations>
     <!-- This is going to be replaced with the episode catalog publisher field, which in this example it is assumed
     it contains a notification email address -->
-    <configuration key="to">${catalogs['episode']['publisher']}</configuration>
+    <configuration key="to">${catalogs['dublincore/episode']['publisher']}</configuration>
     <!-- This is going to be replaced with the episode catalog title field -->
-    <configuration key="subject">${catalogs['episode']['title']} is ready for EDIT</configuration>
+    <configuration key="subject">${catalogs['dublincore/episode']['title']} is ready for EDIT</configuration>
     <!-- Email body is going to be built using the sample template found in <config_dir>/etc/email -->
     <configuration key="body-template-file">sample</configuration>
   </configurations>
@@ -164,9 +164,9 @@ The contents of the `…/etc/email/sample` email template:
 
 ```
 Event Details
-<#if catalogs['series']?has_content>
-Series Title: ${catalogs['series']['title']}
-Instructor: ${catalogs['series']['contributor']}
+<#if catalogs['dublincore/series']?has_content>
+Series Title: ${catalogs['dublincore/series']['title']}
+Instructor: ${catalogs['dublincore/series']['contributor']}
 </#if>
 Media Package Id: ${mediaPackage.identifier}
 Title: ${mediaPackage.title}
@@ -256,7 +256,7 @@ In error handling workflow (email-error):
   description="Sends email">
     <configurations>
     <!-- Note that you can use variable substitution in to, subject, body
-         e.g. ${(catalogs['episode']['FIELD']!'root@localhost'}  -->
+         e.g. ${(catalogs['dublincore/episode']['FIELD']!'root@localhost'}  -->
     <configuration key="to">root@localhost</configuration>
     <configuration key="subject">Failure processing a mediapackage</configuration>
     <configuration key="body-template-file">errorDetails</configuration>
@@ -271,11 +271,11 @@ The contents of the <config_dir>/etc/email/errorDetails email template:
 ```
 Error Details
 
-<#if catalogs['series']?has_content>
-Course: ${catalogs['series']['subject']!'series subject missing'}-${catalogs['series']['title']!'series title missing'}
-Instructor: ${catalogs['series']['contributor']!'instructor missing'}
+<#if catalogs['dublincore/series']?has_content>
+Course: ${catalogs['dublincore/series']['subject']!'series subject missing'}-${catalogs['dublincore/series']['title']!'series title missing'}
+Instructor: ${catalogs['dublincore/series']['contributor']!'instructor missing'}
 </#if>
-Title: ${catalogs['episode']['title']!'title missing'}
+Title: ${catalogs['dublincore/episode']['title']!'title missing'}
 Event Date: ${mediaPackage.date?datetime?iso_local}
 
 <#if failedOperation?has_content>
@@ -305,7 +305,7 @@ The user name is stored in the episode dublin core `contributor` field. There's 
       fail-on-error="false"
       description="Notify user associated to this recording that it is ready to be trimmed">
       <configurations>
-        <configuration key="to">${(catalogs['episode']['contributor'])}</configuration>
+        <configuration key="to">${(catalogs['dublincore/episode']['contributor'])}</configuration>
         <configuration key="subject">Recording is ready for EDIT</configuration>
         <configuration key="body-template-file">eventDetails</configuration>
       </configurations>

--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -28,8 +28,8 @@ Parameter Table
 |------------------|-------|-----------|-------------|
 |body|Email body content.<br>Takes precedence over body-template-file.|`<Recording Title> (<Mediapackage ID>)`|Lecture 1 (4bf316fc-ea78-4903-b00e-9976b0912e4d)|
 |body-template-file|Name of file that will be used as a template for the content of the email body.|EMPTY|templateName|
-|body-html|Email body content send as HTML.<br>Takes precedence over body-template-file-html.|EMPTY|`<h1>${mediapackage.identifier}</h1>`|
-|body-template-file-html|Name of file that will be used as a template for the HTML content of the email body.|EMPTY|templateNameHTML|
+|body-html|Email body content send as HTML.<br>Takes precedence over body-html-template-file.|EMPTY|`<h1>${mediapackage.identifier}</h1>`|
+|body-html-template-file|Name of file that will be used as a template for the HTML content of the email body.|EMPTY|templateNameHTML|
 |subject|Email subject.|EMPTY|Operation has been completed|
 |to|The field `to` of the email<br>i.e. the comma separated list of email accounts the email will be sent to.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |cc|The field `cc` of the email<br>i.e. the comma separated list of email accounts that will receive a carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|

--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -113,6 +113,15 @@ Use `${catalogs['FLAVOR']['FIELD']}`
 |series creator |${catalogs['dublincore/series']['creator']}|
 |series title   |${catalogs['dublincore/series']['title']}|
 
+### Organization properties
+
+Use `${organization['PROPERTY']}`
+
+#### Examples
+
+|Property  |How To Get It|
+|----------|-------------|
+|Engage URL|${organization["org.opencastproject.engage.ui.url"]}|
 
 Examples
 --------

--- a/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/send-email-woh.md
@@ -28,16 +28,18 @@ Parameter Table
 |------------------|-------|-----------|-------------|
 |body|Email body content.<br>Takes precedence over body-template-file.|`<Recording Title> (<Mediapackage ID>)`|Lecture 1 (4bf316fc-ea78-4903-b00e-9976b0912e4d)|
 |body-template-file|Name of file that will be used as a template for the content of the email body.|EMPTY|templateName|
+|body-html|Email body content send as HTML.<br>Takes precedence over body-template-file-html.|EMPTY|`<h1>${mediapackage.identifier}</h1>`|
+|body-template-file-html|Name of file that will be used as a template for the HTML content of the email body.|EMPTY|templateNameHTML|
 |subject|Email subject.|EMPTY|Operation has been completed|
 |to|The field `to` of the email<br>i.e. the comma separated list of email accounts the email will be sent to.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |cc|The field `cc` of the email<br>i.e. the comma separated list of email accounts that will receive a carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
 |bcc|The field `bcc` of the email<br>i.e. the comma separated list of email accounts that will receive a blind carbon copy of the email.|EMPTY|email-account@email-domain.org,second-account@second-domain.org|
-|use-html|Flag to indicate that the email content should be displayed as 'text/html'|false|true/false|
 |address-separator|Separator to use for splitting a string into separate email addresses|`, <tab>`|`,`|
 |skip-invalid-address|If the operation should skip invalid addresses instead of failing|false|true/false|
 
 **Some other email parameters can be customized in the SMTP Service configuration**
 
+If both a text and HTML body is set, a multipart email body is sent.
 
 Variable Substitution
 ---------------------

--- a/etc/email/errorDetails
+++ b/etc/email/errorDetails
@@ -1,10 +1,10 @@
 Error Details
 
-<#if catalogs['series']?has_content>
-Course: ${catalogs['series']['subject']!'series subject missing'} - ${catalogs['series']['title']!'series title missing'}
-Instructor: ${catalogs['series']['contributor']!'instructor missing'}
+<#if catalogs['dublincore/series']?has_content>
+Course: ${catalogs['dublincore/series']['subject']!'series subject missing'} - ${catalogs['dublincore/series']['title']!'series title missing'}
+Instructor: ${catalogs['dublincore/series']['contributor']!'instructor missing'}
 </#if>
-Title: ${catalogs['episode']['title']!'title missing'}
+Title: ${catalogs['dublincore/episode']['title']!'title missing'}
 Event Date: ${mediaPackage.date?datetime?iso_local}
 
 <#if failedOperation?has_content>

--- a/modules/email-template-service-impl/pom.xml
+++ b/modules/email-template-service-impl/pom.xml
@@ -49,12 +49,41 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-index-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.fileinstall</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-elasticsearch-index</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-series-service-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-ingest-service-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-list-providers-service</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -85,6 +114,10 @@
           <ignoredUnusedDeclaredDependencies>
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-elasticsearch-index</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-series-service-api</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-ingest-service-api</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.opencastproject:opencast-list-providers-service</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailData.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailData.java
@@ -48,6 +48,7 @@ public class EmailData extends DocData {
   private final HashMap<String, HashMap<String, String>> catalogs;
   private final WorkflowOperationInstance failed;
   private final List<Incident> incidents;
+  private final Map<String, String> orgProperties;
 
   /**
    * Create the base data object for populating email fields.
@@ -62,9 +63,11 @@ public class EmailData extends DocData {
    *          workflow operation that caused the workflow to fail
    * @param incidents
    *          incidents
+   * @param orgProperties
+   *          organization properties
    */
   public EmailData(String name, WorkflowInstance workflow, HashMap<String, HashMap<String, String>> catalogs,
-          WorkflowOperationInstance failed, List<Incident> incidents) {
+          WorkflowOperationInstance failed, List<Incident> incidents, Map<String, String> orgProperties) {
     super(name, null, null);
 
     this.workflow = workflow;
@@ -76,6 +79,7 @@ public class EmailData extends DocData {
     this.catalogs = catalogs;
     this.failed = failed;
     this.incidents = incidents;
+    this.orgProperties = orgProperties;
   }
 
   /**
@@ -100,6 +104,7 @@ public class EmailData extends DocData {
     m.put("catalogs", catalogs);
     m.put("failedOperation", failed); // Will be null if no errors
     m.put("incident", incidents); // Will be null if no incidents
+    m.put("organization", orgProperties);
     return m;
   }
 

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailData.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailData.java
@@ -43,8 +43,8 @@ public class EmailData extends DocData {
   private final Map<String, String> workflowConfig;
   private final MediaPackage mediaPackage;
   // The hash map below looks like this:
-  // "episode" --> { "creator": "John Harvard", "type": "L05", "isPartOf": "20140224038"... }
-  // "series" --> { "creator": "Harvard", "identifier": "20140224038"... }
+  // "dublincore/episode" --> { "creator": "John Harvard", "type": "L05", "isPartOf": "20140224038"... }
+  // "dublincore/series" --> { "creator": "Harvard", "identifier": "20140224038"... }
   private final HashMap<String, HashMap<String, String>> catalogs;
   private final WorkflowOperationInstance failed;
   private final List<Incident> incidents;

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
@@ -21,11 +21,14 @@
 package org.opencastproject.email.template.impl;
 
 import org.opencastproject.email.template.api.EmailTemplateService;
+import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.job.api.Incident;
 import org.opencastproject.job.api.IncidentTree;
 import org.opencastproject.mediapackage.Catalog;
 import org.opencastproject.mediapackage.EName;
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.metadata.dublincore.CatalogUIAdapter;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCores;
@@ -47,10 +50,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 @Component(
     immediate = true,
@@ -72,6 +80,8 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
 
   /** The incident service (to list errors in email) */
   private IncidentService incidentService = null;
+
+  private IndexService indexService;
 
   @Activate
   protected void activate(ComponentContext context) {
@@ -130,11 +140,25 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
    */
   private HashMap<String, HashMap<String, String>> initCatalogs(MediaPackage mediaPackage, String delimiter) {
     HashMap<String, HashMap<String, String>> catalogs = new HashMap<String, HashMap<String, String>>();
-    Catalog[] dcs = mediaPackage.getCatalogs(DublinCoreCatalog.ANY_DUBLINCORE);
 
-    for (int i = 0; dcs != null && i < dcs.length; i++) {
+    Set<MediaPackageElementFlavor> catalogFlavors = new HashSet<>();
+    catalogFlavors.add(indexService.getCommonEventCatalogUIAdapter().getFlavor());
+    catalogFlavors.add(indexService.getCommonSeriesCatalogUIAdapter().getFlavor());
+    catalogFlavors.addAll(indexService.getEventCatalogUIAdapters().stream()
+        .map(CatalogUIAdapter::getFlavor)
+        .collect(Collectors.toSet()));
+    catalogFlavors.addAll(indexService.getSeriesCatalogUIAdapters().stream()
+        .map(CatalogUIAdapter::getFlavor)
+        .collect(Collectors.toSet()));
+
+    Set<Catalog> catalogElements = catalogFlavors.stream()
+        .flatMap(f -> Arrays.stream(mediaPackage.getCatalogs(f)))
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+
+    for (Catalog c : catalogElements) {
       DublinCoreCatalog dc;
-      try (InputStream in = workspace.read(dcs[i].getURI())) {
+      try (InputStream in = workspace.read(c.getURI())) {
         dc = DublinCores.read(in);
       } catch (Exception e) {
         logger.warn("Error when populating catalog data", e);
@@ -142,13 +166,17 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
         continue;
       }
 
-      String catalogFlavor = dcs[i].getFlavor().getSubtype();
       HashMap<String, String> catalogHash = new HashMap<>();
       for (EName ename : dc.getProperties()) {
         String name = ename.getLocalName();
         catalogHash.put(name, dc.getAsText(ename, DublinCore.LANGUAGE_ANY, delimiter));
       }
-      catalogs.put(catalogFlavor, catalogHash);
+
+      catalogs.put(c.getFlavor().toString(), catalogHash);
+      // Backwards compatibility: use only subtype of the flavor as key
+      if (c.getFlavor().getType().equals("dublincore")) {
+        catalogs.put(c.getFlavor().getSubtype(), catalogHash);
+      }
     }
 
     return catalogs;
@@ -242,4 +270,8 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
     this.incidentService = incidentService;
   }
 
+  @Reference
+  public void setIndexService(IndexService indexService) {
+    this.indexService = indexService;
+  }
 }

--- a/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
+++ b/modules/email-template-service-impl/src/main/java/org/opencastproject/email/template/impl/EmailTemplateServiceImpl.java
@@ -32,6 +32,8 @@ import org.opencastproject.metadata.dublincore.CatalogUIAdapter;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCores;
+import org.opencastproject.security.api.Organization;
+import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.serviceregistry.api.IncidentService;
 import org.opencastproject.util.doc.DocUtil;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -55,6 +57,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -82,6 +85,8 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
   private IncidentService incidentService = null;
 
   private IndexService indexService;
+
+  private SecurityService securityService;
 
   @Activate
   protected void activate(ComponentContext context) {
@@ -131,8 +136,14 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
       }
     }
 
-    return DocUtil.generate(new EmailData(templateName, workflowInstance, catalogs, failed, incidentList),
-            templateContent);
+    Map<String, String> orgProperties = null;
+    Organization org = securityService.getOrganization();
+    if (org != null) {
+      orgProperties = org.getProperties();
+    }
+
+    return DocUtil.generate(new EmailData(templateName, workflowInstance, catalogs, failed, incidentList,
+            orgProperties), templateContent);
   }
 
   /**
@@ -273,5 +284,10 @@ public class EmailTemplateServiceImpl implements EmailTemplateService {
   @Reference
   public void setIndexService(IndexService indexService) {
     this.indexService = indexService;
+  }
+
+  @Reference
+  protected void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
   }
 }

--- a/modules/email-template-service-impl/src/test/java/org/opencastproject/email/template/impl/EmailDataTest.java
+++ b/modules/email-template-service-impl/src/test/java/org/opencastproject/email/template/impl/EmailDataTest.java
@@ -57,6 +57,7 @@ public class EmailDataTest {
   private Incident incident2;
   private List<Incident> incidents;
   private URI uriMP;
+  private Map<String, String> orgProperties;
 
   @Before
   public void setUp() throws Exception {
@@ -104,6 +105,9 @@ public class EmailDataTest {
 
     failedOperation = new WorkflowOperationInstance("operation1", OperationState.FAILED);
 
+    orgProperties = new HashMap<>();
+    orgProperties.put("org.opencastproject.engage.ui.url", "http://engage.my.edu");
+
     WorkflowOperationInstance operation = new WorkflowOperationInstance("email", OperationState.RUNNING);
     List<WorkflowOperationInstance> operationList = new ArrayList<>();
     operationList.add(failedOperation);
@@ -125,7 +129,7 @@ public class EmailDataTest {
 
   @Test
   public void testToMap() throws Exception {
-    EmailData emailData = new EmailData("data1", workflowInstance, catalogs, failedOperation, incidents);
+    EmailData emailData = new EmailData("data1", workflowInstance, catalogs, failedOperation, incidents, orgProperties);
 
     Map<String, Object> map = emailData.toMap();
 
@@ -169,6 +173,11 @@ public class EmailDataTest {
     Assert.assertEquals(2, ((List) inc).size());
     Assert.assertTrue(((List) inc).contains(incident1));
     Assert.assertTrue(((List) inc).contains(incident2));
+
+    Object orgProp = map.get("organization");
+    Assert.assertNotNull(orgProp);
+    Assert.assertTrue(orgProp instanceof Map);
+    Assert.assertEquals("http://engage.my.edu", ((Map) orgProp).get("org.opencastproject.engage.ui.url"));
   }
 
 }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/mail/SmtpService.java
@@ -34,7 +34,9 @@ import java.util.Dictionary;
 import javax.mail.Message.RecipientType;
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
 
 /**
  * OSGi service that allows to send e-mails using <code>javax.mail</code>.
@@ -61,6 +63,9 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    * Pattern to split strings containing lists of emails. This pattern matches any number of contiguous spaces or commas
    */
   private static final String SPLIT_PATTERN = "[\\s,]+";
+
+  /** Define the MIME type for text mail content */
+  private static final String TEXT_PLAIN = "text/plain; charset=UTF-8";
 
   /** Define the MIME type for HTML mail content */
   private static final String TEXT_HTML = "text/html";
@@ -171,13 +176,13 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *          Recipient of the message
    * @param subject
    *          Subject of the message
-   * @param body
-   *          Body of the message
+   * @param bodyText
+   *          Text body of the message (null if there should be no text part)
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String to, String subject, String body) throws MessagingException {
-    send(to, subject, body, false);
+  public void send(String to, String subject, String bodyText) throws MessagingException {
+    send(to, subject, bodyText, null);
   }
 
   /**
@@ -187,24 +192,15 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *          Recipient of the message
    * @param subject
    *          Subject of the message
-   * @param body
-   *          Body of the message
-   * @param isHTML
-   *          Is the body of the message in HTML
+   * @param bodyText
+   *          Text body of the message (null if there should be no text part)
+   * @param bodyHTML
+   *          HTML body of the message (null if there should be no HTML part)
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String to, String subject, String body, Boolean isHTML) throws MessagingException {
-    MimeMessage message = createMessage();
-    message.addRecipient(RecipientType.TO, new InternetAddress(to));
-    message.setSubject(subject);
-    if (isHTML) {
-        message.setContent(body, TEXT_HTML);
-    } else {
-        message.setText(body);
-    }
-    message.saveChanges();
-    send(message);
+  public void send(String to, String subject, String bodyText, String bodyHTML) throws MessagingException {
+    send(to, null, null, subject, bodyText, bodyHTML);
   }
 
   /**
@@ -218,13 +214,13 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *          "BCC:" message recipient(s), separated by commas and/or spaces
    * @param subject
    *          Subject of the message
-   * @param body
-   *          Body of the message
+   * @param bodyText
+   *          Text body of the message (null if there should be no text part)
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String to, String cc, String bcc, String subject, String body) throws MessagingException {
-    send(to, cc, bcc, subject, body, false);
+  public void send(String to, String cc, String bcc, String subject, String bodyText) throws MessagingException {
+    send(to, cc, bcc, subject, bodyText, null);
   }
 
   /**
@@ -238,14 +234,14 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *          "BCC:" message recipient(s), separated by commas and/or spaces
    * @param subject
    *          Subject of the message
-   * @param body
-   *          Body of the message
-   * @param isHTML
-   *          Is the body of the message in HTML
+   * @param bodyText
+   *          Text body of the message (null if there should be no text part)
+   * @param bodyHTML
+   *          HTML body of the message (null if there should be no HTML part)
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String to, String cc, String bcc, String subject, String body, Boolean isHTML) throws MessagingException {
+  public void send(String to, String cc, String bcc, String subject, String bodyText, String bodyHTML) throws MessagingException {
     String[] toArray = null;
     String[] ccArray = null;
     String[] bccArray = null;
@@ -259,7 +255,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
     if (bcc != null)
       bccArray = bcc.trim().split(SPLIT_PATTERN, 0);
 
-    send(toArray, ccArray, bccArray, subject, body, isHTML);
+    send(toArray, ccArray, bccArray, subject, bodyText, bodyHTML);
   }
 
   /**
@@ -273,13 +269,13 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *          Array with the "BCC:" recipients of the message
    * @param subject
    *          Subject of the message
-   * @param body
-   *          Body of the message
+   * @param bodyText
+   *          Text body of the message (null if there should be no text part)
    * @throws MessagingException
    *           if sending the message failed
    */
-  public void send(String[] to, String[] cc, String[] bcc, String subject, String body) throws MessagingException {
-    send(to, cc, bcc, subject, body, false);
+  public void send(String[] to, String[] cc, String[] bcc, String subject, String bodyText) throws MessagingException {
+    send(to, cc, bcc, subject, bodyText, null);
   }
 
   /**
@@ -293,24 +289,39 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *          Array with the "BCC:" recipients of the message
    * @param subject
    *          Subject of the message
-   * @param body
-   *          Body of the message
-   * @param isHTML
-   *          Is the body of the message in HTML
+   * @param bodyText
+   *          Text body of the message (null if there should be no text part)
+   * @param bodyHTML
+   *          HTML body of the message (null if there should be no HTML part)
    * @throws MessagingException
-   *           if sending the message failed
+   *          if sending the message failed
+   * @throws IllegalArgumentException
+   *          if both bodyText and bodyHTML are null
    */
-  public void send(String[] to, String[] cc, String[] bcc, String subject, String body, boolean isHTML) throws MessagingException {
+  public void send(String[] to, String[] cc, String[] bcc, String subject, String bodyText, String bodyHTML) throws MessagingException {
+    if (bodyText == null && bodyHTML == null) {
+      throw new IllegalArgumentException("bodyText and bodyHTML cannot both be empty");
+    }
+
     MimeMessage message = createMessage();
     addRecipients(message, RecipientType.TO, to);
     addRecipients(message, RecipientType.CC, cc);
     addRecipients(message, RecipientType.BCC, bcc);
     message.setSubject(subject);
-    if (isHTML) {
-        message.setContent(body, TEXT_HTML);
-    } else {
-        message.setText(body);
+
+    MimeMultipart mp = new MimeMultipart("alternative");
+    // the text/plain part needs to be added first!
+    if (bodyText != null) {
+      MimeBodyPart part = new MimeBodyPart();
+      part.setContent(bodyText, TEXT_PLAIN);
+      mp.addBodyPart(part);
     }
+    if (bodyHTML != null) {
+      MimeBodyPart part = new MimeBodyPart();
+      part.setContent(bodyHTML, TEXT_HTML);
+      mp.addBodyPart(part);
+    }
+    message.setContent(mp);
     message.saveChanges();
     send(message);
   }
@@ -322,7 +333,7 @@ public class SmtpService extends BaseSmtpService implements ManagedService {
    *          The message to add the recipients to
    * @param type
    *          The type of recipient
-   * @param addresses
+   * @param strAddresses
    * @throws MessagingException
    */
   private static void addRecipients(MimeMessage message, RecipientType type, String... strAddresses)

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -80,9 +80,9 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
   static final String BCC_PROPERTY = "bcc";
   static final String SUBJECT_PROPERTY = "subject";
   static final String BODY_PROPERTY = "body";
-  static final String BODY_HTML_PROPERTY = "body-html";
   static final String BODY_TEMPLATE_FILE_PROPERTY = "body-template-file";
-  static final String BODY_TEMPLATE_FILE_HTML_PROPERTY = "body-template-file-html";
+  static final String BODY_HTML_PROPERTY = "body-html";
+  static final String BODY_HTML_TEMPLATE_FILE_PROPERTY = "body-html-template-file";
   static final String ADDRESS_SEPARATOR_PROPERTY = "address-separator";
   static final String ADDRESS_SEPARATOR_DEFAULT = ", \t";
   static final String SKIP_INVALID_ADDRESS_PROPERTY = "skip-invalid-address";
@@ -125,15 +125,15 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
     String subject = applyTemplateIfNecessary(workflowInstance, operation, SUBJECT_PROPERTY);
 
     String bodyCfg = operation.getConfiguration(BODY_PROPERTY);
-    String bodyHtmlCfg = operation.getConfiguration(BODY_HTML_PROPERTY);
     String bodyTemplateFileCfg = operation.getConfiguration(BODY_TEMPLATE_FILE_PROPERTY);
-    String bodyTemplateFileHtmlCfg = operation.getConfiguration(BODY_TEMPLATE_FILE_HTML_PROPERTY);
+    String bodyHtmlCfg = operation.getConfiguration(BODY_HTML_PROPERTY);
+    String bodyHtmlTemplateFileCfg = operation.getConfiguration(BODY_HTML_TEMPLATE_FILE_PROPERTY);
 
     String bodyText = null;
     String bodyHTML = null;
 
     // Body informed? If not, use the default.
-    if (bodyCfg == null && bodyHtmlCfg == null && bodyTemplateFileCfg == null && bodyTemplateFileHtmlCfg == null) {
+    if (bodyCfg == null && bodyHtmlCfg == null && bodyTemplateFileCfg == null && bodyHtmlTemplateFileCfg == null) {
       // Set the body of the message to be the ID of the media package
       bodyText = String.format("%s (%s)", srcPackage.getTitle(), srcPackage.getIdentifier());
     }
@@ -146,8 +146,8 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
 
     if (bodyHtmlCfg != null) {
       bodyHTML = applyTemplateIfNecessary(workflowInstance, operation, BODY_HTML_PROPERTY);
-    } else if (bodyTemplateFileHtmlCfg != null) {
-      bodyHTML = applyTemplateIfNecessary(workflowInstance, operation, BODY_TEMPLATE_FILE_HTML_PROPERTY);
+    } else if (bodyHtmlTemplateFileCfg != null) {
+      bodyHTML = applyTemplateIfNecessary(workflowInstance, operation, BODY_HTML_TEMPLATE_FILE_PROPERTY);
     }
 
     try {
@@ -222,7 +222,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
     String templateName = null;
     String templateContent = null;
 
-    if (BODY_TEMPLATE_FILE_PROPERTY.equals(configName) || BODY_TEMPLATE_FILE_HTML_PROPERTY.equals(configName)) {
+    if (BODY_TEMPLATE_FILE_PROPERTY.equals(configName) || BODY_HTML_TEMPLATE_FILE_PROPERTY.equals(configName)) {
       templateName = configValue; // Use body template file name
     } else if (configValue != null && configValue.contains("${")) {
       // If value contains a "${", it may be a template so apply it

--- a/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
+++ b/modules/notification-workflowoperation/src/main/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandler.java
@@ -80,11 +80,12 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
   static final String BCC_PROPERTY = "bcc";
   static final String SUBJECT_PROPERTY = "subject";
   static final String BODY_PROPERTY = "body";
+  static final String BODY_HTML_PROPERTY = "body-html";
   static final String BODY_TEMPLATE_FILE_PROPERTY = "body-template-file";
+  static final String BODY_TEMPLATE_FILE_HTML_PROPERTY = "body-template-file-html";
   static final String ADDRESS_SEPARATOR_PROPERTY = "address-separator";
   static final String ADDRESS_SEPARATOR_DEFAULT = ", \t";
   static final String SKIP_INVALID_ADDRESS_PROPERTY = "skip-invalid-address";
-  static final String IS_HTML = "use-html";
 
   /*
    * (non-Javadoc)
@@ -122,26 +123,39 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
     }
 
     String subject = applyTemplateIfNecessary(workflowInstance, operation, SUBJECT_PROPERTY);
-    String bodyText;
-    String body = operation.getConfiguration(BODY_PROPERTY);
-    boolean isHTML = BooleanUtils.toBoolean(operation.getConfiguration(IS_HTML));
-    // If specified, templateFile is a file that contains the Freemarker template
-    String bodyTemplateFile = operation.getConfiguration(BODY_TEMPLATE_FILE_PROPERTY);
+
+    String bodyCfg = operation.getConfiguration(BODY_PROPERTY);
+    String bodyHtmlCfg = operation.getConfiguration(BODY_HTML_PROPERTY);
+    String bodyTemplateFileCfg = operation.getConfiguration(BODY_TEMPLATE_FILE_PROPERTY);
+    String bodyTemplateFileHtmlCfg = operation.getConfiguration(BODY_TEMPLATE_FILE_HTML_PROPERTY);
+
+    String bodyText = null;
+    String bodyHTML = null;
+
     // Body informed? If not, use the default.
-    if (body == null && bodyTemplateFile == null) {
+    if (bodyCfg == null && bodyHtmlCfg == null && bodyTemplateFileCfg == null && bodyTemplateFileHtmlCfg == null) {
       // Set the body of the message to be the ID of the media package
       bodyText = String.format("%s (%s)", srcPackage.getTitle(), srcPackage.getIdentifier());
-    } else if (body != null) {
+    }
+
+    if (bodyCfg != null) {
       bodyText = applyTemplateIfNecessary(workflowInstance, operation, BODY_PROPERTY);
-    } else {
+    } else if (bodyTemplateFileCfg != null) {
       bodyText = applyTemplateIfNecessary(workflowInstance, operation, BODY_TEMPLATE_FILE_PROPERTY);
     }
 
+    if (bodyHtmlCfg != null) {
+      bodyHTML = applyTemplateIfNecessary(workflowInstance, operation, BODY_HTML_PROPERTY);
+    } else if (bodyTemplateFileHtmlCfg != null) {
+      bodyHTML = applyTemplateIfNecessary(workflowInstance, operation, BODY_TEMPLATE_FILE_HTML_PROPERTY);
+    }
+
     try {
-      logger.debug("Sending e-mail notification with subject '{}' and body '{}' to '{}', CC '{}' and BCC '{}'",
-              subject, bodyText, to, cc, bcc);
+      logger.debug("Sending e-mail notification with subject '{}' and text body '{}' / HTML body '{}' "
+              + "to '{}', CC '{}' and BCC '{}'",
+              subject, bodyText, bodyHTML, to, cc, bcc);
       // "To", "CC" and "BCC" can be comma- or space-separated lists of emails
-      smtpService.send(to, cc, bcc, subject, bodyText, isHTML);
+      smtpService.send(to, cc, bcc, subject, bodyText, bodyHTML);
       logger.info("E-mail notification sent to {}, CC addresses {} and BCC addresses {}", to, cc, bcc);
     } catch (MessagingException e) {
       throw new WorkflowOperationException(e);
@@ -208,7 +222,7 @@ public class EmailWorkflowOperationHandler extends AbstractWorkflowOperationHand
     String templateName = null;
     String templateContent = null;
 
-    if (BODY_TEMPLATE_FILE_PROPERTY.equals(configName)) {
+    if (BODY_TEMPLATE_FILE_PROPERTY.equals(configName) || BODY_TEMPLATE_FILE_HTML_PROPERTY.equals(configName)) {
       templateName = configValue; // Use body template file name
     } else if (configValue != null && configValue.contains("${")) {
       // If value contains a "${", it may be a template so apply it

--- a/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
+++ b/modules/notification-workflowoperation/src/test/java/org/opencastproject/workflow/handler/notification/EmailWorkflowOperationHandlerTest.java
@@ -184,7 +184,7 @@ public class EmailWorkflowOperationHandlerTest {
     operation.setConfiguration(EmailWorkflowOperationHandler.BCC_PROPERTY, DEFAULT_BCC);
     operation.setConfiguration(EmailWorkflowOperationHandler.SUBJECT_PROPERTY, DEFAULT_SUBJECT);
     operation.setConfiguration(EmailWorkflowOperationHandler.BODY_TEMPLATE_FILE_PROPERTY, "template1");
-    operation.setConfiguration(EmailWorkflowOperationHandler.BODY_TEMPLATE_FILE_HTML_PROPERTY, "template1html");
+    operation.setConfiguration(EmailWorkflowOperationHandler.BODY_HTML_TEMPLATE_FILE_PROPERTY, "template1html");
 
     WorkflowOperationResult result = operationHandler.start(workflowInstance, null);
 


### PR DESCRIPTION
Users currently have to choose between text or HTML mails. This adds support for multipart mails containing both as alternative parts allowing mail clients to choose.

This is based on #4376 and #4380 to prevent merge conflicts.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
