### PR TITLE
Paella Player 7 URL parameters documentation fixed

### DIFF
--- a/docs/guides/admin/docs/modules/paella.player7/url.parameter.md
+++ b/docs/guides/admin/docs/modules/paella.player7/url.parameter.md
@@ -1,6 +1,8 @@
 Paella Player 7 - URL Parameters
 ==============================
+
 The player support different URL parameters to modify the behaviour or the target event.
+
 Parameter      | Example    | Description
 ---------------|------------|------------
 **id**         | `SOME-ID`  | Video Id to play


### PR DESCRIPTION
This patch fixes the markdown table syntax for Paella Player7 URL parameter documentation.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
