### PR TITLE
Set new default editor

### DIFF
--- a/docs/guides/admin/docs/modules/editor.md
+++ b/docs/guides/admin/docs/modules/editor.md
@@ -1,10 +1,6 @@
 Stand-Alone Video Editor
 ========================
 
-<div class=warn>
-The editor is still <b>beta</b>.
-</div>
-
 Opencast's stand-alone video editor provides a tool for users to cut videos without full access to the admin interface.
 It strives to be simple and easy to use while providing enough features for most common use-cases.
 

--- a/docs/guides/admin/docs/releasenotes/editor.txt
+++ b/docs/guides/admin/docs/releasenotes/editor.txt
@@ -1,0 +1,11 @@
+New Default Editor
+------------------
+
+The default editor of Opencast has changed.
+If you want to continue using the internal editor of the old admin interface,
+you need to specifically configure this in `etc/org.opencastproject.organization-mh_default_org.cfg`
+by configuring `prop.admin.editor.url`.
+
+Note that the old admin interface is deprecated and will be removed in one of the next major releases.
+Even if you use the old editor for now, please make sure to test the new one
+and report potential problems.

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -356,6 +356,6 @@ prop.admin.shortcut.add_media.previous_tab=shift+alt+left
 # Format: A URL or path
 # Common values:
 #   The internal editor: #!/events/events/$id/tools/editor
-#   The external editing tool: /editor-ui/index.html?mediaPackageId=$id
-# Default: #!/events/events/$id/tools/editor
-#prop.admin.editor.url=#!/events/events/$id/tools/editor
+#   The external editing tool: /editor-ui/index.html?id=$id
+# Default: /editor-ui/index.html?id=$id
+#prop.admin.editor.url=/editor-ui/index.html?id=$id

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventsController.js
@@ -47,7 +47,7 @@ angular.module('adminNg.controllers')
     AuthService.getUser().$promise.then(function (user) {
       $scope.editorUrl = user.org.properties['admin.editor.url'];
       if (!$scope.editorUrl) {
-        $scope.editorUrl = '#!/events/events/$id/tools/editor';
+        $scope.editorUrl = '/editor-ui/index.html?id=$id';
       }
     }).catch(angular.noop);
 


### PR DESCRIPTION
This patch sets the new video editor as the default editor when clicking on the scissors icon in the admin interface.

It also removes the `beta` flag from the documentation.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
