### PR TITLE
Properly encode adopter registration data

### DIFF
--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
@@ -137,7 +137,7 @@ public class Sender {
       request = new HttpPost(url);
       request.addHeader("Content-Type", "application/json; utf-8");
       request.addHeader("Accept", "application/json");
-      ((HttpPost) request).setEntity(new StringEntity(json));
+      ((HttpPost) request).setEntity(new StringEntity(json, StandardCharsets.UTF_8));
     }
 
     HttpResponse resp = client.execute(request);


### PR DESCRIPTION
Previously we fed our http libs `latin-1` data, and told it we were sending `utf-8`.  This works, until you need the utf-8 bits, then it breaks the server.

Fixed in the backend with https://github.com/opencast/adopter-registration-server/pull/17/commits/9c4ce73a93049364bbbe81d7a0aa8cdd711348ce, fixing the client end with this PR.

Fixes: #4310

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
