### PR TITLE
Count user references

### DIFF
--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
@@ -68,7 +68,7 @@ import javax.persistence.Query;
         "service.description=Provides a user reference directory"
     },
     immediate = true,
-    service = { UserProvider.class, RoleProvider.class, UserReferenceProvider.class }
+    service = { UserProvider.class, RoleProvider.class, UserReferenceProvider.class, JpaUserReferenceProvider.class }
 )
 public class JpaUserReferenceProvider implements UserReferenceProvider, UserProvider, RoleProvider {
 


### PR DESCRIPTION
This PR fixes (in theory) the user count reported to the adoption registration server.  The existing implementation counts the raw JPA users, but does not count the user *references*.  This PR should hopefully count the references.

Fixes: #5031

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
