### PR TITLE
Add missing expected response code

### DIFF
--- a/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
+++ b/modules/series-service-remote/src/main/java/org/opencastproject/series/remote/SeriesServiceRemoteImpl.java
@@ -645,7 +645,7 @@ public class SeriesServiceRemoteImpl extends RemoteBase implements SeriesService
     HttpPut put = new HttpPut("/" + seriesID + "/elements/" + type);
     put.setEntity(new ByteArrayEntity(data, ContentType.DEFAULT_BINARY));
 
-    HttpResponse response = getResponse(put, SC_NO_CONTENT, SC_INTERNAL_SERVER_ERROR);
+    HttpResponse response = getResponse(put, SC_CREATED, SC_NO_CONTENT, SC_INTERNAL_SERVER_ERROR);
     try {
       if (response == null) {
         throw new SeriesException(format("Error while updating element of type '%s' in series '%s'", type, seriesID));


### PR DESCRIPTION
The HTTP status code 201 is a valid return code of the updateSeriesElement endpoint, but the corresponding series service remote implementation does not expect it.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
