### PR TITLE
Remove Track Selection Restrictions from the Old Editor

### DIFF
--- a/docs/guides/admin/docs/releasenotes/old-editor-restrictions
+++ b/docs/guides/admin/docs/releasenotes/old-editor-restrictions
@@ -1,0 +1,3 @@
+Restrictions in regards to what kind of streams can be selected in the old integrated video editor were eased to allow
+for more diverse use cases. Previous errors were demoted to warnings. The user still has to select at least one stream,
+but publishing e.g. of an audio stream without a video stream is now allowed. For more details see PR 5023.

--- a/modules/admin-ui-frontend/app/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/subresources/controllers/toolsController.js
@@ -155,23 +155,30 @@ angular.module('adminNg.controllers')
       $scope.area = area;
     };
 
+    $scope.anyTrackPresent = function (type) {
+      if ($scope.video.source_tracks === undefined) {
+        return false;
+      }
+      for(var i = 0; i < $scope.video.source_tracks.length; i++) {
+        var t = $scope.video.source_tracks[i][type];
+        if (t.present === true) {
+          return true;
+        }
+      }
+      return false;
+    };
+
     $scope.anyTrackSelected = function (type) {
       if ($scope.video.source_tracks === undefined) {
         return false;
       }
-      var present = false;
       for(var i = 0; i < $scope.video.source_tracks.length; i++) {
         var t = $scope.video.source_tracks[i][type];
-        if (t.present === true) {
-          present = true;
-          // track selected?
-          if (t.hidden === false) {
-            return true;
-          }
+        if (t.present === true && t.hidden === false) {
+          return true;
         }
       }
-      // If we don't have any tracks at all, selecting none is valid
-      return !present;
+      return false;
     };
 
     $scope.trackClicked = function(index, type) {
@@ -199,11 +206,11 @@ angular.module('adminNg.controllers')
           videoTrackCount++;
         }
       }
-      return audioTrackCount > videoTrackCount;
+      return audioTrackCount >= 2 && audioTrackCount > videoTrackCount;
     };
 
