### PR TITLE
Escape ES query string in external API endpoints

### DIFF
--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -839,4 +839,27 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
       throw new SearchIndexException("Error querying theme index", t);
     }
   }
+
+  /**
+   * Escapes all reserved Elasticsearch characters in a given string
+   * Useful for when a given query string does not know about Elasticsearch query syntax
+   * @param text String to escape reserved characters in
+   * @return the given string with escaped characters
+   */
+  public String escapeQuery(String text) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < text.length(); i++) {
+      char c = text.charAt(i);
+      // These characters are part of the query syntax and must be escaped
+      // CHECKSTYLE:OFF
+      if (c == '\\' || c == '+' || c == '-' || c == '!' || c == '(' || c == ')' || c == ':'
+              || c == '^' || c == '[' || c == ']' || c == '\"' || c == '{' || c == '}' || c == '~'
+              || c == '*' || c == '?' || c == '|' || c == '&' || c == '/') {
+        sb.append('\\');
+      }
+      // CHECKSTYLE:ON
+      sb.append(c);
+    }
+    return sb.toString();
+  }
 }

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -846,20 +846,18 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
    * @param text String to escape reserved characters in
    * @return the given string with escaped characters
    */
-  public String escapeQuery(String text) {
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < text.length(); i++) {
-      char c = text.charAt(i);
-      // These characters are part of the query syntax and must be escaped
-      // CHECKSTYLE:OFF
-      if (c == '\\' || c == '+' || c == '-' || c == '!' || c == '(' || c == ')' || c == ':'
-              || c == '^' || c == '[' || c == ']' || c == '\"' || c == '{' || c == '}' || c == '~'
-              || c == '*' || c == '?' || c == '|' || c == '&' || c == '/') {
-        sb.append('\\');
-      }
-      // CHECKSTYLE:ON
-      sb.append(c);
+public String escapeQuery(String text) {
+  Set<Character> specialChars = Set.of('\\', '+', '-', '!', '(', ')', ':', '^', '[', ']', '\"', '{', '}', '~', '*', '?', '|', '&', '/');
+  
+  StringBuilder sb = new StringBuilder(text.length());
+  
+  for (char c : text.toCharArray()) {
+    if (specialChars.contains(c)) {
+      sb.append('\\');
     }
-    return sb.toString();
+    sb.append(c);
   }
+  
+  return sb.toString();
+}
 }

--- a/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
+++ b/modules/elasticsearch-index/src/main/java/org/opencastproject/elasticsearch/index/ElasticsearchIndex.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Function;
 
@@ -846,18 +847,19 @@ public class ElasticsearchIndex extends AbstractElasticsearchIndex {
    * @param text String to escape reserved characters in
    * @return the given string with escaped characters
    */
-public String escapeQuery(String text) {
-  Set<Character> specialChars = Set.of('\\', '+', '-', '!', '(', ')', ':', '^', '[', ']', '\"', '{', '}', '~', '*', '?', '|', '&', '/');
-  
-  StringBuilder sb = new StringBuilder(text.length());
-  
-  for (char c : text.toCharArray()) {
-    if (specialChars.contains(c)) {
-      sb.append('\\');
+  public String escapeQuery(String text) {
+    Set<Character> specialChars = Set.of('\\', '+', '-', '!', '(', ')', ':', '^', '[', ']', '\"', '{', '}', '~', '*',
+            '?', '|', '&', '/');
+
+    StringBuilder sb = new StringBuilder(text.length());
+
+    for (char c : text.toCharArray()) {
+      if (specialChars.contains(c)) {
+        sb.append('\\');
+      }
+      sb.append(c);
     }
-    sb.append(c);
+
+    return sb.toString();
   }
-  
-  return sb.toString();
-}
 }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -775,7 +775,7 @@ public class EventsEndpoint implements ManagedService {
           } else if ("location".equals(name)) {
             query.withLocation(value);
           } else if ("textFilter".equals(name)) {
-            query.withText("*" + value + "*");
+            query.withText("*" + elasticsearchIndex.escapeQuery(value) + "*");
           } else if ("series".equals(name)) {
             query.withSeriesId(value);
           } else if ("subject".equals(name)) {

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -272,7 +272,7 @@ public class SeriesEndpoint {
           } else if ("Creator".equals(name)) {
             query.withCreator(value);
           } else if ("textFilter".equals(name)) {
-            query.withText("*" + value + "*");
+            query.withText("*" + elasticsearchIndex.escapeQuery(value) + "*");
           } else if ("language".equals(name)) {
             query.withLanguage(value);
           } else if ("license".equals(name)) {
@@ -1341,7 +1341,7 @@ public class SeriesEndpoint {
       q.withEdit(edit);
     }
     if (StringUtils.isNotEmpty(text)) {
-      q.withText(fuzzyMatch.booleanValue(), text);
+      q.withText(fuzzyMatch.booleanValue(), elasticsearchIndex.escapeQuery(text));
     }
     if (StringUtils.isNotEmpty(seriesId)) {
       q.withIdentifier(seriesId);


### PR DESCRIPTION
Some external API endpoints have optional query parameters that are internally treated as ElasticSearch queries. Endpoint users are not informed about this, due to which they may include characters in their parameter that are actually reserved in Elasticsearch without escaping them. At best, the endpoint then might return unexpected results, at worst it goes into an endless loops that spams the Opencast log with error messages until the disk is full.

Example: The `/api/series/series.json` endpoint. Set the parameter `q` to `T9-VB-20-Online:`.

This commit suggests fixing the problem by adding a method for sanitizing parameters. It simply escapes ElasticSearch reserved characters. 
Another way of fixing this would be to explicitly inform users that a certain parameter will be an ElasticSearch query and let them decide which reserved characters they want to escape in their query.

If people are happy with simply sanitizing incoming strings, the code suggested here could likely be approved upon by burying it deeper in the Elasticsearch modules. But that's a pain so I refrained from doing that for now ^^'.