### PR TITLE
docs: Fix NGINX configuration template preventing alias traversals

### DIFF
--- a/docs/guides/admin/docs/configuration/serving-static-files.md
+++ b/docs/guides/admin/docs/configuration/serving-static-files.md
@@ -94,7 +94,7 @@ This will be picked up by Nginx if it is used as reverse proxy and treated as an
 Thus, for this to work, there needs to be a matching internal location configuration like this:
 
 ```
-location /protected {
+location /protected/ {
   internal;
   alias /srv/opencast/downloads/;
 }


### PR DESCRIPTION
We provide a documentation example of a potentially insecure Nginx configuration that may allow alias traversal. According to https://labs.hakaioffsec.com/nginx-alias-traversal/ when there is an `alias` directive present within the `location` directive, then the `location` directive should end with a trailing slash in its path and the `alias` directive should end with a trailing slash as well.

### Your pull request should…

* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
