### PR TITLE
Log dispatch interval in seconds, not milliseconds

### DIFF
--- a/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
+++ b/modules/serviceregistry/src/main/java/org/opencastproject/serviceregistry/impl/JobDispatcher.java
@@ -216,7 +216,7 @@ public class JobDispatcher {
         logger.warn("Dispatch interval {} ms too low, adjusting to {}", dispatchInterval, MIN_DISPATCH_INTERVAL);
         dispatchInterval = MIN_DISPATCH_INTERVAL;
       } else {
-        logger.info("Dispatch interval set to {} ms", dispatchInterval);
+        logger.info("Dispatch interval set to {} seconds", dispatchInterval);
       }
     }
 


### PR DESCRIPTION
When we altered the dispatch logic to dispatch in seconds, we forgot to fix the logging entry.  This resolves the confusion.

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
