### PR TITLE
Fix editing custom actions in the ACL editor

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -53,7 +53,7 @@ angular.module('adminNg.controllers')
             write : write !== undefined ? write : false,
             actions : {
               name : 'event-acl-actions',
-              value : actionValues !== undefined ? actionValues : [],
+              value : actionValues !== undefined ? actionValues.slice() : [],
             },
             user: undefined,
           };

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
@@ -36,7 +36,7 @@ angular.module('adminNg.services')
           write : write !== undefined ? write : false,
           actions : {
             name : 'new-event-acl-actions',
-            value : actionValues !== undefined ? actionValues : [],
+            value : actionValues !== undefined ? actionValues.slice() : [],
           },
           user: undefined,
         };


### PR DESCRIPTION
Right now you can't edit custom actions of individual policies in the ACL editor; all the actions of all policies are kind of tied together.

This is due to a bug in the JavaScript caused by the select components all operating on the same shared array. This PR fixes that bug by just making copies in appropriate places to break that link.