### PR TITLE
Add Tag-Engage Workflow Operation Handler

### DIFF
--- a/docs/guides/admin/docs/releasenotes/tag-engage-woh
+++ b/docs/guides/admin/docs/releasenotes/tag-engage-woh
@@ -1,0 +1,2 @@
+Added a tag-engage-WOH which can be used to update tags and flavors directly
+in the engage publication. This change was initially targeted at 12.x.

--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -21,98 +21,99 @@ definitions consist of a list of workflow operations, which basically map a piec
 
 The following table contains the workflow operations that are available in an out-of-the-box Opencast installation:
 
-|Operation Handler   |Description                                                    |Details|
-|--------------------|---------------------------------------------------------------|------------------------------------|
-|add-catalog         |Add a catalog to the media package                             |[Documentation](add-catalog-woh.md)|
-|analyze-audio       |Analyze first audio stream                                     |[Documentation](analyzeaudio-woh.md)|
-|analyze-tracks      |Analyze tracks in media package                                |[Documentation](analyze-tracks-woh.md)|
-|analyze-mediapackage |Analyze media package                                         |[Documentation](analyze-mediapackage-woh.md)|
-|animate             |Create animated video sequence                                 |[Documentation](animate-woh.md)|
-|amberscript-start-transcription|Start AmberScript Transcription                     |[Documentation](amberscript-start-transcription-woh.md)|
-|amberscript-attach-transcription|Attach AmberScript Transcription                   |[Documentation](amberscript-attach-transcription-woh.md)|
-|asset-delete        |Deletes the current mediapackage from the Archive              |[Documentation](asset-delete-woh.md)|
-|attach-watson-transcription|Attaches automated transcripts to mediapackage          |[Documentation](attach-watson-transcription-woh.md)|
-|cleanup             |Cleanup the working file repository                            |[Documentation](cleanup-woh.md)|
-|clone               |Clone media package elements to another flavor                 |[Documentation](clone-woh.md)|
-|comment             |Add, resolve or delete a comment                               |[Documentation](comment-woh.md)|
-|composite           |Compose two videos on one canvas.                              |[Documentation](composite-woh.md)|
-|concat              |Concatenate multiple video tracks into one video track         |[Documentation](concat-woh.md)|
-|conditional-config  |Configure workflow configuration variable based on coditions   |[Documentation](conditional-config-woh.md)|
-|configure-by-dcterm |Set workflow parameter if dublincore term matches value        |[Documentation](configure-by-dcterm-woh.md)|
-|copy                |Copy media package elements to target directory                |[Documentation](copy-woh.md)|
-|cover-image         |Generate a cover-image containing metadata                     |[Documentation](coverimage-woh.md)|
-|crop-video          |Checks for black bars on the sides of the video                |[Documentation](cropvideo-woh.md)|
-|cut-marks-to-smil   |Parses timestamps into a SMIL for the editor workflow          |[Documentation](cut-marks-to-smil-woh.md)|
-|defaults            |Applies default workflow configuration values                  |[Documentation](defaults-woh.md)|
-|demux               |Demuxes streams to multiple output files                       |[Documentation](demux-woh.md)|
-|duplicate-event     |Create an event by cloning an existing one                     |[Documentation](duplicate-event-woh.md)|
-|editor              |Waiting for user to review, then cut video based on edit-list  |[Documentation](editor-woh.md)|
-|encode              |Encode media files to differents formats in parallel           |[Documentation](encode-woh.md)|
-|error-resolution    |Internal operation to pause a workflow in error                |[Documentation](error-resolution-woh.md)|
-|execute-many        |Execute a command for each matching element in a MediaPackage  |[Documentation](execute-many-woh.md)
-|execute-once        |Execute a command for a MediaPackage                           |[Documentation](execute-once-woh.md)
-|export-wf-properties|Export workflow properties                                     |[Documentation](export-wf-properties-woh.md)|
-|extract-text        |Extracting text from presentation segments                     |[Documentation](extracttext-woh.md)|
-|failing             |Operations that always fails                                   |[Documentation](failing-woh.md)|
-|google-speech-attach-transcription|Attaches automated transcripts to mediapackage   |[Documentation](google-speech-attach-transcription-woh.md)|
-|google-speech-start-transcription|Starts automated transcription provided by Google Speech|[Documentation](google-speech-start-transcription-woh.md)|
-|http-notify         |Notifies an HTTP endpoint about the process of the workflow    |[Documentation](httpnotify-woh.md)|
-|image               |Extract images from a video using FFmpeg                       |[Documentation](image-woh.md)|
-|image-convert       |Convert images using FFmpeg                                    |[Documentation](image-convert-woh.md)|
-|image-to-video      |Create a video track from a source image                       |[Documentation](imagetovideo-woh.md)|
-|import-wf-properties|Import workflow properties                                     |[Documentation](import-wf-properties-woh.md)|
-|incident            |Testing incidents on a dummy job                               |[Documentation](incident-woh.md)|
-|include             |Include workflow definition in current workflow                |[Documentation](include-woh.md)|
-|ingest-download     |Download files from external URL for ingest                    |[Documentation](ingestdownload-woh.md)|
-|inspect             |Inspect the media (check if it is valid)                       |[Documentation](inspect-woh.md)|
-|log                 |Log workflow status                                            |[Documentation](log-woh.md)|
-|metadata-to-acl     |Add read/write access based on metadata                        |[Documentation](metadata-to-acl.md)
-|microsoft-azure-attach-transcription|Attaches automated transcripts to mediapackage   |[Documentation](microsoft-azure-attach-transcription-woh.md)|
-|microsoft-azure-start-transcription|Starts automated transcription provided by Microsoft Azure|[Documentation](microsoft-azure-start-transcription-woh.md)|
-|multiencode         |Encode to multiple profiles in one operation                   |[Documentation](multiencode-woh.md)|
-|normalize-audio     |Normalize first audio stream                                   |[Documentation](normalizeaudio-woh.md)|
-|partial-import      |Import partial tracks and process according to a SMIL document |[Documentation](partial-import-woh.md)|
-|post-mediapackage   |Send mediapackage to remote service                            |[Documentation](postmediapackage-woh.md)|
-|prepare-av          |Preparing audio and video work versions                        |[Documentation](prepareav-woh.md)|
-|probe-resolution    |Set workflow instance variables based on video resolution      |[Documentation](probe-resolution-woh.md)|
-|process-smil        |Edit and Encode media defined by a SMIL file                   |[Documentation](process-smil-woh.md)|
-|publication-to-workspace|Copy publication element to mediapackage in workspace       |[Documentation](publication-to-workspace-woh.md)|
-|publish-configure-aws|Distribute and publish media to the configured publication using Amazon S3 and Cloudfront|[Documentation](publish-configure-aws-woh.md)|
-|publish-configure   |Distribute and publish media to the configured publication     |[Documentation](publish-configure-woh.md)|
-|publish-engage-aws  |Distribute and publish media to the engage player using Amazon S3 and Cloudfront|[Documentation](publish-engage-aws-woh.md)|
-|publish-engage      |Distribute and publish media to the engage player              |[Documentation](publish-engage-woh.md)|
-|publish-oaipmh      |Distribute and publish media to a OAI-PMH repository           |[Documentation](publish-oaipmh-woh.md)|
-|publish-youtube     |Distribute and publish media to YouTube                        |[Documentation](publish-youtube-woh.md)|
-|rename-files        |Rename media files using metadata                              |[Documentation](rename-files-woh.md)|
-|republish-oaipmh    |Update media in a OAI-PMH repository                           |[Documentation](republish-oaipmh-woh.md)|
-|retract-configure-aws|Retracts media from configured publication in AWS S3 and Cloudfront|[Documentation](retract-configure-aws-woh.md)|
-|retract-configure   |Retracts media from configured publication                     |[Documentation](retract-configure-woh.md)|
-|retract-engage-aws  |Retracts media from AWS S3 and Cloudfront publication          |[Documentation](retract-engage-aws-woh.md)|
-|retract-engage      |Retracts media from Opencast Media Module publication          |[Documentation](retract-engage-woh.md)|
-|retract-partial-aws |Retract a subset of the mediapackage from a publication in Amazon S3 and Cloudfront|[Documentation](retract-partial-aws-woh.md)|
-|retract-partial     |Retract a subset of the mediapackage from a publication        |[Documentation](retract-partial-woh.md)|
-|retract-oaipmh      |Retracts media from a OAI-PMH repository                       |[Documentation](retract-oaipmh-woh.md)
-|retract-partial     |Retract a subset of the mediapackage from a publication        |[Documentation](retract-partial-woh.md)|
-|retract-youtube     |Retracts media from YouTube                                    |[Documentation](retract-youtube-woh.md)|
-|segment-video       |Extracting segments from presentation                          |[Documentation](segmentvideo-woh.md)|
-|segmentpreviews     |Extract segment images from a video using FFmpeg               |[Documentation](segmentpreviews-woh.md)|
-|select-streams      |Select streams for further processing                          |[Documentation](select-streams-woh.md)|
-|select-version      |Select a version of the media package to run the current workflow with|[Documentation](select-version-woh.md)|
-|send-email          |Sends email notifications at any part of a workflow            |[Documentation](send-email-woh.md)|
-|series              |Apply series to the mediapackage                               |[Documentation](series-woh.md)|
-|silence             |Silence detection on audio of the mediapackage                 |[Documentation](silence-woh.md)|
-|snapshot            |Archive the current state of the mediapackage                  |[Documentation](snapshot-woh.md)|
-|speech-to-text      |Create subtitles for video and audio sources                   |[Documentation](speech-to-text-woh.md)|
-|start-watson-transcription|Starts automated transcription provided by IBM Watson    |[Documentation](start-watson-transcription-woh.md)|
-|start-workflow      |Start a new workflow for given media package ID                |[Documentation](start-workflow-woh.md)|
-|statistics-writer   |Log statistical data about the video                           |[Documentation](statistics-writer.md)|
-|tag                 |Modify the tag sets of media package elements                  |[Documentation](tag-woh.md)|
-|tag-by-dcterm       |Modify the tags if dublincore term matches value               |[Documentation](tag-by-dcterm-woh.md)|
-|theme               |Make settings of themes available to processing                |[Documentation](theme-woh.md)|
-|timelinepreviews    |Create a preview image stream from a given video track         |[Documentation](timelinepreviews-woh.md)|
-|transfer-metadata   |Transfer metadata fields between catalogs                      |[Documentation](transfer-metadata-woh.md)|
-|waveform            |Create a waveform image of the audio of the mediapackage       |[Documentation](waveform-woh.md)|
-|zip                 |Create zipped archive of the current state of the mediapackage |[Documentation](zip-woh.md)|
+| Operation Handler                    | Description                                                                               | Details                                                      |
+|--------------------------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| add-catalog                          | Add a catalog to the media package                                                        | [Documentation](add-catalog-woh.md)                          |
+| analyze-audio                        | Analyze first audio stream                                                                | [Documentation](analyzeaudio-woh.md)                         |
+| analyze-tracks                       | Analyze tracks in media package                                                           | [Documentation](analyze-tracks-woh.md)                       |
+| analyze-mediapackage                 | Analyze media package                                                                     | [Documentation](analyze-mediapackage-woh.md)                 |
+| animate                              | Create animated video sequence                                                            | [Documentation](animate-woh.md)                              |
+| amberscript-start-transcription      | Start AmberScript Transcription                                                           | [Documentation](amberscript-start-transcription-woh.md)      |
+| amberscript-attach-transcription     | Attach AmberScript Transcription                                                          | [Documentation](amberscript-attach-transcription-woh.md)     |
+| asset-delete                         | Deletes the current mediapackage from the Archive                                         | [Documentation](asset-delete-woh.md)                         |
+| attach-watson-transcription          | Attaches automated transcripts to mediapackage                                            | [Documentation](attach-watson-transcription-woh.md)          |
+| cleanup                              | Cleanup the working file repository                                                       | [Documentation](cleanup-woh.md)                              |
+| clone                                | Clone media package elements to another flavor                                            | [Documentation](clone-woh.md)                                |
+| comment                              | Add, resolve or delete a comment                                                          | [Documentation](comment-woh.md)                              |
+| composite                            | Compose two videos on one canvas.                                                         | [Documentation](composite-woh.md)                            |
+| concat                               | Concatenate multiple video tracks into one video track                                    | [Documentation](concat-woh.md)                               |
+| conditional-config                   | Configure workflow configuration variable based on coditions                              | [Documentation](conditional-config-woh.md)                   |
+| configure-by-dcterm                  | Set workflow parameter if dublincore term matches value                                   | [Documentation](configure-by-dcterm-woh.md)                  |
+| copy                                 | Copy media package elements to target directory                                           | [Documentation](copy-woh.md)                                 |
+| cover-image                          | Generate a cover-image containing metadata                                                | [Documentation](coverimage-woh.md)                           |
+| crop-video                           | Checks for black bars on the sides of the video                                           | [Documentation](cropvideo-woh.md)                            |
+| cut-marks-to-smil                    | Parses timestamps into a SMIL for the editor workflow                                     | [Documentation](cut-marks-to-smil-woh.md)                    |
+| defaults                             | Applies default workflow configuration values                                             | [Documentation](defaults-woh.md)                             |
+| demux                                | Demuxes streams to multiple output files                                                  | [Documentation](demux-woh.md)                                |
+| duplicate-event                      | Create an event by cloning an existing one                                                | [Documentation](duplicate-event-woh.md)                      |
+| editor                               | Waiting for user to review, then cut video based on edit-list                             | [Documentation](editor-woh.md)                               |
+| encode                               | Encode media files to differents formats in parallel                                      | [Documentation](encode-woh.md)                               |
+| error-resolution                     | Internal operation to pause a workflow in error                                           | [Documentation](error-resolution-woh.md)                     |
+| execute-many                         | Execute a command for each matching element in a MediaPackage                             | [Documentation](execute-many-woh.md)                         |
+| execute-once                         | Execute a command for a MediaPackage                                                      | [Documentation](execute-once-woh.md)                         |
+| export-wf-properties                 | Export workflow properties                                                                | [Documentation](export-wf-properties-woh.md)                 |
+| extract-text                         | Extracting text from presentation segments                                                | [Documentation](extracttext-woh.md)                          |
+| failing                              | Operations that always fails                                                              | [Documentation](failing-woh.md)                              |
+| google-speech-attach-transcription   | Attaches automated transcripts to mediapackage                                            | [Documentation](google-speech-attach-transcription-woh.md)   |
+| google-speech-start-transcription    | Starts automated transcription provided by Google Speech                                  | [Documentation](google-speech-start-transcription-woh.md)    |
+| http-notify                          | Notifies an HTTP endpoint about the process of the workflow                               | [Documentation](httpnotify-woh.md)                           |
+| image                                | Extract images from a video using FFmpeg                                                  | [Documentation](image-woh.md)                                |
+| image-convert                        | Convert images using FFmpeg                                                               | [Documentation](image-convert-woh.md)                        |
+| image-to-video                       | Create a video track from a source image                                                  | [Documentation](imagetovideo-woh.md)                         |
+| import-wf-properties                 | Import workflow properties                                                                | [Documentation](import-wf-properties-woh.md)                 |
+| incident                             | Testing incidents on a dummy job                                                          | [Documentation](incident-woh.md)                             |
+| include                              | Include workflow definition in current workflow                                           | [Documentation](include-woh.md)                              |
+| ingest-download                      | Download files from external URL for ingest                                               | [Documentation](ingestdownload-woh.md)                       |
+| inspect                              | Inspect the media (check if it is valid)                                                  | [Documentation](inspect-woh.md)                              |
+| log                                  | Log workflow status                                                                       | [Documentation](log-woh.md)                                  |
+| metadata-to-acl                      | Add read/write access based on metadata                                                   | [Documentation](metadata-to-acl.md)                          |
+| microsoft-azure-attach-transcription | Attaches automated transcripts to mediapackage                                            | [Documentation](microsoft-azure-attach-transcription-woh.md) |
+| microsoft-azure-start-transcription  | Starts automated transcription provided by Microsoft Azure                                | [Documentation](microsoft-azure-start-transcription-woh.md)  |
+| multiencode                          | Encode to multiple profiles in one operation                                              | [Documentation](multiencode-woh.md)                          |
+| normalize-audio                      | Normalize first audio stream                                                              | [Documentation](normalizeaudio-woh.md)                       |
+| partial-import                       | Import partial tracks and process according to a SMIL document                            | [Documentation](partial-import-woh.md)                       |
+| post-mediapackage                    | Send mediapackage to remote service                                                       | [Documentation](postmediapackage-woh.md)                     |
+| prepare-av                           | Preparing audio and video work versions                                                   | [Documentation](prepareav-woh.md)                            |
+| probe-resolution                     | Set workflow instance variables based on video resolution                                 | [Documentation](probe-resolution-woh.md)                     |
+| process-smil                         | Edit and Encode media defined by a SMIL file                                              | [Documentation](process-smil-woh.md)                         |
+| publication-to-workspace             | Copy publication element to mediapackage in workspace                                     | [Documentation](publication-to-workspace-woh.md)             |
+| publish-configure-aws                | Distribute and publish media to the configured publication using Amazon S3 and Cloudfront | [Documentation](publish-configure-aws-woh.md)                |
+| publish-configure                    | Distribute and publish media to the configured publication                                | [Documentation](publish-configure-woh.md)                    |
+| publish-engage-aws                   | Distribute and publish media to the engage player using Amazon S3 and Cloudfront          | [Documentation](publish-engage-aws-woh.md)                   |
+| publish-engage                       | Distribute and publish media to the engage player                                         | [Documentation](publish-engage-woh.md)                       |
+| publish-oaipmh                       | Distribute and publish media to a OAI-PMH repository                                      | [Documentation](publish-oaipmh-woh.md)                       |
+| publish-youtube                      | Distribute and publish media to YouTube                                                   | [Documentation](publish-youtube-woh.md)                      |
+| rename-files                         | Rename media files using metadata                                                         | [Documentation](rename-files-woh.md)                         |
+| republish-oaipmh                     | Update media in a OAI-PMH repository                                                      | [Documentation](republish-oaipmh-woh.md)                     |
+| retract-configure-aws                | Retracts media from configured publication in AWS S3 and Cloudfront                       | [Documentation](retract-configure-aws-woh.md)                |
+| retract-configure                    | Retracts media from configured publication                                                | [Documentation](retract-configure-woh.md)                    |
+| retract-engage-aws                   | Retracts media from AWS S3 and Cloudfront publication                                     | [Documentation](retract-engage-aws-woh.md)                   |
+| retract-engage                       | Retracts media from Opencast Media Module publication                                     | [Documentation](retract-engage-woh.md)                       |
+| retract-partial-aws                  | Retract a subset of the mediapackage from a publication in Amazon S3 and Cloudfront       | [Documentation](retract-partial-aws-woh.md)                  |
+| retract-partial                      | Retract a subset of the mediapackage from a publication                                   | [Documentation](retract-partial-woh.md)                      |
+| retract-oaipmh                       | Retracts media from a OAI-PMH repository                                                  | [Documentation](retract-oaipmh-woh.md)                       |
+| retract-partial                      | Retract a subset of the mediapackage from a publication                                   | [Documentation](retract-partial-woh.md)                      |
+| retract-youtube                      | Retracts media from YouTube                                                               | [Documentation](retract-youtube-woh.md)                      |
+| segment-video                        | Extracting segments from presentation                                                     | [Documentation](segmentvideo-woh.md)                         |
+| segmentpreviews                      | Extract segment images from a video using FFmpeg                                          | [Documentation](segmentpreviews-woh.md)                      |
+| select-streams                       | Select streams for further processing                                                     | [Documentation](select-streams-woh.md)                       |
+| select-version                       | Select a version of the media package to run the current workflow with                    | [Documentation](select-version-woh.md)                       |
+| send-email                           | Sends email notifications at any part of a workflow                                       | [Documentation](send-email-woh.md)                           |
+| series                               | Apply series to the mediapackage                                                          | [Documentation](series-woh.md)                               |
+| silence                              | Silence detection on audio of the mediapackage                                            | [Documentation](silence-woh.md)                              |
+| snapshot                             | Archive the current state of the mediapackage                                             | [Documentation](snapshot-woh.md)                             |
+| speech-to-text                       | Create subtitles for video and audio sources                                              | [Documentation](speech-to-text-woh.md)                       |
+| start-watson-transcription           | Starts automated transcription provided by IBM Watson                                     | [Documentation](start-watson-transcription-woh.md)           |
+| start-workflow                       | Start a new workflow for given media package ID                                           | [Documentation](start-workflow-woh.md)                       |
+| statistics-writer                    | Log statistical data about the video                                                      | [Documentation](statistics-writer.md)                        |
+| tag                                  | Modify the tag sets of media package elements                                             | [Documentation](tag-woh.md)                                  |
+| tag-by-dcterm                        | Modify the tags if dublincore term matches value                                          | [Documentation](tag-by-dcterm-woh.md)                        |
+| tag-engage                           | Modify the tag sets of media package elements in the engage publication                   | [Documentation](tag-engage-woh.md)                           |
+| theme                                | Make settings of themes available to processing                                           | [Documentation](theme-woh.md)                                |
+| timelinepreviews                     | Create a preview image stream from a given video track                                    | [Documentation](timelinepreviews-woh.md)                     |
+| transfer-metadata                    | Transfer metadata fields between catalogs                                                 | [Documentation](transfer-metadata-woh.md)                    |
+| waveform                             | Create a waveform image of the audio of the mediapackage                                  | [Documentation](waveform-woh.md)                             |
+| zip                                  | Create zipped archive of the current state of the mediapackage                            | [Documentation](zip-woh.md)                                  |
 
 ## State Mappings
 Technically, a workflow can be in one of the following states:

