### PR TITLE
Asset manager multiple storage

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -73,10 +73,9 @@ org.opencastproject.storage.dir=${karaf.data}/opencast
 # Default: ${org.opencastproject.storage.dir}/archive
 #org.opencastproject.episode.rootdir=${org.opencastproject.storage.dir}/archive
 
-# Instead of specifying just one asset manager directory, you can specify multiple directories.
+# You can specify additional asset manager directories.
 # This can be useful in case you want to use multiple nfs shares.
-# To do so, leave the line above commented out, (the one specifying org.opencastproject.episode.rootdir)
-# Then for each path, write a line like org.opencastproject.episode.rootdir.X=path,
+# For each additional directory, write a line like `org.opencastproject.episode.rootdir.X=path`,
 # where "X" is a number starting at 1 and incrementing for each line.
 #org.opencastproject.episode.rootdir.1=${org.opencastproject.storage.dir}/archiveOriginal
 #org.opencastproject.episode.rootdir.2=/srv/opencast-zwei/archive
@@ -121,16 +120,16 @@ org.opencastproject.download.directory=${org.opencastproject.storage.dir}/downlo
 
 # Opencast comes with the jdbc drivers for MariaDB (org.mariadb.jdbc.Driver) and PostgreSQL (org.postgresql.Driver).
 # To add other jdbcDrivers to the Opencast runtime, rebuild the db module with your desired drivers.
-#org.opencastproject.db.jdbc.driver=org.mariadb.jdbc.Driver
+org.opencastproject.db.jdbc.driver=org.mariadb.jdbc.Driver
 
 # The jdbc connection url, username, and password
 # Defaults:
 #  .url=jdbc:h2:${org.opencastproject.storage.dir}/db
 #  .user=sa
 #  .pass=sa
-#org.opencastproject.db.jdbc.url=jdbc:mariadb://localhost/opencast?useMysqlMetadata=true
-#org.opencastproject.db.jdbc.user=opencast
-#org.opencastproject.db.jdbc.pass=dbpassword
+org.opencastproject.db.jdbc.url=jdbc:mariadb://localhost/opencast?useMysqlMetadata=true
+org.opencastproject.db.jdbc.user=opencast
+org.opencastproject.db.jdbc.pass=dbpassword
 
 # The jdbc connection pool properties. See https://mchange.com/projects/c3p0/#basic_pool_configuration
 # max.idle.time should be lower than the database server idle connection timeout duration (wait_timeout for MariaDB)

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -73,6 +73,14 @@ org.opencastproject.storage.dir=${karaf.data}/opencast
 # Default: ${org.opencastproject.storage.dir}/archive
 #org.opencastproject.episode.rootdir=${org.opencastproject.storage.dir}/archive
 
+# Instead of specifying just one asset manager directory, you can specify multiple directories.
+# This can be useful in case you want to use multiple nfs shares.
+# To do so, leave the line above commented out, (the one specifying org.opencastproject.episode.rootdir)
+# Then for each path, write a line like org.opencastproject.episode.rootdir.X=path,
+# where "X" is a number starting at 1 and incrementing for each line.
+#org.opencastproject.episode.rootdir.1=${org.opencastproject.storage.dir}/archiveOriginal
+#org.opencastproject.episode.rootdir.2=/srv/opencast-zwei/archive
+
 # The path to the repository of files used during media processing.
 #org.opencastproject.file.repo.path=${org.opencastproject.storage.dir}/files
 

--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -120,16 +120,16 @@ org.opencastproject.download.directory=${org.opencastproject.storage.dir}/downlo
 
 # Opencast comes with the jdbc drivers for MariaDB (org.mariadb.jdbc.Driver) and PostgreSQL (org.postgresql.Driver).
 # To add other jdbcDrivers to the Opencast runtime, rebuild the db module with your desired drivers.
-org.opencastproject.db.jdbc.driver=org.mariadb.jdbc.Driver
+#org.opencastproject.db.jdbc.driver=org.mariadb.jdbc.Driver
 
 # The jdbc connection url, username, and password
 # Defaults:
 #  .url=jdbc:h2:${org.opencastproject.storage.dir}/db
 #  .user=sa
 #  .pass=sa
