### PR TITLE
Switch to Opensearch by default

### DIFF
--- a/docs/guides/admin/docs/configuration/basic.md
+++ b/docs/guides/admin/docs/configuration/basic.md
@@ -62,10 +62,10 @@ Details about the configuration can be found at:
 - [Database Configuration](database.md)
 
 
-Step 4: Setting up Elasticsearch
+Step 4: Setting up OpenSearch
 --------------------------------
 
-Opencast requires Elasticsearch. Instructions for installing Elasticsearch can be found in the
+Opencast requires OpenSearch. Instructions for installing OpenSearch can be found in the
 [installation documentation](../installation/index.md).
 
 

--- a/docs/guides/admin/docs/configuration/firewall.md
+++ b/docs/guides/admin/docs/configuration/firewall.md
@@ -12,7 +12,7 @@ General rules are:
 - Users communicate with Opencast via HTTP(S)
 - Capture agents communicate with Opencast via HTTP(S)
 - Opencast nodes communicate among each other via HTTP(S)
-- Often Elasticsearch runs on the admin node since this node communicates with these services exclusively
+- Often OpenSearch runs on the admin node since this node communicates with these services exclusively
 - All servers should get access to the storage infrastructure
 - All Opencast nodes need database access
 
@@ -30,7 +30,7 @@ graph LR
   oc1 -->|e.g. 3306| db(Database)
   oc2 -->|e.g. 3306| db
   oc3 -->|e.g. 3306| db
-  oc1 -->|9200| es(Elasticsearch)
+  oc1 -->|9200| os(OpenSearch)
   oc1 --> storage(Storage)
   oc2 --> storage
   oc3 --> storage
@@ -65,5 +65,5 @@ If you want a more complex, stricter set of rules:
 
 1. Allow external HTTP and HTTPS communication to admin, presentation and possibly ingest
 2. Allow all Opencast nodes to access the database
-3. Allow the admin node to access Elasticsearch
+3. Allow the admin node to access OpenSearch
 4. Allow all nodes access to the storage infrastructure

--- a/docs/guides/admin/docs/configuration/https/migration.md
+++ b/docs/guides/admin/docs/configuration/https/migration.md
@@ -8,8 +8,8 @@ migrations. For that, the following steps might help.
 > Note that you modify stored data directly without any safety nets usually provided by Opencast. You should understand
 > what you are doing!
 
-1. Backup your database, and the Solr and Elasticsearch indexes.
-    - Elasticsearch: `{data}/index`
+1. Backup your database, and the Solr and OpenSearch/Elasticsearch indexes.
+    - OpenSearch/Elasticsearch: `{data}/index`
     - Solr: `{data}/solr-indexes`
 2. Configure Opencast to use HTTPS and test your set-up with a new publication.
 3. Put all your nodes into maintenance mode or, at least, do not process any videos.
@@ -38,7 +38,7 @@ migrations. For that, the following steps might help.
 6. Remove the search service's Solr index. It usually is located at `solr-indexes/search` but its location really
    depends on `org.opencastproject.solr.dir` and `org.opencastproject.search.solr.dir`
 7. Rebuild the Solr indices by re-starting your Opencast node running the search service (usually presentation).
-8. Rebuild the Elasticsearch indices using the REST endpoint listed in the docs:
+8. Rebuild the OpenSearch indices using the REST endpoint listed in the docs:
    https://admin.opencast.example.com/docs.html?path=/index
 
 Note: If the solr index does not repopulate by itself please check if your nodes are still in maintenance mode and

--- a/docs/guides/admin/docs/configuration/opensearch.md
+++ b/docs/guides/admin/docs/configuration/opensearch.md
@@ -1,12 +1,12 @@
-Opensearch Configuration
+OpenSearch Configuration
 ===========================
 
-Opensearch powers the external API as well as the administrative user interface of Opencast.
+OpenSearch powers the external API as well as the administrative user interface of Opencast.
 
 Configuring External Nodes
 --------------------------
 
-Opencast's Opensearch settings can be found in the `etc/custom.properties` configuration file.
+Opencast's OpenSearch settings can be found in the `etc/custom.properties` configuration file.
 
 Relevant configuration keys are:
 
@@ -16,12 +16,12 @@ Relevant configuration keys are:
 * `org.opencastproject.elasticsearch.username`
 * `org.opencastproject.elasticsearch.password`
 
-Therefore only `admin`, `adminpresentation`, and `allinone` need to connect to Opensearch.
+Therefore only `admin`, `adminpresentation`, and `allinone` need to connect to OpenSearch.
 
