### PR TITLE
Fix REST docs login problem

### DIFF
--- a/docs/checkstyle/eslintrc.js
+++ b/docs/checkstyle/eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   'extends': 'eslint:recommended',
   'parserOptions': {
-    'ecmaVersion': 2015
+    'ecmaVersion': 2017
   },
   'plugins': [
     'header'

--- a/modules/runtime-info-ui/src/main/resources/ui/rest_docs.html
+++ b/modules/runtime-info-ui/src/main/resources/ui/rest_docs.html
@@ -10,7 +10,6 @@
 
 <link rel=stylesheet type=text/css href=styles/rest_docs.css />
 
-<script src=js/jquery/dist/jquery.min.js></script>
 <script src=scripts/rest_docs.js></script>
 </head>
 <body>
@@ -24,15 +23,11 @@
 
 <nav>
   <div class=center>
-    <input type=text placeholder="Search…" autofocus />
+    <input id=search type=text placeholder="Search…" autofocus />
   </div>
 </nav>
 
 <ul class=center id=docs> </ul>
-
-<script id=template type=x-tmpl>
-  <li><a><span class=path></span><span class=desc></span></a></li>
-</script>
 
 </body>
 </html>

--- a/modules/runtime-info-ui/src/main/resources/ui/scripts/rest_docs.js
+++ b/modules/runtime-info-ui/src/main/resources/ui/scripts/rest_docs.js
@@ -19,36 +19,40 @@
  *
  */
 
-/* global $ */
-
 function search() {
-  var value = $('input').val();
-  $('li').each(function() {
-    $(this).toggle($(this).text().toLowerCase().indexOf(value.toLowerCase()) >= 0);
-  });
+  const value = document.getElementById('search').value.toLowerCase();
+  for (const li of document.getElementsByTagName('li')) {
+    li.style.display = li.innerText.toLowerCase().indexOf(value) >= 0 ? 'block' : 'none';
+  }
 }
 
-$(document).ready(function($) {
-  $('input').change(search);
-  $('input').keyup(search);
+async function init() {
+  const input = document.getElementById('search');
+  input.addEventListener('keyup', search);
+  input.addEventListener('change', search);
 
-  $.getJSON('/info/components.json', function(data) {
-    var docs = $('#docs'),
-        tpl = $('#template').html();
-    $.each(data, function(section) {
-      if ('rest' == section) {
-        data.rest.sort((a,b) => a.path > b.path ? 1 : -1);
-        $.each(data.rest, function(i) {
-          let path = data.rest[i].path,
-              service = $(tpl);
-          $('a', service).attr('href', '/docs.html?path=' + path);
-          $('.path', service).text(path);
-          $('.desc', service).text(data.rest[i].description);
-          docs.append(service);
-        });
-        return;
-      }
-    });
-    search();
-  });
-});
+  const docs = document.getElementById('docs');
+
+  const response = await fetch('/info/components.json');
+  const rest = (await response.json()).rest;
+  rest.sort((a,b) => a.path > b.path ? 1 : -1);
+
+  for (const endpoint of rest) {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = '/docs.html?path=' + endpoint.path;
+    li.appendChild(a);
+    const path = document.createElement('span');
+    path.classList = ['path'];
+    path.innerText = endpoint.path;
+    a.appendChild(path);
+    const desc = document.createElement('span');
+    desc.classList = ['desc'];
+    desc.innerText = endpoint.description;
+    a.appendChild(desc);
+    docs.appendChild(li);
+  }
+  search();
+}
+
+addEventListener('DOMContentLoaded', () => init());


### PR DESCRIPTION
The REST docs of Opencast have always been publicly available, but the recently added new admin interface seems to have broken this. Going to the REST docs overview page and not being logged in causes an empty page to be displayed.

This patch fixes the issue by moving from using jQuery to implementing the whole functionality in pure JavaScript which isn't really any harder with modern JavaScript.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
