### PR TITLE
Shows event Title on Paella 7 browser tab

### DIFF
--- a/modules/engage-paella-player-7/src/index.js
+++ b/modules/engage-paella-player-7/src/index.js
@@ -113,6 +113,11 @@ const initParams = {
       }
     }
 
+    // Add event title to browser tab
+    var videoTitle = data?.metadata?.title ?? 'Unknown video title';
+    var seriesTitle = data?.metadata?.seriestitle ?? 'No series';
+    document.title =  videoTitle + ' - ' + seriesTitle + ' | Opencast';
+
     // Load stats
     const stats = await loadStats();
     if (stats) {

--- a/modules/engage-paella-player-7/src/index.js
+++ b/modules/engage-paella-player-7/src/index.js
@@ -114,9 +114,9 @@ const initParams = {
     }
 
     // Add event title to browser tab
-    var videoTitle = data?.metadata?.title ?? 'Unknown video title';
-    var seriesTitle = data?.metadata?.seriestitle ?? 'No series';
-    document.title =  videoTitle + ' - ' + seriesTitle + ' | Opencast';
+    const videoTitle = data?.metadata?.title ?? 'Unknown video title';
+    const seriesTitle = data?.metadata?.seriestitle ?? 'No series';
+    document.title = `${videoTitle} - ${seriesTitle} | Opencast`;
 
     // Load stats
     const stats = await loadStats();

--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -141,6 +141,10 @@ function getMetadata(episode) {
     UID: episode?.id
   };
 
+
+  //Add event title to browser tab
+  document.title = title;
+
   return result;
 }
 

--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -141,10 +141,6 @@ function getMetadata(episode) {
     UID: episode?.id
   };
 
-
-  //Add event title to browser tab
-  document.title = title;
-
   return result;
 }
 


### PR DESCRIPTION
This little PR adds the title on Paella's 7 browser tab

@miesgre  This works but I don't know if is the best place to add it. I set up inside Opencast Plugin instead paella. Feel free to change it or close it if you think that an implementation in Paella 7 upstream would be more appropriate. 


* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
