### PR TITLE
Ensure segments.segment is array

### DIFF
--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -206,6 +206,9 @@ function processSegments(episode, manifest) {
   const { segments } = episode;
   if (segments) {
     manifest.transcriptions = manifest.transcriptions || [];
+    if (!Array.isArray(segments.segment)) {
+      segments.segment = [segments.segment];
+    }
     segments.segment.forEach(({ index, previews, text, time, duration}) => {
       manifest.transcriptions.push({
         index,


### PR DESCRIPTION
The search endpoint does not return a segment list with a single object as an array. Instead, it's represented as a JSON object. This fix ensures that `segments.segment` is an array.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