--- a/docs/guides/admin/docs/workflowoperationhandlers/tag-engage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/tag-engage-woh.md
@@ -1,0 +1,36 @@
+# Tag Engage Workflow Operation
+
+ID: 'tag-engage'
+
+## Description
+
+With the tag-engage operation, it's possible to modify the tags and flavors of media package elements (catalogs, 
+attachments or media) directly in the engage publication. Its behavior is based on the [tag](tag-woh.md) 
+operation. The publication is updated in the archive (don't forget to take a snapshot) as well as the search service. 
+Since no files have to be downloaded into the workspace, this operation is usually very quick.
+
+## Parameter Table
+
+| configuration keys | example                        | description                                                                                                                                                                                                                                                                                                      | default value |
+|--------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| source-tags        | "engage,atom,rss,-publish"     | Tag any media package elements with one of these (comma separated) tags. If a source-tag starts with a '-', media package elements with this tag will be excluded.                                                                                                                                               | EMPTY         |
+| source-flavors     | "presentation/trimmed"         | Tag any media package elements with one of these (comma separated) flavors.                                                                                                                                                                                                                                      | EMPTY         |
+| target-tags        | "tagged,+rss" / "-rss,+tagged" | Apply these (comma separated) tags to any media package elements. If a target-tag starts with a '-', it will be removed from preexisting tags, if a target-tag starts with a '+', it will be added to preexisting tags. If there is no prefix, all preexisting tags are removed and replaced by the target-tags. | EMPTY         |
+| target-flavor      | "presentation/tagged"          | Apply this flavor to any media package elements.                                                                                                                                                                                                                                                                 | EMPTY         |
+
+Tags and flavors can be used in combination. For examples see the [tag](tag-woh.md) operation.
+
+## Operation Example
+
+```xml
+    <operation
+    id="tag-engage"
+    description="Remove tag from composites in Engage">
+  <configurations>
+    <configuration key="source-flavors">presenter/*</configuration>
+    <configuration key="source-tags">engage-streaming</configuration>
+    <configuration key="target-flavor">presenter/tagged</configuration>
+    <configuration key="target-tags">+test</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -249,6 +249,7 @@ nav:
    - Statistics Writer: 'workflowoperationhandlers/statistics-writer.md'
    - Tag: 'workflowoperationhandlers/tag-woh.md'
    - Tag-By-DCTerm: 'workflowoperationhandlers/tag-by-dcterm-woh.md'
+   - Tag-Engage: 'workflowoperationhandlers/tag-engage-woh.md'
    - Timelinepreviews: 'workflowoperationhandlers/timelinepreviews-woh.md'
    - Transfer Metadata: 'workflowoperationhandlers/transfer-metadata-woh.md'
    - Theme: 'workflowoperationhandlers/theme-woh.md'

--- a/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/TagEngageWorkflowOperationHandler.java
+++ b/modules/distribution-workflowoperation/src/main/java/org/opencastproject/workflow/handler/distribution/TagEngageWorkflowOperationHandler.java
@@ -1,0 +1,232 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.distribution;
+
+import static org.opencastproject.workflow.handler.distribution.EngagePublicationChannel.CHANNEL_ID;
+
+import org.opencastproject.job.api.Job;
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.Publication;
+import org.opencastproject.mediapackage.selector.SimpleElementSelector;
+import org.opencastproject.search.api.SearchException;
+import org.opencastproject.search.api.SearchQuery;
+import org.opencastproject.search.api.SearchResult;
+import org.opencastproject.search.api.SearchService;
+import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.serviceregistry.api.ServiceRegistryException;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component(
+        immediate = true,
+        service = WorkflowOperationHandler.class,
+        property = {
+                "service.description=Tag Engage Workflow Operation Handler",
+                "workflow.operation=tag-engage"
+        }
+)
+public class TagEngageWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+
+  private static final Logger logger = LoggerFactory.getLogger(TagEngageWorkflowOperationHandler.class);
+
+  private static final String PLUS = "+";
+  private static final String MINUS = "-";
+
+  private SearchService searchService = null;
+
+  @Reference
+  public void setSearchService(SearchService searchService) {
+    this.searchService = searchService;
+  }
+
+  @Reference
+  public void setServiceRegistry(ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @Override
+  @Activate
+  protected void activate(ComponentContext cc) {
+    super.activate(cc);
+    logger.info("Registering tag engage workflow operation handler");
+  }
+
+  @Override
+  public WorkflowOperationResult start(WorkflowInstance instance, JobContext context)
+          throws WorkflowOperationException {
+
+    MediaPackage currentMediaPackage = instance.getMediaPackage();
+    String mediaPackageId = currentMediaPackage.getIdentifier().toString();
+
+    // parse config
+    ConfiguredTagsAndFlavors config = getTagsAndFlavors(instance,
+            Configuration.many,  // source-tags
+            Configuration.many,  // source-flavors
+            Configuration.many,  // target-tags
+            Configuration.many); //target-flavors
+
+    Set<String> removeTags = new HashSet<>();
+    Set<String> addTags = new HashSet<>();
+    Set<String> overrideTags = new HashSet<>();
+
+    for (String tag : config.getTargetTags()) {
+      if (tag.startsWith(MINUS)) {
+        removeTags.add(tag);
+      } else if (tag.startsWith(PLUS)) {
+        addTags.add(tag);
+      } else {
+        overrideTags.add(tag);
+      }
+    }
+
+    SimpleElementSelector mpeSelector = new SimpleElementSelector();
+    for (MediaPackageElementFlavor flavor : config.getSrcFlavors()) {
+      mpeSelector.addFlavor(flavor);
+    }
+    for (String tag : config.getSrcTags()) {
+      mpeSelector.addTag(tag);
+    }
+
+    // get published mp
+    SearchResult result = searchService.getByQuery(new SearchQuery().withId(mediaPackageId));
+    if (result.size() == 0) {
+      throw new WorkflowOperationException(
+              "Media package " + mediaPackageId + " can't be updated in Search because it " + "isn't published.");
+    } else if (result.size() > 1) {
+      throw new WorkflowOperationException("Media package " + mediaPackageId + " can't be updated in Search because "
+              + "more than one media package with that id was found.");
+    }
+    MediaPackage mediaPackageForSearch = result.getItems()[0].getMediaPackage();
+
+    // update tags & flavors in published mp
+    Collection<MediaPackageElement> searchElements = mpeSelector.select(mediaPackageForSearch, false);
+    boolean changedMediaPackageForSearch = updateTagsAndFlavors(searchElements, config, removeTags, addTags,
+            overrideTags);
+    if (!changedMediaPackageForSearch) {
+      logger.info("No element changed, not publishing anything.");
+      return createResult(currentMediaPackage, WorkflowOperationResult.Action.SKIP);
+    }
+
+    // update engage publication as well
+    boolean changedPublication = false;
+    for (Publication publication : currentMediaPackage.getPublications()) {
+      if (CHANNEL_ID.equals(publication.getChannel())) {
+        List<MediaPackageElement> publicationElements =
+                Stream.of(publication.getAttachments(), publication.getCatalogs(), publication.getTracks())
+                        .flatMap(Stream::of).collect(Collectors.toList());
+        Collection<MediaPackageElement> selectedElements = mpeSelector.select(publicationElements, false);
+        changedPublication = updateTagsAndFlavors(selectedElements, config, removeTags, addTags, overrideTags);
+      }
+    }
+    if (!changedPublication) {
+      throw new WorkflowOperationException("Publication for " + mediaPackageId + " couldn't be updated.");
+    }
+
+    // publish updated mp to search
+    Job publishJob;
+    try {
+      publishJob = searchService.add(mediaPackageForSearch);
+      if (!waitForStatus(publishJob).isSuccess()) {
+        throw new WorkflowOperationException("Media package " + mediaPackageId + " could not be published.");
+      }
+    } catch (SearchException | MediaPackageException | UnauthorizedException | ServiceRegistryException e) {
+      throw new WorkflowOperationException("Error publishing media package", e);
+    }
+
+    return createResult(currentMediaPackage, WorkflowOperationResult.Action.CONTINUE);
+  }
+
+  private boolean updateTagsAndFlavors(Collection<MediaPackageElement> elements, ConfiguredTagsAndFlavors config,
+          Set<String> removeTags, Set<String> addTags, Set<String> overrideTags) {
+
+    boolean changed = false;
+    for (MediaPackageElement element : elements) {
+
+      // update flavor
+      if (!config.getTargetFlavors().isEmpty()) {
+        MediaPackageElementFlavor currentFlavor = element.getFlavor();
+        MediaPackageElementFlavor targetFlavor = config.getTargetFlavors().get(0);
+
+        String newFlavorType = targetFlavor.getType();
+        String newFlavorSubtype = targetFlavor.getSubtype();
+        if (MediaPackageElementFlavor.WILDCARD.equals(newFlavorType)) {
+          newFlavorType = currentFlavor.getType();
+        }
+        if (MediaPackageElementFlavor.WILDCARD.equals(newFlavorSubtype)) {
+          newFlavorSubtype = currentFlavor.getSubtype();
+        }
+        MediaPackageElementFlavor newFlavor = MediaPackageElementFlavor.parseFlavor(
+                newFlavorType + MediaPackageElementFlavor.SEPARATOR + newFlavorSubtype);
+
+        if (!newFlavor.equals(currentFlavor)) {
+          element.setFlavor(newFlavor);
+          changed = true;
+        }
+      }
+
+      // update tags
+      Set<String> currentTags = new HashSet<>(Arrays.asList(element.getTags()));
+      if (overrideTags.size() > 0) {
+        element.clearTags();
+        for (String tag : overrideTags) {
+          element.addTag(tag);
+        }
+      } else {
+        for (String tag : removeTags) {
+          element.removeTag(tag.substring(MINUS.length()));
+        }
+        for (String tag : addTags) {
+          element.addTag(tag.substring(PLUS.length()));
+        }
+      }
+      Set<String> newTags = new HashSet<>(Arrays.asList(element.getTags()));
+      if (!currentTags.equals(newTags)) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+}


### PR DESCRIPTION
This adds a new workflow operation handler with which you can update tags and flavors of media package elements directly in the engage publication. :tada: This means that for such changes, it's no longer necessary to pull the files from the publication into the workspace, saving lots of time. The operation works almost exactly the same as the tag WOH except that it looks at published elements and does not support `copy`. The publication is updated in the archive as well as the search service.

This could probably be generalized to work for other publications, but this is currently out of scope.