### PR TITLE
Extend configuration options of Amberscript integration

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/amberscript-start-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/amberscript-start-transcription-woh.md
@@ -14,13 +14,13 @@ an audio or video file to be transcribed and captioned.
 Parameter Table
 ---------------
 
-| configuration keys    | description                                                                | default      | example            |
-|-----------------------|----------------------------------------------------------------------------|--------------|--------------------|
-| source-tag            | A tag selecting the audio or video file to be sent for translation/transcription. | -     | engage-download    |
-| source-flavor         | A flavor selecting the audio or video file to be sent for translation/transcription. | -  | \*/themed           |
-| jobtype               | direct (automated, fast) or perfect (additional manual improvements, slow) | direct       | perfect            |
-| language              | The assumed language for transcription.                                    | en           | nl                 |
-| skip-if-flavor-exists | If this flavor already exists in the media package, skip this operation.   | captions/vtt | captions/timedtext |
+| configuration keys    | description                                                                          | default      | example            |
+|-----------------------|--------------------------------------------------------------------------------------|--------------|--------------------|
+| source-tag            | A tag selecting the audio or video file to be sent for translation/transcription.    | -            | engage-download    |
+| source-flavor         | A flavor selecting the audio or video file to be sent for translation/transcription. | -            | \*/themed          |
+| jobtype               | direct (automated, fast) or perfect (additional manual improvements, slow).          | direct       | perfect            |
+| language              | The assumed language for transcription.                                              | en           | nl                 |
+| skip-if-flavor-exists | If this flavor already exists in the media package, skip this operation.             | captions/vtt | captions/timedtext |
 
 ### Supported Languages
 

--- a/docs/guides/admin/docs/workflowoperationhandlers/amberscript-start-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/amberscript-start-transcription-woh.md
@@ -19,7 +19,7 @@ Parameter Table
 | source-tag            | A tag selecting the audio or video file to be sent for translation/transcription. | -     | engage-download    |
 | source-flavor         | A flavor selecting the audio or video file to be sent for translation/transcription. | -  | \*/themed           |
 | jobtype               | direct (automated, fast) or perfect (additional manual improvements, slow) | direct       | perfect            |
-| language              | The target language for transcription.                                     | en           | nl                 |
+| language              | The assumed language for transcription.                                    | en           | nl                 |
 | skip-if-flavor-exists | If this flavor already exists in the media package, skip this operation.   | captions/vtt | captions/timedtext |
 
 ### Supported Languages

--- a/docs/guides/admin/docs/workflowoperationhandlers/amberscript-start-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/amberscript-start-transcription-woh.md
@@ -14,18 +14,18 @@ an audio or video file to be transcribed and captioned.
 Parameter Table
 ---------------
 
-| configuration keys    | description                                                                              | default       | example                  |
-|-----------------------|------------------------------------------------------------------------------------------|---------------|--------------------------|
-| source-tag            | A tag selecting the audio or video file to be sent for translation/transcription.        | -             | engage-download          |
-| source-flavor         | A flavor selecting the audio or video file to be sent for translation/transcription.     | -             | \*/themed                |
-| jobtype               | direct (automated, fast) or perfect (additional manual improvements, slow).              | direct        | perfect                  |
-| language              | The assumed language for transcription.                                                  | en            | nl                       |
-| speaker               | The number of speakers in the recording.                                                 | 1             | 2                        |
-| transcriptiontype     | transcription, captions or translatedSubtitles                                           | transcription | captions                 |
-| glossary              | An ID of a custom glossary to use. See https://amberscript.github.io/api-docs/#glossary. | -             | 643966c3f3e91e0c96e9e060 |
-| transcriptionstyle    | cleanread or verbatim                                                                    | cleanread     | verbatim                 |
-| targetlanguage        | The language of the resulting transcriptions.                                            | -             | en                       |
-| skip-if-flavor-exists | If this flavor already exists in the media package, skip this operation.                 | captions/vtt  | captions/timedtext       |
+| configuration keys    | description                                                                          | default       | example                  |
+|-----------------------|--------------------------------------------------------------------------------------|---------------|--------------------------|
+| source-tag            | A tag selecting the audio or video file to be sent for translation/transcription.    | -             | engage-download          |
+| source-flavor         | A flavor selecting the audio or video file to be sent for translation/transcription. | -             | \*/themed                |
+| jobtype               | direct (automated, fast) or perfect (additional manual improvements, slow).          | direct        | perfect                  |
+| language              | The assumed language for transcription.                                              | en            | nl                       |
+| speaker               | The number of speakers in the recording.                                             | 1             | 2                        |
+| transcriptiontype     | transcription, captions or translatedSubtitles                                       | transcription | captions                 |
+| glossary              | An ID of a custom glossary to use.                                                   | -             | 643966c3f3e91e0c96e9e060 |
+| transcriptionstyle    | cleanread or verbatim                                                                | cleanread     | verbatim                 |
+| targetlanguage        | The language of the resulting transcriptions.                                        | -             | en                       |
+| skip-if-flavor-exists | If this flavor already exists in the media package, skip this operation.             | captions/vtt  | captions/timedtext       |
 
 ### Supported Languages
 
@@ -40,3 +40,15 @@ At time of writing Amberscript supports the following language codes:
 - nl
 - no
 - sv
+
+### Glossaries
+
+The `glossary` ID needs to be a valid ID for a previously created custom glossary.
+See also https://amberscript.github.io/api-docs/#glossary.
+If this parameter is unset, the default configured in
+`etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg`
+is used.
+
+If you don't want to use a glossary in a specific workflow (instance)
+even though a fallback is configured in that file,
+you can provide an empty string as glossary ID, i.e. `glossary=""`.

