### PR TITLE
New workflow implementation and migration fixes (OC 13)

### DIFF
--- a/docs/upgrade/11_to_12/workflows_mariadb.py
+++ b/docs/upgrade/11_to_12/workflows_mariadb.py
@@ -17,6 +17,7 @@ from datetime import datetime
 user = "opencast"
 password = "dbpassword"
 host = "127.0.0.1"
+port = 3306
 database = "opencast"
 
 # Constants
@@ -33,12 +34,13 @@ XML_DECLARATION = "<?xml version='1.0' encoding='UTF-8'?>"
 
 
 # DB functions
-def create_connection(host_name, user_name, user_password, db_name):
+def create_connection(host_name, port_number, user_name, user_password, db_name):
     connection = mysql.connector.connect(
         host=host_name,
+        port=port_number,
         user=user_name,
         passwd=user_password,
-        database=db_name
+        database=db_name,
     )
     connection.row_factory = lambda cursor, row: row[0]
     print("Connection to database successful")
@@ -120,7 +122,7 @@ def parse_bool(value):
 
 # Connect
 print("Creating connection to database...")
-connection = create_connection(host, user, password, database)
+connection = create_connection(host, port, user, password, database)
 
 # Create new tables
 #  Currently added indexes:

--- a/docs/upgrade/11_to_12/workflows_mariadb.py
+++ b/docs/upgrade/11_to_12/workflows_mariadb.py
@@ -257,10 +257,11 @@ for offset in range(0, workflow_count, 100):
 
         # oc_workflow_configuration
         for configuration in root.find(f"{WORKFLOW_NS}configurations"):
+            value = configuration.text
             workflow_config.append([
                 workflow_id,
                 get_attrib_from_node(configuration, "key"),
-                configuration.text])
+                value if value is not None else ""])
 
         # oc_workflow_operation
         operation_position = 0
@@ -293,10 +294,11 @@ for offset in range(0, workflow_count, 100):
 
             # oc_workflow_operation_configuration
             for op_config in operation.find("{http://workflow.opencastproject.org}configurations"):
+                value = op_config.text
                 workflow_operation_config.append([
                     operation_id,
                     get_attrib_from_node(op_config, "key"),
-                    op_config.text])
+                    value if value is not None else ""])
 
             # Generate ID and position for next operation
             operation_id += 1

--- a/docs/upgrade/11_to_12/workflows_postgresql.py
+++ b/docs/upgrade/11_to_12/workflows_postgresql.py
@@ -254,10 +254,11 @@ for offset in range(0, workflow_count, 100):
 
         # oc_workflow_configuration
         for configuration in root.find(f"{WORKFLOW_NS}configurations"):
+            value = configuration.text
             workflow_config.append([
                 workflow_id,
                 get_attrib_from_node(configuration, "key"),
-                configuration.text])
+                value if value is not None else ""])
 
         # oc_workflow_operation
         operation_position = 0
@@ -290,10 +291,11 @@ for offset in range(0, workflow_count, 100):
 
             # oc_workflow_operation_configuration
             for op_config in operation.find("{http://workflow.opencastproject.org}configurations"):
+                value = op_config.text
                 workflow_operation_config.append([
                     operation_id,
                     get_attrib_from_node(op_config, "key"),
-                    op_config.text])
+                    value if value is not None else ""])
 
             # Generate ID and position for next operation
             operation_id += 1

--- a/docs/upgrade/11_to_12/workflows_postgresql.py
+++ b/docs/upgrade/11_to_12/workflows_postgresql.py
@@ -15,6 +15,7 @@ from datetime import datetime
 user = "opencast"
 password = "dbpassword"
 host = "127.0.0.1"
+port = 5432
 database = "opencast"
 
 # Constants
@@ -31,12 +32,13 @@ XML_DECLARATION = "<?xml version='1.0' encoding='UTF-8'?>"
 
 
 # DB functions
-def create_connection(host_name, user_name, user_password, db_name):
+def create_connection(host_name, port_number, user_name, user_password, db_name):
     connection = psycopg2.connect(
         host=host_name,
+        port=port_number,
         user=user_name,
         password=user_password,
-        database=db_name
+        database=db_name,
     )
     print("Connection to database successful")
     return connection
@@ -117,7 +119,7 @@ def parse_bool(value):
 
 # Connect
 print("Creating connection to database...")
