### PR TITLE
Mark tag operation as skipped if nothing happened

### DIFF
--- a/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
+++ b/modules/workflow-workflowoperation/src/main/java/org/opencastproject/workflow/handler/workflow/TagWorkflowOperationHandler.java
@@ -129,6 +129,10 @@ public class TagWorkflowOperationHandler extends AbstractWorkflowOperationHandle
     }
 
     Collection<MediaPackageElement> elements = elementSelector.select(mediaPackage, false);
+    if (elements.size() == 0) {
+      return createResult(mediaPackage, Action.SKIP);
+    }
+
     for (MediaPackageElement e : elements) {
       MediaPackageElement element = e;
       if (copy) {


### PR DESCRIPTION
If no elements matched the selection criteria, mark the operation as Skipped instead of Succeeded. This will hopefully make understanding what happened during a workflow a bit easier, especially when you're trying to find a bug.
