### PR TITLE
Upload Allinone as Actions Workflow Artifact

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -158,3 +158,12 @@ jobs:
           && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/r/'))
         run: |
           s3cmd put -P *.commit opencast-dist-allinone*tar.gz s3://opencast-daily/
+
+      - name: upload tarball as workflow asset
+        if: >
+          matrix.java == 11
+          && github.repository == 'opencast/opencast'
+        uses: actions/upload-artifact@v3
+        with:
+          name: opencast-allinone
+          path: build/opencast-dist-allinone*.tar.gz


### PR DESCRIPTION
We build and test Opencast with each `push` or `pull_request` event on GitHub actions anyway. But sometimes that is not enough and you will need to build it locally again to properly test a patch.

This patch will make GitHub store a pre-built artifact along with the workflow run for the usual 90 days. As a developer, this allows you to just download and run the tarball for testing, making the review process easier.

![Screenshot from 2023-04-20 13-16-40](https://user-images.githubusercontent.com/1008395/233350569-4956a294-ef7f-4faf-8a60-c1fdacba95e8.png)


### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
