### PR TITLE
Remove obsolete maven-bundle-plugin config

### DIFF
--- a/modules/elasticsearch-impl/pom.xml
+++ b/modules/elasticsearch-impl/pom.xml
@@ -190,6 +190,7 @@
               !javax.activation.*,
               !javax.annotation,
               !jdk.net,
+              !java.nio.file.spi.*,
               !org.elasticsearch.geometry.*,
               !org.elasticsearch.secure_sm.*,
               !org.jctools.queues.*,

--- a/pom.xml
+++ b/pom.xml
@@ -574,8 +574,6 @@
               <Bundle-DocURL>https://opencast.org/</Bundle-DocURL>
               <Bundle-Vendor>The Opencast Project</Bundle-Vendor>
               <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-              <!-- Can be removed after upgrading to OSGi R7 or later. -->
-              <_noimportjava>true</_noimportjava>
             </instructions>
           </configuration>
         </plugin>


### PR DESCRIPTION
Removes obsolete `<_noimportjava>true</_noimportjava>` and fixes elasticsearch package imports.

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
