### PR TITLE
Fix Admin Interface Redirect

### DIFF
--- a/modules/runtime-info-ui/src/main/resources/ui/scripts/index.js
+++ b/modules/runtime-info-ui/src/main/resources/ui/scripts/index.js
@@ -40,12 +40,14 @@ $(document).ready(function () {
               url: '/rest_docs.html',
               type: 'HEAD',
               error: function () {
-                // Give up
+                window.location.replace(adminUIUrl);
               },
               success: function () {
                 window.location.replace('/rest_docs.html');
               }
             });
+          } else {
+            window.location.replace(adminUIUrl);
           }
         },
         success: function () {


### PR DESCRIPTION
With the introduction of the new admin interface, users are dynamically redirected after the login. Unfortunately, if a user does not have the necessary permissions, instead of the forbidden/switch user page he used to end up, there will just be a blank page. That's confusing.

This patch slightly modifies the code so that users end up on the 401 error page after all.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
