### PR TITLE
Turn Paella 6 into a plugin

### DIFF
--- a/assemblies/karaf-features/src/main/feature/feature.xml
+++ b/assemblies/karaf-features/src/main/feature/feature.xml
@@ -191,7 +191,6 @@
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-email-template-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-email-template-service-impl/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-engage-paella-player/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-engage-paella-player-7/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-engage-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-event-comment/${project.version}</bundle>
@@ -435,7 +434,6 @@
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-email-template-service-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-email-template-service-impl/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-engage-paella-player/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-engage-paella-player-7/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-engage-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-event-comment/${project.version}</bundle>
@@ -631,7 +629,6 @@
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service-remote/${project.version}</bundle>
     <bundle start-level="83">mvn:org.opencastproject/opencast-editor-service-api/${project.version}</bundle>
-    <bundle start-level="82">mvn:org.opencastproject/opencast-engage-paella-player/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-engage-paella-player-7/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-engage-ui/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-lti/${project.version}</bundle>
@@ -730,6 +727,15 @@
     </conditional>
     <bundle start-level="82">mvn:org.opencastproject/opencast-annotation-api/${project.version}</bundle>
     <bundle start-level="82">mvn:org.opencastproject/opencast-annotation-impl/${project.version}</bundle>
+  </feature>
+
+  <feature name="opencast-plugin-paella-player-6" version="${project.version}">
+    <conditional>
+      <condition>opencast-allinone</condition>
+      <condition>opencast-presentation</condition>
+      <condition>opencast-adminpresentation</condition>
+    </conditional>
+    <bundle start-level="82">mvn:org.opencastproject/opencast-engage-paella-player/${project.version}</bundle>
   </feature>
 
   <feature name="opencast-pluginmanager" version="${project.version}">

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -122,6 +122,7 @@
               <feature>opencast-security-cas</feature>
               <feature>opencast-security-jwt</feature>
               <feature>opencast-plugin-legacy-annotation</feature>
+              <feature>opencast-plugin-paella-player-6</feature>
               <feature>opencast-plugin-transcription-services</feature>
               <feature>opencast-plugin-userdirectory-brightspace</feature>
               <feature>opencast-plugin-userdirectory-canvas</feature>

--- a/docs/guides/admin/docs/modules/paella.player/configuration.md
+++ b/docs/guides/admin/docs/modules/paella.player/configuration.md
@@ -21,6 +21,9 @@ or see them live on paella [demos page](https://paellaplayer.upv.es/demos/)
 Configuration
 -------------
 
+The Paelly player version 6 is no longer enabled by default.
+To use the player, enable the plugin in `etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg`.
+
 The configurations for the paella player are done for each tenant. The paella configuration files are located in
 `etc/ui-config/<tenant_id>/paella/config.json`.
 

--- a/docs/guides/admin/docs/modules/plugin-management.md
+++ b/docs/guides/admin/docs/modules/plugin-management.md
@@ -11,6 +11,8 @@ List of Available Plugins
 - opencast-plugin-legacy-annotation
     - Legacy annotation functionality. We do not recommend turning this on. It also requires additional configuration in
       the player. It's kept for a few legacy use-cases.
+- opencast-plugin-paella-player-6
+    - Old paella player version 6
 - opencast-plugin-transcription-services
     - Support for the Amberscript transcription service
     - Support for the Google cloud transcription service

--- a/etc/org.opencastproject.organization-mh_default_org.cfg
+++ b/etc/org.opencastproject.organization-mh_default_org.cfg
@@ -178,7 +178,7 @@ prop.adminui.user.external_role_display=false
 # Path to the default video player used by the engage interfaces and the LTI tools. Parameters for selecting the
 # specific videos will be appended automatically.  Common values include:
 #
-# - paella player: /paella/ui/watch.html?id=#{id}
+# - paella player 6: /paella/ui/watch.html?id=#{id}    ← requires plugin
 # - paella player 7: /paella7/ui/watch.html?id=#{id}
 #
 # Default: /paella7/ui/watch.html?id=#{id}

--- a/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
+++ b/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
@@ -7,6 +7,7 @@
 
 # List of available plugins
 opencast-plugin-legacy-annotation           = off
+opencast-plugin-paella-player-6             = off
 opencast-plugin-transcription-services      = off
 opencast-plugin-userdirectory-brightspace   = off
 opencast-plugin-userdirectory-canvas        = off


### PR DESCRIPTION
This patch turns the version 6 of the Paella Player included in Opencast into an optional plugin.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
