### PR TITLE
Do not forget videos detected previously in Paella

### DIFF
--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -274,7 +274,7 @@ class OpencastToPaellaConverter {
           if (videoCanvas) {
             currentStream.canvas = [videoCanvas];
           }
-        } else {
+        } else if (currentStream.type === undefined) {
           // Explicitly set the type, else Paella will assume this track to be 'video' type (Causing an exception
           // if it is actually not)
           currentStream.type = 'noType';


### PR DESCRIPTION
Paella Player needs at least one video stream. Looking through the tracks, Paella-Player marks the streams as type audio or video, preferring video if video was previously detected, so it can play that stream as a video. However, the `noType` was added unconditionally if the last track's source type was null (for instance for MP3s or Opus Audio) causing an error "no video streams found. at least one video stream is required by paella".

![paella player screenshot: "no video streams found. at least one video stream is required by paella"](https://user-images.githubusercontent.com/2311611/203376935-c3f86c3c-85a7-4695-8f26-66803a2c62f4.png)


This PR will prefer audio, video or whatever has been found amongst the tracks over `noType` avoiding this error message if you deliver MP3/ Opus audio amongst your videos.

### Your pull request should…

* [x] have a concise title
* [-] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [-] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
