### PR TITLE
Fix tainted canvas in editor thumbnail extractor

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/player.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/player.html
@@ -1,6 +1,6 @@
 <div class="video-player">
   <div>
-    <video id="player">
+    <video id="player" crossorigin="anonymous">
       <source ng-repeat="preview in video.previews" ng-src="{{ preview.uri | trusted }}" type="video/mp4" />
       Your browser does not support HTML5 video.
     </video>


### PR DESCRIPTION
The issue
---
In some Opencast 13.2 installations, a thumbnail cannot be extracted from a video in the (old, in-the-admin-ui) editor. Instead nothing happens, and an error appears in the web-console:

Firefox:
```
DOMException: The operation is insecure.
changeThumbnailPreview toolsController.js:101
```

Chrome:
```
angular.js:15697 DOMException: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported.
at u.changeThumbnailPreview (https://admin.opencast-test.unibe.ch/admin-ng/scripts/scripts.46453c99.js:1:269930)
```

Unfortunately I am not quite sure how to reproduce this, so testing this PR might be hard.

The solution
------

Since 2b92420, the thumbnail extractor uses a canvas element in the frontend. This canvas element can become tainted if a proper CORS header is missing on the source, preventing any image extraction from the canvas. This PR fixes that by ensuring that a CORS header is set.

### Your pull request should…

* [x] have a concise title
~* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
~* [ ] include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