--- a/docs/guides/admin/docs/workflowoperationhandlers/amberscript-start-transcription-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/amberscript-start-transcription-woh.md
@@ -14,13 +14,18 @@ an audio or video file to be transcribed and captioned.
 Parameter Table
 ---------------
 
-| configuration keys    | description                                                                          | default      | example            |
-|-----------------------|--------------------------------------------------------------------------------------|--------------|--------------------|
-| source-tag            | A tag selecting the audio or video file to be sent for translation/transcription.    | -            | engage-download    |
-| source-flavor         | A flavor selecting the audio or video file to be sent for translation/transcription. | -            | \*/themed          |
-| jobtype               | direct (automated, fast) or perfect (additional manual improvements, slow).          | direct       | perfect            |
-| language              | The assumed language for transcription.                                              | en           | nl                 |
-| skip-if-flavor-exists | If this flavor already exists in the media package, skip this operation.             | captions/vtt | captions/timedtext |
+| configuration keys    | description                                                                              | default       | example                  |
+|-----------------------|------------------------------------------------------------------------------------------|---------------|--------------------------|
+| source-tag            | A tag selecting the audio or video file to be sent for translation/transcription.        | -             | engage-download          |
+| source-flavor         | A flavor selecting the audio or video file to be sent for translation/transcription.     | -             | \*/themed                |
+| jobtype               | direct (automated, fast) or perfect (additional manual improvements, slow).              | direct        | perfect                  |
+| language              | The assumed language for transcription.                                                  | en            | nl                       |
+| speaker               | The number of speakers in the recording.                                                 | 1             | 2                        |
+| transcriptiontype     | transcription, captions or translatedSubtitles                                           | transcription | captions                 |
+| glossary              | An ID of a custom glossary to use. See https://amberscript.github.io/api-docs/#glossary. | -             | 643966c3f3e91e0c96e9e060 |
+| transcriptionstyle    | cleanread or verbatim                                                                    | cleanread     | verbatim                 |
+| targetlanguage        | The language of the resulting transcriptions.                                            | -             | en                       |
+| skip-if-flavor-exists | If this flavor already exists in the media package, skip this operation.                 | captions/vtt  | captions/timedtext       |
 
 ### Supported Languages
 

--- a/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
@@ -47,7 +47,7 @@ client.key=
 #workflow.dispatch.interval=60
 
 # How long to wait after a transcription is supposed to finish before marking the job as
-# canceled in the databas in seconds
+# cancelled in the database in seconds
 # Default: 48 hours
 #max.overdue.time=691200
 
@@ -68,10 +68,10 @@ client.key=
 #speaker.from.dublincore=true
 
 # Configure which metadata field shall be considered when "counting" the
-# number of speakers. The "presenter" or the "contributor" field.
+# number of speakers. The "presenter" field, the "contributor" field
+# or both (i.e. the union of those lists).
 # Note for developers: the "presenter" becomes the "creator" in the Operation Handler
 # possible values: presenter, contributor, both
-# Both means, that both list will be joined (union)
 # Default: presenter
 #speaker.metadata.field=presenter
 
@@ -83,13 +83,14 @@ client.key=
 
 # Default glossary to use.
 # You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
+# By default, no glossary is used.
 #glossary=
 
 # Default transcription style to use.
 # You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
 # Can be one of: cleanread, verbatim
 # Default: cleanread
-#transcriptiontype=transcription
+#transcriptionstyle=cleanread
 
 # The default target language of the transcriptions.
 # You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).

--- a/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
@@ -55,6 +55,18 @@ client.key=
 # Default: 7 days
 #cleanup.results.days=7
 
+# Default number of speakers to assume.
+# You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
+# Default: 1
+#speaker=1
+
+# Set to true if the number of speakers should be taken from the DublinCore catalog.
+# If the number of speakers in the DublinCore catalog specified below is 0,
+# the default will be used. Note, that the speaker field in the workflow operation
+# will be overwritten, in case there are speakers in the DublinCore catalog.
+# Default=true
+#speaker.from.dublincore=true
+
 # Configure which metadata field shall be considered when "counting" the
 # number of speakers. The "presenter" or the "contributor" field.
 # Note for developers: the "presenter" becomes the "creator" in the Operation Handler
@@ -62,3 +74,24 @@ client.key=
 # Both means, that both list will be joined (union)
 # Default: presenter
 #speaker.metadata.field=presenter
+
+# Default transcription type to use.
+# You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
+# Can be one of: transcription, captions, translatedSubtitles
+# Default: transcription
+#transcriptiontype=transcription
+
+# Default glossary to use.
+# You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
+#glossary=
+
+# Default transcription style to use.
+# You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
+# Can be one of: cleanread, verbatim
+# Default: cleanread
+#transcriptiontype=transcription
+
+# The default target language of the transcriptions.
+# You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
+# Can be one of: nl, en, de, fr, da, sv, fi, no, es
+#targetlanguage=

--- a/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
+++ b/etc/org.opencastproject.transcription.amberscript.AmberscriptTranscriptionService.cfg
@@ -2,25 +2,28 @@
 # Default: false
 # enabled=false
 
-# Default Language to be used transcribing.
-# You can override this within you workflow (see workflowoperationhandler amberscript-start-transcription).
-# Default: en
+# AmberScript API key
+client.key=
+
+# Default language to be used transcribing.
+# You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
 # Can be one of: nl, en, de, fr, da, sv, fi, no, es
