### PR TITLE
Plugin Manager Default Configuration

### DIFF
--- a/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
+++ b/etc/org.opencastproject.plugin.impl.PluginManagerImpl.cfg
@@ -17,4 +17,5 @@ opencast-plugin-usertracking                = off
 
 # Enables Karaf's verbose feature activateion logs.
 # Note that Karaf writes these to stdout, not to the logger.
-verbose = false
+# Default: false
+#verbose = false


### PR DESCRIPTION
This patch sets the default value of the plugin manager's “verbose” option in the configuration file.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
