### PR TITLE
Cache FFmpeg Versions

### DIFF
--- a/.github/workflows/store-ffmpeg-builds.yml
+++ b/.github/workflows/store-ffmpeg-builds.yml
@@ -1,0 +1,42 @@
+name: Cache FFmpeg
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 6' # at 03:00 on Saturday
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    name: Get FFmpeg (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    if: github.repository == 'opencast/opencast'
+    steps:
+      - name: Download FFmpeg
+        run: |
+          https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-${{ matrix.arch }}-static.tar.xz
+
+      - name: Unpack FFmpeg
+        run: |
+          tar xf ffmpeg-release-${{ matrix.arch }}-static.tar.xz
+
+      - name: Repack FFmpeg
+        run: |
+          set -eu
+          NAME="$(ls -d ffmpeg-*-static)"
+          tar cf "${NAME}.tar.xz" "${NAME}"
+
+      - name: Configure s3cmd
+        uses: lkiesow/configure-s3cmd@v1
+        with:
+          host: ${{ secrets.S3_HOST }}
+          access_key: ${{ secrets.S3_ACCESS_KEY }}
+          secret_key: ${{ secrets.S3_SECRET_KEY }}
+
+      - name: Upload RPMs
+        run: |
+          s3cmd put -P *.tar.xz s3://opencast-ffmpeg-static/


### PR DESCRIPTION
Every Sunday at 3am, the workflow added with this patch downloads the latest static FFmpeg build from johnvansickle.com/ffmpeg/, labels it with the correct version and stores it in Opencast's S3 storage.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
