### PR TITLE
Automate PR comments with built tarball links

### DIFF
--- a/.github/workflows/comment-on-prs.yml
+++ b/.github/workflows/comment-on-prs.yml
@@ -1,0 +1,77 @@
+name: Comment on Pull request
+#Cribbed from https://github.com/orgs/community/discussions/51403#discussioncomment-5535167
+
+on:
+  workflow_run:
+    workflows: [Test Opencast]
+    types:
+      - completed
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Artifact and Pull request info
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_EVENT_OBJ: ${{ toJSON(github.event.workflow_run) }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+        run: |
+          PREVIOUS_JOB_ID=$(jq -r '.id' <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          echo "Previous Job ID: $PREVIOUS_JOB_ID"
+          echo "PREVIOUS_JOB_ID=$PREVIOUS_JOB_ID" >> "$GITHUB_ENV"
+          
+          SUITE_ID=$(jq -r '.check_suite_id' <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          echo "Previous Suite ID: $SUITE_ID"
+          echo "SUITE_ID=$SUITE_ID" >> "$GITHUB_ENV"
+          
+          ARTIFACT_ID=$(gh api "/repos/$OWNER/$REPO/actions/artifacts" \
+            --jq ".artifacts.[] |
+            select(.workflow_run.id==${PREVIOUS_JOB_ID}) |
+            select(.expired==false) |
+            .id")
+          
+          echo "Artifact ID: $ARTIFACT_ID"
+          echo "ARTIFACT_ID=$ARTIFACT_ID" >> "$GITHUB_ENV"
+          
+          PR_NUMBER=$(jq -r '.pull_requests[0].number' \
+            <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          
+          echo "Pull request Number: $PR_NUMBER"
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_ENV"
+          
+          HEAD_SHA=$(jq -r '.pull_requests[0].head.sha' \
+            <<< "$WORKFLOW_RUN_EVENT_OBJ")
+          
+          echo "Head SHA: $HEAD_SHA"
+          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+      - name: Find Comment
+        uses: peter-evans/find-comment@v2
+        id: find-comment
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-author: 'github-actions[bot]'
+      - name: Update Comment
+        env:
+          JOB_PATH: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.PREVIOUS_JOB_ID }}"
+          ARTIFACT_URL: "${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.ARTIFACT_ID }}"
+          HEAD_SHA: "${{ env.HEAD_SHA }}"
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ env.PR_NUMBER }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: |-
+            ![badge]
+            
+            Build Successful! You can find a link to the downloadable artifact below.
+            
+            | Name     | Link                    |
+            | -------- | ----------------------- |
+            | Commit   | ${{ env.HEAD_SHA }}     |
+            | Logs     | ${{ env.JOB_PATH }}     |
+            | Download | ${{ env.ARTIFACT_URL }} |
+            
+            [badge]: https://img.shields.io/badge/Build_Success!-0d1117?style=for-the-badge&labelColor=3fb950&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiBmaWxsPSIjZmZmZmZmIj48cGF0aCBkPSJNMjEuMDMgNS43MmEuNzUuNzUgMCAwIDEgMCAxLjA2bC0xMS41IDExLjVhLjc0Ny43NDcgMCAwIDEtMS4wNzItLjAxMmwtNS41LTUuNzVhLjc1Ljc1IDAgMSAxIDEuMDg0LTEuMDM2bDQuOTcgNS4xOTVMMTkuOTcgNS43MmEuNzUuNzUgMCAwIDEgMS4wNiAwWiI+PC9wYXRoPjwvc3ZnPg==

--- a/.github/workflows/comment-on-prs.yml
+++ b/.github/workflows/comment-on-prs.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-author: 'github-actions[bot]'
+          body-includes: 'You can find a link to the downloadable artifacts below'
+
       - name: Update Comment
         env:
           JOB_PATH: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.PREVIOUS_JOB_ID }}"

--- a/.github/workflows/comment-on-prs.yml
+++ b/.github/workflows/comment-on-prs.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   comment:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: > 
+      github.event.workflow_run.conclusion == 'success'
+      && github.repository == 'opencast/opencast'
     runs-on: ubuntu-latest
     steps:
       - name: Get Artifact and Pull request info

--- a/.github/workflows/comment-on-prs.yml
+++ b/.github/workflows/comment-on-prs.yml
@@ -24,7 +24,15 @@ jobs:
           PREVIOUS_JOB_ID=$(jq -r '.id' <<< "$WORKFLOW_RUN_EVENT_OBJ")
           echo "Previous Job ID: $PREVIOUS_JOB_ID"
           echo "PREVIOUS_JOB_ID=$PREVIOUS_JOB_ID" >> "$GITHUB_ENV"
-          
+
+          PREVIOUS_TYPE=$(gh api "/repos/$OWNER/$REPO/actions/runs/$PREVIOUS_JOB_ID" \
+            --jq ".event")
+          echo "Previous event was a $PREVIOUS_TYPE"
+          echo "PREVIOUS_TYPE=$PREVIOUS_TYPE" >> "$GITHUB_ENV"
+          if [[ "pull_request" != "$PREVIOUS_TYPE" ]]; then
+            exit 0
+          fi
+
           SUITE_ID=$(jq -r '.check_suite_id' <<< "$WORKFLOW_RUN_EVENT_OBJ")
           echo "Previous Suite ID: $SUITE_ID"
           echo "SUITE_ID=$SUITE_ID" >> "$GITHUB_ENV"
@@ -52,12 +60,14 @@ jobs:
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: find-comment
+        if: env.PR_NUMBER != 'null' && env.PREVIOUS_TYPE == 'pull_request'
         with:
           issue-number: ${{ env.PR_NUMBER }}
           comment-author: 'github-actions[bot]'
           body-includes: 'You can find a link to the downloadable artifacts below'
 
       - name: Update Comment
+        if: env.PR_NUMBER != 'null' && env.PREVIOUS_TYPE == 'pull_request'
         env:
           JOB_PATH: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ env.PREVIOUS_JOB_ID }}"
           ARTIFACT_URL: "${{ github.server_url }}/${{ github.repository }}/suites/${{ env.SUITE_ID }}/artifacts/${{ env.ARTIFACT_ID }}"


### PR DESCRIPTION
This PR automates creation of a comment with both the build log, and a download link for all relevant PRs.  As the PR gets updated new builds will *update* the existing comment.  I think this is a reasonable approach, but we can just have it post a new comment if that's better for our uses.

See https://github.com/gregorydlogan/opencast/pull/176 for an example (although the 'tarball' is just junk data).

### Your pull request should…

* [x] have a concise title
* [x] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
