### PR TITLE
Enrich LDAP users with name and mail address

### DIFF
--- a/etc/org.opencastproject.userdirectory.ldap.cfg.template
+++ b/etc/org.opencastproject.userdirectory.ldap.cfg.template
@@ -50,6 +50,19 @@ org.opencastproject.userdirectory.ldap.roleattributes=
 #org.opencastproject.userdirectory.ldap.userDn=
 #org.opencastproject.userdirectory.ldap.password=
 
+## The attributes used to construct the user details.
+## If left empty, the user details wont be mapped.
+## The name config key is a comma-separated list of attributes that will be joined
+##   with a whitespace character in the order they appear.
+## Example:
+##  org.opencastproject.userdirectory.ldap.userattributes.name=givenName,sn
+##  org.opencastproject.userdirectory.ldap.userattributes.mail=mail
+## Result:
+##   name: John Doe
+##   mail: john.doe@example.org
+#org.opencastproject.userdirectory.ldap.userattributes.name=
+#org.opencastproject.userdirectory.ldap.userattributes.mail=
+
 ## The maximum number of users to cache
 ## Default: 1000
 #org.opencastproject.userdirectory.ldap.cache.size=1000

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/LdapUserProviderFactory.java
@@ -90,6 +90,12 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
   /** The key to look up the role attributes in the service configuration properties */
   private static final String ROLE_ATTRIBUTES_KEY = "org.opencastproject.userdirectory.ldap.roleattributes";
 
+  /** The key to look up the users name attributes **/
+  private static final String USER_NAME_ATTRIBUTES_KEY = "org.opencastproject.userdirectory.ldap.userattributes.name";
+
+  /** The key to look up the users attribute to set its mail address**/
+  private static final String USER_MAIL_ATTRIBUTE_KEY = "org.opencastproject.userdirectory.ldap.userattributes.mail";
+
   /** The key to look up the organization identifier in the service configuration properties */
   private static final String ORGANIZATION_KEY = "org.opencastproject.userdirectory.ldap.org";
 
@@ -250,6 +256,8 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
     String organization = (String) properties.get(ORGANIZATION_KEY);
     String userDn = (String) properties.get(SEARCH_USER_DN);
     String password = (String) properties.get(SEARCH_PASSWORD);
+    String[] userAttributeName = StringUtils.split((String) properties.get(USER_NAME_ATTRIBUTES_KEY),',');
+    String userAttributeMail = (String) properties.get(USER_MAIL_ATTRIBUTE_KEY);
 
     // optional with default values
     String rolePrefix = Objects.toString(properties.get(ROLE_PREFIX_KEY), "ROLE_");
@@ -385,9 +393,14 @@ public class LdapUserProviderFactory implements ManagedServiceFactory {
     authoritiesPopulatorRegistrations.put(pid,
             bundleContext.registerService(LdapAuthoritiesPopulator.class.getName(), authoritiesPopulator, dict));
 
+    OpencastUserDetailsContextMapper mapper = null;
+    if (userAttributeName != null && userAttributeMail != null) {
+      mapper = new OpencastUserDetailsContextMapper(userAttributeName, userAttributeMail);
+    }
+
     LdapUserProviderInstance provider = new LdapUserProviderInstance(pid, org, searchBase, searchFilter, url, userDn,
         password, roleAttributes, cacheSize,
-        cacheExpiration, securityService, authoritiesPopulator);
+        cacheExpiration, securityService, authoritiesPopulator, mapper);
 
     providerRegistrations.put(pid, bundleContext.registerService(UserProvider.class.getName(), provider, null));
 

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulator.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastLdapAuthoritiesPopulator.java
@@ -55,8 +55,8 @@ public class OpencastLdapAuthoritiesPopulator implements LdapAuthoritiesPopulato
   private String groupCheckPrefix = null;
   private boolean applyAttributesAsRoles = true;
   private boolean applyAttributesAsGroups = true;
