### PR TITLE
Fix caption creation in lti for subtitles as tracks

### DIFF
--- a/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
+++ b/modules/lti-service-impl/src/main/java/org/opencastproject/lti/service/impl/LtiServiceImpl.java
@@ -291,17 +291,17 @@ public class LtiServiceImpl implements LtiService {
 
       if (captions != null) {
         final MediaPackageElementFlavor captionsFlavor = new MediaPackageElementFlavor(
-            "captions", captionFormat + "+" + captionLanguage
+            "captions", "source"
         );
         final MediaPackageElementBuilder elementBuilder =
             MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
         final MediaPackageElement captionsMediaPackage = elementBuilder
-                .newElement(MediaPackageElement.Type.Attachment, captionsFlavor);
-        if ("dfxp".equals(captionFormat)) {
-          captionsMediaPackage.setMimeType(mimeType("application", "xml"));
-        } else {
-          captionsMediaPackage.setMimeType(mimeType("text", captionFormat));
+                .newElement(MediaPackageElement.Type.Track, captionsFlavor);
+        if (!"vtt".equals(captionFormat)) {
+          throw new IllegalArgumentException("Subtitle format must be vtt, but was " + captionFormat);
         }
+        captionsMediaPackage.setMimeType(mimeType("text", captionFormat));
+
         captionsMediaPackage.addTag("lang:" + captionLanguage);
         mediaPackage.add(captionsMediaPackage);
         final URI captionsUri = workspace


### PR DESCRIPTION
*This PR aims at contributing to the implementation of #4407, but touches on just one of the aspects to realize #4407's vision. It should therefore likely not be merged alone, but alongside other PRs.*

Changes how a caption file is added to an event upserted through lti by the new standards.

This can likely be improved upon by someone who actually knows how lti and the ltitools are used in practice. For now the goal was to simply keep everything in working order.