### PR TITLE
Fix User ACL Wording

### DIFF
--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1485,7 +1485,7 @@
              "DESCRIPTION" : "Please choose a pre-configured set of policies or add custom policies below",
              "NEW_USER": "New user",
              "USER": "User",
-             "USERS": "Users who are authorized for the access policy",
+             "USERS": "Users who are authorized by this access policy",
              "HELP": {
                "READ": "By setting read rights, the access policy becomes visible for the selected user",
                "WRITE": "By setting write rights, the selected user can edit the access policy"
@@ -1534,7 +1534,7 @@
              "DESCRIPTION" : "Please choose a pre-configured set of policies or add custom policies below",
              "NEW_USER": "New user",
              "USER": "User",
-             "USERS": "Users who are authorized for the access policy",
+             "USERS": "Users who are authorized by this access policy",
              "NONEXISTENT_USER": "Nonexistent user",
              "HELP": {
                "READ": "By setting read rights, the access policy becomes visible for the selected user",

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1487,8 +1487,8 @@
              "USER": "User",
              "USERS": "Users who are authorized by this access policy",
              "HELP": {
-               "READ": "By setting read rights, the access policy becomes visible for the selected user",
-               "WRITE": "By setting write rights, the selected user can edit the access policy"
+               "READ": "By setting read permissions, the entity to which this access policy is assigned becomes visible to the selected user.",
+               "WRITE": "By setting write permissions, the entity to which this access policy is assigned can be modified by the selected user."
              }
            },
            "ROLES": {
@@ -1537,8 +1537,8 @@
              "USERS": "Users who are authorized by this access policy",
              "NONEXISTENT_USER": "Nonexistent user",
              "HELP": {
-               "READ": "By setting read rights, the access policy becomes visible for the selected user",
-               "WRITE": "By setting write rights, the selected user can edit the access policy"
+               "READ": "By setting read permissions, the entity to which this access policy is assigned becomes visible to the selected user.",
+               "WRITE": "By setting write permissions, the entity to which this access policy is assigned can be modified by the selected user."
              }
            },
            "ROLES": {


### PR DESCRIPTION
This patch fixes the wording of the ACL editor label for adding users. Users are not “authorized for an access policy”. They are authorized for something else by that access policy.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
