### PR TITLE
Revert "Enable Tobira adopter stats tracking"

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/resources/adopterStatisticSummaryResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/adopterStatisticSummaryResource.js
@@ -32,7 +32,6 @@ angular.module('adminNg.resources')
           var shortenedServices = data['statistics']['hosts'][host]['services'].substring(0, 50) + '[...]';
           data['statistics']['hosts'][host]['services'] = shortenedServices;
         }*/
-        data['statistics']['tobira'] = data['tobira'];
         return {'general': data['general'], 'statistics': data['statistics']};
       }
     }

--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -82,12 +82,6 @@
       <groupId>org.osgi</groupId>
       <artifactId>osgi.cmpn</artifactId>
     </dependency>
-      <dependency>
-          <groupId>org.opencastproject</groupId>
-          <artifactId>opencast-tobira</artifactId>
-          <version>13-SNAPSHOT</version>
-          <scope>compile</scope>
-      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
@@ -54,8 +54,6 @@ public class Sender {
   private static final String GENERAL_DATA_URL_SUFFIX = "api/1.0/adopter";
   private static final String STATISTIC_URL_SUFFIX = "api/1.0/statistic";
 
-  private static final String TOBIRA_URL_SUFFIX = "api/1.0/tobira";
-
   //================================================================================
   // Constructor
   //================================================================================
@@ -100,15 +98,6 @@ public class Sender {
    */
   public void sendStatistics(String json) throws IOException {
     send(json, STATISTIC_URL_SUFFIX);
-  }
-
-  /**
-   * Executes the 'send' method with the proper REST URL suffix.
-   * @param json The data which shall be sent.
-   * @throws IOException General exception that can occur while sending the data.
-   */
-  public void sendTobiraData(String json) throws IOException {
-    send(json, TOBIRA_URL_SUFFIX);
   }
 
   /**

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -58,18 +58,6 @@
       <artifactId>opencast-dublincore</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -92,8 +80,7 @@
               *
             </Import-Package>
             <Export-Package>
-              org.opencastproject.tobira;version=${project.version},
-              org.opencastproject.tobira.impl;version=${project.version}
+              org.opencastproject.tobira;version=${project.version}
             </Export-Package>
           </instructions>
         </configuration>


### PR DESCRIPTION
Reverts opencast/opencast#5040

The admin node is broken because the adopter registration code requires the tobira bundle, which is, for a distributed setup, only available on the presentation node.
```
2023-07-31T14:53:35,919 | ERROR | (BootFeaturesInstaller:113) - Error installing boot features
org.apache.felix.resolver.reason.ReasonException: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=opencast-admin; type=karaf.feature; version="[13.8.0,13.8.0]"; filter:="(&(osgi.identity=opencast-admin)(type=karaf.feature)(version>=13.8.0)(version<=13.8.0))" [caused by: Unable to resolve opencast-admin/13.8.0: missing requirement [opencast-admin/13.8.0] osgi.identity; osgi.identity=opencast-adopter-registration-impl; type=osgi.bundle; version="[13.8.0,13.8.0]"; resolution:=mandatory [caused by: Unable to resolve opencast-adopter-registration-impl/13.8.0: missing requirement [opencast-adopter-registration-impl/13.8.0] osgi.wiring.package; filter:="(&(osgi.wiring.package=org.opencastproject.tobira.impl)(version>=13.8.0)(!(version>=14.0.0)))"]]
        at org.apache.felix.resolver.Candidates$MissingRequirementError.toException(Candidates.java:1343) ~[?:?]
        at org.apache.felix.resolver.ResolverImpl.doResolve(ResolverImpl.java:392) ~[?:?]
        at org.apache.felix.resolver.ResolverImpl.resolve(ResolverImpl.java:378) ~[?:?]
        at org.apache.felix.resolver.ResolverImpl.resolve(ResolverImpl.java:332) ~[?:?]
        at org.apache.karaf.features.internal.region.SubsystemResolver.resolve(SubsystemResolver.java:257) ~[?:?]
        at org.apache.karaf.features.internal.service.Deployer.deploy(Deployer.java:401) ~[?:?]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.doProvision(FeaturesServiceImpl.java:1063) ~[?:?]
        at org.apache.karaf.features.internal.service.FeaturesServiceImpl.lambda$doProvisionInThread$13(FeaturesServiceImpl.java:998) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: org.apache.felix.resolver.reason.ReasonException: Unable to resolve opencast-admin/13.8.0: missing requirement [opencast-admin/13.8.0] osgi.identity; osgi.identity=opencast-adopter-registration-impl; type=osgi.bundle; version="[13.8.0,13.8.0]"; resolution:=mandatory [caused by: Unable to resolve opencast-adopter-registration-impl/13.8.0: missing requirement [opencast-adopter-registration-impl/13.8.0] osgi.wiring.package; filter:="(&(osgi.wiring.package=org.opencastproject.tobira.impl)(version>=13.8.0)(!(version>=14.0.0)))"]
        at org.apache.felix.resolver.Candidates$MissingRequirementError.toException(Candidates.java:1343) ~[?:?]
        ... 12 more
```