### PR TITLE
Allow CA users to retract live publications and update search

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackage.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackage.java
@@ -531,4 +531,11 @@ public interface MediaPackage extends Cloneable {
    */
   Object clone();
 
+  /**
+   * Whether the media package contains live tracks.
+   *
+   * @return if mp is live
+   */
+  boolean isLive();
+
 }

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageImpl.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/MediaPackageImpl.java
@@ -1464,6 +1464,11 @@ public final class MediaPackageImpl implements MediaPackage {
     this.title = title;
   }
 
+  @Override
+  public boolean isLive() {
+    return Arrays.stream(getTracks()).anyMatch(Track::isLive);
+  }
+
   /**
    * Returns the media package element that matches the given reference.
    *
@@ -1589,5 +1594,4 @@ public final class MediaPackageImpl implements MediaPackage {
     }
     return attachments;
   }
-
 }

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -270,7 +270,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     } else {
       // Check if the media package found in the search index is live. We have to check because we may get a
       // notification for past events if the admin ui index is rebuilt
-      if (!isLive(mp)) {
+      if (!mp.isLive()) {
         logger.info("Media package {} is in search index but not live so not updating it.", mpId);
         return false;
       }
@@ -285,7 +285,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       logger.debug("Live media package {} not found in search index", mpId);
       return false;
     } else {
-      if (!isLive(mp)) {
+      if (!mp.isLive()) {
         logger.info("Media package {} is not live. Not retracting.", mpId);
         return false;
       }
@@ -297,7 +297,7 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   public boolean updateLiveEventAcl(String mpId, AccessControlList acl) throws LiveScheduleException {
     MediaPackage previousMp = getMediaPackageFromSearch(mpId);
     if (previousMp != null) {
-      if (!isLive(previousMp)) {
+      if (!previousMp.isLive()) {
         logger.info("Media package {} is not live. Not updating acl.", mpId);
         return false;
       }
@@ -622,19 +622,6 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
     matcher.appendTail(sb);
     return sb.toString();
-  }
-
-  private boolean isLive(MediaPackage mp) {
-    Track[] tracks = mp.getTracks();
-    if (tracks != null) {
-      for (Track track : tracks) {
-        if (track.isLive()) {
-          return true;
-        }
-      }
-    }
-
-    return false;
   }
 
   private JobBarrier.Result waitForStatus(Job... jobs) throws IllegalStateException, IllegalArgumentException {

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/SearchServiceImpl.java
@@ -22,6 +22,7 @@
 package org.opencastproject.search.impl;
 
 import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_CAPTURE_AGENT_ROLE;
 
 import org.opencastproject.job.api.AbstractJobProducer;
 import org.opencastproject.job.api.Job;
@@ -469,7 +470,14 @@ public final class SearchServiceImpl extends AbstractJobProducer implements Sear
   public boolean deleteSynchronously(final String mediaPackageId) throws SearchException {
     SearchResult result;
     try {
-      result = solrRequester.getForWrite(new SearchQuery().withId(mediaPackageId));
+      SearchQuery q = new SearchQuery().withId(mediaPackageId);
+      User user = securityService.getUser();
+      // allow ca users to retract live publications without putting them into the ACL
+      if (user.hasRole(GLOBAL_CAPTURE_AGENT_ROLE)) {
+        result = solrRequester.getForAdministrativeRead(q); // action doesn't matter here
+      } else {
+        result = solrRequester.getForWrite(q); // also checks admin rights which are always part of the ACL in search
+      }
       if (result.getItems().length == 0) {
         logger.warn("Can not delete mediapackage {}, which is not available for the current user to delete from the "
                     + "search index.", mediaPackageId);

--- a/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
+++ b/modules/search-service-impl/src/main/java/org/opencastproject/search/impl/persistence/SearchServiceDatabaseImpl.java
@@ -369,7 +369,7 @@ public class SearchServiceDatabaseImpl implements SearchServiceDatabase {
       } else {
         // Ensure this user is allowed to update this media package
         String accessControlXml = entity.getAccessControl();
-        if (accessControlXml != null) {
+        if (accessControlXml != null && entity.getDeletionDate() == null) {
           AccessControlList accessList = AccessControlParser.parseAcl(accessControlXml);
           User currentUser = securityService.getUser();
           Organization currentOrg = securityService.getOrganization();


### PR DESCRIPTION
This pull request fixes the following issues:
1. A capture agent user cannot currently retract a live publication from search (which is needed because it's the change of the capture agent status which triggers this), and
2. if a live publication existed (even if it was successfully marked as deleted), a capture agent user cannot create an engage publication afterwards.

I fixed the first issue by giving everybody with ROLE_CAPTURE_AGENT the right to mark only live publications as deleted in search. 

Then the second issue is fixed by not checking for permission when updating a media package in search if it was marked as deleted prior. Since we also don't check for permission for new publications, this seemed reasonable to me, but this might be controversial. Alternatively I could allow a capture agent user the general right to update media packages in search. Let me know if you have an opinion on this.