### PR TITLE
Copy active inputs between CAs if they have the same set of inputs

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -651,7 +651,7 @@ angular.module('adminNg.controllers')
             id: $scope.resourceId,
             entries: $scope.source,
             previousId: oldObj ? oldObj.id : undefined,
-            previousEntries: oldObj? oldObj.inputMethods : undefined
+            previousEntries: oldObj ? oldObj.inputMethods : undefined
           }, function () {
             fetchChildResources($scope.resourceId);
           });
@@ -661,10 +661,10 @@ angular.module('adminNg.controllers')
           if (oldObj && $scope.source.device.inputs && oldObj.inputs) {
             var sourceInputs = $scope.source.device.inputs.map(function(input){
               return input.id;
-            }).join(",");
+            }).join(',');
             var oldObjInputs = oldObj.inputs.map(function(input){
               return input.id;
-            }).join(",");
+            }).join(',');
             if (sourceInputs === oldObjInputs) {
               $scope.source.device.inputMethods = oldObj.inputMethods;
             }

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -650,8 +650,8 @@ angular.module('adminNg.controllers')
           EventSchedulingResource.save({
             id: $scope.resourceId,
             entries: $scope.source,
-            previousId: oldObj.id,
-            previousEntries: oldObj.inputMethods
+            previousId: oldObj ? oldObj.id : undefined,
+            previousEntries: oldObj? oldObj.inputMethods : undefined
           }, function () {
             fetchChildResources($scope.resourceId);
           });

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -655,6 +655,20 @@ angular.module('adminNg.controllers')
           }, function () {
             fetchChildResources($scope.resourceId);
           });
+
+          // Getting the update may take several seconds on large installations
+          // Fill in input channel values if possible
+          if (oldObj && $scope.source.device.inputs && oldObj.inputs) {
+            var sourceInputs = $scope.source.device.inputs.map(function(input){
+              return input.id;
+            }).join(",");
+            var oldObjInputs = oldObj.inputs.map(function(input){
+              return input.id;
+            }).join(",");
+            if (sourceInputs === oldObjInputs) {
+              $scope.source.device.inputMethods = oldObj.inputMethods;
+            }
+          }
         }, me.conflictsDetected);
       }
     };

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -626,7 +626,7 @@ angular.module('adminNg.controllers')
       });
     };
 
-    $scope.saveScheduling = function () {
+    $scope.saveScheduling = function (newObj, oldObj) {
       if (me.readyToPollConflicts()) {
         if (!me.checkValidity()) {
           return;
@@ -649,7 +649,9 @@ angular.module('adminNg.controllers')
 
           EventSchedulingResource.save({
             id: $scope.resourceId,
-            entries: $scope.source
+            entries: $scope.source,
+            previousId: oldObj.id,
+            previousEntries: oldObj.inputMethods
           }, function () {
             fetchChildResources($scope.resourceId);
           });

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -363,7 +363,7 @@
                           pre-select-from="captureAgents"
                           ng-disabled="checkingConflicts || !hasCurrentAgentAccess()"
                           data-width="'200px'"
-                          ng-change="roomChanged(); saveScheduling()"
+                          ng-change="roomChanged(); saveScheduling(source.device, {{source.device || 'null'}})"
                           ng-model="source.device"
                           ng-options="ca.name for ca in captureAgents | filter:currentAgentOrAccess track by ca.id"
                           placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.SOURCE.PLACEHOLDER.LOCATION' | translate }}'"

--- a/modules/admin-ui-frontend/app/scripts/shared/resources/eventSchedulingResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/eventSchedulingResource.js
@@ -62,12 +62,16 @@ angular.module('adminNg.resources')
         if (angular.isDefined(data)) {
           start = JsHelper.toZuluTimeString(data.entries.start);
           end = JsHelper.toZuluTimeString(data.entries.start, data.entries.duration);
-          result = $.param({scheduling: angular.toJson({
-            agentId: data.entries.agentId,
-            start: start,
-            end: end,
-            agentConfiguration: data.entries.agentConfiguration,
-          })});
+          result = $.param({
+            scheduling: angular.toJson({
+              agentId: data.entries.agentId,
+              start: start,
+              end: end,
+              agentConfiguration: data.entries.agentConfiguration,
+              previousAgentId: data.previousId,
+              previousEntries: data.previousEntries
+            })
+          });
         }
 
         return result;

--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -674,14 +674,14 @@ public abstract class AbstractEventEndpoint {
       previousAgentId = Opt.some(schedulingJson.getString(SCHEDULING_PREVIOUS_AGENTID));
     }
 
-    Opt<String> previousAgentInputs = Opt.none();
-    Opt<String> agentInputs = Opt.none();
+    Optional<String> previousAgentInputs = Optional.empty();
+    Optional<String> agentInputs = Optional.empty();
     if (agentId.isSome() && previousAgentId.isSome()) {
       Agent previousAgent = getCaptureAgentStateService().getAgent(previousAgentId.get());
       Agent agent = getCaptureAgentStateService().getAgent(agentId.get());
 
-      previousAgentInputs = Opt.some(previousAgent.getCapabilities().getProperty(CaptureParameters.CAPTURE_DEVICE_NAMES));
-      agentInputs = Opt.some(agent.getCapabilities().getProperty(CaptureParameters.CAPTURE_DEVICE_NAMES));
+      previousAgentInputs = Optional.ofNullable(previousAgent.getCapabilities().getProperty(CaptureParameters.CAPTURE_DEVICE_NAMES));
+      agentInputs = Optional.ofNullable(agent.getCapabilities().getProperty(CaptureParameters.CAPTURE_DEVICE_NAMES));
     }
 
     // Check if we are allowed to re-schedule on this agent
@@ -721,7 +721,7 @@ public abstract class AbstractEventEndpoint {
 
     // If we had previously selected an agent, and both the old and new agent have the same set of input channels,
     // copy which input channels are active to the new agent
-    if (previousAgentInputs.isSome() && previousAgentInputs.isSome() && agentInputs.isSome()) {
+    if (previousAgentInputs.isPresent() && previousAgentInputs.isPresent() && agentInputs.isPresent()) {
       Map<String, String> map = previousAgentInputMethods.get();
       String mapAsString = map.keySet().stream()
               .collect(Collectors.joining(","));


### PR DESCRIPTION
For a scheduled event in the admin ui, the capture agent for the event can be changed in the event details. However, when changing the capture agent, the input channels for the capture agent will always be unset (except for the capture agent the event was created with). As most institutions usually use multiple capture agents of the same brand, with the same set of input channels, having to manually reactivate every input after switching capture agents is quite cumbersome.

This PR changes the default behaviour for switching capture agents. If both capture agents have the same set of input channels, which inpus are active will now be copied over from the previously selected capture agent to the newly selected one.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
