### PR TITLE
Fix reindex of multi-tanant systems

### DIFF
--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesSearchQuery.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/objects/series/SeriesSearchQuery.java
@@ -20,6 +20,8 @@
  */
 package org.opencastproject.elasticsearch.index.objects.series;
 
+import static org.opencastproject.security.api.SecurityConstants.GLOBAL_ADMIN_ROLE;
+
 import org.opencastproject.elasticsearch.api.SearchTerms;
 import org.opencastproject.elasticsearch.impl.AbstractSearchQuery;
 import org.opencastproject.security.api.Permissions;
@@ -73,8 +75,10 @@ public class SeriesSearchQuery extends AbstractSearchQuery {
     this.organization = organization;
     this.user = user;
     this.actions.add(Permissions.Action.READ.toString());
-    if (!user.getOrganization().getId().equals(organization)) {
-      throw new IllegalStateException("User's organization must match search organization");
+    if (!user.hasRole(GLOBAL_ADMIN_ROLE)) {
+      if (!user.getOrganization().getId().equals(organization)) {
+        throw new IllegalStateException("User's organization must match search organization");
+      }
     }
   }
 


### PR DESCRIPTION
Index of the asset manager fails for multi-tenant systems because it is assumed that the initiating user (part of one org) has access to events from other organizations. We already set up the security context with a system user for the snapshot organization and can reuse that user object for the reindex as well.

Additionally, this changes the series query check as is done for events with #4313.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
