### PR TITLE
Update tag support for subtitles as tracks in Paella Player

### DIFF
--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -303,9 +303,12 @@ function readCaptions(potentialNewCaptions, captions) {
       let captions_match = captions_regex.exec(potentialCaption.type);
 
       if (captions_match) {
+        // Fallback for captions which use the old flavor style, e.g. "captions/vtt+en"
         let captions_lang = captions_match[3];
+        let captions_generated = '';
+        let captions_closed = '';
 
-        if (!captions_lang && potentialCaption.tags && potentialCaption.tags.tag) {
+        if (potentialCaption.tags && potentialCaption.tags.tag) {
           if (!(potentialCaption.tags.tag instanceof Array)) {
             potentialCaption.tags.tag = [potentialCaption.tags.tag];
           }
@@ -313,15 +316,28 @@ function readCaptions(potentialNewCaptions, captions) {
             if (tag.startsWith('lang:')){
               captions_lang = tag.substring('lang:'.length);
             }
+            if (tag.startsWith('generator-type:') && tag.substring('generator-type:'.length) === 'auto') {
+              captions_generated = ' (automatically generated)';
+            }
+            if (tag.startsWith('type:') && tag.substring('type:'.length) === 'closed-caption') {
+              captions_closed = '[CC] ';
+            }
           });
         }
 
         let captions_format = potentialCaption.url.split('.').pop();
 
+        let captions_description = undefined;
+        if (captions_lang) {
+          let languageNames = new Intl.DisplayNames([window.navigator.language], {type: 'language'});
+          let captions_language_name = languageNames.of(captions_lang) || 'unknown language';
+          captions_description = captions_closed + captions_language_name + captions_generated;
+        }
+
         captions.push({
           id: potentialCaption.id,
           lang: captions_lang,
-          text: captions_lang || 'unknown language',
+          text: captions_description,
           url: potentialCaption.url,
           format: captions_format
         });
@@ -335,10 +351,8 @@ function getCaptions(episode) {
   var captions = [];
 
   var attachments = episode.mediapackage.attachments.attachment;
-  var catalogs = episode.mediapackage.metadata.catalog;
   var tracks = episode.mediapackage.media.track;
   if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
-  if (!(catalogs instanceof Array)) { catalogs = catalogs ? [catalogs] : []; }
   if (!(tracks instanceof Array)) { tracks = tracks ? [tracks] : []; }
 
   // Read the attachments
@@ -346,37 +360,6 @@ function getCaptions(episode) {
 
   // Read the tracks
   readCaptions(tracks, captions);
-
-  // Read the catalogs
-  catalogs.forEach((currentCatalog) => {
-    try {
-      // backwards compatibility:
-      // Catalogs flavored as 'captions/timedtext' are assumed to be dfxp
-      if (currentCatalog.type == 'captions/timedtext') {
-        let captions_lang;
-        if (currentCatalog.tags && currentCatalog.tags.tag) {
-          if (!(currentCatalog.tags.tag instanceof Array)) {
-            currentCatalog.tags.tag = [currentCatalog.tags.tag];
-          }
-          currentCatalog.tags.tag.forEach((tag)=>{
-            if (tag.startsWith('lang:')){
-              captions_lang = tag.substring('lang:'.length);
-            }
-          });
-        }
-
-        let captions_label = captions_lang || 'unknown language';
-        captions.push({
-          id: currentCatalog.id,
-          lang: captions_lang,
-          text: captions_label,
-          url: currentCatalog.url,
-          format: 'dfxp'
-        });
-      }
-    }
-    catch (err) {/**/}
-  });
 
   return captions;
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/03_oc_search_converter.js
@@ -390,12 +390,12 @@ class OpencastToPaellaConverter {
         let captions_match = captions_regex.exec(potentialCaption.type);
 
         if (captions_match) {
+          // Fallback for captions which use the old flavor style, e.g. "captions/vtt+en"
           let captions_lang = captions_match[3];
+          let captions_generated = '';
+          let captions_closed = '';
 
-          // TODO: read the lang from the dfxp file
-          //if (captions_format == "dfxp") {}
-
-          if (!captions_lang && potentialCaption.tags && potentialCaption.tags.tag) {
+          if (potentialCaption.tags && potentialCaption.tags.tag) {
             if (!(potentialCaption.tags.tag instanceof Array)) {
               potentialCaption.tags.tag = [potentialCaption.tags.tag];
             }
@@ -403,15 +403,28 @@ class OpencastToPaellaConverter {
               if (tag.startsWith('lang:')){
                 captions_lang = tag.substring('lang:'.length);
               }
+              if (tag.startsWith('generator-type:') && tag.substring('generator-type:'.length) === 'auto') {
+                captions_generated = ' (automatically generated)';
+              }
+              if (tag.startsWith('type:') && tag.substring('type:'.length) === 'closed-caption') {
+                captions_closed = '[CC] ';
+              }
             });
           }
 
           let captions_format = potentialCaption.url.split('.').pop();
 
+          let captions_description = undefined;
+          if (captions_lang) {
+            let languageNames = new Intl.DisplayNames([window.navigator.language], {type: 'language'});
+            let captions_language_name = languageNames.of(captions_lang) || 'unknown language';
+            captions_description = captions_closed + captions_language_name + captions_generated;
+          }
+
           captions.push({
             id: potentialCaption.id,
             lang: captions_lang,
-            text: captions_lang || 'unknown language',
+            text: captions_description,
             url: potentialCaption.url,
             format: captions_format
           });
@@ -425,10 +438,8 @@ class OpencastToPaellaConverter {
     var captions = [];
 
     var attachments = episode.mediapackage.attachments.attachment;
-    var catalogs = episode.mediapackage.metadata.catalog;
     var tracks = episode.mediapackage.media.track;
     if (!(attachments instanceof Array)) { attachments = attachments ? [attachments] : []; }
-    if (!(catalogs instanceof Array)) { catalogs = catalogs ? [catalogs] : []; }
     if (!(tracks instanceof Array)) { tracks = tracks ? [tracks] : []; }
 
     // Read the attachments
@@ -436,38 +447,6 @@ class OpencastToPaellaConverter {
 
     // Read the tracks
     this.readCaptions(tracks, captions);
-
-    // Read the catalogs
-    catalogs.forEach((currentCatalog) => {
-      try {
-        // backwards compatibility:
-        // Catalogs flavored as 'captions/timedtext' are assumed to be dfxp
-        if (currentCatalog.type == 'captions/timedtext') {
-          let captions_lang;
-
-          if (currentCatalog.tags && currentCatalog.tags.tag) {
-            if (!(currentCatalog.tags.tag instanceof Array)) {
-              currentCatalog.tags.tag = [currentCatalog.tags.tag];
-            }
-            currentCatalog.tags.tag.forEach((tag)=>{
-              if (tag.startsWith('lang:')){
-                captions_lang = tag.substring('lang:'.length);
-              }
-            });
-          }
-
-          let captions_label = captions_lang || 'unknown language';
-          captions.push({
-            id: currentCatalog.id,
-            lang: captions_lang,
-            text: captions_label,
-            url: currentCatalog.url,
-            format: 'dfxp'
-          });
-        }
-      }
-      catch (err) {/**/}
-    });
 
     return captions;
   }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/da-DK.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/da-DK.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Videoindlæsningsfejl! Igen videospor fundet",
-	"Error loading video {0}": "Videoindlæsningsfejl {0}",
-	"CAPTIONS_undefined": "Ukendt sprog",
-	"CAPTIONS_es": "Spansk",
-	"CAPTIONS_en": "Engelsk",
-	"CAPTIONS_de": "Tysk"
+	"Error loading video {0}": "Videoindlæsningsfejl {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/de-DE.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/de-DE.json
@@ -1,8 +1,5 @@
 {
 	"Error loading video! No video tracks found": "Das Video konnte nicht geladen werden, da keine Videospuren gefunden wurden",
 	"Error loading video {0}": "Das Video {0} konnte nicht geladen werden",
-	"CAPTIONS_undefined": "Unbekannte Sprache",
-	"CAPTIONS_es": "Spanisch",
-	"CAPTIONS_en": "Englisch",
-	"CAPTIONS_de": "Deutsch"
+	"CAPTIONS_undefined": "Unbekannte Sprache"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/el-GR.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/el-GR.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Σφάλμα φόρτωσης βίντεο! Δεν βρέθηκε κομμάτι βίντεο",
-	"Error loading video {0}": "Σφάλμα κατά τη φόρτωση βίντεο {0}",
-	"CAPTIONS_undefined": "Άγνωστη γλώσσα",
-	"CAPTIONS_es": "Ισπανικά",
-	"CAPTIONS_en": "Αγγλικά",
-	"CAPTIONS_de": "Γερμανικά"
+	"Error loading video {0}": "Σφάλμα κατά τη φόρτωση βίντεο {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/en-GB.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/en-GB.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Error loading video! No video tracks found",
-	"Error loading video {0}": "Error loading video {0}",
-	"CAPTIONS_undefined": "Unknown language",
-	"CAPTIONS_es": "Spanish",
-	"CAPTIONS_en": "English",
-	"CAPTIONS_de": "German"
+	"Error loading video {0}": "Error loading video {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/en-US.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/en-US.json
@@ -1,9 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Error loading video! No video tracks found",
-	"Error loading video {0}": "Error loading video {0}",
-
-	"CAPTIONS_undefined": "Unknown language",
-	"CAPTIONS_es": "Spanish",
-	"CAPTIONS_en": "English",
-	"CAPTIONS_de": "German"
+	"Error loading video {0}": "Error loading video {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/es-ES.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/es-ES.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "¡Error al cargar el video! No se han encontrado pistas de video",
-	"Error loading video {0}": "Error al cargar el video {0}",
-	"CAPTIONS_undefined": "Idioma desconocido",
-	"CAPTIONS_es": "Español",
-	"CAPTIONS_en": "Inglés",
-	"CAPTIONS_de": "Alemán"
+	"Error loading video {0}": "Error al cargar el video {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/fr-FR.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/fr-FR.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Erreur lors du chargement de la vidéo! Aucune piste vidéo trouvée",
-	"Error loading video {0}": "Erreur lors du chargement de la vidéo {0}",
-	"CAPTIONS_undefined": "Langue inconnue",
-	"CAPTIONS_es": "Espagnol",
-	"CAPTIONS_en": "Anglais",
-	"CAPTIONS_de": "Allemand"
+	"Error loading video {0}": "Erreur lors du chargement de la vidéo {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/gl-ES.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/gl-ES.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Erro ó cargar o vídeo! Non se atoparon pistas de vídeo",
-	"Error loading video {0}": "Erro ó cargar o vídeo {0}",
-	"CAPTIONS_undefined": "Idioma descoñecido",
-	"CAPTIONS_es": "Español",
-	"CAPTIONS_en": "Inglés",
-	"CAPTIONS_de": "Alemán"
+	"Error loading video {0}": "Erro ó cargar o vídeo {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/he-IL.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/he-IL.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "שגיאה בטעינת הוידאו! לא נמצאו רצועות וידאו",
-	"Error loading video {0}": "שגיאה בטעינת הוידאו {0}",
-	"CAPTIONS_undefined": "שפה לא ידועה",
-	"CAPTIONS_es": "ספרדית",
-	"CAPTIONS_en": "אנגלית",
-	"CAPTIONS_de": "גרמנית"
+	"Error loading video {0}": "שגיאה בטעינת הוידאו {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/it-IT.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/it-IT.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Errore nel caricamento del video! Nessuna traccia video trovata",
-	"Error loading video {0}": "Errore nel caricamento del video {0}",
-	"CAPTIONS_undefined": "Lingua sconosciuta",
-	"CAPTIONS_es": "Spagnolo",
-	"CAPTIONS_en": "Inglese",
-	"CAPTIONS_de": "Tedesco"
+	"Error loading video {0}": "Errore nel caricamento del video {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/nl-NL.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/nl-NL.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Fout bij het laden van de video. Geen videosporen gevonden",
-	"Error loading video {0}": "Fout bij het laden van video {0}",
-	"CAPTIONS_undefined": "Onbekende taal",
-	"CAPTIONS_es": "Spaans",
-	"CAPTIONS_en": "Engels",
-	"CAPTIONS_de": "Duits"
+	"Error loading video {0}": "Fout bij het laden van video {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/pl-PL.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/pl-PL.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Błąd ładowania wideo! Nie znaleziono żandej ścieżki",
-	"Error loading video {0}": "Błąd ładowania wideo {0}",
-	"CAPTIONS_undefined": "Nieznany język",
-	"CAPTIONS_es": "Hiszpański",
-	"CAPTIONS_en": "Angielski",
-	"CAPTIONS_de": "Niemiecki"
+	"Error loading video {0}": "Błąd ładowania wideo {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/sl-SI.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/sl-SI.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Napaka pri nalaganju video datoteke! Ni bilo najdenih video datotek",
-	"Error loading video {0}": "Napaka pri nalaganju videa {0}",
-	"CAPTIONS_undefined": "Neznani jezik",
-	"CAPTIONS_es": "Špansko",
-	"CAPTIONS_en": "Angleško",
-	"CAPTIONS_de": "Nemško"
+	"Error loading video {0}": "Napaka pri nalaganju videa {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/sv-SE.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/sv-SE.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Fel uppstod när videon skulle laddas! Inget ljudspår hittades",
-	"Error loading video {0}": "Fel uppstod vid laddningen av video {0}",
-	"CAPTIONS_undefined": "Okänt språk",
-	"CAPTIONS_es": "Spanska",
-	"CAPTIONS_en": "Engelska",
-	"CAPTIONS_de": "Tyska"
+	"Error loading video {0}": "Fel uppstod vid laddningen av video {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/tr-TR.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/tr-TR.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "Video yüklenirken hata oluştu! Hiçbir video parçası bulunamadı",
-	"Error loading video {0}": "Video yüklenirken hata oluştu {0}",
-	"CAPTIONS_undefined": "Bilinmeyen dil",
-	"CAPTIONS_es": "İspanyolca",
-	"CAPTIONS_en": "İngilizce",
-	"CAPTIONS_de": "Almanca"
+	"Error loading video {0}": "Video yüklenirken hata oluştu {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/zh-CN.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/zh-CN.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "载入视频出错！未发现视频轨",
-	"Error loading video {0}": "载入视频出错 {0}",
-	"CAPTIONS_undefined": "未知语言",
-	"CAPTIONS_es": "西班牙语",
-	"CAPTIONS_en": "英语",
-	"CAPTIONS_de": "德语"
+	"Error loading video {0}": "载入视频出错 {0}"
 }

--- a/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/zh-TW.json
+++ b/modules/engage-paella-player/src/main/paella-opencast/plugins/es.upv.paella.opencast.loader/localization/zh-TW.json
@@ -1,8 +1,4 @@
 {
 	"Error loading video! No video tracks found": "載入影片時出錯！ 未找到影片軌道",
-	"Error loading video {0}": "載入影片 {0} 時出錯",
-	"CAPTIONS_undefined": "未知的語言",
-	"CAPTIONS_es": "西班牙語",
-	"CAPTIONS_en": "英語",
-	"CAPTIONS_de": "德語"
+	"Error loading video {0}": "載入影片 {0} 時出錯"
 }


### PR DESCRIPTION
*This PR aims at contributing to the implementation of #4407, but touches on just one of the aspects to realize #4407's vision. It should therefore likely not be merged alone, but alongside other PRs.*

Since the Paella Player already supports subtitles as tracks, this merely adds some support for tags that will be used with subtitles in the future.

This also drops anything dfxp related, support for subtitles as catalogs, and some unused
translation strings.
