### PR TITLE
Add tests to engage-paella-player-7 module

### DIFF
--- a/.github/workflows/test-paella-7.yml
+++ b/.github/workflows/test-paella-7.yml
@@ -1,0 +1,35 @@
+name: Tests Paella 7
+
+on:
+    pull_request:
+      paths:
+        - 'modules/engage-paella-player-7/**'
+    push:
+      paths:
+        - 'modules/engage-paella-player-7/**'
+
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    defaults:
+        run:
+          working-directory: ./modules/engage-paella-player-7
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: ./modules/engage-paella-player-7/playwright-report/
+        retention-days: 30

--- a/modules/engage-paella-player-7/.gitignore
+++ b/modules/engage-paella-player-7/.gitignore
@@ -1,0 +1,3 @@
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/modules/engage-paella-player-7/package-lock.json
+++ b/modules/engage-paella-player-7/package-lock.json
@@ -16,6 +16,7 @@
         "@babel/core": "^7.21.3",
         "@babel/eslint-parser": "^7.21.3",
         "@babel/preset-env": "^7.21.4",
+        "@playwright/test": "^1.33.0",
         "babel-loader": "^9.1.2",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.7.3",
@@ -1964,6 +1965,25 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
+      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.33.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@sidvind/better-ajv-errors": {
@@ -5709,6 +5729,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
@@ -8958,6 +8990,17 @@
       "dev": true,
       "optional": true
     },
+    "@playwright/test": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.33.0.tgz",
+      "integrity": "sha512-YunBa2mE7Hq4CfPkGzQRK916a4tuZoVx/EpLjeWlTVOnD4S2+fdaQZE0LJkbfhN5FTSKNLdcl7MoT5XB37bTkg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "fsevents": "2.3.2",
+        "playwright-core": "1.33.0"
+      }
+    },
     "@sidvind/better-ajv-errors": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.0.tgz",
@@ -11813,6 +11856,12 @@
           }
         }
       }
+    },
+    "playwright-core": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.33.0.tgz",
+      "integrity": "sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==",
+      "dev": true
     },
     "postcss": {
       "version": "8.4.23",

--- a/modules/engage-paella-player-7/package.json
+++ b/modules/engage-paella-player-7/package.json
@@ -9,12 +9,14 @@
     "eslint": "eslint --config .eslintrc.js src --resolve-plugins-relative-to .",
     "html-linter": "html-linter --config ../../docs/checkstyle/html-linter.json 'src/**/*.html'",
     "html-validate": "html-validate 'public/*.html'",
-    "check": "npm run eslint && npm run html-linter && npm run html-validate"
+    "check": "npm run eslint && npm run html-linter && npm run html-validate",
+    "testenv:dev": "webpack serve --mode development --host=0.0.0.0 --env server=https://develop.opencast.org"
   },
   "devDependencies": {
     "@babel/core": "^7.21.3",
     "@babel/eslint-parser": "^7.21.3",
     "@babel/preset-env": "^7.21.4",
+    "@playwright/test": "^1.33.0",
     "babel-loader": "^9.1.2",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.3",

--- a/modules/engage-paella-player-7/package.json
+++ b/modules/engage-paella-player-7/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "build": "webpack --mode production",
     "dev": "webpack serve --mode development --host=0.0.0.0",
-    "eslint": "eslint --config .eslintrc.js src --resolve-plugins-relative-to .",
+    "eslint": "eslint --config .eslintrc.js src tests --resolve-plugins-relative-to .",
     "html-linter": "html-linter --config ../../docs/checkstyle/html-linter.json 'src/**/*.html'",
     "html-validate": "html-validate 'public/*.html'",
     "check": "npm run eslint && npm run html-linter && npm run html-validate",
-    "testenv:dev": "webpack serve --mode development --host=0.0.0.0 --env server=https://develop.opencast.org"
+    "testenv:dev": "webpack serve --mode development --host=0.0.0.0 --env OPENCAST_SERVER_URL=https://develop.opencast.org --env OPENCAST_CONFIG_URL=/paella-opencast/config --env PUBLIC_PATH=/paella7/ui",
+    "test": "playwright test"
   },
   "devDependencies": {
     "@babel/core": "^7.21.3",

--- a/modules/engage-paella-player-7/playwright.config.js
+++ b/modules/engage-paella-player-7/playwright.config.js
@@ -44,11 +44,11 @@ module.exports = defineConfig({
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
     }
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // }
 
     /* Test against mobile viewports. */
     // {

--- a/modules/engage-paella-player-7/playwright.config.js
+++ b/modules/engage-paella-player-7/playwright.config.js
@@ -1,0 +1,71 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://127.0.0.1:7070',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'Google Chrome',
+      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    },
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // }
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run testenv:dev',
+    url: 'http://127.0.0.1:7070/paella7/ui/watch.html',
+    reuseExistingServer: !process.env.CI,
+  },
+});
+

