### PR TITLE
Include Amberscript-Transcription Documentation in Module Overview 

### DIFF
--- a/docs/guides/admin/docs/modules/index.md
+++ b/docs/guides/admin/docs/modules/index.md
@@ -24,6 +24,7 @@ Documentation for modules included in Opencast.
 * Termination State
     * [Basic](terminationstate.md)
     * [AWS AutoScaling](terminationstate.aws.autoscaling.md)
+* [Transcripts (Amberscript)](transcription.modules/amberscripttranscripts.md)
 * [Transcripts (Google Speech)](transcription.modules/googlespeechtranscripts.md)
 * [Transcripts (IBM Watson)](transcription.modules/watsontranscripts.md)
 * [Transcripts (Microsoft Azure)](transcription.modules/microsoftazuretranscripts.md)


### PR DESCRIPTION
Updating the overview file to also include a link to the Amberscript Transcription module documentation

- While the documentation is already available, it is not yet mentioned on the Overview Page regarding the modules
- This is simply just adding the link to it to the page