### PR TITLE
Added check of tenants when adding roles to user

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -65,7 +65,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -347,10 +346,7 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
         }
 
         for (Role role : roleProvider.getRolesForUser(user.getUsername())) {
-          if (Objects.equals(JaxbOrganization.fromOrganization(user.getOrganization()).getId(),
-                  role.getOrganizationId())) {
-            roles.add(JaxbRole.fromRole(role));
-          }
+          roles.add(JaxbRole.fromRole(role));
         }
       }
     }

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -340,6 +340,12 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
     // Consult roleProviders if this is not an internal system user
     if (!InMemoryUserAndRoleProvider.PROVIDER_NAME.equals(user.getProvider())) {
       for (RoleProvider roleProvider : roleProviders) {
+        String providerOrgId = roleProvider.getOrganization();
+
+        if (!ALL_ORGANIZATIONS.equals(providerOrgId) && !orgUser.getA().equals(providerOrgId)) {
+          continue;
+        }
+
         for (Role role : roleProvider.getRolesForUser(user.getUsername())) {
           if (Objects.equals(JaxbOrganization.fromOrganization(user.getOrganization()).getId(),
                   role.getOrganizationId())) {

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/UserAndRoleDirectoryServiceImpl.java
@@ -65,6 +65,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -340,7 +341,10 @@ public class UserAndRoleDirectoryServiceImpl implements UserDirectoryService, Us
     if (!InMemoryUserAndRoleProvider.PROVIDER_NAME.equals(user.getProvider())) {
       for (RoleProvider roleProvider : roleProviders) {
         for (Role role : roleProvider.getRolesForUser(user.getUsername())) {
-          roles.add(JaxbRole.fromRole(role));
+          if (Objects.equals(JaxbOrganization.fromOrganization(user.getOrganization()).getId(),
+                  role.getOrganizationId())) {
+            roles.add(JaxbRole.fromRole(role));
+          }
         }
       }
     }


### PR DESCRIPTION
This PR should fix #4524 . It adds a check in the same fashion as when creating a `JaxbUser` User, so that no roles of other tenants are trying to get added. 
