### PR TITLE
Fix Auto-update Tests

### DIFF
--- a/.github/workflows/auto-update-npm-libraries.yml
+++ b/.github/workflows/auto-update-npm-libraries.yml
@@ -47,7 +47,7 @@ jobs:
           done
 
       - name: make sure tests still work
-        working-directory: modules/engage-theodul-core
+        working-directory: modules
         run: |
           set -ue
           for module in $(ls -1 engage-theodul-*/package.json | sed 's_/package.json__')


### PR DESCRIPTION
This patch fixes the path for testing that the auto-updates we apply actually work. Right now, we just get:

    ls: cannot access 'engage-theodul-*/package.json':
    No such file or directorY

Which does not let the test fail, because the error happens in a sub-shell.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
