### PR TITLE
Fix index rebuild

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -955,12 +955,12 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
       RichAResult r;
       int current = 0;
       logIndexRebuildBegin(logger, index.getIndexName(), total, "snapshot(s)");
+      var updatedEventRange = new ArrayList<Event>();
       do {
         r = enrich(q.select(q.snapshot()).where(q.version().isLatest()).orderBy(q.mediapackageId().desc())
           .page(offset, PAGE_SIZE).run());
         offset += PAGE_SIZE;
-        int n = 16;
-        var updatedEventRange = new ArrayList<Event>();
+        int n = 20;
 
         final Map<String, List<Snapshot>> byOrg = r.getSnapshots().groupMulti(Snapshots.getOrganizationId);
         for (String orgId : byOrg.keySet()) {

--- a/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
+++ b/modules/event-comment/src/main/java/org/opencastproject/event/comment/persistence/EventCommentDatabaseServiceImpl.java
@@ -410,7 +410,7 @@ public class EventCommentDatabaseServiceImpl extends AbstractIndexProducer imple
       logIndexRebuildBegin(logger, index.getIndexName(), total, "events with comment");
       final int[] current = new int[1];
       current[0] = 0;
-      int n = 16;
+      int n = 20;
       var updatedEventRange = new ArrayList<Event>();
 
       final Map<String, List<String>> eventsWithComments = getEventsWithComments();

--- a/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
+++ b/modules/scheduler-impl/src/main/java/org/opencastproject/scheduler/impl/SchedulerServiceImpl.java
@@ -1722,7 +1722,7 @@ public class SchedulerServiceImpl extends AbstractIndexProducer implements Sched
       }
       logIndexRebuildBegin(logger, index.getIndexName(), total, "scheduled events");
       final int[] current = {0};
-      int n = 16;
+      int n = 20;
       var updatedEventRange = new ArrayList<Event>();
 
       for (Organization organization: orgDirectoryService.getOrganizations()) {

--- a/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
+++ b/modules/series-service-impl/src/main/java/org/opencastproject/series/impl/SeriesServiceImpl.java
@@ -515,7 +515,7 @@ public class SeriesServiceImpl extends AbstractIndexProducer implements SeriesSe
       final int total = databaseSeries.size();
       logIndexRebuildBegin(logger, index.getIndexName(), total, "series");
       int current = 0;
-      int n = 16;
+      int n = 20;
       var updatedSeriesRange = new ArrayList<Series>();
 
       for (SeriesEntity series: databaseSeries) {

--- a/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
+++ b/modules/themes/src/main/java/org/opencastproject/themes/persistence/ThemesServiceDatabaseImpl.java
@@ -305,7 +305,7 @@ public class ThemesServiceDatabaseImpl extends AbstractIndexProducer implements 
           int total = themes.size();
           logIndexRebuildBegin(logger, index.getIndexName(), total, "themes", organization);
           int current = 0;
-          int n = 16;
+          int n = 20;
           List<IndexTheme> updatedThemeRange = new ArrayList<>();
 
           for (Theme theme : themes) {

--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2172,7 +2172,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
       if (total > 0) {
         logIndexRebuildBegin(logger.getSlf4jLogger(), index.getIndexName(), total, "workflows");
         int current = 0;
-        int n = 16;
+        int n = 20;
         List<WorkflowIndexData> workflowIndexData;
 
         int limit = 1000;


### PR DESCRIPTION
This PR fixes a bug in that the last eight events of the current rebuild batch were not indexed because it never reached the required bulk update size and got reset afterward.

>1000 contains 62 bulk updates of size 16, but it only updates if the updatedEventRange size is greater than equals 16, which means the last batch of size 8 will be skipped. 

Maybe controversial: I changed all the bulk updates to 20 for consistency.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
