### PR TITLE
Update to Node 18

### DIFF
--- a/modules/engage-paella-player/pom.xml
+++ b/modules/engage-paella-player/pom.xml
@@ -89,7 +89,10 @@
                   <goal>install-node-and-npm</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>${node.version}</nodeVersion>
+                  <!-- Still building this with the old version of node -->
+                  <!-- This is going soon anyway. -->
+                  <!-- No need to work on an update -->
+                  <nodeVersion>v16.13.0</nodeVersion>
                 </configuration>
               </execution>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <joda-time.version>2.12.5</joda-time.version>
     <json-simple.version>1.1.1</json-simple.version>
     <karaf.version>4.4.3</karaf.version>
-    <node.version>v16.13.0</node.version>
+    <node.version>v18.16.0</node.version>
     <osgi.core.version>8.0.0</osgi.core.version>
     <osgi.annotation.version>8.1.0</osgi.annotation.version>
     <org.osgi.service.component.version>1.5.0</org.osgi.service.component.version>


### PR DESCRIPTION
This patch updates Opencast to use the current LTS version of Node.js for building the JavaScript components.

This deliberately excludes Paella Player 6 since it's build infrastructure causes problems. But since we are in the process of replacing that component anyway, I don't think it is worth working on that.

This fixes  #4268

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