+# Default: en
 # language=en
 
-# Set to true if the transcription language should be taken from the dublincore catalog
-# If the dublincore catalog doesn't contain a language, the default process for determine
-# the language will be taken. Note, that the language field in the workflow operation
-# will be overwritten, in case the dublincore catalog has a language
-# Default=false
+# Set to true if the transcription language should be taken from the DublinCore catalog.
+# If the DublinCore catalog doesn't contain a language, the default language will be used.
+# Note, that the language field in the workflow operation will be overwritten,
+# in case the DublinCore catalog has a language.
+# Default: false
 #language.from.dublincore=false
 
-# Manual mapping for language codes
+# Manual mapping for language codes.
 # Here you can set which language spellings/codes from your system shall be
-# mapped to the corresponding amberscript language. In general the amberscript workflow
-# should figure it out by itself. Use this, if you have some special language strings and run into errors
-# You can map a language to the amberscript code with a Colon ':'
-# You can separate multiple mappings with a comma ','
+# mapped to the corresponding Amberscript language. In general the Amberscript workflow
+# should figure it out by itself. Use this, if you have some special language strings and run into errors.
+# You can map a language to the Amberscript code with a colon ':'.
+# You can separate multiple mappings with a comma ','.
 # Examples:
 # language.code.map=english:en
 # language.code.map=german:de,french:fr,spanish:es
@@ -28,37 +31,34 @@
 # These are three different examples, please note that you can specify 'language.code.map' only once
 #language.code.map=
 
-# Default Job Type to use
-# You can override this within you workflow (see workflowoperationhandler amberscript-start-transcription).
-# Default: direct
+# Default job type to use.
+# You can override this within you workflow (see workflow operation handler `amberscript-start-transcription`).
 # Can be one of: perfect, direct
+# Default: direct
 # jobtype=direct
 
-# AmberScript API key
-client.key=
-
 # Workflow to be executed when results are ready to be attached to media package (workflow-id)
-# Defaults: amberscript-attach-transcripts
+# Default: amberscript-attach-transcripts
 #workflow=amberscript-attach-transcripts
 
 # Interval the workflow dispatcher runs to start workflows to attach transcripts to the media package
-# after the transcription job is completed.
-# (in seconds) Default is 1 minute.
+# after the transcription job is completed in seconds.
+# Default: 1 minute
 #workflow.dispatch.interval=60
 
 # How long to wait after a transcription is supposed to finish before marking the job as
-# canceled in the database. Default is 48 hours.
-# (in seconds)
+# canceled in the databas in seconds
+# Default: 48 hours
 #max.overdue.time=691200
 
 # How long to keep result files in the working file repository in days.
-# The default is 7 days.
+# Default: 7 days
 #cleanup.results.days=7
 
 # Configure which metadata field shall be considered when "counting" the
 # number of speakers. The "presenter" or the "contributor" field.
 # Note for developers: the "presenter" becomes the "creator" in the Operation Handler
 # possible values: presenter, contributor, both
-# Both means, that both list will be joined (Union)
-# The default is presenter
+# Both means, that both list will be joined (union)
+# Default: presenter
 #speaker.metadata.field=presenter

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/SanitizeAdaptiveWorkflowOperationHandler.java
@@ -56,8 +56,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.function.Function;
 
 /**
@@ -79,16 +77,6 @@ public class SanitizeAdaptiveWorkflowOperationHandler extends AbstractWorkflowOp
   private static final String PLUS = "+";
   private static final String MINUS = "-";
 
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put("source-flavor", "The \"flavor\" of the track to use as a video source input");
-    CONFIG_OPTIONS.put("target-flavor", "The flavor to apply to the encoded file");
-    CONFIG_OPTIONS.put("target-tags", "The tags to apply to the encoded file");
-  }
-
   /** The local workspace */
   private Workspace workspace = null;
 