-org.opencastproject.db.jdbc.url=jdbc:mariadb://localhost/opencast?useMysqlMetadata=true
-org.opencastproject.db.jdbc.user=opencast
-org.opencastproject.db.jdbc.pass=dbpassword
+#org.opencastproject.db.jdbc.url=jdbc:mariadb://localhost/opencast?useMysqlMetadata=true
+#org.opencastproject.db.jdbc.user=opencast
+#org.opencastproject.db.jdbc.pass=dbpassword
 
 # The jdbc connection pool properties. See https://mchange.com/projects/c3p0/#basic_pool_configuration
 # max.idle.time should be lower than the database server idle connection timeout duration (wait_timeout for MariaDB)

--- a/modules/asset-manager-storage-fs/pom.xml
+++ b/modules/asset-manager-storage-fs/pom.xml
@@ -27,6 +27,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
     <!-- Opencast -->
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
@@ -272,31 +272,6 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
     });
   }
 
-  //TODO: Fix or remove these
-  @Override
-//  public Option<Long> getUsedSpace() {
-//    return Option.some(FileUtils.sizeOfDirectory(new File(getRootDirectory())));
-//  }
-  public Option<Long> getUsedSpace() {
-    return Option.some(1L);
-  }
-
-  @Override
-//  public Option<Long> getUsableSpace() {
-//    return Option.some(new File(getRootDirectory()).getUsableSpace());
-//  }
-  public Option<Long> getUsableSpace() {
-    return Option.some(1L);
-  }
-
-  @Override
-//  public Option<Long> getTotalSpace() {
-//    return Option.some(new File(getRootDirectory()).getTotalSpace());
-//  }
-  public Option<Long> getTotalSpace() {
-    return Option.some(1L);
-  }
-
   @Override
   public String getStoreType() {
     return storeType;

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
@@ -69,6 +69,7 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
   protected abstract Workspace getWorkspace();
 
   protected abstract String getRootDirectory();
+  protected abstract String getRootDirectory(String orgId, String mpId);
 
   @Override
   public void put(StoragePath storagePath, Source source) throws AssetStoreException {
@@ -147,7 +148,8 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
     try {
       FileUtils.deleteDirectory(dir);
       // also delete the media package directory if all versions have been deleted
-      FileSupport.deleteHierarchyIfEmpty(file(path(getRootDirectory(), sel.getOrganizationId())), dir.getParentFile());
+      FileSupport.deleteHierarchyIfEmpty(file(path(getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId()),
+              sel.getOrganizationId())), dir.getParentFile());
       return true;
     } catch (IOException e) {
       logger.error("Error deleting directory from archive {}", dir);
@@ -163,7 +165,8 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
    * @return the directory file
    */
   private File getDeletionSelectorDir(DeletionSelector sel) {
-    final String basePath = path(getRootDirectory(), sel.getOrganizationId(), sel.getMediaPackageId());
+    final String basePath = path(getRootDirectory(sel.getOrganizationId(), sel.getMediaPackageId()),
+            sel.getOrganizationId(), sel.getMediaPackageId());
     for (Version v : sel.getVersion()) {
       return file(basePath, v.toString());
     }
@@ -223,6 +226,20 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
                     .getMediaPackageElementId());
   }
 
+  private File getExistingFile(StoragePath p, Opt<String> extension) {
+    String rootDirectory = getRootDirectory(p.getOrganizationId(), p.getMediaPackageId());
+    if (rootDirectory == null) {
+      return null;
+    }
+    return file(
+            rootDirectory,
+            p.getOrganizationId(),
+            p.getMediaPackageId(),
+            p.getVersion().toString(),
+            extension.isSome() ? p.getMediaPackageElementId() + EXTENSION_SEPARATOR + extension.get() : p
+                    .getMediaPackageElementId());
+  }
+
   /**
    * Returns a file {@link Option} from a storage path if one is found or an empty {@link Option}
    *
@@ -237,7 +254,7 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
         return FilenameUtils.getBaseName(name).equals(storagePath.getMediaPackageElementId());
       }
     };
-    final File containerDir = createFile(storagePath, Opt.none(String.class)).getParentFile();
+    final File containerDir = getExistingFile(storagePath, Opt.none(String.class)).getParentFile();
     return nul(containerDir.listFiles(filter)).bind(new Fn<File[], Opt<File>>() {
       @Override
       public Opt<File> apply(File[] files) {
@@ -254,19 +271,29 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
     });
   }
 
+  //TODO: Fix or remove these
   @Override
+//  public Option<Long> getUsedSpace() {
+//    return Option.some(FileUtils.sizeOfDirectory(new File(getRootDirectory())));
+//  }
   public Option<Long> getUsedSpace() {
-    return Option.some(FileUtils.sizeOfDirectory(new File(getRootDirectory())));
+    return Option.some(1L);
   }
 
   @Override
+//  public Option<Long> getUsableSpace() {
+//    return Option.some(new File(getRootDirectory()).getUsableSpace());
+//  }
   public Option<Long> getUsableSpace() {
-    return Option.some(new File(getRootDirectory()).getUsableSpace());
+    return Option.some(1L);
   }
 
   @Override
+//  public Option<Long> getTotalSpace() {
+//    return Option.some(new File(getRootDirectory()).getTotalSpace());
+//  }
   public Option<Long> getTotalSpace() {
-    return Option.some(new File(getRootDirectory()).getTotalSpace());
+    return Option.some(1L);
   }
 
   @Override

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStore.java
@@ -226,6 +226,7 @@ public abstract class AbstractFileSystemAssetStore implements AssetStore {
                     .getMediaPackageElementId());
   }
 
+  /** Returns a file from a storage path if it exists, null otherwise */
   private File getExistingFile(StoragePath p, Opt<String> extension) {
     String rootDirectory = getRootDirectory(p.getOrganizationId(), p.getMediaPackageId());
     if (rootDirectory == null) {

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
@@ -47,6 +47,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -158,7 +159,7 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
   }
 
   private List<String> getRootDirectories() {
-    return rootDirectories;
+    return Collections.unmodifiableList(rootDirectories);
   }
 
   protected void setupCache() {

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
@@ -146,6 +146,17 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
     return null;
   }
 
+  protected void setupCache() {
+    cache = CacheBuilder.newBuilder().maximumSize(cacheSize).expireAfterWrite(cacheExpiration, TimeUnit.MINUTES)
+            .build(new CacheLoader<String, Object>() {
+              @Override
+              public Object load(String orgAndMpId) throws Exception {
+                String rootDirectory = getRootDirectoryForMediaPackage(orgAndMpId);
+                return rootDirectory == null ? null : rootDirectory;
+              }
+            });
+  }
+
   /**
    * OSGi DI.
    */
@@ -201,13 +212,6 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
 
     // Setup rootDirectory cache
     // Remembers the root directory for a given mediapackage
-    cache = CacheBuilder.newBuilder().maximumSize(cacheSize).expireAfterWrite(cacheExpiration, TimeUnit.MINUTES)
-            .build(new CacheLoader<String, Object>() {
-              @Override
-              public Object load(String orgAndMpId) throws Exception {
-                String rootDirectory = getRootDirectoryForMediaPackage(orgAndMpId);
-                return rootDirectory == null ? null : rootDirectory;
-              }
-            });
+    setupCache();
   }
 }

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
@@ -228,8 +228,8 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
           continue;
         }
         if (isChild(rootDirectories.get(j), rootDirectories.get(i))) {
-          throw new ConfigurationException("Storage directory " + rootDirectories.get(j) + " is a subdirectory of " +
-              rootDirectories.get(i) + ". This is not allowed.");
+          throw new ConfigurationException("Storage directory " + rootDirectories.get(j) + " is a subdirectory of "
+              + rootDirectories.get(i) + ". This is not allowed.");
         }
       }
     }

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
@@ -23,7 +23,14 @@ package org.opencastproject.assetmanager.storage.impl.fs;
 import static org.opencastproject.util.IoSupport.file;
 
 import org.opencastproject.assetmanager.api.storage.AssetStore;
