### PR TITLE
Mitigate not loading ACLs

### DIFF
--- a/etc/org.apache.felix.fileinstall-acl.cfg
+++ b/etc/org.apache.felix.fileinstall-acl.cfg
@@ -5,7 +5,10 @@ felix.fileinstall.dir=${karaf.etc}/acl
 felix.fileinstall.filter=.*\\.xml
 
 # Number of milliseconds between 2 polls of the directory
-felix.fileinstall.poll=5000
+felix.fileinstall.poll=15000
+
+# Wait poll interval before doing an initial scan
+felix.fileinstall.noInitialDelay = false
 
 # If set to a value different from 0, File Install will set the start level
 # for deployed bundles to that value. If set to 0, the default framework


### PR DESCRIPTION
This patch mitigates #3083.

A race condition between loading organizations and ACLs causes ACL templates often not being available on fresh installs. The reason for this is that once ACLs are detected, they are added to all available organizations. If the organizations are not yet available, no ACLs are added.

This slight configuration change causes ACLs to be loaded with an initial delay. Not very elegant, but should fix the issue in basically all cases.

That said, we should implement a proper solution at one point.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
