### PR TITLE
Karaf upgrade 4.4.3

### DIFF
--- a/assemblies/dist-develop/pom.xml
+++ b/assemblies/dist-develop/pom.xml
@@ -104,6 +104,7 @@
             <feature>service</feature>
             <feature>system</feature>
             <feature>config</feature>
+            <feature>pax-web-karaf</feature>
             <!-- Opencast external features -->
             <feature>jpa</feature>
             <feature>http</feature>

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -15,6 +15,7 @@
     <!-- Base features -->
     <feature>http</feature>
     <feature>http-whiteboard</feature>
+    <feature>pax-web-http-whiteboard</feature>
     <feature>scr</feature>
     <feature>cxf-jaxrs</feature>
     <feature>cxf-http-jetty</feature>
@@ -107,7 +108,7 @@
   </feature>
 
   <feature name="opencast-core" version="${project.version}">
-    <feature start-level="80">ext-core</feature>
+    <feature>ext-core</feature>
 
     <!-- Opencast -->
     <bundle start-level="82">mvn:org.opencastproject/opencast-asset-manager-api/${project.version}</bundle>
@@ -153,9 +154,9 @@
   </feature>
 
   <feature name="opencast-allinone" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
-    <feature start-level="80">opencast-services-processing-heavy-load</feature>
-    <feature start-level="80">opencast-services-processing-light-load</feature>
+    <feature>opencast-core</feature>
+    <feature>opencast-services-processing-heavy-load</feature>
+    <feature>opencast-services-processing-light-load</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-frontend/${project.version}</bundle>
@@ -263,7 +264,7 @@
   </feature>
 
   <feature name="opencast-admin" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-frontend/${project.version}</bundle>
@@ -393,7 +394,7 @@
   </feature>
 
   <feature name="opencast-adminpresentation" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-admin-ui-frontend/${project.version}</bundle>
@@ -532,7 +533,7 @@
   </feature>
 
   <feature name="opencast-ingest" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-inspection-service-remote/${project.version}</bundle>
@@ -548,7 +549,7 @@
   </feature>
 
   <feature name="opencast-services-processing-heavy-load" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-animate-impl/${project.version}</bundle>
@@ -574,7 +575,7 @@
   </feature>
 
   <feature name="opencast-services-processing-light-load" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-caption-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-caption-impl/${project.version}</bundle>
@@ -606,9 +607,9 @@
   </feature>
 
   <feature name="opencast-worker" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
-    <feature start-level="80">opencast-services-processing-heavy-load</feature>
-    <feature start-level="80">opencast-services-processing-light-load</feature>
+    <feature>opencast-core</feature>
+    <feature>opencast-services-processing-heavy-load</feature>
+    <feature>opencast-services-processing-light-load</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-publication-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-publication-service-youtube-v3/${project.version}</bundle>
@@ -619,7 +620,7 @@
   </feature>
 
   <feature name="opencast-presentation" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
 
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-distribution-service-aws-s3-api/${project.version}</bundle>
@@ -666,32 +667,32 @@
   </feature>
 
   <feature name="opencast-security-jwt" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
     <bundle start-level="82">mvn:org.opencastproject/opencast-security-jwt/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-plugin-userdirectory-moodle" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
     <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-moodle/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-plugin-userdirectory-sakai" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
     <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-sakai/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-plugin-userdirectory-brightspace" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
     <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-brightspace/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-plugin-userdirectory-canvas" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
     <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-canvas/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-plugin-userdirectory-studip" version="${project.version}">
-    <feature start-level="80">opencast-core</feature>
+    <feature>opencast-core</feature>
     <bundle start-level="82">mvn:org.opencastproject/opencast-userdirectory-studip/${project.version}</bundle>
   </feature>
 

--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -65,6 +65,7 @@
     <bundle>mvn:org.apache.commons/commons-lang3/${commons-lang3.version}</bundle>
     <bundle>mvn:org.apache.commons/commons-text/${commons-text.version}</bundle>
     <bundle>mvn:org.apache.neethi/neethi/3.0.1</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xalan/2.7.2_3</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.bcel/5.2_3</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.batik/1.7_3</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.cglib/3.2.4_1</bundle>

--- a/assemblies/resources/system.properties.append
+++ b/assemblies/resources/system.properties.append
@@ -10,3 +10,6 @@ javax.xml.transform.TransformerFactory=org.apache.xalan.processor.TransformerFac
 
 # Decode files with UTF-8
 felix.fileinstall.configEncoding=UTF-8
+
+# Disable default cxf servlet
+org.apache.cxf.osgi.http.transport.disable = true

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -23,7 +23,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- opencast -->
     <dependency>

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -19,7 +19,7 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -80,7 +80,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>
@@ -93,7 +97,7 @@
           <ignoredUnusedDeclaredDependencies>
             <!-- runtime tests -->
             <ignoredUnusedDeclaredDependency>com.sun.jersey:jersey-bundle</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.osgi:osgi.cmpn</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.component</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -76,7 +76,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/analyze-mediapackage-workflowoperation/pom.xml
+++ b/modules/analyze-mediapackage-workflowoperation/pom.xml
@@ -31,7 +31,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
 
     <!-- testing -->

--- a/modules/animate-impl/pom.xml
+++ b/modules/animate-impl/pom.xml
@@ -47,7 +47,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/modules/animate-impl/pom.xml
+++ b/modules/animate-impl/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/modules/animate-remote/pom.xml
+++ b/modules/animate-remote/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/animate-workflowoperation/pom.xml
+++ b/modules/animate-workflowoperation/pom.xml
@@ -61,7 +61,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/annotation-impl/pom.xml
+++ b/modules/annotation-impl/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/annotation-impl/pom.xml
+++ b/modules/annotation-impl/pom.xml
@@ -35,7 +35,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -81,7 +81,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/modules/asset-manager-static-file-authorization/pom.xml
+++ b/modules/asset-manager-static-file-authorization/pom.xml
@@ -26,7 +26,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/modules/asset-manager-storage-aws/pom.xml
+++ b/modules/asset-manager-storage-aws/pom.xml
@@ -68,7 +68,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/asset-manager-storage-aws/pom.xml
+++ b/modules/asset-manager-storage-aws/pom.xml
@@ -72,7 +72,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/asset-manager-storage-fs/pom.xml
+++ b/modules/asset-manager-storage-fs/pom.xml
@@ -55,7 +55,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/asset-manager-storage-fs/pom.xml
+++ b/modules/asset-manager-storage-fs/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/asset-manager-workflowoperation/pom.xml
+++ b/modules/asset-manager-workflowoperation/pom.xml
@@ -21,7 +21,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -60,7 +60,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -92,7 +96,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>osgi.cmpn</artifactId>
+          <artifactId>org.osgi.service.component.annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -88,7 +88,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/authorization-xacml/pom.xml
+++ b/modules/authorization-xacml/pom.xml
@@ -98,7 +98,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/caption-impl/pom.xml
+++ b/modules/caption-impl/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/caption-impl/pom.xml
+++ b/modules/caption-impl/pom.xml
@@ -49,7 +49,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/caption-remote/pom.xml
+++ b/modules/caption-remote/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/capture-admin-service-impl/pom.xml
+++ b/modules/capture-admin-service-impl/pom.xml
@@ -60,7 +60,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/capture-admin-service-impl/pom.xml
+++ b/modules/capture-admin-service-impl/pom.xml
@@ -56,7 +56,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/comments-workflowoperation/pom.xml
+++ b/modules/comments-workflowoperation/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.entwinemedia.common</groupId>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -194,6 +194,11 @@
       <version>2.4.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http.whiteboard</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -74,7 +74,7 @@
     <!-- OSGi -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -78,7 +78,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- Persistence -->
     <dependency>

--- a/modules/common/src/main/java/org/opencastproject/mediapackage/ChainingMediaPackageSerializer.java
+++ b/modules/common/src/main/java/org/opencastproject/mediapackage/ChainingMediaPackageSerializer.java
@@ -49,7 +49,7 @@ import java.util.List;
     service = MediaPackageSerializer.class,
     property = {
         "service.pid=org.opencastproject.mediapackage.ChainingMediaPackageSerializer",
-        "service.ranking=1000"
+        "service.ranking:Integer=1000"
     }
 )
 public class ChainingMediaPackageSerializer implements MediaPackageSerializer {

--- a/modules/common/src/main/java/org/opencastproject/rest/RestConstants.java
+++ b/modules/common/src/main/java/org/opencastproject/rest/RestConstants.java
@@ -39,7 +39,7 @@ public interface RestConstants {
   String SERVICE_JOBPRODUCER_PROPERTY = "opencast.service.jobproducer";
 
   /** The ID by which this http context is known by the extended http service */
-  String HTTP_CONTEXT_ID = "opencast.httpcontext";
+  String HTTP_CONTEXT_ID = "opencast";
 
   /** The OSGI service filter that returns all registered services published as REST endpoints */
   String SERVICES_FILTER = "(&(!(objectClass=javax.servlet.Servlet))(" + RestConstants.SERVICE_PATH_PROPERTY + "=*))";

--- a/modules/common/src/main/java/org/opencastproject/util/OsgiUtil.java
+++ b/modules/common/src/main/java/org/opencastproject/util/OsgiUtil.java
@@ -24,7 +24,6 @@ package org.opencastproject.util;
 import static org.opencastproject.util.data.Option.option;
 
 import org.opencastproject.rest.RestConstants;
-import org.opencastproject.rest.SharedHttpContext;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.functions.Strings;
 
@@ -33,6 +32,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -160,9 +160,9 @@ public final class OsgiUtil {
 
   public static ServiceRegistration<?> registerServlet(BundleContext bundleContext, Object service, String alias) {
     Dictionary<String, String> resourceProps = new Hashtable<>();
-    resourceProps.put(SharedHttpContext.CONTEXT_ID, RestConstants.HTTP_CONTEXT_ID);
-    resourceProps.put(SharedHttpContext.SHARED, "true");
-    resourceProps.put(SharedHttpContext.ALIAS, alias);
+    resourceProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=" + RestConstants.HTTP_CONTEXT_ID + ")");
+    resourceProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, alias);
+    resourceProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, alias + "/*");
     return bundleContext.registerService(Servlet.class.getName(), service, resourceProps);
   }
 

