### PR TITLE
Fixing adopter statistics data gathering

### DIFF
--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -27,8 +27,6 @@ import org.opencastproject.adopter.statistic.dto.GeneralData;
 import org.opencastproject.adopter.statistic.dto.Host;
 import org.opencastproject.adopter.statistic.dto.StatisticData;
 import org.opencastproject.assetmanager.api.AssetManager;
-import org.opencastproject.assetmanager.api.query.AQueryBuilder;
-import org.opencastproject.assetmanager.api.query.AResult;
 import org.opencastproject.capture.admin.api.CaptureAgentStateService;
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
@@ -289,8 +287,6 @@ public class ScheduledDataCollector extends TimerTask {
     });
     statisticData.setJobCount(serviceRegistry.count(null, null));
 
-    AQueryBuilder q = assetManager.createQuery();
-
     statisticData.setSeriesCount(seriesService.getSeriesCount());
     statisticData.setUserCount(userAndRoleProvider.countAllUsers());
 
@@ -308,8 +304,7 @@ public class ScheduledDataCollector extends TimerTask {
 
     for (Organization org : orgs) {
       SecurityUtil.runAs(securityService, org, systemAdminUser, () -> {
-        AResult result = q.select(q.snapshot()).where(q.version().isLatest()).run();
-        statisticData.setEventCount(statisticData.getEventCount() + result.getSize());
+        statisticData.setEventCount(statisticData.getEventCount() + assetManager.countEvents(org.getId()));
 
         //Calculate the number of attached CAs for this org, add it to the total
         long current = statisticData.getCACount();


### PR DESCRIPTION
This PR uses a much saner query to generate the adopter stats gathering event counts.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
