### PR TITLE
Enable Java 17 support

### DIFF
--- a/.github/workflows/test-opencast-build.yml
+++ b/.github/workflows/test-opencast-build.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         java:
           - 11
-          - 13
+          - 17
     name: build (java ${{ matrix.java }})
     runs-on: ubuntu-22.04
     steps:

--- a/assemblies/resources/bin/setenv
+++ b/assemblies/resources/bin/setenv
@@ -38,7 +38,7 @@
 # export JAVA_DEBUG_PORT   # Set debug port (defaults to 5005)
 
 
-export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8 -Dlog4j2.formatMsgNoLookups=true"
+export EXTRA_JAVA_OPTS="${EXTRA_JAVA_OPTS} -Dorg.eclipse.jetty.server.Request.maxFormContentSize=1500000 -Dfile.encoding=UTF-8 -Dlog4j2.formatMsgNoLookups=true --add-opens java.base/java.util=ALL-UNNAMED"
 export JAVA_MAX_MEM="${JAVA_MAX_MEM:-1G}"
 export JAVA_PERM_MEM="${JAVA_PERM_MEM:-256M}"
 export KARAF_NOROOT=true

--- a/modules/admin-ui/pom.xml
+++ b/modules/admin-ui/pom.xml
@@ -55,6 +55,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-message-broker-api</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
@@ -166,6 +167,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-kernel</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
@@ -275,6 +277,7 @@
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.commons-httpclient</artifactId>
+      <scope>test</scope>
     </dependency>
     <!-- Testing -->
     <dependency>
@@ -360,6 +363,10 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>org.opencastproject:opencast-elasticsearch-impl</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>joda-time:joda-time</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>org.apache.httpcomponents:httpcore-osgi</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.mnode.ical4j:ical4j</ignoredUnusedDeclaredDependency>

--- a/modules/asset-manager-impl/pom.xml
+++ b/modules/asset-manager-impl/pom.xml
@@ -98,6 +98,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -128,6 +129,10 @@
     <dependency>
       <groupId>com.mysema.querydsl</groupId>
       <artifactId>querydsl-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
     </dependency>
     <!--
       - JPA
@@ -179,7 +184,7 @@
     <dependency>
       <groupId>org.mutabilitydetector</groupId>
       <artifactId>MutabilityDetector</artifactId>
-      <version>0.10.2</version>
+      <version>0.10.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/asset-manager-storage-aws/pom.xml
+++ b/modules/asset-manager-storage-aws/pom.xml
@@ -101,6 +101,7 @@
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/modules/asset-manager-storage-fs/pom.xml
+++ b/modules/asset-manager-storage-fs/pom.xml
@@ -37,6 +37,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-asset-manager-impl</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/authorization-manager/pom.xml
+++ b/modules/authorization-manager/pom.xml
@@ -29,6 +29,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workspace-api</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
@@ -103,6 +104,7 @@
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jettison</groupId>
@@ -170,6 +172,9 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>org.opencastproject:opencast-elasticsearch-impl</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>

--- a/modules/authorization-xacml/pom.xml
+++ b/modules/authorization-xacml/pom.xml
@@ -105,6 +105,11 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/capture-admin-service-impl/pom.xml
+++ b/modules/capture-admin-service-impl/pom.xml
@@ -95,6 +95,7 @@
     <dependency>
       <groupId>com.entwinemedia.common</groupId>
       <artifactId>functional</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/modules/common-jpa-impl/pom.xml
+++ b/modules/common-jpa-impl/pom.xml
@@ -31,11 +31,12 @@
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Testing -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
     </dependency>
-    <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -148,7 +148,6 @@
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
       <version>9.6.0-4</version>
-      <scope>test</scope>
     </dependency>
     <!--
     - Parameterized tests for JUnit
@@ -212,6 +211,8 @@
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
             <!-- probably needed for the module scheduler-api -->
             <ignoredUnusedDeclaredDependency>org.mnode.ical4j:ical4j</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>com.h2database:h2</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>net.sf.saxon:Saxon-HE</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/composer-workflowoperation/pom.xml
