### PR TITLE
Fix double subtitle when a flavor has several videos

### DIFF
--- a/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/speechtotext-woh.md
@@ -10,6 +10,8 @@ The speech to text operation can be used to generate subtitles for Videos or Aud
 engines available, [Whisper](../modules/transcription.modules/whisper.md) and 
 [Vosk](../modules/transcription.modules/vosk.md). The subtitles file format ist WebVTT.
 
+This operation is designed to only work with one source file per flavor. If you want to use multiple source files in one
+flavor, you need to set the same tag to each element.
 
 Parameter Table
 ---------------
@@ -17,6 +19,7 @@ Parameter Table
 | configuration keys | required | Example           | description                                                                                                                                        |
 |--------------------|----------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 | source-flavor      | yes      | source/presenter  | The source media package to use                                                                                                                    |
+| source-tags        | no       | 1080p             | The tags that the source track uses                                                                                                                   |
 | target-flavor      | yes      | archive           | Flavor of the produced subtitle file. The subflavor supports the language-code placeholder `#{lang}`                                               |
 | target-element     | no       | attachment        | Define where to append the subtitles file. Possibilities are: as a 'track' or as an 'attachment'. The default is "attachment".                     |
 | language-code      | no       | de                | The language of the video or audio source (default is "eng"). Vosk only: It has to match the name of the language model directory. See 'vosk-cli'. |

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -185,6 +185,8 @@ public class
 
     // Translate to english
     Boolean translate = getTranslationMode(mediaPackage, workflowInstance);
+
+    // Subtitles creation
     if (sourceTagList.isEmpty() && (tracks.length > 1)) {
       logger.info("Multiple tracks found but no source tags specified");
       logger.info("Using the first track in the flavor list");

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -134,7 +134,7 @@ public class
 
 
     ConfiguredTagsAndFlavors tagsAndFlavors = getTagsAndFlavors(workflowInstance,
-            Configuration.none, Configuration.one,
+            Configuration.many, Configuration.one,
             Configuration.many, Configuration.one);
     List<MediaPackageElementFlavor> sourceFlavor = tagsAndFlavors.getSrcFlavors();
     List<String> sourceTagList = tagsAndFlavors.getSrcTags();

--- a/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
+++ b/modules/speech-to-text-workflowoperation/src/main/java/org/opencastproject/workflow/handler/speechtotext/SpeechToTextWorkflowOperationHandler.java
@@ -138,7 +138,10 @@ public class
               String.format("No tracks with source flavor '%s' found for transcription", sourceFlavor));
     }
 
-    logger.info("Found {} track(s) with source flavor '{}'.", tracks.length, sourceFlavor);
+    if (tracks.length > 1) {
+      logger.warn("Found {} track(s) with source flavor '{}'.", tracks.length, sourceFlavor);
+      logger.warn("Only 1 subtitle will be generated for the flavor");
+    }
 
     // Get the information in which language the audio track should be
     String languageCode = getMediaPackageLanguage(mediaPackage, workflowInstance);


### PR DESCRIPTION
This PR addresses an issue when an event has a flavour with multiple videos on it. Whisper or Vosk will try to create subtitles for each video, instead of making only one. Now will select the first track from the targeted flavor.


Furthermore, adds the option `source-tags` to any user who wants to select a specific track from the targeted flavor.


* [x] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