-connection = create_connection(host, user, password, database)
+connection = create_connection(host, port, user, password, database)
 
 # Create new tables
 #  Currently added indexes:

--- a/docs/upgrade/12_to_13/mariadb.sql
+++ b/docs/upgrade/12_to_13/mariadb.sql
@@ -7,3 +7,15 @@ ALTER TABLE oc_workflow
 ALTER TABLE oc_workflow_operation
   MODIFY COLUMN `description` LONGTEXT DEFAULT NULL,
   MODIFY COLUMN `if_condition` LONGTEXT DEFAULT NULL;
+
+ALTER TABLE oc_workflow_configuration
+  DROP FOREIGN KEY IF EXISTS FK_oc_workflow_configuration_workflow_id,
+  ADD FOREIGN KEY IF NOT EXISTS IX_oc_workflow_configuration_workflow_id (`workflow_id`) REFERENCES `oc_workflow` (`id`);
+
+ALTER TABLE oc_workflow_operation
+  DROP FOREIGN KEY IF EXISTS FK_oc_workflow_operation_workflow_id,
+  ADD FOREIGN KEY IF NOT EXISTS IX_oc_workflow_operation_workflow_id (`workflow_id`) REFERENCES `oc_workflow` (`id`);
+
+ALTER TABLE oc_workflow_operation_configuration
+  DROP FOREIGN KEY IF EXISTS cworkflowoperationconfigurationworkflowoperationid,
+  ADD FOREIGN KEY IF NOT EXISTS IX_oc_workflow_operation_configuration_workflow_operation_id (`workflow_operation_id`) REFERENCES `oc_workflow_operation` (`id`);

--- a/docs/upgrade/12_to_13/mariadb.sql
+++ b/docs/upgrade/12_to_13/mariadb.sql
@@ -1,2 +1,9 @@
 CREATE INDEX IF NOT EXISTS IX_oc_aws_asset_mapping_object_key ON oc_aws_asset_mapping (object_key);
 CREATE INDEX IF NOT EXISTS IX_oc_job_argument_id ON oc_job_argument (id);
+
+ALTER TABLE oc_workflow
+  MODIFY COLUMN `description` LONGTEXT DEFAULT NULL;
+
+ALTER TABLE oc_workflow_operation
+  MODIFY COLUMN `description` LONGTEXT DEFAULT NULL,
+  MODIFY COLUMN `if_condition` LONGTEXT DEFAULT NULL;

--- a/docs/upgrade/12_to_13/mariadb.sql
+++ b/docs/upgrade/12_to_13/mariadb.sql
@@ -19,3 +19,11 @@ ALTER TABLE oc_workflow_operation
 ALTER TABLE oc_workflow_operation_configuration
   DROP FOREIGN KEY IF EXISTS cworkflowoperationconfigurationworkflowoperationid,
   ADD FOREIGN KEY IF NOT EXISTS IX_oc_workflow_operation_configuration_workflow_operation_id (`workflow_operation_id`) REFERENCES `oc_workflow_operation` (`id`);
+
+UPDATE oc_workflow_configuration
+SET configuration_value = ''
+WHERE configuration_value IS NULL;
+
+UPDATE oc_workflow_operation_configuration
+SET configuration_value = ''
+WHERE configuration_value IS NULL;

--- a/docs/upgrade/12_to_13/postgresql.sql
+++ b/docs/upgrade/12_to_13/postgresql.sql
@@ -1,2 +1,9 @@
 CREATE INDEX IF NOT EXISTS IX_oc_aws_asset_mapping_object_key ON oc_aws_asset_mapping (object_key);
 CREATE INDEX IF NOT EXISTS IX_oc_job_argument_id ON oc_job_argument (id);
+
+ALTER TABLE oc_workflow
+  ALTER COLUMN description TYPE TEXT;
+
+ALTER TABLE oc_workflow_operation
+  ALTER COLUMN description TYPE TEXT,
+  ALTER COLUMN if_condition TYPE TEXT;

--- a/docs/upgrade/12_to_13/postgresql.sql
+++ b/docs/upgrade/12_to_13/postgresql.sql
@@ -11,3 +11,11 @@ ALTER TABLE oc_workflow_operation
 CREATE INDEX IF NOT EXISTS IX_oc_workflow_configuration_workflow_id ON oc_workflow_configuration (workflow_id);
 CREATE INDEX IF NOT EXISTS IX_oc_workflow_operation_workflow_id ON oc_workflow_operation (workflow_id);
 CREATE INDEX IF NOT EXISTS IX_oc_workflow_operation_configuration_workflow_operation_id ON oc_workflow_operation_configuration (workflow_operation_id);
