### PR TITLE
Change default hotkeys for create dialogs in admin UI

### DIFF
--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -225,8 +225,8 @@ prop.admin.shortcut.general.main_menu=m
 
 # Shortcut definitions for admin UI add-event and add-series modals
 # Format: prop.admin.shortcut.add_media.<action>=<key(s)>
-prop.admin.shortcut.add_media.next_tab=alt+enter
-prop.admin.shortcut.add_media.previous_tab=alt+backspace
+prop.admin.shortcut.add_media.next_tab=shift+alt+right
+prop.admin.shortcut.add_media.previous_tab=shift+alt+left
 
 # Default values for fields in the tab Source of the Add Event wizard
 #


### PR DESCRIPTION
In the admin UI, you can switch between different tabs in a create dialog via hotkeys. Per default, they use `Enter` and `Backspace`, which feels weird to use. This commit changes them for the `left` and `right` arrow keys. It also adds an extra `Shift` as a requirement, as the arrow keys would otherwise cause conflicts with various browsers and operating systems.