### PR TITLE
Run auto-update on main repo only

### DIFF
--- a/.github/workflows/auto-update-npm-libraries.yml
+++ b/.github/workflows/auto-update-npm-libraries.yml
@@ -12,8 +12,9 @@ on:
 jobs:
   update-npm-libs:
     runs-on: ubuntu-latest
+    if: github.repository == 'opencast/opencast'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: prepare git
         run: |


### PR DESCRIPTION
This patch prevents the auto-update for NPM libraries to run on any but the main Opencast repository.

Running the updates anywhere else should not be necessary and this prevents weird effects like this updating pull requests if someone creates one from their `develop` branch like here: https://github.com/opencast/opencast/pull/4617/commits

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
