### PR TITLE
Fix template losing user role when creating an event in the admin ui

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
@@ -258,6 +258,7 @@ angular.module('adminNg.services')
           });
 
           me.ud.policies = [];
+          me.ud.policiesUser = [];
           // After loading an ACL template add the user's role to the top of the ACL list if it isn't included
           if (angular.isDefined(AuthService.getUserRole())
             && !angular.isDefined(newPolicies[AuthService.getUserRole()])) {
@@ -269,7 +270,6 @@ angular.module('adminNg.services')
             }
           });
 
-          me.ud.policiesUser = [];
           angular.forEach(newPolicies, function (policy) {
             if (policy.role.startsWith(me.roleUserPrefix)) {
               var id = policy.role.split(me.roleUserPrefix).pop().toLowerCase();

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-series/access.js
@@ -124,6 +124,7 @@ angular.module('adminNg.services')
           });
 
           me.ud.policies = [];
+          me.ud.policiesUser = [];
           // After loading an ACL template add the user's role to the top of the ACL list if it isn't included
           if (angular.isDefined(AuthService.getUserRole())
             && !angular.isDefined(newPolicies[AuthService.getUserRole()])) {
@@ -135,7 +136,6 @@ angular.module('adminNg.services')
             }
           });
 
-          me.ud.policiesUser = [];
           angular.forEach(newPolicies, function (policy) {
             if (policy.role.startsWith(me.roleUserPrefix)) {
               var id = policy.role.split(me.roleUserPrefix).pop();


### PR DESCRIPTION
A non-admin user creating an event/series through the create dialog in the admin ui may accidentally remove his own role from the event because selecting a template in the access policy tab will lose the users role, thereby making them unable to access the event. This fixes that.

Resolves #4911.