### PR TITLE
Add Opencast 13.3 release notes

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -4,6 +4,19 @@
 Opencast 13.2
 -------------
 
+The third maintenance release of Opencast 13.
+
+-  Batch Dependabot Updates for Paella 7 ([#4734](https://github.com/opencast/opencast/pull/4734))
+-  Paella 7 matomo plugin ([#4722](https://github.com/opencast/opencast/pull/4722))
+-  Dependabot-batcher update ([#4707](https://github.com/opencast/opencast/pull/4707))
+-  Fix typo and adds recomendations to whisper doc ([#4683](https://github.com/opencast/opencast/pull/4683))
+
+See [changelog](changelog.md) for a comprehensive list of changes.
+
+
+Opencast 13.2
+-------------
+
 The second maintenance release of Opencast 13.
 
 -  Fix calendar.json endpoint ([#4619](https://github.com/opencast/opencast/pull/4619))

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -6,6 +6,7 @@ Opencast 13.3
 
 The third maintenance release of Opencast 13.
 
+-  Add paging to asset manager index rebuild ([#4783](https://github.com/opencast/opencast/pull/4740))
 -  Fix reindex of multi-tanant systems ([#4740](https://github.com/opencast/opencast/pull/4740))
 -  Fix exception when retrieving comments where the author is missing ([#4739](https://github.com/opencast/opencast/pull/4739))
 -  Paella 7 matomo plugin ([#4722](https://github.com/opencast/opencast/pull/4722))

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -1,12 +1,13 @@
 # Opencast 13: Release Notes
 
 
-Opencast 13.2
+Opencast 13.3
 -------------
 
 The third maintenance release of Opencast 13.
 
--  Batch Dependabot Updates for Paella 7 ([#4734](https://github.com/opencast/opencast/pull/4734))
+-  Fix reindex of multi-tanant systems ([#4740](https://github.com/opencast/opencast/pull/4740))
+-  Fix exception when retrieving comments where the author is missing ([#4739](https://github.com/opencast/opencast/pull/4739))
 -  Paella 7 matomo plugin ([#4722](https://github.com/opencast/opencast/pull/4722))
 -  Dependabot-batcher update ([#4707](https://github.com/opencast/opencast/pull/4707))
 -  Fix typo and adds recomendations to whisper doc ([#4683](https://github.com/opencast/opencast/pull/4683))


### PR DESCRIPTION
This PR will add the Opencast 13.3 release notes.

The release will probably be on March 15, 2023. Until then, this will be a draft PR.