--- a/modules/composer-ffmpeg/pom.xml
+++ b/modules/composer-ffmpeg/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -75,7 +75,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/composer-ffmpeg/pom.xml
+++ b/modules/composer-ffmpeg/pom.xml
@@ -50,7 +50,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -79,7 +87,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>osgi.cmpn</artifactId>
+          <artifactId>org.osgi.service.component.annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/modules/composer-service-remote/pom.xml
+++ b/modules/composer-service-remote/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/composer-workflowoperation/pom.xml
+++ b/modules/composer-workflowoperation/pom.xml
@@ -17,7 +17,11 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/conductor/pom.xml
+++ b/modules/conductor/pom.xml
@@ -75,7 +75,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/modules/conductor/pom.xml
+++ b/modules/conductor/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -37,7 +37,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -197,7 +197,7 @@
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-anim</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-awt-util</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-bridge</ignoredUnusedDeclaredDependency>

--- a/modules/cover-image-remote/pom.xml
+++ b/modules/cover-image-remote/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/cover-image-workflowoperation/pom.xml
+++ b/modules/cover-image-workflowoperation/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/cover-image-workflowoperation/pom.xml
+++ b/modules/cover-image-workflowoperation/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/crop-ffmpeg/pom.xml
+++ b/modules/crop-ffmpeg/pom.xml
@@ -46,7 +46,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/crop-ffmpeg/pom.xml
+++ b/modules/crop-ffmpeg/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/crop-remote/pom.xml
+++ b/modules/crop-remote/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/crop-workflowoperation/pom.xml
+++ b/modules/crop-workflowoperation/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/dictionary-hunspell/pom.xml
+++ b/modules/dictionary-hunspell/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/dictionary-hunspell/pom.xml
+++ b/modules/dictionary-hunspell/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/dictionary-none/pom.xml
+++ b/modules/dictionary-none/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/modules/dictionary-none/pom.xml
+++ b/modules/dictionary-none/pom.xml
@@ -36,7 +36,7 @@
     <!-- Thirdparty dependencies -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/dictionary-regexp/pom.xml
+++ b/modules/dictionary-regexp/pom.xml
@@ -44,7 +44,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/modules/dictionary-regexp/pom.xml
+++ b/modules/dictionary-regexp/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-service-aws-s3-remote/pom.xml
+++ b/modules/distribution-service-aws-s3-remote/pom.xml
@@ -45,7 +45,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/distribution-service-aws-s3/pom.xml
+++ b/modules/distribution-service-aws-s3/pom.xml
@@ -68,7 +68,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-service-aws-s3/pom.xml
+++ b/modules/distribution-service-aws-s3/pom.xml
@@ -72,7 +72,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/distribution-service-download-remote/pom.xml
+++ b/modules/distribution-service-download-remote/pom.xml
@@ -40,7 +40,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/distribution-service-download/pom.xml
+++ b/modules/distribution-service-download/pom.xml
@@ -73,7 +73,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/distribution-service-download/pom.xml
+++ b/modules/distribution-service-download/pom.xml
@@ -69,7 +69,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-service-streaming-remote/pom.xml
+++ b/modules/distribution-service-streaming-remote/pom.xml
@@ -40,7 +40,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/distribution-service-streaming-wowza/pom.xml
+++ b/modules/distribution-service-streaming-wowza/pom.xml
@@ -53,7 +53,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/distribution-service-streaming-wowza/pom.xml
+++ b/modules/distribution-service-streaming-wowza/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-workflowoperation/pom.xml
+++ b/modules/distribution-workflowoperation/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/distribution-workflowoperation/pom.xml
+++ b/modules/distribution-workflowoperation/pom.xml
@@ -68,7 +68,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/dublincore/pom.xml
+++ b/modules/dublincore/pom.xml
@@ -89,7 +89,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/editor-service-remote/pom.xml
+++ b/modules/editor-service-remote/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/editor-service/pom.xml
+++ b/modules/editor-service/pom.xml
@@ -17,7 +17,11 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/editor-service/pom.xml
+++ b/modules/editor-service/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <!-- Opencast dependencies -->
     <dependency>
@@ -140,7 +140,7 @@
         <extensions>true</extensions>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.glassfish.jersey.core:jersey-server</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/modules/elasticsearch-impl/pom.xml
+++ b/modules/elasticsearch-impl/pom.xml
@@ -31,7 +31,7 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/elasticsearch-impl/pom.xml
+++ b/modules/elasticsearch-impl/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
     </dependency>
     <!-- elasticsearch -->
     <dependency>

--- a/modules/elasticsearch-index/pom.xml
+++ b/modules/elasticsearch-index/pom.xml
@@ -19,7 +19,11 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -137,7 +141,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.osgi:osgi.cmpn</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/elasticsearch-index/pom.xml
+++ b/modules/elasticsearch-index/pom.xml
@@ -24,7 +24,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
       <scope>compile</scope>
     </dependency>
     <!-- Logging -->

--- a/modules/email-template-service-impl/pom.xml
+++ b/modules/email-template-service-impl/pom.xml
@@ -21,7 +21,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/email-template-service-impl/pom.xml
+++ b/modules/email-template-service-impl/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/engage-ui/pom.xml
+++ b/modules/engage-ui/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/event-comment/pom.xml
+++ b/modules/event-comment/pom.xml
@@ -53,7 +53,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/execute-impl/pom.xml
+++ b/modules/execute-impl/pom.xml
@@ -37,7 +37,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/execute-impl/pom.xml
+++ b/modules/execute-impl/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/execute-remote/pom.xml
+++ b/modules/execute-remote/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/execute-workflowoperation/pom.xml
+++ b/modules/execute-workflowoperation/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -18,7 +18,15 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- opencast -->
     <dependency>

--- a/modules/fileupload/pom.xml
+++ b/modules/fileupload/pom.xml
@@ -55,7 +55,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/fileupload/pom.xml
+++ b/modules/fileupload/pom.xml
@@ -59,7 +59,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>

--- a/modules/hello-world-impl/pom.xml
+++ b/modules/hello-world-impl/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/modules/hello-world-workflowoperation/pom.xml
+++ b/modules/hello-world-workflowoperation/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/incident-workflowoperation/pom.xml
+++ b/modules/incident-workflowoperation/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -18,7 +18,7 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -22,7 +22,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/modules/ingest-download-service-impl/pom.xml
+++ b/modules/ingest-download-service-impl/pom.xml
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/ingest-download-service-remote/pom.xml
+++ b/modules/ingest-download-service-remote/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/ingest-download-service-workflowoperation/pom.xml
+++ b/modules/ingest-download-service-workflowoperation/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -91,7 +91,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -161,7 +169,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>osgi.cmpn</artifactId>
+          <artifactId>org.osgi.service.component.annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/modules/ingest-service-impl/pom.xml
+++ b/modules/ingest-service-impl/pom.xml
@@ -87,7 +87,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -157,7 +157,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/inspection-service-ffmpeg/pom.xml
+++ b/modules/inspection-service-ffmpeg/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/inspection-service-ffmpeg/pom.xml
+++ b/modules/inspection-service-ffmpeg/pom.xml
@@ -40,7 +40,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/inspection-service-remote/pom.xml
+++ b/modules/inspection-service-remote/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/inspection-workflowoperation/pom.xml
+++ b/modules/inspection-workflowoperation/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -153,6 +153,10 @@
       <artifactId>org.osgi.service.http</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http.whiteboard</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.fileinstall</artifactId>
       <exclusions>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -134,7 +134,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -146,7 +146,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -138,7 +138,19 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>
@@ -150,7 +162,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>osgi.cmpn</artifactId>
+          <artifactId>org.osgi.service.component.annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/filter/https/HttpsFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/filter/https/HttpsFilter.java
@@ -45,7 +45,7 @@ import javax.servlet.http.HttpServletRequest;
         "service.description=Https Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=2",
+        "service.ranking:Integer=2",
         "urlPatterns=*"
     }
 )

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/filter/https/HttpsFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/filter/https/HttpsFilter.java
@@ -22,6 +22,11 @@
 package org.opencastproject.kernel.filter.https;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,16 +44,16 @@ import javax.servlet.http.HttpServletRequest;
  * This filter is wrapping <code>HttpServletRequest</code>s in such a way that they feature the https scheme.
  */
 @Component(
-    immediate = true,
     service = Filter.class,
+    scope = ServiceScope.PROTOTYPE,
     property = {
         "service.description=Https Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=2",
-        "urlPatterns=*"
     }
 )
