### PR TITLE
Fixed long WF description 11_to_12 DB upgrade script bug for Maria and PSQL

### DIFF
--- a/docs/upgrade/11_to_12/workflows_postgresql.py
+++ b/docs/upgrade/11_to_12/workflows_postgresql.py
@@ -15,6 +15,7 @@ from datetime import datetime
 user = "opencast"
 password = "dbpassword"
 host = "127.0.0.1"
+port = 5432
 database = "opencast"
 
 # Constants
@@ -31,12 +32,13 @@ XML_DECLARATION = "<?xml version='1.0' encoding='UTF-8'?>"
 
 
 # DB functions
-def create_connection(host_name, user_name, user_password, db_name):
+def create_connection(host_name, port_number, user_name, user_password, db_name):
     connection = psycopg2.connect(
         host=host_name,
+        port=port_number,
         user=user_name,
         password=user_password,
-        database=db_name
+        database=db_name,
     )
     print("Connection to database successful")
     return connection
@@ -117,7 +119,7 @@ def parse_bool(value):
 
 # Connect
 print("Creating connection to database...")
-connection = create_connection(host, user, password, database)
+connection = create_connection(host, port, user, password, database)
 
 # Create new tables
 #  Currently added indexes:
@@ -230,12 +232,20 @@ for offset in range(0, workflow_count, 100):
         workflow_operations = []
         workflow_operation_config = []
         workflow_config = []
+        description_limited = get_node_value(root, 'description', WORKFLOW_NS)
+        if description_limited is None:
+          description_limited = None
+        else:
+          description_limited = description_limited.lstrip().rstrip()
+          description_limited = description_limited.replace('\n','').replace('    ', ' ')
+          if (len(description_limited) > 255):
+            description_limited = description_limited[0:252] + "..."
         workflow = [
             workflow_id,
             get_node_value(root, 'creator-id', SECURITY_NS),
             date_completed,
             date_created,
-            get_node_value(root, 'description', WORKFLOW_NS),
+            description_limited,
             get_node_value(root, 'organization-id', SECURITY_NS),
             parse_workflow_state(get_attrib_from_node(root, "state")),
             get_node_value(root, 'template', WORKFLOW_NS),
@@ -252,10 +262,11 @@ for offset in range(0, workflow_count, 100):
 
         # oc_workflow_configuration
         for configuration in root.find(f"{WORKFLOW_NS}configurations"):
+            value = configuration.text
             workflow_config.append([
                 workflow_id,
                 get_attrib_from_node(configuration, "key"),
-                configuration.text])
+                value if value is not None else ""])
 
         # oc_workflow_operation
         operation_position = 0
@@ -288,10 +299,11 @@ for offset in range(0, workflow_count, 100):
 
             # oc_workflow_operation_configuration
             for op_config in operation.find("{http://workflow.opencastproject.org}configurations"):
+                value = op_config.text
                 workflow_operation_config.append([
                     operation_id,
                     get_attrib_from_node(op_config, "key"),
-                    op_config.text])
+                    value if value is not None else ""])
 
             # Generate ID and position for next operation
             operation_id += 1


### PR DESCRIPTION
11_to_12 DB Upgrade script fails, if there exists a WF with a description longer than 255 chars. Added a check for description field, and changed the script to cut description near 255 limit, and add three dots - "..."

Note: Messed up my old PR branch, made new PR: https://github.com/opencast/opencast/pull/4792
Note 2: It seems like 11_to_12 script has port implemented on OC branch 13.x, but not in 12.x. I used the script from 13.x so in my PR port implementation also exists. If it should be changed let me know.