### PR TITLE
Allow deletion of reference users from the Admin UI

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/users/partials/userActionsCell.html
+++ b/modules/admin-ui-frontend/app/scripts/modules/users/partials/userActionsCell.html
@@ -10,6 +10,6 @@
    data-object="row"
    class="remove"
    title="{{ 'USERS.USERS.TABLE.TOOLTIP.DELETE' | translate }}"
-   ng-if="row.manageable"
+   ng-if="row.manageable || ( row.provider != 'opencast' && row.provider != 'system' )"
    with-role="ROLE_UI_USERS_DELETE">
 </a>

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/UsersEndpoint.java
@@ -48,6 +48,7 @@ import org.opencastproject.security.impl.jpa.JpaOrganization;
 import org.opencastproject.security.impl.jpa.JpaRole;
 import org.opencastproject.security.impl.jpa.JpaUser;
 import org.opencastproject.userdirectory.JpaUserAndRoleProvider;
+import org.opencastproject.userdirectory.JpaUserReferenceProvider;
 import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.SmartIterator;
 import org.opencastproject.util.UrlSupport;
@@ -123,6 +124,9 @@ public class UsersEndpoint {
   /** The internal role and user provider */
   private JpaUserAndRoleProvider jpaUserAndRoleProvider;
 
+  /** The internal user reference provider */
+  private JpaUserReferenceProvider jpaUserReferenceProvider;
+
   /** The security service */
   private SecurityService securityService;
 
@@ -160,6 +164,15 @@ public class UsersEndpoint {
   @Reference
   public void setJpaUserAndRoleProvider(JpaUserAndRoleProvider jpaUserAndRoleProvider) {
     this.jpaUserAndRoleProvider = jpaUserAndRoleProvider;
+  }
+
+  /**
+   * @param jpaUserReferenceProvider
+   *          the user provider to set
+   */
+  @Reference
+  public void setJpaUserReferenceProvider(JpaUserReferenceProvider jpaUserReferenceProvider) {
+    this.jpaUserReferenceProvider = jpaUserReferenceProvider;
   }
 
   /** OSGi callback. */
@@ -406,9 +419,25 @@ public class UsersEndpoint {
           @RestResponse(responseCode = SC_NOT_FOUND, description = "User not found.") })
   public Response deleteUser(@PathParam("username") String username) throws NotFoundException {
     Organization organization = securityService.getOrganization();
+    boolean userReferenceNotFound = false;
+    boolean userNotFound = false;
 
     try {
-      jpaUserAndRoleProvider.deleteUser(username, organization.getId());
+      try {
+        jpaUserReferenceProvider.deleteUser(username, organization.getId());
+      } catch (NotFoundException e) {
+        userReferenceNotFound = true;
+      }
+      try {
+        jpaUserAndRoleProvider.deleteUser(username, organization.getId());
+      } catch (NotFoundException e) {
+        userNotFound = true;
+      }
+
+      if (userNotFound && userReferenceNotFound) {
+        throw new NotFoundException();
+      }
+
       userDirectoryService.invalidate(username);
     } catch (NotFoundException e) {
       logger.debug("User {} not found.", username);

--- a/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
+++ b/modules/userdirectory/src/main/java/org/opencastproject/userdirectory/JpaUserReferenceProvider.java
@@ -29,6 +29,7 @@ import org.opencastproject.security.api.Group;
 import org.opencastproject.security.api.Role;
 import org.opencastproject.security.api.RoleProvider;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.security.api.User;
 import org.opencastproject.security.api.UserProvider;
 import org.opencastproject.security.impl.jpa.JpaOrganization;
@@ -36,6 +37,9 @@ import org.opencastproject.security.impl.jpa.JpaRole;
 import org.opencastproject.security.impl.jpa.JpaUserReference;
 import org.opencastproject.userdirectory.api.AAIRoleProvider;
 import org.opencastproject.userdirectory.api.UserReferenceProvider;
+import org.opencastproject.userdirectory.utils.UserDirectoryUtils;
+import org.opencastproject.util.NotFoundException;
+import org.opencastproject.util.function.ThrowingConsumer;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -72,7 +76,7 @@ import javax.persistence.TypedQuery;
         "service.description=Provides a user reference directory"
     },
     immediate = true,
-    service = { UserProvider.class, RoleProvider.class, UserReferenceProvider.class }
+    service = { UserProvider.class, RoleProvider.class, UserReferenceProvider.class, JpaUserReferenceProvider.class }
 )
 public class JpaUserReferenceProvider implements UserReferenceProvider, UserProvider, RoleProvider {
 
@@ -502,6 +506,44 @@ public class JpaUserReferenceProvider implements UserReferenceProvider, UserProv
   public void invalidate(String userName) {
     String orgId = securityService.getOrganization().getId();
     cache.invalidate(userName.concat(DELIMITER).concat(orgId));
+  }
+
+  /**
+   * Delete the given user
+   *
+   * @param username
+   *          the name of the user to delete
+   * @param orgId
+   *          the organization id
+   * @throws NotFoundException
+   *          if the requested user is not exist
+   * @throws org.opencastproject.security.api.UnauthorizedException
+   *          if you havn't permissions to delete an admin user (only admins may do that)
+   * @throws Exception
+   */
+  public void deleteUser(String username, String orgId) throws NotFoundException, UnauthorizedException, Exception {
+    User user = loadUser(username);
+    if (user != null && !UserDirectoryUtils.isCurrentUserAuthorizedHandleRoles(securityService, user.getRoles())) {
+      throw new UnauthorizedException("The user is not allowed to delete an admin user");
+    }
+
+    // Remove the user's group membership
+    groupRoleProvider.removeMemberFromAllGroups(username, orgId);
+
+    // Remove the user
+    db.execTxChecked(deleteUserQuery(username, orgId));
+
+    cache.invalidate(username + DELIMITER + orgId);
+  }
+
+  private ThrowingConsumer<EntityManager, NotFoundException> deleteUserQuery(String username, String orgId) {
+    return em -> {
+      Optional<JpaUserReference> user = findUserReferenceQuery(username, orgId).apply(em);
+      if (user.isEmpty()) {
+        throw new NotFoundException("User with name " + username + " does not exist");
+      }
+      em.remove(em.merge(user.get()));
+    };
   }
 
   public void setRoleProvider(RoleProvider roleProvider) {


### PR DESCRIPTION
Resolves #4789

External user providers will store users in the opencast database table `oc_user_refs`. However, external user providers may fail to remove users from Opencast when they should not exist anymore, and there is currently no easy way to remove users from that table (besides directly modifying the database). This can make it difficult for adopter to comply with data privacy policies.

This commit adds deletion functionality to the `JpaUserReferenceProvider`, and allows deletion of users from other providers than "system" or "opencast", even if they are not "manageable" (which applies to all these users). It does not allow any changes beyond that, i.e. you may now delete a user created by an external provider, but you still can't change their name.

### Your pull request should…

* [ ] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
~* [ ] include migration scripts and documentation, if appropriate~
* [ ] pass automated tests
* [x] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