+import org.opencastproject.util.data.Option;
 import org.opencastproject.workspace.api.Workspace;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.osgi.service.component.ComponentContext;
@@ -33,8 +40,15 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 @Component(
     property = {
@@ -48,6 +62,13 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
   /** Log facility */
   private static final Logger logger = LoggerFactory.getLogger(OsgiFileSystemAssetStore.class);
 
+  /** A cache of mediapckage ids and their associated storages */
+  private LoadingCache<String, Object> cache = null;
+  private int cacheSize = 1000;
+  private int cacheExpiration = 60;
+  /** A token to store in the miss cache */
+  protected Object nullToken = new Object();
+
   /** Configuration key for the default Opencast storage directory. A value is optional. */
   public static final String CFG_OPT_STORAGE_DIR = "org.opencastproject.storage.dir";
 
@@ -60,8 +81,8 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
   /** Configuration key for the archive root directory. */
   public static final String CONFIG_STORE_ROOT_DIR = "org.opencastproject.episode.rootdir";
 
-  /** The root directory for storing files */
-  private String rootDirectory;
+  /** The root directories for storing files (typically one) */
+  private List<String> rootDirectories;
 
   /** The workspace */
   private Workspace workspace;
@@ -72,7 +93,58 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
 
   @Override
   protected String getRootDirectory() {
-    return rootDirectory;
+    // Determine which storage to return by amount of remaining usable space
+    long usableSpace = 0;
+    String mostUsableDirectory = null;
+    for (String path : rootDirectories) {
+      Option<Long> maybeUsableSpace = Option.some(new File(path).getUsableSpace());
+      if (maybeUsableSpace.isNone()) {
+        continue;
+      }
+      if (maybeUsableSpace.get() > usableSpace) {
+        usableSpace = maybeUsableSpace.get();
+        mostUsableDirectory = path;
+      }
+    }
+
+    return mostUsableDirectory;
+  }
+
+  /**
+   * Looks for the root directory of the given mediapackage id
+   * @param orgId the organization which the mediapackage belongs to
+   * @param mpId the mediapackage id
+   * @return The root directory path of the given mediapackage, or null if the mediapackage could not be found anywhere
+   */
+  protected String getRootDirectory(String orgId, String mpId) {
+    try {
+      Object path = cache.getUnchecked(Paths.get(orgId, mpId).toString());
+      if (path == nullToken) {
+        logger.debug("Path could not be found, returning null.");
+        return null;
+      } else {
+        logger.debug("Returning path to mediapackage " + mpId);
+        return (String) path;
+      }
+    } catch (ExecutionError e) {
+      logger.warn("Exception while getting path for mediapackage {}", mpId, e);
+      return null;
+    } catch (UncheckedExecutionException e) {
+      logger.warn("Exception while getting path for  mediapackage {}", mpId, e);
+      return null;
+    }
+  }
+
+  private String getRootDirectoryForMediaPackage(String orgAndMpId) {
+    // Search the mediapackage on all storages
+    for (String path : rootDirectories) {
+      Path dirPath = Path.of(path, orgAndMpId);
+      if (Files.exists(dirPath) && Files.isDirectory(dirPath)) {
+        return path;
+      }
+    }
+
+    return null;
   }
 
   /**
@@ -90,19 +162,60 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
    *          the component context
    */
   @Activate
-  public void activate(final ComponentContext cc) throws IllegalStateException, IOException {
+  public void activate(final ComponentContext cc)
+          throws IllegalStateException, IOException {
     storeType = (String) cc.getProperties().get(AssetStore.STORE_TYPE_PROPERTY);
     logger.info("{} is: {}", AssetStore.STORE_TYPE_PROPERTY, storeType);
 
-    rootDirectory = StringUtils.trimToNull(cc.getBundleContext().getProperty(CONFIG_STORE_ROOT_DIR));
-    if (rootDirectory == null) {
-      final String storageDir = StringUtils.trimToNull(cc.getBundleContext().getProperty(CFG_OPT_STORAGE_DIR));
-      if (storageDir == null) {
-        throw new IllegalArgumentException("Storage directory must be set");
+    // Read in multiple directories
+    rootDirectories = new ArrayList<>();
+    int index = 1;
+    boolean isRootDirectory = true;
+    while (isRootDirectory) {
+      String directory;
+      try {
+        directory = StringUtils.trimToNull(cc.getBundleContext().getProperty(CONFIG_STORE_ROOT_DIR + "." + index));
+      } catch (Exception e) {
+        isRootDirectory = false;
+        throw e;
       }
-      rootDirectory = Paths.get(storageDir, DEFAULT_STORE_DIRECTORY).toFile().getAbsolutePath();
+
+      if (directory != null) {
+        rootDirectories.add(directory);
+      } else {
+        isRootDirectory = false;
+      }
+      index++;
     }
-    mkDirs(file(rootDirectory));
-    logger.info("Start asset manager files system store at {}", rootDirectory);
+    for (String directory: rootDirectories) {
+      mkDirs(file(directory));
+    }
+
+    // Read in single directory
+    if (rootDirectories.size() == 0) {
+      String rootDirectory = StringUtils.trimToNull(cc.getBundleContext().getProperty(CONFIG_STORE_ROOT_DIR));
+      if (rootDirectory == null) {
+        final String storageDir = StringUtils.trimToNull(cc.getBundleContext().getProperty(CFG_OPT_STORAGE_DIR));
+        if (storageDir == null) {
+          throw new IllegalArgumentException("Storage directory must be set");
+        }
+        rootDirectory = Paths.get(storageDir, DEFAULT_STORE_DIRECTORY).toFile().getAbsolutePath();
+      }
+      mkDirs(file(rootDirectory));
+      rootDirectories.add(rootDirectory);
+    }
+
+    logger.info("Start asset manager files system store at {}", rootDirectories);
+
+    // Setup rootDirectory cache
+    // Remembers the rootdirectory for a given mediapackage
+    cache = CacheBuilder.newBuilder().maximumSize(cacheSize).expireAfterWrite(cacheExpiration, TimeUnit.MINUTES)
+            .build(new CacheLoader<String, Object>() {
+              @Override
+              public Object load(String orgAndMpId) throws Exception {
+                String rootDirectory = getRootDirectoryForMediaPackage(orgAndMpId);
+                return rootDirectory == null ? null : rootDirectory;
+              }
+            });
   }
 }

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
@@ -237,6 +237,12 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
     for (String directory: rootDirectories) {
       mkDirs(file(directory));
     }
+    // Check for write access
+    for (String directory : rootDirectories) {
+      File tmp = new File(directory + "/tobedeleted.tmp");
+      tmp.createNewFile();
+      tmp.delete();
+    }
 
     logger.info("Start asset manager files system store at {}", rootDirectories);
 

--- a/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
+++ b/modules/asset-manager-storage-fs/src/main/java/org/opencastproject/assetmanager/storage/impl/fs/OsgiFileSystemAssetStore.java
@@ -91,6 +91,10 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
   }
 
   @Override
+  /**
+   * Returns the root directory with the most usable space left
+   * @return The root directory path
+   */
   protected String getRootDirectory() {
     // Determine which storage to return by amount of remaining usable space
     long usableSpace = 0;
@@ -134,6 +138,12 @@ public class OsgiFileSystemAssetStore extends AbstractFileSystemAssetStore {
     }
   }
 
+  /**
+   * Looks for the root directory that contains the given mediapackage id.
+   * Used by the cache.
+   * @param orgAndMpId The part of the path that contains the organization id and mediapacakge id
+   * @return The root directory path of the given mediapackage
+   */
   private String getRootDirectoryForMediaPackage(String orgAndMpId) {
     // Search the mediapackage on all storages
     for (String path : rootDirectories) {

--- a/modules/asset-manager-storage-fs/src/test/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStoreTest.java
+++ b/modules/asset-manager-storage-fs/src/test/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStoreTest.java
@@ -95,6 +95,9 @@ public class AbstractFileSystemAssetStoreTest {
       @Override protected String getRootDirectory() {
         return tmpRoot.getAbsolutePath();
       }
+      @Override protected String getRootDirectory(String orgId, String mpId) {
+        return tmpRoot.getAbsolutePath();
+      }
     };
 
     sampleElemDir = new File(

--- a/modules/asset-manager-storage-fs/src/test/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStoreTest.java
+++ b/modules/asset-manager-storage-fs/src/test/java/org/opencastproject/assetmanager/storage/impl/fs/AbstractFileSystemAssetStoreTest.java
@@ -48,6 +48,9 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public class AbstractFileSystemAssetStoreTest {
   private static final String XML_EXTENSTION = ".xml";
@@ -65,13 +68,17 @@ public class AbstractFileSystemAssetStoreTest {
   private static final VersionImpl VERSION_2 = new VersionImpl(2);
 
   private File tmpRoot;
+  private File tmpRoot2;
 
-  private AbstractFileSystemAssetStore repo;
+  private OsgiFileSystemAssetStore repo;
 
   private File sampleElemDir;
 
   @Rule
   public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Rule
+  public TemporaryFolder tmpFolder2 = new TemporaryFolder();
 
   @Before
   public void setUp() throws Exception {
@@ -86,19 +93,17 @@ public class AbstractFileSystemAssetStoreTest {
     EasyMock.replay(workspace);
 
     tmpRoot = tmpFolder.newFolder();
+    tmpRoot2 = tmpFolder2.newFolder();
 
-    repo = new AbstractFileSystemAssetStore() {
+    repo = new OsgiFileSystemAssetStore() {
       @Override protected Workspace getWorkspace() {
         return workspace;
       }
-
-      @Override protected String getRootDirectory() {
-        return tmpRoot.getAbsolutePath();
-      }
-      @Override protected String getRootDirectory(String orgId, String mpId) {
-        return tmpRoot.getAbsolutePath();
-      }
     };
+    Field rootDirectories = OsgiFileSystemAssetStore.class.getDeclaredField("rootDirectories");
+    rootDirectories.setAccessible(true);
+    rootDirectories.set(repo, new ArrayList(Arrays.asList(tmpRoot.getAbsolutePath(), tmpRoot2.getAbsolutePath())));
+    repo.setupCache();
 
     sampleElemDir = new File(
             PathSupport.concat(new String[] { tmpRoot.toString(), ORG_ID, MP_ID, VERSION_2.toString() }));

--- a/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/AssetPathUtils.java
+++ b/modules/shared-filesystem-utils/src/main/java/org/opencastproject/assetmanager/util/AssetPathUtils.java
@@ -65,29 +65,7 @@ public final class AssetPathUtils {
     }
     final BundleContext bundleContext = componentContext.getBundleContext();
 
-    // Read in multiple directories
     List<String> assetManagerDirs = new ArrayList<>();
-    int index = 1;
-    boolean isAssetManagerDir = true;
-    while (isAssetManagerDir) {
-      String directory;
-      try {
-        directory = StringUtils.trimToNull(bundleContext.getProperty(CONFIG_ASSET_MANAGER_ROOT + "." + index));
-      } catch (Exception e) {
-        isAssetManagerDir = false;
-        throw e;
-      }
-
-      if (directory != null) {
-        assetManagerDirs.add(directory);
-      } else {
-        isAssetManagerDir = false;
-      }
-      index++;
-    }
-    if (assetManagerDirs.size() > 0) {
-      return assetManagerDirs;
-    }
 
     // Read in single directory
     String assetManagerDir = StringUtils.trimToNull(bundleContext.getProperty(CONFIG_ASSET_MANAGER_ROOT));
@@ -97,11 +75,25 @@ public final class AssetPathUtils {
         assetManagerDir = new File(assetManagerDir, "archive").getAbsolutePath();
       }
     }
+    assetManagerDirs.add(assetManagerDir);
+
+    // Read in multiple directories
+    int index = 1;
+    boolean isAssetManagerDir = true;
+    while (isAssetManagerDir) {
+      String directory = StringUtils.trimToNull(bundleContext.getProperty(CONFIG_ASSET_MANAGER_ROOT + "." + index));
+
+      if (directory != null) {
+        assetManagerDirs.add(directory);
+      } else {
+        isAssetManagerDir = false;
+      }
+      index++;
+    }
 
     // Is the asset manager available locally?
     if (assetManagerDir != null && new File(assetManagerDir).isDirectory()) {
       logger.debug("Found local asset manager directory at {}", assetManagerDir);
-      assetManagerDirs.add(assetManagerDir);
       return assetManagerDirs;
     }
 

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -89,6 +89,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -162,7 +163,7 @@ public final class WorkspaceImpl implements Workspace {
   private boolean waitForResourceFlag = false;
 
   /** the asset manager directory if locally available */
-  private String assetManagerPath = null;
+  private List<String> assetManagerPaths = null;
 
   /** the download url and directory if locally available */
   private String downloadUrl = null;
@@ -318,7 +319,7 @@ public final class WorkspaceImpl implements Workspace {
     staticCollections.add("waveform");
 
     // Check if we can read from the asset manager locally to avoid downloading files via HTTP
-    assetManagerPath = AssetPathUtils.getAssetManagerPath(cc);
+    assetManagerPaths = AssetPathUtils.getAssetManagerPath(cc);
 
     // Check if we can read published files locally to avoid downloading files via HTTP
     downloadUrl = DistributionPathUtils.getDownloadUrl(cc);
@@ -390,7 +391,7 @@ public final class WorkspaceImpl implements Workspace {
     }
 
     // Check if we can get the files directly from the asset manager
-    final File asset = AssetPathUtils.getLocalFile(assetManagerPath, securityService.getOrganization().getId(), uri);
+    final File asset = AssetPathUtils.getLocalFile(assetManagerPaths, securityService.getOrganization().getId(), uri);
     if (asset != null) {
       logger.debug("Copy local file {} from asset manager to workspace", asset);
       Files.copy(asset.toPath(), inWs.toPath(), StandardCopyOption.REPLACE_EXISTING);
@@ -420,7 +421,7 @@ public final class WorkspaceImpl implements Workspace {
     }
 
     // Check if we can get the files directly from the asset manager
-    final File asset = AssetPathUtils.getLocalFile(assetManagerPath, securityService.getOrganization().getId(), uri);
+    final File asset = AssetPathUtils.getLocalFile(assetManagerPaths, securityService.getOrganization().getId(), uri);
     if (asset != null) {
       return new FileInputStream(asset);
     }


### PR DESCRIPTION
> The Problem
>
>The storage of Opencast systems can easily be split between the asset manager/archive and the distributions. But splitting the archive itself is extremely hard and tricky.
>
>Unfortunately, some storage systems have limitations on how much data they can store. This means that you may have a limitation on how large your system can get based on the underlying storage system.
>
>That is why it would be incredibly helpful if Opencast could use more than one storage location/storage system for storing the asset manager data.

> Solution: Tracking Media Packages
> For this, we don’t need any migration since we would keep the same storage path structure we have in the asset manager right now:
>
> `.../archive[1..N]/<organization>/<mediapackage>/<version>/...`
>
>But to allow for dynamically adding new storage systems, we would have Opencast keep track of which media package goes to which storage, building a map like this:
>
>```
># storage(<mediapackage>) -> location
>storage("ID1") -> ".../storage/a/"
>storage("ID2") -> ".../storage/b/"
>```
>
>This means that for adding new media packages, Opencast could automatically select the storage with the lowest usage and that users could add new storage to Opencast at any time.

(lkiesow, 2022)

This PR attempts to solve the problem mentioned above by implementing the solution mentioned above.
