### PR TITLE
Make Paella 7 Default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
   directory: "/modules/engage-paella-player-7"
   schedule:
     interval: monthly
-  target-branch: "r/13.x"
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/modules/admin-ui-frontend"

--- a/docs/guides/admin/docs/modules/paella.player/configuration.md
+++ b/docs/guides/admin/docs/modules/paella.player/configuration.md
@@ -1,5 +1,10 @@
-Paella Player
-=============
+Paella Player 6
+===============
+
+<div class=warn>
+This documentation is about the old Paella Player.
+For the new default player, take a look at the Paella Player 7 documentation section.
+</div>
 
 The Paella `(pronounced 'paeja')` [Player](https://paellaplayer.upv.es) is an Open Source
 JavaScript video player capable of playing an unlimited number of audio & video streams 
@@ -11,8 +16,6 @@ Paella has been specially designed for lecture recordings. It works with all HTM
 
 Have a look to the paella [features list](https://paellaplayer.upv.es/features/)
 or see them live on paella [demos page](https://paellaplayer.upv.es/demos/)
-
-Paella is Opencast's default player.
 
 
 Configuration

--- a/docs/guides/admin/docs/modules/paella.player7/configuration.md
+++ b/docs/guides/admin/docs/modules/paella.player7/configuration.md
@@ -1,6 +1,8 @@
 Paella Player 7
 ===============
 
+Paella 7 is Opencast's default player.
+
 The Paella `(pronounced 'paeja')` [Player](https://paellaplayer.upv.es) is an Open Source
 JavaScript video player capable of playing an unlimited number of audio & video streams 
 synchronously, Live Streaming, Zoom, Captions, contributed user plugins and a lot more. 

--- a/docs/guides/admin/docs/modules/player.configuration.md
+++ b/docs/guides/admin/docs/modules/player.configuration.md
@@ -11,4 +11,4 @@ Select the Opencast Player
 
 To change the default player for a tenant, set the following key in `.../etc/org.opencastproject.organization-<tenant>.cfg`.
 
-    prop.player=/paella/ui/watch.html?id=#{id}
+    prop.player=/paella7/ui/watch.html?id=#{id}

--- a/docs/guides/admin/docs/releasenotes/paella7.txt
+++ b/docs/guides/admin/docs/releasenotes/paella7.txt
@@ -1,0 +1,6 @@
+New Default Player
+------------------
+
+- Paella 7 is the new default
+- Paella 6 is still available and can be configured
+- Theodul is no longer available

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -179,10 +179,10 @@ prop.adminui.user.external_role_display=false
 # specific videos will be appended automatically.  Common values include:
 #
 # - paella player: /paella/ui/watch.html?id=#{id}
-# - paella player 7 (beta): /paella7/ui/watch.html?id=#{id}
+# - paella player 7: /paella7/ui/watch.html?id=#{id}
 #
-# Default: /paella/ui/watch.html?id=#{id}
-#prop.player=/paella/ui/watch.html?id=#{id}
+# Default: /paella7/ui/watch.html?id=#{id}
+#prop.player=/paella7/ui/watch.html?id=#{id}
 
 # Shortcut definitions for admin UI video player
 # Format: prop.admin.shortcut.player<action>=<key>

--- a/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
+++ b/modules/engage-ui/src/main/java/org/opencastproject/engage/ui/PlayerRedirect.java
@@ -66,7 +66,7 @@ public class PlayerRedirect {
 
   private static final Logger logger = LoggerFactory.getLogger(PlayerRedirect.class);
 
-  private static final String PLAYER_DEFAULT = "/paella/ui/watch.html?id=#{id}";
+  private static final String PLAYER_DEFAULT = "/paella7/ui/watch.html?id=#{id}";
 
   private SecurityService securityService;
 


### PR DESCRIPTION
This patch updates the default configuration to make Paella 7 the default player for Opencast 14. Paella 6 is still available though and adopters can easily switch back by changing a single configuration option.

This patch also adjust the automatic dependency updates. We argued that we could do half-tested updates for something that is in beta (and actually broke the player once or twice in that process), but we cannot do that for our default players.

Updates should be properly tested from now on and automated updates should go into `develop`.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
