### PR TITLE
Add paging to asset manager index rebuild

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -954,10 +954,10 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       final AQueryBuilder q = createQuery();
       RichAResult r;
       int current = 0;
+      logIndexRebuildBegin(logger, index.getIndexName(), total, "snapshot(s)");
       do {
         r = enrich(q.select(q.snapshot()).where(q.version().isLatest()).page(offset, PAGE_SIZE).run());
         offset += PAGE_SIZE;
-        logIndexRebuildBegin(logger, index.getIndexName(), total, "snapshot(s)");
         int n = 16;
         var updatedEventRange = new ArrayList<Event>();
 

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SnapshotDto.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/persistence/SnapshotDto.java
@@ -70,8 +70,9 @@ import javax.persistence.UniqueConstraint;
     }, uniqueConstraints = {
     @UniqueConstraint(columnNames = {"mediapackage_id", "version"}) })
 @NamedQueries({
-        @NamedQuery(name = "Snapshot.countEvents", query = "select count(distinct s.mediaPackageId) from Snapshot s "
+        @NamedQuery(name = "Snapshot.countOrgEvents", query = "select count(distinct s.mediaPackageId) from Snapshot s "
                 + "where s.organizationId = :organizationId"),
+        @NamedQuery(name = "Snapshot.countEvents", query = "select count(distinct s.mediaPackageId) from Snapshot s"),
         @NamedQuery(name = "Snapshot.countByMediaPackage", query = "select count(s) from Snapshot s "
                 + "where s.mediaPackageId = :mediaPackageId"),
         @NamedQuery(name = "Snapshot.countByMediaPackageAndOrg", query = "select count(s) from Snapshot s "
@@ -258,8 +259,12 @@ public class SnapshotDto {
   public static Function<EntityManager, Long> countEventsQuery(final String organization) {
     return em -> {
       TypedQuery<Long> query;
-      query = em.createNamedQuery("Snapshot.countEvents", Long.class)
-          .setParameter("organizationId", organization);
+      if (null != organization) {
+        query = em.createNamedQuery("Snapshot.countOrgEvents", Long.class)
+            .setParameter("organizationId", organization);
+      } else {
+        query = em.createNamedQuery("Snapshot.countEvents", Long.class);
+      }
       logger.debug("Executing query {}", query);
       return query.getSingleResult();
     };


### PR DESCRIPTION
This PR adds paging to the asset manager index rebuild to prevent loading *all* of the snapshots into ram at the same time.

Fixes #4748

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
