### PR TITLE
remove static dependencies on publication service event handlers

### DIFF
--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingEpisodeUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingEpisodeUpdatedEventHandler.java
@@ -29,6 +29,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,8 +80,16 @@ public class ConductingEpisodeUpdatedEventHandler implements AssetManagerUpdateH
   /**
    * OSGi DI callback.
    */
-  @Reference
+  @Reference (
+      policy = ReferencePolicy.DYNAMIC,
+      cardinality = ReferenceCardinality.OPTIONAL,
+      unbind = "unsetOaiPmhUpdatedEventHandler"
+  )
   public void setOaiPmhUpdatedEventHandler(OaiPmhUpdatedEventHandler h) {
     this.oaiPmhUpdatedEventHandler = h;
+  }
+
+  public void unsetOaiPmhUpdatedEventHandler(OaiPmhUpdatedEventHandler h) {
+    this.oaiPmhUpdatedEventHandler = null;
   }
 }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingSeriesUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/ConductingSeriesUpdatedEventHandler.java
@@ -29,6 +29,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +52,7 @@ public class ConductingSeriesUpdatedEventHandler implements SeriesUpdateHandler 
   private static final Logger logger = LoggerFactory.getLogger(ConductingSeriesUpdatedEventHandler.class);
 
   private AssetManagerUpdatedEventHandler assetManagerUpdatedEventHandler;
-  private SeriesUpdatedEventHandler seriesUpdatedEventHandler;
+  private SearchUpdatedEventHandler searchUpdatedEventHandler;
 
 
   @Activate
@@ -70,7 +72,9 @@ public class ConductingSeriesUpdatedEventHandler implements SeriesUpdateHandler 
     } else if (SeriesItem.Type.UpdateCatalog.equals(seriesItem.getType())
                  || SeriesItem.Type.UpdateAcl.equals(seriesItem.getType())
                  || SeriesItem.Type.Delete.equals(seriesItem.getType())) {
-      seriesUpdatedEventHandler.handleEvent(seriesItem);
+      if (searchUpdatedEventHandler != null) {
+        searchUpdatedEventHandler.handleEvent(seriesItem);
+      }
       assetManagerUpdatedEventHandler.handleEvent(seriesItem);
     }
   }
@@ -82,8 +86,16 @@ public class ConductingSeriesUpdatedEventHandler implements SeriesUpdateHandler 
   }
 
   /** OSGi DI callback. */
-  @Reference
-  public void setSeriesUpdatedEventHandler(SeriesUpdatedEventHandler h) {
-    this.seriesUpdatedEventHandler = h;
+  @Reference (
+      policy = ReferencePolicy.DYNAMIC,
+      cardinality = ReferenceCardinality.OPTIONAL,
+      unbind = "unsetSearchUpdatedEventHandler"
+  )
+  public void setSearchUpdatedEventHandler(SearchUpdatedEventHandler h) {
+    this.searchUpdatedEventHandler = h;
+  }
+
+  public void unsetSearchUpdatedEventHandler(SearchUpdatedEventHandler h) {
+    this.searchUpdatedEventHandler = null;
   }
 }

--- a/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
+++ b/modules/conductor/src/main/java/org/opencastproject/event/handler/SearchUpdatedEventHandler.java
@@ -75,16 +75,16 @@ import java.net.URI;
 @Component(
     immediate = true,
     service = {
-        SeriesUpdatedEventHandler.class
+        SearchUpdatedEventHandler.class
     },
     property = {
-        "service.description=Series Updated Event Handler"
+        "service.description=Search Updated Event Handler"
     }
 )
-public class SeriesUpdatedEventHandler {
+public class SearchUpdatedEventHandler {
 
   /** The logger */
-  protected static final Logger logger = LoggerFactory.getLogger(SeriesUpdatedEventHandler.class);
+  protected static final Logger logger = LoggerFactory.getLogger(SearchUpdatedEventHandler.class);
 
   /** The service registry */
   protected ServiceRegistry serviceRegistry = null;


### PR DESCRIPTION
fixes #4736

Avoid static dependencies on storage services that may not be deployed.

Changed `SeriesUpdatedEventHandler` to `SearchUpdatedEventHandler` as it is specific to that data storage service and this matching the naming of the corresponding `AssetManager` and `OaiPmh`  `UpdatedEventHandlers`.

The `Conducting*UpdatedEventHandlers`  dynamically reference the storage-specific handlers. There was a comment that Oaipmh was dynamic though the reference was static. 

### Future work
I don't think the Conductor bundle is the right place for the storage specific handlers either, as they creates a dependency on all the the storage services (with event handlers) when only a subset may be deployed. Maybe they should be in the service-api bundles instead?
