### PR TITLE
Update maven-bundle-plugin to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.2</version>
+          <version>5.1.9</version>
           <inherited>true</inherited>
           <configuration>
             <instructions>
@@ -577,6 +577,8 @@
               <Bundle-DocURL>https://opencast.org/</Bundle-DocURL>
               <Bundle-Vendor>The Opencast Project</Bundle-Vendor>
               <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+              <!-- Can be removed after upgrading to OSGi R7 or later. -->
+              <_noimportjava>true</_noimportjava>
             </instructions>
           </configuration>
         </plugin>


### PR DESCRIPTION
The maven bundle plugin version 5.1.2 generates a corrupt zip header.
This closes #5157.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
