### PR TITLE
Make debug output in the JWT filters simpler and more idiomatic

### DIFF
--- a/docs/guides/admin/docs/configuration/security.jwt.md
+++ b/docs/guides/admin/docs/configuration/security.jwt.md
@@ -75,8 +75,6 @@ sections found in `etc/security/mh_default_org.xml`. Some of the options are con
   <property name="loginHandler" ref="jwtLoginHandler" />
   <!-- Throws an exception if a request is missing the configured header (default: true) -->
   <property name="exceptionIfHeaderMissing" value="false" />
-  <!-- Logs the header contents for debug purposes (default: false) -->
-  <property name="debug" value="false" />
 </bean>
 
 <!-- General JWT request parameter extraction filter -->
@@ -87,8 +85,6 @@ sections found in `etc/security/mh_default_org.xml`. Some of the options are con
   <property name="loginHandler" ref="jwtLoginHandler" />
   <!-- Throws an exception if a request is missing the configured parameter (default: true) -->
   <property name="exceptionIfParameterMissing" value="false" />
-  <!-- Logs the header contents for debug purposes (default: false) -->
-  <property name="debug" value="false" />
 </bean>
 ```
 * Configure the `jwtLoginHandler`. For the JWT validation, either configure the `secret` property for JWTs signed with

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -720,7 +720,6 @@
     <property name="authenticationManager" ref="authenticationManager" />
     <property name="loginHandler" ref="jwtLoginHandler" />
     <property name="exceptionIfHeaderMissing" value="false" />
-    <property name="debug" value="false" />
   </bean>-->
 
   <!-- General JWT request parameter extraction filter
@@ -729,7 +728,6 @@
     <property name="authenticationManager" ref="authenticationManager" />
     <property name="loginHandler" ref="jwtLoginHandler" />
     <property name="exceptionIfParameterMissing" value="false" />
-    <property name="debug" value="false" />
   </bean>-->
 
   <!-- JWT login handler

--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/JWTRequestHeaderAuthenticationFilter.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/JWTRequestHeaderAuthenticationFilter.java
@@ -37,9 +37,6 @@ public class JWTRequestHeaderAuthenticationFilter extends RequestHeaderAuthentic
   /** Login handler. */
   private JWTLoginHandler loginHandler = null;
 
-  /** If set to true, all request headers will be logged. */
-  private boolean debug = false;
-
   @Override
   public void afterPropertiesSet() {
     super.afterPropertiesSet();
@@ -48,9 +45,7 @@ public class JWTRequestHeaderAuthenticationFilter extends RequestHeaderAuthentic
 
   @Override
   protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
-    if (debug) {
-      Util.debug(logger, request);
-    }
+    Util.debug(logger, request);
 
     String username = null;
 
@@ -84,15 +79,6 @@ public class JWTRequestHeaderAuthenticationFilter extends RequestHeaderAuthentic
    */
   public void setLoginHandler(JWTLoginHandler loginHandler) {
     this.loginHandler = loginHandler;
-  }
-
-  /**
-   * Setter for the debug switch.
-   *
-   * @param debug Value for the debug switch.
-   */
-  public void setDebug(boolean debug) {
-    this.debug = debug;
   }
 
 }

--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/JWTRequestParameterAuthenticationFilter.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/JWTRequestParameterAuthenticationFilter.java
@@ -44,9 +44,6 @@ public class JWTRequestParameterAuthenticationFilter extends AbstractPreAuthenti
   /** If set to true, throws an exception when the configured parameter is not provided. */
   private boolean exceptionIfParameterMissing = true;
 
-  /** If set to true, all request headers will be logged. */
-  private boolean debug = false;
-
   @Override
   public void afterPropertiesSet() {
     super.afterPropertiesSet();
@@ -56,9 +53,7 @@ public class JWTRequestParameterAuthenticationFilter extends AbstractPreAuthenti
 
   @Override
   protected Object getPreAuthenticatedPrincipal(HttpServletRequest request) {
-    if (debug) {
-      Util.debug(logger, request);
-    }
+    Util.debug(logger, request);
 
     String token = request.getParameter(parameterName);
     if (token == null && exceptionIfParameterMissing) {
@@ -100,15 +95,6 @@ public class JWTRequestParameterAuthenticationFilter extends AbstractPreAuthenti
    */
   public void setExceptionIfParameterMissing(boolean exceptionIfParameterMissing) {
     this.exceptionIfParameterMissing = exceptionIfParameterMissing;
-  }
-
-  /**
-   * Setter for the debug switch.
-   *
-   * @param debug Value for the debug switch.
-   */
-  public void setDebug(boolean debug) {
-    this.debug = debug;
   }
 
 }

--- a/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/Util.java
+++ b/modules/security-jwt/src/main/java/org/opencastproject/security/jwt/Util.java
@@ -39,6 +39,10 @@ public final class Util {
    * @param request The request.
    */
   protected static void debug(Log logger, HttpServletRequest request) {
+    if (!logger.isDebugEnabled()) {
+      return;
+    }
+
     Enumeration<String> he = request.getHeaderNames();
     while (he.hasMoreElements()) {
       String headerName = he.nextElement();


### PR DESCRIPTION
This makes the JWT filter(s) use the preexisting debug configuration of their logger to decide whether to log debug output instead of a bespoke property as suggested by @geichelberger. (See https://github.com/opencast/opencast/pull/4412#discussion_r1037999226.)

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
