### PR TITLE
Let Editor know if files are available locally

### DIFF
--- a/etc/org.opencastproject.editor.EditorServiceImpl.cfg
+++ b/etc/org.opencastproject.editor.EditorServiceImpl.cfg
@@ -68,3 +68,14 @@
 # Flavors need to be fully qualified, separated by comma.
 # Example: thumbnail.priority.flavor=presenter/preview,presentation/preview
 #thumbnail.priority.flavor=
+
+# Indicator if publications are available locally from this server.
+# This should usually be the case if your download directory lives on an NFS mount.
+# Based on this, the editor front-end can decide to modify the location of requested files.
+#
+# The value can be a boolean or `auto`.
+# Set to auto, the code will determine if files are available locally by checking if the files returned in the first
+# request exist locally.
+#
+# Default: auto
+#publication.local = auto

--- a/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
+++ b/modules/editor-service-api/src/main/java/org/opencastproject/editor/api/EditingData.java
@@ -48,10 +48,11 @@ public class EditingData {
   private final Boolean workflowActive;
   private final List<String> waveformURIs;
   private final List<Subtitle> subtitles;
+  private final Boolean local;
 
   public EditingData(List<SegmentData> segments, List<TrackData> tracks, List<WorkflowData> workflows, Long duration,
           String title, String recordingStartDate, String seriesId, String seriesName, Boolean workflowActive,
-          List<String> waveformURIs, List<Subtitle> subtitles) {
+          List<String> waveformURIs, List<Subtitle> subtitles, Boolean local) {
     this.segments = segments;
     this.tracks = tracks;
     this.workflows = workflows;
@@ -62,6 +63,7 @@ public class EditingData {
     this.workflowActive = workflowActive;
     this.waveformURIs = waveformURIs;
     this.subtitles = subtitles;
+    this.local = local;
   }
 
   public static EditingData parse(String json) {

--- a/modules/editor-service/src/test/java/org/opencastproject/editor/EditorServiceImplTest.java
+++ b/modules/editor-service/src/test/java/org/opencastproject/editor/EditorServiceImplTest.java
@@ -21,6 +21,7 @@
 package org.opencastproject.editor;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -50,6 +51,7 @@ import org.apache.commons.io.IOUtils;
 import org.easymock.EasyMock;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 
 import java.io.InputStream;
@@ -208,8 +210,13 @@ public class EditorServiceImplTest {
     dictionary.put(EditorServiceImpl.OPT_SMIL_CATALOG_FLAVOR, "smil/cutting");
     dictionary.put(EditorServiceImpl.OPT_SMIL_SILENCE_FLAVOR, "*/silence");
 
+    BundleContext bundleContext = EasyMock.createMock(BundleContext.class);
+    expect(bundleContext.getProperty(anyString())).andReturn("/").anyTimes();
+    replay(bundleContext);
+
     ComponentContext cc = EasyMock.createNiceMock(ComponentContext.class);
     expect(cc.getProperties()).andReturn(dictionary).anyTimes();
+    expect(cc.getBundleContext()).andReturn(bundleContext).anyTimes();
     replay(cc);
 
     editorService.activate(cc);


### PR DESCRIPTION
This patch is in preparation to fixing #3538: The editor is deployed on both the admin and the presentation server. But the publication only points to one of these servers by default. This means that one of the servers needs to return special HTTP headers so that the other one can load data or cross-origin requests will fail.

In reality though, most installations will either have the distribution on a network file system, meaning it is available from all servers and we could easily circumvent the issue, or they have dedicated and hopefully properly configured download servers anyway.

In case the latter exist, there shouldn't be an issue in the first place. This patch now indicates to the editor if the former is the case and the editor can load files from the local server.

This should always be true in the recommended installation of Opencast, but this actually lets us react to the cases where it is not true.

The status is indicated in the `/editor/<id>/edit.json`:

```json
{
  "local": true
}
```

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
