### PR TITLE
Adds the 'add-force-flavors' config to the publish-engage workflow

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/publish-engage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/publish-engage-woh.md
@@ -29,7 +29,12 @@ Parameter Table
 |streaming-target-tags      |Add tags (comma separated) to published media                                                |
 |streaming-target-subflavors|Subflavor to use for distributed material                                                    |
 |merge-force-flavors        |Flavors of elements for which an update is enforced when merging catalogs.                   |
-|                           |Defaults to `dublincore/*,security/*`.
+|                           |Defaults to `dublincore/*,security/*`.                                                       |
+|add-force-flavors          |Works only if strategy 'merge' is used.                                                      |
+|                           |Elements with these flavors will be added to an existing publication.                        |
+|                           |No published elements will be deleted or overwritten.                                        |
+|                           |You can use: 'presenter/delivery' for example to add another track.                          |
+|                           |Default: empty                                                                               |
 
 Operation Example
 -----------------

--- a/modules/distribution-workflowoperation/src/test/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandlerTest.java
+++ b/modules/distribution-workflowoperation/src/test/java/org/opencastproject/workflow/handler/distribution/PublishEngageWorkflowOperationHandlerTest.java
@@ -263,7 +263,7 @@ public class PublishEngageWorkflowOperationHandlerTest {
 
     operation.setConfiguration(PublishEngageWorkflowOperationHandler.DOWNLOAD_SOURCE_TAGS, "engage");
     operation.setConfiguration(PublishEngageWorkflowOperationHandler.STRATEGY,
-            PublishEngageWorkflowOperationHandler.MERGE_STRATEGY);
+            PublishEngageWorkflowOperationHandler.PUBLISH_STRATEGY_MERGE);
     // Do not merge force any flavors
     operation.setConfiguration(PublishEngageWorkflowOperationHandler.MERGE_FORCE_FLAVORS, "dummy/dummy"); // flavors
     WorkflowOperationResult result = handler.start(workflowInstance, null);
@@ -321,7 +321,7 @@ public class PublishEngageWorkflowOperationHandlerTest {
 
     operation.setConfiguration(PublishEngageWorkflowOperationHandler.DOWNLOAD_SOURCE_TAGS, "engage");
     operation.setConfiguration(PublishEngageWorkflowOperationHandler.STRATEGY,
-            PublishEngageWorkflowOperationHandler.MERGE_STRATEGY);
+            PublishEngageWorkflowOperationHandler.PUBLISH_STRATEGY_MERGE);
     // Use default merge force flavors. Remove "engage" tag from episode catalog so
     // that it's deleted from published mp.
     MediaPackageElement mpe = workflowInstance.getMediaPackage().getElementById("d84b6672-ff84-4df5-9ada-f1cdc0f2d901");
@@ -367,7 +367,7 @@ public class PublishEngageWorkflowOperationHandlerTest {
 
     operation.setConfiguration(PublishEngageWorkflowOperationHandler.DOWNLOAD_SOURCE_TAGS, "engage");
     operation.setConfiguration(PublishEngageWorkflowOperationHandler.STRATEGY,
-            PublishEngageWorkflowOperationHandler.MERGE_STRATEGY);
+            PublishEngageWorkflowOperationHandler.PUBLISH_STRATEGY_MERGE);
 
     WorkflowOperationResult result = handler.start(workflowInstance, null);
 


### PR DESCRIPTION
You can use this new configuration if the publish strategy 'merge' is activated. Elements with these flavors will be added to an existing publication without deleting or overwriting existing elements.

For example, you can add a track with another resolution, without running the whole publishing workflow again.