### PR TITLE
Fix directory cleanup for symlinks

### DIFF
--- a/modules/common/src/main/java/org/opencastproject/cleanup/RecursiveDirectoryCleaner.java
+++ b/modules/common/src/main/java/org/opencastproject/cleanup/RecursiveDirectoryCleaner.java
@@ -76,7 +76,7 @@ public final class RecursiveDirectoryCleaner implements FileVisitor<Path> {
   @Override
   public FileVisitResult visitFileFailed(Path path, IOException e) throws IOException {
     if (!(e instanceof NoSuchFileException)) {
-      logger.warn("Visiting file {} failed with exception {}", path, e);
+      logger.warn("Visiting file {} failed", path, e);
     }
     return FileVisitResult.CONTINUE;
   }
@@ -98,6 +98,17 @@ public final class RecursiveDirectoryCleaner implements FileVisitor<Path> {
     if (!Files.exists(startingDir)) {
       logger.warn("Directory {} to cleanup is not existing", startingDir);
       return false;
+    }
+
+    if (Files.isSymbolicLink(startingDir)) {
+      logger.warn("Directory {} is a symlink. Trying to resolve it.", startingDir);
+      try {
+        startingDir = Path.of(startingDir.toFile().getCanonicalPath());
+      } catch (IOException ioException) {
+        logger.error("Couldn't resolve symlink {}", startingDir, ioException);
+        return false;
+      }
+      logger.warn("New cleanup directory after symlink was resolved: {}", startingDir);
     }
 
     if (!Files.isDirectory(startingDir)) {


### PR DESCRIPTION
This PR fixes the directory cleanup regarding symbolic links. Currently, if your workspace (for example) is a symlink, the cleanup process will delete it, instead of iterating through the files within the directory it's referencing.

To test this, you can set a lower cleanup period in your custom.properties (like 30 seconds, for example) and the value for the maximum age of a file (5 seconds, for example).

In the following example, the period and maximum age are already set to a lower value:
```
######### Workspace Cleanup #########

# The scheduled period in seconds, at which a workspace cleanup operation is performed.
# 86400 seconds equals 24 hours.
# Default value: -1 (Disable cleanup scheduler)
org.opencastproject.workspace.cleanup.period=30

# The maximum age a file must reach in seconds before a deletion of the file in the workspace cleanup operation is
# performed. 2592000 seconds equals 30 days.
# Default value: -1 (max age will never be reached)
org.opencastproject.workspace.cleanup.max.age=5
```

In the second step, you have to delete your workspace directory (or any directory the cleanup service is cleaning up)  and create a symlink instead. Absolute paths as well as relative paths should work.