### PR TITLE
Fix Distribution of Elements for Live Events

### DIFF
--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -645,7 +645,6 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       MediaPackage mp = (MediaPackage) snapshot.getMediaPackage().clone();
 
       Set<String> elementIds = new HashSet<>();
-
       if (mp.getCatalogs(MediaPackageElements.EPISODE).length > 0) {
         elementIds.add(mp.getCatalogs(MediaPackageElements.EPISODE)[0].getIdentifier());
       }
@@ -666,18 +665,22 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
                 "Element(s) for live media package " + mp.getIdentifier() + " could not be distributed");
       }
 
-      for (String id : elementIds) {
-        MediaPackageElement e = mp.getElementById(id);
-        // Cleanup workspace/wfr
+      // remove all elements from mp
+      for (MediaPackageElement e: mp.getElements()) {
         mp.remove(e);
-        workspace.delete(e.getURI());
       }
 
-      // Add distributed element(s) to mp
+      // Re-add distributed elements
       List<MediaPackageElement> distributedElements = (List<MediaPackageElement>) MediaPackageElementParser
               .getArrayFromXml(distributionJob.getPayload());
-      for (MediaPackageElement mpe : distributedElements) {
-        mp.add(mpe);
+      for (MediaPackageElement distributedElement : distributedElements) {
+        mp.add(distributedElement);
+      }
+
+      // Clean up
+      for (String id : elementIds) {
+        MediaPackageElement e = mp.getElementById(id);
+        workspace.delete(e.getURI());
       }
 
       return mp;

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -645,21 +645,12 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       MediaPackage mp = (MediaPackage) snapshot.getMediaPackage().clone();
 
       Set<String> elementIds = new HashSet<>();
-      // Then, add series catalog if needed
-      if (StringUtils.isNotEmpty(mp.getSeries())) {
-        DublinCoreCatalog catalog = seriesService.getSeries(mp.getSeries());
-        // Create temporary catalog and save to workspace
-        mp.add(catalog);
-        URI uri = workspace.put(mp.getIdentifier().toString(), catalog.getIdentifier(), "series.xml",
-                dublinCoreService.serialize(catalog));
-        catalog.setURI(uri);
-        catalog.setChecksum(null);
-        catalog.setFlavor(MediaPackageElements.SERIES);
-        elementIds.add(catalog.getIdentifier());
-      }
 
       if (mp.getCatalogs(MediaPackageElements.EPISODE).length > 0) {
         elementIds.add(mp.getCatalogs(MediaPackageElements.EPISODE)[0].getIdentifier());
+      }
+      if (mp.getCatalogs(MediaPackageElements.SERIES).length > 0) {
+        elementIds.add(mp.getCatalogs(MediaPackageElements.SERIES)[0].getIdentifier());
       }
       if (mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE).length > 0) {
         elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE)[0].getIdentifier());

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -44,6 +44,7 @@ import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.mediapackage.PublicationImpl;
 import org.opencastproject.mediapackage.Track;
+import org.opencastproject.mediapackage.selector.SimpleElementSelector;
 import org.opencastproject.mediapackage.track.TrackImpl;
 import org.opencastproject.mediapackage.track.VideoStreamImpl;
 import org.opencastproject.metadata.dublincore.DCMIPeriod;
