### PR TITLE
Remove empty options in ACL template select (#4910)

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
@@ -78,7 +78,7 @@
                             <p translate="USERS.ACLS.DETAILS.ACCESS.ACCESS_POLICY.DESCRIPTION">
                             <!-- Description -->
                             </p>
-                            <select
+                            <select chosen
                                     pre-select-from="acls"
                                     data-width="'200px'"
                                     ng-change="changeBaseAcl(baseAclId)"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -570,7 +570,7 @@
                             <!-- Description -->
                             </p>
                             <div ng-show="!transactions.read_only">
-                              <select
+                              <select chosen
                                       pre-select-from="acls"
                                       data-width="'200px'"
                                       ng-disabled="((tab == 'access') && !$root.userIs('ROLE_UI_EVENTS_DETAILS_ACL_EDIT'))"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
@@ -180,7 +180,7 @@
                             <p translate="EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.DESCRIPTION">
                             <!-- Description -->
                             </p>
-                            <select
+                            <select chosen
                                     pre-select-from="acls"
                                     ng-disabled="(tab == 'permissions') && (!$root.userIs('ROLE_UI_SERIES_DETAILS_ACL_EDIT') || aclLocked)"
                                     data-width="'200px'"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
@@ -53,7 +53,7 @@
                           <p translate="USERS.ACLS.NEW.ACCESS.ACCESS_POLICY.DESCRIPTION">
                           <!-- Description -->
                           </p>
-                          <select pre-select-from="wizard.step.acls"
+                          <select chosen pre-select-from="wizard.step.acls"
                                          data-width="'200px'"
                                          tabindex="1"
                                          focushere

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
@@ -513,7 +513,7 @@
                     <tr>
                       <td>
                         <div class="obj-container padded">
-                          <select
+                          <select chosen
                                   data-width="'200px'"
                                   tabindex="1"
                                   focushere
@@ -522,9 +522,7 @@
                                   ng-options="id as name for (id, name) in wizard.step.acls"
                                   placeholder-text-single="'{{ 'EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.LABEL' | translate }}'"
                                   no-results-text="'{{ 'EVENTS.SERIES.NEW.ACCESS.ACCESS_POLICY.EMPTY' | translate }}'"
-                                  >
-                                  <option value=""></option>
-                          </select>
+                                  ></select>
                         </div>
                       </td>
                     </tr>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
@@ -78,7 +78,7 @@
                     <tr>
                       <td>
                         <div class="obj-container padded">
-                          <select
+                          <select chosen
                                   pre-select-from="wizard.step.acls"
                                   data-width="'200px'"
                                   tabindex="1"


### PR DESCRIPTION
Fix the dropdown for the ACL templates in the admin ui by adding the attribute `chosen` to the `select` tag.

Fix #4910

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
