### PR TITLE
Editor remote enforce charset for StringEntity

### DIFF
--- a/modules/editor-service-remote/src/main/java/org/opencastproject/editor/remote/EditorServiceRemoteImpl.java
+++ b/modules/editor-service-remote/src/main/java/org/opencastproject/editor/remote/EditorServiceRemoteImpl.java
@@ -41,7 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 @Component(
     property = {
@@ -116,7 +116,7 @@ public class EditorServiceRemoteImpl extends RemoteBase implements EditorService
     HttpPost post = new HttpPost(mediaPackageId + urlSuffix);
     HttpResponse response = null;
     try {
-      StringEntity editJson = new StringEntity(data);
+      StringEntity editJson = new StringEntity(data, StandardCharsets.UTF_8);
       post.setEntity(editJson);
       post.setHeader("Content-type", "application/json");
       response = getResponse(post, HttpStatus.SC_OK, HttpStatus.SC_NOT_FOUND, HttpStatus.SC_BAD_REQUEST);
@@ -126,8 +126,6 @@ public class EditorServiceRemoteImpl extends RemoteBase implements EditorService
       if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
         evaluateResponseCode(response);
       }
-    } catch (UnsupportedEncodingException e) {
-      throw new EditorServiceException("Editor Remote call failed", ErrorStatus.UNKNOWN, e);
     } finally {
       closeConnection(response);
     }


### PR DESCRIPTION
Editing the metadata via the presentation node Opencast Editor causes encoding problems. e.g. characters like ü,ä,ö are mapped to � characters.

Pinning the StringEntity charset to UTF-8 solves the problem.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