@@ -108,10 +96,6 @@ public class SanitizeAdaptiveWorkflowOperationHandler extends AbstractWorkflowOp
   @Override
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {
     super.setServiceRegistry(serviceRegistry);
-  }
-
-  public SortedMap<String, String> getConfigurationOptions() {
-    return CONFIG_OPTIONS;
   }
 
   /**

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -341,6 +341,11 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
 
   @Override
   public Job startTranscription(String mpId, Track track, String... args) throws TranscriptionServiceException {
+    if (!enabled) {
+      throw new TranscriptionServiceException("AmberScript Transcription Service disabled."
+              + " If you want to enable it, please update the service configuration.");
+    }
+
     String language = null;
 
     if (languageFromDublinCore) {
@@ -400,11 +405,6 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
 
     if (speakers.size() > 1) {
       numberOfSpeakers = speakers.size();
-    }
-
-    if (!enabled) {
-      throw new TranscriptionServiceException("AmberScript Transcription Service disabled."
-              + " If you want to enable it, please update the service configuration.");
     }
 
     logger.info("New transcription job for mpId '{}' language '{}' JobType '{}' Speakers '{}'.",

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -346,8 +346,13 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
 
     Option<String> transcriptionTypeOpt = OsgiUtil.getOptCfg(cc.getProperties(), TRANSCRIPTIONTYPE);
     if (transcriptionTypeOpt.isSome()) {
-      transcriptionType = transcriptionTypeOpt.get();
-      logger.info("Default transcription type is set to '{}'.", transcriptionType);
+      if (List.of("transcription", "captions", "translatedSubtitles").contains(transcriptionType)) {
+        transcriptionType = transcriptionTypeOpt.get();
+        logger.info("Default transcription type is set to '{}'.", transcriptionType);
+      } else {
+        logger.warn("Value '{}' is invalid for configuration '{}'. Using default: '{}'.",
+            transcriptionTypeOpt.get(), TRANSCRIPTIONTYPE, transcriptionType);
+      }
     } else {
       logger.info("Default transcription type '{}' will be used.", transcriptionType);
     }
@@ -362,8 +367,13 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
 
     Option<String> transcriptionStyleOpt = OsgiUtil.getOptCfg(cc.getProperties(), TRANSCRIPTIONSTYLE);
     if (transcriptionStyleOpt.isSome()) {
-      transcriptionStyle = transcriptionStyleOpt.get();
-      logger.info("Default transcription style is set to '{}'.", transcriptionStyle);
+      if (List.of("cleanread", "verbatim").contains(transcriptionStyle)) {
+        transcriptionStyle = transcriptionStyleOpt.get();
+        logger.info("Default transcription style is set to '{}'.", transcriptionStyle);
+      } else {
+        logger.warn("Value '{}' is invalid for configuration '{}'. Using default: '{}'.",
+            transcriptionStyleOpt.get(), TRANSCRIPTIONSTYLE, transcriptionStyle);
+      }
     } else {
       logger.info("Default transcription style '{}' will be used.", transcriptionStyle);
     }

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -336,7 +336,7 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
 
   @Override
   public Job startTranscription(String mpId, Track track) throws TranscriptionServiceException {
-    return startTranscription(mpId, track, getLanguage(), getAmberscriptJobType());
+    throw new UnsupportedOperationException("Not supported.");
   }
 
   @Override

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -169,7 +169,13 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
   private static final String DISPATCH_WORKFLOW_INTERVAL_CONFIG = "workflow.dispatch.interval";
   private static final String MAX_PROCESSING_TIME_CONFIG = "max.overdue.time";
   private static final String CLEANUP_RESULTS_DAYS_CONFIG = "cleanup.results.days";
+  private static final String SPEAKER = "speaker";
+  private static final String SPEAKER_FROM_DUBLINCORE = "speaker.from.dublincore";
   private static final String SPEAKER_METADATA_FIELD = "speaker.metadata.field";
+  private static final String TRANSCRIPTIONTYPE = "transcriptiontype";
+  private static final String GLOSSARY = "glossary";
+  private static final String TRANSCRIPTIONSTYLE = "cleanread";
+  private static final String TARGETLANGUAGE = "targetlanguage";
 
   // service configuration default values
   private boolean enabled = false;
@@ -183,7 +189,12 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
   private long maxProcessingSeconds = 8 * 24 * 60 * 60; // maximum runtime for jobType perfect is 8 days
   private int cleanupResultDays = 7;
   private int numberOfSpeakers = 1;
+  private boolean speakerFromDublinCore = true;
   private SpeakerMetadataField speakerMetadataField = SpeakerMetadataField.creator;
+  private String transcriptionType = "transcription";
+  private String glossary = "";
+  private String transcriptionStyle = "cleanread";
+  private String targetLanguage = "";
 
   /**
    * Contains mappings from several possible ways of writing a language name/code to the
@@ -302,6 +313,26 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
     }
     logger.info("Cleanup result files after {} days.", cleanupResultDays);
 
+    Option<String> speakerOpt = OsgiUtil.getOptCfg(cc.getProperties(), SPEAKER);
+    if (speakerOpt.isSome()) {
+      try {
+        numberOfSpeakers = Integer.parseInt(speakerOpt.get());
+      } catch (NumberFormatException e) {
+        logger.warn("Configured '{}' is invalid. Using default.", SPEAKER);
+      }
+    }
+    logger.info("Default number of speakers is set to '{}'.", numberOfSpeakers);
+
+    Option<String> speakerFromDublinCoreOpt = OsgiUtil.getOptCfg(cc.getProperties(), SPEAKER_FROM_DUBLINCORE);
+    if (speakerFromDublinCoreOpt.isSome()) {
+      try {
+        speakerFromDublinCore = Boolean.parseBoolean(speakerFromDublinCoreOpt.get());
+      } catch (Exception e) {
+        logger.warn("Configuration value for '{}' is invalid, defaulting to true.", SPEAKER_FROM_DUBLINCORE);
+      }
+    }
+    logger.info("Configuration value for '{}' is set to '{}'.", SPEAKER_FROM_DUBLINCORE, speakerFromDublinCore);
+
     Option<String> speakerMetadataFieldOpt = OsgiUtil.getOptCfg(cc.getProperties(), SPEAKER_METADATA_FIELD);
     if (speakerMetadataFieldOpt.isSome()) {
       try {
@@ -312,6 +343,38 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
       }
     }
     logger.info("Default metadata field for calculating the amount of speakers is set to '{}'.", speakerMetadataField);
+
+    Option<String> transcriptionTypeOpt = OsgiUtil.getOptCfg(cc.getProperties(), TRANSCRIPTIONTYPE);
+    if (transcriptionTypeOpt.isSome()) {
+      transcriptionType = transcriptionTypeOpt.get();
+      logger.info("Default transcription type is set to '{}'.", transcriptionType);
+    } else {
+      logger.info("Default transcription type '{}' will be used.", transcriptionType);
+    }
+
+    Option<String> glossaryOpt = OsgiUtil.getOptCfg(cc.getProperties(), GLOSSARY);
+    if (glossaryOpt.isSome()) {
+      glossary = glossaryOpt.get();
+      logger.info("Default glossary is set to '{}'.", glossary);
+    } else {
+      logger.info("No glossary will be used by default");
+    }
+
+    Option<String> transcriptionStyleOpt = OsgiUtil.getOptCfg(cc.getProperties(), TRANSCRIPTIONSTYLE);
+    if (transcriptionStyleOpt.isSome()) {
+      transcriptionStyle = transcriptionStyleOpt.get();
+      logger.info("Default transcription style is set to '{}'.", transcriptionStyle);
+    } else {
+      logger.info("Default transcription style '{}' will be used.", transcriptionStyle);
+    }
+
+    Option<String> targetLanguageOpt = OsgiUtil.getOptCfg(cc.getProperties(), TARGETLANGUAGE);
+    if (targetLanguageOpt.isSome()) {
+      targetLanguage = targetLanguageOpt.get();
+      logger.info("Default target language is set to '{}'.", targetLanguage);
+    } else {
+      logger.info("Transcriptions won't be translated");
+    }
 
     systemAccount = OsgiUtil.getContextProperty(cc, OpencastConstants.DIGEST_USER_PROPERTY);
 
@@ -379,38 +442,77 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
       jobType = getAmberscriptJobType();
     }
 
-    int numberOfSpeakers = getNumberOfSpeakers();
-    Set<String> speakers = new HashSet<>();
-    for (Catalog catalog : track.getMediaPackage().getCatalogs(MediaPackageElements.EPISODE)) {
-      try (InputStream in = workspace.read(catalog.getURI())) {
-        DublinCoreCatalog dublinCatalog = DublinCores.read(in);
-        if (speakerMetadataField.equals(SpeakerMetadataField.creator)
-            || speakerMetadataField.equals(SpeakerMetadataField.both)) {
-          dublinCatalog.get(DublinCore.PROPERTY_CREATOR).stream()
-              .map(DublinCoreValue::getValue).forEach(speakers::add);
-        }
-        if (speakerMetadataField.equals(SpeakerMetadataField.contributor)
-            || speakerMetadataField.equals(SpeakerMetadataField.both)) {
-          dublinCatalog.get(DublinCore.PROPERTY_CONTRIBUTOR).stream()
-              .map(DublinCoreValue::getValue).forEach(speakers::add);
-        }
+    int numberOfSpeakers = 0;
+    if (speakerFromDublinCore) {
+      Set<String> speakers = new HashSet<>();
+      for (Catalog catalog : track.getMediaPackage().getCatalogs(MediaPackageElements.EPISODE)) {
+        try (InputStream in = workspace.read(catalog.getURI())) {
+          DublinCoreCatalog dublinCatalog = DublinCores.read(in);
+          if (speakerMetadataField.equals(SpeakerMetadataField.creator)
+                  || speakerMetadataField.equals(SpeakerMetadataField.both)) {
+            dublinCatalog.get(DublinCore.PROPERTY_CREATOR).stream()
+                    .map(DublinCoreValue::getValue).forEach(speakers::add);
+          }
+          if (speakerMetadataField.equals(SpeakerMetadataField.contributor)
+                  || speakerMetadataField.equals(SpeakerMetadataField.both)) {
+            dublinCatalog.get(DublinCore.PROPERTY_CONTRIBUTOR).stream()
+                    .map(DublinCoreValue::getValue).forEach(speakers::add);
+          }
 
-      } catch (IOException | NotFoundException e) {
-        logger.error("Unable to load dublin core catalog for event '{}'",
-            track.getMediaPackage().getIdentifier(), e);
+        } catch (IOException | NotFoundException e) {
+          logger.error("Unable to load dublin core catalog for event '{}'",
+                  track.getMediaPackage().getIdentifier(), e);
+        }
+      }
+
+      if (speakers.size() >= 1) {
+        numberOfSpeakers = speakers.size();
       }
     }
 
-    if (speakers.size() > 1) {
-      numberOfSpeakers = speakers.size();
+    if (numberOfSpeakers == 0) {
+      if (args.length > 2 && StringUtils.isNotBlank(args[2])) {
+        numberOfSpeakers = Integer.parseInt(args[2]);
+      } else {
+        numberOfSpeakers = getNumberOfSpeakers();
+      }
     }
 
-    logger.info("New transcription job for mpId '{}' language '{}' JobType '{}' Speakers '{}'.",
-        mpId, language, jobType, numberOfSpeakers);
+    String transcriptionType;
+    if (args.length > 3 && StringUtils.isNotBlank(args[3])) {
+      transcriptionType = args[3];
+    } else {
+      transcriptionType = getTranscriptionType();
+    }
+
+    String glossary;
+    if (args.length > 4 && args[4] != null) {
+      glossary = args[4];
+    } else {
+      glossary = getGlossary();
+    }
+
+    String transcriptionStyle;
+    if (args.length > 5 && StringUtils.isNotBlank(args[5])) {
+      transcriptionStyle = args[5];
+    } else {
+      transcriptionStyle = getTranscriptionStyle();
+    }
+
+    String targetLanguage;
+    if (args.length > 6 && args[6] != null) {
+      targetLanguage = args[6];
+    } else {
+      targetLanguage = getTargetLanguage();
+    }
+
+    logger.info("New transcription job for mpId '{}' language '{}' job type '{}' speakers '{}' transcription type '{}'"
+            + "glossary '{}'.", mpId, language, jobType, numberOfSpeakers, transcriptionType, glossary);
 
     try {
       return serviceRegistry.createJob(JOB_TYPE, Operation.StartTranscription.name(), Arrays.asList(
-          mpId, MediaPackageElementParser.getAsXml(track), language, jobType, Integer.toString(numberOfSpeakers)));
+          mpId, MediaPackageElementParser.getAsXml(track), language, jobType, Integer.toString(numberOfSpeakers),
+          transcriptionType, glossary, transcriptionStyle, targetLanguage));
     } catch (ServiceRegistryException e) {
       throw new TranscriptionServiceException("Unable to create a job", e);
     } catch (MediaPackageException e) {
@@ -473,6 +575,22 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
     return numberOfSpeakers;
   }
 
+  public String getTranscriptionType() {
+    return transcriptionType;
+  }
+
+  public String getGlossary() {
+    return glossary;
+  }
+
+  public String getTranscriptionStyle() {
+    return transcriptionStyle;
+  }
+
+  public String getTargetLanguage() {
+    return targetLanguage;
+  }
+
   // Called by workflow
   @Override
   protected String process(Job job) throws Exception {
@@ -488,7 +606,12 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
         String languageCode = arguments.get(2);
         String jobType = arguments.get(3);
         String numberOfSpeakers = arguments.get(4);
-        createRecognitionsJob(mpId, track, languageCode, jobType, numberOfSpeakers);
+        String transcriptionType = arguments.get(5);
+        String glossary = arguments.get(6);
+        String transcriptionStyle = arguments.get(7);
+        String targetLanguage = arguments.get(8);
+        createRecognitionsJob(mpId, track, languageCode, jobType, numberOfSpeakers, transcriptionType, glossary,
+                transcriptionStyle, targetLanguage);
         break;
       default:
         throw new IllegalStateException("Don't know how to handle operation '" + operation + "'");
@@ -496,7 +619,8 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
     return result;
   }
 
-  void createRecognitionsJob(String mpId, Track track, String languageCode, String jobType, String numberOfSpeakers)
+  void createRecognitionsJob(String mpId, Track track, String languageCode, String jobType, String numberOfSpeakers,
+          String transcriptionType, String glossary, String transcriptionStyle, String targetLanguage)
           throws TranscriptionServiceException {
     // Timeout 3 hours (needs to include the time for the remote service to
     // fetch the media URL before sending final response)
@@ -508,7 +632,14 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
             + "&language=" + languageCode
             + "&jobType=" + jobType
             + "&numberOfSpeakers=" + numberOfSpeakers
-            + "&transcriptionType=transcription";
+            + "&transcriptionType=" + transcriptionType
+            + "&transcriptionStyle=" + transcriptionStyle;
+    if (StringUtils.isNotBlank(glossary)) {
+      submitUrl += "&glossary=" + glossary;
+    }
+    if (StringUtils.isNotBlank(targetLanguage)) {
+      submitUrl += "&targetLanguage=" + targetLanguage;
+    }
 
     try {
       FileBody fileBody = new FileBody(workspace.get(track.getURI()), ContentType.DEFAULT_BINARY);

--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/endpoint/AmberscriptTranscriptionRestService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/endpoint/AmberscriptTranscriptionRestService.java
@@ -27,7 +27,6 @@ import org.opencastproject.transcription.amberscript.AmberscriptTranscriptionSer
 import org.opencastproject.util.doc.rest.RestService;
 import org.opencastproject.workingfilerepository.api.WorkingFileRepository;
 
-import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -80,7 +79,7 @@ public class AmberscriptTranscriptionRestService extends AbstractJobProducerEndp
   protected WorkingFileRepository wfr;
 
   @Activate
-  public void activate(ComponentContext cc) {
+  public void activate() {
     logger.debug("activate()");
   }
 

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
@@ -95,7 +95,7 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
     List<String> targetTagOption = tagsAndFlavors.getTargetTags();
     String captionFormatOption = StringUtils.trimToNull(operation.getConfiguration(TARGET_CAPTION_FORMAT));
 
-    MediaPackageElementFlavor flavor = null;
+    MediaPackageElementFlavor flavor;
     if (!targetFlavorOption.isEmpty()) {
       flavor = targetFlavorOption.get(0);
     } else {
@@ -112,7 +112,7 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
       MediaPackageElement transcription
           = service.getGeneratedTranscription(mediaPackage.getIdentifier().toString(), jobId);
 
-      MediaPackageElement convertedTranscription = null;
+      MediaPackageElement convertedTranscription;
       if (captionFormatOption != null) {
         Job job = captionService.convert(transcription, "subrip", captionFormatOption, service.getLanguage());
         if (!waitForStatus(job).isSuccess()) {

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
@@ -48,8 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 @Component(
     immediate = true,
@@ -65,25 +63,12 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
 
   /** Workflow configuration option keys */
   static final String TRANSCRIPTION_JOB_ID = "transcription-job-id";
