### PR TITLE
Add index for oc_job_argument table (OC 13)

### DIFF
--- a/docs/upgrade/12_to_13/mariadb.sql
+++ b/docs/upgrade/12_to_13/mariadb.sql
@@ -1,1 +1,2 @@
 CREATE INDEX IF NOT EXISTS IX_oc_aws_asset_mapping_object_key ON oc_aws_asset_mapping (object_key);
+CREATE INDEX IF NOT EXISTS IX_oc_job_argument_id ON oc_job_argument (id);

--- a/docs/upgrade/12_to_13/postgresql.sql
+++ b/docs/upgrade/12_to_13/postgresql.sql
@@ -1,1 +1,2 @@
 CREATE INDEX IF NOT EXISTS IX_oc_aws_asset_mapping_object_key ON oc_aws_asset_mapping (object_key);
+CREATE INDEX IF NOT EXISTS IX_oc_job_argument_id ON oc_job_argument (id);

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
@@ -178,7 +178,11 @@ public class JpaJob {
   @OrderColumn(name = "argument_index")
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(name = "oc_job_argument",
-      joinColumns = @JoinColumn(name = "id", referencedColumnName = "id", nullable = false))
+      joinColumns = @JoinColumn(name = "id", referencedColumnName = "id", nullable = false),
+      indexes = {
+          @Index(name = "IX_oc_job_argument_id", columnList = ("id")),
+      }
+  )
   private List<String> arguments;
 
   @Column(name = "date_completed")


### PR DESCRIPTION
This is an updated version of #4179 for OC 13.

JPA previously did not create an index for the job_argument table (that has no primary key). This differs compared to the custom DDL script we used to have until Opencast 8. We have seen very slow query times resulting in slow scheduling.

Also see #4076.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
