### PR TITLE
fix capture agent ingest error when using automatic series creation

### DIFF
--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -47,6 +47,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-userdirectory</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-working-file-repository-service-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/impl/IngestServiceImpl.java
@@ -24,6 +24,8 @@ package org.opencastproject.ingest.impl;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_IDENTIFIER;
 import static org.opencastproject.metadata.dublincore.DublinCore.PROPERTY_TITLE;
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 import static org.opencastproject.util.JobUtil.waitForJob;
 import static org.opencastproject.util.data.Monadics.mlist;
 import static org.opencastproject.util.data.Option.none;
@@ -66,6 +68,7 @@ import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.TrustedHttpClient;
 import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.series.api.SeriesException;
@@ -73,6 +76,7 @@ import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
 import org.opencastproject.smil.api.util.SmilUtil;
+import org.opencastproject.userdirectory.UserIdRoleProvider;
 import org.opencastproject.util.ConfigurationException;
 import org.opencastproject.util.IoSupport;
 import org.opencastproject.util.LoadUtil;
@@ -134,6 +138,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Dictionary;
@@ -1977,6 +1982,13 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       logger.debug("No series name provided");
       return mp;
     }
+
+    // Verify user is a CA by checking roles and captureAgentId
+    User user = securityService.getUser();
+    if (!user.hasRole(GLOBAL_ADMIN_ROLE) && !user.hasRole(GLOBAL_CAPTURE_AGENT_ROLE)) {
+      logger.info("User '{}' is missing capture agent roles, won't apply CASeries", user.getUsername());
+      return mp;
+    }
     //Get capture agent name
     String captureAgentId = null;
     Catalog[] catalog = mp.getCatalogs(MediaPackageElementFlavor.flavor("dublincore", "episode"));
@@ -1989,12 +2001,10 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       }
     }
     if (captureAgentId == null) {
-      logger.info("No Capture Agent ID defined for MediaPackage {}", mp.getIdentifier());
+      logger.info("No Capture Agent ID defined for MediaPackage {}, won't apply CASeries", mp.getIdentifier());
       return mp;
     }
-
-    String roleName = SecurityUtil.getCaptureAgentRole(captureAgentId);
-    logger.debug("Capture agent role name: {}", roleName);
+    logger.info("Applying CASeries to MediaPackage {} for capture agent '{}'", mp.getIdentifier(), captureAgentId);
 
     // Find or create CA series
     String seriesId = captureAgentId.replaceAll("[^\\w-_.:;()]+", "_");
@@ -2004,7 +2014,16 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
       seriesService.getSeries(seriesId);
     } catch (NotFoundException nfe) {
       try {
-        createSeries(seriesId, seriesName, roleName);
+        List<String> roleNames = new ArrayList<>();
+        String roleName = SecurityUtil.getCaptureAgentRole(captureAgentId);
+        roleNames.add(roleName);
+        logger.debug("Capture agent role name: {}", roleName);
+
+        String username = user.getUsername();
+        roleNames.add(UserIdRoleProvider.getUserIdRole(username));
+
+        logger.info("Creating new series for capture agent '{}' and user '{}'", captureAgentId, username);
+        createSeries(seriesId, seriesName, roleNames);
       } catch (Exception e) {
         logger.error("Unable to create series {} for event {}", seriesName, mp, e);
         return mp;
@@ -2021,7 +2040,7 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     return mp;
   }
 
-  private DublinCoreCatalog createSeries(String seriesId, String seriesName, String roleName)
+  private DublinCoreCatalog createSeries(String seriesId, String seriesName, List<String> roleNames)
       throws SeriesException, UnauthorizedException, NotFoundException {
     DublinCoreCatalog dc = DublinCores.mkOpencastSeries().getCatalog();
     dc.set(PROPERTY_IDENTIFIER, seriesId);
@@ -2031,9 +2050,14 @@ public class IngestServiceImpl extends AbstractJobProducer implements IngestServ
     DublinCoreCatalog createdSeries = seriesService.updateSeries(dc);
 
     // fill acl
-    AccessControlEntry aceRead = new AccessControlEntry(roleName, Permissions.Action.READ.toString(), true);
-    AccessControlEntry aceWrite = new AccessControlEntry(roleName, Permissions.Action.WRITE.toString(), true);
-    AccessControlList acl = new AccessControlList(aceRead, aceWrite);
+    List<AccessControlEntry> aces = new ArrayList();
+    for (String roleName : roleNames) {
+      AccessControlEntry aceRead = new AccessControlEntry(roleName, Permissions.Action.READ.toString(), true);
+      AccessControlEntry aceWrite = new AccessControlEntry(roleName, Permissions.Action.WRITE.toString(), true);
+      aces.add(aceRead);
+      aces.add(aceWrite);
+    }
+    AccessControlList acl = new AccessControlList(aces);
     seriesService.updateAccessControl(seriesId, acl);
     logger.info("Created capture agent series with name {} and id {}", seriesName, seriesId);
 


### PR DESCRIPTION
When ingesting with a capture agent while using the `add.series.to.event.appendix` configuration option Opencast creates a series and tries to add the event to the series.
This can lead to a failing workflow when the CA is missing permissions to access the series (e.g. only having ROLE_CAPTURE_AGENT).

This PR fixes the bug by adding the user role to the created series, it also adds additional checks before considering an ingester as a capture agent.