### PR TITLE
Fix adopter data gathering bugs

### DIFF
--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -29,7 +29,7 @@
      "UNDETERMINED": "Indeterminable version"
    },
    "MONITOR": {
-     "REGISTRATION": "Opencast has sent a registration update in more than a week"
+     "REGISTRATION": "Out of date"
    },
    "LTI": {
      "ERROR_LOADING_METADATA": "Error loading event metadata. Please try again later.",

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -290,10 +290,6 @@ public class ScheduledDataCollector extends TimerTask {
     statisticData.setJobCount(serviceRegistry.count(null, null));
 
     AQueryBuilder q = assetManager.createQuery();
-    SecurityUtil.runAs(this.securityService, this.defaultOrganization, this.systemAdminUser, () -> {
-      AResult result = q.select(q.snapshot()).where(q.version().isLatest()).run();
-      statisticData.setEventCount(result.getSize());
-    });
 
     statisticData.setSeriesCount(seriesService.getSeriesCount());
     statisticData.setUserCount(userAndRoleProvider.countAllUsers());
@@ -312,6 +308,9 @@ public class ScheduledDataCollector extends TimerTask {
 
     for (Organization org : orgs) {
       SecurityUtil.runAs(securityService, org, systemAdminUser, () -> {
+        AResult result = q.select(q.snapshot()).where(q.version().isLatest()).run();
+        statisticData.setEventCount(statisticData.getEventCount() + result.getSize());
+
         //Calculate the number of attached CAs for this org, add it to the total
         long current = statisticData.getCACount();
         int orgCAs = caStateService.getKnownAgents().size();

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -332,7 +332,7 @@ public class ScheduledDataCollector extends TimerTask {
                                        .map(MediaPackage::getDuration)
                                        .mapToLong(Long::valueOf)
                                        .sum() / 1000L;
-          } while (false); //offset + SEARCH_ITERATION_SIZE <= total);
+          } while (offset + SEARCH_ITERATION_SIZE <= total);
         } catch (UnauthorizedException e) {
           //This should never happen, but...
           logger.warn("Unable to calculate total minutes, unauthorized");


### PR DESCRIPTION
This PR does the following:
- Shortening the (excessively long) registration warning message
- Counting events across all orgs, not just the default one
- Counting minutes across all events, not just the first 100.

Fixes: #4371

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
