### PR TITLE
Fix bullet points in Developer Docs

### DIFF
--- a/docs/guides/developer/docs/participate/development-process.md
+++ b/docs/guides/developer/docs/participate/development-process.md
@@ -98,10 +98,11 @@ Only a committer can perform a merge, so if a reviewed pull request has not yet 
 feel free to contact one.
 
 There are a couple of rules that committers must follow when merging pull requests. These are:
+
 * A pull request requires at least one approving review before merging.
     * More reviews are always welcome.
 * A pull request must be approved at the weekly technical meeting before merging (visit https://docs.opencast.org/ for
-the time and place of the technical meeting).
+  the time and place of the technical meeting).
 * Reviewing or merging your own pull requests is strongly discouraged, but technically allowed.
     * It is advised to be pragmatic and only do so if necessary.
 


### PR DESCRIPTION
A markdown list needs a new line before and after a bullet point list to work correctly.

### Your pull request should…

* [x] have a concise title
* [ ] ~~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~~include migration scripts and documentation, if appropriate~~
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