+@ServiceRanking(990)
+@HttpWhiteboardFilterName("HttpsFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class HttpsFilter implements Filter {
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(HttpsFilter.class);

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/filter/proxy/TransparentProxyFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/filter/proxy/TransparentProxyFilter.java
@@ -47,7 +47,7 @@ import javax.servlet.http.HttpServletRequest;
         "service.description=Transparent Proxy Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=9",
+        "service.ranking:Integer=9",
         "urlPatterns=*"
     }
 )

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/filter/proxy/TransparentProxyFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/filter/proxy/TransparentProxyFilter.java
@@ -23,6 +23,11 @@ package org.opencastproject.kernel.filter.proxy;
 
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,16 +46,16 @@ import javax.servlet.http.HttpServletRequest;
  * original IP.
  */
 @Component(
-    immediate = true,
     service = Filter.class,
+    scope = ServiceScope.PROTOTYPE,
     property = {
         "service.description=Transparent Proxy Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=9",
-        "urlPatterns=*"
     }
 )
+@ServiceRanking(6)
+@HttpWhiteboardFilterName("TransparentProxyFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class TransparentProxyFilter implements Filter {
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(TransparentProxyFilter.class);

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/http/SharedHttpContext.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/http/SharedHttpContext.java
@@ -31,7 +31,10 @@ import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.ServiceScope;
 import org.osgi.service.http.HttpContext;
+import org.osgi.service.http.context.ServletContextHelper;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,15 +51,14 @@ import javax.servlet.http.HttpServletResponse;
  * registrations should use the {@link HttpContext} that is registered with the OSGi service registry.
  */
 @Component(
-    immediate = true,
-    service = HttpContext.class,
+    service = ServletContextHelper.class,
+    scope = ServiceScope.BUNDLE,
     property = {
         "service.description=Opencast HttpContent",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true"
     }
 )
-public class SharedHttpContext implements HttpContext {
+@HttpWhiteboardContext(path = "/", name = "opencast")
+public class SharedHttpContext extends ServletContextHelper {
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(SharedHttpContext.class);
 

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CleanSessionsFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CleanSessionsFilter.java
@@ -52,7 +52,7 @@ import javax.servlet.http.HttpSession;
         "service.description=Clean Digest Sessions and Set Max Inactive Interval Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=1",
+        "service.ranking:Integer=1",
         "urlPatterns=*"
     }
 )

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CleanSessionsFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CleanSessionsFilter.java
@@ -24,6 +24,10 @@ package org.opencastproject.kernel.rest;
 import org.opencastproject.rest.RestConstants;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,16 +50,15 @@ import javax.servlet.http.HttpSession;
  * http://opencast.jira.com/browse/MH-8205 for more details and discussion.
  */
 @Component(
-    immediate = true,
     service = Filter.class,
     property = {
         "service.description=Clean Digest Sessions and Set Max Inactive Interval Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=1",
-        "urlPatterns=*"
     }
 )
+@ServiceRanking(1000)
+@HttpWhiteboardFilterName("CleanSessionsFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class CleanSessionsFilter implements Filter {
   private static final int NO_MAX_INACTIVE_INTERVAL_SET = -1;
   /** The logger */

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CurrentJobFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CurrentJobFilter.java
@@ -52,7 +52,7 @@ import javax.servlet.http.HttpServletResponse;
         "service.description=Current Job Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=4",
+        "service.ranking:Integer=4",
         "urlPatterns=*"
     }
 )

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CurrentJobFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CurrentJobFilter.java
@@ -28,6 +28,11 @@ import org.opencastproject.util.NotFoundException;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,16 +51,16 @@ import javax.servlet.http.HttpServletResponse;
  * Inspects request current job header and sets the current job for the request.
  */
 @Component(
-    immediate = true,
     service = Filter.class,
+    scope = ServiceScope.PROTOTYPE,
     property = {
         "service.description=Current Job Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=4",
-        "urlPatterns=*"
     }
 )
+@ServiceRanking(9)
+@HttpWhiteboardFilterName("CurrentJobFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class CurrentJobFilter implements Filter {
 
   public static final String CURRENT_JOB_HEADER = "X-Opencast-Matterhorn-Current-Job-Id";
@@ -123,9 +128,9 @@ public class CurrentJobFilter implements Filter {
         serviceRegistry.setCurrentJob(currentJob);
       }
     } catch (NotFoundException e) {
-      logger.debug("Unable to set non-existing current job {}: {}", currentJobId, e);
+      logger.debug("Unable to set non-existing current job {}", currentJobId, e);
     } catch (Exception e) {
-      logger.error("Unable to set the current job {}: {}", currentJobId, e);
+      logger.error("Unable to set the current job {}", currentJobId, e);
       httpResponse.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
               "Was not able to set the current job id {} to the service registry" + currentJobId);
     }

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/JsonpFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/JsonpFilter.java
@@ -55,7 +55,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
         "service.description=JSONP Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=10",
+        "service.ranking:Integer=10",
         "urlPatterns=*"
     }
 )

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/JsonpFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/JsonpFilter.java
@@ -24,6 +24,11 @@ package org.opencastproject.kernel.rest;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,16 +54,16 @@ import javax.servlet.http.HttpServletResponseWrapper;
  * Adds padding to json responses when the 'jsonp' parameter is specified.
  */
 @Component(
-    immediate = true,
     service = Filter.class,
+    scope = ServiceScope.PROTOTYPE,
     property = {
         "service.description=JSONP Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=10",
-        "urlPatterns=*"
     }
 )
