### PR TITLE
Fix possible deadlock spanning DB transaction and caching lock with user references

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
@@ -336,8 +336,10 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
         throw new IllegalStateException("User '" + user.getUsername() + "' already exists");
       }
       em.persist(userReference);
-      cache.put(user.getUsername() + DELIMITER + user.getOrganization().getId(), user.toUser(PROVIDER_NAME));
     });
+    // There is still a race when this method is executed multiple times. However, the user reference is unlikely to be
+    // different.
+    cache.put(user.getUsername() + DELIMITER + user.getOrganization().getId(), user.toUser(PROVIDER_NAME));
     updateGroupMembership(user);
   }
 
@@ -356,8 +358,10 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
       foundUserRef.get().setLastLogin(user.getLastLogin());
       foundUserRef.get().setRoles(UserDirectoryPersistenceUtil.saveRolesQuery(user.getRoles()).apply(em));
       em.merge(foundUserRef.get());
-      cache.put(user.getUsername() + DELIMITER + user.getOrganization().getId(), user.toUser(PROVIDER_NAME));
     });
+    // There is still a race when this method is executed multiple times. However, the user reference is unlikely to be
+    // different.
+    cache.put(user.getUsername() + DELIMITER + user.getOrganization().getId(), user.toUser(PROVIDER_NAME));
     updateGroupMembership(user);
   }
 

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
@@ -52,7 +52,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -315,7 +314,7 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
       JpaOrganization organization = UserDirectoryPersistenceUtil.saveOrganizationQuery(
           (JpaOrganization) user.getOrganization()).apply(em);
       JpaUserReference userReference = new JpaUserReference(user.getUsername(), user.getName(), user.getEmail(),
-          mechanism, new Date(), organization, roles);
+          mechanism, user.getLastLogin(), organization, roles);
 
       // Then save the user reference
       Optional<JpaUserReference> foundUserRef = findUserReferenceQuery(user.getUsername(),
@@ -341,7 +340,7 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
       }
       foundUserRef.get().setName(user.getName());
       foundUserRef.get().setEmail(user.getEmail());
-      foundUserRef.get().setLastLogin(new Date());
+      foundUserRef.get().setLastLogin(user.getLastLogin());
       foundUserRef.get().setRoles(UserDirectoryPersistenceUtil.saveRolesQuery(user.getRoles()).apply(em));
       em.merge(foundUserRef.get());
       cache.put(user.getUsername() + DELIMITER + user.getOrganization().getId(), user.toUser(PROVIDER_NAME));


### PR DESCRIPTION
The JpaUserReferenceProvider#updateUserReference updates an in-memory cache as part of the DB transaction context. Putting something in the cache will acquire a lock on the cache. If the JpaUserReferenceProvider#loadUser method is called after the start of the DB transaction but before putting the object in the cache, the cache loader will try to read the user reference from the DB and put it into the cache if it cannot be found (e.g. after a Opencast startup). This also requires a lock from the cache but will block in the DB since the DB transaction is already running. Since this deadlock uses in-memory Java locks, it cannot be detected by the DB and the DB transaction will not be canceled.

This moves the cache update outside of the DB transaction context. When multiple user reference updates run at the same time there is still a race to insert into DB/cache. However, in practice the user reference is probably the same except for the last login date.

Two other commits are cleaning up `JpaUserReferenceProvider` a bit.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
