### PR TITLE
Allow dots in template file names

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/util/doc/DocData.java
+++ b/modules/common/src/main/java/org/opencastproject/util/doc/DocData.java
@@ -21,6 +21,9 @@
 
 package org.opencastproject.util.doc;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,24 +106,9 @@ public class DocData {
     }
   }
 
-  public static boolean isBlank(String str) {
-    boolean blank = false;
-    if (str == null || "".equals(str)) {
-      blank = true;
-    }
-    return blank;
-  }
-
   public static boolean isValidName(String name) {
-    boolean valid = true;
-    if (isBlank(name)) {
-      valid = false;
-    } else {
-      if (!name.matches("^(\\w|-)+$")) {
-        valid = false;
-      }
-    }
-    return valid;
+    return isNotBlank(name)
+        && name.matches("^(\\w|-|\\.)+$");
   }
 
   public String getMetaData(String key) {

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestDocData.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestDocData.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.runtimeinfo.rest;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import org.opencastproject.util.doc.DocData;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestEndpointData.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/rest/RestEndpointData.java
@@ -21,6 +21,8 @@
 
 package org.opencastproject.runtimeinfo.rest;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import org.opencastproject.util.JaxbXmlSchemaGenerator;
 import org.opencastproject.util.doc.DocData;
 import org.opencastproject.util.doc.rest.RestParameter;
@@ -253,7 +255,7 @@ public class RestEndpointData implements Comparable<RestEndpointData> {
    *           if note is blank (e.g. null, empty string)
    */
   public void addNote(String note) throws IllegalArgumentException {
-    if (DocData.isBlank(note)) {
+    if (isBlank(note)) {
       throw new IllegalArgumentException("Note must not be null or blank.");
     }
     if (notes == null) {


### PR DESCRIPTION
This adds dots to allowed characters in template files names (e.g. email templates). This also replaces the custom `isBlank` implementation.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