+++ b/modules/composer-workflowoperation/pom.xml
@@ -37,6 +37,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-inspection-workflowoperation</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
@@ -77,6 +78,7 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
+++ b/modules/composer-workflowoperation/src/main/java/org/opencastproject/workflow/handler/composer/ImageWorkflowOperationHandler.java
@@ -31,7 +31,6 @@ import static com.entwinemedia.fn.parser.Parsers.opt;
 import static com.entwinemedia.fn.parser.Parsers.space;
 import static com.entwinemedia.fn.parser.Parsers.symbol;
 import static com.entwinemedia.fn.parser.Parsers.token;
-import static com.entwinemedia.fn.parser.Parsers.yield;
 import static java.lang.String.format;
 import static org.opencastproject.util.EqualsUtil.eq;
 
@@ -543,13 +542,13 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
     static final Parser<Double> number = token(Parsers.dbl);
     static final Parser<MediaPosition> seconds = number.bind(new Fn<Double, Parser<MediaPosition>>() {
       @Override public Parser<MediaPosition> apply(Double p) {
-        return yield(new MediaPosition(PositionType.Seconds, p));
+        return Parsers.yield(new MediaPosition(PositionType.Seconds, p));
       }
     });
     static final Parser<MediaPosition> percentage =
             number.bind(Parsers.<Double, String>ignore(symbol("%"))).bind(new Fn<Double, Parser<MediaPosition>>() {
               @Override public Parser<MediaPosition> apply(Double p) {
-                return yield(new MediaPosition(PositionType.Percentage, p));
+                return Parsers.yield(new MediaPosition(PositionType.Percentage, p));
               }
             });
     static final Parser<Character> comma = token(character(','));
@@ -565,7 +564,7 @@ public class ImageWorkflowOperationHandler extends AbstractWorkflowOperationHand
                 return many(opt(comma).bind(Parsers.ignorePrevious(position)))
                         .bind(new Fn<List<MediaPosition>, Parser<List<MediaPosition>>>() {
                           @Override public Parser<List<MediaPosition>> apply(List<MediaPosition> rest) {
-                            return yield($(first).append(rest).toList());
+                            return Parsers.yield($(first).append(rest).toList());
                           }
                         });
               }

--- a/modules/cover-image-impl/pom.xml
+++ b/modules/cover-image-impl/pom.xml
@@ -189,6 +189,11 @@
       <version>1.0-RC1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/db/pom.xml
+++ b/modules/db/pom.xml
@@ -93,6 +93,7 @@
             <ignoredUnusedDeclaredDependency>org.postgresql:postgresql</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.checkerframework:checker-qual</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>net.java.dev.jna:jna</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>com.h2database:h2</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/modules/distribution-service-download/pom.xml
+++ b/modules/distribution-service-download/pom.xml
@@ -22,10 +22,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>

--- a/modules/distribution-service-streaming-wowza/pom.xml
+++ b/modules/distribution-service-streaming-wowza/pom.xml
@@ -94,6 +94,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -102,6 +103,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
@@ -110,6 +112,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>javax.servlet:javax.servlet-api</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>

--- a/modules/elasticsearch-index/pom.xml
+++ b/modules/elasticsearch-index/pom.xml
@@ -131,6 +131,11 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/event-comment/pom.xml
+++ b/modules/event-comment/pom.xml
@@ -104,6 +104,11 @@
       <version>2.4.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -136,10 +136,12 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -198,6 +200,11 @@
       <groupId>uk.co.datumedge</groupId>
       <artifactId>hamcrest-json</artifactId>
       <version>0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/index-service/pom.xml
+++ b/modules/index-service/pom.xml
@@ -222,6 +222,11 @@
       <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -230,6 +235,9 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>org.opencastproject:opencast-elasticsearch-impl</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>

--- a/modules/inspection-workflowoperation/pom.xml
+++ b/modules/inspection-workflowoperation/pom.xml
@@ -81,6 +81,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>org.opencastproject:opencast-metadata-api</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- provide a logger for tests -->
             <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>

--- a/modules/kernel/pom.xml
+++ b/modules/kernel/pom.xml
@@ -104,6 +104,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>

