### PR TITLE
Allow hotkeys in create dialogs in input elements

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/directives/wizardDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/wizardDirective.js
@@ -269,6 +269,18 @@ angular.module('adminNg.directives')
 
       HotkeysService.activateHotkey(scope, 'add_media.next_tab', (event) => {
         if (!scope.wizard.isLast()) {
+          // Trigger submit function on form elements, thereby updating the requiredMetadata array of the form.
+          // This allows the hotkey to trigger the "next" step while the form element is still in focus, if all
+          // requirements are met.
+          // It would  be preferable to just trigger 'blur'/'change' on the element, but since the execution of their
+          // callbacks is asynchronous, there is no guarantee that the callbacks will have run before the check for
+          // the "next" step is run.
+          var targetElement = angular.element(event.target);
+          if (targetElement.parents('form').length > 0) {
+            var targetScope = targetElement.scope();
+            targetScope.submit();
+          }
+
           scope.wizard.toTab(event, 'next');
         } else {
           scope.submit();

--- a/modules/admin-ui-frontend/app/scripts/shared/directives/wizardDirective.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/directives/wizardDirective.js
@@ -274,12 +274,14 @@ angular.module('adminNg.directives')
           scope.submit();
         }
         event.preventDefault();
-      });
+      },
+      ['INPUT', 'TEXTAREA', 'SELECT']);
 
       HotkeysService.activateHotkey(scope, 'add_media.previous_tab', (event) => {
         scope.wizard.toTab(event, 'previous');
         event.preventDefault();
-      });
+      },
+      ['INPUT', 'TEXTAREA', 'SELECT']);
     }
   };
 }]);

--- a/modules/admin-ui-frontend/app/scripts/shared/services/hotkeysService.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/hotkeysService.js
@@ -52,7 +52,7 @@ angular.module('adminNg.services')
         });
       };
 
-      function activateHotkey(hotkeys, keyIdentifier, callback) {
+      function activateHotkey(hotkeys, keyIdentifier, callback, allowIn) {
         me.loading.then(function () {
           var key = me.keyBindings[keyIdentifier];
           if (key) {
@@ -63,18 +63,21 @@ angular.module('adminNg.services')
               // information, which we need in our custom cheat sheet template
               // to translate and group the keys.
               description: keyIdentifier,
-              callback: callback
+              callback: callback,
+              // array of strings, allows shortcut execution in these html elements
+              // Possible values: 'INPUT', 'TEXTAREA', 'SELECT'
+              allowIn: allowIn,
             });
           }
         });
       }
 
-      this.activateHotkey = function (scope, keyIdentifier, callback) {
-        activateHotkey(hotkeys.bindTo(scope), keyIdentifier, callback);
+      this.activateHotkey = function (scope, keyIdentifier, callback, allowIn) {
+        activateHotkey(hotkeys.bindTo(scope), keyIdentifier, callback, allowIn);
       };
 
-      this.activateUniversalHotkey = function (keyIdentifier, callback) {
-        activateHotkey(hotkeys, keyIdentifier, callback);
+      this.activateUniversalHotkey = function (keyIdentifier, callback, allowIn) {
+        activateHotkey(hotkeys, keyIdentifier, callback, allowIn);
       };
 
       this.loading = this.loadHotkeys();


### PR DESCRIPTION
In the Admin UI, the "Create event" and "Create series" dialogs both have hotkeys with which one can easily jump to the previous/next tab of the dialog (provided the requirements to go to the next tab are met of course). However, one can get "stuck" in the metadata views if an input field or dropdown is in focus, as the hotkeys won't trigger in that case. This fixes that by allowing them to trigger.

Behaviour for any other hotkeys is unchanged.