### PR TITLE
Fix Check for Whether Live Publication has Changed

### DIFF
--- a/modules/live-schedule-impl/pom.xml
+++ b/modules/live-schedule-impl/pom.xml
@@ -28,6 +28,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-capture-admin-service-api</artifactId>
       <version>${project.version}</version>

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -645,7 +645,6 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       MediaPackage mp = (MediaPackage) snapshot.getMediaPackage().clone();
 
       Set<String> elementIds = new HashSet<>();
-
       if (mp.getCatalogs(MediaPackageElements.EPISODE).length > 0) {
         elementIds.add(mp.getCatalogs(MediaPackageElements.EPISODE)[0].getIdentifier());
       }
@@ -666,18 +665,22 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
                 "Element(s) for live media package " + mp.getIdentifier() + " could not be distributed");
       }
 
-      for (String id : elementIds) {
-        MediaPackageElement e = mp.getElementById(id);
-        // Cleanup workspace/wfr
+      // remove all elements from mp
+      for (MediaPackageElement e: mp.getElements()) {
         mp.remove(e);
-        workspace.delete(e.getURI());
       }
 
-      // Add distributed element(s) to mp
+      // Re-add distributed elements
       List<MediaPackageElement> distributedElements = (List<MediaPackageElement>) MediaPackageElementParser
               .getArrayFromXml(distributionJob.getPayload());
-      for (MediaPackageElement mpe : distributedElements) {
-        mp.add(mpe);
+      for (MediaPackageElement distributedElement : distributedElements) {
+        mp.add(distributedElement);
+      }
+
+      // Clean up
+      for (String id : elementIds) {
+        MediaPackageElement e = mp.getElementById(id);
+        workspace.delete(e.getURI());
       }
 
       return mp;

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -645,21 +645,12 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       MediaPackage mp = (MediaPackage) snapshot.getMediaPackage().clone();
 
       Set<String> elementIds = new HashSet<>();
-      // Then, add series catalog if needed
-      if (StringUtils.isNotEmpty(mp.getSeries())) {
-        DublinCoreCatalog catalog = seriesService.getSeries(mp.getSeries());
-        // Create temporary catalog and save to workspace
-        mp.add(catalog);
-        URI uri = workspace.put(mp.getIdentifier().toString(), catalog.getIdentifier(), "series.xml",
-                dublinCoreService.serialize(catalog));
-        catalog.setURI(uri);
-        catalog.setChecksum(null);
-        catalog.setFlavor(MediaPackageElements.SERIES);
-        elementIds.add(catalog.getIdentifier());
-      }
 
       if (mp.getCatalogs(MediaPackageElements.EPISODE).length > 0) {
         elementIds.add(mp.getCatalogs(MediaPackageElements.EPISODE)[0].getIdentifier());
+      }
+      if (mp.getCatalogs(MediaPackageElements.SERIES).length > 0) {
+        elementIds.add(mp.getCatalogs(MediaPackageElements.SERIES)[0].getIdentifier());
       }
       if (mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE).length > 0) {
         elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE)[0].getIdentifier());

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -44,6 +44,7 @@ import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.mediapackage.PublicationImpl;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.mediapackage.track.TrackImpl;
 import org.opencastproject.mediapackage.track.VideoStreamImpl;
 import org.opencastproject.metadata.dublincore.DCMIPeriod;