@@ -90,6 +91,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -105,6 +107,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Component(
     immediate = true,
@@ -151,6 +154,10 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   public static final String LIVE_DISTRIBUTION_SERVICE = "live.distributionService";
   public static final String LIVE_PUBLISH_STREAMING = "live.publishStreaming";
 
+  private static final MediaPackageElementFlavor[] publishFlavors = { MediaPackageElements.EPISODE,
+      MediaPackageElements.SERIES, MediaPackageElements.XACML_POLICY_EPISODE,
+      MediaPackageElements.XACML_POLICY_SERIES }; // make configurable later
+
   /** The logger */
   private static final Logger logger = LoggerFactory.getLogger(LiveScheduleServiceImpl.class);
 
@@ -181,6 +188,8 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
   private SecurityService securityService;
 
   private long jobPollingInterval = JobBarrier.DEFAULT_POLLING_INTERVAL;
+
+  private SimpleElementSelector publishElementSelector;
 
   /**
    * OSGi callback on component activation.
@@ -248,6 +257,11 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     }
     publishedStreamingFormats = Arrays.asList(Optional.ofNullable(StringUtils.split(
             (String)properties.get(LIVE_PUBLISH_STREAMING), ",")).orElse(new String[0]));
+
+    publishElementSelector = new SimpleElementSelector();
+    for (MediaPackageElementFlavor flavor : publishFlavors) {
+      publishElementSelector.addFlavor(flavor);
+    }
 
     logger.info(
         "Configured live stream name: {}, mime type: {}, resolution: {}, target flavors: {}, distribution service: {}",
@@ -644,28 +658,18 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
     try {
       MediaPackage mp = (MediaPackage) snapshot.getMediaPackage().clone();
 
-      Set<String> elementIds = new HashSet<>();
-      if (mp.getCatalogs(MediaPackageElements.EPISODE).length > 0) {
-        elementIds.add(mp.getCatalogs(MediaPackageElements.EPISODE)[0].getIdentifier());
-      }
-      if (mp.getCatalogs(MediaPackageElements.SERIES).length > 0) {
-        elementIds.add(mp.getCatalogs(MediaPackageElements.SERIES)[0].getIdentifier());
-      }
-      if (mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE).length > 0) {
-        elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE)[0].getIdentifier());
-      }
-      if (mp.getAttachments(MediaPackageElements.XACML_POLICY_SERIES).length > 0) {
-        elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_SERIES)[0].getIdentifier());
-      }
+      // Select elements
+      Collection<MediaPackageElement> elements = publishElementSelector.select(mp, false);
+      Set<String> elementIds = elements.stream().map(MediaPackageElement::getIdentifier).collect(Collectors.toSet());
 
-      // Distribute element(s)
+      // Distribute elements
       Job distributionJob = downloadDistributionService.distribute(CHANNEL_ID, mp, elementIds, false);
       if (!waitForStatus(distributionJob).isSuccess()) {
         throw new LiveScheduleException(
                 "Element(s) for live media package " + mp.getIdentifier() + " could not be distributed");
       }
 
-      // remove all elements from mp
+      // Remove all elements from mp
       for (MediaPackageElement e: mp.getElements()) {
         mp.remove(e);
       }

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImpl.java
@@ -655,6 +655,9 @@ public class LiveScheduleServiceImpl implements LiveScheduleService {
       if (mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE).length > 0) {
         elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_EPISODE)[0].getIdentifier());
       }
+      if (mp.getAttachments(MediaPackageElements.XACML_POLICY_SERIES).length > 0) {
+        elementIds.add(mp.getAttachments(MediaPackageElements.XACML_POLICY_SERIES)[0].getIdentifier());
+      }
 
       // Distribute element(s)
       Job distributionJob = downloadDistributionService.distribute(CHANNEL_ID, mp, elementIds, false);

--- a/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
+++ b/modules/live-schedule-impl/src/test/java/org/opencastproject/liveschedule/impl/LiveScheduleServiceImplTest.java
@@ -83,7 +83,6 @@ import org.junit.Test;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -150,8 +149,6 @@ public class LiveScheduleServiceImplTest {
     EasyMock.expect(downloadDistributionService.getDistributionType())
             .andReturn(LiveScheduleServiceImpl.DEFAULT_LIVE_DISTRIBUTION_SERVICE).anyTimes();
     workspace = EasyMock.createNiceMock(Workspace.class);
-    EasyMock.expect(workspace.put(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyString(),
-            EasyMock.anyObject(InputStream.class))).andReturn(new URI("http://someUrl"));
     dublinCoreService = EasyMock.createNiceMock(DublinCoreCatalogService.class);
     assetManager = EasyMock.createNiceMock(AssetManager.class);
     authService = new AuthorizationServiceMock();
@@ -386,7 +383,7 @@ public class LiveScheduleServiceImplTest {
     Assert.assertEquals("http://10.10.10.50/static/mh_default_org/engage-live/security_policy_episode.xml",
             att.getURI().toString());
     Assert.assertEquals("security/xacml+episode", att.getFlavor().toString());
-    EasyMock.verify(downloadDistributionService, workspace);
+    EasyMock.verify(downloadDistributionService);
   }
 
   @Test


### PR DESCRIPTION
Yes it's about the live schedule service again, the gift that keeps on giving. It started with investigating a bug in #4927 which causes an endless update loop for the live publication, and ended with... this. This is basically 4 bug fixes/improvements in a trench coat:

1. The actual cause of said bug: The live schedule service creates a duplicate of the series catalog in search, which breaks the comparison. So let's just...not do that.
2. While we're at it, we might as well distribute the series ACL as well, because that might be useful.
3. While the live schedule service distributes only selected number of elements, the media package that's published to search references all of them, even elements in the archive. Big yikes. So remove those before publishing to search. (This affects #4927, which will be updated accordingly.)
4. Instead of our own creative way of selecting elements, let's just use a selector. This also allows other parts of the code (like #4927) to use it as well. Also put the flavors we publish somewhere up top, because maybe, just maybe, we could make that configurable in the future.

The most relevant is probably 3, which means that only the episode dublincore, episode ACL, series dublincore and series ACL will be put into the search index for live events. It's possible that somebody is relying on the old behavior, but I don't think this is very likely. Will bring this up in the Technical Meeting.