### PR TITLE
Allow Manual Translation Update

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -2,6 +2,7 @@ name: Update translations
 
 # Update every Monday at 5am
 on:
+  workflow_dispatch:
   schedule:
   - cron: "0 5 * * 1"
 


### PR DESCRIPTION
This patch allows committers to trigger the translation update process manually. This is handy if you want to e.g. quickly update translations before creating a new release.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
