### PR TITLE
Paella7 backwards support for old captions/dfxp flavored xml files

### DIFF
--- a/modules/engage-paella-player-7/src/js/EpisodeConversor.js
+++ b/modules/engage-paella-player-7/src/js/EpisodeConversor.js
@@ -304,6 +304,7 @@ function readCaptions(potentialNewCaptions, captions) {
 
       if (captions_match) {
         let captions_lang = captions_match[3];
+        const captions_subtype = captions_match[1];
 
         if (!captions_lang && potentialCaption.tags && potentialCaption.tags.tag) {
           if (!(potentialCaption.tags.tag instanceof Array)) {
@@ -317,6 +318,10 @@ function readCaptions(potentialNewCaptions, captions) {
         }
 
         let captions_format = potentialCaption.url.split('.').pop();
+        // Backwards support for 'captions/dfxp' flavored xml files
+        if (captions_subtype === 'dfxp' && captions_format === 'xml') {
+          captions_format = captions_subtype;
+        }
 
         captions.push({
           id: potentialCaption.id,


### PR DESCRIPTION
Issue: DFXP flavored xml files are given am 'xml' format instead of a 'dfxp' caption format.

This pull patches the EpisodeConversor for Paella7 to support backwards compatibility for old mediapackagesa with the historic "captions/dfxp" flavored XML attachments and catalogs.

