### PR TITLE
Allow opencast to share the oc-remember-me cookie between nodes

### DIFF
--- a/docs/guides/admin/docs/releasenotes/global-oc-remember-me-cookie.txt
+++ b/docs/guides/admin/docs/releasenotes/global-oc-remember-me-cookie.txt
@@ -1,0 +1,5 @@
+Global 'oc-remember-me' cookie
+--------------------------
+
+It's now possible, to use the same 'oc-remember-me' cookie for all nodes.
+So, if you log into the admin node for example, you don't have to log in again, when switching to the presentation node.

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -421,8 +421,11 @@
     <!-- All following settings are optional -->
     <property name="tokenValiditySeconds" value="1209600"/>
     <property name="cookieName" value="oc-remember-me"/>
-    <!-- The following key will be augmented by system properties. Thus, leaving this untouched is okay -->
-    <!-- This key must be equal to the key passed to rememberMeAuthenticationProvider (s. below) -->
+    <!-- The following key will be augmented by system properties. Thus, leaving this untouched is okay.
+         This key must be equal to the key passed to rememberMeAuthenticationProvider (s. below)
+         'Augmented' means, leaving this as 'opencast' will result in a random key. So if you log into the
+         admin server for example and switch to the presentation server, you will have to log in again.
+         The key won't be augmented/randomized if you use something different than 'opencast'. -->
     <property name="key" value="opencast"/>
   </bean>
 

--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -421,11 +421,10 @@
     <!-- All following settings are optional -->
     <property name="tokenValiditySeconds" value="1209600"/>
     <property name="cookieName" value="oc-remember-me"/>
-    <!-- The following key will be augmented by system properties. Thus, leaving this untouched is okay.
-         This key must be equal to the key passed to rememberMeAuthenticationProvider (s. below)
-         'Augmented' means, leaving this as 'opencast' will result in a random key. So if you log into the
-         admin server for example and switch to the presentation server, you will have to log in again.
-         The key won't be augmented/randomized if you use something different than 'opencast'. -->
+    <!-- The following key will be augmented by system properties if left at the default value.
+         Thus, leaving this untouched is okay. This key must be equal to the key passed to
+         rememberMeAuthenticationProvider (s. below). To generate cookies which are valid for the whole cluster,
+         set this manually. The key won't be augmented/randomized if you use something different than 'opencast'. -->
     <property name="key" value="opencast"/>
   </bean>
 

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenRememberMeUtils.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenRememberMeUtils.java
@@ -44,10 +44,19 @@ public final class SystemTokenRememberMeUtils {
 
   private static final Logger logger = LoggerFactory.getLogger(SystemTokenRememberMeUtils.class);
 
+  /** This is the default cookie key, that is configured in Opencast **/
+  private static final String defaultCookieKey = "opencast";
+
   private SystemTokenRememberMeUtils() {
   }
 
   public static String augmentKey(String key) {
+
+    if (!defaultCookieKey.equals(key)) {
+      logger.debug("The default cookie key 'opencast' is not in use. The given key won't be augmented.");
+      return key;
+    }
+
     // Start with a user key if provided
     StringBuilder keyBuilder = new StringBuilder(Objects.toString(key, ""));
 

--- a/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenRememberMeUtils.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/security/SystemTokenRememberMeUtils.java
@@ -45,15 +45,15 @@ public final class SystemTokenRememberMeUtils {
   private static final Logger logger = LoggerFactory.getLogger(SystemTokenRememberMeUtils.class);
 
   /** This is the default cookie key, that is configured in Opencast **/
-  private static final String defaultCookieKey = "opencast";
+  private static final String DEFAULT_COOKIE_KEY = "opencast";
 
   private SystemTokenRememberMeUtils() {
   }
 
   public static String augmentKey(String key) {
 
-    if (!defaultCookieKey.equals(key)) {
-      logger.debug("The default cookie key 'opencast' is not in use. The given key won't be augmented.");
+    if (!DEFAULT_COOKIE_KEY.equals(key)) {
+      logger.debug("The default cookie key '{}' is not in use. The given key won't be augmented.", DEFAULT_COOKIE_KEY);
       return key;
     }
 


### PR DESCRIPTION
In a multi node scenario, if you configure a different cookie-key than 'opencast', the same cookie-key will be used for all nodes. Therefore, you can log into the admin node for example and open up a published video without logging into the presentation server again.

You also have to configure the subdomain for the cookie in your nginx configuration: https://docs.opencast.org/develop/admin/#configuration/https/nginx/
