### PR TITLE
Sets values in specific config file to default

### DIFF
--- a/etc/listproviders/acl.default.create.properties
+++ b/etc/listproviders/acl.default.create.properties
@@ -4,19 +4,19 @@ list.name=ACL.DEFAULTS
 
 # New access policy automatically have the read attribute set.
 # Default: true
-read_enabled = true
+#read_enabled = true
 
 # New access policy automatically have the write attribute set.
 # Default: false
-write_enabled = true
+#write_enabled = false
 
 # The read property of the displayed access policy cannot be changed
 # Default: true
-read_readonly = true
+#read_readonly = true
 
 # The write property of the displayed access policy cannot be changed
 # Default: false
-write_readonly = false
+#write_readonly = false
 
 # Default actions for every new role
 # Default: No actions
@@ -24,14 +24,14 @@ write_readonly = false
 
 # The prefix for user roles. Should be the same as in org.opencastproject.userdirectory.UserIdRoleProvider.cfg
 # Default: ROLE_USER_
-role_user_prefix=ROLE_AAI_USER_
+#role_user_prefix=ROLE_USER_
 
 # Sanitize user roles. Should be the same as in org.opencastproject.userdirectory.UserIdRoleProvider.cfg
 # Default: true
-sanitize=false
+#sanitize=true
 
 # When switching to a new template, all roles that don't belong to the new template are removed
 # To keep roles between template switches, specify role prefixes below
 # Example: ROLE_AAI_USER_,ROLE_ADMIN
 # Default: None
-keep_on_template_switch_role_prefixes=ROLE_AAI_USER_
+#keep_on_template_switch_role_prefixes=ROLE_USER_


### PR DESCRIPTION
This sets the config values in the listproviders file `acl.default.create.properties` to their default values. This should already have happened in the PR associated with the files creation, but was simply overlooked. With these values set to their defaults, the ACL tab in the event and series details view in the Admin UI should function again.
