### PR TITLE
Set Dependabot Interval to Monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
 - package-ecosystem: npm
   directory: "/docs/guides"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/engage-ui"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/lti"
@@ -18,38 +18,38 @@ updates:
 - package-ecosystem: npm
   directory: "/modules/runtime-info-ui-ng"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/runtime-info-ui"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/engage-paella-player"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/engage-paella-player-7"
   schedule:
-    interval: daily
+    interval: monthly
   target-branch: "r/13.x"
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/admin-ui-frontend"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
 
 # Java dependencies
 - package-ecosystem: maven
   directory: "/modules/metrics-exporter"
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10
 - package-ecosystem: maven
   directory: /modules/db
   schedule:
-    interval: daily
+    interval: monthly
   open-pull-requests-limit: 10


### PR DESCRIPTION
This patch consistently sets the Dependabot update interval to monthly for all components watched by Dependabot. This should hopefully make things more manageable.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
