### PR TITLE
Allow engage ui and ltitools to handle non-16/9 thumbnails

### DIFF
--- a/modules/engage-ui/src/main/resources/ui/css/engage-ui.css
+++ b/modules/engage-ui/src/main/resources/ui/css/engage-ui.css
@@ -19,6 +19,9 @@
 
 .thumbnail {
     padding-bottom: 5px;
+    object-fit: contain;
+    width: 100%;
+    height: 100%;
 }
 
 /* title */
@@ -167,10 +170,10 @@ strong {
 }
 
 .tile img {
-    width: 50%;
     float: left;
     margin-right: 2%;
-    max-height: 163px; 
+    max-height: 90px;
+    max-width: 160px;
 }
 
 .headline {
@@ -183,16 +186,19 @@ strong {
 @media (min-width: 768px) {
     .tile img {
 	max-height: 77px;
+	max-width: 137px;
     }
 }
 @media (min-width: 992px) {
     .tile img {
 	max-height: 65px;
+	max-width: 115px;
     }
 }
 @media (min-width: 1200px) {
     .tile img {
 	max-height: 84px;
+	max-width: 150px;
     }
 }
 

--- a/modules/lti/src/App.css
+++ b/modules/lti/src/App.css
@@ -6,3 +6,16 @@ header {
 .episode-item {
     cursor: pointer;
 }
+
+.thumbnail-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 160px;
+  height: 90px;
+}
+
+.thumbnail-image {
+  max-width: 100%;
+  max-height: 100%;
+}

--- a/modules/lti/src/components/Series.tsx
+++ b/modules/lti/src/components/Series.tsx
@@ -59,8 +59,8 @@ const SeriesEpisode: React.StatelessComponent<EpisodeProps> = ({ episode, delete
     return <div
         className="list-group-item list-group-item-action d-flex justify-content-start align-items-center episode-item"
         onClick={(_) => { window.location.href = "/play/" + episode.id; }}>
-        <div>
-            <img alt="Preview" className="img-fluid" src={image} />
+        <div className="thumbnail-container">
+            <img alt="Preview" className="img-fluid thumbnail-image" src={image} />
         </div>
         <div className="ms-3">
             <h4>{episode.dcTitle}</h4>


### PR DESCRIPTION
While looking at Lukas request to get better thumbnails in Opencast (#5054), I noticed that the `engage ui` and the `ltitools series subtool` rely on their thumbnails being generated exactly at 160x90 pixels. That is kind of annoying if you e.g. want bigger thumbnails, or have a thumbnail for a portrait video. This PR adapts some CSS to allow for more arbitrary thumbnail sizes and ratios in the mentioned tools. Hopefully this helps with Lukas' dream.
