### PR TITLE
Fixes Session IllegalStateException 

### DIFF
--- a/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CleanSessionsFilter.java
+++ b/modules/kernel/src/main/java/org/opencastproject/kernel/rest/CleanSessionsFilter.java
@@ -94,7 +94,7 @@ public class CleanSessionsFilter implements Filter {
 
     // Cast the request and response to HTTP versions
     HttpServletRequest request = (HttpServletRequest) req;
-    if (request != null && request.getSession() != null) {
+    if (request != null && request.getSession(false) != null) {
       if (request.getSession().getMaxInactiveInterval() == NO_MAX_INACTIVE_INTERVAL_SET) {
         // There is no maxInactiveInterval set so we need to set one.
         logger.trace("Setting maxInactiveInterval to " + RestConstants.MAX_INACTIVE_INTERVAL + " on request @" + request.getRequestURL());


### PR DESCRIPTION
This PR fixes the IllegalStateException on retrieving a session. Instead of requesting a new session, only return existing ones. Since that change, the error did not occur on my dev setup.

https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getSession(boolean)

Fixes https://github.com/opencast/opencast/issues/4971

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
