### PR TITLE
Fix changed pax web config keys

### DIFF
--- a/docs/guides/admin/docs/configuration/https/opencast.only.md
+++ b/docs/guides/admin/docs/configuration/https/opencast.only.md
@@ -26,11 +26,11 @@ org.osgi.service.http.port.secure=8443
 #     -keypass password -storepass password -keystore keystore.jks
 org.ops4j.pax.web.ssl.keystore=<path_to_keystore>
 
-# Password used for keystore integrity check.
-org.ops4j.pax.web.ssl.password=<the_keystore_password>
-
 # Password used for keystore.
-org.ops4j.pax.web.ssl.keypassword=<the_key_password>
+org.ops4j.pax.web.ssl.keystore.password=<the_keystore_password>
+
+#  Password for private key entry inside server keystore.
+org.ops4j.pax.web.ssl.key.password=<the_key_password>
 ```
 
 

--- a/etc/org.ops4j.pax.web.cfg
+++ b/etc/org.ops4j.pax.web.cfg
@@ -32,11 +32,13 @@ org.osgi.service.http.port.secure=8443
 #     -keypass password -storepass password -keystore keystore.jks
 org.ops4j.pax.web.ssl.keystore=${karaf.etc}/keystore.jks
 
-# Password used for keystore integrity check.
-org.ops4j.pax.web.ssl.password=password
-
 # Password used for keystore.
-org.ops4j.pax.web.ssl.keypassword=password
+org.ops4j.pax.web.ssl.keystore.password=password
+
+#  Password for private key entry inside server keystore.
+org.ops4j.pax.web.ssl.key.password=password
+
+
 
 # Custom jetty config file. Uncomment this if necessary to configure the jetty http connector idleTimeout value (MH-12329)
 # Adjust the settings in the file below to match the listening address and port settings above.


### PR DESCRIPTION
This PR is fixing the pax web SSL config keys. They changed with PAX WEB 8 by accident.
https://groups.google.com/g/ops4j/c/Pk9iu7HIPhs

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