-`username` and `password` are optional. If configured, requests to Opensearch are secured by
-HTTP basic authentication (which is unsecure without TLS encryption). Refer to [the Opensearch
+`username` and `password` are optional. If configured, requests to OpenSearch are secured by
+HTTP basic authentication (which is unsecure without TLS encryption). Refer to [the OpenSearch
 documentation](https://opensearch.org/docs/latest/security-plugin/configuration/index/)
-to properly secure Opensearch.
+to properly secure OpenSearch.
 
 Additionally, the following settings can be configured in
 `org.opencastproject.elasticsearch.index.ElasticsearchIndex.cfg`:
@@ -33,14 +33,14 @@ Additionally, the following settings can be configured in
 * `retry.waiting.period.update`
 
 The identifier defines which index opencast is looking for. This might be interesting if you run an
-Opensearch cluster and want to follow a naming scheme. But you should be aware that the index actually consists of
+OpenSearch cluster and want to follow a naming scheme. But you should be aware that the index actually consists of
 multiple subindices whose identifiers will be appended to the base name with an _ (e.g. "opencast_event").
 If an index doesn't exist, Opencast will create it. The name is used for logging purposes only.
 
 The max retry attempts and the waiting periods will be used in case of an ElasticsearchStatusException, e.g. if there
 are too many concurrent requests. The retry behavior can be configured differently for get and update/delete requests.
 This way you could set more retry attempts for index updates because of the more serious consequences if those requests
-fail. The waiting period is used to not overwhelm the Opensearch with retry requests, making the problem worse. By
+fail. The waiting period is used to not overwhelm the OpenSearch with retry requests, making the problem worse. By
 default, no retry will be attempted.
 
 Version

--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -91,7 +91,7 @@ Install Opencast
 
 For a basic installation (All-In-One) just run:
 
-    apt-get install opencast-{{ opencast_major_version() }}-allinone elasticsearch-oss
+    apt-get install opencast-{{ opencast_major_version() }}-allinone opensearch
 
 This will install the default distribution of Opencast and all its dependencies, including the 3rd-Party-Tools.  Note
 that while the repository provides a packaged version of FFmpeg, your distribution may have a version which is

--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -58,37 +58,29 @@ First you have to install the necessary repositories so that your package manage
         apt-get update
 
 
-Install Elasticsearch
----------------------
+Install Opensearch
+------------------
 
-Starting with Opencast 9, Elasticsearch is now a dependency.  Our packages do not explicitly depend on Elasticsearch
-because it runs externally to Opencast.  By default we expect Elasticsearch to be running on the admin node, however
+Starting with Opencast 14, Opensearch is now a dependency.  Our packages do not explicitly depend on Opensearch
+because it runs externally to Opencast.  By default we expect Opensearch to be running on the admin node, however
 you can configure the URL in Opencast's configuration files.
 
-In our repository we provide validated Elasticsearch packages copied from the upstream repository.  Installation can be
+In our repository we provide validated Opensearch packages copied from the upstream repository.  Installation can be
 accomplished by running the following:
 
-    apt-get install elasticsearch-oss
+    apt-get install opensearch
 
-If you wish to use the upstream Elasticsearch repository directly be aware that Opencast only formally supports Elasticsearch
-versions with the same major and minor version values.  That is, if our 9.x repository has Elasticsearch 7.9.2 then
-Opencast only formally supports Elasticsearch versions starting with 7.9.
+If you wish to use the upstream Opensearc repository directly be aware that Opencast only supported with Opensearch 1.x
+and will not work with Opensearch 2.x yet.  Future support for this is forthcoming.
 
-The default Elasticsearch configuration should work for Opencast out of the box, however there is one change you should make.
-[Log4Shell](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) affects Elasticsearch, and you should mitigate this by adding a
-file at `/etc/elasticsearch/jvm.options.d/log4shell.options` with the content:
+The default Opensearch configuration should work for Opencast out of the box, although we encourage you to set your
+index up in a secure manner.
 
-```
--Dlog4j2.formatMsgNoLookups=true
-```
-
-This applies a mitigation for the security issue.  Once applied, you should restart Elasticsearch.
-
-Finally, make sure to start and enable the service:
+After installing an configuring make sure to start and enable the service:
 
 ```sh
-systemctl start elasticsearch
-systemctl enable elasticsearch
+systemctl restart opensearch
+systemctl enable opensearch
 ```
 
 

--- a/docs/guides/admin/docs/installation/debs.md
+++ b/docs/guides/admin/docs/installation/debs.md
@@ -58,22 +58,22 @@ First you have to install the necessary repositories so that your package manage
         apt-get update
 
 
-Install Opensearch
+Install OpenSearch
 ------------------
 
-Starting with Opencast 14, Opensearch is now a dependency.  Our packages do not explicitly depend on Opensearch
-because it runs externally to Opencast.  By default we expect Opensearch to be running on the admin node, however
+Starting with Opencast 14, OpenSearch is now a dependency.  Our packages do not explicitly depend on OpenSearch
+because it runs externally to Opencast.  By default we expect OpenSearch to be running on the admin node, however
 you can configure the URL in Opencast's configuration files.
 
-In our repository we provide validated Opensearch packages copied from the upstream repository.  Installation can be
+In our repository we provide validated OpenSearch packages copied from the upstream repository.  Installation can be
 accomplished by running the following:
 
     apt-get install opensearch
 
-If you wish to use the upstream Opensearc repository directly be aware that Opencast only supported with Opensearch 1.x
-and will not work with Opensearch 2.x yet.  Future support for this is forthcoming.
+If you wish to use the upstream OpenSearch repository directly be aware that Opencast only supported with OpenSearch 1.x
+and will not work with OpenSearch 2.x yet.  Future support for this is forthcoming.
 
-The default Opensearch configuration should work for Opencast out of the box, although we encourage you to set your
+The default OpenSearch configuration should work for Opencast out of the box, although we encourage you to set your
 index up in a secure manner.
 
 After installing an configuring make sure to start and enable the service:

--- a/docs/guides/admin/docs/installation/source-linux.md
+++ b/docs/guides/admin/docs/installation/source-linux.md
@@ -53,7 +53,7 @@ Required:
 
 Required (not necessarily on the same machine):
 
-    Elasticsearch 7.9.x
+    OpenSearch 1.x
 
 Required for text extraction (recommended):
 
@@ -78,7 +78,7 @@ website:
 
 * [Get FFmpeg](http://ffmpeg.org/download.html)
 * [Get Apache Maven](https://maven.apache.org/download.cgi)
-* [Get Elasticsearch](https://elastic.co)
+* [Get OpenSearch](https://opensearch.org)
 
 Building Opencast
 -----------------

--- a/docs/guides/admin/docs/installation/source-macosx.md
+++ b/docs/guides/admin/docs/installation/source-macosx.md
@@ -59,7 +59,7 @@ Required:
 
 Required (not necessarily on the same machine):
 
-    Elasticsearch 7.9.x
+    OpenSearch 1.x
 
 Required for text extraction:
 
@@ -94,11 +94,12 @@ Homebrew is a package manager for OS X. For installation instruction see [their 
     brew install sox
     brew install synfig
 
-#### Elasticsearch on macOS
+#### OpenSearch on macOS
 
-If you want to install Elasticsearch in the same machine run Elasticsearch as a Docker container
+If you want to install OpenSearch in the same machine run OpenSearch as a Docker container
 
-    docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 -e 'discovery.type=single-node' elasticsearch:7.9.3
+    docker run -d --name opensearch -p 9200:9200 -p 9300:9300 -e 'discovery.type=single-node' opensearchproject/opensearch:1
+
 #### Using pre-built binaries
 
 Pre-built versions of most dependencies can be downloaded from the respective project website:

--- a/docs/guides/admin/docs/modules/searchindex/index.md
+++ b/docs/guides/admin/docs/modules/searchindex/index.md
@@ -4,9 +4,9 @@ Search Indexes
 Opencast comes with multiple search indexes which act both as a cache and as a fast way to perform full text searches on
 metadata. By default, the Solr search indexes are created automatically and no additional external software is required.
 
-For Opensearch/Elasticsearch, a separate installation is required since Opencast version 9.0.  Opencast 12 now supports
-both Opensearch and Elasticsearch, with Elasticsearch being the default.  We are planning on deprecating Elasticsearch 
-support with Opencast 13, and removing it with Opencast 14.  New installs should use Opensearch.
+For OpenSearch/Elasticsearch, a separate installation is required since Opencast version 9.0.  Opencast 12 added support
+both OpenSearch and Elasticsearch, with Opencast 14 now preferring OpenSearch by default.  We are planning on
+deprecating Elasticsearch support with Opencast 15, and removing it with Opencast 16.  New installs should use OpenSearch.
 
 While this works well, all indexes can be deployed separately. This comes with the obvious drawback of a harder
 deployment but has also a few advantages like a smaller core system or being able to have some service redundancies
@@ -19,9 +19,9 @@ which would not be possible otherwise.
 
     [Solr Configuration Guide](solr.md)
 
-- Opensearch/Elasticsearch powers the external API as well as the administrative user interface of Opencast.  Pick one of the following
+- OpenSearch/Elasticsearch powers the external API as well as the administrative user interface of Opencast.  Pick one of the following
 
+    [OpenSearch Configuration Guide](../../configuration/opensearch.md)
     [Elasticsearch Configuration Guide](../../configuration/elasticsearch.md)
-    [Opensearch Configuration Guide](../../configuration/opensearch.md)
 
 ---

--- a/docs/guides/admin/mkdocs.yml
+++ b/docs/guides/admin/mkdocs.yml
@@ -70,7 +70,7 @@ nav:
    - Firewall: 'configuration/firewall.md'
    - Asset Manager: 'configuration/asset-manager.md'
    - Elasticsearch: 'configuration/elasticsearch.md'
-   - Opensearch: 'configuration/opensearch.md'
+   - OpenSearch: 'configuration/opensearch.md'
    - Metadata: 'configuration/metadata.md'
    - Encoding: 'configuration/encoding.md'
    - Inbox: 'configuration/inbox.md'


### PR DESCRIPTION
This PR alters the debian documentation to install opensearch over elasticsearch.  Elasticsearch will still work, but new installs should prefer opensearch in the absense of an existing ES install.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
