### PR TITLE
Do not allow dot in file names

### DIFF
--- a/etc/org.opencastproject.workingfilerepository.impl.WorkingFileRepository.cfg
+++ b/etc/org.opencastproject.workingfilerepository.impl.WorkingFileRepository.cfg
@@ -5,17 +5,18 @@
 # look like this:
 #
 #   original:  -problematic-file/../name&&&%.ext
-#   converted: _problematic-file_.._name____.ext
+#   converted: _problematic-file____name____.ext
 #
 # This option allows you to control which characters are not allowed. All parts of the file name matched by the
 # configured pattern will be replaced by `_`. The replacement is applied separately to the base file name and the
 # extension. In any case, both base name and extension are limited to 255 characters each.
 #
 # WARNING: This setting is dangerous. It lets you configure Opencast in a way that poses a security risk to your system
-#          by e.g. allowing for path traversal attacks.
+#          by e.g. allowing for path traversal attacks. Note that allowing dot characters can lead to paths, which are
+#          not allowed to be served (i.e. containing "..").
 # BETA:    For a long time, this was a very restricted, fixed value. Consider this to be an unstable configuration which
 #          might lead to problems since some component somewhere assumes the old restricted behavior. Test your system
 #          very carefully after changing this. Feedback about problems and successful changes are welcome.
 #
-# Default: (^\\W|[^\\w-.])
-#filename.forbidden.pattern = (^\\W|[^\\w-_.])
+# Default: (^\\W|[^\\w-])
+#filename.forbidden.pattern = (^\\W|[^\\w-_])

--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -118,7 +118,7 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
   protected String servicePath = null;
 
   /** The default pattern for characters forbidden in filenames */
-  private static final String FILENAME_REGEX_DEFAULT = "(^\\W|[^\\w-.])";
+  private static final String FILENAME_REGEX_DEFAULT = "(^\\W|[^\\w-])";
 
   /** Key for configuring the filename pattern specifying forbidden characters */
   private static final String FILENAME_REGEX_KEY = "filename.forbidden.pattern";


### PR DESCRIPTION
The StaticResourceServlet will not allow paths containing two conse- cutive dots (..) and will return an SC_FORBIDDEN in such a case. Disallowing dots in the first place and replacing them with under- scores will mitigate the 403ish issue users may otherwise run into.

Resolves #4649

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
*  include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