+@ServiceRanking(5)
+@HttpWhiteboardFilterName("JsonpFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class JsonpFilter implements Filter {
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(JsonpFilter.class);

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/RestPublisher.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/RestPublisher.java
@@ -22,7 +22,6 @@
 package org.opencastproject.kernel.rest;
 
 import org.opencastproject.rest.RestConstants;
-import org.opencastproject.rest.SharedHttpContext;
 import org.opencastproject.rest.StaticResource;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.systems.OpencastConstants;
@@ -41,8 +40,6 @@ import org.apache.cxf.jaxrs.JAXRSBindingFactory;
 import org.apache.cxf.jaxrs.JAXRSServerFactoryBean;
 import org.apache.cxf.jaxrs.ext.ResourceComparator;
 import org.apache.cxf.jaxrs.impl.UriInfoImpl;
-import org.apache.cxf.jaxrs.lifecycle.ResourceProvider;
-import org.apache.cxf.jaxrs.lifecycle.SingletonResourceProvider;
 import org.apache.cxf.jaxrs.model.ClassResourceInfo;
 import org.apache.cxf.jaxrs.model.OperationResourceInfo;
 import org.apache.cxf.jaxrs.provider.json.JSONProvider;
@@ -66,6 +63,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.http.HttpService;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.osgi.util.tracker.BundleTracker;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
@@ -84,10 +82,10 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.Servlet;
-import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -116,6 +114,7 @@ public class RestPublisher implements RestConstants {
   /** The rest publisher looks for any non-servlet with the 'opencast.service.path' property */
   public static final String JAX_RS_SERVICE_FILTER = "(&(!(objectClass=javax.servlet.Servlet))(" + SERVICE_PATH_PROPERTY
           + "=*))";
+  //public static final String JAX_RS_SERVICE_FILTER = "(&(!(objectClass=javax.servlet.Servlet))(opencast.jaxrs.resource=true))";
 
   /** A map that sets default xml namespaces in {@link XMLStreamWriter}s */
   protected static final ConcurrentHashMap<String, String> NAMESPACE_MAP;
@@ -152,11 +151,11 @@ public class RestPublisher implements RestConstants {
 
   private ServiceRegistration<Bus> busServiceRegistration;
 
-  /** The map of JAX-RS resource providers */
-  private Map<ServiceReference<?>, ResourceProvider> resourceProviders = new ConcurrentHashMap<>();
+  /** The List of JAX-RS resources */
+  private final List<Object> serviceBeans = new CopyOnWriteArrayList<>();
 
   /** A token to store in the miss cache */
-  private Object nullToken = new Object();
+  private final Object nullToken = new Object();
 
   private final CacheLoader<Class<?>, Object> servicePathLoader = new CacheLoader<Class<?>, Object>() {
     @Override
@@ -295,8 +294,9 @@ public class RestPublisher implements RestConstants {
     String serviceType = (String) ref.getProperty(SERVICE_TYPE_PROPERTY);
     String servicePath = (String) ref.getProperty(SERVICE_PATH_PROPERTY);
     boolean servicePublishFlag = ref.getProperty(SERVICE_PUBLISH_PROPERTY) == null
-            || Boolean.parseBoolean((String) ref.getProperty(SERVICE_PUBLISH_PROPERTY));
-    boolean jobProducer = Boolean.parseBoolean((String) ref.getProperty(SERVICE_JOBPRODUCER_PROPERTY));
+            || Boolean.parseBoolean(ref.getProperty(SERVICE_PUBLISH_PROPERTY).toString());
+    boolean jobProducer = ref.getProperty(SERVICE_JOBPRODUCER_PROPERTY) != null
+            && Boolean.parseBoolean(ref.getProperty(SERVICE_JOBPRODUCER_PROPERTY).toString());
 
     ServiceRegistration<?> reg = servletRegistrationMap.get(servicePath);
     if (reg != null) {
@@ -308,14 +308,15 @@ public class RestPublisher implements RestConstants {
     cxf.setBus(bus);
     try {
       Dictionary<String, Object> props = new Hashtable<>();
-      props.put(SharedHttpContext.ALIAS, servicePath);
-      props.put(SharedHttpContext.SERVLET_NAME, service.toString());
-      props.put(SharedHttpContext.CONTEXT_ID, RestConstants.HTTP_CONTEXT_ID);
-      props.put(SharedHttpContext.SHARED, "true");
+
       props.put(SERVICE_TYPE_PROPERTY, serviceType);
       props.put(SERVICE_PATH_PROPERTY, servicePath);
       props.put(SERVICE_PUBLISH_PROPERTY, servicePublishFlag);
       props.put(SERVICE_JOBPRODUCER_PROPERTY, jobProducer);
+      props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=" + RestConstants.HTTP_CONTEXT_ID + ")");
+      props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, servicePath);
+      props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, servicePath + "/*");
+
       reg = componentContext.getBundleContext().registerService(Servlet.class.getName(), cxf, props);
     } catch (Exception e) {
       logger.info("Problem registering REST endpoint {} : {}", servicePath, e.getMessage());
@@ -323,28 +324,7 @@ public class RestPublisher implements RestConstants {
     }
     servletRegistrationMap.put(servicePath, reg);
 
-    // Wait for the servlet to be initialized as long as one minute. Since the servlet is published via the whiteboard,
-    // this may happen asynchronously. However, after 30 seconds we expect the HTTP service and the whiteboard
-    // implementation to be loaded and active.
-    int count = 0;
-    while (!cxf.isInitialized() && count < 300) {
-      logger.debug("Waiting for the servlet at '{}' to be initialized", servicePath);
-      try {
-        Thread.sleep(100);
-        count++;
-      } catch (InterruptedException e) {
-        logger.warn("Interrupt while waiting for RestServlet initialization");
-        break;
-      }
-    }
-
-    // Was initialization successful
-    if (!cxf.isInitialized()) {
-      logger.error("Whiteboard implementation failed to pick up REST endpoint declaration {}", serviceType);
-      return;
-    }
-
-    resourceProviders.put(ref, new SingletonResourceProvider(service));
+    serviceBeans.add(service);
 
     rewire();
 
@@ -359,12 +339,12 @@ public class RestPublisher implements RestConstants {
    *
    * @param alias
    *          The URL space to reclaim
-   * @param reference
+   * @param service
    *          The service reference
    */
-  protected void destroyEndpoint(String alias, ServiceReference<?> reference) {
+  protected void destroyEndpoint(String alias, Object service) {
     ServiceRegistration<?> reg = servletRegistrationMap.remove(alias);
-    resourceProviders.remove(reference);
+    serviceBeans.remove(service);
     if (reg != null) {
       reg.unregister();
     }
@@ -374,8 +354,8 @@ public class RestPublisher implements RestConstants {
 
   private synchronized void rewire() {
 
-    if (resourceProviders.isEmpty()) {
-      logger.debug("No resource classes skip JAX-RS server recreation");
+    if (serviceBeans.isEmpty()) {
+      logger.info("No resource classes skip JAX-RS server recreation");
       return;
     }
 
@@ -385,7 +365,6 @@ public class RestPublisher implements RestConstants {
     sf.setProviders(providers);
 
     // Set the service class
-    sf.setResourceProviders(new ArrayList<>(resourceProviders.values()));
     sf.setResourceComparator(new OsgiCxfEndpointComparator());
 
     sf.setAddress("/");
@@ -402,6 +381,7 @@ public class RestPublisher implements RestConstants {
       server.destroy();
     }
 
+    sf.setServiceBeans(serviceBeans);
     server = sf.create();
   }
 
@@ -456,7 +436,7 @@ public class RestPublisher implements RestConstants {
     @Override
     public void removedService(ServiceReference<Object> reference, Object service) {
       String servicePath = (String) reference.getProperty(SERVICE_PATH_PROPERTY);
-      destroyEndpoint(servicePath, reference);
+      destroyEndpoint(servicePath, service);
       super.removedService(reference, service);
     }
 
@@ -532,17 +512,22 @@ public class RestPublisher implements RestConstants {
 
       if (classpath != null && alias != null) {
         Dictionary<String, String> props = new Hashtable<>();
-        props.put(SharedHttpContext.ALIAS, alias);
-        props.put(SharedHttpContext.CONTEXT_ID, RestConstants.HTTP_CONTEXT_ID);
-        props.put(SharedHttpContext.SHARED, "true");
+
+        props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=" + RestConstants.HTTP_CONTEXT_ID + ")");
+        props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, alias);
+        if ("/".equals(alias)) {
+          props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, alias);
+        } else {
+          props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, alias + "/*");
+        }
         StaticResource servlet = new StaticResource(new StaticResourceClassLoader(bundle), classpath, alias,
                 welcomeFile, spaRedirect);
 
         // We use the newly added bundle's context to register this service, so when that bundle shuts down, it brings
         // down this servlet with it
-        logger.debug("Registering servlet with alias {}", alias);
+        logger.info("Registering servlet with alias {}", alias + "/*");
 
-        ServiceRegistration serviceRegistration = componentContext.getBundleContext()
+        ServiceRegistration<?> serviceRegistration = componentContext.getBundleContext()
                 .registerService(Servlet.class.getName(), servlet, props);
         servlets.put(bundle, serviceRegistration);
       }
@@ -573,29 +558,11 @@ public class RestPublisher implements RestConstants {
     /** Serialization UID */
     private static final long serialVersionUID = -8963338160276371426L;
 
-    /** Whether this servlet has been initialized by the http service */
-    private boolean initialized = false;
-
-    /**
-     * Whether the http service has initialized this servlet.
-     *
-     * @return the initialization state
-     */
-    public boolean isInitialized() {
-      return initialized;
-    }
-
     /**
      * Default constructor needed by Jetty
      */
     public RestServlet() {
 
-    }
-
-    @Override
-    public void init(ServletConfig servletConfig) throws ServletException {
-      super.init(servletConfig);
-      initialized = true;
     }
 
     @Override

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
@@ -55,7 +55,7 @@ import javax.servlet.http.HttpServletResponse;
         "service.description=Organization Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=2",
+        "service.ranking:Integer=2",
         "urlPatterns=*"
     }
 )

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/OrganizationFilter.java
@@ -29,6 +29,11 @@ import org.opencastproject.util.NotFoundException;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,16 +54,16 @@ import javax.servlet.http.HttpServletResponse;
  * Inspects request URLs and sets the organization for the request.
  */
 @Component(
-    immediate = true,
     service = Filter.class,
+    scope = ServiceScope.PROTOTYPE,
     property = {
         "service.description=Organization Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=2",
-        "urlPatterns=*"
     }
 )
+@ServiceRanking(980)
+@HttpWhiteboardFilterName("OrganizationFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class OrganizationFilter implements Filter {
 
   private static final String X_FORWARDED_FOR = "X-Forwarded-For";

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
@@ -74,7 +74,7 @@ import javax.servlet.http.HttpServletResponse;
         "service.description=Remote User and Organization Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=5",
+        "service.ranking:Integer=5",
         "urlPatterns=*"
     }
 )

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/RemoteUserAndOrganizationFilter.java
@@ -48,6 +48,11 @@ import com.entwinemedia.fn.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,16 +73,16 @@ import javax.servlet.http.HttpServletResponse;
  * Security filter used to set the organization and user in remote implementations.
  */
 @Component(
-    immediate = true,
     service = Filter.class,
+    scope = ServiceScope.PROTOTYPE,
     property = {
         "service.description=Remote User and Organization Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=5",
-        "urlPatterns=*"
     }
 )
+@ServiceRanking(8)
+@HttpWhiteboardFilterName("RemoteUserAndOrganizationFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class RemoteUserAndOrganizationFilter implements Filter {
 
   /** The logger */

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SecurityFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SecurityFilter.java
@@ -51,7 +51,7 @@ import javax.servlet.http.HttpServletResponse;
         "service.description=Security Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=3",
+        "service.ranking:Integer=3",
         "urlPatterns=*"
     }
 )

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SecurityFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SecurityFilter.java
@@ -26,6 +26,10 @@ import org.opencastproject.security.api.SecurityService;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,16 +49,15 @@ import javax.servlet.http.HttpServletResponse;
  * A servlet filter that delegates to the appropriate spring filter chain
  */
 @Component(
-    immediate = true,
-    service = { Filter.class,SecurityFilter.class },
+    service = { Filter.class, SecurityFilter.class },
     property = {
         "service.description=Security Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=3",
-        "urlPatterns=*"
     }
 )
+@ServiceRanking(970)
+@HttpWhiteboardFilterName("SecurityFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public final class SecurityFilter implements Filter {
 
   /** The logger */

--- a/modules/list-providers-service/pom.xml
+++ b/modules/list-providers-service/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/live-schedule-impl/pom.xml
+++ b/modules/live-schedule-impl/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/live-schedule-impl/pom.xml
+++ b/modules/live-schedule-impl/pom.xml
@@ -21,7 +21,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/modules/logging-workflowoperation/pom.xml
+++ b/modules/logging-workflowoperation/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <!-- Test Dependencies -->
     <dependency>

--- a/modules/lti-service-impl/pom.xml
+++ b/modules/lti-service-impl/pom.xml
@@ -18,7 +18,11 @@
     <!-- osgi support -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <!-- opencast -->
     <dependency>

--- a/modules/lti-service-remote/pom.xml
+++ b/modules/lti-service-remote/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/lti/pom.xml
+++ b/modules/lti/pom.xml
@@ -58,7 +58,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/lti/pom.xml
+++ b/modules/lti/pom.xml
@@ -41,6 +41,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http.whiteboard</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
     </dependency>

--- a/modules/lti/src/main/java/org/opencastproject/lti/LtiServlet.java
+++ b/modules/lti/src/main/java/org/opencastproject/lti/LtiServlet.java
@@ -24,6 +24,9 @@ package org.opencastproject.lti;
 import org.apache.commons.lang3.StringUtils;
 import org.json.simple.JSONObject;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,15 +54,14 @@ import javax.ws.rs.core.UriBuilder;
  * produce JSON containing the LTI parameters passed during LTI launch.
  */
 @Component(
-    immediate = true,
     service = Servlet.class,
     property = {
         "service.description=LTI Servlet",
-        "alias=/lti",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true"
     }
 )
+@HttpWhiteboardServletName("/lti")
+@HttpWhiteboardServletPattern("/lti/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class LtiServlet extends HttpServlet {
 
   private static final String LTI_CUSTOM_PREFIX = "custom_";

--- a/modules/mattermost-notification-workflowoperation/pom.xml
+++ b/modules/mattermost-notification-workflowoperation/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/message-broker-api/pom.xml
+++ b/modules/message-broker-api/pom.xml
@@ -58,7 +58,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/metadata-to-acl-workflowoperation/pom.xml
+++ b/modules/metadata-to-acl-workflowoperation/pom.xml
@@ -46,9 +46,13 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+      <scope>compile</scope>
+    </dependency>
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -66,6 +70,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/modules/metadata/pom.xml
+++ b/modules/metadata/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/metrics-exporter/pom.xml
+++ b/modules/metrics-exporter/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/metrics-exporter/pom.xml
+++ b/modules/metrics-exporter/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>

--- a/modules/mpeg7/pom.xml
+++ b/modules/mpeg7/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/notification-workflowoperation/pom.xml
+++ b/modules/notification-workflowoperation/pom.xml
@@ -72,7 +72,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
   </dependencies>
   <build>
@@ -80,6 +88,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/modules/oaipmh-persistence/pom.xml
+++ b/modules/oaipmh-persistence/pom.xml
@@ -42,7 +42,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/modules/oaipmh-remote/pom.xml
+++ b/modules/oaipmh-remote/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/oaipmh/pom.xml
+++ b/modules/oaipmh/pom.xml
@@ -79,7 +79,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/oaipmh/pom.xml
+++ b/modules/oaipmh/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/plugin-manager/pom.xml
+++ b/modules/plugin-manager/pom.xml
@@ -34,8 +34,12 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.cm</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/presets/pom.xml
+++ b/modules/presets/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/publication-service-configurable-remote/pom.xml
+++ b/modules/publication-service-configurable-remote/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/publication-service-configurable/pom.xml
+++ b/modules/publication-service-configurable/pom.xml
@@ -41,7 +41,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/publication-service-oaipmh-remote/pom.xml
+++ b/modules/publication-service-oaipmh-remote/pom.xml
@@ -22,7 +22,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/publication-service-oaipmh/pom.xml
+++ b/modules/publication-service-oaipmh/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/publication-service-youtube-remote/pom.xml
+++ b/modules/publication-service-youtube-remote/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -142,7 +142,7 @@
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <!-- The following dependencies are required at runtime: -->
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.checkerframework:checker-qual</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.felix:org.apache.felix.http.bundle</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>

--- a/modules/publication-service-youtube-v3/pom.xml
+++ b/modules/publication-service-youtube-v3/pom.xml
@@ -57,7 +57,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -173,6 +181,7 @@
               !oracle.xml.parser.*,
               !org.jaxen.*,
               !sun.security.util,
+              !org.osgi.service.log,
               javax.ws.rs;version=2.0.1,
               javax.ws.rs.core;version=2.0.1,
               *

--- a/modules/redirect/pom.xml
+++ b/modules/redirect/pom.xml
@@ -22,7 +22,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/modules/rename-files-workflowoperation/pom.xml
+++ b/modules/rename-files-workflowoperation/pom.xml
@@ -45,7 +45,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/runtime-info/pom.xml
+++ b/modules/runtime-info/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http.whiteboard</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -99,7 +103,6 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Build-Number>${buildNumber}</Build-Number>
-            <Bundle-Activator>org.opencastproject.runtimeinfo.Activator</Bundle-Activator>
             <Private-Package>
               org.opencastproject.runtimeinfo.rest
             </Private-Package>

--- a/modules/runtime-info/pom.xml
+++ b/modules/runtime-info/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/runtime-info/pom.xml
+++ b/modules/runtime-info/pom.xml
@@ -43,7 +43,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -76,6 +84,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
         <extensions>true</extensions>
       </plugin>
       <plugin>

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RestDocsServlet.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RestDocsServlet.java
@@ -34,19 +34,21 @@ import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestService;
 
 import org.apache.commons.lang3.StringUtils;
-import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Dictionary;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 
 import javax.servlet.Servlet;
@@ -59,10 +61,17 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
 /** A bundle activator that registers the REST documentation servlet. */
-public class Activator extends HttpServlet implements BundleActivator {
+@Component(service = Servlet.class)
+@HttpWhiteboardServletName(RestDocsServlet.SERVLET_PATH)
+@HttpWhiteboardServletPattern(RestDocsServlet.SERVLET_PATH)
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
+public class RestDocsServlet extends HttpServlet {
 
   /** The logger */
-  private static final Logger logger = LoggerFactory.getLogger(Activator.class);
+  private static final Logger logger = LoggerFactory.getLogger(RestDocsServlet.class);
+
+  /** The servlet path */
+  public static final String SERVLET_PATH = "/docs.html";
 
   /** The query string parameter used to specify a specific service */
   private static final String PATH_PARAM = "path";
@@ -76,13 +85,10 @@ public class Activator extends HttpServlet implements BundleActivator {
   /** A map of global macro values for REST documentation. */
   private Map<String, String> globalMacro;
 
-  @Override
+  @Activate
   public void start(BundleContext bundleContext) throws Exception {
     this.bundleContext = bundleContext;
-    Dictionary<String, String> props = new Hashtable<String, String>();
-    props.put("alias", "/docs.html");
     prepareMacros();
-    bundleContext.registerService(Servlet.class.getName(), this, props);
   }
 
   /** Add a list of global information, such as the server URL, to the globalMacro map. */
@@ -93,7 +99,6 @@ public class Activator extends HttpServlet implements BundleActivator {
     globalMacro.put("LOCAL_STORAGE_DIRECTORY", bundleContext.getProperty("org.opencastproject.storage.dir"));
   }
 
-  @Override
   public void stop(BundleContext bundleContext) throws Exception {
   }
 

--- a/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
+++ b/modules/runtime-info/src/main/java/org/opencastproject/runtimeinfo/RuntimeInfo.java
@@ -46,6 +46,7 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -90,12 +91,11 @@ import javax.ws.rs.core.MediaType;
     notes = {}
 )
 @Component(
-    immediate = true,
     service = RuntimeInfo.class,
     property = {
         "service.description=Runtime Information REST Endpoint",
         "opencast.service.type=org.opencastproject.info",
-        "opencast.service.path=/info"
+        "opencast.service.path=/info",
     }
 )
 public class RuntimeInfo {
@@ -159,6 +159,7 @@ public class RuntimeInfo {
     return bundleContext.getAllServiceReferences(Servlet.class.getName(), "(&(alias=*)(classpath=*))");
   }
 
+  @Activate
   public void activate(ComponentContext cc) throws MalformedURLException {
     logger.debug("start()");
     this.bundleContext = cc.getBundleContext();

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -121,7 +121,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -117,7 +117,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/scheduler-remote/pom.xml
+++ b/modules/scheduler-remote/pom.xml
@@ -58,7 +58,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/search-service-feeds/pom.xml
+++ b/modules/search-service-feeds/pom.xml
@@ -37,7 +37,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/search-service-feeds/pom.xml
+++ b/modules/search-service-feeds/pom.xml
@@ -41,7 +41,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>osgi.cmpn</artifactId>
+          <artifactId>org.osgi.service.component.annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -51,7 +51,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -94,7 +94,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>com.rometools</groupId>

--- a/modules/search-service-impl/pom.xml
+++ b/modules/search-service-impl/pom.xml
@@ -90,7 +90,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/search-service-remote/pom.xml
+++ b/modules/search-service-remote/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/security-jwt/pom.xml
+++ b/modules/security-jwt/pom.xml
@@ -62,7 +62,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/modules/security-lti/pom.xml
+++ b/modules/security-lti/pom.xml
@@ -35,7 +35,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/series-service-impl/pom.xml
+++ b/modules/series-service-impl/pom.xml
@@ -76,7 +76,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/series-service-impl/pom.xml
+++ b/modules/series-service-impl/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/series-service-remote/pom.xml
+++ b/modules/series-service-remote/pom.xml
@@ -77,7 +77,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -56,7 +56,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/modules/serviceregistry/pom.xml
+++ b/modules/serviceregistry/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/shared-filesystem-utils/pom.xml
+++ b/modules/shared-filesystem-utils/pom.xml
@@ -47,7 +47,7 @@
     <!-- -->
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/shared-filesystem-utils/pom.xml
+++ b/modules/shared-filesystem-utils/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/silencedetection-impl/pom.xml
+++ b/modules/silencedetection-impl/pom.xml
@@ -75,7 +75,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/modules/silencedetection-impl/pom.xml
+++ b/modules/silencedetection-impl/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/silencedetection-remote/pom.xml
+++ b/modules/silencedetection-remote/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/smil-impl/pom.xml
+++ b/modules/smil-impl/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/smil-workflowoperation/pom.xml
+++ b/modules/smil-workflowoperation/pom.xml
@@ -77,7 +77,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/solr/pom.xml
+++ b/modules/solr/pom.xml
@@ -22,7 +22,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/solr/pom.xml
+++ b/modules/solr/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.solr</groupId>

--- a/modules/sox-impl/pom.xml
+++ b/modules/sox-impl/pom.xml
@@ -49,7 +49,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.cm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/modules/sox-impl/pom.xml
+++ b/modules/sox-impl/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/sox-remote/pom.xml
+++ b/modules/sox-remote/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/sox-workflowoperation/pom.xml
+++ b/modules/sox-workflowoperation/pom.xml
@@ -68,7 +68,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/speech-to-text-impl/pom.xml
+++ b/modules/speech-to-text-impl/pom.xml
@@ -43,7 +43,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/modules/speech-to-text-impl/pom.xml
+++ b/modules/speech-to-text-impl/pom.xml
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/speech-to-text-remote/pom.xml
+++ b/modules/speech-to-text-remote/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/speech-to-text-workflowoperation/pom.xml
+++ b/modules/speech-to-text-workflowoperation/pom.xml
@@ -66,7 +66,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/static-file-service-api/pom.xml
+++ b/modules/static-file-service-api/pom.xml
@@ -46,7 +46,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/static-file-service-api/pom.xml
+++ b/modules/static-file-service-api/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/static-file-service-impl/pom.xml
+++ b/modules/static-file-service-impl/pom.xml
@@ -47,7 +47,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/static-file-service-impl/pom.xml
+++ b/modules/static-file-service-impl/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/static/pom.xml
+++ b/modules/static/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http.whiteboard</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/modules/static/pom.xml
+++ b/modules/static/pom.xml
@@ -29,7 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/static/pom.xml
+++ b/modules/static/pom.xml
@@ -33,7 +33,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/modules/static/src/main/java/org/opencastproject/fsresources/StaticResourceServlet.java
+++ b/modules/static/src/main/java/org/opencastproject/fsresources/StaticResourceServlet.java
@@ -34,6 +34,9 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,13 +66,12 @@ import javax.servlet.http.HttpServletResponse;
 @Component(
     property = {
         "service.description=Opencast Download Resources",
-        "alias=/static",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true"
     },
-    immediate = true,
     service = Servlet.class
 )
+@HttpWhiteboardServletName(StaticResourceServlet.SERVLET_PATH)
+@HttpWhiteboardServletPattern(StaticResourceServlet.SERVLET_PATH + "/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
 public class StaticResourceServlet extends HttpServlet {
 
   /** The serialization UID */
@@ -86,6 +88,8 @@ public class StaticResourceServlet extends HttpServlet {
   static {
     FULL_RANGE = new ArrayList<>();
   }
+
+  public static final String SERVLET_PATH = "/static";
 
   /** The filesystem directory to serve files fro */
   private String distributionDirectory;

--- a/modules/statistics-export-service-impl/pom.xml
+++ b/modules/statistics-export-service-impl/pom.xml
@@ -66,7 +66,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/statistics-provider-influx/pom.xml
+++ b/modules/statistics-provider-influx/pom.xml
@@ -37,7 +37,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -57,7 +65,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>osgi.cmpn</artifactId>
+          <artifactId>org.osgi.service.cm</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/modules/statistics-provider-influx/pom.xml
+++ b/modules/statistics-provider-influx/pom.xml
@@ -53,7 +53,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/statistics-provider-random/pom.xml
+++ b/modules/statistics-provider-random/pom.xml
@@ -28,7 +28,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -44,7 +48,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>osgi.cmpn</artifactId>
+          <artifactId>org.osgi.service.cm</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/modules/statistics-provider-random/pom.xml
+++ b/modules/statistics-provider-random/pom.xml
@@ -40,7 +40,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/statistics-service-impl/pom.xml
+++ b/modules/statistics-service-impl/pom.xml
@@ -35,7 +35,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/statistics-service-remote/pom.xml
+++ b/modules/statistics-service-remote/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/statistics-writer-workflowoperation/pom.xml
+++ b/modules/statistics-writer-workflowoperation/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/termination-state-api/pom.xml
+++ b/modules/termination-state-api/pom.xml
@@ -35,7 +35,13 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -61,7 +67,8 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>org.osgi:osgi.cmpn</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.component</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/termination-state-api/pom.xml
+++ b/modules/termination-state-api/pom.xml
@@ -31,7 +31,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -60,7 +60,7 @@
         <extensions>true</extensions>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.osgi:osgi.cmpn</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/modules/termination-state-aws/pom.xml
+++ b/modules/termination-state-aws/pom.xml
@@ -40,7 +40,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/termination-state-impl/pom.xml
+++ b/modules/termination-state-impl/pom.xml
@@ -39,7 +39,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/textanalyzer-impl/pom.xml
+++ b/modules/textanalyzer-impl/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -68,7 +68,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <!-- without osgi.core the module doesn't compile, even though it isn't used directly, but in oc-common -->
-            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.core</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:osgi.core</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/textanalyzer-impl/pom.xml
+++ b/modules/textanalyzer-impl/pom.xml
@@ -57,7 +57,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/textanalyzer-remote/pom.xml
+++ b/modules/textanalyzer-remote/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/textanalyzer-workflowoperation/pom.xml
+++ b/modules/textanalyzer-workflowoperation/pom.xml
@@ -55,7 +55,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/textextractor-tesseract/pom.xml
+++ b/modules/textextractor-tesseract/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/textextractor-tesseract/pom.xml
+++ b/modules/textextractor-tesseract/pom.xml
@@ -50,7 +50,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/modules/themes-workflowoperation/pom.xml
+++ b/modules/themes-workflowoperation/pom.xml
@@ -17,7 +17,7 @@
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.entwinemedia.common</groupId>

--- a/modules/themes/pom.xml
+++ b/modules/themes/pom.xml
@@ -40,7 +40,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/timelinepreviews-ffmpeg/pom.xml
+++ b/modules/timelinepreviews-ffmpeg/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/timelinepreviews-ffmpeg/pom.xml
+++ b/modules/timelinepreviews-ffmpeg/pom.xml
@@ -57,7 +57,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>

--- a/modules/timelinepreviews-remote/pom.xml
+++ b/modules/timelinepreviews-remote/pom.xml
@@ -43,8 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
-      <scope>compile</scope>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
 

--- a/modules/timelinepreviews-workflowoperation/pom.xml
+++ b/modules/timelinepreviews-workflowoperation/pom.xml
@@ -53,7 +53,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -33,7 +33,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/transcription-service-amberscript/pom.xml
+++ b/modules/transcription-service-amberscript/pom.xml
@@ -73,7 +73,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/modules/transcription-service-google-speech-impl/pom.xml
+++ b/modules/transcription-service-google-speech-impl/pom.xml
@@ -74,7 +74,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -137,6 +145,7 @@
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <!-- provide a database for testing -->
             <ignoredUnusedDeclaredDependency>com.h2database:h2</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/transcription-service-google-speech-impl/pom.xml
+++ b/modules/transcription-service-google-speech-impl/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/transcription-service-ibm-watson-impl/pom.xml
+++ b/modules/transcription-service-ibm-watson-impl/pom.xml
@@ -82,7 +82,16 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -134,6 +143,7 @@
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <!-- test database -->
             <ignoredUnusedDeclaredDependency>com.h2database:h2</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/transcription-service-ibm-watson-impl/pom.xml
+++ b/modules/transcription-service-ibm-watson-impl/pom.xml
@@ -78,7 +78,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/transcription-service-microsoft-azure/pom.xml
+++ b/modules/transcription-service-microsoft-azure/pom.xml
@@ -79,7 +79,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
@@ -127,6 +135,7 @@
             <!-- provide a database for testing -->
             <ignoredUnusedDeclaredDependency>com.h2database:h2</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.servicemix.bundles</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.osgi:org.osgi.service.cm</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/transcription-service-microsoft-azure/pom.xml
+++ b/modules/transcription-service-microsoft-azure/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/transcription-service-persistence/pom.xml
+++ b/modules/transcription-service-persistence/pom.xml
@@ -26,7 +26,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/transcription-service-workflowoperation/pom.xml
+++ b/modules/transcription-service-workflowoperation/pom.xml
@@ -46,7 +46,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/urlsigning-service-impl/pom.xml
+++ b/modules/urlsigning-service-impl/pom.xml
@@ -46,7 +46,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- Opencast -->
     <dependency>

--- a/modules/urlsigning-verifier-service-impl/pom.xml
+++ b/modules/urlsigning-verifier-service-impl/pom.xml
@@ -32,7 +32,6 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
@@ -41,12 +40,17 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
-    <!-- Opencast -->
     <dependency>
-      <groupId>org.opencastproject</groupId>
-      <artifactId>opencast-common</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http.whiteboard</artifactId>
+      <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <!-- Opencast -->
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-urlsigning-common</artifactId>

--- a/modules/urlsigning-verifier-service-impl/pom.xml
+++ b/modules/urlsigning-verifier-service-impl/pom.xml
@@ -32,9 +32,14 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- Opencast -->
     <dependency>

--- a/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilter.java
+++ b/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilter.java
@@ -60,7 +60,7 @@ import javax.servlet.http.HttpServletResponse;
         "service.description=Url Signing Filter",
         "httpContext.id=opencast.httpcontext",
         "httpContext.shared=true",
-        "service.ranking=9",
+        "service.ranking:Integer=9",
         "urlPatterns=*"
     }
 )

--- a/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilter.java
+++ b/modules/urlsigning-verifier-service-impl/src/main/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilter.java
@@ -24,23 +24,25 @@ package org.opencastproject.security.urlsigning.filter;
 import org.opencastproject.security.urlsigning.exception.UrlSigningException;
 import org.opencastproject.security.urlsigning.verifier.UrlSigningVerifier;
 import org.opencastproject.urlsigning.common.ResourceRequest;
-import org.opencastproject.util.OsgiUtil;
-import org.opencastproject.util.data.Option;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.osgi.service.cm.ConfigurationException;
-import org.osgi.service.cm.ManagedService;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.component.propertytypes.ServiceRanking;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterName;
+import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardFilterPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,17 +56,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Component(
-    immediate = true,
-    service = { Filter.class,ManagedService.class },
+    scope = ServiceScope.PROTOTYPE,
     property = {
         "service.description=Url Signing Filter",
-        "httpContext.id=opencast.httpcontext",
-        "httpContext.shared=true",
-        "service.ranking:Integer=9",
-        "urlPatterns=*"
     }
 )
-public class UrlSigningFilter implements Filter, ManagedService {
+@ServiceRanking(7)
+@HttpWhiteboardFilterName("UrlSigningFilter")
+@HttpWhiteboardFilterPattern("/*")
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=opencast)")
+public class UrlSigningFilter implements Filter {
   /** The prefix in the configuration file to define the regex that will match a url path. */
   public static final String URL_REGEX_PREFIX = "url.regex";
   /** The property in the configuration file to enable or disable this filter. */
@@ -206,13 +207,14 @@ public class UrlSigningFilter implements Filter, ManagedService {
     return this.getClass().getSimpleName();
   }
 
-  @Override
-  public void updated(Dictionary<String, ?> properties) throws ConfigurationException {
+  @Activate
+  @Modified
+  public void updated(Map<String, Object> properties) {
     logger.info("Updating UrlSigningFilter");
 
-    Option<String> enableFilterConfig = OsgiUtil.getOptCfg(properties, ENABLE_FILTER_CONFIG_KEY);
-    if (enableFilterConfig.isSome()) {
-      enabled = Boolean.parseBoolean(enableFilterConfig.get());
+    String enableFilterConfig = (String) properties.get(ENABLE_FILTER_CONFIG_KEY);
+    if (enableFilterConfig != null) {
+      enabled = Boolean.parseBoolean(enableFilterConfig);
       if (enabled) {
         logger.info("The UrlSigningFilter is configured to be enabled.");
       } else {
@@ -226,9 +228,9 @@ public class UrlSigningFilter implements Filter, ManagedService {
           ENABLE_FILTER_CONFIG_KEY);
     }
 
-    Option<String> strictFilterConfig = OsgiUtil.getOptCfg(properties, STRICT_FILTER_CONFIG_KEY);
-    if (strictFilterConfig.isSome()) {
-      strict = Boolean.parseBoolean(strictFilterConfig.get());
+    String strictFilterConfig = (String) properties.get(STRICT_FILTER_CONFIG_KEY);
+    if (strictFilterConfig != null) {
+      strict = Boolean.parseBoolean(strictFilterConfig);
       if (strict) {
         logger.info("The UrlSigningFilter is configured to use strict checking of resource URLs.");
       } else {
@@ -250,9 +252,7 @@ public class UrlSigningFilter implements Filter, ManagedService {
       return;
     }
 
-    Enumeration<String> propertyKeys = properties.keys();
-    while (propertyKeys.hasMoreElements()) {
-      String propertyKey = propertyKeys.nextElement();
+    for (String propertyKey : properties.keySet()) {
       if (!propertyKey.startsWith(URL_REGEX_PREFIX)) {
         continue;
       }
@@ -261,10 +261,8 @@ public class UrlSigningFilter implements Filter, ManagedService {
       logger.debug("Looking for configuration of {} and found '{}'", propertyKey, urlRegularExpression);
       // Has the url signing provider been fully configured
       if (urlRegularExpression == null) {
-        logger.debug(
-            "Unable to configure url regular expression with id '{}' because it is missing. "
-                + "Stopping to look for new keys.",
-            propertyKey);
+        logger.debug("Unable to configure url regular expression with id '{}' because it is missing. "
+            + "Stopping to look for new keys.", propertyKey);
         break;
       }
 

--- a/modules/urlsigning-verifier-service-impl/src/test/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilterTest.java
+++ b/modules/urlsigning-verifier-service-impl/src/test/java/org/opencastproject/security/urlsigning/filter/UrlSigningFilterTest.java
@@ -37,6 +37,7 @@ import org.osgi.service.cm.ConfigurationException;
 
 import java.io.IOException;
 import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Properties;
@@ -49,14 +50,14 @@ import javax.servlet.http.HttpServletResponse;
 
 public class UrlSigningFilterTest {
   private static final String BASE_URL = "http://test.com";
-  private Dictionary<String, String> matchAllProperties;
+  private HashMap<String, Object> matchAllProperties;
   private String keyId = "TheKeyID";
   private String key = "TheFullKey";
   private String clientIp = "10.0.0.1";
 
   @Before
   public void setUp() {
-    matchAllProperties = new Hashtable<>();
+    matchAllProperties = new HashMap<>();
     matchAllProperties.put(UrlSigningFilter.URL_REGEX_PREFIX + ".foo", ".*");
   }
 
@@ -109,7 +110,7 @@ public class UrlSigningFilterTest {
     Properties properties = new Properties();
     properties.load(IOUtils.toInputStream(IOUtils.toString(getClass().getResource("/UrlSigningFilter.properties"))));
     UrlSigningFilter filter = new UrlSigningFilter();
-    filter.updated(new Hashtable<>(properties.entrySet().stream()
+    filter.updated(new HashMap<>(properties.entrySet().stream()
             .collect(Collectors.toMap(
                     (Map.Entry<Object, Object> entry) -> (String) entry.getKey(),
                     Map.Entry::getValue))));

--- a/modules/user-interface-configuration/pom.xml
+++ b/modules/user-interface-configuration/pom.xml
@@ -32,7 +32,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/modules/user-interface-configuration/pom.xml
+++ b/modules/user-interface-configuration/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-brightspace/pom.xml
+++ b/modules/userdirectory-brightspace/pom.xml
@@ -28,7 +28,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-brightspace/pom.xml
+++ b/modules/userdirectory-brightspace/pom.xml
@@ -32,7 +32,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/userdirectory-canvas/pom.xml
+++ b/modules/userdirectory-canvas/pom.xml
@@ -26,7 +26,15 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.cmpn</artifactId>
+            <artifactId>org.osgi.service.component</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.component.annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.cm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/modules/userdirectory-ldap/pom.xml
+++ b/modules/userdirectory-ldap/pom.xml
@@ -47,7 +47,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/userdirectory-ldap/pom.xml
+++ b/modules/userdirectory-ldap/pom.xml
@@ -43,7 +43,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-moodle/pom.xml
+++ b/modules/userdirectory-moodle/pom.xml
@@ -30,7 +30,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/userdirectory-moodle/pom.xml
+++ b/modules/userdirectory-moodle/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-sakai/pom.xml
+++ b/modules/userdirectory-sakai/pom.xml
@@ -30,7 +30,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/userdirectory-sakai/pom.xml
+++ b/modules/userdirectory-sakai/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory-studip/pom.xml
+++ b/modules/userdirectory-studip/pom.xml
@@ -30,7 +30,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.cm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/userdirectory-studip/pom.xml
+++ b/modules/userdirectory-studip/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -56,7 +56,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.cm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/modules/usertracking-impl/pom.xml
+++ b/modules/usertracking-impl/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/usertracking-impl/pom.xml
+++ b/modules/usertracking-impl/pom.xml
@@ -51,7 +51,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/videoeditor-ffmpeg-impl/pom.xml
+++ b/modules/videoeditor-ffmpeg-impl/pom.xml
@@ -96,7 +96,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/videoeditor-ffmpeg-impl/pom.xml
+++ b/modules/videoeditor-ffmpeg-impl/pom.xml
@@ -100,7 +100,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/videoeditor-remote/pom.xml
+++ b/modules/videoeditor-remote/pom.xml
@@ -72,8 +72,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
-      <scope>compile</scope>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/modules/videoeditor-workflowoperation/pom.xml
+++ b/modules/videoeditor-workflowoperation/pom.xml
@@ -73,7 +73,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/videogrid-remote/pom.xml
+++ b/modules/videogrid-remote/pom.xml
@@ -45,8 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
-      <scope>compile</scope>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/videogrid-service-impl/pom.xml
+++ b/modules/videogrid-service-impl/pom.xml
@@ -51,7 +51,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/modules/videogrid-workflowoperation/pom.xml
+++ b/modules/videogrid-workflowoperation/pom.xml
@@ -84,8 +84,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
-      <scope>compile</scope>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/videosegmenter-ffmpeg/pom.xml
+++ b/modules/videosegmenter-ffmpeg/pom.xml
@@ -63,7 +63,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/modules/videosegmenter-ffmpeg/pom.xml
+++ b/modules/videosegmenter-ffmpeg/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/videosegmenter-remote/pom.xml
+++ b/modules/videosegmenter-remote/pom.xml
@@ -41,7 +41,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/videosegmenter-workflowoperation/pom.xml
+++ b/modules/videosegmenter-workflowoperation/pom.xml
@@ -45,7 +45,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/waveform-ffmpeg/pom.xml
+++ b/modules/waveform-ffmpeg/pom.xml
@@ -52,7 +52,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/waveform-ffmpeg/pom.xml
+++ b/modules/waveform-ffmpeg/pom.xml
@@ -56,7 +56,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <!-- Testing -->
     <dependency>

--- a/modules/waveform-remote/pom.xml
+++ b/modules/waveform-remote/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/modules/waveform-workflowoperation/pom.xml
+++ b/modules/waveform-workflowoperation/pom.xml
@@ -37,7 +37,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/workflow-service-api/pom.xml
+++ b/modules/workflow-service-api/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/workflow-service-api/pom.xml
+++ b/modules/workflow-service-api/pom.xml
@@ -38,7 +38,12 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -96,7 +96,15 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.cm</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>
@@ -108,7 +116,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>osgi.cmpn</artifactId>
+          <artifactId>org.osgi.service.cm</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -104,7 +104,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.felix</groupId>
-          <artifactId>org.osgi.core</artifactId>
+          <artifactId>osgi.core</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.felix</groupId>

--- a/modules/workflow-service-remote/pom.xml
+++ b/modules/workflow-service-remote/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -138,7 +138,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -134,7 +134,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -145,6 +145,10 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http.whiteboard</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>

--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ResumableWorkflowOperationHandlerBase.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/ResumableWorkflowOperationHandlerBase.java
@@ -34,6 +34,7 @@ import org.opencastproject.workflow.api.WorkflowOperationResult.Action;
 import org.apache.commons.io.FilenameUtils;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -131,9 +132,10 @@ public class ResumableWorkflowOperationHandlerBase extends AbstractWorkflowOpera
     String path = FilenameUtils.getPathNoEndSeparator(resourcePath);
     String welcomeFile = FilenameUtils.getName(resourcePath);
     staticResource = new StaticResource(getClass().getClassLoader(), path, alias, welcomeFile);
-    Dictionary<String, String> props = new Hashtable<String, String>();
-    props.put("httpContext.id", RestConstants.HTTP_CONTEXT_ID);
-    props.put("alias", alias);
+    Dictionary<String, String> props = new Hashtable<>();
+    props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=" + RestConstants.HTTP_CONTEXT_ID + ")");
+    props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, alias);
+    props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN, alias + "/*");
     staticResourceRegistration = componentContext.getBundleContext().registerService(Servlet.class.getName(),
             staticResource, props);
     return staticResource.getDefaultUrl();

--- a/modules/working-file-repository-service-impl/pom.xml
+++ b/modules/working-file-repository-service-impl/pom.xml
@@ -55,7 +55,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/modules/working-file-repository-service-impl/pom.xml
+++ b/modules/working-file-repository-service-impl/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/workspace-impl/pom.xml
+++ b/modules/workspace-impl/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
+      <artifactId>osgi.core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/modules/workspace-impl/pom.xml
+++ b/modules/workspace-impl/pom.xml
@@ -53,7 +53,11 @@
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
-      <artifactId>osgi.cmpn</artifactId>
+      <artifactId>org.osgi.service.component</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <commons-io.version>2.8.0</commons-io.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-text.version>1.10.0</commons-text.version>
-    <cxf.version>3.4.6</cxf.version>
+    <cxf.version>3.5.5</cxf.version>
     <eclipselink.version>2.7.8</eclipselink.version>
     <failureaccess.version>1.0.1</failureaccess.version>
     <freemarker.version>2.3.31</freemarker.version>
@@ -45,11 +45,15 @@
     <karaf.version>4.4.3</karaf.version>
     <node.version>v16.13.0</node.version>
     <osgi.core.version>8.0.0</osgi.core.version>
+    <osgi.annotation.version>8.1.0</osgi.annotation.version>
     <org.osgi.service.component.version>1.5.0</org.osgi.service.component.version>
     <org.osgi.service.component.annotations.version>1.5.0</org.osgi.service.component.annotations.version>
     <org.osgi.service.cm.version>1.6.0</org.osgi.service.cm.version>
     <org.osgi.service.log.version>1.5.0</org.osgi.service.log.version>
     <org.osgi.service.http.version>1.2.1</org.osgi.service.http.version>
+    <org.osgi.service.http.whiteboard.version>1.1.1</org.osgi.service.http.whiteboard.version>
+    <org.osgi.service.jaxrs.version>1.0.1</org.osgi.service.jaxrs.version>
+    <pax.web.version>8.0.15</pax.web.version>
     <querydsl.version>3.7.4</querydsl.version>
     <rest-assured.version>4.4.0</rest-assured.version>
     <spring.version>3.1.4.RELEASE</spring.version>
@@ -896,9 +900,25 @@
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.http.whiteboard</artifactId>
+        <version>${org.osgi.service.http.whiteboard.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
         <artifactId>org.osgi.service.component.annotations</artifactId>
         <version>${org.osgi.service.component.annotations.version}</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.jaxrs</artifactId>
+        <version>${org.osgi.service.jaxrs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>osgi.annotation</artifactId>
+        <version>${osgi.annotation.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.felix</groupId>
@@ -1368,8 +1388,14 @@
       </dependency>
       <dependency>
         <groupId>org.ops4j.pax.web</groupId>
+        <artifactId>pax-web-api</artifactId>
+        <version>${pax.web.version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.web</groupId>
         <artifactId>pax-web-extender-whiteboard</artifactId>
-        <version>8.0.15</version>
+        <version>${pax.web.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,14 @@
     <jettison.version>1.5.4</jettison.version>
     <joda-time.version>2.12.5</joda-time.version>
     <json-simple.version>1.1.1</json-simple.version>
-    <karaf.version>4.2.16</karaf.version>
+    <karaf.version>4.4.3</karaf.version>
     <node.version>v16.13.0</node.version>
-    <osgi.compendium.version>6.0.0</osgi.compendium.version>
-    <osgi.core.version>6.0.0</osgi.core.version>
+    <osgi.core.version>8.0.0</osgi.core.version>
+    <org.osgi.service.component.version>1.5.0</org.osgi.service.component.version>
+    <org.osgi.service.component.annotations.version>1.5.0</org.osgi.service.component.annotations.version>
+    <org.osgi.service.cm.version>1.6.0</org.osgi.service.cm.version>
+    <org.osgi.service.log.version>1.5.0</org.osgi.service.log.version>
+    <org.osgi.service.http.version>1.2.1</org.osgi.service.http.version>
     <querydsl.version>3.7.4</querydsl.version>
     <rest-assured.version>4.4.0</rest-assured.version>
     <spring.version>3.1.4.RELEASE</spring.version>
@@ -868,8 +872,32 @@
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
-        <artifactId>osgi.cmpn</artifactId>
-        <version>${osgi.compendium.version}</version>
+        <artifactId>org.osgi.service.cm</artifactId>
+        <version>${org.osgi.service.cm.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.log</artifactId>
+        <version>${org.osgi.service.log.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.component</artifactId>
+        <version>${org.osgi.service.component.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.http</artifactId>
+        <version>${org.osgi.service.http.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.service.component.annotations</artifactId>
+        <version>${org.osgi.service.component.annotations.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -1125,12 +1153,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.33</version>
+        <version>1.7.36</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.33</version>
+        <version>1.7.36</version>
       </dependency>
       <!-- apache commons syncing -->
       <dependency>
@@ -1337,6 +1365,11 @@
             <artifactId>stax-api</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.ops4j.pax.web</groupId>
+        <artifactId>pax-web-extender-whiteboard</artifactId>
+        <version>8.0.15</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -862,7 +862,7 @@
       <!-- OSGi -->
       <dependency>
         <groupId>org.osgi</groupId>
-        <artifactId>org.osgi.core</artifactId>
+        <artifactId>osgi.core</artifactId>
         <version>${osgi.core.version}</version>
         <scope>provided</scope>
       </dependency>


### PR DESCRIPTION
This PR upgrades Karaf to version 4.4.3 and OSGi to version 8. 

Changes:
- The OSGi compendium got split up into several bundles
- Switching to OSGi Http Whiteboard pattern
- Filters are ordered from highest rank to lowest. 

The pax-web-karaf feature adds the following console commands to the develop distribution:

- web:servlet-list
- web:context-list

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