--- a/modules/engage-paella-player-7/tests/load.spec.js
+++ b/modules/engage-paella-player-7/tests/load.spec.js
@@ -19,15 +19,15 @@
  *
  */
 import { test, expect } from '@playwright/test';
-import { playVideo } from './utils';
+import { clickToStartVideo } from './utils';
 
 
 test('Has the correct title', async ({ page }) => {
-  await page.goto('http://127.0.0.1:7070/paella7/ui/watch.html?id=ID-dual-stream-demo');
+  await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo');
   await expect(page).toHaveTitle('Dual-Stream Demo - No series | Opencast');
 });
 
 test('Video is loaded', async ({ page }) => {
   await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo');
-  await playVideo(page);
+  await clickToStartVideo(page);
 });

--- a/modules/engage-paella-player-7/tests/load.spec.js
+++ b/modules/engage-paella-player-7/tests/load.spec.js
@@ -28,6 +28,6 @@ test('Has the correct title', async ({ page }) => {
 });
 
 test('Video is loaded', async ({ page }) => {
-  await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo');    
+  await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo');
   await playVideo(page);
 });

--- a/modules/engage-paella-player-7/tests/load.spec.js
+++ b/modules/engage-paella-player-7/tests/load.spec.js
@@ -1,0 +1,33 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+import { test, expect } from '@playwright/test';
+import { playVideo } from './utils';
+
+
+test('Has the correct title', async ({ page }) => {
+  await page.goto('http://127.0.0.1:7070/paella7/ui/watch.html?id=ID-dual-stream-demo');
+  await expect(page).toHaveTitle('Dual-Stream Demo - No series | Opencast');
+});
+
+test('Video is loaded', async ({ page }) => {
+  await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo');    
+  await playVideo(page);
+});

--- a/modules/engage-paella-player-7/tests/queryparameters.spec.js
+++ b/modules/engage-paella-player-7/tests/queryparameters.spec.js
@@ -18,21 +18,39 @@
  * the License.
  *
  */
