### PR TITLE
Remove RPM instructions from nightly documentation

### DIFF
--- a/docs/guides/admin/docs/index.md
+++ b/docs/guides/admin/docs/index.md
@@ -21,7 +21,6 @@ The Opencast Release Documentation is the official Opencast documentation for ea
 * [Release Notes](releasenotes.md)
     * [Upgrade](upgrade.md)
     * [Changelog](changelog.md)
-    * [Prerelease Testing](prereleases.md)
 * [Installation Guides](installation/index.md)
 * [Configuration Guides](configuration/index.md)
     * [Basic Configuration](configuration/basic.md)

--- a/docs/guides/admin/docs/installation/index.md
+++ b/docs/guides/admin/docs/installation/index.md
@@ -63,3 +63,10 @@ We provide configuration scripts to install and configure Opencast automatically
 packages from the repository above.
 
 * [Ansible](ansible.md)
+
+Prerelease repository testing
+----------------------------
+
+We build nightly packages in all of our packaging types.  The [prerelease documentation](prereleases.md) documents how
+to enable it.  This packaging is only for experts and should not be used by anyone aside from an experienced Opencast
+adopter.

--- a/docs/guides/admin/docs/installation/prereleases.md
+++ b/docs/guides/admin/docs/installation/prereleases.md
@@ -4,9 +4,11 @@ Shortly after a branch cut we start providing prerelease packages for the new br
 verison any time a pull request has been merged.  This may be more than once a day, or it may be very rare late in the
 life cycle of a branch.
 
+<div class=warn>
 Note: These packages come with *absolutely no support*, and may be broken at any time.  Do not install these on
 anything other than a testing system.  Do not feed the only copy of your recordings to these systems.  These
 packages may break their host operating system, and may eat your dog.  Do not feed these packages after midnight.
+</div>
 
 
 Redhat Based Distributions

--- a/docs/guides/admin/docs/installation/prereleases.md
+++ b/docs/guides/admin/docs/installation/prereleases.md
@@ -23,7 +23,7 @@ version must match your distribution's version!
     gpgkey = http://ci.opencast.org/keys/public-signing-key.gpg
 
 Note: This repo still requires the normal Opencast repository for dependencies (notably ffmpeg).  Configuration for
-these packages should follow the [standard instructions](configuration/basic.md)
+these packages should follow the [standard instructions](../configuration/basic.md)
 
 Debian Based Distributions
 --------------------------
@@ -37,7 +37,7 @@ The insert the following into `/etc/apt/sources.list.d/opencast-unstable.list`
     deb [signed-by=/usr/share/keyrings/opencast-unstable.gpg] http://ci.opencast.org/debian {{ opencast_major_version() }}.x unstable
 
 Note: This repo still requires the normal Opencast repository for dependencies (notably ffmpeg).  Configuration for
-these packages should follow the [standard instructions](configuration/basic.md)
+these packages should follow the [standard instructions](../configuration/basic.md)
 
 Docker Images
 -------------
@@ -46,4 +46,4 @@ All container images provide a `next` tag, e.g. `quay.io/opencast/allinone:next`
 next upcoming major version. As such, it follows the latest release branch `r/Y.x` until `Y.0` is released. After that,
 it builds from `develop` until the next release branch is cut. This change is announced on list.
 
-Configuration for these images should follow the [standard instructions](configuration/basic.md)
+Configuration for these images should follow the [standard instructions](../configuration/basic.md)

--- a/docs/guides/admin/docs/installation/prereleases.md
+++ b/docs/guides/admin/docs/installation/prereleases.md
@@ -10,7 +10,7 @@ anything other than a testing system.  Do not feed the only copy of your recordi
 packages may break their host operating system, and may eat your dog.  Do not feed these packages after midnight.
 </div>
 
-
+<!--
 Redhat Based Distributions
 --------------------------
 
@@ -26,6 +26,7 @@ version must match your distribution's version!
 
 Note: This repo still requires the normal Opencast repository for dependencies (notably ffmpeg).  Configuration for
 these packages should follow the [standard instructions](../configuration/basic.md)
+-->
 
 Debian Based Distributions
 --------------------------

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -39,7 +39,6 @@ nav:
 - Release Notes: 'releasenotes.md'
 - Upgrade: 'upgrade.md'
 - Changelog: 'changelog.md'
-- Prerelease Testing: 'prereleases.md'
 - Installation:
    - Overview: 'installation/index.md'
    - Hardware Requirements: installation/server-requirements.md
@@ -56,6 +55,7 @@ nav:
       - Ansible: 'installation/ansible.md'
    - Installation with Docker:
       - Testing Locally: 'installation/docker-local.md'
+   - Prerelease Testing: 'installation/prereleases.md'
 - Configuration:
    - Overview: 'configuration/index.md'
    - Basic: 'configuration/basic.md'


### PR DESCRIPTION
- Moved the prerelease package documentation deeper into the doc tree to make it harder for newbies to find it.
- Remove RPM instructions from the nightly instructions per @lkiesow request.  Nightlies will be provided at some future point.
- Amplified warning on the page since I felt it wasn't clear enough