### PR TITLE
Remove dead `CONFIG_OPTIONS` from WOHs

### DIFF
--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
@@ -56,8 +56,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.function.Function;
 
 /**
@@ -79,16 +77,6 @@ public class SanitizeAdaptiveWorkflowOperationHandler extends AbstractWorkflowOp
   private static final String PLUS = "+";
   private static final String MINUS = "-";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-flavor", "The \"flavor\" of the track to use as a video source input");
-    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the encoded file");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the encoded file");
-  }
-
   /** The local workspace */
   private Workspace workspace = null;
 
@@ -108,10 +96,6 @@ public class SanitizeAdaptiveWorkflowOperationHandler extends AbstractWorkflowOp
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
-  }
-
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
@@ -48,8 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 @Component(
     immediate = true,
@@ -65,25 +63,12 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
 
   /** Workflow configuration option keys */
   static final String TRANSCRIPTION_JOB_ID = "transcription-job-id";
-  static final String TARGET_FLAVOR = "target-flavor";
-  static final String TARGET_TAGS = "target-tags";
   static final String TARGET_CAPTION_FORMAT = "target-caption-format";
 
   private TranscriptionService service = null;
   private CaptionService captionService;
 
   private Workspace workspace;
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(TRANSCRIPTION_JOB_ID, "The job id that identifies the file to be attached");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR, "The target \"flavor\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_TAGS, "The target \"tags\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_CAPTION_FORMAT, "The target caption format of the transcription file (dfxp, etc)");
-  }
 
   @Override
   @Activate

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
@@ -50,8 +50,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 @Component(
     immediate = true,
@@ -66,27 +64,12 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
   private static final Logger logger = LoggerFactory.getLogger(AmberscriptStartTranscriptionOperationHandler.class);
 
   /** Workflow configuration option keys */
-  static final String SOURCE_FLAVOR = "source-flavor";
-  static final String SOURCE_TAG = "source-tag";
   static final String LANGUAGE = "language";
   static final String JOBTYPE = "jobtype";
   static final String SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
 
   /** The transcription service */
   private TranscriptionService service = null;
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR, "The \"flavor\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(SOURCE_TAG, "The \"tag\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(LANGUAGE, "The \"language\" the transcription service will use");
-    CONFIG_OPTIONS.put(JOBTYPE, "The \"jobtype\" the transcription service will use");
-    CONFIG_OPTIONS.put(SKIP_IF_FLAVOR_EXISTS,
-        "If this \"flavor\" is already in the media package, skip this operation");
-  }
 
   @Override
   @Activate

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
@@ -64,8 +64,6 @@ public class AttachTranscriptionOperationHandler extends AbstractWorkflowOperati
 
   /** Workflow configuration option keys */
   static final String TRANSCRIPTION_JOB_ID = "transcription-job-id";
