### PR TITLE
Better handling for AM AWS Glacier file access

### DIFF
--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/Asset.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/Asset.java
@@ -53,6 +53,9 @@ public interface Asset {
   /** Tell about the availability of the asset. */
   Availability getAvailability();
 
+  /** How many milliseconds to wait before checking availability again. */
+  int getNextCheckIn();
+
   /** Get the store ID of the asset store where this snapshot currently lives */
   String getStorageId();
 

--- a/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/storage/RemoteAssetStore.java
+++ b/modules/asset-manager-api/src/main/java/org/opencastproject/assetmanager/api/storage/RemoteAssetStore.java
@@ -21,8 +21,34 @@
 
 package org.opencastproject.assetmanager.api.storage;
 
+import org.opencastproject.assetmanager.api.Availability;
+
+import java.io.InputStream;
+
 public interface RemoteAssetStore extends AssetStore {
   // Defines the root directory to be used for any caching done by a remote
   // asset store.  Caches should live as directories under this directory.
   String ASSET_STORE_CACHE_ROOT = "org.opencastproject.assetmanager.storage.cache.rootdir";
+
+  InputStream streamNotReady = new InputStream() {
+    @Override
+    public int read() {
+      return -1;  // end of stream
+    }
+
+    @Override
+    public int available() {
+      return 0;
+    }
+  };
+
+  Availability getAvailability(StoragePath path) throws AssetStoreException;
+
+  /**
+   * Returns an estimate in millisecs of when the element stream might be ready to read
+   * @param path to element
+   * @return
+   * @throws AssetStoreException
+   */
+  Integer getReadyEstimate(StoragePath path) throws AssetStoreException;
 }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetImpl.java
@@ -36,8 +36,27 @@ public class AssetImpl implements Asset {
   private final Opt<MimeType> mimeType;
   private final long size;
   private final Availability availability;
+  private final int nextCheck;
   private final String storageId;
   private final Checksum checksum;
+
+  public AssetImpl(
+      AssetId id,
+      InputStream in,
+      Opt<MimeType> mimeType,
+      long size,
+      String storeId,
+      Availability availability,
+      Checksum checksum) {
+    this.id = id;
+    this.in = in;
+    this.mimeType = mimeType;
+    this.size = size;
+    this.availability = availability;
+    this.nextCheck = 0;
+    this.storageId = storeId;
+    this.checksum = checksum;
+  }
 
   public AssetImpl(
           AssetId id,
@@ -46,12 +65,14 @@ public class AssetImpl implements Asset {
           long size,
           String storeId,
           Availability availability,
+          int nextCheck,
           Checksum checksum) {
     this.id = id;
     this.in = in;
     this.mimeType = mimeType;
     this.size = size;
     this.availability = availability;
+    this.nextCheck = nextCheck;
     this.storageId = storeId;
     this.checksum = checksum;
   }
@@ -75,6 +96,11 @@ public class AssetImpl implements Asset {
   @Override public Availability getAvailability() {
     return availability;
   }
+
+  @Override public int getNextCheckIn() {
+    return nextCheck;
+  }
+
 
   @Override public String getStorageId() {
     return storageId;

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -177,7 +177,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
   private static final String MANIFEST_DEFAULT_NAME = "manifest";
 
-  private CopyOnWriteArrayList<AssetManagerUpdateHandler> handlers = new CopyOnWriteArrayList<>();
+  private final CopyOnWriteArrayList<AssetManagerUpdateHandler> handlers = new CopyOnWriteArrayList<>();
 
   private SecurityService securityService;
   private AuthorizationService authorizationService;
@@ -511,8 +511,6 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
    *
    * @param snapshot
    *         The newest snapshot of the event to update
-   * @param index
-   *         The Elasticsearch index to update
    */
   private void updateEventInIndex(Snapshot snapshot) {
     final MediaPackage mp = snapshot.getMediaPackage();
@@ -585,8 +583,6 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
    *
    * @param eventId
    *         The id of the event to remove
-   * @param index
-   *         The Elasticsearch index to update
    */
   private void removeArchivedVersionFromIndex(String eventId) {
     final String orgId = securityService.getOrganization().getId();

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerTestBase.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerTestBase.java
@@ -25,6 +25,7 @@ import static com.entwinemedia.fn.fns.Booleans.eq;
 import static org.junit.Assert.assertEquals;
 import static org.opencastproject.util.data.Tuple.tuple;
 
+import org.opencastproject.assetmanager.api.Availability;
 import org.opencastproject.assetmanager.api.Snapshot;
 import org.opencastproject.assetmanager.api.Version;
 import org.opencastproject.assetmanager.api.fn.Snapshots;
@@ -413,6 +414,17 @@ public abstract class AssetManagerTestBase {
    */
   protected RemoteAssetStore mkRemoteAssetStore(String storeType) {
     return new RemoteAssetStore() {
+
+      @Override
+      public Availability getAvailability(StoragePath path) throws AssetStoreException {
+        return Availability.ONLINE;
+      }
+
+      @Override
+      public Integer getReadyEstimate(StoragePath path) throws AssetStoreException {
+        return 0;
+      }
+
       private Set<StoragePath> store = new HashSet<>();
 
       private void logSize() {

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
@@ -32,6 +32,7 @@ import org.opencastproject.assetmanager.aws.persistence.AwsAssetDatabase;
 import org.opencastproject.assetmanager.aws.persistence.AwsAssetDatabaseException;
 import org.opencastproject.assetmanager.aws.persistence.AwsAssetMapping;
 import org.opencastproject.assetmanager.impl.VersionImpl;
+import org.opencastproject.assetmanager.impl.persistence.Database;
 import org.opencastproject.util.ConfigurationException;
 import org.opencastproject.util.MimeType;
 import org.opencastproject.util.NotFoundException;
@@ -58,6 +59,7 @@ public abstract class AwsAbstractArchive implements AssetStore {
   private static final Logger logger = LoggerFactory.getLogger(AwsAbstractArchive.class);
 
   protected Workspace workspace;
+  protected Database amDatabase;
   protected AwsAssetDatabase database;
 
   /** The store type e.g. aws (long-term), or other implementations */
@@ -105,6 +107,11 @@ public abstract class AwsAbstractArchive implements AssetStore {
   /** OSGi Di */
   public void setDatabase(AwsAssetDatabase db) {
     this.database = db;
+  }
+
+  /** OSGi Di */
+  public void setAssetManagerDatabase(Database amDatabase) {
+    this.amDatabase = amDatabase;
   }
 
   /** @see AssetStore#copy(StoragePath, StoragePath) */

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/AwsAbstractArchive.java
@@ -207,7 +207,7 @@ public abstract class AwsAbstractArchive implements AssetStore {
       }
 
       logger.debug("Getting archive object from AWS {}: {}", getStoreType(), map.getObjectKey());
-      return Opt.some(getObject(map));
+      return Opt.some(getObject(path, map));
 
     } catch (AssetStoreException e) {
       throw e;
@@ -216,7 +216,7 @@ public abstract class AwsAbstractArchive implements AssetStore {
     }
   }
 
-  protected abstract InputStream getObject(AwsAssetMapping map) throws AssetStoreException;
+  protected abstract InputStream getObject(StoragePath path, AwsAssetMapping map) throws AssetStoreException;
 
   /** @see AssetStore#delete(DeletionSelector) */
   public boolean delete(DeletionSelector sel) throws AssetStoreException {

--- a/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
+++ b/modules/asset-manager-storage-aws/src/main/java/org/opencastproject/assetmanager/aws/s3/AwsS3AssetStore.java
@@ -122,6 +122,8 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
   public static final String AWS_S3_MAX_RETRIES = "org.opencastproject.assetmanager.aws.s3.max.retries";
   public static final String AWS_GLACIER_RESTORE_DAYS = "org.opencastproject.assetmanager.aws.s3.glacier.restore.days";
 
+  public static final String AWS_OVERRIDE_RESTORE_MIN_WAIT = "org.opencastproject.assetmanager.aws.s3.glacier.min.wait";
+  public static final String AWS_OVERRIDE_RESTORE_POLL = "org.opencastproject.assetmanager.aws.s3.glacier.poll";
   public static final Integer AWS_S3_GLACIER_RESTORE_DAYS_DEFAULT = 2;
 
   // defaults
@@ -144,6 +146,9 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
 
   /** The Glacier storage class, restore period **/
   private Integer restorePeriod;
+
+  private Integer glacierRestoreInitialWait = RESTORE_MIN_WAIT;
+  private Integer glacierRestorePollTime = RESTORE_POLL;
 
   protected boolean bucketCreated = false;
 
@@ -205,6 +210,11 @@ public class AwsS3AssetStore extends AwsAbstractArchive implements RemoteAssetSt
       // Glacier storage class restore period
       restorePeriod = OsgiUtil.getOptCfgAsInt(cc.getProperties(), AWS_GLACIER_RESTORE_DAYS)
           .getOrElse(AWS_S3_GLACIER_RESTORE_DAYS_DEFAULT);
+
+      glacierRestoreInitialWait = OsgiUtil.getOptCfgAsInt(cc.getProperties(), AWS_OVERRIDE_RESTORE_MIN_WAIT)
+          .getOrElse(RESTORE_MIN_WAIT);
+      glacierRestorePollTime = OsgiUtil.getOptCfgAsInt(cc.getProperties(), AWS_OVERRIDE_RESTORE_POLL)
+          .getOrElse(RESTORE_POLL);
 
       // Explicit credentials are optional.
       AWSCredentialsProvider provider = null;


### PR DESCRIPTION
Harkening back to comments made on #4521, this PR adds better handling for files which are currently in AWS S3 cold storage (ie, Glacier).  This code exposes a way to guestimate how long it will be until the file is available, and prevents waiting for hours be immediately returning an end-of-stream if the file is not in standard S3.  This PR also adds a larger test case to verify S3 Glacier behaviour.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
