### PR TITLE
Show user information in event workflow details

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -422,7 +422,7 @@
                     <tr ng-repeat="item in workflows.entries|orderBy:'submitted':true track by $index">
                       <td>{{ item.id }}</td>
                       <td>{{ item.title }}</td>
-                      <td>{{ item.submitter }}</td>
+                      <td>{{ item.submitterName + '&lt;' + item.submitterEmail + '&gt;' + ' (' + item.submitter + ')'}}</td>
                       <td>{{ item.submitted | localizeDate : 'dateTime' : 'medium' }}</td>
                       <td>{{ item.status | translate }}</td>
                       <td ng-if="$root.userIs('ROLE_UI_EVENTS_DETAILS_WORKFLOWS_EDIT')">

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -124,6 +124,7 @@ import org.opencastproject.security.api.Permissions;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.security.urlsigning.exception.UrlSigningException;
 import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.security.util.SecurityUtil;
@@ -273,6 +274,8 @@ public abstract class AbstractEventEndpoint {
   public abstract Boolean getOnlySeriesWithWriteAccessEventModal();
 
   public abstract Boolean getOnlyEventsWithWriteAccessEventsTab();
+
+  public abstract UserDirectoryService getUserDirectoryService();
 
   /** Default server URL */
   protected String serverUrl = "http://localhost:8080";
@@ -1813,7 +1816,11 @@ public abstract class AbstractEventEndpoint {
         for (WorkflowInstance instance : workflowInstances) {
           long instanceId = instance.getId();
           Date created = instance.getDateCreated();
-          String creatorName = instance.getCreatorName();
+          String userId = instance.getCreatorName();
+
+          User user = getUserDirectoryService().loadUser(userId);
+          String creatorName = user.getName() + "<" + user.getEmail() + ">";
+
           jsonList.add(obj(f("id", v(instanceId)), f("title", v(instance.getTitle(), Jsons.BLANK)),
                   f("status", v(WORKFLOW_STATUS_TRANSLATION_PREFIX + instance.getState().toString())),
                   f("submitted", v(created != null ? DateTimeSupport.toUTC(created.getTime()) : "", Jsons.BLANK)),

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1816,15 +1816,18 @@ public abstract class AbstractEventEndpoint {
         for (WorkflowInstance instance : workflowInstances) {
           long instanceId = instance.getId();
           Date created = instance.getDateCreated();
-          String userId = instance.getCreatorName();
+          String submitter = instance.getCreatorName();
 
-          User user = getUserDirectoryService().loadUser(userId);
-          String creatorName = user.getName() + "<" + user.getEmail() + ">";
+          User user = getUserDirectoryService().loadUser(submitter);
+          String submitterName = user.getName();
+          String submitterEmail = user.getEmail();
 
           jsonList.add(obj(f("id", v(instanceId)), f("title", v(instance.getTitle(), Jsons.BLANK)),
                   f("status", v(WORKFLOW_STATUS_TRANSLATION_PREFIX + instance.getState().toString())),
                   f("submitted", v(created != null ? DateTimeSupport.toUTC(created.getTime()) : "", Jsons.BLANK)),
-                  f("submitter", v(creatorName, Jsons.BLANK))));
+                  f("submitter", v(submitter, Jsons.BLANK)),
+                  f("submitterName", v(submitterName, Jsons.BLANK)),
+                  f("submitterEmail", v(submitterEmail, Jsons.BLANK))));
         }
         JObject json = obj(f("results", arr(jsonList)), f("count", v(workflowInstances.size())));
         return okJson(json);

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/OsgiEventEndpoint.java
@@ -32,6 +32,7 @@ import org.opencastproject.index.service.api.IndexService;
 import org.opencastproject.scheduler.api.SchedulerService;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.security.urlsigning.utils.UrlSigningServiceOsgiUtil;
 import org.opencastproject.util.doc.rest.RestService;
@@ -83,6 +84,7 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint {
   private UrlSigningService urlSigningService;
   private WorkflowService workflowService;
   private AdminUIConfiguration adminUIConfiguration;
+  private UserDirectoryService userDirectoryService;
 
   private long expireSeconds = UrlSigningServiceOsgiUtil.DEFAULT_URL_SIGNING_EXPIRE_DURATION;
   private Boolean signWithClientIP = UrlSigningServiceOsgiUtil.DEFAULT_SIGN_WITH_CLIENT_IP;
@@ -244,6 +246,17 @@ public class OsgiEventEndpoint extends AbstractEventEndpoint {
   @Reference
   public void setUrlSigningService(UrlSigningService urlSigningService) {
     this.urlSigningService = urlSigningService;
+  }
+
+  @Override
+  public UserDirectoryService getUserDirectoryService() {
+    return userDirectoryService;
+  }
+
+  /** Sets the user directory service */
+  @Reference
+  public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
+    this.userDirectoryService = userDirectoryService;
   }
 
   @Activate

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/AbstractEventEndpointTest.java
@@ -41,6 +41,7 @@ import org.opencastproject.scheduler.api.RecordingState;
 import org.opencastproject.scheduler.api.SchedulerService;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.security.urlsigning.service.UrlSigningService;
 import org.opencastproject.test.rest.NotFoundExceptionMapper;
 import org.opencastproject.test.rest.RestServiceTestEnv;
@@ -698,6 +699,7 @@ public class AbstractEventEndpointTest {
     private CaptureAgentStateService captureAgentStateService;
     private ElasticsearchIndex index;
     private UrlSigningService urlSigningService;
+    private UserDirectoryService userDirectoryService;
 
     public WorkflowService getWorkflowService() {
       return workflowService;
@@ -809,6 +811,14 @@ public class AbstractEventEndpointTest {
 
     public UrlSigningService getUrlSigningService() {
       return urlSigningService;
+    }
+
+    public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
+      this.userDirectoryService = userDirectoryService;
+    }
+
+    public UserDirectoryService getUserDirectoryService() {
+      return userDirectoryService;
     }
 
   }

--- a/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
+++ b/modules/admin-ui/src/test/java/org/opencastproject/adminui/endpoint/TestEventEndpoint.java
@@ -357,6 +357,8 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
     EasyMock.replay(workflowService);
     env.setWorkflowService(workflowService);
 
+
+
     SeriesEndpoint seriesEndpoint = EasyMock.createNiceMock(SeriesEndpoint.class);
     EasyMock.expect(seriesEndpoint.getOnlySeriesWithWriteAccessEventsFilter()).andReturn(false).anyTimes();
     EasyMock.expect(seriesEndpoint.getUserSeriesByAccess(EasyMock.anyBoolean())).andReturn(new HashMap<>()).anyTimes();
@@ -421,6 +423,7 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
     UserDirectoryService userDirectoryService = EasyMock.createMock(UserDirectoryService.class);
     EasyMock.expect(userDirectoryService.loadUser(EasyMock.anyString())).andReturn(userWithPermissions).anyTimes();
     EasyMock.replay(userDirectoryService);
+    env.setUserDirectoryService(userDirectoryService);
 
     JobEndpoint endpoint = new JobEndpoint();
     endpoint.setServiceRegistry(serviceRegistry);
@@ -762,5 +765,10 @@ public class TestEventEndpoint extends AbstractEventEndpoint {
   @Override
   public Boolean getOnlyEventsWithWriteAccessEventsTab() {
     return false;
+  }
+
+  @Override
+  public UserDirectoryService getUserDirectoryService() {
+    return env.getUserDirectoryService();
   }
 }

--- a/modules/admin-ui/src/test/resources/eventWorkflows.json
+++ b/modules/admin-ui/src/test/resources/eventWorkflows.json
@@ -6,21 +6,21 @@
             "title": "Full",
             "status": "EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.INSTANTIATED",
             "submitted": "2014-06-05T15:00:00Z",
-            "submitter": "WithPermissions"
+            "submitter": "WithPermissions<with@permissions.com>"
         },
         {
             "id": 2,
             "title": "Full",
             "status": "EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.INSTANTIATED",
             "submitted": "2014-06-05T15:00:00Z",
-            "submitter": ""
+            "submitter": "WithPermissions<with@permissions.com>"
         },
         {
             "id": 3,
             "title": "Full",
             "status": "EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.INSTANTIATED",
             "submitted": "2014-06-05T15:00:00Z",
-            "submitter": ""
+            "submitter": "WithPermissions<with@permissions.com>"
         }
     ]
 }

--- a/modules/admin-ui/src/test/resources/eventWorkflows.json
+++ b/modules/admin-ui/src/test/resources/eventWorkflows.json
@@ -6,21 +6,27 @@
             "title": "Full",
             "status": "EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.INSTANTIATED",
             "submitted": "2014-06-05T15:00:00Z",
-            "submitter": "WithPermissions<with@permissions.com>"
+            "submitter": "WithPermissions",
+            "submitterName": "WithPermissions",
+            "submitterEmail": "with@permissions.com"
         },
         {
             "id": 2,
             "title": "Full",
             "status": "EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.INSTANTIATED",
             "submitted": "2014-06-05T15:00:00Z",
-            "submitter": "WithPermissions<with@permissions.com>"
+            "submitter": "",
+            "submitterName": "WithPermissions",
+            "submitterEmail": "with@permissions.com"
         },
         {
             "id": 3,
             "title": "Full",
             "status": "EVENTS.EVENTS.DETAILS.WORKFLOWS.OPERATION_STATUS.INSTANTIATED",
             "submitted": "2014-06-05T15:00:00Z",
-            "submitter": "WithPermissions<with@permissions.com>"
+            "submitter": "",
+            "submitterName": "WithPermissions",
+            "submitterEmail": "with@permissions.com"
         }
     ]
 }


### PR DESCRIPTION
Currently, if you go to the workflows tab of the event details modal and check which user started a workflow, you will see that users id. If you are using auth services like e.g. Shibboleth, the user id is likely to be a random assortment of letters and numbers that are not helpful in determining who started the workflow. This PR changes the "submitter" value returned from the backend, so that instead of the user id the user name and email are displayed.

How it currently looks:
![Bildschirmfoto vom 2023-05-26 10-01-42](https://github.com/opencast/opencast/assets/14070005/3047357e-b682-452f-87e4-1fe09165ebc9)
With the PR:
![Bildschirmfoto vom 2023-05-26 10-02-04](https://github.com/opencast/opencast/assets/14070005/17bf2398-c6c3-49f3-991b-91bcbba87f69)

This PR presumes that no one actually has a use for the user id in the workflow tab. If you think otherwise, please let me know. We can work something out, e.g. keeping the user id and creating an extra column for the user name and email.

### Your pull request should…

* [x] have a concise title
* ~[ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* ~[ ] include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