--- a/modules/oaipmh-remote/pom.xml
+++ b/modules/oaipmh-remote/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>org.osgi.service.component.annotations</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/oaipmh/pom.xml
+++ b/modules/oaipmh/pom.xml
@@ -39,15 +39,18 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-series-service-api</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workspace-api</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/modules/publication-service-oaipmh-remote/pom.xml
+++ b/modules/publication-service-oaipmh-remote/pom.xml
@@ -42,6 +42,7 @@
     <dependency>
       <groupId>com.entwinemedia.common</groupId>
       <artifactId>functional</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -58,6 +59,7 @@
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/rest-test-environment/pom.xml
+++ b/modules/rest-test-environment/pom.xml
@@ -59,6 +59,10 @@
       <artifactId>jetty-servlet</artifactId>
       <version>9.4.20.v20190813</version>
     </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/scheduler-impl/pom.xml
+++ b/modules/scheduler-impl/pom.xml
@@ -59,6 +59,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-authorization-xacml</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
@@ -102,6 +103,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/modules/security-aai/pom.xml
+++ b/modules/security-aai/pom.xml
@@ -42,6 +42,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -85,6 +90,11 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -106,10 +116,10 @@
                 <ignoredUsedUndeclaredDependency>org.springframework:spring-core</ignoredUsedUndeclaredDependency>
                 <ignoredUsedUndeclaredDependency>org.springframework.security:spring-security-core</ignoredUsedUndeclaredDependency>
                 <ignoredUsedUndeclaredDependency>org.springframework:spring-beans</ignoredUsedUndeclaredDependency>
-                <ignoredUsedUndeclaredDependency>org.hamcrest:hamcrest</ignoredUsedUndeclaredDependency>
               </ignoredUsedUndeclaredDependencies>
               <ignoredUnusedDeclaredDependencies>
                 <ignoredUnusedDeclaredDependency>org.springframework:org.springframework.context</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedUndeclaredDependency>org.hamcrest:hamcrest</ignoredUnusedUndeclaredDependency>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>

--- a/modules/sox-workflowoperation/pom.xml
+++ b/modules/sox-workflowoperation/pom.xml
@@ -18,6 +18,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/termination-state-api/pom.xml
+++ b/modules/termination-state-api/pom.xml
@@ -24,6 +24,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-serviceregistry</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>

--- a/modules/textextractor-tesseract/pom.xml
+++ b/modules/textextractor-tesseract/pom.xml
@@ -25,6 +25,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-common</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <!--  Thirdparty dependencies -->
     <dependency>

--- a/modules/transcription-service-google-speech-impl/pom.xml
+++ b/modules/transcription-service-google-speech-impl/pom.xml
@@ -132,6 +132,11 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>jakarta.persistence</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/transcription-service-ibm-watson-impl/pom.xml
+++ b/modules/transcription-service-ibm-watson-impl/pom.xml
@@ -130,6 +130,11 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>jakarta.persistence</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/transcription-service-microsoft-azure/pom.xml
+++ b/modules/transcription-service-microsoft-azure/pom.xml
@@ -118,6 +118,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>jakarta.persistence</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>
       <artifactId>org.apache.servicemix.bundles.xerces</artifactId>
     </dependency>

--- a/modules/transcription-service-workflowoperation/pom.xml
+++ b/modules/transcription-service-workflowoperation/pom.xml
@@ -68,6 +68,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/modules/urlsigning-verifier-service-impl/pom.xml
+++ b/modules/urlsigning-verifier-service-impl/pom.xml
@@ -19,6 +19,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -27,6 +28,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/userdirectory/pom.xml
+++ b/modules/userdirectory/pom.xml
@@ -37,6 +37,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>

--- a/modules/videoeditor-ffmpeg-impl/pom.xml
+++ b/modules/videoeditor-ffmpeg-impl/pom.xml
@@ -69,6 +69,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-inspection-service-ffmpeg</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>

--- a/modules/videosegmenter-ffmpeg/pom.xml
+++ b/modules/videosegmenter-ffmpeg/pom.xml
@@ -52,6 +52,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/modules/workflow-service-impl/pom.xml
+++ b/modules/workflow-service-impl/pom.xml
@@ -154,6 +154,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>jakarta.persistence</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
@@ -162,6 +167,7 @@
       <groupId>org.opencastproject</groupId>
       <artifactId>opencast-workflow-workflowoperation</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/modules/workflow-workflowoperation/pom.xml
