### PR TITLE
Fix exception when retrieving comments where the author is missing

### DIFF
--- a/modules/event-comment/pom.xml
+++ b/modules/event-comment/pom.xml
@@ -22,6 +22,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common-jpa-impl</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
       <artifactId>opencast-elasticsearch-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -185,7 +185,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
       if (event.isEmpty()) {
         throw new NotFoundException("Event comment with ID " + commentId + " does not exist");
       }
-      return event.get().toComment(userDirectoryService);
+      return event.get().toComment(userDirectoryService, organizationDirectoryService);
     } catch (NotFoundException e) {
       throw e;
     } catch (Exception e) {
@@ -252,7 +252,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
     try {
       final EventCommentDto commentDto = EventCommentDto.from(comment);
       final EventComment updatedComment = db.execTx(namedQuery.persistOrUpdate(commentDto))
-          .toComment(userDirectoryService);
+          .toComment(userDirectoryService, organizationDirectoryService);
       updateIndices(updatedComment.getEventId());
       return updatedComment;
     } catch (Exception e) {
@@ -285,7 +285,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
               Pair.of("eventId", eventId),
               Pair.of("org", securityService.getOrganization().getId())
           )).stream()
-          .map(c -> c.toComment(userDirectoryService))
+          .map(c -> c.toComment(userDirectoryService, organizationDirectoryService))
           .sorted((c1, c2) -> {
             boolean v1 = c1.isResolvedStatus();
             boolean v2 = c2.isResolvedStatus();

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDto.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDto.java
@@ -25,8 +25,11 @@ import static org.opencastproject.util.RequireUtil.notNull;
 
 import org.opencastproject.event.comment.EventComment;
 import org.opencastproject.event.comment.EventCommentReply;
+import org.opencastproject.security.api.OrganizationDirectoryService;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserDirectoryService;
+import org.opencastproject.security.impl.jpa.JpaOrganization;
+import org.opencastproject.security.impl.jpa.JpaUser;
 import org.opencastproject.util.data.Option;
 
 import java.util.ArrayList;
@@ -364,8 +367,16 @@ public class EventCommentDto {
    *
    * @return the business object model of this comment
    */
-  public EventComment toComment(UserDirectoryService userDirectoryService) {
+  public EventComment toComment(UserDirectoryService userDirectoryService,
+      OrganizationDirectoryService organizationDirectoryService) {
     User user = userDirectoryService.loadUser(author);
+    if (user == null) {
+      JpaOrganization org = null;
+      try {
+        org = (JpaOrganization) organizationDirectoryService.getOrganization(organization);
+      } catch (Exception ignore) { }
+      user = new JpaUser(author, null, org, author, "ghost@localhost", "ghost", false);
+    }
     EventComment comment = EventComment.create(Option.option(id), eventId, organization, text, user, reason,
             resolvedStatus, creationDate, modificationDate);
     for (EventCommentReplyDto reply : replies) {
@@ -373,5 +384,4 @@ public class EventCommentDto {
     }
     return comment;
   }
-
 }


### PR DESCRIPTION
Comment authors can be missing e.g. when a user was deleted. Currently this leads to exceptions when the comment is retrieved e.g. in the admin UI or during a reindex.

This creates an in-memory user based on the stored username but with static user details.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
