### PR TITLE
Remove duplicated oc_workflow columns

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIndexData.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowIndexData.java
@@ -21,6 +21,7 @@
 
 package org.opencastproject.workflow.api;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityResult;
 import javax.persistence.FieldResult;
@@ -62,7 +63,11 @@ public class WorkflowIndexData {
   @Id
   private Long id;
   private int state;
+
+  @Column(name = "mediapackage_id", length = 128) //NB: This column definition needs to match WorkflowInstance!
   private String mediaPackageId;
+
+  @Column(name = "organization_id") //NB: This column definition needs to match WorkflowInstance!
   private String organizationId;
 
 

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -142,7 +142,7 @@ public class WorkflowInstance {
   @Column(name = "creator_id")
   private String creatorName;
 
-  @Column(name = "organization_id")
+  @Column(name = "organization_id")  //NB: This column definition needs to match WorkflowInstance!
   private String organizationId;
 
   @Column(name = "date_created")
@@ -179,7 +179,7 @@ public class WorkflowInstance {
   @Column(name = "configuration_value")
   protected Map<String, String> configurations;
 
-  @Column(name = "mediapackage_id", length = 128)
+  @Column(name = "mediapackage_id", length = 128) //NB: This column definition needs to match WorkflowInstance!
   protected String mediaPackageId;
 
   @Column(name = "series_id", length = 128)

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -142,7 +142,7 @@ public class WorkflowInstance {
   @Column(name = "creator_id")
   private String creatorName;
 
-  @Column(name = "organization_id")  //NB: This column definition needs to match WorkflowInstance!
+  @Column(name = "organization_id")  //NB: This column definition needs to match WorkflowIndexData!
   private String organizationId;
 
   @Column(name = "date_created")
@@ -179,7 +179,7 @@ public class WorkflowInstance {
   @Column(name = "configuration_value")
   protected Map<String, String> configurations;
 
-  @Column(name = "mediapackage_id", length = 128) //NB: This column definition needs to match WorkflowInstance!
+  @Column(name = "mediapackage_id", length = 128) //NB: This column definition needs to match WorkflowIndexData!
   protected String mediaPackageId;
 
   @Column(name = "series_id", length = 128)


### PR DESCRIPTION
This PR prevents duplicated mp and org id columns from being created in `oc_workflow`.

Discussion questions:
- Should a migration step which *removes* these columns be added to `develop`?

Fixes #4696

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
