### PR TITLE
Add a configuration file for the WebVTTCaptionConverter

### DIFF
--- a/etc/org.opencastproject.caption.converters.WebVttCaptionConverter.cfg
+++ b/etc/org.opencastproject.caption.converters.WebVttCaptionConverter.cfg
@@ -1,0 +1,5 @@
+
+# defines the mediapackage element type of the subtitle files
+# possible values: Attachment, Track
+# default: Attachment
+#mediapackage-element-type=Attachment

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
@@ -137,7 +137,7 @@ public class WebVttCaptionConverter implements CaptionConverter {
       mediapackageElementType = OsgiUtil.getOptCfg(cc.getProperties(), MEDIAPACKAGE_ELEMENT_TYPE_CONFIG_KEY).get();
       // capitalize the first letter
       mediapackageElementType = mediapackageElementType.substring(0, 1).toUpperCase()
-          + mediapackageElementType.substring(1);
+          + mediapackageElementType.substring(1).toLowerCase();
       return MediaPackageElement.Type.valueOf(mediapackageElementType);
     } catch (Exception e) {
       logger.warn("Couldn't convert configuration '{}'='{}' into enum. Using default '{}'.",

--- a/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
+++ b/modules/caption-impl/src/main/java/org/opencastproject/caption/converters/WebVttCaptionConverter.java
@@ -153,11 +153,9 @@ public class WebVttCaptionConverter implements CaptionConverter {
     if (EnumUtils.isValidEnumIgnoreCase(MediaPackageElement.Type.class, mediaPackageElementType)) {
       return EnumUtils.getEnumIgnoreCase(MediaPackageElement.Type.class, mediaPackageElementType);
     }
-    // Conversion didn't work. Print an error and throw an exception
-    String additionalErrorInfo = String.format("Please check the config file '%s'.", this.getClass().getName());
-    String errorMessage = String.format("Couldn't convert configuration '%s'='%s' into enum. " + additionalErrorInfo,
+    // Conversion didn't work, throw an exception
+    String errorMessage = String.format("Couldn't convert configuration '%s'='%s' into enum.",
         MEDIAPACKAGE_ELEMENT_TYPE_CONFIG_KEY, mediaPackageElementType);
-    logger.error(errorMessage);
     throw new IllegalArgumentException(errorMessage);
   }
 


### PR DESCRIPTION
With this change, you can set how subtitle files will be appended to a mediapackage after a conversion.
