### PR TITLE
Improve event catalog handling in External API

### DIFF
--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/CatalogUIAdapter.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/CatalogUIAdapter.java
@@ -81,4 +81,13 @@ public interface CatalogUIAdapter {
    */
   DublinCoreMetadataCollection getRawFields(Map<String, ResourceListQuery> collectionQueryOverrides);
 
+  /**
+   * Returns all fields of this catalog in a raw data format. Allows to hand over custom queries to fill the collection
+   * of a metadata field (defined by its output id) from a list provider.
+   *
+   * @param collectionQueryOverride
+   *          A custom list provider query mapped to every metadata field.
+   * @return The fields with raw data
+   */
+  DublinCoreMetadataCollection getRawFields(ResourceListQuery collectionQueryOverride);
 }

--- a/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreMetadataCollection.java
+++ b/modules/dublincore/src/main/java/org/opencastproject/metadata/dublincore/DublinCoreMetadataCollection.java
@@ -239,6 +239,11 @@ public class DublinCoreMetadataCollection {
         ResourceListQuery resourceListQuery;
         if (collectionQueryOverrideOpt.isPresent()) {
           resourceListQuery = collectionQueryOverrideOpt.get();
+
+          // shortcut: don't query list provider if limit is set to 0
+          if (resourceListQuery.getLimit().getOrElseNull() == 0) {
+            return Collections.emptyMap();
+          }
         } else {
           resourceListQuery = new ResourceListQueryImpl();
         }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -63,6 +63,7 @@ import org.opencastproject.index.service.util.RequestUtils;
 import org.opencastproject.index.service.util.RestUtils;
 import org.opencastproject.ingest.api.IngestException;
 import org.opencastproject.ingest.api.IngestService;
+import org.opencastproject.list.impl.EmptyResourceListQuery;
 import org.opencastproject.mediapackage.Attachment;
 import org.opencastproject.mediapackage.AudioStream;
 import org.opencastproject.mediapackage.Catalog;
@@ -1370,8 +1371,8 @@ public class EventsEndpoint implements ManagedService {
         if (fields != null) metadataList.add(catalogUIAdapter, fields);
       }
     }
-    // TODO: This is slow:
-    DublinCoreMetadataCollection collection = EventUtils.getEventMetadata(event, eventCatalogUIAdapter);
+    DublinCoreMetadataCollection collection = EventUtils.getEventMetadata(event, eventCatalogUIAdapter,
+        EmptyResourceListQuery.get());
     ExternalMetadataUtils.changeSubjectToSubjects(collection);
     ExternalMetadataUtils.removeCollectionList(collection);
     metadataList.add(eventCatalogUIAdapter, collection);
