### PR TITLE
Fix Firefox install for admin ui tests in GHA

### DIFF
--- a/.github/workflows/test-admin-interface-frontend.yml
+++ b/.github/workflows/test-admin-interface-frontend.yml
@@ -26,6 +26,17 @@ jobs:
       with:
         node-version: 16.x
 
+    # Ubuntu 22.04 lies wrt to firefox in its repo
+    # the 'firefox' package is just a script which tells you to use snap
+    # This adds Mozilla's PPA, and installs it from there
+    - name: install firefox manually
+      run: |
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository -y ppa:mozillateam/ppa
+        echo -e 'Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001' | sudo tee /etc/apt/preferences.d/mozilla-firefox
+        sudo apt-get install -y firefox
+        firefox --version
+
     - name: install dependencies
       run: |
         cd modules/admin-ui-frontend


### PR DESCRIPTION
Fixing firefox source in GHA/CI builds.  Ubuntu 22.04 lies about whether it's actually installing firefox by default, instead installing a script which tells you to install it from snap.  This doesn't work in several cases, so we're switching to a valid repo which provides proper debian packaging.

Fixes #4437

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
