### PR TITLE
Publish Captions by Default

### DIFF
--- a/etc/workflows/partial-error.xml
+++ b/etc/workflows/partial-error.xml
@@ -12,7 +12,7 @@
       fail-on-error="false"
       description="Preserve the current recording state">
       <configurations>
-        <configuration key="source-flavors">*/source,dublincore/*,security/*</configuration>
+        <configuration key="source-flavors">*/source,dublincore/*,security/*,captions/*</configuration>
         <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>

--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -280,7 +280,7 @@
       exception-handler-workflow="partial-error"
       description="Publishing to Opencast Media Module">
       <configurations>
-        <configuration key="download-source-flavors">dublincore/*,security/*</configuration>
+        <configuration key="download-source-flavors">dublincore/*,security/*,captions/*</configuration>
         <configuration key="download-source-tags">engage-download,atom,rss</configuration>
         <configuration key="streaming-source-tags">engage-streaming</configuration>
         <configuration key="check-availability">false</configuration>

--- a/etc/workflows/publish.xml
+++ b/etc/workflows/publish.xml
@@ -58,6 +58,7 @@
       id="snapshot"
       description="Archive publishing information">
       <configurations>
+        <configuration key="source-flavors">captions/*</configuration>
         <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>

--- a/etc/workflows/schedule-and-upload.xml
+++ b/etc/workflows/schedule-and-upload.xml
@@ -65,6 +65,7 @@
       id="snapshot"
       description="Archive raw recording after ingest">
       <configurations>
+        <configuration key="source-flavors">captions/*</configuration>
         <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>
@@ -85,6 +86,7 @@
       id="snapshot"
       description="Archive preview information">
       <configurations>
+        <configuration key="source-flavors">captions/*</configuration>
         <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>
@@ -132,6 +134,7 @@
       if="${straightToPublishing}"
       description="Archive publishing information">
       <configurations>
+        <configuration key="source-flavors">captions/*</configuration>
         <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>


### PR DESCRIPTION
### Similar to the patch applied to the testing workflow PR - (https://github.com/opencast/opencast/pull/4307). This pull request should close Issue - (https://github.com/opencast/opencast/issues/4326). I have updated ```publish-engage``` and ```snapshot``` configuration to automatically publish captions in the default production workflows. 

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
