### PR TITLE
Allow ROLE_ADMIN_UI to run index.js

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -347,6 +347,7 @@
     <sec:intercept-url pattern="/admin-ng/" method="GET" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/admin-ng/index.html" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/index.html" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
+    <sec:intercept-url pattern="/index.js" access="ROLE_ADMIN, ROLE_ADMIN_UI" />
     <sec:intercept-url pattern="/**" access="ROLE_ADMIN" />
 
     <!-- ############################# -->


### PR DESCRIPTION
Implements @karendolan 's suggestion in #3959.

Gives users with the role ROLE_ADMIN_UI the permission to run the index.js associated with an index.html.
