### PR TITLE
Add migration notes for subtitles as tracks

### DIFF
--- a/docs/guides/admin/docs/releasenotes/subtitles-as-first-class-citizens.txt
+++ b/docs/guides/admin/docs/releasenotes/subtitles-as-first-class-citizens.txt
@@ -8,7 +8,7 @@ handled going forward in [Subtitles](../modules/subtitles.md).
 This comes with a bit of migration. Namely, subtitles should not be stored as "attachments" anymore, but as "media"
 (as they is called in the Admin UI) or "tracks" (as the are called internally). Therefore, all subtitle files currently
 stored as attachments in your events should be moved to tracks. This can easily be accomplished with the "changetype"
-workflow operation handler new to Opencast 14. See example below.
+workflow operation handler new to Opencast 14. See example below. (Subtitles should then be republished)
 
 Additionally, we recommend adding a language tag `lang:<language-code>` to your subtitle files. While tags for subtitles
 are optional, the flavor will not encode the given language for a subtitle anymore, so a language tag is useful for 

--- a/docs/guides/admin/docs/releasenotes/subtitles-as-first-class-citizens.txt
+++ b/docs/guides/admin/docs/releasenotes/subtitles-as-first-class-citizens.txt
@@ -1,0 +1,87 @@
+- With OC14 we change a lot how subtitles work in Opencast, you may need to migrate!
+
+Subtitles as first class citizens
+---------------------------------------
+With Opencast 14 we want to put more emphasis on subtitles. You can find more details on how subtitles should be
+handled going forward in [Subtitles](../modules/subtitles.md).
+
+This comes with a bit of migration. Namely, subtitles should not be stored as "attachments" anymore, but as "media"
+(as they is called in the Admin UI) or "tracks" (as the are called internally). Therefore, all subtitle files currently
+stored as attachments in your events should be moved to tracks. This can easily be accomplished with the "changetype"
+workflow operation handler new to Opencast 14. See example below.
+
+Additionally, we recommend adding a language tag `lang:<language-code>` to your subtitle files. While tags for subtitles
+are optional, the flavor will not encode the given language for a subtitle anymore, so a language tag is useful for 
+identification and display purposes. 
+You can read more about subtitles tags in [Subtitles](../modules/subtitles.md).
+
+If your subtitles are not in WebVTT format, they should be converted to WebVTT as well. While other formats are possible,
+WebVTT is the only one that will be guaranteed to work.
+TODO: Some recommendations on how to best convert subtitles in Opencast to vtt
+
+#### Example workflow for changing subtitle type to track
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<definition xmlns="http://workflow.opencastproject.org">
+
+  <id>change-subtitles</id>
+  <title>Change Subtitles Type</title>
+  <tags>
+    <tag>archive</tag>
+  </tags>
+  <description></description>
+  <operations>
+
+    <!-- Add a language tag for the english subtitles -->
+
+    <operation
+        id="tag"
+        description="Tagging media package elements">
+      <configurations>
+        <configuration key="source-flavors">captions/vtt+en</configuration>
+        <configuration key="target-tags">+lang:en</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Change the type of all files with the "captions/*" flavor to track -->
+    <!-- And their flavor to "captions/source" -->
+
+    <operation
+        id="changetype"
+        description="Retracting elements flavored with presentation and tagged with preview from Engage">
+      <configurations>
+        <configuration key="source-flavors">captions/*</configuration>
+        <configuration key="target-flavor">captions/source</configuration>
+        <configuration key="target-type">track</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Save changes -->
+
+    <operation
+        id="snapshot"
+        if="NOT (${presenter_delivery_exists} OR ${presentation_delivery_exists})"
+        description="Archive publishing information">
+      <configurations>
+        <configuration key="source-tags">archive</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Clean up work artifacts -->
+
+    <operation
+        id="cleanup"
+        fail-on-error="false"
+        description="Remove temporary processing artifacts">
+      <configurations>
+        <!-- On systems with shared workspace or working file repository -->
+        <!-- you want to set this option to false. -->
+        <configuration key="delete-external">true</configuration>
+        <!-- ACLs are required again when working through ActiveMQ messages -->
+        <configuration key="preserve-flavors">security/*</configuration>
+      </configurations>
+    </operation>
+
+  </operations>
+</definition>
+```

--- a/docs/guides/admin/docs/releasenotes/subtitles-as-first-class-citizens.txt
+++ b/docs/guides/admin/docs/releasenotes/subtitles-as-first-class-citizens.txt
@@ -5,9 +5,9 @@ Subtitles as first class citizens
 With Opencast 14 we want to put more emphasis on subtitles. You can find more details on how subtitles should be
 handled going forward in [Subtitles](../modules/subtitles.md).
 
-This comes with a bit of migration. Namely, subtitles should not be stored as "attachments" anymore, but as "media"
+This comes with a bit of migration. Namely, subtitles should not be stored as "attachments" or "catalogs" anymore, but as "media"
 (as they is called in the Admin UI) or "tracks" (as the are called internally). Therefore, all subtitle files currently
-stored as attachments in your events should be moved to tracks. This can easily be accomplished with the "changetype"
+stored as attachments or catalogs in your events should be moved to tracks. This can easily be accomplished with the "changetype"
 workflow operation handler new to Opencast 14. See example below. (Subtitles should then be republished)
 
 Additionally, we recommend adding a language tag `lang:<language-code>` to your subtitle files. While tags for subtitles

--- a/docs/guides/admin/docs/releasenotes/subtitles-as-first-class-citizens.txt
+++ b/docs/guides/admin/docs/releasenotes/subtitles-as-first-class-citizens.txt
@@ -1,14 +1,14 @@
-- With OC14 we change a lot how subtitles work in Opencast, you may need to migrate!
+- With OC15 we change a lot how subtitles work in Opencast, you may need to migrate!
 
 Subtitles as first class citizens
 ---------------------------------------
-With Opencast 14 we want to put more emphasis on subtitles. You can find more details on how subtitles should be
+With Opencast 15 we want to put more emphasis on subtitles. You can find more details on how subtitles should be
 handled going forward in [Subtitles](../modules/subtitles.md).
 
 This comes with a bit of migration. Namely, subtitles should not be stored as "attachments" or "catalogs" anymore, but as "media"
 (as they is called in the Admin UI) or "tracks" (as the are called internally). Therefore, all subtitle files currently
 stored as attachments or catalogs in your events should be moved to tracks. This can easily be accomplished with the "changetype"
-workflow operation handler new to Opencast 14. See example below. (Subtitles should then be republished)
+workflow operation handler new to Opencast 15. See example below. (Subtitles should then be republished)
 
 Additionally, we recommend adding a language tag `lang:<language-code>` to your subtitle files. While tags for subtitles
 are optional, the flavor will not encode the given language for a subtitle anymore, so a language tag is useful for 

--- a/docs/guides/admin/docs/workflowoperationhandlers/changetype-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/changetype-woh.md
@@ -1,4 +1,4 @@
-Clone Workflow Operation
+Change Type Workflow Operation
 ========================
 
 ID: `changetype`
@@ -12,12 +12,12 @@ The change type workflow operation can be used to change the type of media packa
 Parameter Table
 ---------------
 
-|Configuration Key         |Description                                       |Example           |
-|--------------------------|--------------------------------------------------|------------------|
-|source-flavors            |The source flavor(s) to clone                     |presenter/source  |
-|source-tags               |Comma-separated list of source-tags               |archive           |
-|target-flavor\*           |The target flavor                                 |presenter/target  |
-|target-type\*             |The target type                                   |track             |
+|Configuration Key         | Description                         |Example           |
+|--------------------------|-------------------------------------|------------------|
+|source-flavors            | The source flavor(s) to select from |presenter/source  |
+|source-tags               | Comma-separated list of source-tags |archive           |
+|target-flavor\*           | The target flavor                   |presenter/target  |
+|target-type\*             | The target type                     |track             |
 
 \* mandatory configuration key
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/changetype-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/changetype-woh.md
@@ -23,6 +23,7 @@ Parameter Table
 
 Notes:
 
+- Valid target types are: Track, Catalog, Attachment
 - *source-flavor* and *source-tags* may be used both together to select media package elements based on both flavors and
   tags If *source-flavor* is not specified, all media package elements matching *source-tags* will be selected
 - In case that neither *source-flavor* nor *source-tags* are specified, the operation will be skipped

--- a/docs/guides/admin/docs/workflowoperationhandlers/changetype-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/changetype-woh.md
@@ -1,0 +1,45 @@
+Clone Workflow Operation
+========================
+
+ID: `changetype`
+
+Description
+-----------
+
+The change type workflow operation can be used to change the type of media package elements.
+
+
+Parameter Table
+---------------
+
+|Configuration Key         |Description                                       |Example           |
+|--------------------------|--------------------------------------------------|------------------|
+|source-flavors            |The source flavor(s) to clone                     |presenter/source  |
+|source-tags               |Comma-separated list of source-tags               |archive           |
+|target-flavor\*           |The target flavor                                 |presenter/target  |
+|target-type\*             |The target type                                   |track             |
+
+\* mandatory configuration key
+
+Notes:
+
+- *source-flavor* and *source-tags* may be used both together to select media package elements based on both flavors and
+  tags If *source-flavor* is not specified, all media package elements matching *source-tags* will be selected
+- In case that neither *source-flavor* nor *source-tags* are specified, the operation will be skipped
+- In case no media package elements match *source-flavor* and *source-tags*, the operation will be skipped
+
+
+Operation Example
+-----------------
+
+```xml
+<operation
+    id="changetype"
+    description="Change type of captions to track">
+  <configurations>
+    <configuration key="source-flavors">captions/*</configuration>
+    <configuration key="target-flavor">captions/source</configuration>
+    <configuration key="target-type">track</configuration>
+  </configurations>
+</operation>
+```

--- a/docs/guides/admin/docs/workflowoperationhandlers/index.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/index.md
@@ -33,6 +33,7 @@ The following table contains the workflow operations that are available in an ou
 | assert                               | Verify preconditions with assertion                                                       | [Documentation](assert-woh.md)                               |
 | asset-delete                         | Deletes the current mediapackage from the Archive                                         | [Documentation](asset-delete-woh.md)                         |
 | attach-watson-transcription          | Attaches automated transcripts to mediapackage                                            | [Documentation](attach-watson-transcription-woh.md)          |
+| changetype                           | Change type of media package elements                                                     | [Documentation](changetype-woh.md)                           |
 | cleanup                              | Cleanup the working file repository                                                       | [Documentation](cleanup-woh.md)                              |
 | clone                                | Clone media package elements to another flavor                                            | [Documentation](clone-woh.md)                                |
 | comment                              | Add, resolve or delete a comment                                                          | [Documentation](comment-woh.md)                              |

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -175,6 +175,7 @@ nav:
    - Asset Snapshot: 'workflowoperationhandlers/snapshot-woh.md'
    - Asset Delete: 'workflowoperationhandlers/asset-delete-woh.md'
    - Attach Watson Transcription: 'workflowoperationhandlers/attach-watson-transcription-woh.md'
+   - Change Type: 'workflowoperationhandlers/changetype-woh.md'
    - Cleanup: 'workflowoperationhandlers/cleanup-woh.md'
    - Comment: 'workflowoperationhandlers/comment-woh.md'
    - Composite: 'workflowoperationhandlers/composite-woh.md'

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ChangeTypeWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ChangeTypeWorkflowOperationHandler.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import org.opencastproject.job.api.JobContext;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageElement;
+import org.opencastproject.mediapackage.MediaPackageElementBuilder;
+import org.opencastproject.mediapackage.MediaPackageElementBuilderFactory;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageSupport;
+import org.opencastproject.mediapackage.selector.AbstractMediaPackageElementSelector;
+import org.opencastproject.mediapackage.selector.SimpleElementSelector;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
+import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationHandler;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Workflow operation handler for changing the type of a mediapckage element
+ */
+@Component(
+        immediate = true,
+        service = WorkflowOperationHandler.class,
+        property = {
+                "service.description=Change Type Workflow Operation Handler",
+                "workflow.operation=changetype"
+        }
+)
+public class ChangeTypeWorkflowOperationHandler extends AbstractWorkflowOperationHandler {
+
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory.getLogger(CloneWorkflowOperationHandler.class);
+
+  public static final String OPT_SOURCE_FLAVOR = "source-flavors";
+  public static final String OPT_SOURCE_TAGS = "source-tags";
+  public static final String OPT_TARGET_FLAVOR = "target-flavor";
+  public static final String TARGET_TYPE = "target-type";
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public WorkflowOperationResult start(WorkflowInstance workflowInstance, JobContext context)
+          throws WorkflowOperationException {
+    logger.debug("Running change type workflow operation on workflow {}", workflowInstance.getId());
+
+    MediaPackage mediaPackage = workflowInstance.getMediaPackage();
+    WorkflowOperationInstance currentOperation = workflowInstance.getCurrentOperation();
+
+    // Check which tags have been configured
+    ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance,
+            Configuration.many, Configuration.many, Configuration.none, Configuration.one);
+    List<String> sourceTagsOption = tagsAndFlavors.getSrcTags();
+    List<MediaPackageElementFlavor> sourceFlavorOptionList = tagsAndFlavors.getSrcFlavors();
+    String targetFlavorOption = StringUtils.trimToNull(currentOperation.getConfiguration(OPT_TARGET_FLAVOR));
+    String targetTypeOption = StringUtils.trimToEmpty(currentOperation.getConfiguration(TARGET_TYPE));
+    MediaPackageElement.Type type = null;
+    if (!targetTypeOption.isEmpty()) {
+      // Case insensitive matching between user input (workflow config key) and enum value
+      for (MediaPackageElement.Type t : MediaPackageElement.Type.values()) {
+        if (t.name().equalsIgnoreCase(targetTypeOption)) {
+          type = t;
+        }
+      }
+      if (type == null) {
+        throw new IllegalArgumentException(String.format("The given type '%s' for mediapackage %s was illegal. Please"
+                + "check the operations' configuration keys.", type, mediaPackage.getIdentifier()));
+      }
+    } else {
+      throw new IllegalArgumentException(String.format("The given type '%s' for mediapackage %s was illegal. Please"
+              + "check the operations' configuration keys.", type, mediaPackage.getIdentifier()));
+    }
+
+    AbstractMediaPackageElementSelector<MediaPackageElement> elementSelector = new SimpleElementSelector();
+
+    // Make sure either one of tags or flavors are provided
+    if (sourceTagsOption.isEmpty() && sourceFlavorOptionList.isEmpty()) {
+      logger.info("No source tags or flavors have been specified, not matching anything. Operation will be skipped.");
+      return createResult(mediaPackage, Action.SKIP);
+    }
+
+    // Select the source flavors
+    for (MediaPackageElementFlavor sourceFlavor : sourceFlavorOptionList) {
+      elementSelector.addFlavor(sourceFlavor);
+    }
+    if (sourceFlavorOptionList.isEmpty()) {
+      elementSelector.addFlavor(new MediaPackageElementFlavor("*","*"));
+    }
+
+    // Select the source tags
+    for (String tag : sourceTagsOption) {
+      elementSelector.addTag(tag);
+    }
+
+    // Look for elements matching the tags and the flavor
+    Collection<MediaPackageElement> elements = elementSelector.select(mediaPackage, true);
+
+    // Check the number of element returned
+    if (elements.size() == 0) {
+      // If no one found, we skip the operation
+      logger.debug("No matching elements found, skipping operation.");
+      return createResult(mediaPackage, Action.SKIP);
+    } else {
+      logger.debug("Copy" + elements.size() + " elements to new flavor: {}", targetFlavorOption);
+
+      MediaPackageElementFlavor targetFlavor = MediaPackageElementFlavor.parseFlavor(targetFlavorOption);
+
+      for (MediaPackageElement element : elements) {
+        // apply the target flavor to the element
+        MediaPackageElementFlavor flavor = targetFlavor.applyTo(element.getFlavor());
+
+        MediaPackageElementBuilder mpeBuilder = MediaPackageElementBuilderFactory.newInstance().newElementBuilder();
+        MediaPackageElement newElement = mpeBuilder.newElement(type, flavor);
+        newElement.setIdentifier(element.getIdentifier());
+        newElement.setURI(element.getURI());
+        newElement.setElementDescription(element.getElementDescription());
+        newElement.setMimeType(element.getMimeType());
+        newElement.setReference(element.getReference());
+        newElement.setSize(element.getSize());
+        newElement.setChecksum(element.getChecksum());
+        for (String tag : element.getTags()) {
+          newElement.addTag(tag);
+        }
+
+        // Copy element and set new flavor
+        MediaPackageSupport.updateElement(mediaPackage, newElement);
+      }
+    }
+
+    return createResult(mediaPackage, Action.CONTINUE);
+  }
+
+  @Reference
+  @Override
+  public void setServiceRegistry(ServiceRegistry serviceRegistry) {
+    super.setServiceRegistry(serviceRegistry);
+  }
+}

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ChangeTypeWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ChangeTypeWorkflowOperationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to The Apereo Foundation under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ChangeTypeWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ChangeTypeWorkflowOperationHandlerTest.java
@@ -1,0 +1,185 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencastproject.workflow.handler.workflow;
+
+import org.opencastproject.mediapackage.Attachment;
+import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.mediapackage.MediaPackageBuilder;
+import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
+import org.opencastproject.mediapackage.MediaPackageElementFlavor;
+import org.opencastproject.mediapackage.MediaPackageElementParser;
+import org.opencastproject.mediapackage.Track;
+import org.opencastproject.workflow.api.WorkflowInstance;
+import org.opencastproject.workflow.api.WorkflowInstance.WorkflowState;
+import org.opencastproject.workflow.api.WorkflowOperationException;
+import org.opencastproject.workflow.api.WorkflowOperationInstance;
+import org.opencastproject.workflow.api.WorkflowOperationInstance.OperationState;
+import org.opencastproject.workflow.api.WorkflowOperationResult;
+import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ChangeTypeWorkflowOperationHandlerTest {
+
+  private ChangeTypeWorkflowOperationHandler operationHandler;
+
+  // local resources
+  private MediaPackage mp;
+
+  private MediaPackageElementFlavor sourceFlavor;
+
+//  // mock services and objects
+//  private Workspace workspace = null;
+
+  @Before
+  public void setUp() throws Exception {
+    MediaPackageBuilder builder = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder();
+
+    // test resources
+    sourceFlavor = MediaPackageElementFlavor.parseFlavor("presentation/source");
+
+    mp = MediaPackageBuilderFactory.newInstance().newMediaPackageBuilder().createNew();
+
+    URI vttURI = ChangeTypeWorkflowOperationHandler.class.getResource("/vtt.xml").toURI();
+    String vttXml = FileUtils.readFileToString(new File(vttURI));
+    Attachment captionVtt = (Attachment) MediaPackageElementParser.getFromXml(vttXml);
+    captionVtt.setFlavor(sourceFlavor);
+    captionVtt.addTag("first");
+
+    mp.add(captionVtt);
+
+    // set up service
+    operationHandler = new ChangeTypeWorkflowOperationHandler();
+  }
+
+  @Test
+  public void testAttachmentToTrack() throws Exception {
+    // operation configuration
+    Map<String, String> configurations = new HashMap<String, String>();
+    configurations.put(ChangeTypeWorkflowOperationHandler.OPT_SOURCE_FLAVOR, sourceFlavor.toString());
+    configurations.put(ChangeTypeWorkflowOperationHandler.OPT_TARGET_FLAVOR, "presentation/source");
+    configurations.put(ChangeTypeWorkflowOperationHandler.TARGET_TYPE, "track");
+
+    MediaPackageElementFlavor newFlavor = MediaPackageElementFlavor.parseFlavor(sourceFlavor.toString());
+    Attachment[] attachments = mp.getAttachments(newFlavor);
+    Assert.assertTrue(attachments.length == 1);
+    Track[] tracks = mp.getTracks(newFlavor);
+    Assert.assertTrue(tracks.length == 0);
+
+    // run the operation handler
+    WorkflowOperationResult result = getWorkflowOperationResult(mp, configurations);
+
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    Assert.assertTrue(result.getMediaPackage().getElementsByFlavor(newFlavor).length == 1);
+    attachments = mp.getAttachments(newFlavor);
+    Assert.assertTrue(attachments.length == 0);
+    tracks = result.getMediaPackage().getTracks(newFlavor);
+    Assert.assertTrue(tracks.length == 1);
+  }
+
+  @Test
+  public void testAttachmentToAttachment() throws Exception {
+    // operation configuration
+    Map<String, String> configurations = new HashMap<String, String>();
+    configurations.put(ChangeTypeWorkflowOperationHandler.OPT_SOURCE_FLAVOR, "*/source");
+    configurations.put(ChangeTypeWorkflowOperationHandler.OPT_TARGET_FLAVOR, "*/target");
+    configurations.put(ChangeTypeWorkflowOperationHandler.TARGET_TYPE, "attachment");
+
+    MediaPackageElementFlavor newFlavor = MediaPackageElementFlavor.parseFlavor("*/source");
+    Attachment[] attachments = mp.getAttachments(newFlavor);
+    Assert.assertTrue(attachments.length == 1);
+    Track[] tracks = mp.getTracks(newFlavor);
+    Assert.assertTrue(tracks.length == 0);
+
+    // run the operation handler
+    WorkflowOperationResult result = getWorkflowOperationResult(mp, configurations);
+
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    newFlavor = MediaPackageElementFlavor.parseFlavor("*/target");
+    Assert.assertTrue(result.getMediaPackage().getElementsByFlavor(newFlavor).length == 1);
+    attachments = mp.getAttachments(newFlavor);
+    Assert.assertTrue(attachments.length == 1);
+    tracks = result.getMediaPackage().getTracks(newFlavor);
+    Assert.assertTrue(tracks.length == 0);
+  }
+
+  @Test
+  public void testTagsAsSourceSelector() throws Exception {
+    // operation configuration
+    Map<String, String> configurations = new HashMap<String, String>();
+    configurations.put(ChangeTypeWorkflowOperationHandler.OPT_SOURCE_TAGS, "first");
+    configurations.put(ChangeTypeWorkflowOperationHandler.OPT_TARGET_FLAVOR, "*/source");
+    configurations.put(ChangeTypeWorkflowOperationHandler.TARGET_TYPE, "attachment");
+
+    MediaPackageElementFlavor newFlavor = MediaPackageElementFlavor.parseFlavor(sourceFlavor.toString());
+    Attachment[] attachments = mp.getAttachments(newFlavor);
+    Assert.assertTrue(attachments.length == 1);
+    Track[] tracks = mp.getTracks(newFlavor);
+    Assert.assertTrue(tracks.length == 0);
+
+    // run the operation handler
+    WorkflowOperationResult result = getWorkflowOperationResult(mp, configurations);
+
+    Assert.assertEquals(Action.CONTINUE, result.getAction());
+
+    Assert.assertTrue(result.getMediaPackage().getElementsByFlavor(newFlavor).length == 1);
+    attachments = mp.getAttachments(newFlavor);
+    Assert.assertTrue(attachments.length == 1);
+    tracks = result.getMediaPackage().getTracks(newFlavor);
+    Assert.assertTrue(tracks.length == 0);
+  }
+
+  private WorkflowOperationResult getWorkflowOperationResult(MediaPackage mp, Map<String, String> configurations)
+          throws WorkflowOperationException {
+    // Add the mediapackage to a workflow instance
+    WorkflowInstance workflowInstance = new WorkflowInstance();
+    workflowInstance.setId(1);
+    workflowInstance.setState(WorkflowState.RUNNING);
+    workflowInstance.setMediaPackage(mp);
+    WorkflowOperationInstance operation = new WorkflowOperationInstance("op", OperationState.RUNNING);
+    operation.setTemplate("changetype");
+    operation.setState(OperationState.RUNNING);
+    for (String key : configurations.keySet()) {
+      operation.setConfiguration(key, configurations.get(key));
+    }
+
+    List<WorkflowOperationInstance> operationsList = new ArrayList<WorkflowOperationInstance>();
+    operationsList.add(operation);
+    workflowInstance.setOperations(operationsList);
+
+    // Run the media package through the operation handler, ensuring that metadata gets added
+    return operationHandler.start(workflowInstance, null);
+  }
+
+}

