### PR TITLE
Add Opencast 13.2 release notes

### DIFF
--- a/docs/guides/admin/docs/changelog.md
+++ b/docs/guides/admin/docs/changelog.md
@@ -4,6 +4,29 @@ Changelog
 Opencast 13
 -----------
 
+### Opencast 13.2
+
+*Released on February 15th, 2023*
+
+- [[#4616](https://github.com/opencast/opencast/pull/4616)] -
+  Fix adopter data gathering bugs
+- [[#4687](https://github.com/opencast/opencast/pull/4687)] -
+  Bump eslint from 8.33.0 to 8.34.0 in /modules/engage-paella-player-7
+- [[#4680](https://github.com/opencast/opencast/pull/4680)] -
+  Bump html-validate from 7.13.1 to 7.13.2 in /modules/engage-paella-player-7
+- [[#4657](https://github.com/opencast/opencast/pull/4657)] -
+  Bump eslint from 8.32.0 to 8.33.0 in /modules/engage-paella-player-7
+- [[#4654](https://github.com/opencast/opencast/pull/4654)] -
+  Add webvtt-to-cutmarks to list of workflow operations
+- [[#4648](https://github.com/opencast/opencast/pull/4648)] -
+  Bump paella-core from 1.14.2 to 1.16.0 in /modules/engage-paella-player-7
+- [[#4628](https://github.com/opencast/opencast/pull/4628)] -
+  Add missing expected response code
+- [[#4619](https://github.com/opencast/opencast/pull/4619)] -
+  Fix calendar.json endpoint
+- [[#4607](https://github.com/opencast/opencast/pull/4607)] -
+  Add Opencast 13.1 release notes
+
 ### Opencast 13.1
 
 *Released on January 18th, 2023*

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -1,6 +1,18 @@
 # Opencast 13: Release Notes
 
 
+Opencast 13.2
+-------------
+
+The second maintenance release of Opencast 13.
+
+-  Fix calendar.json endpoint ([#4619](https://github.com/opencast/opencast/pull/4619))
+-  Add missing expected response code ([#4628](https://github.com/opencast/opencast/pull/4628))
+-  Add webvtt-to-cutmarks to list of workflow operations ([#4654](https://github.com/opencast/opencast/pull/4654))
+
+See [changelog](changelog.md) for a comprehensive list of changes.
+
+
 Opencast 13.1
 -------------
 

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -9,6 +9,7 @@ The second maintenance release of Opencast 13.
 -  Fix calendar.json endpoint ([#4619](https://github.com/opencast/opencast/pull/4619))
 -  Add missing expected response code ([#4628](https://github.com/opencast/opencast/pull/4628))
 -  Add webvtt-to-cutmarks to list of workflow operations ([#4654](https://github.com/opencast/opencast/pull/4654))
+-  Fix multiple bugs in the adopters registration resulting in incorrect counts ([#4616](https://github.com/opencast/opencast/pull/4616))
 
 See [changelog](changelog.md) for a comprehensive list of changes.
 


### PR DESCRIPTION
This PR will add the Opencast 13.2 release notes.

The release will probably be on February 15, 2023. Until then, this will be a draft PR.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
