### PR TITLE
Allow creating releases manually

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    workflow_dispatch:
     tags:
       - '*.*'
 


### PR DESCRIPTION
This patch is a quick workaround for the problem that the automatically cut release tags do not trigger the GitHub Actions workflow to create a release on GitHub. This patch allows committers to trigger the workflow manually.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