--- a/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ChangeTypeWorkflowOperationHandlerTest.java
+++ b/modules/workflow-workflowoperation/src/test/java/org/opencastproject/workflow/handler/workflow/ChangeTypeWorkflowOperationHandlerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to The Apereo Foundation under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.

--- a/modules/workflow-workflowoperation/src/test/resources/vtt.xml
+++ b/modules/workflow-workflowoperation/src/test/resources/vtt.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns2:attachment xmlns:ns2="http://mediapackage.opencastproject.org" type="captions/vtt+en"
+                id="dc560f38-fde0-46df-b9f0-2cc196b4911b">
+  <ns2:mimetype>text/vtt</ns2:mimetype>
+  <ns2:url>http://opencast.server.com/137e416e-111b-49f9-b6c0-24b55877a2ce/dc560f38-fde0-46df-b9f0-2cc196b4911b.vtt</ns2:url>
+  <ns2:checksum type="md5">84da724b3f17c163a043c7afd5a6c956</ns2:checksum>
+  <ns2:tags><ns2:tag>lang:en</ns2:tag></ns2:tags>
+</ns2:attachment>


### PR DESCRIPTION
*This PR aims at contributing to the implementation of #4407, but touches on just one of the aspects to realize #4407's vision. It should therefore likely not be merged alone, but alongside other PRs.*

Adds some release notes about subtitles the changes to subtitles and how to migrate exisiting subtitles to conform to the changes. Put it in release notes since the migration is not just a script everyone can run and be done with, but will vary by institution.

Also adds a new WOH for migration. It allows to change the type of MediaPackageElements, e.g. from attachment to track.

