### PR TITLE
Add endpoint to get languages & licenses

### DIFF
--- a/docs/guides/developer/docs/api/listprovider-api.md
+++ b/docs/guides/developer/docs/api/listprovider-api.md
@@ -1,0 +1,52 @@
+[TOC]
+
+# Information
+
+The ListProvider API is available since API version 1.10.0.
+
+### GET /api/listproviders/languages
+
+Returns a list of languages as configured in the listproviders.
+
+__Response__
+
+`200 (OK)`: The languages are returned as key value pairs in a JSON object.
+
+Field     | Type                       | Description
+:---------|:---------------------------|:-----------
+`key `    | [`string`](types.md#basic) | Three letter ISO language codes
+`value`   | [`string`](types.md#basic) | The translation string used in the Opencast Admin UI
+
+
+__Example__
+
+```
+{
+  "dan": "LANGUAGES.DANISH",
+  "nor": "LANGUAGES.NORWEGIAN",
+  "tur": "LANGUAGES.TURKISH",
+}
+```
+
+### GET /api/listproviders/licenses
+
+Returns a list of licenses as configured in the listproviders.
+
+__Response__
+
+`200 (OK)`: The licenses are returned as key value pairs in a JSON object.
+
+Field     | Type                       | Description
+:---------|:---------------------------|:-----------
+`key `    | [`string`](types.md#basic) | Three license codes
+`value`   | [`object`](types.md#basic) | An object containing information for display in the Opencast Admin UI
+
+
+__Example__
+
+```
+{
+  "CC-BY-NC-SA": "{\"label\":\"EVENTS.LICENSE.CCBYNCSA\", \"order\":6, \"selectable\": true}",
+  "CC-BY": "{\"label\":\"EVENTS.LICENSE.CCBY\", \"order\":2, \"selectable\": true}",
+}
+```

--- a/docs/guides/developer/docs/api/listprovider-api.md
+++ b/docs/guides/developer/docs/api/listprovider-api.md
@@ -4,45 +4,44 @@
 
 The ListProvider API is available since API version 1.10.0.
 
-### GET /api/listproviders/languages
+### GET /api/listproviders/providers.json
 
-Returns a list of languages as configured in the listproviders.
+Returns a list of listproviders.
 
 __Response__
 
-`200 (OK)`: The languages are returned as key value pairs in a JSON object.
+`200 (OK)`: The listproviders are returned as a list.
 
 Field     | Type                       | Description
 :---------|:---------------------------|:-----------
-`key `    | [`string`](types.md#basic) | Three letter ISO language codes
-`value`   | [`string`](types.md#basic) | The translation string used in the Opencast Admin UI
+`value`   | [`string`](types.md#basic) | The string used to identify a provider, e.g. "LANGUAGES"
 
 
 __Example__
 
 ```
 {
-  "dan": "LANGUAGES.DANISH",
-  "nor": "LANGUAGES.NORWEGIAN",
-  "tur": "LANGUAGES.TURKISH",
+  "LICENSES",
+  "LANGUAGES",
+  "SERIES",
 }
 ```
 
-### GET /api/listproviders/licenses
+### GET /api/listproviders/{source}.json
 
-Returns a list of licenses as configured in the listproviders.
+Provides key-value list from the given listprovider.
 
 __Response__
 
-`200 (OK)`: The licenses are returned as key value pairs in a JSON object.
+`200 (OK)`: The key-value list are returned as a JSON object.
 
 Field     | Type                       | Description
 :---------|:---------------------------|:-----------
-`key `    | [`string`](types.md#basic) | Three license codes
-`value`   | [`object`](types.md#basic) | An object containing information for display in the Opencast Admin UI
+`key `    | [`string`](types.md#basic) | Source key
+`value`   | [`object`](types.md#basic) | Source value
 
 
-__Example__
+__Example for "LICENSES"__
 
 ```
 {

--- a/docs/guides/developer/mkdocs.yml
+++ b/docs/guides/developer/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
    - Base API: 'api/base-api.md'
    - Agents API: 'api/agents-api.md'
    - Events API: 'api/events-api.md'
+   - ListProvider API: 'api/listprovider-api.md'
    - Series API: 'api/series-api.md'
    - Statistics API: 'api/statistics-api.md'
    - Groups API: 'api/groups-api.md'

--- a/modules/external-api/pom.xml
+++ b/modules/external-api/pom.xml
@@ -175,6 +175,11 @@
       <artifactId>opencast-asset-manager-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiMediaType.java
@@ -22,6 +22,7 @@ package org.opencastproject.external.common;
 
 public final class ApiMediaType {
 
+  public static final String VERSION_1_10_0 = "application/v1.10.0+json";
   public static final String VERSION_1_9_0 = "application/v1.9.0+json";
   public static final String VERSION_1_8_0 = "application/v1.8.0+json";
   public static final String VERSION_1_7_0 = "application/v1.7.0+json";
@@ -50,8 +51,10 @@ public final class ApiMediaType {
   public static ApiMediaType parse(String acceptHeader) throws ApiMediaTypeException {
     /* MH-12802: The External API does not support content negotiation */
     ApiMediaType mediaType;
-    if (acceptHeader == null || acceptHeader.contains(VERSION_1_9_0) || acceptHeader.contains(JSON)
+    if (acceptHeader == null || acceptHeader.contains(VERSION_1_10_0) || acceptHeader.contains(JSON)
     || acceptHeader.contains(APPLICATION_ANY) || acceptHeader.contains(ANY)) {
+      mediaType = new ApiMediaType(ApiVersion.VERSION_1_10_0, ApiFormat.JSON, VERSION_1_10_0);
+    } else if (acceptHeader.contains(VERSION_1_9_0)) {
       mediaType = new ApiMediaType(ApiVersion.VERSION_1_9_0, ApiFormat.JSON, VERSION_1_9_0);
     } else if (acceptHeader.contains(VERSION_1_8_0)) {
       mediaType = new ApiMediaType(ApiVersion.VERSION_1_8_0, ApiFormat.JSON, VERSION_1_8_0);

--- a/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/common/ApiVersion.java
@@ -32,10 +32,11 @@ public enum ApiVersion {
   VERSION_1_6_0(1, 6, 0),
   VERSION_1_7_0(1, 7, 0),
   VERSION_1_8_0(1, 8, 0),
-  VERSION_1_9_0(1, 9, 0);
+  VERSION_1_9_0(1, 9, 0),
+  VERSION_1_10_0(1, 10, 0);
 
   /** The most recent version of the External API */
-  public static final ApiVersion CURRENT_VERSION = VERSION_1_9_0;
+  public static final ApiVersion CURRENT_VERSION = VERSION_1_10_0;
 
   private int major;
   private int minor;

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/BaseEndpoint.java
@@ -75,7 +75,7 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0 })
 @RestService(name = "externalapiservice", title = "External API Service", notes = {},
              abstractText = "Provides a location for external apis to query the current server of the API.")
 @Component(
@@ -230,6 +230,7 @@ public class BaseEndpoint {
     versions.add(v(ApiVersion.VERSION_1_7_0.toString()));
     versions.add(v(ApiVersion.VERSION_1_8_0.toString()));
     versions.add(v(ApiVersion.VERSION_1_9_0.toString()));
+    versions.add(v(ApiVersion.VERSION_1_10_0.toString()));
     JValue json = obj(f("versions", arr(versions)), f("default", v(ApiVersion.CURRENT_VERSION.toString())));
     return RestUtil.R.ok(MediaType.APPLICATION_JSON_TYPE, serializer.toJson(json));
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/CaptureAgentsEndpoint.java
@@ -59,7 +59,8 @@ import javax.ws.rs.core.Response;
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
             ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
-            ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0, ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0, ApiMediaType.VERSION_1_9_0,
+            ApiMediaType.VERSION_1_10_0 })
 @RestService(
     name = "externalapicaptureagents",
     title = "External API Capture Agents Service",

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/EventsEndpoint.java
@@ -185,7 +185,7 @@ import javax.ws.rs.core.Response.Status;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0 })
 @RestService(name = "externalapievents", title = "External API Events Service", notes = {},
              abstractText = "Provides resources and operations related to the events")
 @Component(

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/GroupsEndpoint.java
@@ -94,7 +94,7 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0 })
 @RestService(name = "externalapigroups", title = "External API Groups Service", notes = {}, abstractText = "Provides resources and operations related to the groups")
 @Component(
     immediate = true,

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/ListProviderEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/ListProviderEndpoint.java
@@ -27,7 +27,6 @@ import org.opencastproject.list.api.ListProvidersService;
 import org.opencastproject.list.api.ResourceListQuery;
 import org.opencastproject.list.impl.ListProviderNotFoundException;
 import org.opencastproject.list.impl.ResourceListQueryImpl;
-import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
 import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
@@ -48,7 +47,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 @Path("/")
@@ -113,25 +111,17 @@ public class ListProviderEndpoint {
           name = "getlanguages",
           description = "Returns a list of configured languages",
           returnDescription = "",
-          restParameters = {
-            @RestParameter(description = "The maximum number of items to return per page", isRequired = false, name = "limit", type = RestParameter.Type.INTEGER),
-            @RestParameter(description = "The offset", isRequired = false, name = "offset", type = RestParameter.Type.INTEGER),
-          },
           responses = {
                   @RestResponse(description = "The list is returned.", responseCode = HttpServletResponse.SC_OK),
           }
   )
   public Response getLanguages(
-          @QueryParam("limit") final int limit,
-          @QueryParam("offset") final int offset,
           @HeaderParam("Accept") String acceptHeader
   ) throws Exception {
 
     final String source = "LANGUAGES";
 
     ResourceListQueryImpl query = new ResourceListQueryImpl();
-    query.setLimit(limit);
-    query.setOffset(offset);
 
     return getList(source, query);
   }
@@ -142,25 +132,17 @@ public class ListProviderEndpoint {
           name = "getlicenses",
           description = "Returns a list of configured licenses",
           returnDescription = "",
-          restParameters = {
-                  @RestParameter(description = "The maximum number of items to return per page", isRequired = false, name = "limit", type = RestParameter.Type.INTEGER),
-                  @RestParameter(description = "The offset", isRequired = false, name = "offset", type = RestParameter.Type.INTEGER),
-          },
           responses = {
                   @RestResponse(description = "The list is returned.", responseCode = HttpServletResponse.SC_OK),
           }
   )
   public Response getLicenses(
-          @QueryParam("limit") final int limit,
-          @QueryParam("offset") final int offset,
           @HeaderParam("Accept") String acceptHeader
   ) throws Exception {
 
     final String source = "LICENSES";
 
     ResourceListQueryImpl query = new ResourceListQueryImpl();
-    query.setLimit(limit);
-    query.setOffset(offset);
 
     return getList(source, query);
   }

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/ListProviderEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/ListProviderEndpoint.java
@@ -1,0 +1,168 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.external.endpoint;
+
+import org.opencastproject.external.common.ApiMediaType;
+import org.opencastproject.external.common.ApiResponses;
+import org.opencastproject.list.api.ListProviderException;
+import org.opencastproject.list.api.ListProvidersService;
+import org.opencastproject.list.api.ResourceListQuery;
+import org.opencastproject.list.impl.ListProviderNotFoundException;
+import org.opencastproject.list.impl.ResourceListQueryImpl;
+import org.opencastproject.util.doc.rest.RestParameter;
+import org.opencastproject.util.doc.rest.RestQuery;
+import org.opencastproject.util.doc.rest.RestResponse;
+import org.opencastproject.util.doc.rest.RestService;
+
+import com.google.gson.Gson;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+@Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_10_0 })
+@RestService(
+        name = "externalapilistproviders",
+        title = "External API List Providers Service",
+        notes = {},
+        abstractText = "Provides resources and operations related to configurable lists"
+)
+@Component(
+        immediate = true,
+        service = ListProviderEndpoint.class,
+        property = {
+                "service.description=External API - List Providers Endpoint",
+                "opencast.service.type=org.opencastproject.external.listproviders",
+                "opencast.service.path=/api/listproviders"
+        }
+)
+public class ListProviderEndpoint {
+
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory.getLogger(ListProviderEndpoint.class);
+
+  /** The capture agent service */
+  private ListProvidersService listProvidersService;
+
+  /** OSGi DI */
+  @Reference
+  public void setListProvidersService(ListProvidersService listProvidersService) {
+    this.listProvidersService = listProvidersService;
+  }
+
+  /** OSGi activation method */
+  @Activate
+  void activate(ComponentContext cc) {
+    logger.info("Activating External API - List Providers Endpoint");
+  }
+
+
+  private Response getList(String source, ResourceListQuery query) {
+    Map<String, String> autocompleteList;
+    try {
+      autocompleteList = listProvidersService.getList(source, query, false);
+    } catch (ListProviderNotFoundException e) {
+      logger.debug("No list found for {}", source, e);
+      return ApiResponses.notFound("");
+    } catch (ListProviderException e) {
+      logger.error("Server error when getting list from provider {}", source, e);
+      return ApiResponses.serverError("");
+    }
+
+
+    Gson gson = new Gson();
+    String jsonList = gson.toJson(autocompleteList);
+    return Response.ok(jsonList).build();
+  }
+
+  @GET
+  @Path("languages")
+  @RestQuery(
+          name = "getlanguages",
+          description = "Returns a list of configured languages",
+          returnDescription = "",
+          restParameters = {
+            @RestParameter(description = "The maximum number of items to return per page", isRequired = false, name = "limit", type = RestParameter.Type.INTEGER),
+            @RestParameter(description = "The offset", isRequired = false, name = "offset", type = RestParameter.Type.INTEGER),
+          },
+          responses = {
+                  @RestResponse(description = "The list is returned.", responseCode = HttpServletResponse.SC_OK),
+          }
+  )
+  public Response getLanguages(
+          @QueryParam("limit") final int limit,
+          @QueryParam("offset") final int offset,
+          @HeaderParam("Accept") String acceptHeader
+  ) throws Exception {
+
+    final String source = "LANGUAGES";
+
+    ResourceListQueryImpl query = new ResourceListQueryImpl();
+    query.setLimit(limit);
+    query.setOffset(offset);
+
+    return getList(source, query);
+  }
+
+  @GET
+  @Path("licenses")
+  @RestQuery(
+          name = "getlicenses",
+          description = "Returns a list of configured licenses",
+          returnDescription = "",
+          restParameters = {
+                  @RestParameter(description = "The maximum number of items to return per page", isRequired = false, name = "limit", type = RestParameter.Type.INTEGER),
+                  @RestParameter(description = "The offset", isRequired = false, name = "offset", type = RestParameter.Type.INTEGER),
+          },
+          responses = {
+                  @RestResponse(description = "The list is returned.", responseCode = HttpServletResponse.SC_OK),
+          }
+  )
+  public Response getLicenses(
+          @QueryParam("limit") final int limit,
+          @QueryParam("offset") final int offset,
+          @HeaderParam("Accept") String acceptHeader
+  ) throws Exception {
+
+    final String source = "LICENSES";
+
+    ResourceListQueryImpl query = new ResourceListQueryImpl();
+    query.setLimit(limit);
+    query.setOffset(offset);
+
+    return getList(source, query);
+  }
+}
+

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SecurityEndpoint.java
@@ -68,7 +68,7 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0 })
 @RestService(name = "externalapisecurity", title = "External API Security Service", notes = {}, abstractText = "Provides security operations related to the external API")
 @Component(
     immediate = true,

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/SeriesEndpoint.java
@@ -137,7 +137,7 @@ import javax.ws.rs.core.Response.Status;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_0_0, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0,
             ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0 })
 @RestService(name = "externalapiseries", title = "External API Series Service", notes = {},
              abstractText = "Provides resources and operations related to the series")
 @Component(

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/StatisticsEndpoint.java
@@ -84,7 +84,7 @@ import javax.ws.rs.core.Response;
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_3_0, ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0,
             ApiMediaType.VERSION_1_6_0, ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0 })
 @RestService(
   name = "externalapistatistics", title = "External API Statistics Endpoint",
   notes = {}, abstractText = "Provides statistics")

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowDefinitionsEndpoint.java
@@ -82,7 +82,7 @@ import javax.ws.rs.core.Response;
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
             ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
             ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0,
-            ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_9_0, ApiMediaType.VERSION_1_10_0 })
 @RestService(name = "externalapiworkflowdefinitions", title = "External API Workflow Definitions Service", notes = {},
              abstractText = "Provides resources and operations related to the workflow definitions")
 @Component(

--- a/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
+++ b/modules/external-api/src/main/java/org/opencastproject/external/endpoint/WorkflowsEndpoint.java
@@ -97,7 +97,8 @@ import javax.ws.rs.core.Response;
 @Path("/")
 @Produces({ ApiMediaType.JSON, ApiMediaType.VERSION_1_1_0, ApiMediaType.VERSION_1_2_0, ApiMediaType.VERSION_1_3_0,
             ApiMediaType.VERSION_1_4_0, ApiMediaType.VERSION_1_5_0, ApiMediaType.VERSION_1_6_0,
-            ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0, ApiMediaType.VERSION_1_9_0 })
+            ApiMediaType.VERSION_1_7_0, ApiMediaType.VERSION_1_8_0, ApiMediaType.VERSION_1_9_0,
+            ApiMediaType.VERSION_1_10_0 })
 @RestService(name = "externalapiworkflowinstances", title = "External API Workflow Instances Service", notes = {},
              abstractText = "Provides resources and operations related to the workflow instances")
 @Component(

--- a/modules/external-api/src/test/java/org/opencastproject/external/common/ApiMediaTypeTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/common/ApiMediaTypeTest.java
@@ -29,24 +29,24 @@ public class ApiMediaTypeTest {
   @Test
   public void testDefaultVersionAndFormat() throws Exception {
     ApiMediaType type = ApiMediaType.parse("*/*");
-    assertEquals(ApiVersion.VERSION_1_9_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_10_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.9.0+json", type.toExternalForm());
+    assertEquals("application/v1.10.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse("application/*");
-    assertEquals(ApiVersion.VERSION_1_9_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_10_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.9.0+json", type.toExternalForm());
+    assertEquals("application/v1.10.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse("application/json");
-    assertEquals(ApiVersion.VERSION_1_9_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_10_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.9.0+json", type.toExternalForm());
+    assertEquals("application/v1.10.0+json", type.toExternalForm());
 
     type = ApiMediaType.parse(null);
-    assertEquals(ApiVersion.VERSION_1_9_0, type.getVersion());
+    assertEquals(ApiVersion.VERSION_1_10_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
-    assertEquals("application/v1.9.0+json", type.toExternalForm());
+    assertEquals("application/v1.10.0+json", type.toExternalForm());
   }
 
   @Test
@@ -100,6 +100,11 @@ public class ApiMediaTypeTest {
     assertEquals(ApiVersion.VERSION_1_9_0, type.getVersion());
     assertEquals(ApiFormat.JSON, type.getFormat());
     assertEquals("application/v1.9.0+json", type.toExternalForm());
+
+    type = ApiMediaType.parse("application/v1.10.0+json");
+    assertEquals(ApiVersion.VERSION_1_10_0, type.getVersion());
+    assertEquals(ApiFormat.JSON, type.getFormat());
+    assertEquals("application/v1.10.0+json", type.toExternalForm());
   }
 
   @Test(expected = ApiMediaTypeException.class)

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/BaseEndpointTest.java
@@ -60,7 +60,7 @@ public class BaseEndpointTest {
 
     JSONObject json = (JSONObject) parser.parse(response);
     assertEquals("https://api.opencast.org", json.get("url"));
-    assertEquals("v1.9.0", json.get("version"));
+    assertEquals("v1.10.0", json.get("version"));
   }
 
   /** Test case for {@link BaseEndpoint#getUserInfo()} */
@@ -121,7 +121,7 @@ public class BaseEndpointTest {
 
     JSONObject json = (JSONObject) parser.parse(response);
     JSONArray version = (JSONArray) json.get("versions");
-    assertEquals("v1.9.0", json.get("default"));
+    assertEquals("v1.10.0", json.get("default"));
     assertTrue(version.contains("v1.0.0"));
     assertTrue(version.contains("v1.1.0"));
     assertTrue(version.contains("v1.2.0"));
@@ -132,7 +132,8 @@ public class BaseEndpointTest {
     assertTrue(version.contains("v1.7.0"));
     assertTrue(version.contains("v1.8.0"));
     assertTrue(version.contains("v1.9.0"));
-    assertEquals(10, version.size());
+    assertTrue(version.contains("v1.10.0"));
+    assertEquals(11, version.size());
   }
 
   /** Test case for {@link BaseEndpoint#getVersionDefault()} */
@@ -142,7 +143,7 @@ public class BaseEndpointTest {
             .asString();
 
     JSONObject json = (JSONObject) parser.parse(response);
-    assertEquals("v1.9.0", json.get("default"));
+    assertEquals("v1.10.0", json.get("default"));
   }
 
 }

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/ListProviderEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/ListProviderEndpointTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.external.endpoint;
+
+import static io.restassured.RestAssured.given;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.junit.Assert.assertEquals;
+import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
+
+import org.opencastproject.test.rest.RestServiceTestEnv;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Unit tests for {@link ListProviderEndpoint} */
+public class ListProviderEndpointTest {
+
+  /** The REST test environment */
+  private static final RestServiceTestEnv env = testEnvForClasses(TestListProviderEndpoint.class);
+
+  private static final JSONParser parser = new JSONParser();
+
+  @BeforeClass
+  public static void oneTimeSetUp() {
+    env.setUpServer();
+  }
+
+  @AfterClass
+  public static void oneTimeTearDown() {
+    env.tearDownServer();
+  }
+
+  @Test
+  public void testGetLanguages() throws Exception {
+    final String response = given()
+            .queryParam("limit", 0)
+            .queryParam("offset", 0)
+            .expect()
+            .statusCode(SC_OK)
+            .when()
+            .get(env.host("/languages"))
+            .asString();
+
+    final JSONObject json = (JSONObject) parser.parse(response);
+    assertEquals(3, json.size());
+
+    assertEquals("LANGUAGES.ARABIC",json.get("ara"));
+    assertEquals("LANGUAGES.DANISH",json.get("dan"));
+  }
+
+  @Test
+  public void testGetLicenses() throws Exception {
+    final String response = given()
+            .queryParam("limit", 0)
+            .queryParam("offset", 0)
+            .expect()
+            .statusCode(SC_OK)
+            .when()
+            .get(env.host("/licenses"))
+            .asString();
+
+    final JSONObject json = (JSONObject) parser.parse(response);
+    assertEquals(3, json.size());
+
+    assertEquals("{\"label\":\"EVENTS.LICENSE.CC0\", \"order\":8, \"selectable\": true}",json.get("CC0"));
+    assertEquals("{\"label\":\"EVENTS.LICENSE.CCBYSA\", \"order\":3, \"selectable\": true}",json.get("CC-BY-SA"));
+  }
+}

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/ListProviderEndpointTest.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/ListProviderEndpointTest.java
@@ -23,15 +23,22 @@ package org.opencastproject.external.endpoint;
 import static io.restassured.RestAssured.given;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.reflect.TypeToken;
+
 import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.lang.reflect.Type;
+import java.util.List;
 
 /** Unit tests for {@link ListProviderEndpoint} */
 public class ListProviderEndpointTest {
@@ -39,7 +46,7 @@ public class ListProviderEndpointTest {
   /** The REST test environment */
   private static final RestServiceTestEnv env = testEnvForClasses(TestListProviderEndpoint.class);
 
-  private static final JSONParser parser = new JSONParser();
+  private static final Gson gson = new Gson();
 
   @BeforeClass
   public static void oneTimeSetUp() {
@@ -52,6 +59,23 @@ public class ListProviderEndpointTest {
   }
 
   @Test
+  public void testGetProviders() throws Exception {
+    final String response = given()
+            .expect()
+            .statusCode(SC_OK).when()
+            .get(env.host("/providers.json"))
+            .asString();
+
+    JsonArray json = gson.fromJson(response, JsonArray.class);
+    Type listType = new TypeToken<List<String>>() { }.getType();
+    List<String> yourList = new Gson().fromJson(json.get(0), listType);
+    assertEquals(3, yourList.size());
+
+    assertTrue(yourList.contains("LANGUAGES"));
+    assertTrue(yourList.contains("LICENSES"));
+  }
+
+  @Test
   public void testGetLanguages() throws Exception {
     final String response = given()
             .queryParam("limit", 0)
@@ -59,10 +83,10 @@ public class ListProviderEndpointTest {
             .expect()
             .statusCode(SC_OK)
             .when()
-            .get(env.host("/languages"))
+            .get(env.host("/LANGUAGES.json"))
             .asString();
 
-    final JSONObject json = (JSONObject) parser.parse(response);
+    final JSONObject json = gson.fromJson(response, JSONObject.class);
     assertEquals(3, json.size());
 
     assertEquals("LANGUAGES.ARABIC",json.get("ara"));
@@ -77,10 +101,10 @@ public class ListProviderEndpointTest {
             .expect()
             .statusCode(SC_OK)
             .when()
-            .get(env.host("/licenses"))
+            .get(env.host("/LICENSES.json"))
             .asString();
 
-    final JSONObject json = (JSONObject) parser.parse(response);
+    final JSONObject json = gson.fromJson(response, JSONObject.class);
     assertEquals(3, json.size());
 
     assertEquals("{\"label\":\"EVENTS.LICENSE.CC0\", \"order\":8, \"selectable\": true}",json.get("CC0"));

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestListProviderEndpoint.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestListProviderEndpoint.java
@@ -30,7 +30,9 @@ import org.opencastproject.list.api.ResourceListQuery;
 import org.easymock.EasyMock;
 import org.junit.Ignore;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.Path;
@@ -40,6 +42,11 @@ import javax.ws.rs.Path;
 public class TestListProviderEndpoint extends ListProviderEndpoint {
 
   public TestListProviderEndpoint() throws Exception {
+    List<String> providers = new ArrayList<>();
+    providers.add("LANGUAGES");
+    providers.add("LICENSES");
+    providers.add("YES");
+
     Map<String, String> languages = new HashMap<>();
     languages.put("ara", "LANGUAGES.ARABIC");
     languages.put("dan", "LANGUAGES.DANISH");
@@ -51,6 +58,7 @@ public class TestListProviderEndpoint extends ListProviderEndpoint {
     licenses.put("CC-BY-NC-ND", "{\"label\":\"EVENTS.LICENSE.CCBYNCND\", \"order\":7, \"selectable\": true}");
 
     ListProvidersService service = createNiceMock(ListProvidersService.class);
+    expect(service.getAvailableProviders()).andReturn(providers);
     expect(service.getList(EasyMock.matches("LANGUAGES"), EasyMock.anyObject(ResourceListQuery.class),
             EasyMock.anyBoolean())).andReturn(languages);
     expect(service.getList(EasyMock.matches("LICENSES"), EasyMock.anyObject(ResourceListQuery.class),

--- a/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestListProviderEndpoint.java
+++ b/modules/external-api/src/test/java/org/opencastproject/external/endpoint/TestListProviderEndpoint.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.opencastproject.external.endpoint;
+
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+
+import org.opencastproject.list.api.ListProvidersService;
+import org.opencastproject.list.api.ResourceListQuery;
+
+import org.easymock.EasyMock;
+import org.junit.Ignore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.Path;
+
+@Path("")
+@Ignore
+public class TestListProviderEndpoint extends ListProviderEndpoint {
+
+  public TestListProviderEndpoint() throws Exception {
+    Map<String, String> languages = new HashMap<>();
+    languages.put("ara", "LANGUAGES.ARABIC");
+    languages.put("dan", "LANGUAGES.DANISH");
+    languages.put("deu", "LANGUAGES.GERMAN");
+
+    Map<String, String> licenses = new HashMap<>();
+    licenses.put("CC0", "{\"label\":\"EVENTS.LICENSE.CC0\", \"order\":8, \"selectable\": true}");
+    licenses.put("CC-BY-SA", "{\"label\":\"EVENTS.LICENSE.CCBYSA\", \"order\":3, \"selectable\": true}");
+    licenses.put("CC-BY-NC-ND", "{\"label\":\"EVENTS.LICENSE.CCBYNCND\", \"order\":7, \"selectable\": true}");
+
+    ListProvidersService service = createNiceMock(ListProvidersService.class);
+    expect(service.getList(EasyMock.matches("LANGUAGES"), EasyMock.anyObject(ResourceListQuery.class),
+            EasyMock.anyBoolean())).andReturn(languages);
+    expect(service.getList(EasyMock.matches("LICENSES"), EasyMock.anyObject(ResourceListQuery.class),
+            EasyMock.anyBoolean())).andReturn(licenses);
+    replay(service);
+
+    setListProvidersService(service);
+  }
+}


### PR DESCRIPTION
Attempts to resolve https://github.com/opencast/opencast/issues/5099.

Adds two new endpoints to the external API. They return the languages/licenses configured in the listproviders.

The endpoint behaviour is fairly straightly copied from their Admin UI endpoint counterpart in `admin-ng/resources`. The key difference is that `admin-ng/resources` allows for request for any provider, whereas this commit created two explicit endpoints for two explicit providers. The reasoning is that users of the external api should not have access to every provider, and that most providers only make sense in the context of the Admin UI anyway. I'd be happy to hear other opinions on this.

Another issue is that both the language & license endpoint return translation identifiers that are only useful to the Admin UI instead of more useful labels (e.g. `LANGUAGE.ARABIC` instead of `Arabic`). And I don't see a clean way of getting those translations from the Admin UI, short of copying the entire translation to the external-api module (like the lti module did).

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