-  private Map<String, String[]> ldapAssignmentRoleMap = new HashMap();
-  private Map<String, String[]> ldapAssignmentGroupMap = new HashMap();
+  private Map<String, String[]> ldapAssignmentRoleMap = new HashMap<>();
+  private Map<String, String[]> ldapAssignmentGroupMap = new HashMap<>();
   private boolean uppercase = true;
   private Organization organization;
   private SecurityService securityService;

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastUserDetails.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastUserDetails.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.userdirectory.ldap;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import javax.naming.Name;
+
+public class OpencastUserDetails implements UserDetails {
+
+  private String dn;
+
+  private String password;
+
+  private String username;
+
+  private String name;
+
+  private String mail;
+
+  private Collection<GrantedAuthority> authorities = AuthorityUtils.NO_AUTHORITIES;
+  private boolean accountNonExpired = true;
+  private boolean accountNonLocked = true;
+  private boolean credentialsNonExpired = true;
+  private boolean enabled = true;
+
+  protected OpencastUserDetails() {
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof OpencastUserDetails) {
+      return dn.equals(((OpencastUserDetails) obj).dn);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return dn.hashCode();
+  }
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(super.toString()).append(": ");
+    sb.append("Dn: ").append(dn).append("; ");
+    sb.append("Username: ").append(this.username).append("; ");
+    sb.append("Password: [PROTECTED]; ");
+    sb.append("Name: ").append(this.name);
+    sb.append("Mail: ").append(this.mail);
+    sb.append("Enabled: ").append(this.enabled).append("; ");
+    sb.append("AccountNonExpired: ").append(this.accountNonExpired).append("; ");
+    sb.append("CredentialsNonExpired: ").append(this.credentialsNonExpired).append("; ");
+    sb.append("AccountNonLocked: ").append(this.accountNonLocked).append("; ");
+
+    if (this.getAuthorities() != null) {
+      sb.append("Granted Authorities: ");
+      boolean first = true;
+
+      for (Object authority : this.getAuthorities()) {
+        if (first) {
+          first = false;
+        } else {
+          sb.append(", ");
+        }
+
+        sb.append(authority.toString());
+      }
+    } else {
+      sb.append("Not granted any authorities");
+    }
+
+    return sb.toString();
+  }
+
+  public String getDn() {
+    return dn;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return authorities;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  public String getMail() {
+    return mail;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return accountNonExpired;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return accountNonLocked;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return credentialsNonExpired;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public static class Essence {
+    protected OpencastUserDetails instance = createTarget();
+    private List<GrantedAuthority> mutableAuthorities = new ArrayList<>();
+
+    public Essence() {
+    }
+
+    protected OpencastUserDetails createTarget() {
+      return new OpencastUserDetails();
+    }
+
+    /**
+     * Adds the authority to the list, unless it is already there, in which case it is ignored
+     */
+    public void addAuthority(GrantedAuthority a) {
+      if (!hasAuthority(a)) {
+        mutableAuthorities.add(a);
+      }
+    }
+
+    private boolean hasAuthority(GrantedAuthority a) {
+      for (GrantedAuthority authority : mutableAuthorities) {
+        if (authority.equals(a)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    public OpencastUserDetails createUserDetails() {
+      Objects.requireNonNull(instance,"Essence can only be used to create a single instance");
+      Objects.requireNonNull(instance, "Essence can only be used to create a single instance");
+      Objects.requireNonNull(instance.username, "username must not be null");
+      Objects.requireNonNull(instance.getDn(), "Distinguished name must not be null");
+
+      instance.authorities = Collections.unmodifiableList(mutableAuthorities);
+
+      OpencastUserDetails newInstance = instance;
+
+      instance = null;
+
+      return newInstance;
+    }
+
+    public Collection<GrantedAuthority> getGrantedAuthorities() {
+      return mutableAuthorities;
+    }
+
+    public void setAccountNonExpired(boolean accountNonExpired) {
+      instance.accountNonExpired = accountNonExpired;
+    }
+
+    public void setAccountNonLocked(boolean accountNonLocked) {
+      instance.accountNonLocked = accountNonLocked;
+    }
+
+    public void setAuthorities(Collection<? extends GrantedAuthority> authorities) {
+      mutableAuthorities = new ArrayList<>();
+      mutableAuthorities.addAll(authorities);
+    }
+
+    public void setCredentialsNonExpired(boolean credentialsNonExpired) {
+      instance.credentialsNonExpired = credentialsNonExpired;
+    }
+
+    public void setDn(String dn) {
+      instance.dn = dn;
+    }
+
+    public void setDn(Name dn) {
+      instance.dn = dn.toString();
+    }
+
+    public void setEnabled(boolean enabled) {
+      instance.enabled = enabled;
+    }
+
+    public void setPassword(String password) {
+      instance.password = password;
+    }
+
+    public void setUsername(String username) {
+      instance.username = username;
+    }
+
+    public void setName(String name) {
+      instance.name = name;
+    }
+
+    public void setMail(String mail) {
+      instance.mail = mail;
+    }
+
+  }
+}

--- a/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastUserDetailsContextMapper.java
+++ b/modules/userdirectory-ldap/src/main/java/org/opencastproject/userdirectory/ldap/OpencastUserDetailsContextMapper.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.userdirectory.ldap;
+
+import org.springframework.ldap.core.DirContextAdapter;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.ldap.userdetails.UserDetailsContextMapper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class OpencastUserDetailsContextMapper implements UserDetailsContextMapper {
+
+  private final String[] name;
+
+  private final String mail;
+
+  public OpencastUserDetailsContextMapper(String[] name, String mail) {
+    Objects.requireNonNull(name);
+    Objects.requireNonNull(mail);
+    this.name = name;
+    this.mail = mail;
+  }
+
+  @Override
+  public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
+      Collection<? extends GrantedAuthority> authorities) {
+    String dn = ctx.getNameInNamespace();
+
+    OpencastUserDetails.Essence essence = new OpencastUserDetails.Essence();
+    essence.setDn(dn);
+    essence.setUsername(username);
+    essence.setName(buildName(ctx));
+    essence.setMail(ctx.getStringAttribute(mail));
+
+    // Add the supplied authorities
+    for (GrantedAuthority authority : authorities) {
+      essence.addAuthority(authority);
+    }
+
+    return essence.createUserDetails();
+  }
+  private String buildName(DirContextOperations ctx) {
+    StringJoiner joiner = new StringJoiner(" ");
+    for (String attribute: name) {
+      joiner.add(ctx.getStringAttribute(attribute));
+    }
+    return joiner.toString();
+  }
+
+  @Override
+  public void mapUserToContext(UserDetails user, DirContextAdapter ctx) {
+    throw new UnsupportedOperationException("OpencastUserContextMapper only supports reading from a context. Please"
+        + "use a subclass if mapUserToContext() is required.");
+  }
+
+  public String[] getAttributes() {
+    List<String> attributes = new ArrayList<>(Arrays.asList(name));
+    attributes.add(mail);
+    return attributes.toArray(new String[] {});
+  }
+}


### PR DESCRIPTION
For some metadata fields (e.g., presenters), it's possible to enter usernames, and they will be mapped to their corresponding names. If LDAP is enabled, Opencast will dismiss the looked-up users because the name attribute is not set.

This PR enables Opencast to retrieve user attributes like name and mail from LDAP.

The attributes are only mapped if the corresponding config keys are set, else it will fall back to the default behavior.

Example:
```ini
org.opencastproject.userdirectory.ldap.userattributes.name=givenName,sn
org.opencastproject.userdirectory.ldap.userattributes.mail=mail
```

Based on: [#4383](https://github.com/opencast/opencast/pull/4383)

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
