### PR TITLE
Rename OSGi Core dependency artifact id

### DIFF
--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -19,7 +19,7 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/animate-impl/pom.xml
+++ b/modules/animate-impl/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/modules/annotation-impl/pom.xml
+++ b/modules/annotation-impl/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/asset-manager-storage-aws/pom.xml
+++ b/modules/asset-manager-storage-aws/pom.xml
@@ -64,7 +64,7 @@
     <!-- AWS SDK END -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/asset-manager-storage-fs/pom.xml
+++ b/modules/asset-manager-storage-fs/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -88,7 +88,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/caption-impl/pom.xml
+++ b/modules/caption-impl/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/capture-admin-service-impl/pom.xml
+++ b/modules/capture-admin-service-impl/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -74,7 +74,7 @@
     <!-- OSGi -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/composer-ffmpeg/pom.xml
+++ b/modules/composer-ffmpeg/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -75,7 +75,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/conductor/pom.xml
+++ b/modules/conductor/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -197,7 +197,7 @@
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-anim</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-awt-util</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-bridge</ignoredUnusedDeclaredDependency>

--- a/modules/cover-image-workflowoperation/pom.xml
+++ b/modules/cover-image-workflowoperation/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/crop-ffmpeg/pom.xml
+++ b/modules/crop-ffmpeg/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/dictionary-hunspell/pom.xml
+++ b/modules/dictionary-hunspell/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/dictionary-none/pom.xml
+++ b/modules/dictionary-none/pom.xml
@@ -36,7 +36,7 @@
     <!-- Thirdparty dependencies -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/dictionary-regexp/pom.xml
+++ b/modules/dictionary-regexp/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-service-aws-s3/pom.xml
+++ b/modules/distribution-service-aws-s3/pom.xml
@@ -68,7 +68,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-service-download/pom.xml
+++ b/modules/distribution-service-download/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-service-streaming-wowza/pom.xml
+++ b/modules/distribution-service-streaming-wowza/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-workflowoperation/pom.xml
+++ b/modules/distribution-workflowoperation/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/editor-service/pom.xml
+++ b/modules/editor-service/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <!-- Opencast dependencies -->
     <dependency>
@@ -140,7 +140,7 @@
         <extensions>true</extensions>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.glassfish.jersey.core:jersey-server</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/modules/elasticsearch-impl/pom.xml
+++ b/modules/elasticsearch-impl/pom.xml
@@ -31,7 +31,7 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/elasticsearch-index/pom.xml
+++ b/modules/elasticsearch-index/pom.xml
@@ -24,7 +24,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
       <scope>compile</scope>
     </dependency>
     <!-- Logging -->

--- a/modules/email-template-service-impl/pom.xml
+++ b/modules/email-template-service-impl/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/execute-impl/pom.xml
+++ b/modules/execute-impl/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/fileupload/pom.xml
+++ b/modules/fileupload/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -18,7 +18,7 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -87,7 +87,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -157,7 +157,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/inspection-service-ffmpeg/pom.xml
+++ b/modules/inspection-service-ffmpeg/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -134,7 +134,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -146,7 +146,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/live-schedule-impl/pom.xml
+++ b/modules/live-schedule-impl/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/metrics-exporter/pom.xml
+++ b/modules/metrics-exporter/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/oaipmh/pom.xml
+++ b/modules/oaipmh/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -142,7 +142,7 @@
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <!-- The following dependencies are required at runtime: -->
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.checkerframework:checker-qual</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.felix:org.apache.felix.http.bundle</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>

--- a/modules/runtime-info/pom.xml
+++ b/modules/runtime-info/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -117,7 +117,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/search-service-feeds/pom.xml
+++ b/modules/search-service-feeds/pom.xml
@@ -37,7 +37,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -90,7 +90,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/series-service-impl/pom.xml
+++ b/modules/series-service-impl/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/shared-filesystem-utils/pom.xml
+++ b/modules/shared-filesystem-utils/pom.xml
@@ -47,7 +47,7 @@
     <!-- -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/silencedetection-impl/pom.xml
+++ b/modules/silencedetection-impl/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/solr/pom.xml
+++ b/modules/solr/pom.xml
@@ -22,7 +22,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/sox-impl/pom.xml
+++ b/modules/sox-impl/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/speech-to-text-impl/pom.xml
+++ b/modules/speech-to-text-impl/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/static-file-service-api/pom.xml
+++ b/modules/static-file-service-api/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/static-file-service-impl/pom.xml
+++ b/modules/static-file-service-impl/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/static/pom.xml
+++ b/modules/static/pom.xml
@@ -29,7 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/statistics-provider-influx/pom.xml
+++ b/modules/statistics-provider-influx/pom.xml
@@ -53,7 +53,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/statistics-provider-random/pom.xml
+++ b/modules/statistics-provider-random/pom.xml
@@ -40,7 +40,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/termination-state-api/pom.xml
+++ b/modules/termination-state-api/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -60,7 +60,7 @@
         <extensions>true</extensions>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.osgi:osgi.cmpn</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/modules/textanalyzer-impl/pom.xml
+++ b/modules/textanalyzer-impl/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -68,7 +68,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <!-- without osgi.core the module doesn't compile, even though it isn't used directly, but in oc-common -->
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/textextractor-tesseract/pom.xml
+++ b/modules/textextractor-tesseract/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/timelinepreviews-ffmpeg/pom.xml
+++ b/modules/timelinepreviews-ffmpeg/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/transcription-service-google-speech-impl/pom.xml
+++ b/modules/transcription-service-google-speech-impl/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/transcription-service-ibm-watson-impl/pom.xml
+++ b/modules/transcription-service-ibm-watson-impl/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/transcription-service-microsoft-azure/pom.xml
+++ b/modules/transcription-service-microsoft-azure/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/user-interface-configuration/pom.xml
+++ b/modules/user-interface-configuration/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-brightspace/pom.xml
+++ b/modules/userdirectory-brightspace/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-ldap/pom.xml
+++ b/modules/userdirectory-ldap/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-moodle/pom.xml
+++ b/modules/userdirectory-moodle/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-sakai/pom.xml
+++ b/modules/userdirectory-sakai/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-studip/pom.xml
+++ b/modules/userdirectory-studip/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/usertracking-impl/pom.xml
+++ b/modules/usertracking-impl/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/videoeditor-ffmpeg-impl/pom.xml
+++ b/modules/videoeditor-ffmpeg-impl/pom.xml
@@ -96,7 +96,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/videosegmenter-ffmpeg/pom.xml
+++ b/modules/videosegmenter-ffmpeg/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/waveform-ffmpeg/pom.xml
+++ b/modules/waveform-ffmpeg/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/workflow-service-api/pom.xml
+++ b/modules/workflow-service-api/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -104,7 +104,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -134,7 +134,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/working-file-repository-service-impl/pom.xml
+++ b/modules/working-file-repository-service-impl/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/workspace-impl/pom.xml
+++ b/modules/workspace-impl/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -862,7 +862,7 @@
       <!-- OSGi -->
       <dependency>
         <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.core</artifactId>
+        <artifactId>osgi.core</artifactId>
         <version>${osgi.core.version}</version>
         <scope>provided</scope>
       </dependency>


### PR DESCRIPTION
The OSGi Core artifact moved from org.osgi:org.osgi.core to org.osgi:osgi.core.

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
