### PR TITLE
Add whisper-ctranslate2 flags to WhisperEngine.java

### DIFF
--- a/docs/guides/admin/docs/modules/transcription.modules/whisper.md
+++ b/docs/guides/admin/docs/modules/transcription.modules/whisper.md
@@ -20,6 +20,8 @@ Enable Whisper engine
 To enable Whisper as for the `SpeechToText` WoH, follow these steps.
 
 1. [Install whisper](https://github.com/openai/whisper#setup) on the worker nodes.
+    - Or install [whisper-ctranslate2](https://github.com/Softcatala/whisper-ctranslate2) for faster processing
+      on CPU.
 2. Enable whisper and set Job load in `org.opencastproject.speechtotext.impl.SpeechToTextServiceImpl.cfg`.
 3. Set the target model to use in `org.opencastproject.speechtotext.impl.engine.WhisperEngine`.
 
@@ -40,3 +42,19 @@ the Whisper machines (Whose nodes have higher job load set).
     - Performance bottleneck with too many parallel transcriptions.
 
 
+Whisper-ctranslate2
+-------------------
+
+[whisper-ctranslate2](https://github.com/Softcatala/whisper-ctranslate2) offers the same command line interface
+as OpenAIs whisper, so it can easily be used in lieu of it. The main benefit of whisper-ctranslate2 is its
+out-of-the-box processing speed increase, especially on CPUs, compared to OpenAIs whisper. Otherwise the two
+should behave highly similar, so the above notes still apply.
+
+To use whisper-ctranslate2 instead of OpenAis whisper, change the `whisper.root.path` in
+`org.opencastproject.speechtotext.impl.engine.WhisperEngine` to your installation path.
+
+Additional features:
+- Enabling quantization in `org.opencastproject.speechtotext.impl.engine.WhisperEngine` can increase processing
+  speed even further.
+- Enabling Voice Activity Detection in `org.opencastproject.speechtotext.impl.engine.WhisperEngine` can prevent
+  whisper from transcribing non-speech or silence.

--- a/etc/org.opencastproject.speechtotext.impl.engine.WhisperEngine.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.engine.WhisperEngine.cfg
@@ -16,9 +16,9 @@
 # On CPU int8 will give the best performance
 # Possible values: auto,int8,int8_float16,int16,float16,float32
 # Default: none
-#whisper.quantization: int8
+#whisper.quantization=int8
 
 # Voice Activity Detection (VAD)
 # Filter out parts of the audio without speech using the Silero VAD model
 # Default: none
-#whisper.vad_enabled: true
+#whisper.vad_enabled=true

--- a/etc/org.opencastproject.speechtotext.impl.engine.WhisperEngine.cfg
+++ b/etc/org.opencastproject.speechtotext.impl.engine.WhisperEngine.cfg
@@ -6,3 +6,19 @@
 # Available models: tiny, base, medium, large.
 # Default: base
 #whisper.model=base
+
+### Additional config options for whisper-ctranslate2
+# The following options are for use with whisper-ctranslate2.
+# Will only work when using whisper-ctranslate2 and lead to exceptions otherwise!
+
+# Quantization
+# Quantization is a technique that can reduce the model size and accelerate its execution with little to no degradation in accuracy.
+# On CPU int8 will give the best performance
+# Possible values: auto,int8,int8_float16,int16,float16,float32
+# Default: none
+#whisper.quantization: int8
+
+# Voice Activity Detection (VAD)
+# Filter out parts of the audio without speech using the Silero VAD model
+# Default: none
+#whisper.vad_enabled: true


### PR DESCRIPTION
`whisper-ctranslate2`(https://github.com/Softcatala/whisper-ctranslate2) is an OpenAI whisper derivative with the main benefit of being significantly more performant on CPUs.
It also intentionally comes with the same CLI, so it works with our current implementation of whisper in `WhisperEngine.java`.

This PR makes mention of `whisper-ctranslate2` in the Opencast docs. It also adds configuration for two potentially useful flags exclusive to `whisper-ctranslate2` to `WhisperEngine.cfg`.

### Your pull request should…

* [x] have a concise title
* ~[ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
