### PR TITLE
Support AWS S3 Glacier tiering

### DIFF
--- a/etc/org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore.cfg
+++ b/etc/org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore.cfg
@@ -12,9 +12,9 @@ org.opencastproject.assetmanager.aws.s3.enabled=false
 # Example: cluster-name-file-assetmanager
 #org.opencastproject.assetmanager.aws.s3.bucket=
 
-+# The number of days which to restore objects in the Glacier storage class for.
-+# Default: 2
-+#org.opencastproject.assetmanager.aws.s3.glacier.restore=2
+# The number of days which to restore objects in the Glacier storage class for.
+# Default: 2
+#org.opencastproject.assetmanager.aws.s3.glacier.restore=2
 
 # The AWS access key ID to use for connecting to S3.
 #org.opencastproject.assetmanager.aws.s3.access.id=

--- a/etc/org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore.cfg
+++ b/etc/org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore.cfg
@@ -12,6 +12,10 @@ org.opencastproject.assetmanager.aws.s3.enabled=false
 # Example: cluster-name-file-assetmanager
 #org.opencastproject.assetmanager.aws.s3.bucket=
 
++# The number of days which to restore objects in the Glacier storage class for.
++# Default: 2
++#org.opencastproject.assetmanager.aws.s3.glacier.restore=2
+
 # The AWS access key ID to use for connecting to S3.
 #org.opencastproject.assetmanager.aws.s3.access.id=
 

--- a/etc/org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore.cfg
+++ b/etc/org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore.cfg
@@ -14,7 +14,7 @@ org.opencastproject.assetmanager.aws.s3.enabled=false
 
 # The number of days which to restore objects in the Glacier storage class for.
 # Default: 2
-#org.opencastproject.assetmanager.aws.s3.glacier.restore=2
+#org.opencastproject.assetmanager.aws.s3.glacier.restore.days=2
 
 # The AWS access key ID to use for connecting to S3.
 #org.opencastproject.assetmanager.aws.s3.access.id=

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManagerException.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManagerException.java
@@ -20,6 +20,11 @@
  */
 package org.opencastproject.assetmanager.api;
 
+import static org.opencastproject.util.data.functions.Misc.chuck;
+
+import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.util.NotFoundException;
+
 /**
  * A common exception indicating various issues.
  */
@@ -38,4 +43,26 @@ public class AssetManagerException extends RuntimeException {
   public AssetManagerException(Throwable cause) {
     super(cause);
   }
+
+  /** Returns true if the exception is caused by a {@link org.opencastproject.security.api.UnauthorizedException}. */
+  // todo is an authorization failure really unrecoverable?
+  public boolean isCauseNotAuthorized() {
+    return getCause() instanceof UnauthorizedException;
+  }
+
+  /** Returns true if the exception is caused by a {@link org.opencastproject.util.NotFoundException}. */
+  public boolean isCauseNotFound() {
+    return getCause() instanceof NotFoundException;
+  }
+
+  /**
+   * If the exception is caused by an {@link org.opencastproject.security.api.UnauthorizedException}
+   * rethrow it, otherwise do nothing.
+   */
+  public void rethrowUnauthorizedException() {
+    if (isCauseNotAuthorized()) {
+      chuck(getCause());
+    }
+  }
+
 }

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManagerException.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/AssetManagerException.java
@@ -20,8 +20,6 @@
  */
 package org.opencastproject.assetmanager.api;
 
-import static org.opencastproject.util.data.functions.Misc.chuck;
-
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.util.NotFoundException;
 
@@ -53,16 +51,6 @@ public class AssetManagerException extends RuntimeException {
   /** Returns true if the exception is caused by a {@link org.opencastproject.util.NotFoundException}. */
   public boolean isCauseNotFound() {
     return getCause() instanceof NotFoundException;
-  }
-
-  /**
-   * If the exception is caused by an {@link org.opencastproject.security.api.UnauthorizedException}
-   * rethrow it, otherwise do nothing.
-   */
-  public void rethrowUnauthorizedException() {
-    if (isCauseNotAuthorized()) {
-      chuck(getCause());
-    }
   }
 
 }

--- a/modules/asset-manager-storage-aws/pom.xml
+++ b/modules/asset-manager-storage-aws/pom.xml
@@ -63,6 +63,10 @@
     </dependency>
     <!-- AWS SDK END -->
     <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
     </dependency>

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
@@ -33,6 +33,7 @@ import org.opencastproject.assetmanager.aws.persistence.AwsAssetDatabaseExceptio
 import org.opencastproject.assetmanager.aws.persistence.AwsAssetMapping;
 import org.opencastproject.assetmanager.impl.VersionImpl;
 import org.opencastproject.util.ConfigurationException;
+import org.opencastproject.util.MimeType;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.OsgiUtil;
 import org.opencastproject.util.data.Option;