@@ -1400,7 +1401,8 @@ public class EventsEndpoint implements ManagedService {
       // Try the main catalog first as we load it from the index.
       EventCatalogUIAdapter eventCatalogUIAdapter = indexService.getCommonEventCatalogUIAdapter();
       if (flavor.get().equals(eventCatalogUIAdapter.getFlavor())) {
-        DublinCoreMetadataCollection collection = EventUtils.getEventMetadata(event, eventCatalogUIAdapter);
+        DublinCoreMetadataCollection collection = EventUtils.getEventMetadata(event, eventCatalogUIAdapter,
+            EmptyResourceListQuery.get());
         ExternalMetadataUtils.changeSubjectToSubjects(collection);
         ExternalMetadataUtils.removeCollectionList(collection);
         convertStartDateTimeToApiV1(collection);

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1368,7 +1368,10 @@ public class EventsEndpoint implements ManagedService {
       for (EventCatalogUIAdapter catalogUIAdapter : catalogUIAdapters) {
         // TODO: This is very slow:
         DublinCoreMetadataCollection fields = catalogUIAdapter.getFields(mediaPackage);
-        if (fields != null) metadataList.add(catalogUIAdapter, fields);
+        if (fields != null) {
+          ExternalMetadataUtils.removeCollectionList(fields);
+          metadataList.add(catalogUIAdapter, fields);
+        }
       }
     }
     DublinCoreMetadataCollection collection = EventUtils.getEventMetadata(event, eventCatalogUIAdapter,

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -1347,8 +1347,8 @@ public class EventsEndpoint implements ManagedService {
     List<EventCatalogUIAdapter> catalogUIAdapters = getEventCatalogUIAdapters();
     EventCatalogUIAdapter eventCatalogUIAdapter = indexService.getCommonEventCatalogUIAdapter();
     catalogUIAdapters.remove(eventCatalogUIAdapter);
-    MediaPackage mediaPackage = indexService.getEventMediapackage(event);
     if (catalogUIAdapters.size() > 0) {
+      MediaPackage mediaPackage = indexService.getEventMediapackage(event);
       for (EventCatalogUIAdapter catalogUIAdapter : catalogUIAdapters) {
         // TODO: This is very slow:
         DublinCoreMetadataCollection fields = catalogUIAdapter.getFields(mediaPackage);

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/ConfigurableDCCatalogUIAdapter.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/catalog/adapter/ConfigurableDCCatalogUIAdapter.java
@@ -131,6 +131,22 @@ public abstract class ConfigurableDCCatalogUIAdapter implements CatalogUIAdapter
     return rawFields;
   }
 
+  @Override
+  public DublinCoreMetadataCollection getRawFields(ResourceListQuery collectionQueryOverride) {
+    DublinCoreMetadataCollection rawFields = new DublinCoreMetadataCollection();
+    for (MetadataField metadataField : dublinCoreProperties.values()) {
+      try {
+        String defaultKey = getCollectionDefault(metadataField, listProvidersService);
+
+        rawFields.addField(new MetadataField(metadataField), Optional.ofNullable(defaultKey),
+            Optional.ofNullable(collectionQueryOverride), listProvidersService);
+      } catch (IllegalArgumentException e) {
+        logger.error("Skipping metadata field '{}' because of error", metadataField, e);
+      }
+    }
+    return rawFields;
+  }
+
   protected DublinCoreMetadataCollection getFieldsFromCatalogs(List<DublinCoreCatalog> dcCatalogs) {
     Map<String,List<MetadataField>> metadataFields = new HashMap<>();
     List<MetadataField> emptyFields = new ArrayList<>(dublinCoreProperties.values());

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventUtils.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/util/EventUtils.java
@@ -22,6 +22,7 @@
 package org.opencastproject.index.service.impl.util;
 
 import org.opencastproject.elasticsearch.index.objects.event.Event;
+import org.opencastproject.list.api.ResourceListQuery;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreMetadataCollection;
@@ -54,7 +55,6 @@ public final class EventUtils {
   }
 
   private EventUtils() {
-
   }
 
   /**
@@ -62,6 +62,8 @@ public final class EventUtils {
    *
    * @param event
    *          the source {@link Event}
+   * @param eventCatalogUIAdapter
+   *          the catalog definition
    * @return a {@link DublinCoreMetadataCollection} instance with all the event metadata
    *
    * @throws ParseException
@@ -69,6 +71,28 @@ public final class EventUtils {
   public static DublinCoreMetadataCollection getEventMetadata(Event event, EventCatalogUIAdapter eventCatalogUIAdapter)
           throws ParseException {
     DublinCoreMetadataCollection eventMetadata = new DublinCoreMetadataCollection(eventCatalogUIAdapter.getRawFields());
+    setEventMetadataValues(event, eventMetadata);
+    return eventMetadata;
+  }
+
+  /**
+   * Loads the metadata for the given event
+   *
+   * @param event
+   *          the source {@link Event}
+   * @param eventCatalogUIAdapter
+   *          the catalog definition
+   * @param collectionQueryOverride
+   *          a custom list provider query mapped to every metadata field.
+   *
+   * @return a {@link DublinCoreMetadataCollection} instance with all the event metadata
+   *
+   * @throws ParseException
+   */
+  public static DublinCoreMetadataCollection getEventMetadata(Event event, EventCatalogUIAdapter eventCatalogUIAdapter,
+      ResourceListQuery collectionQueryOverride) throws ParseException {
+    DublinCoreMetadataCollection eventMetadata = new DublinCoreMetadataCollection(
+        eventCatalogUIAdapter.getRawFields(collectionQueryOverride));
     setEventMetadataValues(event, eventMetadata);
     return eventMetadata;
   }

--- a/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/EmptyResourceListQuery.java
+++ b/modules/list-providers-service/src/main/java/org/opencastproject/list/impl/EmptyResourceListQuery.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.list.impl;
+
+import org.opencastproject.list.api.ResourceListFilter;
+import org.opencastproject.list.api.ResourceListQuery;
+import org.opencastproject.util.data.Option;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * ResourceListQuery that should result in an empty list after execution.
+ */
+public final class EmptyResourceListQuery implements ResourceListQuery {
+  private static final EmptyResourceListQuery instance = new EmptyResourceListQuery();
+
+  private EmptyResourceListQuery() {
+  }
+
+  public static ResourceListQuery get() {
+    return instance;
+  }
+
+  @Override
+  public List<ResourceListFilter<?>> getFilters() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<ResourceListFilter<?>> getAvailableFilters() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public ResourceListFilter<?> getFilter(String name) {
+    return null;
+  }
+
+  @Override
+  public Option<Integer> getLimit() {
+    return Option.some(0);
+  }
+
+  @Override
+  public Option<Integer> getOffset() {
+    return Option.none();
+  }
+
+  @Override
+  public Option<String> getSortBy() {
+    return Option.none();
+  }
+
+  @Override
+  public Boolean hasFilter(String name) {
+    return false;
+  }
+}


### PR DESCRIPTION
This is based on #4181

This adds four improvements to event catalog handling in the External API

1. Avoid DB query is not necessary.
2. Cache map of organization to list of catalogs instead of always calculating it.
3. Avoid calling list providers to fetch collection data if this is later on not used (e.g. all series).
4. Remove collection data from responses for extended metadata.

The last point can be seen as a change to the External API. However, one can also see this as a bug, as other methods in the class hide the collection data from extended metadata.

All changes can add up when requesting multiple events with `/events` especially with many events and series.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
