### PR TITLE
Add webvtt-to-cutmarks to list of workflow operations

### DIFF
--- a/docs/guides/admin/docs/modules/transcription.modules/vosk.md
+++ b/docs/guides/admin/docs/modules/transcription.modules/vosk.md
@@ -4,7 +4,7 @@ Vosk Transcription Engine
 Overview
 --------
 [Vosk](https://alphacephei.com/vosk/) is an offline open-source speech recognition toolkit. It enables speech recognition for 20+ languages.
-This engine is use by [SpeechToText WoH](../../workflowoperationhandlers/speech-to-text-woh.md)
+This engine is use by [SpeechToText WoH](../../workflowoperationhandlers/speechtotext-woh.md)
 
 Enable Vosk in Opencast
 -----------------------

--- a/docs/guides/admin/docs/modules/transcription.modules/whisper.md
+++ b/docs/guides/admin/docs/modules/transcription.modules/whisper.md
@@ -5,7 +5,7 @@ Overview
 --------
 
 Opencast can take advantage of [Open AI's Whisper Project]() to generate automatic transcriptions on premise through 
-[SpeechToText WoH](../../workflowoperationhandlers/speech-to-text-woh.md).
+[SpeechToText WoH](../../workflowoperationhandlers/speechtotext-woh.md).
 
 Advantages
 ----------

--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -117,6 +117,7 @@ The following table contains the workflow operations that are available in an ou
 | transfer-metadata                    | Transfer metadata fields between catalogs                                                 | [Documentation](transfer-metadata-woh.md)                    |
 | video-grid                           | Put parallel video streams on a single video canvas                                       | [Documentation](video-grid-woh.md)                           |
 | waveform                             | Create a waveform image of the audio of the mediapackage                                  | [Documentation](waveform-woh.md)                             |
+| webvtt-to-cutmarks                   | Create cutting suggestions from subtitles                                                 | [Documentation](webvtt-to-cutmarks.md)                       |
 | zip                                  | Create zipped archive of the current state of the mediapackage                            | [Documentation](zip-woh.md)                                  |
 
 ## State Mappings

--- a/docs/guides/admin/docs/workflowoperationhandlers/webvtt-to-cutmarks.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/webvtt-to-cutmarks.md
@@ -33,10 +33,8 @@ Operation Example
 
 ```xml
 <operation
-        id="webvtt-to-cutmarks"
-    description="Use WebVTT as a silence detection"
-    fail-on-error="true"
-    exception-handler-workflow="partial-error">
+    id="webvtt-to-cutmarks"
+    description="Use WebVTT as a silence detection">
   <configurations>
     <configuration key="source-flavor">captions/vtt+en</configuration>
     <configuration key="target-flavor">cut-marks/json</configuration>


### PR DESCRIPTION
This patch add the webvtt-to-cutmarks operation to the comprehensive list of all Opencast workflow operations.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
