### PR TITLE
Engage UI docs

### DIFF
--- a/docs/guides/admin/docs/modules/mediamodule.configuration.md
+++ b/docs/guides/admin/docs/modules/mediamodule.configuration.md
@@ -3,12 +3,5 @@ Media Module Configuration
 
 The media module is the default overview of the distributed media files.
 
-The configurations for the media module are done for each tenant. So the configuration keys are located in
-`etc/org.opencastproject.organization-mh_default_org.cfg`:
-
-- `prop.logo_mediamodule`
-    - This logo file will be displayed in the upper left of the media module page
-    - Default: Opencast logo
-- `prop.player`
-    - The player that should be use to play the videos.
-    - Default: Paella player
+The configurations for the media module are done for each tenant.
+The configuration can be found at `etc/ui-config/mh_default_org/engage-ui/config.yml`.


### PR DESCRIPTION
This patch updates the documentation of the Engage UI which was pointing
to an incorrect location for the configuration.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