-  static final String TARGET_FLAVOR = "target-flavor";
-  static final String TARGET_TAGS = "target-tags";
   static final String TARGET_CAPTION_FORMAT = "target-caption-format";
 
   /** The transcription service */

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechAttachTranscriptionOperationHandler.java
@@ -47,8 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 @Component(
     immediate = true,
@@ -69,8 +67,6 @@ public class GoogleSpeechAttachTranscriptionOperationHandler extends AbstractWor
    * Workflow configuration option keys
    */
   static final String TRANSCRIPTION_JOB_ID = "transcription-job-id";
-  static final String TARGET_FLAVOR = "target-flavor";
-  static final String TARGET_TAGS = "target-tags";
   static final String TARGET_CAPTION_FORMAT = "target-caption-format";
   static final String TRANSCRIPTION_LINE_SIZE = "line-size";
   static final String DEFAULT_LINE_SIZE = "100";
@@ -81,20 +77,6 @@ public class GoogleSpeechAttachTranscriptionOperationHandler extends AbstractWor
   private TranscriptionService service = null;
   private Workspace workspace;
   private CaptionService captionService;
-
-  /**
-   * The configuration options for this handler
-   */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(TRANSCRIPTION_JOB_ID, "The job id that identifies the file to be attached");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR, "The target \"flavor\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_TAGS, "The target \"tag\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_CAPTION_FORMAT, "The target caption format of the transcription file (vtt, dfxp, etc)");
-    CONFIG_OPTIONS.put(TRANSCRIPTION_LINE_SIZE, "Line size of transcription text to display on video");
-  }
 
   @Override
   protected void activate(ComponentContext cc) {

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechStartTranscriptionOperationHandler.java
@@ -50,8 +50,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 @Component(
     immediate = true,
@@ -71,8 +69,6 @@ public class GoogleSpeechStartTranscriptionOperationHandler extends AbstractWork
   /**
    * Workflow configuration option keys
    */
-  static final String SOURCE_FLAVOR = "source-flavor";
-  static final String SOURCE_TAG = "source-tag";
   static final String LANGUAGE_CODE = "language-code";
   static final String SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
 
@@ -85,20 +81,6 @@ public class GoogleSpeechStartTranscriptionOperationHandler extends AbstractWork
    * The language code
    */
   private String language = null;
-
-  /**
-   * The configuration options for this handler
-   */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR, "The \"flavor\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(SOURCE_TAG, "The \"tag\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(LANGUAGE_CODE, "The \"language code\" to use for the transcription");
-    CONFIG_OPTIONS
-            .put(SKIP_IF_FLAVOR_EXISTS, "If this \"flavor\" is already in the media package, skip this operation");
-  }
 
   @Override
   @Activate

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/MicrosoftAzureStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/MicrosoftAzureStartTranscriptionOperationHandler.java
@@ -66,8 +66,6 @@ public class MicrosoftAzureStartTranscriptionOperationHandler extends AbstractWo
   private static final Logger logger = LoggerFactory.getLogger(MicrosoftAzureStartTranscriptionOperationHandler.class);
 
   /** Workflow configuration option keys */
-  static final String SOURCE_FLAVOR = "source-flavor";
-  static final String SOURCE_TAG = "source-tag";
   static final String OPT_LANGUAGE_CODE = "language-code";
   static final String OPT_SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
   static final String OPT_AUTO_DETECT_LANGUAGE = "auto-detect-language";

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
@@ -65,8 +65,6 @@ public class StartTranscriptionOperationHandler extends AbstractWorkflowOperatio
   private static final Logger logger = LoggerFactory.getLogger(StartTranscriptionOperationHandler.class);
 
   /** Workflow configuration option keys */
-  static final String SOURCE_FLAVOR = "source-flavor";
-  static final String SOURCE_TAG = "source-tag";
   static final String SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
 
   /** The transcription service */

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
@@ -77,14 +77,14 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
   /** Config for Tag Parsing operation */
   protected enum Configuration { none, one, many };
 
-  private static final String TARGET_FLAVORS = "target-flavors";
-  private static final String TARGET_FLAVOR = "target-flavor";
-  private static final String TARGET_TAGS = "target-tags";
-  private static final String TARGET_TAG = "target-tag";
-  private static final String SOURCE_FLAVORS = "source-flavors";
-  private static final String SOURCE_FLAVOR = "source-flavor";
-  private static final String SOURCE_TAG = "source-tag";
-  private static final String SOURCE_TAGS = "source-tags";
+  public static final String TARGET_FLAVORS = "target-flavors";
+  public static final String TARGET_FLAVOR = "target-flavor";
+  public static final String TARGET_TAGS = "target-tags";
+  public static final String TARGET_TAG = "target-tag";
+  public static final String SOURCE_FLAVORS = "source-flavors";
+  public static final String SOURCE_FLAVOR = "source-flavor";
+  public static final String SOURCE_TAG = "source-tag";
+  public static final String SOURCE_TAGS = "source-tags";
 
   /**
    * Activates this component with its properties once all of the collaborating services have been set


### PR DESCRIPTION
There are these weird static initializer blocks
building an unused map of config options in some of our WOHs. Probably some remnant of copy&paste driven development. 🤷

This PR removes them.

It also removes related constants that were only used for this purpose from these WOHs; specifically the ones describing the `/(source|target)-(tag|flavor)s?/`-options. (Yes, that's a regex.) These were either unused or only used in tests,
since reading these options is now centralized in
`AbstractWorkflowOperationHandler`.
To keep the tests working
I just made the constants used in there `public`,
so all the WOHs inherit them, and the tests can access them (through either the abstract or concrete class; it doesn't matter).

Note: I only did this for the WOHs that had a
"`CONFIG_OPTIONS`-block". In particular I did not check other WOHs for similar "unused" constants.