### PR TITLE
Add Opencast 13.6 release notes

### DIFF
--- a/docs/guides/admin/docs/changelog.md
+++ b/docs/guides/admin/docs/changelog.md
@@ -4,6 +4,37 @@ Changelog
 Opencast 13
 -----------
 
+### Opencast 13.6
+
+*Released on Mai 26th, 2023*
+
+- [[#4961](https://github.com/opencast/opencast/pull/4961)] -
+  Remove empty options in ACL template select (#4910)
+- [[#4925](https://github.com/opencast/opencast/pull/4925)] -
+  Ensure all plugin jars are present in tarballs.
+- [[#4923](https://github.com/opencast/opencast/pull/4923)] -
+  Mitigate not loading ACLs
+- [[#4920](https://github.com/opencast/opencast/pull/4920)] -
+  Batch Dependabot Updates for Paella 7
+- [[#4890](https://github.com/opencast/opencast/pull/4890)] -
+  Bump eslint from 8.37.0 to 8.39.0 in /modules/engage-paella-player-7
+- [[#4885](https://github.com/opencast/opencast/pull/4885)] -
+  Bump html-validate from 7.14.0 to 7.15.1 in /modules/engage-paella-player-7
+- [[#4879](https://github.com/opencast/opencast/pull/4879)] -
+  Editor Release 2023-04-20
+- [[#4870](https://github.com/opencast/opencast/pull/4870)] -
+  TermsFeed Cookie Consent NOTICE
+- [[#4869](https://github.com/opencast/opencast/pull/4869)] -
+  [Whisper] Fixes automatic language detection
+- [[#4868](https://github.com/opencast/opencast/pull/4868)] -
+  Extend configuration options of Amberscript integration
+- [[#4864](https://github.com/opencast/opencast/pull/4864)] -
+  Remove dead `CONFIG_OPTIONS` from WOHs
+- [[#4853](https://github.com/opencast/opencast/pull/4853)] -
+  Bump webpack from 5.77.0 to 5.78.0 in /modules/engage-paella-player-7
+- [[#4851](https://github.com/opencast/opencast/pull/4851)] -
+  Bump paella-zoom-plugin from 1.2.1 to 1.27.0 in /modules/engage-paella-player-7
+
 ### Opencast 13.5
 
 *Released on April 19th, 2023*

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -6,12 +6,11 @@ Opencast 13.6
 
 The sixth maintenance release of Opencast 13.
 
-- Remove dead CONFIG_OPTIONS from WOHs ([#4864](https://github.com/opencast/opencast/pull/4864))
-- TermsFeed Cookie Consent NOTICE ([#4870](https://github.com/opencast/opencast/pull/4870))
+- Extend configuration options of Amberscript integration ([#4868](https://github.com/opencast/opencast/pull/4868))
+- Mitigate not loading ACLs on first start ([#4923](https://github.com/opencast/opencast/pull/4923))
+- Remove empty options in ACL template select ([#4961](https://github.com/opencast/opencast/pull/4961))
 - Editor Release 2023-04-20 ([#4879](https://github.com/opencast/opencast/pull/4879))
-- Mitigate not loading ACLs ([#4923](https://github.com/opencast/opencast/pull/4923))
-- Ensure all plugin jars are present in tarballs. ([#4925](https://github.com/opencast/opencast/pull/4925))
-
+- Fix missing JARs in released distributions ([#4925](https://github.com/opencast/opencast/pull/4925))
 
 See [changelog](changelog.md) for a comprehensive list of changes.
 
@@ -28,7 +27,6 @@ The fifth maintenance release of Opencast 13.
 - Add paging to asset manager index rebuild ([#4783](https://github.com/opencast/opencast/pull/4783))
 - Fixed pagination when reindexing asset manager ([#4843](https://github.com/opencast/opencast/pull/4843))
 
-
 See [changelog](changelog.md) for a comprehensive list of changes.
 
 
@@ -37,8 +35,8 @@ Opencast 13.4
 
 The fourth maintenance release of Opencast 13.
 
--  Fix default values for the Admin UI ACL editor. Previously the roles set for new events might not correspond to the
-   rest of Opencast's defaults. ([#4799](https://github.com/opencast/opencast/pull/4799))
+- Fix default values for the Admin UI ACL editor. Previously the roles set for new events might not correspond to the
+  rest of Opencast's defaults. ([#4799](https://github.com/opencast/opencast/pull/4799))
 
 See [changelog](changelog.md) for a comprehensive list of changes.
 
@@ -48,12 +46,12 @@ Opencast 13.3
 
 The third maintenance release of Opencast 13.
 
--  Add paging to asset manager index rebuild ([#4783](https://github.com/opencast/opencast/pull/4783))
--  Fix reindex of multi-tanant systems ([#4740](https://github.com/opencast/opencast/pull/4740))
--  Fix exception when retrieving comments where the author is missing ([#4739](https://github.com/opencast/opencast/pull/4739))
--  Paella 7 matomo plugin ([#4722](https://github.com/opencast/opencast/pull/4722))
--  Dependabot-batcher update ([#4707](https://github.com/opencast/opencast/pull/4707))
--  Fix typo and adds recomendations to whisper doc ([#4683](https://github.com/opencast/opencast/pull/4683))
+- Add paging to asset manager index rebuild ([#4783](https://github.com/opencast/opencast/pull/4783))
+- Fix reindex of multi-tanant systems ([#4740](https://github.com/opencast/opencast/pull/4740))
+- Fix exception when retrieving comments where the author is missing ([#4739](https://github.com/opencast/opencast/pull/4739))
+- Paella 7 matomo plugin ([#4722](https://github.com/opencast/opencast/pull/4722))
+- Dependabot-batcher update ([#4707](https://github.com/opencast/opencast/pull/4707))
+- Fix typo and adds recomendations to whisper doc ([#4683](https://github.com/opencast/opencast/pull/4683))
 
 See [changelog](changelog.md) for a comprehensive list of changes.
 
@@ -63,10 +61,10 @@ Opencast 13.2
 
 The second maintenance release of Opencast 13.
 
--  Fix calendar.json endpoint ([#4619](https://github.com/opencast/opencast/pull/4619))
--  Add missing expected response code ([#4628](https://github.com/opencast/opencast/pull/4628))
--  Add webvtt-to-cutmarks to list of workflow operations ([#4654](https://github.com/opencast/opencast/pull/4654))
--  Fix multiple bugs in the adopters registration resulting in incorrect counts ([#4616](https://github.com/opencast/opencast/pull/4616))
+- Fix calendar.json endpoint ([#4619](https://github.com/opencast/opencast/pull/4619))
+- Add missing expected response code ([#4628](https://github.com/opencast/opencast/pull/4628))
+- Add webvtt-to-cutmarks to list of workflow operations ([#4654](https://github.com/opencast/opencast/pull/4654))
+- Fix multiple bugs in the adopters registration resulting in incorrect counts ([#4616](https://github.com/opencast/opencast/pull/4616))
 
 See [changelog](changelog.md) for a comprehensive list of changes.
 

--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -1,6 +1,21 @@
 # Opencast 13: Release Notes
 
 
+Opencast 13.6
+-------------
+
+The sixth maintenance release of Opencast 13.
+
+- Remove dead CONFIG_OPTIONS from WOHs ([#4864](https://github.com/opencast/opencast/pull/4864))
+- TermsFeed Cookie Consent NOTICE ([#4870](https://github.com/opencast/opencast/pull/4870))
+- Editor Release 2023-04-20 ([#4879](https://github.com/opencast/opencast/pull/4879))
+- Mitigate not loading ACLs ([#4923](https://github.com/opencast/opencast/pull/4923))
+- Ensure all plugin jars are present in tarballs. ([#4925](https://github.com/opencast/opencast/pull/4925))
+
+
+See [changelog](changelog.md) for a comprehensive list of changes.
+
+
 Opencast 13.5
 -------------
 
@@ -15,6 +30,7 @@ The fifth maintenance release of Opencast 13.
 
 
 See [changelog](changelog.md) for a comprehensive list of changes.
+
 
 Opencast 13.4
 -------------


### PR DESCRIPTION
This PR will add the Opencast 13.6 release notes.

The release will probably be on May 17, 2023. Until then, this will be a draft PR.
