### PR TITLE
Ensure workflows have an associated org after upgrade

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -96,6 +96,10 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
                 query = "SELECT w FROM WorkflowInstance as w where w.workflowId=:workflowId and w.organizationId=:organizationId"
         ),
         @NamedQuery(
+            name = "Workflow.workflowByIdOrganizationIndependent",
+            query = "SELECT w FROM WorkflowInstance as w where w.workflowId=:workflowId"
+        ),
+        @NamedQuery(
                 name = "Workflow.getCount",
                 query = "select COUNT(w) from WorkflowInstance w where w.organizationId=:organizationId "
                         + "and (:state is null or w.state = :state) "

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
@@ -46,6 +46,19 @@ public interface WorkflowServiceDatabase {
   WorkflowInstance getWorkflow(long workflowId) throws NotFoundException, WorkflowDatabaseException;
 
   /**
+   * Gets a single workflow by its identifier
+   *
+   * @param workflowId
+   *          the series identifier
+   * @return the {@link WorkflowInstance} for this workflow
+   * @throws NotFoundException
+   *           if there is no workflow with this identifier
+   * @throws WorkflowDatabaseException
+   *           if there is a problem communicating with the underlying data store
+   */
+  WorkflowInstance getWorkflow(long workflowId, String orgId) throws NotFoundException, WorkflowDatabaseException;
+
+  /**
    * Gets workflow instances for current organization.
    *
    * @param limit

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
@@ -110,13 +110,25 @@ public class WorkflowServiceDatabaseImpl implements WorkflowServiceDatabase {
    */
   @Override
   public WorkflowInstance getWorkflow(long workflowId) throws NotFoundException, WorkflowDatabaseException {
+    return getWorkflow(workflowId, securityService.getOrganization().getId());
+  }
+
+  public WorkflowInstance getWorkflow(long workflowId, String orgId) throws NotFoundException, WorkflowDatabaseException {
     try {
-      return db.exec(namedQuery.find(
-          "Workflow.workflowById",
-          WorkflowInstance.class,
-          Pair.of("workflowId", workflowId),
-          Pair.of("organizationId", securityService.getOrganization().getId())
-      ));
+      if (null != orgId) {
+        return db.exec(namedQuery.find(
+            "Workflow.workflowById",
+            WorkflowInstance.class,
+            Pair.of("workflowId", workflowId),
+            Pair.of("organizationId", orgId)
+        ));
+      } else {
+        return db.exec(namedQuery.find(
+            "Workflow.workflowByIdOrganizationIndependent",
+            WorkflowInstance.class,
+            Pair.of("workflowId", workflowId)
+        ));
+      }
     } catch (NoResultException e) {
       throw new NotFoundException("No workflow with id=" + workflowId + " exists");
     } catch (Exception e) {

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
@@ -193,11 +193,33 @@ public class WorkflowServiceDatabaseImpl implements WorkflowServiceDatabase {
   public List<WorkflowIndexData> getWorkflowIndexData(int limit, int offset) throws WorkflowDatabaseException {
     try {
       return db.exec(em -> {
-        return em
+        List<WorkflowIndexData> results = em
             .createNamedQuery("WorkflowIndexData.getAll", WorkflowIndexData.class)
             .setMaxResults(limit)
             .setFirstResult(offset)
             .getResultList();
+        //2023-02: Reports of workflows with missing org IDs in adopters upgrading to 13.x, fixing.
+        for (WorkflowIndexData entry : results) {
+          if (null == entry.getOrganizationId()) {
+            WorkflowInstance actualWorkflow = em.createNamedQuery("Workflow.workflowById", WorkflowInstance.class)
+                .setMaxResults(1)
+                .setParameter("workflowId", entry.getId())
+                //NB: This query filters by org, so we have to explicitly null out the org
+                .setParameter("organizationId", null)
+                .getSingleResult();
+            logger.warn("Detected workflow with missing org id.  Workflow ID {}", entry.getId());
+            logger.warn("If you see this message a lot please report it.");
+            actualWorkflow.setOrganizationId(securityService.getOrganization().getId());
+            try {
+              updateInDatabase(actualWorkflow);
+              logger.warn("Repaired workflow ID {}", entry.getId());
+            } catch (WorkflowDatabaseException wde) {
+              //If this errors out then we should probably die?  Chances are the DB connection is broken anyway.
+              throw new RuntimeException(wde);
+            }
+          }
+        }
+        return results;
       });
     } catch (Exception e) {
       throw new WorkflowDatabaseException(e);

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2212,7 +2212,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
                   instance.setOrganizationId(orgid);
                   persistence.updateInDatabase(instance);
                 } catch (NotFoundException e) {
-                  logger.warn("Workflow {} not found in the database, but present in the index", indexData.getId());
+                  //Technically this should never happen, but getWorkflow throws it.
                 }
               }
               var updatedWorkflowData = index.getEvent(indexData.getMediaPackageId(), orgid, securityService.getUser());


### PR DESCRIPTION
This PR ensures that all workflows have an organization associated with them after an upgrade.  This was reported on list by Sven Laudel, along with the fix by Tilman

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
