### PR TITLE
Allow CA user to get series

### DIFF
--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/persistence/SeriesServiceDatabaseImpl.java
@@ -378,18 +378,8 @@ public class SeriesServiceDatabaseImpl implements SeriesServiceDatabase {
         throw new NotFoundException("No series with id=" + seriesId + " exists");
       }
       // Ensure this user is allowed to read this series
-      String accessControlXml = entity.getAccessControl();
-      if (accessControlXml != null) {
-        AccessControlList acl = AccessControlParser.parseAcl(accessControlXml);
-        User currentUser = securityService.getUser();
-        Organization currentOrg = securityService.getOrganization();
-        // There are several reasons a user may need to load a series: to read content, to edit it, or add content
-        if (!AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.READ.toString())
-                && !AccessControlUtil.isAuthorized(acl, currentUser, currentOrg,
-                        Permissions.Action.CONTRIBUTE.toString())
-                && !AccessControlUtil.isAuthorized(acl, currentUser, currentOrg, Permissions.Action.WRITE.toString())) {
-          throw new UnauthorizedException(currentUser + " is not authorized to see series " + seriesId);
-        }
+      if (!userHasReadAccess(entity)) {
+        throw new UnauthorizedException(securityService.getUser() + " is not authorized to see series " + seriesId);
       }
       return dcService.load(IOUtils.toInputStream(entity.getDublinCoreXML(), "UTF-8"));
     } catch (NotFoundException e) {


### PR DESCRIPTION
If a capture agent user tries to run the series WOH, they will cause an UnauthorizedException. This commit fixes that by granting capture agent users the same exemption from permission checks for getting a series dublincore catalog that they already have for getting a series properties.

Resolves #4266

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