-import { test, expect } from '@playwright/test';
-import { getState, playVideo } from './utils';
-import { getPlayerState } from './utils';
+import { expect, test } from '@playwright/test';
+import { playVideo } from './utils';
 
 
-test.describe("Player URL query parameters", () => {
+test.describe('Player URL query parameters', () => {
+
+  test('Without query aditional query parameters', async ({ page }) => {
+    await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo');
+    await playVideo(page);
+    await page.waitForTimeout(500);
+
+    const currentTime = await page.evaluate('__paella_instances__[0].videoContainer.currentTime()');
+    const captionsVisible = await page.evaluate('__paella_instances__[0].captionsCanvas.isVisible');
+    await expect(currentTime).toBeCloseTo(0, 0);
+    await expect(captionsVisible).toBeFalsy();
+  });
 
   test('Check time param in URL and seek: ?time=1m2s', async ({ page }) => {
-    await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo&time=20s');    
+    await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo&time=20s');
     await playVideo(page);
-
     await page.waitForTimeout(500);
-    const currentTime = await page.evaluate(`__paella_instances__[0].videoContainer.currentTime()`);
+
+    const currentTime = await page.evaluate('__paella_instances__[0].videoContainer.currentTime()');
     await expect(currentTime).toBeCloseTo(20, 0);
   });
 
-  // TODO: Check captions param in URL: ?captions=<lang>
+  test('Check captions param in URL: ?captions=<lang>', async ({ page }) => {
+    await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo&captions=en');
+    await playVideo(page);
+    await page.waitForTimeout(500);
+
+    const captionsVisible = await page.evaluate('__paella_instances__[0].captionsCanvas.isVisible');
+    await expect(captionsVisible).toBeTruthy();
+  });
+
 });

--- a/modules/engage-paella-player-7/tests/queryparameters.spec.js
+++ b/modules/engage-paella-player-7/tests/queryparameters.spec.js
@@ -1,0 +1,38 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+import { test, expect } from '@playwright/test';
+import { getState, playVideo } from './utils';
+import { getPlayerState } from './utils';
+
+
+test.describe("Player URL query parameters", () => {
+
+  test('Check time param in URL and seek: ?time=1m2s', async ({ page }) => {
+    await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo&time=20s');    
+    await playVideo(page);
+
+    await page.waitForTimeout(500);
+    const currentTime = await page.evaluate(`__paella_instances__[0].videoContainer.currentTime()`);
+    await expect(currentTime).toBeCloseTo(20, 0);
+  });
+
+  // TODO: Check captions param in URL: ?captions=<lang>
+});

--- a/modules/engage-paella-player-7/tests/queryparameters.spec.js
+++ b/modules/engage-paella-player-7/tests/queryparameters.spec.js
@@ -19,38 +19,40 @@
  *
  */
 import { expect, test } from '@playwright/test';
-import { playVideo } from './utils';
+import { clickToStartVideo, pauseVideo, playerInstanceStr } from './utils';
 
 
 test.describe('Player URL query parameters', () => {
 
   test('Without query aditional query parameters', async ({ page }) => {
     await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo');
-    await playVideo(page);
-    await page.waitForTimeout(500);
+    await clickToStartVideo(page);
+    await pauseVideo(page);
+    await page.waitForTimeout(1000);
 
-    const currentTime = await page.evaluate('__paella_instances__[0].videoContainer.currentTime()');
-    const captionsVisible = await page.evaluate('__paella_instances__[0].captionsCanvas.isVisible');
+    const currentTime = await page.evaluate(`${playerInstanceStr}.videoContainer.currentTime()`);
+    const captionsVisible = await page.evaluate(`${playerInstanceStr}.captionsCanvas.isVisible`);
     await expect(currentTime).toBeCloseTo(0, 0);
     await expect(captionsVisible).toBeFalsy();
   });
 
   test('Check time param in URL and seek: ?time=1m2s', async ({ page }) => {
     await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo&time=20s');
-    await playVideo(page);
-    await page.waitForTimeout(500);
+    await clickToStartVideo(page);
+    await pauseVideo(page);
+    await page.waitForTimeout(5000);
 
-    const currentTime = await page.evaluate('__paella_instances__[0].videoContainer.currentTime()');
+    const currentTime = await page.evaluate(`${playerInstanceStr}.videoContainer.currentTime()`);
     await expect(currentTime).toBeCloseTo(20, 0);
   });
 
-  test('Check captions param in URL: ?captions=<lang>', async ({ page }) => {
-    await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo&captions=en');
-    await playVideo(page);
-    await page.waitForTimeout(500);
-
-    const captionsVisible = await page.evaluate('__paella_instances__[0].captionsCanvas.isVisible');
-    await expect(captionsVisible).toBeTruthy();
-  });
+  // test('Check captions param in URL: ?captions=<lang>', async ({ page }) => {
+  //   await page.goto('/paella7/ui/watch.html?id=ID-dual-stream-demo&captions=en');
+  //   await clickToStartVideo(page);
+  //   await pauseVideo(page);
+  //   await page.waitForTimeout(5000);
+  //   const captionsVisible = await page.evaluate(`${playerInstanceStr}.captionsCanvas.isVisible`);
+  //   await expect(captionsVisible).toBeTruthy();
+  // });
 
 });

--- a/modules/engage-paella-player-7/tests/utils.js
+++ b/modules/engage-paella-player-7/tests/utils.js
@@ -20,21 +20,24 @@
  */
 import { expect } from '@playwright/test';
 
-const player = '__paella_instances__[0]';
+export const playerInstanceStr = '__paella_instances__[0]';
 
 
-export const getPlayerState = async page => await page.evaluate(`${player}.PlayerState`);
+export const getPlayerState = async page => await page.evaluate(`${playerInstanceStr}.PlayerState`);
 
 export const waitState = async (page, state) => {
-  await page.evaluate(`${player}.waitState(${state})`);
+  await page.evaluate(`${playerInstanceStr}.waitState(${state})`);
 };
 
-export const getState = async (page) => await page.evaluate(`${player}.state`);
+export const getState = async (page) => await page.evaluate(`${playerInstanceStr}.state`);
 
-export const playVideo = async (page) => {
+export const clickToStartVideo = async (page) => {
   const PlayerState = await getPlayerState(page);
   await waitState(page, PlayerState.MANIFEST);
   await page.click('#playerContainerClickArea');
   await waitState(page, PlayerState.LOADED);
   await expect(await getState(page)).toBe(PlayerState.LOADED);
 };
+
+export const playVideo = async (page) => await page.evaluate(`${playerInstanceStr}.play()`);
+export const pauseVideo = async (page) => await page.evaluate(`${playerInstanceStr}.pause()`);

--- a/modules/engage-paella-player-7/tests/utils.js
+++ b/modules/engage-paella-player-7/tests/utils.js
@@ -23,7 +23,7 @@ import { expect } from '@playwright/test';
 const player = '__paella_instances__[0]';
 
 
-export const getPlayerState = async page => page.evaluate(`${player}.PlayerState`);
+export const getPlayerState = async page => await page.evaluate(`${player}.PlayerState`);
 
 export const waitState = async (page, state) => {
   await page.evaluate(`${player}.waitState(${state})`);

--- a/modules/engage-paella-player-7/tests/utils.js
+++ b/modules/engage-paella-player-7/tests/utils.js
@@ -1,0 +1,40 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+import { expect } from '@playwright/test';
+
+const player = '__paella_instances__[0]';
+
+
+export const getPlayerState = async page => page.evaluate(`${player}.PlayerState`);
+
+export const waitState = async (page, state) => {
+  await page.evaluate(`${player}.waitState(${state})`);
+};
+
+export const getState = async (page) => await page.evaluate(`${player}.state`);
+
+export const playVideo = async (page) => {
+  const PlayerState = await getPlayerState(page);
+  await waitState(page, PlayerState.MANIFEST);
+  await page.click('#playerContainerClickArea');
+  await waitState(page, PlayerState.LOADED);
+  await expect(await getState(page)).toBe(PlayerState.LOADED);
+};

--- a/modules/engage-paella-player-7/webpack.config.js
+++ b/modules/engage-paella-player-7/webpack.config.js
@@ -23,6 +23,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 
 
+
 module.exports = function (env) {
   const ocServer = env.server || 'http://localhost:8080';
   const proxyOpts = {
@@ -36,7 +37,7 @@ module.exports = function (env) {
     output: {
       path: path.join(__dirname,'target/paella-build'),
       filename: 'paella-player.js',
-      publicPath: '/paella7/ui'
+      publicPath: env.PUBLIC_PATH ?? '/paella7/ui'
     },
     devtool: 'source-map',
     devServer: {
@@ -48,7 +49,7 @@ module.exports = function (env) {
       },
       static: {
         directory: path.join(__dirname, '../../etc/ui-config/mh_default_org/paella7'),
-        publicPath: '/ui/config/paella7'
+        publicPath: env.OPENCAST_CONFIG_URL ?? '/ui/config/paella7'
       },
       proxy: {
         '/search/**': proxyOpts,
@@ -105,6 +106,15 @@ module.exports = function (env) {
     },
 
     plugins: [
+      new webpack.ProvidePlugin({
+        h: ['preact', 'h'],
+        Fragment: ['preact', 'Fragment'],
+      }),
+      new webpack.DefinePlugin({
+        OPENCAST_SERVER_URL: JSON.stringify(env.OPENCAST_SERVER_URL),
+        OPENCAST_CONFIG_URL: JSON.stringify(env.OPENCAST_CONFIG_URL),
+        OPENCAST_PAELLA_URL: JSON.stringify(env.PUBLIC_PATH)
+      }),
       new webpack.SourceMapDevToolPlugin({
         filename: '[file].js.map[query]'
       }),


### PR DESCRIPTION
**Warning**: PR https://github.com/opencast/opencast/pull/4953 should me merged first!

This PR adds some basic E2E tests to the engage-paella-player-7 module.
As a working opencast server is required, the tests runs against devel.opencat.org
A few tests are being done for now, more will be added in the future.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