@@ -176,7 +177,7 @@ public abstract class AwsAbstractArchive implements AssetStore {
     String objectVersion = null;
     try {
       // Upload file to AWS
-      AwsUploadOperationResult result = uploadObject(origin, objectName);
+      AwsUploadOperationResult result = uploadObject(origin, objectName, source.getMimeType());
       objectName = result.getObjectName();
       objectVersion = result.getObjectVersion();
     } catch (Exception e) {
@@ -193,7 +194,8 @@ public abstract class AwsAbstractArchive implements AssetStore {
     }
   }
 
-  protected abstract AwsUploadOperationResult uploadObject(File origin, String objectName) throws AssetStoreException;
+  protected abstract AwsUploadOperationResult uploadObject(File origin, String objectName, Opt<MimeType> mimeType)
+          throws AssetStoreException;
 
   /** @see AssetStore#get(StoragePath) */
   public Opt<InputStream> get(final StoragePath path) throws AssetStoreException {

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
@@ -111,7 +111,7 @@ public abstract class AwsAbstractArchive implements AssetStore {
   public boolean copy(final StoragePath from, final StoragePath to) throws AssetStoreException {
     try {
       AwsAssetMapping map = database.findMapping(from);
-      if (map == null) {
+      if (!contains(from)) {
         logger.warn("Origin file mapping not found in database: {}", from);
         return false;
       }

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
@@ -336,9 +336,9 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
   }
 
   /**
-   +   * Return the object key of the asset in S3
-   +   * @param storagePath asset storage path
-   +   */
+   * Return the object key of the asset in S3
+   * @param storagePath asset storage path
+   */
   public String getAssetObjectKey(StoragePath storagePath) throws AssetStoreException {
     try {
       AwsAssetMapping map = database.findMapping(storagePath);
@@ -390,7 +390,7 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
       StorageClass objectStorageClass = StorageClass.fromValue(getObjectStorageClass(objectName));
 
       if (storageClass != objectStorageClass) {
-        /* objects can only be retrived from Glacier not moved */
+        /* objects can only be retrieved from Glacier not moved */
         if (objectStorageClass == StorageClass.Glacier || objectStorageClass == StorageClass.DeepArchive) {
           logger.warn("S3 Object {} can not be moved from storage class {}", objectStorageClass);
           return objectStorageClass;

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
@@ -400,8 +400,8 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
         if (storageClass == StorageClass.Glacier || objectStorageClass == StorageClass.DeepArchive) {
           GetObjectTaggingRequest gotr = new GetObjectTaggingRequest(bucketName, objectName);
           GetObjectTaggingResult objectTaggingRequest = s3.getObjectTagging(gotr);
-          logger.info("S3 object {} is not suitable for storage class {}", objectName, storageClass);
           if (!objectTaggingRequest.getTagSet().contains(freezable)) {
+            logger.info("S3 object {} is not suitable for storage class {}", objectName, storageClass);
             return objectStorageClass;
           }
         }

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
@@ -390,9 +390,11 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
       StorageClass objectStorageClass = StorageClass.fromValue(getObjectStorageClass(objectName));
 
       if (storageClass != objectStorageClass) {
+        boolean restored = null != s3.getObjectMetadata(bucketName, objectName).getRestoreExpirationTime();
         /* objects can only be retrieved from Glacier not moved */
-        if (objectStorageClass == StorageClass.Glacier || objectStorageClass == StorageClass.DeepArchive) {
-          logger.warn("S3 Object {} can not be moved from storage class {}", objectStorageClass);
+        if (objectStorageClass == StorageClass.Glacier || objectStorageClass == StorageClass.DeepArchive && !restored) {
+          logger.warn("S3 Object {} can not be moved from storage class {} to {} without restoring the object first",
+              objectStorageClass, storageClass);
           return objectStorageClass;
         }
 

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
@@ -427,7 +427,7 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
   protected InputStream getObject(AwsAssetMapping map) {
     String storageClassId = getObjectStorageClass(map.getObjectKey());
 
-    if (StorageClass.Glacier.equals(storageClassId)) {
+    if (StorageClass.Glacier.name().equals(storageClassId) || StorageClass.DeepArchive.name().equals(storageClassId)) {
       // restore object and wait until available if necessary
       restoreGlacierObject(map.getObjectKey(), restorePeriod, true);
     }

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/endpoint/AwsS3RestEndpoint.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/endpoint/AwsS3RestEndpoint.java
@@ -1,0 +1,435 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.assetmanager.aws.s3.endpoint;
+
+import static org.opencastproject.util.RestUtil.R.noContent;
+import static org.opencastproject.util.RestUtil.R.notFound;
+import static org.opencastproject.util.RestUtil.R.ok;
+import static org.opencastproject.util.RestUtil.R.serverError;
+
+import org.opencastproject.assetmanager.api.AssetManager;
+import org.opencastproject.assetmanager.api.AssetManagerException;
+import org.opencastproject.assetmanager.api.query.AQueryBuilder;
+import org.opencastproject.assetmanager.api.query.ARecord;
+import org.opencastproject.assetmanager.api.query.AResult;
+import org.opencastproject.assetmanager.api.query.ASelectQuery;
+import org.opencastproject.assetmanager.api.storage.AssetStoreException;
+import org.opencastproject.assetmanager.api.storage.StoragePath;
+import org.opencastproject.assetmanager.aws.s3.AwsS3AssetStore;
+import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.util.data.Function0;
+import org.opencastproject.util.doc.rest.RestParameter;
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
+import org.opencastproject.util.doc.rest.RestService;
+
+import com.amazonaws.services.s3.model.StorageClass;
+
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+@RestService(name = "archive-aws-s3", title = "AWS S3 Archive",
+    notes = {
+        "All paths are relative to the REST endpoint base (something like http://your.server/files)",
+        "If you notice that this service is not working as expected, there might be a bug! "
+            + "You should file an error report with your server logs from the time when the error occurred: "
+            + "<a href=\"http://opencast.jira.com\">Opencast Issue Tracker</a>"
+    },
+    abstractText = "This service handles AWS S3 archived assets")
+@Component(
+    immediate = true,
+    service = AwsS3RestEndpoint.class,
+    property = {
+        "service.description=AssetManager S3 REST Endpoint",
+        "opencast.service.type=org.opencastproject.assetmanager.aws-s3",
+        "opencast.service.path=/assets/aws/s3",
+    }
+)
+public class AwsS3RestEndpoint {
+
+  private static final Logger logger = LoggerFactory.getLogger(AwsS3RestEndpoint.class);
+
+  private AwsS3AssetStore awsS3AssetStore = null;
+  private AssetManager assetManager = null;
+  private SecurityService securityService = null;
+
+  @GET
+  @Path("{mediaPackageId}/assets/storageClass")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(name = "getStorageClass",
+      description = "Get the S3 Storage Class for each asset in the Media Package",
+      pathParameters = {
+          @RestParameter(
+              name = "mediaPackageId", isRequired = true,
+              type = RestParameter.Type.STRING,
+              description = "The media package indentifier.")},
+      responses = {
+          @RestResponse(
+              description = "mediapackage found in S3",
+              responseCode = HttpServletResponse.SC_OK),
+          @RestResponse(
+              description = "mediapackage not found or has no assets in S3",
+              responseCode = HttpServletResponse.SC_NOT_FOUND)
+      },
+      returnDescription = "List each assets's Object Key and S3 Storage Class ")
+  public Response getStorageClass(@PathParam("mediaPackageId") final String mediaPackageId) {
+    return handleException(new Function0<Response>() {
+      private String getMediaPackageId() {
+        return StringUtils.trimToNull(mediaPackageId);
+      }
+
+      @Override public Response apply() {
+        AQueryBuilder q = assetManager.createQuery();
+        final ASelectQuery idQuery = q.select(q.snapshot())
+            .where(
+                q.organizationId(securityService.getOrganization().getId())
+                    .and(q.mediaPackageId(getMediaPackageId()))
+                    .and(q.version().isLatest()));
+        final AResult result = idQuery.run();
+        if (result.getSize() > 1) {
+          return serverError();
+        }
+        if (result.getSize() == 0) {
+          return notFound();
+        }
+        final ARecord item = result.getRecords().head2();
+
+        StringBuilder info = new StringBuilder();
+        for (MediaPackageElement e : assetManager.getMediaPackage(item.getMediaPackageId()).get().elements()) {
+          if (e.getElementType() == MediaPackageElement.Type.Publication) {
+            continue;
+          }
+
+          StoragePath storagePath = new StoragePath(securityService.getOrganization().getId(),
+              getMediaPackageId(),
+              item.getSnapshot().get().getVersion(),
+              e.getIdentifier());
+          if (awsS3AssetStore.contains(storagePath)) {
+            try {
+              info.append(String.format("%s,%s\n", awsS3AssetStore.getAssetObjectKey(storagePath),
+                                                   awsS3AssetStore.getAssetStorageClass(storagePath)));
+            } catch (AssetStoreException ex) {
+              throw new AssetManagerException(ex);
+            }
+          } else {
+            info.append(String.format("%s,NONE\n", e.getURI(), awsS3AssetStore.getStoreType()));
+          }
+        }
+        return ok(info.toString());
+      }
+
+    });
+  }
+
+  @PUT
+  @Path("{mediaPackageId}/assets")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(name = "modifyStorageClass",
+      description = "Move the Media Package assets to the specified S3 Storage Class if possible",
+      pathParameters = {
+          @RestParameter(
+              name = "mediaPackageId",
+              isRequired = true,
+              type = RestParameter.Type.STRING,
+              description = "The media package indentifier.")
+      },
+      restParameters = {
+          @RestParameter(
+              name = "storageClass",
+              isRequired = true,
+              type = RestParameter.Type.STRING,
+              description = "The S3 storage class, valid terms STANDARD, STANDARD_IA, INTELLIGENT_TIERING, ONEZONE_IA,"
+                          + "REDUCED_REDUNDANCY and GLACIER. See https://aws.amazon.com/s3/storage-classes/")
+      },
+      responses = {
+          @RestResponse(
+              description = "mediapackage found in S3",
+              responseCode = HttpServletResponse.SC_OK),
+          @RestResponse(
+              description = "mediapackage not found or has no assets in S3",
+              responseCode = HttpServletResponse.SC_NOT_FOUND)      },
+      returnDescription = "List each asset's Object Key and new S3 Storage Class")
+  public Response modifyStorageClass(@PathParam("mediaPackageId") final String mediaPackageId,
+                                     @FormParam("storageClass") final String storageClass) {
+    return handleException(new Function0<Response>() {
+      private String getMediaPackageId() {
+        return StringUtils.trimToNull(mediaPackageId);
+      }
+
+      private String getStorageClass() {
+        return StringUtils.trimToNull(storageClass);
+      }
+
+      @Override public Response apply() {
+        AQueryBuilder q = assetManager.createQuery();
+        final ASelectQuery idQuery = q.select(q.snapshot())
+            .where(
+                q.organizationId(securityService.getOrganization().getId())
+                    .and(q.mediaPackageId(getMediaPackageId()))
+                    .and(q.version().isLatest()));
+        final AResult result = idQuery.run();
+        if (result.getSize() > 1) {
+          return serverError();
+        }
+        if (result.getSize() == 0) {
+          return notFound();
+        }
+        final ARecord item = result.getRecords().head2();
+
+        StringBuilder info = new StringBuilder();
+        for (MediaPackageElement e : assetManager.getMediaPackage(item.getMediaPackageId()).get().elements()) {
+          if (e.getElementType() == MediaPackageElement.Type.Publication) {
+            continue;
+          }
+
+          StoragePath storagePath = new StoragePath(securityService.getOrganization().getId(),
+              getMediaPackageId(),
+              item.getSnapshot().get().getVersion(),
+              e.getIdentifier());
+          if (awsS3AssetStore.contains(storagePath)) {
+            try {
+              info.append(String.format("%s,%s\n", awsS3AssetStore.getAssetObjectKey(storagePath),
+                                                   awsS3AssetStore.modifyAssetStorageClass(storagePath,
+                                                   getStorageClass())));
+            } catch (AssetStoreException ex) {
+              throw new AssetManagerException(ex);
+            }
+          } else {
+            info.append(String.format("%s,NONE\n", e.getURI(), awsS3AssetStore.getStoreType()));
+          }
+        }
+        return ok(info.toString());
+      }
+
+    });
+  }
+
+  @GET
+  @Path("glacier/{mediaPackageId}/assets")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(name = "restoreAssetsStatus",
+      description = "Get the mediapackage asset's restored status",
+      pathParameters = {
+          @RestParameter(
+              name = "mediaPackageId",
+              isRequired = true,
+              type = RestParameter.Type.STRING,
+              description = "The media package indentifier.")
+      },
+      responses = {
+          @RestResponse(
+              description = "mediapackage found in S3 and assets in Glacier",
+              responseCode = HttpServletResponse.SC_OK),
+          @RestResponse(
+              description = "mediapackage found in S3 but no assets in Glacier",
+              responseCode = HttpServletResponse.SC_NO_CONTENT),
+          @RestResponse(
+              description = "mediapackage not found or has no assets in S3",
+              responseCode = HttpServletResponse.SC_NOT_FOUND)
+      },
+      returnDescription = "List each glacier asset's restoration status and expiration date")
+  public Response restoreAssetsStatus(@PathParam("mediaPackageId") final String mediaPackageId) {
+    return handleException(new Function0<Response>() {
+      private String getMediaPackageId() {
+        return StringUtils.trimToNull(mediaPackageId);
+      }
+
+      @Override public Response apply() {
+        AQueryBuilder q = assetManager.createQuery();
+        final ASelectQuery idQuery = q.select(q.snapshot())
+            .where(
+                q.organizationId(securityService.getOrganization().getId())
+                    .and(q.mediaPackageId(getMediaPackageId()))
+                    .and(q.version().isLatest()));
+        final AResult result = idQuery.run();
+        if (result.getSize() > 1) {
+          return serverError();
+        }
+        if (result.getSize() == 0) {
+          return notFound();
+        }
+        final ARecord item = result.getRecords().head2();
+
+        StringBuilder info = new StringBuilder();
+        for (MediaPackageElement e : assetManager.getMediaPackage(item.getMediaPackageId()).get().elements()) {
+          if (e.getElementType() == MediaPackageElement.Type.Publication) {
+            continue;
+          }
+
+          StoragePath storagePath = new StoragePath(securityService.getOrganization().getId(),
+                                                    getMediaPackageId(),
+                                                    item.getSnapshot().get().getVersion(),
+                                                    e.getIdentifier());
+          String assetStorageClass = awsS3AssetStore.getAssetStorageClass(storagePath);
+          if (awsS3AssetStore.contains(storagePath)
+              && ("GLACIER".equals(assetStorageClass) || "DEEP_ARCHIVE".equals(assetStorageClass))) {
+            try {
+              info.append(String.format("%s,%s\n", awsS3AssetStore.getAssetObjectKey(storagePath),
+                                                   awsS3AssetStore.getAssetRestoreStatusString(storagePath)));
+            } catch (AssetStoreException ex) {
+              throw new AssetManagerException(ex);
+            }
+          }
+        }
+        if (info.length() == 0) {
+          return noContent();
+        }
+        return ok(info.toString());
+      }
+    });
+  }
+
+  @PUT
+  @Path("glacier/{mediaPackageId}/assets")
+  @Produces(MediaType.TEXT_PLAIN)
+  @RestQuery(name = "restoreAssets",
+      description = "Initiate the restore of any assets in Glacier storage class",
+      pathParameters = {
+          @RestParameter(
+              name = "mediaPackageId",
+              isRequired = true,
+              type = RestParameter.Type.STRING,
+              description = "The media package indentifier.")
+      },
+      restParameters = {
+          @RestParameter(
+              name = "restorePeriod",
+              isRequired = false,
+              type = RestParameter.Type.INTEGER,
+              defaultValue = "2",
+              description = "Number of days to restore the assets for, default see service configuration")
+      },
+      responses = {
+          @RestResponse(
+              description = "restore of assets started",
+              responseCode = HttpServletResponse.SC_NO_CONTENT),
+          @RestResponse(
+              description = "mediapackage not found or has no assets in S3",
+              responseCode = HttpServletResponse.SC_NOT_FOUND)
+      },
+      returnDescription = "Restore of assets initiated")
+  public Response restoreAssets(@PathParam("mediaPackageId") final String mediaPackageId,
+                                @FormParam("restorePeriod") final Integer restorePeriod) {
+    return handleException(new Function0<Response>() {
+      private String getMediaPackageId() {
+        return StringUtils.trimToNull(mediaPackageId);
+      }
+
+      private Integer getRestorePeriod() {
+        return restorePeriod != null ? restorePeriod : awsS3AssetStore.getRestorePeriod();
+      }
+
+      @Override public Response apply() {
+        AQueryBuilder q = assetManager.createQuery();
+        final ASelectQuery idQuery = q.select(q.snapshot())
+            .where(
+                q.organizationId(securityService.getOrganization().getId())
+                    .and(q.mediaPackageId(getMediaPackageId()))
+                    .and(q.version().isLatest()));
+        final AResult result = idQuery.run();
+        if (result.getSize() > 1) {
+          return serverError();
+        }
+        if (result.getSize() == 0) {
+          return notFound();
+        }
+        final ARecord item = result.getRecords().head2();
+
+        for (MediaPackageElement e : assetManager.getMediaPackage(item.getMediaPackageId()).get().elements()) {
+          if (e.getElementType() == MediaPackageElement.Type.Publication) {
+            continue;
+          }
+
+          StoragePath storagePath = new StoragePath(securityService.getOrganization().getId(),
+                                                    getMediaPackageId(),
+                                                    item.getSnapshot().get().getVersion(),
+                                                    e.getIdentifier());
+          String assetStorageClass = awsS3AssetStore.getAssetStorageClass(storagePath);
+          if (awsS3AssetStore.contains(storagePath)
+              && (StorageClass.Glacier.equals(assetStorageClass) || "DEEP_ARCHIVE".equals(assetStorageClass))) {
+            try {
+              // Initiate restore and return
+              awsS3AssetStore.initiateRestoreAsset(storagePath, getRestorePeriod());
+            } catch (AssetStoreException ex) {
+              throw new AssetManagerException(ex);
+            }
+          }
+        }
+        return noContent();
+      }
+    });
+  }
+
+
+  /** Unify exception handling. */
+  public static <A> A handleException(final Function0<A> f) {
+    try {
+      return f.apply();
+    } catch (AssetManagerException e) {
+      if (e.isCauseNotAuthorized()) {
+        throw new WebApplicationException(e, Response.Status.UNAUTHORIZED);
+      }
+      if (e.isCauseNotFound()) {
+        throw new WebApplicationException(e, Response.Status.NOT_FOUND);
+      }
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    } catch (Exception e) {
+      logger.error("Error calling archive REST method", e);
+      if (e instanceof NotFoundException) {
+        throw new WebApplicationException(e, Response.Status.NOT_FOUND);
+      }
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @Reference()
+  void setAwsS3AssetStore(AwsS3AssetStore store) {
+    awsS3AssetStore = store;
+  }
+
+  @Reference()
+  void setAssetManager(AssetManager service) {
+    assetManager = service;
+  }
+
+  @Reference()
+  void setSecurityService(SecurityService service) {
+    securityService = service;
+  }
+}

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/endpoint/AwsS3RestEndpoint.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/endpoint/AwsS3RestEndpoint.java
@@ -108,7 +108,7 @@ public class AwsS3RestEndpoint {
               description = "mediapackage not found or has no assets in S3",
               responseCode = HttpServletResponse.SC_NOT_FOUND)
       },
-      returnDescription = "List each assets's Object Key and S3 Storage Class ")
+      returnDescription = "List each assets's Object Key and S3 Storage Class")
   public Response getStorageClass(@PathParam("mediaPackageId") final String mediaPackageId) {
     return handleException(new Function0<Response>() {
       private String getMediaPackageId() {
@@ -265,7 +265,7 @@ public class AwsS3RestEndpoint {
               responseCode = HttpServletResponse.SC_NOT_FOUND)
       },
       returnDescription = "List each glacier asset's restoration status and expiration date")
-  public Response restoreAssetsStatus(@PathParam("mediaPackageId") final String mediaPackageId) {
+  public Response getAssetRestoreState(@PathParam("mediaPackageId") final String mediaPackageId) {
     return handleException(new Function0<Response>() {
       private String getMediaPackageId() {
         return StringUtils.trimToNull(mediaPackageId);

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/endpoint/AwsS3RestEndpoint.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/endpoint/AwsS3RestEndpoint.java
@@ -176,7 +176,7 @@ public class AwsS3RestEndpoint {
               isRequired = true,
               type = RestParameter.Type.STRING,
               description = "The S3 storage class, valid terms STANDARD, STANDARD_IA, INTELLIGENT_TIERING, ONEZONE_IA,"
-                          + "DEEP_ARCHIVE and GLACIER. See https://aws.amazon.com/s3/storage-classes/")
+                          + "GLACIER_IR, GLACIER, and DEEP_ARCHIVE. See https://aws.amazon.com/s3/storage-classes/")
       },
       responses = {
           @RestResponse(

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/endpoint/AwsS3RestEndpoint.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/endpoint/AwsS3RestEndpoint.java
@@ -176,7 +176,7 @@ public class AwsS3RestEndpoint {
               isRequired = true,
               type = RestParameter.Type.STRING,
               description = "The S3 storage class, valid terms STANDARD, STANDARD_IA, INTELLIGENT_TIERING, ONEZONE_IA,"
-                          + "REDUCED_REDUNDANCY and GLACIER. See https://aws.amazon.com/s3/storage-classes/")
+                          + "DEEP_ARCHIVE and GLACIER. See https://aws.amazon.com/s3/storage-classes/")
       },
       responses = {
           @RestResponse(

--- a/modules/asset-manager-storage-aws/src/test/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStoreTest.java
+++ b/modules/asset-manager-storage-aws/src/test/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStoreTest.java
@@ -34,6 +34,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.entwinemedia.fn.data.Opt;
@@ -97,13 +98,18 @@ public class AwsS3AssetStoreTest {
     sampleFile = new File(uri);
 
     // Set up the service
-    objMetadata = EasyMock.createStrictMock(ObjectMetadata.class);
+    ObjectMetadata objMetadata = EasyMock.createStrictMock(ObjectMetadata.class);
     EasyMock.expect(objMetadata.getVersionId()).andReturn(AWS_VERSION_1).anyTimes();
+    EasyMock.expect(objMetadata.getStorageClass()).andReturn(null);
     EasyMock.replay(objMetadata);
     s3Object = EasyMock.createNiceMock(S3Object.class);
+    EasyMock.expect(s3Object.getObjectMetadata()).andReturn(objMetadata).anyTimes();
     s3Client = EasyMock.createStrictMock(AmazonS3Client.class);
     s3Transfer = EasyMock.createStrictMock(TransferManager.class);
     EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andReturn(null);
+    EasyMock.expect(s3Client.getObject(BUCKET_NAME, KEY_VERSION_1 + ASSET_ID + ".xml")).andReturn(s3Object);
+    EasyMock.expect(s3Client.getObjectMetadata(BUCKET_NAME, KEY_VERSION_1 + ASSET_ID + ".xml"))
+        .andReturn(objMetadata).anyTimes();
     // Replay will be called in each test
 
     workspace = EasyMock.createNiceMock(Workspace.class);

--- a/modules/asset-manager-storage-aws/src/test/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStoreTest.java
+++ b/modules/asset-manager-storage-aws/src/test/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStoreTest.java
@@ -34,7 +34,6 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.entwinemedia.fn.data.Opt;
@@ -107,8 +106,8 @@ public class AwsS3AssetStoreTest {
     s3Client = EasyMock.createStrictMock(AmazonS3Client.class);
     s3Transfer = EasyMock.createStrictMock(TransferManager.class);
     EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andReturn(null);
-    EasyMock.expect(s3Client.getObject(BUCKET_NAME, KEY_VERSION_1 + ASSET_ID + ".xml")).andReturn(s3Object);
-    EasyMock.expect(s3Client.getObjectMetadata(BUCKET_NAME, KEY_VERSION_1 + ASSET_ID + ".xml"))
+    EasyMock.expect(s3Client.getObject(BUCKET_NAME, OBJECT_KEY_1)).andReturn(s3Object);
+    EasyMock.expect(s3Client.getObjectMetadata(BUCKET_NAME, OBJECT_KEY_1))
         .andReturn(objMetadata).anyTimes();
     // Replay will be called in each test
 

--- a/modules/asset-manager-storage-aws/src/test/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStoreTest.java
+++ b/modules/asset-manager-storage-aws/src/test/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStoreTest.java
@@ -21,28 +21,43 @@
 
 package org.opencastproject.assetmanager.aws.s3;
 
+import org.opencastproject.assetmanager.api.storage.AssetStoreException;
 import org.opencastproject.assetmanager.api.storage.DeletionSelector;
 import org.opencastproject.assetmanager.api.storage.Source;
 import org.opencastproject.assetmanager.api.storage.StoragePath;
 import org.opencastproject.assetmanager.aws.persistence.AwsAssetDatabaseImpl;
 import org.opencastproject.assetmanager.aws.persistence.AwsAssetMapping;
 import org.opencastproject.assetmanager.impl.VersionImpl;
+import org.opencastproject.util.MimeType;
 import org.opencastproject.util.persistence.PersistenceUtil;
 import org.opencastproject.workspace.api.Workspace;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingResult;
+import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.RestoreObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.SetBucketVersioningConfigurationRequest;
+import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
+import com.amazonaws.services.s3.model.StorageClass;
+import com.amazonaws.services.s3.model.Tag;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.entwinemedia.fn.data.Opt;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
+import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
@@ -50,6 +65,7 @@ import org.osgi.service.component.ComponentContext;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.List;
 
 public class AwsS3AssetStoreTest {
   private ComboPooledDataSource pooledDataSource;
@@ -59,6 +75,8 @@ public class AwsS3AssetStoreTest {
   private AmazonS3Client s3Client;
   private TransferManager s3Transfer;
   private S3Object s3Object;
+
+  private ObjectListing s3ObjectListing;
   private ObjectMetadata objMetadata;
   private Workspace workspace;
 
@@ -97,19 +115,18 @@ public class AwsS3AssetStoreTest {
     sampleFile = new File(uri);
 
     // Set up the service
-    ObjectMetadata objMetadata = EasyMock.createStrictMock(ObjectMetadata.class);
+    objMetadata = EasyMock.createStrictMock(ObjectMetadata.class);
     EasyMock.expect(objMetadata.getVersionId()).andReturn(AWS_VERSION_1).anyTimes();
-    EasyMock.expect(objMetadata.getStorageClass()).andReturn(null);
+    EasyMock.expect(objMetadata.getStorageClass()).andReturn(StorageClass.Standard.toString()).anyTimes();
     EasyMock.replay(objMetadata);
     s3Object = EasyMock.createNiceMock(S3Object.class);
     EasyMock.expect(s3Object.getObjectMetadata()).andReturn(objMetadata).anyTimes();
-    s3Client = EasyMock.createStrictMock(AmazonS3Client.class);
+    s3Client = EasyMock.createNiceMock(AmazonS3Client.class);
+
     s3Transfer = EasyMock.createStrictMock(TransferManager.class);
-    EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andReturn(null);
-    EasyMock.expect(s3Client.getObject(BUCKET_NAME, OBJECT_KEY_1)).andReturn(s3Object);
-    EasyMock.expect(s3Client.getObjectMetadata(BUCKET_NAME, OBJECT_KEY_1))
-        .andReturn(objMetadata).anyTimes();
-    // Replay will be called in each test
+    s3ObjectListing = EasyMock.createNiceMock(ObjectListing.class);
+    EasyMock.replay(s3ObjectListing);
+    EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andReturn(s3ObjectListing);
 
     workspace = EasyMock.createNiceMock(Workspace.class);
     EasyMock.expect(workspace.get(uri)).andReturn(sampleFile).anyTimes();
@@ -128,26 +145,255 @@ public class AwsS3AssetStoreTest {
   }
 
   @Test
-  public void testPut() throws Exception {
+  public void testBucketErrorSetup() throws Exception {
+    AmazonServiceException exception = EasyMock.createNiceMock(AmazonServiceException.class);
+    EasyMock.expect(exception.getStatusCode()).andReturn(999).anyTimes();
+    //Clear the existing behaviour from setup
+    EasyMock.resetToNice(s3Client);
+    EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andThrow(exception);
+
+    Upload upload = EasyMock.createStrictMock(Upload.class);
+
+    EasyMock.replay(exception, upload, s3Client, s3Transfer);
+
+    StoragePath path = new StoragePath(ORG_ID, MP_ID, new VersionImpl(1L), ASSET_ID);
+    try {
+      store.put(path, Source.mk(uri));
+      Assert.fail("Bucket should not be set up, if we get here then there's something wrong.");
+    } catch (AssetStoreException e) {
+      //Verify that the bucket exception code matches
+      Assert.assertEquals(999, ((AmazonServiceException) e.getCause().getCause()).getStatusCode());
+    }
+  }
+
+  @Test
+  public void testBadBucketPerms() throws Exception {
+    AmazonServiceException noperms = EasyMock.createNiceMock(AmazonServiceException.class);
+    //NB: not sure what the code here is, but it's *not* 404
+    EasyMock.expect(noperms.getStatusCode()).andReturn(403).once();
+    EasyMock.expect(noperms.getMessage()).andReturn("Fake message simulating an bad bucket permissions").once();
+
+    //Clear any existing behaviour from setup
+    EasyMock.resetToStrict(s3Client);
+
+    // Pretend bucket pre-existing, but no permissions.
+    EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andThrow(noperms).once();
+    EasyMock.replay(noperms, s3Client);
+
+    try {
+      store.createAWSBucket();
+      Assert.fail("Exception should have been thrown!");
+    } catch (IllegalStateException e) { }
+    Assert.assertFalse(store.bucketCreated);
+    EasyMock.verify();
+  }
+
+  @Test
+  public void testBadBucketName() throws Exception {
+    AmazonServiceException nobucket = EasyMock.createNiceMock(AmazonServiceException.class);
+    EasyMock.expect(nobucket.getStatusCode()).andReturn(404).once();
+    EasyMock.expect(nobucket.getMessage()).andReturn("Fake message simulating initial lack of bucket").once();
+
+    AmazonServiceException badname = EasyMock.createNiceMock(AmazonServiceException.class);
+    EasyMock.expect(badname.getStatusCode()).andReturn(404).once();
+    EasyMock.expect(badname.getMessage()).andReturn("Fake message simulating an invalid bucket name").once();
+
+    //Clear any existing behaviour from setup
+    EasyMock.resetToStrict(s3Client);
+
+    // no bucket exists, so let's create it, but we have a bad bucket name
+    EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andThrow(nobucket).once();
+    EasyMock.expect(s3Client.createBucket(BUCKET_NAME)).andThrow(badname).once();
+    EasyMock.replay(nobucket, badname, s3Client);
+
+    try {
+      store.createAWSBucket();
+      Assert.fail("Exception should have been thrown!");
+    } catch (IllegalStateException e) { }
+    Assert.assertFalse(store.bucketCreated);
+    EasyMock.verify();
+  }
+
+  @Test
+  public void testGoodBucketCreation() throws Exception {
+    AmazonServiceException nobucket = EasyMock.createNiceMock(AmazonServiceException.class);
+    EasyMock.expect(nobucket.getStatusCode()).andReturn(404).once();
+    EasyMock.expect(nobucket.getMessage()).andReturn("Fake message simulating initial lack of bucket").once();
+
+    //Clear any existing behaviour from setup
+    EasyMock.resetToStrict(s3Client);
+
+    // no bucket exists, but creation succeeds and it exists afterwards!
+    EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andThrow(nobucket).once();
+    EasyMock.expect(s3Client.createBucket(BUCKET_NAME)).andReturn(EasyMock.createNiceMock(Bucket.class)).once();
+    s3Client.setBucketVersioningConfiguration(EasyMock.anyObject(SetBucketVersioningConfigurationRequest.class));
+    EasyMock.expectLastCall().once();
+    // Bucket created!
+    EasyMock.expect(s3Client.listObjects(BUCKET_NAME)).andReturn(s3ObjectListing).once();
+    EasyMock.replay(nobucket, s3Client);
+
+    try {
+      store.createAWSBucket();
+    } catch (IllegalStateException e) {
+      Assert.fail("Exception should NOT have been thrown!");
+    }
+    Assert.assertTrue(store.bucketCreated);
+    EasyMock.verify();
+  }
+
+  private void setupUpload(String keyId) throws Exception {
+    setupUpload(keyId, objMetadata);
+  }
+
+  private void setupUpload(String keyId, ObjectMetadata metadata) throws Exception {
     Upload upload = EasyMock.createStrictMock(Upload.class);
     upload.waitForCompletion();
     EasyMock.expectLastCall().once();
     EasyMock.replay(upload);
 
-    EasyMock.expect(s3Transfer.upload(BUCKET_NAME, OBJECT_KEY_1, sampleFile)).andReturn(upload);
-    EasyMock.expect(s3Client.getObjectMetadata(BUCKET_NAME, OBJECT_KEY_1)).andReturn(objMetadata);
+    EasyMock.expect(s3Transfer.upload(BUCKET_NAME, keyId, sampleFile)).andReturn(upload).once();
+    EasyMock.expect(s3Client.getObjectMetadata(BUCKET_NAME, keyId)).andReturn(metadata).anyTimes();
+  }
+
+  @Test
+  public void testPut() throws Exception {
+    setupUpload(OBJECT_KEY_1);
     EasyMock.replay(s3Client, s3Transfer);
 
     StoragePath path = new StoragePath(ORG_ID, MP_ID, new VersionImpl(1L), ASSET_ID);
-    store.put(path, Source.mk(uri));
+    Source source = Source.mk(uri);
+    store.put(path, source);
 
     // Check if mapping saved to db
     AwsAssetMapping mapping = database.findMapping(path);
+    Assert.assertEquals(OBJECT_KEY_1, mapping.getObjectKey());
     Assert.assertNotNull(mapping);
     Assert.assertEquals(ORG_ID, mapping.getOrganizationId());
     Assert.assertEquals(MP_ID, mapping.getMediaPackageId());
     Assert.assertEquals(1L, mapping.getVersion().longValue());
     Assert.assertEquals(ASSET_ID, mapping.getMediaPackageElementId());
+
+    Assert.assertEquals(OBJECT_KEY_1, store.getAssetObjectKey(path));
+  }
+
+  @Test
+  public void testTagging() throws Exception {
+    Capture<SetObjectTaggingRequest> tags = Capture.newInstance();
+    EasyMock.expect(s3Client.setObjectTagging(EasyMock.capture(tags))).andReturn(null).anyTimes();
+    //Fake mimetypes to trigger, or not trigger tagging
+    String[] mimetypes = { "audio", "image", "video" };
+    StoragePath path;
+    String objectKey;
+    Opt<MimeType> type;
+    Source source;
+    for (String mimetype : mimetypes) {
+      path = new StoragePath(ORG_ID, MP_ID, new VersionImpl(1L), mimetype);
+      type = Opt.some(MimeType.mimeType(mimetype, "fake"));
+      objectKey = KEY_VERSION_1 + mimetype + ".xml";
+      source = Source.mk(uri, null, type);
+      //We need to do this every time we upload something.
+      setupUpload(objectKey);
+      EasyMock.replay(s3Client, s3Transfer);
+      store.put(path, source);
+      EasyMock.resetToNice(s3Client, s3Transfer);
+      EasyMock.expect(s3Client.setObjectTagging(EasyMock.capture(tags))).andReturn(null).anyTimes();
+
+      //Check with AWS that the tags are applied correctly
+      Assert.assertTrue(tags.hasCaptured());
+      SetObjectTaggingRequest req = tags.getValue();
+      Assert.assertEquals(BUCKET_NAME, req.getBucketName());
+      Assert.assertEquals(objectKey, req.getKey());
+      Assert.assertEquals("Freezable", req.getTagging().getTagSet().get(0).getKey());
+      Assert.assertEquals("true", req.getTagging().getTagSet().get(0).getValue());
+
+      tags.reset();
+    }
+    path = new StoragePath(ORG_ID, MP_ID, new VersionImpl(1L), "fake");
+    type = Opt.some(MimeType.mimeType("non-freezable", "fake"));
+    objectKey = KEY_VERSION_1 + "fake.xml";
+    source = Source.mk(uri, null, type);
+    setupUpload(objectKey);
+    EasyMock.replay(s3Client, s3Transfer);
+    store.put(path, source);
+    //Check with AWS that the tags are not applied since this isn't in the allowlist
+    Assert.assertFalse(tags.hasCaptured());
+  }
+
+  @Test
+  public void testStorageClasses() throws Exception {
+    GetObjectTaggingResult gotr = EasyMock.createStrictMock(GetObjectTaggingResult.class);
+    List<Tag> tags = List.of(new Tag("Freezable", "true"));
+    EasyMock.expect(gotr.getTagSet()).andReturn(tags).once();
+    ObjectMetadata metadata = EasyMock.createStrictMock(ObjectMetadata.class);
+    EasyMock.expect(metadata.getVersionId()).andReturn(AWS_VERSION_1).anyTimes();
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.Standard.toString()).times(4);
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.Glacier.toString()).once();
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.Standard.toString()).once();
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.DeepArchive.toString()).once();
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.Standard.toString()).once();
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.ReducedRedundancy.toString()).once();
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.Standard.toString()).once();
+    EasyMock.expect(s3Client.getObjectTagging(EasyMock.anyObject(GetObjectTaggingRequest.class)))
+        .andReturn(gotr).once();
+    //FIXME: Mock appropriate results, not that they're checked.
+    EasyMock.expect(s3Client.copyObject(EasyMock.anyObject(CopyObjectRequest.class))).andReturn(null).anyTimes();
+    EasyMock.replay(gotr, metadata);
+
+    setupUpload(OBJECT_KEY_1, metadata);
+    EasyMock.replay(s3Client, s3Transfer);
+
+    StoragePath path = new StoragePath(ORG_ID, MP_ID, new VersionImpl(1L), ASSET_ID);
+    Source source = Source.mk(uri);
+    store.put(path, source);
+
+    //This asset doesn't exist
+    Assert.assertEquals("NONE",
+        store.getAssetStorageClass(new StoragePath(ORG_ID, MP_ID, new VersionImpl(0L), ASSET_ID)));
+    //This does, test the default
+    Assert.assertEquals(OBJECT_KEY_1, store.getAssetObjectKey(path));
+    Assert.assertEquals(StorageClass.Standard.toString(), store.getAssetStorageClass(path));
+
+    //Set the storage class to the same thing -> should be a noop, and not change the class
+    store.modifyAssetStorageClass(path, StorageClass.Standard.toString());
+    Assert.assertEquals(StorageClass.Standard.toString(), store.getAssetStorageClass(path));
+    //change the storage type to glacier or deep archive
+    for (String sc : new String[] { StorageClass.Glacier.toString(), StorageClass.DeepArchive.toString() }) {
+      store.modifyAssetStorageClass(path, sc);
+      Assert.assertEquals(sc, store.getAssetStorageClass(path));
+    }
+    //change the type to some other type that does not have special handling
+    store.modifyAssetStorageClass(path, StorageClass.ReducedRedundancy.toString());
+    Assert.assertEquals(StorageClass.ReducedRedundancy.toString(), store.getAssetStorageClass(path));
+
+    EasyMock.verify();
+  }
+
+  @Test
+  public void testNonFreezableObject() throws Exception {
+    ObjectMetadata metadata = EasyMock.createStrictMock(ObjectMetadata.class);
+    EasyMock.expect(metadata.getVersionId()).andReturn("2").anyTimes();
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.Standard.toString()).anyTimes();
+
+    GetObjectTaggingResult gotr = EasyMock.createStrictMock(GetObjectTaggingResult.class);
+    List<Tag> tags = List.of(new Tag("non-freezable", "fake"));
+    EasyMock.expect(gotr.getTagSet()).andReturn(tags).once();
+
+    EasyMock.expect(s3Client.getObjectTagging(EasyMock.anyObject(GetObjectTaggingRequest.class)))
+        .andReturn(gotr).once();
+    //FIXME: Mock appropriate results, not that they're checked.
+    EasyMock.expect(s3Client.copyObject(EasyMock.anyObject(CopyObjectRequest.class))).andReturn(null).anyTimes();
+    setupUpload(OBJECT_KEY_2, metadata);
+    EasyMock.replay(metadata, gotr, s3Client, s3Transfer);
+
+    StoragePath path = new StoragePath(ORG_ID, MP_ID, new VersionImpl(2L), ASSET_ID);
+    Opt<MimeType> type = Opt.some(MimeType.mimeType("non-freezable", "fake"));
+    Source source = Source.mk(uri, null, type);
+    store.put(path, source);
+
+    store.modifyAssetStorageClass(path, StorageClass.DeepArchive.toString());
+    Assert.assertEquals(StorageClass.Standard.toString(), store.getAssetStorageClass(path));
+
+    EasyMock.verify();
   }
 
   @Test
@@ -208,7 +454,7 @@ public class AwsS3AssetStoreTest {
     EasyMock.replay(upload);
 
     EasyMock.expect(s3Transfer.upload(BUCKET_NAME, OBJECT_KEY_1, sampleFile)).andReturn(upload);
-    EasyMock.expect(s3Client.getObjectMetadata(BUCKET_NAME, OBJECT_KEY_1)).andReturn(objMetadata);
+    EasyMock.expect(s3Client.getObjectMetadata(BUCKET_NAME, OBJECT_KEY_1)).andReturn(objMetadata).anyTimes();
     EasyMock.expect(s3Client.generatePresignedUrl(EasyMock.anyObject(GeneratePresignedUrlRequest.class)))
             .andReturn(uri.toURL());
     EasyMock.replay(s3Object, s3Client, s3Transfer);
@@ -410,4 +656,60 @@ public class AwsS3AssetStoreTest {
     Assert.assertNotNull(mapping2);
   }
 
+  @Test @Ignore
+  public void testAssetRestore() throws Exception {
+    //FIXME: Partially implemented, but the poll time is a constant...
+    GetObjectTaggingResult gotr = EasyMock.createStrictMock(GetObjectTaggingResult.class);
+    List<Tag> tags = List.of(new Tag("Freezable", "true"));
+    EasyMock.expect(gotr.getTagSet()).andReturn(tags).once();
+    ObjectMetadata metadata = EasyMock.createStrictMock(ObjectMetadata.class);
+    EasyMock.expect(metadata.getVersionId()).andReturn(AWS_VERSION_1).anyTimes();
+    EasyMock.expect(metadata.getStorageClass()).andReturn(StorageClass.Standard.toString()).times(1);
+    EasyMock.expect(metadata.getOngoingRestore()).andReturn(false).once();
+    EasyMock.expect(metadata.getRestoreExpirationTime()).andReturn(null).once();
+    EasyMock.expect(metadata.getOngoingRestore()).andReturn(true).once();
+
+    EasyMock.expect(s3Client.getObjectTagging(EasyMock.anyObject(GetObjectTaggingRequest.class)))
+        .andReturn(gotr).once();
+    //FIXME: Mock appropriate results, not that they're checked.
+    EasyMock.expect(s3Client.copyObject(EasyMock.anyObject(CopyObjectRequest.class))).andReturn(null).anyTimes();
+    //FIXME: Mock appropriate results, not that they're checked.
+    EasyMock.expect(s3Client.restoreObjectV2(EasyMock.anyObject(RestoreObjectRequest.class))).andReturn(null).once();
+    EasyMock.replay(gotr, metadata);
+
+    setupUpload(OBJECT_KEY_1, metadata);
+    EasyMock.replay(s3Client, s3Transfer);
+
+    StoragePath path = new StoragePath(ORG_ID, MP_ID, new VersionImpl(1L), ASSET_ID);
+    Source source = Source.mk(uri);
+    store.put(path, source);
+
+    store.modifyAssetStorageClass(path, StorageClass.Glacier.toString());
+
+    //Picked by random dice roll, guaranteed to be random
+    store.initiateRestoreAsset(path, 4);
+    //RestoreObjectRequest requestRestore = new RestoreObjectRequest(bucketName, objectName, objectRestorePeriod);
+    //s3.restoreObjectV2(requestRestore);
+    //s3.getObjectMetadata(bucketName, objectName).getRestoreExpirationTime() -> null
+
+    //Mid restore
+    //String status = store.getAssetRestoreStatusString(path);
+    //Restore is now finished
+    //status = store.getAssetRestoreStatusString(path);
+
+    EasyMock.verify(s3Client, metadata);
+    Assert.fail("Not done");
+  }
+
+  @Test @Ignore
+  public void testGlacierDirectAccess() throws Exception {
+    setupUpload(OBJECT_KEY_1);
+    EasyMock.replay(s3Client, s3Transfer);
+    StoragePath path = new StoragePath(ORG_ID, MP_ID, new VersionImpl(1L), ASSET_ID);
+    Source source = Source.mk(uri);
+    store.put(path, source);
+    store.modifyAssetStorageClass(path, StorageClass.Glacier.toString());
+    Opt<InputStream> stream = store.get(path);
+    Assert.fail("Not done yet");
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- library version specifications -->
-    <aws.version>1.11.469_1</aws.version>
+    <aws.version>1.12.269_1</aws.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-collections.version>4.4</commons-collections.version>
     <commons-compress.version>1.21</commons-compress.version>


### PR DESCRIPTION
This pull request adds AWS S3 storage tiering to the existing AWS AssetManager S3 module.

This is a forward port of production code at Manchester, with the addition of some bug fixes, style changes, and a bunch of mostly-done unit tests.  Initially developed against `r/12.x`, I don't think there's a particular requirement that it go there vs `r/13.x`.

Note: There is *no* UI for this - you need to use the REST docs to trigger things.  I'm open to adding this as later work, but especially with the new new admin UI in the near-term pipeline I didn't see a lot of point of putting a ton of effort into the old new admin UI.

This work was paid for by the University of Manchester.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