-    $scope.sanityCheckFlags = function() {
-      return (!$scope.anyTrackSelected('video') || $scope.tooManyAudios()) || !$scope.anyTrackSelected('audio');
+    $scope.isValid = function() {
+      return $scope.anyTrackSelected('video') || $scope.anyTrackSelected('audio');
     };
 
     // TODO Move the following to a VideoCtrl

--- a/modules/admin-ui-frontend/app/scripts/modules/events/subresources/controllers/toolsController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/subresources/controllers/toolsController.js
@@ -156,25 +156,22 @@ angular.module('adminNg.controllers')
     };
 
     $scope.anyTrackSelected = function (type) {
-      var selected = false;
-      var present = false;
       if ($scope.video.source_tracks === undefined) {
         return false;
       }
+      var present = false;
       for(var i = 0; i < $scope.video.source_tracks.length; i++) {
         var t = $scope.video.source_tracks[i][type];
         if (t.present === true) {
           present = true;
-        }
-        if (t.present === true && t.hidden === false) {
-          selected = true;
+          // track selected?
+          if (t.hidden === false) {
+            return true;
+          }
         }
       }
       // If we don't have any tracks at all, selecting none is valid
-      if (present === false) {
-        return true;
-      }
-      return selected;
+      return !present;
     };
 
     $scope.trackClicked = function(index, type) {

--- a/modules/admin-ui-frontend/app/scripts/modules/events/subresources/partials/tools.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/subresources/partials/tools.html
@@ -302,13 +302,20 @@
           <div ng-if="area === 'tracks'" class="editor-tracks">
             <div class="area-body">
               <div data-admin-ng-notification="" data-type="error"
-                                                 show="!anyTrackSelected('video')" message="VIDEO_TOOL.TRACKS.NOTIFICATION.NO_VIDEO_TRACK_SELECTED">
+                   show="!anyTrackSelected('video') && !anyTrackSelected('audio')"
+                   message="VIDEO_TOOL.TRACKS.NOTIFICATION.NO_TRACK_SELECTED_ERROR">
               </div>
-              <div data-admin-ng-notification="" data-type="error"
-                                                 show="!anyTrackSelected('audio')" message="VIDEO_TOOL.TRACKS.NOTIFICATION.NO_AUDIO_TRACK_SELECTED">
+              <div data-admin-ng-notification="" data-type="warning"
+                   show="anyTrackSelected('audio') && anyTrackPresent('video') && !anyTrackSelected('video')"
+                   message="VIDEO_TOOL.TRACKS.NOTIFICATION.NO_VIDEO_TRACK_SELECTED_WARNING">
               </div>
-              <div data-admin-ng-notification="" data-type="error"
-                                                 show="tooManyAudios() && anyTrackSelected('video')" message="NOTIFICATIONS.VIDEO_TOO_MANY_AUDIOS">
+              <div data-admin-ng-notification="" data-type="warning"
+                   show="anyTrackSelected('video') && anyTrackPresent('audio') && !anyTrackSelected('audio')"
+                   message="VIDEO_TOOL.TRACKS.NOTIFICATION.NO_AUDIO_TRACK_SELECTED_WARNING">
+              </div>
+              <div data-admin-ng-notification="" data-type="warning"
+                   show="tooManyAudios()"
+                   message="VIDEO_TOOL.TRACKS.NOTIFICATION.TOO_MANY_AUDIO_TRACKS_SELECTED_WARNING">
               </div>
               <div class="full-col">
                 <div class="obj tbl-details">
@@ -403,7 +410,7 @@
               </select>
 
               <a ng-click="submit([commonMetadataCatalog], commonMetadataCatalog)"
-                 ng-class="{disabled: activeTransaction || activeSubmission || sanityCheckFlags()}"
+                 ng-class="{disabled: activeTransaction || activeSubmission || !isValid()}"
                  class="save-and-close-button"
                  translate="{{ video.workflow ? 'VIDEO_TOOL.BUTTONS.PROCESS' : 'VIDEO_TOOL.BUTTONS.SAVE' }}">
                 <!-- Save and Continue -->

--- a/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
+++ b/modules/admin-ui-frontend/resources/public/org/opencastproject/adminui/languages/lang-en_US.json
@@ -1869,8 +1869,10 @@
      "TRACKS": {
        "DESCRIPTION": "You can unselect tracks to exclude them from further processing. Please note that you need to (re-)publish the event to actually apply the changes.",
        "NOTIFICATION": {
-         "NO_VIDEO_TRACK_SELECTED": "You must enable at least one video track",
-         "NO_AUDIO_TRACK_SELECTED": "You must enable at least one audio track"
+         "NO_VIDEO_TRACK_SELECTED_WARNING": "You should probably enable at least one video track",
+         "NO_AUDIO_TRACK_SELECTED_WARNING": "You should probably enable at least one audio track",
+         "TOO_MANY_AUDIO_TRACKS_SELECTED_WARNING": "You probably shouldn't enable more audio than video tracks",
+         "NO_TRACK_SELECTED_ERROR": "You must enable at least one track"
        },
        "TRACK": {
          "HEADER": "Track"


### PR DESCRIPTION
Currently you can only save/start a workflow in the old video editor if the following requirements are fulfilled:

1. You have selected at least one video stream, if one exists
2. You have selected at least one audio stream, if one exists
3. You have not selected more audio than video stream

This is, in my opinion, too restrictive and not really helpful. It might be useful to publish a video without an audio, or audio without a video, and the latter use case is actually frequently requested. Additionally, why can I only select two audio streams if I also have two video streams?

In an ideal world, this would be configurable. But giving that the old editor is nearing the end of its life span, that doesn't seem worth the effort. So I suggest that we drop these restrictions altogether, and allow people to save/publish whatever they want, as long as they select _at least one stream_.  The user will still be warned about unusual selections via notifications, but if they decide to proceed, they now can.

---

I made the following changes to the notifications in the track selection tab:

1. Demote current errors to warnings
2. Add new error when no stream, audio or video, is selected
3. Don't show warnings when error is shown
4. Change wording of warnings (I created new translated labels for this because as far as I know, it's not possible to trigger the re-translation for existing labels in Crowdin.)

I also decided to only show the "Too many audio streams" warning if there are two or more audio streams selected. I'm not very happy with this warning as a whole because I'm uncertain what exactly it is supposed to achieve, but I'm gonna leave it for now.