### PR TITLE
Fix documentation syntax error

### DIFF
--- a/docs/checkstyle/check-docs.sh
+++ b/docs/checkstyle/check-docs.sh
@@ -7,6 +7,13 @@ cd docs/guides
 
 for docs in admin developer; do
   cd $docs
+  if test "$( grep -R opencast_major_version | grep '\w}\|{\w' )" != ""; then
+    echo "Error, $docs has a syntax error related to opencast_major_version:"
+    grep -R opencast_major_version | grep '\w}\|{\w'
+    ret=1
+    continue
+  fi
+
   echo "Building $docs documentation…"
   if mkdocs build &> mkdocs.log; then
     if grep \

--- a/docs/checkstyle/check-docs.sh
+++ b/docs/checkstyle/check-docs.sh
@@ -7,9 +7,9 @@ cd docs/guides
 
 for docs in admin developer; do
   cd $docs
-  if test "$( grep -R opencast_major_version | grep '\w}\|{\w' )" != ""; then
+  if test "$( grep -r 'opencast_major_version[()]*}\|{opencast_major_version' )" != ""; then
     echo "Error, $docs has a syntax error related to opencast_major_version:"
-    grep -R opencast_major_version | grep '\w}\|{\w'
+    grep -r 'opencast_major_version[()]*}\|{opencast_major_version'
     ret=1
     continue
   fi

--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -47,7 +47,7 @@ First you have to install the necessary repositories so that your package manage
     repository. If you need the new release prior to its promotion to stable you can use the testing repository.
     Note that the testing repository is an additional repository and still requires the stable repository to be active.
 
-        echo "deb https://pkg.opencast.org/debian {{ opencast_major_version()}}.x stable testing" | sudo tee /etc/apt/sources.list.d/opencast.list
+        echo "deb https://pkg.opencast.org/debian {{ opencast_major_version() }}.x stable testing" | sudo tee /etc/apt/sources.list.d/opencast.list
 
 * Add the repository key to your apt keyring:
 

--- a/docs/guides/developer/docs/development-process.md
+++ b/docs/guides/developer/docs/development-process.md
@@ -46,7 +46,7 @@ That is why patches may only be accepted into releases branches (`r/?.x`) if the
 
 Patches which do not meet these criteria should target the branch `develop` to become part of the next major version.
 
-Note: Patches adding features should target the current stable release (`r/{{ opencast_major_version}}.x`), or
+Note: Patches adding features should target the current stable release (`r/{{ opencast_major_version }}.x`), or
 `develop`, and are strongly discouraged from targetting the legacy release.  Features going into the legacy release
 will need a good reason, and must be highly self contained.
 


### PR DESCRIPTION
This PR:
- Fixes the syntax error
- Adds a check to ensure that the `opencast_major_version` macro in the documentation has appropriate spacing around it

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
