### PR TITLE
Dont copy media files to new scheduled event

### DIFF
--- a/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
+++ b/modules/ingest-service-impl/src/main/java/org/opencastproject/ingest/scanner/Ingestor.java
@@ -30,6 +30,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElements;
 import org.opencastproject.mediapackage.MediaPackageException;
+import org.opencastproject.mediapackage.Track;
 import org.opencastproject.mediapackage.identifier.IdImpl;
 import org.opencastproject.metadata.dublincore.DublinCore;
 import org.opencastproject.metadata.dublincore.DublinCoreCatalog;
@@ -258,6 +259,12 @@ public class Ingestor implements Runnable {
                       var referenceId = mediaPackage.getIdentifier().toString();
                       mediaPackage = (MediaPackage) mediaPackage.clone();
                       mediaPackage.setIdentifier(IdImpl.fromUUID());
+
+                      // Drop copied media files. We don't want them in the new event
+                      for (Track track : mediaPackage.getTracks()) {
+                        logger.info("Remove track: " + track);
+                        mediaPackage.remove(track);
+                      }
 
                       // Update dublincore title and set reference to originally scheduled event
                       try {


### PR DESCRIPTION
Resolves #4312

In case of adding new media files to a scheduled event through the InboxScanner, Opencast creates a copy of the scheduled event with the new media files. Unfortunately, this means it also copies the old media files from the scheduled event, which could lead to unwanted media files in the new event. Therefore, this commit drops all media files after copying the mediapackage.

Copying and then dropping the media files, while simple, is arguably a pretty wasteful solution to the problem. Another approach would be to define which files need to be copied and then only copy those (i.e. if we actually only need the dublincore, we could simply create a new mediapackage and copy the dublincore over).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
~* [ ] include migration scripts and documentation, if appropriate~
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
