### PR TITLE
Dont allow to delete user with active workflow in Admin UI

### DIFF
--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowInstance.java
@@ -117,6 +117,12 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
                 + "w.mediaPackageId = :mediaPackageId and w.organizationId = :organizationId and "
                 + "(w.state = :stateInstantiated or w.state = :statePaused or w.state = :stateRunning "
                 + "or w.state = :stateFailing) order by w.dateCreated"),
+
+        // For users
+        @NamedQuery(name = "Workflow.countActiveByUser", query = "SELECT COUNT(w) FROM WorkflowInstance w where "
+                + "w.creatorName = :userId and w.organizationId = :organizationId and "
+                + "(w.state = :stateInstantiated or w.state = :statePaused or w.state = :stateRunning "
+                + "or w.state = :stateFailing)"),
 })
 public class WorkflowInstance {
 

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowService.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowService.java
@@ -326,6 +326,16 @@ public interface WorkflowService {
   boolean mediaPackageHasActiveWorkflows(String mediaPackageId) throws WorkflowDatabaseException;
 
   /**
+   * Checks if there is at least one workflow currently running started by the given user
+   *
+   * @param userId
+   *          the identifier of the user
+   * @return Whether there is a workflow active started by the user
+   * @throws WorkflowDatabaseException
+   */
+  boolean userHasActiveWorkflows(String userId) throws WorkflowDatabaseException;
+
+  /**
    * Returns all workflows associated with the given mediapackage
    * Current user needs permission to the mediapackage
    *

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabase.java
@@ -135,6 +135,17 @@ public interface WorkflowServiceDatabase {
   boolean mediaPackageHasActiveWorkflows(String mediaPackageId) throws WorkflowDatabaseException;
 
   /**
+   * Returns true there are still workflows running that were created by the user with the given identifier.
+   *
+   * @param userId
+   *          the user identifier
+   * @return true, if a workflow is running; false otherwise
+   * @throws WorkflowDatabaseException
+   *           if there is a problem communicating with the underlying data store
+   */
+  boolean userHasActiveWorkflows(String userId) throws WorkflowDatabaseException;
+
+  /**
    * Updates a single workflow.
    *
    * @param instance

--- a/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
+++ b/modules/workflow-service-api/src/main/java/org/opencastproject/workflow/api/WorkflowServiceDatabaseImpl.java
@@ -285,6 +285,29 @@ public class WorkflowServiceDatabaseImpl implements WorkflowServiceDatabase {
   /**
    * {@inheritDoc}
    *
+   * @see WorkflowServiceDatabase#userHasActiveWorkflows(String mediaPackageId)
+   */
+  public boolean userHasActiveWorkflows(String userId) throws WorkflowDatabaseException {
+    try {
+      long count = db.exec(namedQuery.find(
+              "Workflow.countActiveByUser",
+              Long.class,
+              Pair.of("organizationId", securityService.getOrganization().getId()),
+              Pair.of("userId", userId),
+              Pair.of("stateInstantiated", WorkflowInstance.WorkflowState.INSTANTIATED),
+              Pair.of("stateRunning", WorkflowInstance.WorkflowState.RUNNING),
+              Pair.of("statePaused", WorkflowInstance.WorkflowState.PAUSED),
+              Pair.of("stateFailing", WorkflowInstance.WorkflowState.FAILING)
+      ));
+      return count > 0;
+    } catch (Exception e) {
+      throw new WorkflowDatabaseException(e);
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
    * @see WorkflowServiceDatabase#updateInDatabase(WorkflowInstance instance)
    */
   public void updateInDatabase(WorkflowInstance instance) throws WorkflowDatabaseException {

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/endpoint/WorkflowRestService.java
@@ -348,6 +348,26 @@ public class WorkflowRestService extends AbstractJobProducerEndpoint {
   }
 
   @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("user/{id}/hasActiveWorkflows")
+  @RestQuery(name = "userhasactiveworkflows", description = "Returns if there are currently workflow(s) running that"
+          + "were started by the given user",
+          returnDescription = "Returns if there are currently workflow(s) running that were started by the given user "
+                  + "as a boolean.",
+          pathParameters = {
+                  @RestParameter(name = "id", isRequired = true, description = "The user identifier", type = STRING) },
+          responses = {
+                  @RestResponse(responseCode = SC_OK, description = "Whether there are active workflow for the user.")})
+  public Response userHasActiveWorkflows(@PathParam("id") String userId) {
+    try {
+      return Response.ok(Boolean.toString(service.userHasActiveWorkflows(userId))).build();
+
+    } catch (WorkflowDatabaseException e) {
+      throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @GET
   @Produces(MediaType.TEXT_XML)
   @Path("instance/{id}.xml")
   @RestQuery(name = "workflowasxml", description = "Get a specific workflow instance.", returnDescription = "An XML representation of a workflow instance", pathParameters = { @RestParameter(name = "id", isRequired = true, description = "The workflow instance identifier", type = STRING) }, responses = {

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1360,6 +1360,16 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   }
 
   /**
+   * {@inheritDoc}
+   *
+   * @see org.opencastproject.workflow.api.WorkflowService#userHasActiveWorkflows(String)
+   */
+  @Override
+  public boolean userHasActiveWorkflows(String userId) throws WorkflowDatabaseException {
+    return persistence.userHasActiveWorkflows(userId);
+  }
+
+  /**
    * Callback for workflow operations that were throwing an exception. This implementation assumes that the operation
    * worker has already adjusted the current operation's state appropriately.
    *

--- a/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
+++ b/modules/workflow-service-remote/src/main/java/org/opencastproject/workflow/remote/WorkflowServiceRemoteImpl.java
@@ -221,6 +221,21 @@ public class WorkflowServiceRemoteImpl extends RemoteBase implements WorkflowSer
     throw new WorkflowDatabaseException("Workflow instances can not be loaded from a remote workflow service");
   }
 
+  @Override
+  public boolean userHasActiveWorkflows(String userId) throws WorkflowDatabaseException {
+    HttpGet get = new HttpGet("/user/" + userId + "/hasActiveWorkflows");
+    HttpResponse response = getResponse(get);
+    try {
+      if (response != null)
+        return Boolean.parseBoolean(response.getEntity().getContent().toString());
+    } catch (Exception e) {
+      throw new WorkflowDatabaseException(e);
+    } finally {
+      closeConnection(response);
+    }
+    throw new WorkflowDatabaseException("Workflow instances can not be loaded from a remote workflow service");
+  }
+
   /**
    * {@inheritDoc}
    *


### PR DESCRIPTION
Resolves #5060

If a user starts a workflow, Opencast expects the user to exist for at least the duration of that workflow. However, the Admin UI could be used to delete said user while the workflow was still active, resulting in a broken workflow. This commit prevents that from happening by checking whether a user has any active workflows associated with them before allowing them to be deleted

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
~* [ ] include migration scripts and documentation, if appropriate~
* [] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
