### PR TITLE
Remove useless settings from `persistence.xml` files

### DIFF
--- a/modules/admin-ui/src/main/resources/META-INF/persistence.xml
+++ b/modules/admin-ui/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-adminui-jpa.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-adminui-jpa.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/adopter-registration-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/adopter-registration-impl/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-or-extend-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-adopter-registration-impl.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-adopter-registration-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/annotation-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/annotation-impl/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-annotation-impl.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-annotation-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/asset-manager-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/asset-manager-impl/src/main/resources/META-INF/persistence.xml
@@ -16,8 +16,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-assetmanager.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-assetmanager.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/asset-manager-storage-aws/src/main/resources/META-INF/persistence.xml
+++ b/modules/asset-manager-storage-aws/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-asset-aws.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-asset-aws.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/authorization-manager/src/main/resources/META-INF/persistence.xml
+++ b/modules/authorization-manager/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-xacml-manager.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-xacml-manager.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/capture-admin-service-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/capture-admin-service-impl/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-capture-admin-service-impl.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-capture-admin-service-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/capture-admin-service-impl/src/test/resources/META-INF/persistence.xml
+++ b/modules/capture-admin-service-impl/src/test/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-capture-admin-service-impl.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-capture-admin-service-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/common-jpa-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/common-jpa-impl/src/main/resources/META-INF/persistence.xml
@@ -21,8 +21,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-userdirectory.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-userdirectory.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/event-comment/src/main/resources/META-INF/persistence.xml
+++ b/modules/event-comment/src/main/resources/META-INF/persistence.xml
@@ -14,8 +14,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-comments-jpa.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-comments-jpa.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/kernel/src/main/resources/META-INF/persistence.xml
+++ b/modules/kernel/src/main/resources/META-INF/persistence.xml
@@ -14,8 +14,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-kernel-jpa.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-kernel-jpa.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/oaipmh-persistence/src/main/resources/META-INF/persistence.xml
+++ b/modules/oaipmh-persistence/src/main/resources/META-INF/persistence.xml
@@ -14,8 +14,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-oaipmh.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-oaipmh.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/oaipmh/src/main/resources/META-INF/persistence.xml
+++ b/modules/oaipmh/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-oaipmh-harvester.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-oaipmh-harvester.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/scheduler-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/scheduler-impl/src/main/resources/META-INF/persistence.xml
@@ -14,8 +14,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-scheduler-impl.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-scheduler-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/search-service-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/search-service-impl/src/main/resources/META-INF/persistence.xml
@@ -14,8 +14,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-search-service-impl.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-search-service-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/series-service-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/series-service-impl/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-series-service-impl.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-series-service-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/serviceregistry/src/main/resources/META-INF/persistence.xml
+++ b/modules/serviceregistry/src/main/resources/META-INF/persistence.xml
@@ -14,8 +14,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-serviceregistry.jdbc" />
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-serviceregistry.jdbc" />
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/themes/src/main/resources/META-INF/persistence.xml
+++ b/modules/themes/src/main/resources/META-INF/persistence.xml
@@ -13,8 +13,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-themes-jpa.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-themes-jpa.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/transcription-service-persistence/src/main/resources/META-INF/persistence.xml
+++ b/modules/transcription-service-persistence/src/main/resources/META-INF/persistence.xml
@@ -14,8 +14,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-opencast-transcription.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-opencast-transcription.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/usertracking-impl/src/main/resources/META-INF/persistence.xml
+++ b/modules/usertracking-impl/src/main/resources/META-INF/persistence.xml
@@ -15,8 +15,6 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-usertracking-service-impl.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-usertracking-service-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/modules/workflow-service-api/src/main/resources/META-INF/persistence.xml
+++ b/modules/workflow-service-api/src/main/resources/META-INF/persistence.xml
@@ -15,8 +15,6 @@
       <property name="eclipselink.ddl-generation" value="create-tables" />
       <property name="eclipselink.logging.logger" value="JavaLogger" />
       <property name="eclipselink.logging.level.sql" value="FINE" />
-      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-workflow-service-api.jdbc"/>
-      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-workflow-service-api.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>


### PR DESCRIPTION
The `{create,drop}-ddl-jdbc-file-name` properties only do something when `ddl-generation.output-mode` is `both` or `sql-script`. That setting is not set anywhere, though,
so it defaults to `database`.