### PR TITLE
Fix Wowza signing time scale

### DIFF
--- a/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProvider.java
+++ b/modules/urlsigning-service-impl/src/main/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProvider.java
@@ -132,7 +132,7 @@ public class WowzaUrlSigningProvider extends AbstractUrlSigningProvider {
    */
   private String addSignutureToRequest(Policy policy, String encryptionKeyId, String encryptionKey) throws Exception  {
     final String startTime;
-    final String endTime = Long.toString(policy.getValidUntil().getMillis());
+    final String endTime = Long.toString(policy.getValidUntil().getMillis() / 1000);
     final String ip;
 
     String baseUrl = policy.getBaseUrl();
@@ -148,7 +148,7 @@ public class WowzaUrlSigningProvider extends AbstractUrlSigningProvider {
     }
 
     if (policy.getValidFrom().isPresent()) {
-      startTime = Long.toString(policy.getValidFrom().get().getMillis());
+      startTime = Long.toString(policy.getValidFrom().get().getMillis() / 1000);
     } else {
       startTime = "";
     }

--- a/modules/urlsigning-service-impl/src/test/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProviderTest.java
+++ b/modules/urlsigning-service-impl/src/test/java/org/opencastproject/security/urlsigning/provider/impl/WowzaUrlSigningProviderTest.java
@@ -80,9 +80,9 @@ public class WowzaUrlSigningProviderTest {
     String ip = "192.168.1.2";
     String encryptionKeyId = "myTokenPrefix";
     String encryptionKey = "mySharedSecret";
-    String startTime = "1395230400";
-    String endTime = "1500000000";
-    String predefinedHash = "TgJft5hsjKyC5Rem_EoUNP7xZvxbqVPhhd0GxIcA2oo=";
+    String startTime = "1395230";
+    String endTime = "1500000";
+    String predefinedHash = "E4mSDMQXutPnj6ApllhzFoONFDQVzhAdV39Q9I9TGsU=";
     String predefinedUri = "http://192.168.1.1:1935/vod/sample.mp4/playlist.m3u8?"
             + encryptionKeyId + "endtime=" + endTime
             + "&" + encryptionKeyId + "starttime=" + startTime
@@ -91,7 +91,7 @@ public class WowzaUrlSigningProviderTest {
 
     Policy policy = Policy.mkPolicyValidFromWithIP(
             "http://192.168.1.1:1935/vod/sample.mp4/playlist.m3u8?CustomParameter=abcdef",
-            new DateTime(Long.parseLong(endTime)), new DateTime(Long.parseLong(startTime)), ip);
+            new DateTime(Long.parseLong(endTime) * 1000), new DateTime(Long.parseLong(startTime) * 1000), ip);
     policy.setResourceStrategy(new WowzaResourceStrategyImpl());
 
     String uri = signer.sign(policy);


### PR DESCRIPTION
This PR changes the URL signing time scale to seconds, rather than miliseconds.  This was reported on list back in October, with Ruth Lang providing a fix in November.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
