### PR TITLE
Service statistics DB query optimazation

### DIFF
--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/job/jpa/JpaJob.java
@@ -78,8 +78,7 @@ import javax.persistence.Version;
     @Index(name = "IX_oc_job_date_created", columnList = ("date_created")),
     @Index(name = "IX_oc_job_date_completed", columnList = ("date_completed")),
     @Index(name = "IX_oc_job_dispatchable", columnList = ("dispatchable")),
-    @Index(name = "IX_oc_job_operation", columnList = ("operation")),
-    @Index(name = "IX_oc_job_statistics", columnList = ("processor_service, status, queue_time, run_time")) })
+    @Index(name = "IX_oc_job_operation", columnList = ("operation")) })
 @NamedQueries({
     @NamedQuery(name = "Job", query = "SELECT j FROM Job j "
         + "where j.status = :status and j.creatorServiceRegistration.serviceType = :serviceType "
@@ -221,6 +220,15 @@ public class JpaJob {
   @ManyToOne
   @JoinColumn(name = "processor_service")
   private ServiceRegistrationJpaImpl processorServiceRegistration;
+
+  /**
+   * This readonly field provides the raw value of processor_service database table column
+   * and is defined for performance reason.
+   * Do not use this field in Java!
+   * It should only be used by JPQL named queries.
+   */
+  @Column(name = "processor_service",  updatable = false, insertable = false)
+  private Long processorServiceRegistrationFK;
 
   @JoinColumn(name = "parent", referencedColumnName = "id", nullable = true)
   private JpaJob parentJob = null;

--- a/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
+++ b/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java
@@ -68,12 +68,12 @@ import javax.persistence.UniqueConstraint;
 @NamedQueries({
     @NamedQuery(
         name = "ServiceRegistration.statistics",
-        query = "SELECT job.processorServiceRegistration.id as serviceRegistration, job.status, "
+        query = "SELECT job.processorServiceRegistrationFK as serviceRegistration, job.status, "
             + "count(job.status) as numJobs, "
             + "avg(job.queueTime) as meanQueue, "
             + "avg(job.runTime) as meanRun FROM Job job "
             + "where job.dateCreated >= :minDateCreated and job.dateCreated <= :maxDateCreated "
-            + "group by job.processorServiceRegistration.id, job.status"
+            + "group by job.processorServiceRegistrationFK, job.status"
     ),
     @NamedQuery(
         name = "ServiceRegistration.hostloads",


### PR DESCRIPTION
We noticed a huge performance degradation on Opencast service start caused by the named query `ServiceRegistration.statistics` (see [ServiceRegistrationJpaImpl](https://github.com/opencast/opencast/blob/r/12.x/modules/common-jpa-impl/src/main/java/org/opencastproject/serviceregistry/impl/jpa/ServiceRegistrationJpaImpl.java#L70-L77)). The response of this query took 30-40 minutes (…yes, minutes!!!). The JPA driver creates an implicit join on `oc_job.processor_service` and `oc_service_registration.id` like that:

```sql
SELECT t0.id, t1.status, COUNT(t1.status), AVG(t1.queue_time), AVG(t1.run_time) FROM oc_service_registration t0, oc_job t1 WHERE (((t1.date_created >= '2023-03-15 11:37:34.499') AND (t1.date_created <= '2023-03-30 11:37:34.499')) AND (t0.id = t1.processor_service)) GROUP BY t0.id, t1.status;
```

This heavy query and the unneeded implicit join can be dissolved like that:

```sql
SELECT processor_service, status, COUNT(status), AVG(queue_time), AVG(run_time) FROM oc_job WHERE ((date_created >= '2023-03-15 11:37:34.499') AND (date_created <= '2023-03-30 11:37:34.499')) GROUP BY processor_service, status
```

This query took 2-3 seconds on the same database. To dissolve this query we need to reference the `oc_job.processor_service` column in the java code as a read only variable to make usage of it within the query. But we can leave this variable private and do not expose it to other modules.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
