### PR TITLE
Only show Asset Upload for options of correct type

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -171,7 +171,7 @@
                   <th class="medium">
                     <a translate="EVENTS.EVENTS.NEW.UPLOAD_ASSET.ADD"
                        class="details-link"
-                       ng-show="(uploadAssetOptions && !transactions.read_only)"
+                       ng-show="((uploadAssetOptions | filter: {showAs: 'uploadAsset'}).length > 0 && !transactions.read_only)"
                        ng-click="openSubTab('newAssetUpload', 'EventAssetAttachmentsResource', 'newassetupload', false, true)"
                        with-role="ROLE_UI_EVENTS_DETAILS_ASSETS_EDIT">
                     </a>


### PR DESCRIPTION
Currently the Asset Upload link in the event details is always shown because ng-show also considers the source options, even though these are then not displayed, leading to an empty form with a non-function button. If we don't have options configured for the actual asset upload, we shouldn't show the link in the first place.

Edit: This was unintentionally broken by #3150.
