### PR TITLE
Add rules for merging pull requests to the docs

### DIFF
--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -86,6 +86,21 @@ modules/admin-ui/src/main/java | In case the interface of the Admin UI facade ch
 While a committer may accept a patch even if it does not meet these expectations, it is encouraged that anyone filing
 a pull request ensures that they meet these expectations.
 
+#### Merging Pull Requests
+
+After a pull request has received at least one approving review and passes the automated tests, it is ready for merging.
+Only a committer can perform a merge, so if a reviewed pull request has not yet received attention from a committer
+feel free to contact one.
+
+There are a couple of rules that committers must follow when merging pull requests. These are:
+* You cannot merge your own pull requests.
+* A pull request requires at least one approving review before merging.
+    * More reviews are always welcome.
+* You cannot review your own pull requests.
+    * However, intra-organization reviews are permitted, meaning your co-worker is allowed to review your pull request.
+* A pull request must be approved at the weekly technical meeting before merging (visit https://docs.opencast.org/ for
+the time and place of the technical meeting).
+
 
 Git Repository Branching Model
 ------------------------------

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -93,13 +93,12 @@ Only a committer can perform a merge, so if a reviewed pull request has not yet 
 feel free to contact one.
 
 There are a couple of rules that committers must follow when merging pull requests. These are:
-* You cannot merge your own pull requests.
 * A pull request requires at least one approving review before merging.
     * More reviews are always welcome.
-* You cannot review your own pull requests.
-    * However, intra-organization reviews are permitted, meaning your co-worker is allowed to review your pull request.
 * A pull request must be approved at the weekly technical meeting before merging (visit https://docs.opencast.org/ for
 the time and place of the technical meeting).
+* Reviewing or merging your own pull requests is strongly discouraged, but technically allowed.
+    * It is advised to be pragmatic and only do so if necessary.
 
 
 Git Repository Branching Model


### PR DESCRIPTION
What a committer is and is not allowed when merging a pull request is not clearly documented. The best way to inform myself about the rules I could currently find is sifting through the proposal logs, which is time consuming, confusing and makes it easy to miss relevant proposals. Therefore, I would like to add the rules in a place in the docs where they are easier to find.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
