### PR TITLE
Fix possible duplicate notes in Admin UI

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
@@ -208,15 +208,34 @@ angular.module('adminNg.controllers')
 
     // Type of comments in the notes column
     $scope.table.notesCommentReason = 'EVENTS.EVENTS.DETAILS.COMMENTS.REASONS.ADMINUI_NOTES';
+    // Tmp storage for created comments
+    // Used to avoid creating duplicate comments
+    $scope.table.createdComments = [];
 
     $scope.table.createComment = function(commentText, eventId) {
       if (!commentText || !eventId) {
         return;
       }
-      CommentResource.save(
+
+      // If a comment for this event was already created,
+      // update the existing comment instead
+      const index = $scope.table.createdComments.findIndex(object => {
+        return object.eventId === eventId;
+      })
+      if (index >= 0) {
+        let comment = $scope.table.createdComments[index].comment;
+        comment.text = commentText;
+        $scope.table.updateComment(comment, eventId);
+        return;
+      }
+
+      const comment = CommentResource.save(
         { resource: 'event', resourceId: eventId, type: 'comment' },
         { text: commentText, reason: $scope.table.notesCommentReason }
       );
+
+      // Remember created comment
+      $scope.table.createdComments.push({eventId: eventId, comment: comment});
     };
 
     $scope.table.updateComment = function(comment, eventId) {

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
@@ -221,7 +221,7 @@ angular.module('adminNg.controllers')
       // update the existing comment instead
       const index = $scope.table.createdComments.findIndex(object => {
         return object.eventId === eventId;
-      })
+      });
       if (index >= 0) {
         let comment = $scope.table.createdComments[index].comment;
         comment.text = commentText;


### PR DESCRIPTION
There is a bug in the admin UI where you can accidentally duplicate the notes for an event if you behave a certain way. This fixes that.

How to reproduce the bug this fixes in detail:

0. Enable the notes column in the event view of the Admin UI (disabled by default)
1. Write some text in an empty notes input fields.
2. Click somewhere else on the page, so the input field loses focus.
3. Click back into the input field you just wrote into, and write some more.
4. Reload the page
5. See duplicated notes input field.

 Repeating step 2 and 3 before going to step 4 increases the number of
 duplications.