+
+UPDATE oc_workflow_configuration
+SET configuration_value = ''
+WHERE configuration_value IS NULL;
+
+UPDATE oc_workflow_operation_configuration
+SET configuration_value = ''
+WHERE configuration_value IS NULL;

--- a/docs/upgrade/12_to_13/postgresql.sql
+++ b/docs/upgrade/12_to_13/postgresql.sql
@@ -7,3 +7,7 @@ ALTER TABLE oc_workflow
 ALTER TABLE oc_workflow_operation
   ALTER COLUMN description TYPE TEXT,
   ALTER COLUMN if_condition TYPE TEXT;
+
+CREATE INDEX IF NOT EXISTS IX_oc_workflow_configuration_workflow_id ON oc_workflow_configuration (workflow_id);
+CREATE INDEX IF NOT EXISTS IX_oc_workflow_operation_workflow_id ON oc_workflow_operation (workflow_id);
+CREATE INDEX IF NOT EXISTS IX_oc_workflow_operation_configuration_workflow_operation_id ON oc_workflow_operation_configuration (workflow_operation_id);

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -173,7 +173,10 @@ public class WorkflowInstance {
   @ElementCollection
   @CollectionTable(
           name = "oc_workflow_configuration",
-          joinColumns = @JoinColumn(name = "workflow_id")
+          joinColumns = @JoinColumn(name = "workflow_id"),
+          indexes = {
+                @Index(name = "IX_oc_workflow_configuration_workflow_id", columnList = ("workflow_id")),
+          }
   )
   @MapKeyColumn(name = "configuration_key")
   @Lob

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -137,6 +137,7 @@ public class WorkflowInstance {
   private String title;
 
   @Column(name = "description")
+  @Lob
   private String description;
 
   @Column(name = "creator_id")

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationInstance.java
@@ -71,6 +71,7 @@ public class WorkflowOperationInstance implements Configurable {
   protected OperationState state;
 
   @Column(name = "description")
+  @Lob
   protected String description;
 
   @ElementCollection
@@ -87,6 +88,7 @@ public class WorkflowOperationInstance implements Configurable {
   protected boolean failOnError;
 
   @Column(name = "if_condition")
+  @Lob
   protected String executeCondition;
 
   @Column(name = "exception_handler_workflow")

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowOperationInstance.java
@@ -37,6 +37,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
@@ -50,7 +51,8 @@ import javax.persistence.TemporalType;
  */
 @Entity(name = "WorkflowOperationInstance")
 @Access(AccessType.FIELD)
-@Table(name = "oc_workflow_operation")
+@Table(name = "oc_workflow_operation", indexes = {
+    @Index(name = "IX_oc_workflow_operation_workflow_id", columnList = ("workflow_id"))})
 public class WorkflowOperationInstance implements Configurable {
   public enum OperationState {
     INSTANTIATED, RUNNING, PAUSED, SUCCEEDED, FAILED, SKIPPED, RETRY
@@ -77,7 +79,10 @@ public class WorkflowOperationInstance implements Configurable {
   @ElementCollection
   @CollectionTable(
           name = "oc_workflow_operation_configuration",
-          joinColumns = @JoinColumn(name = "workflow_operation_id")
+          joinColumns = @JoinColumn(name = "workflow_operation_id"),
+          indexes = {
+                @Index(name = "IX_oc_workflow_operation_configuration_workflow_operation_id", columnList = ("workflow_operation_id")),
+          }
   )
   @MapKeyColumn(name = "configuration_key", nullable = false)
   @Lob


### PR DESCRIPTION
This is an updated version of #4221 for OC 13.

This PR fixes a bunch of issues with the new workflow implementation / the migration script:

* Allow setting a port number in the migration script (CockroachDB does not use the default PostgreSQL port)
* Change data types of some columns in the workflow tables to allow for workflow definitions using longer values
* Add and normalize DB indexes in MariaDB and PostgreSQL
* Fix exception due to null values in configuration tables (see commit message for exception log)

Fixes https://github.com/opencast/opencast/issues/4226

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