@@ -90,6 +91,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -105,6 +107,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Component(
     immediate = true,
@@ -151,6 +154,10 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   public static final String LIVE_DISTRIBUTION_SERVICE = "live.distributionService";
   public static final String LIVE_PUBLISH_STREAMING = "live.publishStreaming";
 
+  private static final MediaPackageElementFlavor[] publishFlavors = { MediaPackageElements.EPISODE,
+      MediaPackageElements.SERIES, MediaPackageElements.XACML_POLICY_EPISODE,
+      MediaPackageElements.XACML_POLICY_SERIES }; // make configurable later
+
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(LiveScheduleServiceImpl.class);
 
@@ -181,6 +188,8 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   private SecurityService securityService;
 
   private long jobPollingInterval = JobBarrier.DEFAULT_POLLING_INTERVAL;
+
+  private SimpleElementSelector publishElementSelector;
 
   /**
    * OSGi callback on component activation.
@@ -248,6 +257,11 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
     publishedStreamingFormats = Arrays.asList(Optional.ofNullable(StringUtils.split(
             (String)properties.get(LIVE_PUBLISH_STREAMING), ",")).orElse(new String[0]));
+
+    publishElementSelector = new SimpleElementSelector();
+    for (MediaPackageElementFlavor flavor : publishFlavors) {
+      publishElementSelector.addFlavor(flavor);
+    }
 
     logger.info(
         "Configured live stream name: {}, mime type: {}, resolution: {}, target flavors: {}, distribution service: {}",
@@ -644,28 +658,18 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     try {
       MediaPackage mp = (MediaPackage) snapshot.getMediaPackage().clone();
 
-      Set<String> elementIds = new HashSet<>();
-      if (mp.getCatalogs(MediaPackageElements.EPISODE).length > 0) {
-        elementIds.add(mp.getCatalogs(MediaPackageElements.EPISODE)[0].getIdentifier());
-      }
-      if (mp.getCatalogs(MediaPackageElements.SERIES).length > 0) {
-        elementIds.add(mp.getCatalogs(MediaPackageElements.SERIES)[0].getIdentifier());
-      }
-      if (mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE).length > 0) {
-        elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE)[0].getIdentifier());
-      }
-      if (mp.getAttachments(MediaPackageElements.XACML_POLICY_SERIES).length > 0) {
-        elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_SERIES)[0].getIdentifier());
-      }
+      // Select elements
+      Collection<MediaPackageElement> elements = publishElementSelector.select(mp, false);
+      Set<String> elementIds = elements.stream().map(MediaPackageElement::getIdentifier).collect(Collectors.toSet());
 
-      // Distribute element(s)
+      // Distribute elements
       Job distributionJob = downloadDistributionService.distribute(CHANNEL_ID, mp, elementIds, false);
       if (!waitForStatus(distributionJob).isSuccess()) {
         throw new LiveScheduleException(
                 "Element(s) for live media package " + mp.getIdentifier() + " could not be distributed");
       }
 
-      // remove all elements from mp
+      // Remove all elements from mp
       for (MediaPackageElement e: mp.getElements()) {
         mp.remove(e);
       }

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -655,6 +655,9 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       if (mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE).length > 0) {
         elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE)[0].getIdentifier());
       }
+      if (mp.getAttachments(MediaPackageElements.XACML_POLICY_SERIES).length > 0) {
+        elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_SERIES)[0].getIdentifier());
+      }
 
       // Distribute element(s)
       Job distributionJob = downloadDistributionService.distribute(CHANNEL_ID, mp, elementIds, false);

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -44,6 +44,7 @@ import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.mediapackage.PublicationImpl;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.VideoStream;
 import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.mediapackage.track.TrackImpl;
 import org.opencastproject.mediapackage.track.VideoStreamImpl;
@@ -75,6 +76,8 @@ import com.entwinemedia.fn.data.Opt;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Equator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIUtils;
 import org.osgi.framework.BundleContext;
@@ -96,7 +99,6 @@ import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -782,46 +784,56 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
   }
 
-  private boolean isSameArray(String[] previous, String[] current) {
-    Set<String> previousSet = new HashSet<String>(Arrays.asList(previous));
-    Set<String> currentSet = new HashSet<String>(Arrays.asList(current));
-    return previousSet.equals(currentSet);
-  }
+  boolean isSameMediaPackage(MediaPackage previous, MediaPackage current) {
 
-  private boolean isSameTrackArray(Track[] previous, Track[] current) {
-    Set<Track> previousTracks = new HashSet<Track>(Arrays.asList(previous));
-    Set<Track> currentTracks = new HashSet<Track>(Arrays.asList(current));
-    if (previousTracks.size() != currentTracks.size()) {
-      return false;
-    }
-    for (Track tp : previousTracks) {
-      Iterator<Track> it = currentTracks.iterator();
-      while (it.hasNext()) {
-        Track tc = it.next();
-        if (tp.getURI().equals(tc.getURI()) && tp.getDuration().equals(tc.getDuration())) {
-          currentTracks.remove(tc);
-          break;
-        }
+    Equator<Track> liveTrackEquator = new Equator<>() {
+      @Override
+      public boolean equate(Track track1, Track track2) {
+        // we can safely assume that each live track has exactly one video stream since we generated that ourselves
+        VideoStream videostream1 = (VideoStream) track1.getStreams()[0];
+        VideoStream videostream2 = (VideoStream) track2.getStreams()[0];
+
+        return Objects.equals(track1.getURI(), track2.getURI())
+                && Objects.equals(track1.getFlavor(), track2.getFlavor())
+                && Objects.equals(track1.getMimeType(), track2.getMimeType())
+                && Objects.equals(track1.getDuration(), track2.getDuration())
+                && Objects.equals(videostream1.getFrameWidth(), videostream2.getFrameWidth())
+                && Objects.equals(videostream1.getFrameHeight(), videostream2.getFrameHeight());
       }
-    }
-    if (currentTracks.size() > 0) {
+
+      @Override
+      public int hash(Track track) {
+        VideoStream videostream = (VideoStream) track.getStreams()[0];
+        return Objects.hash(track.getURI(), track.getFlavor(), track.getMimeType(), track.getDuration(),
+                videostream.getFrameWidth(), videostream.getFrameHeight());
+      }
+    };
+
+    Equator<MediaPackageElement> catalogAndAttachmentEquator = new Equator<>() {
+      @Override
+      public boolean equate(MediaPackageElement mpe1, MediaPackageElement mpe2) {
+        return Objects.equals(mpe1.getIdentifier(), mpe2.getIdentifier())
+                && Objects.equals(mpe1.getElementType(), mpe2.getElementType())
+                && Objects.equals(mpe1.getChecksum(), mpe2.getChecksum())
+                && Objects.equals(mpe1.getFlavor(), mpe2.getFlavor());
+      }
+
+      @Override
+      public int hash(MediaPackageElement mpe) {
+        return Objects.hash(mpe.getIdentifier(), mpe.getElementType(), mpe.getChecksum(), mpe.getFlavor());
+      }
+    };
+
+    if (!CollectionUtils.isEqualCollection(Arrays.asList(previous.getTracks()), Arrays.asList(current.getTracks()),
+            liveTrackEquator)) {
       return false;
+    } else if (!CollectionUtils.isEqualCollection(Arrays.asList(previous.getCatalogs()),
+            Arrays.asList(current.getCatalogs()), catalogAndAttachmentEquator)) {
+      return false;
+    } else {
+      return CollectionUtils.isEqualCollection(Arrays.asList(previous.getAttachments()),
+              Arrays.asList(current.getAttachments()), catalogAndAttachmentEquator);
     }
-
-    return true;
-  }
-
-  boolean isSameMediaPackage(MediaPackage previous, MediaPackage current) throws LiveScheduleException {
-    return Objects.equals(previous.getTitle(), current.getTitle())
-            && Objects.equals(previous.getLanguage(), current.getLanguage())
-            && Objects.equals(previous.getSeries(), current.getSeries())
-            && Objects.equals(previous.getSeriesTitle(), current.getSeriesTitle())
-            && Objects.equals(previous.getDuration(), current.getDuration())
-            && Objects.equals(previous.getDate(), current.getDate())
-            && isSameArray(previous.getCreators(), current.getCreators())
-            && isSameArray(previous.getContributors(), current.getContributors())
-            && isSameArray(previous.getSubjects(), current.getSubjects())
-            && isSameTrackArray(previous.getTracks(), current.getTracks());
   }
 
   void retractPreviousElements(MediaPackage previousMp, MediaPackage newMp) throws LiveScheduleException {

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -107,6 +107,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -367,8 +368,13 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       return false;
     }
 
-    // generate new live tracks
+    // create temp mp for comparison
     MediaPackage tmpMp = (MediaPackage) snapshot.getMediaPackage().clone();
+    // remove all elements that would not be published
+    Collection<MediaPackageElement> elements = publishElementSelector.select(tmpMp, false);
+    Arrays.stream(tmpMp.getElements()).filter(Predicate.not(elements::contains)).collect(Collectors.toList())
+            .forEach(tmpMp::remove);
+    // generate new live tracks
     setDurationForMediaPackage(tmpMp, episodeDC); // duration is used by live tracks
     Map<String, Track> liveTracks = addLiveTracksToMediaPackage(tmpMp, episodeDC);
 

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -83,7 +83,6 @@ import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -150,8 +149,6 @@ public class LiveScheduleServiceImplTest {
     EasyMock.expect(downloadDistributionService.getDistributionType())
             .andReturn(LiveScheduleServiceImpl.DEFAULT_LIVE_DISTRIBUTION_SERVICE).anyTimes();
     workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.put(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyString(),
-            EasyMock.anyObject(InputStream.class))).andReturn(new URI("http://someUrl"));
     dublinCoreService = EasyMock.createNiceMock(DublinCoreCatalogService.class);
     assetManager = EasyMock.createNiceMock(AssetManager.class);
     authService = new AuthorizationServiceMock();
@@ -386,7 +383,7 @@ public class LiveScheduleServiceImplTest {
     Assert.assertEquals("http://10.10.10.50/static/mh_default_org/engage-live/security_policy_episode.xml",
             att.getURI().toString());
     Assert.assertEquals("security/xacml+episode", att.getFlavor().toString());
-    EasyMock.verify(downloadDistributionService, workspace);
+    EasyMock.verify(downloadDistributionService);
   }
 
   @Test

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -45,7 +45,6 @@ import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.VideoStream;
 import org.opencastproject.mediapackage.identifier.IdImpl;
-import org.opencastproject.mediapackage.track.TrackImpl;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalogService;
@@ -66,6 +65,8 @@ import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
+import org.opencastproject.util.Checksum;
+import org.opencastproject.util.ChecksumType;
 import org.opencastproject.util.DateTimeSupport;
 import org.opencastproject.util.MimeType;
 import org.opencastproject.util.MimeTypes;
@@ -521,63 +522,36 @@ public class LiveScheduleServiceImplTest {
     mp2.setDuration(DURATION);
     service.addLiveTracksToMediaPackage(mp2, episodeDC);
 
-    // Change title
-    String previous = mp2.getTitle();
-    mp2.setTitle("Changed");
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    mp2.setTitle(previous);
-    // Change language
-    previous = mp2.getLanguage();
-    mp2.setLanguage("Changed");
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    mp2.setLanguage(previous);
-    // Change series
-    previous = mp2.getSeries();
-    mp2.setSeries("Changed");
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    mp2.setSeries(previous);
-    // Change series title
-    previous = mp2.getSeriesTitle();
-    mp2.setSeriesTitle("Changed");
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    mp2.setSeriesTitle(previous);
-    // Change date
-    Date dt = mp2.getDate();
-    mp2.setDate(new Date());
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    mp2.setDate(dt);
-    // Change creators
-    mp2.addCreator("New object");
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    mp2.removeCreator("New object");
-    // Change contributors
-    mp2.addContributor("New object");
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    mp2.removeContributor("New object");
-    // Change subjects
-    mp2.addSubject("New object");
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    mp2.removeSubject("New object");
     // Change track uri
     Track track = mp2.getTracks()[0];
     URI previousURI = track.getURI();
     track.setURI(new URI("http://new.url.com"));
     Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
     track.setURI(previousURI);
-    // Change duration
-    long duration = mp2.getDuration();
-    for (Track t : mp2.getTracks()) {
-      ((TrackImpl) t).setDuration(1L);
-    }
-    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
-    for (Track t : mp2.getTracks()) {
-      ((TrackImpl) t).setDuration(duration);
-    }
+    Assert.assertTrue(service.isSameMediaPackage(mp1, mp2));
+
     // Change number of tracks
     track = (Track) mp2.getTracks()[0].clone();
     mp2.remove(track);
     Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
     mp2.add(track);
+    Assert.assertTrue(service.isSameMediaPackage(mp1, mp2));
+
+    // Change catalog checksum
+    Catalog catalog = mp2.getCatalogs()[0];
+    Checksum previousChecksum = catalog.getChecksum();
+    catalog.setChecksum(Checksum.create(ChecksumType.DEFAULT_TYPE, "123456abcd"));
+    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
+    catalog.setChecksum(previousChecksum);
+    Assert.assertTrue(service.isSameMediaPackage(mp1, mp2));
+
+    // Change attachment flavor
+    Attachment attachment = mp2.getAttachments()[0];
+    MediaPackageElementFlavor previousFlavor = attachment.getFlavor();
+    attachment.setFlavor(MediaPackageElementFlavor.parseFlavor("test/test"));
+    Assert.assertFalse(service.isSameMediaPackage(mp1, mp2));
+    attachment.setFlavor(previousFlavor);
+    Assert.assertTrue(service.isSameMediaPackage(mp1, mp2));
   }
 
   @Test


### PR DESCRIPTION
I have been thinking about this way longer than warranted in an effort to make this less complicated - but I guess it's just complicated, and the fact that the code around this makes less sense the more I keep looking at it doesn't make this any easier. So please, be gentle.

The problem is the following: Before the live schedule service actually updates the live publication, it checks if anything has changed that warrants the effort. However, this check is incomplete: It only compares live tracks, and _some_ metadata fields, namely the one that you can get by directly asking the media package. But if you update for example the description, even though the content of the Dublin Core catalog has changed, the publication isn't actually updated. This is unfortunate because the description field is used by Tobira to display some useful information.

I solved this by checking if the checksum of the catalogs has changed, since I didn't actually want to read the whole thing in, and while I was at it, I did this for attachments as well since they are also part of the publication. I also changed the way the comparison is done in an effort to make it easier to comprehend, but to be honest, I'm not sure if I succeeded. 

This change makes a number of assumptions about the way the live schedule service actually works, which I did my best to confirm. If you have questions about specific things, please don't hesitate to ask. However, the answers might confuse you further...

![By_all_accounts_it_doesn't_make_sense_banner](https://user-images.githubusercontent.com/11960278/234530427-da2689cb-eea7-4df8-95f5-3dc2e9eed7a4.jpg)

-----

Edit: 

Found a bug that I fixed in #5019. This PR is now based on that one. 

Additionally a second commit was necessary to deal with the fact that the live schedule service no longer publishes all catalogs and attachments to search (see #5019 part 3). For the comparison to still be valid, we should only compare elements that are/would be published.
