### PR TITLE
Fix Workflow Condition Parsing

### DIFF
--- a/docs/guides/admin/docs/releasenotes/workflow-condition-fix-12.x
+++ b/docs/guides/admin/docs/releasenotes/workflow-condition-fix-12.x
@@ -1,0 +1,5 @@
+Fix workflow conditions with string variables
+
+Re-enable parsing of workflow conditions with string variables where the variable is unquoted, as was possible
+in 11.x, while still keeping the option to quote string variables as was introduced in 12.0.
+This change was initially aimed at 12.x, 12.8 or higher.

--- a/modules/workflow-condition-parser/src/main/java/org/opencastproject/workflow/conditionparser/WorkflowConditionInterpreter.java
+++ b/modules/workflow-condition-parser/src/main/java/org/opencastproject/workflow/conditionparser/WorkflowConditionInterpreter.java
@@ -97,7 +97,14 @@ public final class WorkflowConditionInterpreter {
               result.append(toAppend);
             }
           } catch (NumberFormatException e) {
-            result.append("'").append(toAppend.replace("''", "'")).append("'");
+            // quote string value if variable not already quoted
+            if (matchStart == 0 || source.charAt(matchStart - 1) != '\'') {
+              result.append("'");
+            }
+            result.append(toAppend.replace("''", "'"));
+            if (matchEnd == source.length() || source.charAt(matchEnd) != '\'') {
+              result.append("'");
+            }
           }
         }
       } else {

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowOperationWorker.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowOperationWorker.java
@@ -176,7 +176,7 @@ final class WorkflowOperationWorker {
       return null;
     };
     final String executionCondition = WorkflowConditionInterpreter.replaceVariables(
-        operation.getExecutionCondition(), variables, null, false);
+        operation.getExecutionCondition(), variables, null, true);
     operation.setExecutionCondition(executionCondition);
     operation.setDescription(WorkflowConditionInterpreter.replaceVariables(
         operation.getDescription(), variables, null, false));

--- a/modules/workflow-service-impl/src/test/resources/workflow-definition-skipping-intricate.xml
+++ b/modules/workflow-service-impl/src/test/resources/workflow-definition-skipping-intricate.xml
@@ -5,7 +5,7 @@
   <operations>
     <operation
       id="op1"
-      if="'${executecondition}' == 'a'"
+      if="${executecondition} == 'a'"
       fail-on-error="true"
       description="operation 1"/>
   </operations>


### PR DESCRIPTION
This restores the behavior of 11.x where the parsing of the workflow execution condition is concerned. Otherwise, one would now need to add ' to all workflow variables in the execution condition that resolve to strings. This was changed - probably unintentionally - by #3376.