+++ b/modules/workflow-workflowoperation/pom.xml
@@ -98,6 +98,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/workspace-impl/pom.xml
+++ b/modules/workspace-impl/pom.xml
@@ -111,6 +111,9 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>com.entwinemedia.common:functional</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <ignoredUnusedDeclaredDependencies>
             <!-- indirectly used when tests are run -->
             <ignoredUnusedDeclaredDependency>org.glassfish.jersey.core:jersey-server</ignoredUnusedDeclaredDependency>

--- a/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
+++ b/modules/workspace-impl/src/main/java/org/opencastproject/workspace/impl/WorkspaceImpl.java
@@ -448,7 +448,7 @@ public final class WorkspaceImpl implements Workspace {
 
   /** {@link #copyOrLink(java.io.File, java.io.File)} as an effect. <code>src -> dst -> ()</code> */
   private Effect<File> copyOrLink(final File src) {
-    return new Effect.X<File>() {
+    return new Effect.X<>() {
       @Override
       protected void xrun(File dst) throws IOException {
         copyOrLink(src, dst);

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,8 @@
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <commons-text.version>1.10.0</commons-text.version>
     <cxf.version>3.5.5</cxf.version>
-    <eclipselink.version>2.7.8</eclipselink.version>
+    <eclipselink.version>2.7.11</eclipselink.version>
+    <eclipselink.asm.version>9.3.0</eclipselink.asm.version>
     <failureaccess.version>1.0.1</failureaccess.version>
     <freemarker.version>2.3.31</freemarker.version>
     <functional.version>1.4.2</functional.version>
@@ -375,7 +376,10 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <useFile>false</useFile>
-          <argLine>-Dfile.encoding=UTF-8</argLine>
+          <argLine>
+            -Dfile.encoding=UTF-8
+            --add-opens java.base/java.util=ALL-UNNAMED
+          </argLine>
           <!-- see https://jira.codehaus.org/browse/SUREFIRE-951 -->
           <systemPropertyVariables>
             <M2_REPO>${settings.localRepository}</M2_REPO>
@@ -685,7 +689,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.6.0</version>
           <executions>
             <execution>
               <id>analyze</id>
@@ -697,18 +701,6 @@
               </configuration>
             </execution>
           </executions>
-          <dependencies>
-            <dependency>
-              <groupId>org.ow2.asm</groupId>
-              <artifactId>asm</artifactId>
-              <version>9.3</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.maven.shared</groupId>
-              <artifactId>maven-dependency-analyzer</artifactId>
-              <version>1.11.1</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.karaf.tooling</groupId>
@@ -959,6 +951,11 @@
         <version>1.2.1</version>
       </dependency>
       <dependency>
+        <groupId>jakarta.annotation</groupId>
+        <artifactId>jakarta.annotation-api</artifactId>
+        <version>1.3.5</version>
+      </dependency>
+      <dependency>
         <groupId>com.sun.mail</groupId>
         <artifactId>jakarta.mail</artifactId>
         <version>${jakarta.mail.version}</version>
@@ -997,7 +994,7 @@
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.asm</artifactId>
-        <version>${eclipselink.version}</version>
+        <version>${eclipselink.asm.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
@@ -1150,7 +1147,7 @@
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
         <scope>test</scope>
-        <version>4.3</version>
+        <version>5.1.0</version>
       </dependency>
       <dependency>
         <groupId>org.easymock</groupId>


### PR DESCRIPTION
This PR updates dependencies to support Java 17.

The dependency scope changes suggested by the maven-dependency-plugin can cause trouble at runtime. We should test all the integrations like Wowza and the AWS and integrations that are not enabled by default.

For backward compatibility with spring security, adding the java option --add-opens java.base/java.util=ALL-UNNAMED is (seems to be) necessary.

Adding the option mitigates the following exception:

java.lang.reflect.InaccessibleObjectException: Unable to make public boolean java.util.Arrays$ArrayList.contains(java.lang.Object) accessible: module java.base does not "opens java.util" to unnamed module @7dc5e7b4

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