-  static final String TARGET_FLAVOR = "target-flavor";
-  static final String TARGET_TAGS = "target-tags";
   static final String TARGET_CAPTION_FORMAT = "target-caption-format";
 
   private TranscriptionService service = null;
   private CaptionService captionService;
 
   private Workspace workspace;
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(TRANSCRIPTION_JOB_ID, "The job id that identifies the file to be attached");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR, "The target \"flavor\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_TAGS, "The target \"tags\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_CAPTION_FORMAT, "The target caption format of the transcription file (dfxp, etc)");
-  }
 
   @Override
   @Activate

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
@@ -102,7 +102,7 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
     List<String> sourceTagOption = tagsAndFlavors.getSrcTags();
     List<MediaPackageElementFlavor> sourceFlavorOption = tagsAndFlavors.getSrcFlavors();
     String language = StringUtils.trimToEmpty(operation.getConfiguration(LANGUAGE));
-    String jobtype = StringUtils.trimToEmpty(operation.getConfiguration(JOBTYPE));
+    String jobType = StringUtils.trimToEmpty(operation.getConfiguration(JOBTYPE));
 
     AbstractMediaPackageElementSelector<Track> elementSelector = new TrackSelector();
 
@@ -122,7 +122,7 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
     Job job = null;
     for (Track track : elements) {
       try {
-        job = service.startTranscription(mediaPackage.getIdentifier().toString(), track, language, jobtype);
+        job = service.startTranscription(mediaPackage.getIdentifier().toString(), track, language, jobType);
         // Only one job per media package
         break;
       } catch (TranscriptionServiceException e) {

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
@@ -50,8 +50,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 @Component(
     immediate = true,
@@ -66,27 +64,12 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
   private static final Logger logger = LoggerFactory.getLogger(AmberscriptStartTranscriptionOperationHandler.class);
 
   /** Workflow configuration option keys */
-  static final String SOURCE_FLAVOR = "source-flavor";
-  static final String SOURCE_TAG = "source-tag";
   static final String LANGUAGE = "language";
   static final String JOBTYPE = "jobtype";
   static final String SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
 
   /** The transcription service */
   private TranscriptionService service = null;
-
-  /** The configuration options for this handler */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR, "The \"flavor\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(SOURCE_TAG, "The \"tag\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(LANGUAGE, "The \"language\" the transcription service will use");
-    CONFIG_OPTIONS.put(JOBTYPE, "The \"jobtype\" the transcription service will use");
-    CONFIG_OPTIONS.put(SKIP_IF_FLAVOR_EXISTS,
-        "If this \"flavor\" is already in the media package, skip this operation");
-  }
 
   @Override
   @Activate

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptStartTranscriptionOperationHandler.java
@@ -66,6 +66,11 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
   /** Workflow configuration option keys */
   static final String LANGUAGE = "language";
   static final String JOBTYPE = "jobtype";
+  static final String SPEAKER = "speaker";
+  static final String TRANSCRIPTIONTYPE = "transcriptiontype";
+  static final String GLOSSARY = "glossary";
+  static final String TRANSCRIPTIONSTYLE = "transcriptionstyle";
+  static final String TARGETLANGUAGE = "targetlanguage";
   static final String SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
 
   /** The transcription service */
@@ -103,6 +108,15 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
     List<MediaPackageElementFlavor> sourceFlavorOption = tagsAndFlavors.getSrcFlavors();
     String language = StringUtils.trimToEmpty(operation.getConfiguration(LANGUAGE));
     String jobType = StringUtils.trimToEmpty(operation.getConfiguration(JOBTYPE));
+    String speaker = StringUtils.trimToEmpty(operation.getConfiguration(SPEAKER));
+    String transcriptionType = StringUtils.trimToEmpty(operation.getConfiguration(TRANSCRIPTIONTYPE));
+    // Note that specifying `""` is different from not specifying a glossary at all!
+    // The former will override the default with not using a glossary for this operation,
+    // while the latter will fall back to said default. Hence, no `trimToEmpty` here.
+    String glossary = StringUtils.trim(operation.getConfiguration(GLOSSARY));
+    String transcriptionStyle = StringUtils.trimToEmpty(operation.getConfiguration(TRANSCRIPTIONSTYLE));
+    // See glossary comment above
+    String targetLanguage = StringUtils.trim(operation.getConfiguration(TARGETLANGUAGE));
 
     AbstractMediaPackageElementSelector<Track> elementSelector = new TrackSelector();
 
@@ -122,7 +136,8 @@ public class AmberscriptStartTranscriptionOperationHandler extends AbstractWorkf
     Job job = null;
     for (Track track : elements) {
       try {
-        job = service.startTranscription(mediaPackage.getIdentifier().toString(), track, language, jobType);
+        job = service.startTranscription(mediaPackage.getIdentifier().toString(), track, language, jobType, speaker,
+            transcriptionType, glossary, transcriptionStyle, targetLanguage);
         // Only one job per media package
         break;
       } catch (TranscriptionServiceException e) {

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AttachTranscriptionOperationHandler.java
@@ -64,8 +64,6 @@ public class AttachTranscriptionOperationHandler extends AbstractWorkflowOperati
 
   /** Workflow configuration option keys */
   static final String TRANSCRIPTION_JOB_ID = "transcription-job-id";
-  static final String TARGET_FLAVOR = "target-flavor";
-  static final String TARGET_TAGS = "target-tags";
   static final String TARGET_CAPTION_FORMAT = "target-caption-format";
 
   /** The transcription service */

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechAttachTranscriptionOperationHandler.java
@@ -47,8 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 @Component(
     immediate = true,
@@ -69,8 +67,6 @@ public class GoogleSpeechAttachTranscriptionOperationHandler extends AbstractWor
    * Workflow configuration option keys
    */
   static final String TRANSCRIPTION_JOB_ID = "transcription-job-id";
-  static final String TARGET_FLAVOR = "target-flavor";
-  static final String TARGET_TAGS = "target-tags";
   static final String TARGET_CAPTION_FORMAT = "target-caption-format";
   static final String TRANSCRIPTION_LINE_SIZE = "line-size";
   static final String DEFAULT_LINE_SIZE = "100";
@@ -81,20 +77,6 @@ public class GoogleSpeechAttachTranscriptionOperationHandler extends AbstractWor
   private TranscriptionService service = null;
   private Workspace workspace;
   private CaptionService captionService;
-
-  /**
-   * The configuration options for this handler
-   */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(TRANSCRIPTION_JOB_ID, "The job id that identifies the file to be attached");
-    CONFIG_OPTIONS.put(TARGET_FLAVOR, "The target \"flavor\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_TAGS, "The target \"tag\" of the transcription file");
-    CONFIG_OPTIONS.put(TARGET_CAPTION_FORMAT, "The target caption format of the transcription file (vtt, dfxp, etc)");
-    CONFIG_OPTIONS.put(TRANSCRIPTION_LINE_SIZE, "Line size of transcription text to display on video");
-  }
 
   @Override
   protected void activate(ComponentContext cc) {

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/GoogleSpeechStartTranscriptionOperationHandler.java
@@ -50,8 +50,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 @Component(
     immediate = true,
@@ -71,8 +69,6 @@ public class GoogleSpeechStartTranscriptionOperationHandler extends AbstractWork
   /**
    * Workflow configuration option keys
    */
-  static final String SOURCE_FLAVOR = "source-flavor";
-  static final String SOURCE_TAG = "source-tag";
   static final String LANGUAGE_CODE = "language-code";
   static final String SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
 
@@ -85,20 +81,6 @@ public class GoogleSpeechStartTranscriptionOperationHandler extends AbstractWork
    * The language code
    */
   private String language = null;
-
-  /**
-   * The configuration options for this handler
-   */
-  private static final SortedMap<String, String> CONFIG_OPTIONS;
-
-  static {
-    CONFIG_OPTIONS = new TreeMap<String, String>();
-    CONFIG_OPTIONS.put(SOURCE_FLAVOR, "The \"flavor\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(SOURCE_TAG, "The \"tag\" of the track to use as audio input");
-    CONFIG_OPTIONS.put(LANGUAGE_CODE, "The \"language code\" to use for the transcription");
-    CONFIG_OPTIONS
-            .put(SKIP_IF_FLAVOR_EXISTS, "If this \"flavor\" is already in the media package, skip this operation");
-  }
 
   @Override
   @Activate

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/MicrosoftAzureStartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/MicrosoftAzureStartTranscriptionOperationHandler.java
@@ -66,8 +66,6 @@ public class MicrosoftAzureStartTranscriptionOperationHandler extends AbstractWo
   private static final Logger logger = LoggerFactory.getLogger(MicrosoftAzureStartTranscriptionOperationHandler.class);
 
   /** Workflow configuration option keys */
-  static final String SOURCE_FLAVOR = "source-flavor";
-  static final String SOURCE_TAG = "source-tag";
   static final String OPT_LANGUAGE_CODE = "language-code";
   static final String OPT_SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
   static final String OPT_AUTO_DETECT_LANGUAGE = "auto-detect-language";

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/StartTranscriptionOperationHandler.java
@@ -65,8 +65,6 @@ public class StartTranscriptionOperationHandler extends AbstractWorkflowOperatio
   private static final Logger logger = LoggerFactory.getLogger(StartTranscriptionOperationHandler.class);
 
   /** Workflow configuration option keys */
-  static final String SOURCE_FLAVOR = "source-flavor";
-  static final String SOURCE_TAG = "source-tag";
   static final String SKIP_IF_FLAVOR_EXISTS = "skip-if-flavor-exists";
 
   /** The transcription service */

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/AbstractWorkflowOperationHandler.java
@@ -77,14 +77,14 @@ public abstract class AbstractWorkflowOperationHandler implements WorkflowOperat
   /** Config for Tag Parsing operation */
   protected enum Configuration { none, one, many };
 
-  private static final String TARGET_FLAVORS = "target-flavors";
-  private static final String TARGET_FLAVOR = "target-flavor";
-  private static final String TARGET_TAGS = "target-tags";
-  private static final String TARGET_TAG = "target-tag";
-  private static final String SOURCE_FLAVORS = "source-flavors";
-  private static final String SOURCE_FLAVOR = "source-flavor";
-  private static final String SOURCE_TAG = "source-tag";
-  private static final String SOURCE_TAGS = "source-tags";
+  public static final String TARGET_FLAVORS = "target-flavors";
+  public static final String TARGET_FLAVOR = "target-flavor";
+  public static final String TARGET_TAGS = "target-tags";
+  public static final String TARGET_TAG = "target-tag";
+  public static final String SOURCE_FLAVORS = "source-flavors";
+  public static final String SOURCE_FLAVOR = "source-flavor";
+  public static final String SOURCE_TAG = "source-tag";
+  public static final String SOURCE_TAGS = "source-tags";
 
   /**
    * Activates this component with its properties once all of the collaborating services have been set


### PR DESCRIPTION
This adds some global and per-workflow options to the Amberscript documentation. The options should be more or less on par with https://amberscript.github.io/api-docs/#uploading-and-status now. (Except for `turnaroundTime` which I honestly don't understand. ¯\\\_(ツ)_/¯)

It also includes some cleanup, moves code around, nitpicks some stuff; there is more to do here, but not enough time, and in the end I had to **not** do a lot of (in my eyes) improvements in the interest of consistency. Anyway, I think this still improves a few things.

For reviewers: The commits can and should probably be reviewed in isolation. Commit messages might contain traces of further information. :wink: The improvements I mentioned above are in their own commits; the new/extended config stuff is mostly in the last one.

Note: Includes #4864.

Work sponsored by Amberscript themselves, by the way. :smile: 