### PR TITLE
Truncate Bundle Info

### DIFF
--- a/docs/guides/admin/docs/releasenotes/upgrade_database.txt
+++ b/docs/guides/admin/docs/releasenotes/upgrade_database.txt
@@ -1,0 +1,5 @@
+Database Migration
+------------------
+
+You can find database upgrade scripts in `docs/upgrade/13_to_14/`. These scripts are suitable for both, MariaDB and
+PostgreSQL. Changes include DB schema optimizations as well as fixes for the new workflow tables.

--- a/docs/upgrade/13_to_14/mariadb.sql
+++ b/docs/upgrade/13_to_14/mariadb.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS IX_oc_job_statistics ON oc_job;

--- a/docs/upgrade/13_to_14/mariadb.sql
+++ b/docs/upgrade/13_to_14/mariadb.sql
@@ -1,1 +1,6 @@
 DROP INDEX IF EXISTS IX_oc_job_statistics ON oc_job;
+
+-- Clean up bundle information from nodes which no longer exist.
+-- This is done automatically for every node if they are shut down *if* they are shut down properly.
+-- We can safely do this since the Opencast cluster should be completely shut down during the database migration.
+truncate oc_bundleinfo;

--- a/docs/upgrade/13_to_14/postgresql.sql
+++ b/docs/upgrade/13_to_14/postgresql.sql
@@ -1,1 +1,6 @@
 DROP INDEX IF EXISTS IX_oc_job_statistics;
+
+-- Clean up bundle information from nodes which no longer exist.
+-- This is done automatically for every node if they are shut down *if* they are shut down properly.
+-- We can safely do this since the Opencast cluster should be completely shut down during the database migration.
+truncate oc_bundleinfo;

--- a/docs/upgrade/13_to_14/postgresql.sql
+++ b/docs/upgrade/13_to_14/postgresql.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS IX_oc_job_statistics;


### PR DESCRIPTION
 This patch adds a cleanup routine for bundle information from nodes
    which no longer exist to the migration scripts.  This is done
    automatically for every node if they are shut down *if* they are shut
    down properly.  We can safely do this since the Opencast cluster should
    be completely shut down during the database migration.

This includes #4945 and should be merged only if that pull request is merged. We don't want a database migration just for this.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
