### PR TITLE
Skip deleting non existent file

### DIFF
--- a/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
+++ b/modules/working-file-repository-service-impl/src/main/java/org/opencastproject/workingfilerepository/impl/WorkingFileRepositoryImpl.java
@@ -432,9 +432,12 @@ public class WorkingFileRepositoryImpl implements WorkingFileRepository, PathMap
     // Clean up any other files
     if (filesToDelete != null && filesToDelete.length > 0) {
       for (File fileToDelete : filesToDelete) {
-        if (!fileToDelete.equals(f) && !fileToDelete.equals(md5File)) {
+        if (!fileToDelete.equals(f) && !fileToDelete.equals(md5File)
+            // On shared filesystems like NFS the move operation may create temporary .nfsXXX files
+            // which will be removed by the NFS subsystem itself. We should skip these files.
+            && !StringUtils.startsWith(fileToDelete.getName(), ".nfs")) {
           logger.trace("delete {}", fileToDelete.getAbsolutePath());
-          if (!fileToDelete.delete()) {
+          if (!fileToDelete.delete() && fileToDelete.exists()) {
             throw new IllegalStateException("Unable to delete file: " + fileToDelete.getAbsolutePath());
           }
         }


### PR DESCRIPTION
On shared filesystems like NFS some file operations may create .nfsXXX cache files. This files are visible to the opencast process but should be managed by NFS subsystem itself. The `WorkingFileRepository` put-operation tries to delete these files as shown in the exception trace below. The delete operation return false as the file was moved/removed at this point. This is fine and not an error.

Exception:
```
2023-08-17T13:17:55,680 | WARN  | (SchedulerRestService:967) - Error updating event with id 'c04165a6-2f72-408c-a671-4edbd0bda5ce'
org.opencastproject.scheduler.api.SchedulerException: java.lang.IllegalStateException: Unable to delete file: /srv/opencast/files/mediapackage/c04165a6-2f72-408c-a671-4edbd0bda5ce/d0c7fcfe-5a4b-4a2b-ab26-b26c1c2b9f4e/.nfs000000002a1a014f00000008
	at org.opencastproject.scheduler.impl.SchedulerServiceImpl.updateEventInternal(SchedulerServiceImpl.java:844) ~[!/:?]
	at org.opencastproject.scheduler.impl.SchedulerServiceImpl.updateEvent(SchedulerServiceImpl.java:659) ~[!/:?]
	at org.opencastproject.scheduler.endpoint.SchedulerRestService.updateEvent(SchedulerRestService.java:961) [!/:?]
	...
Caused by: java.lang.IllegalStateException: Unable to delete file: /srv/opencast/files/mediapackage/c04165a6-2f72-408c-a671-4edbd0bda5ce/d0c7fcfe-5a4b-4a2b-ab26-b26c1c2b9f4e/.nfs000000002a1a014f00000008
	at org.opencastproject.workingfilerepository.impl.WorkingFileRepositoryImpl.put(WorkingFileRepositoryImpl.java:438) ~[?:?]
	at org.opencastproject.workspace.impl.WorkspaceImpl.put(WorkspaceImpl.java:682) ~[?:?]
	at org.opencastproject.scheduler.impl.SchedulerServiceImpl.updateDublincCoreCatalog(SchedulerServiceImpl.java:1663) ~[!/:?]
	at org.opencastproject.scheduler.impl.SchedulerServiceImpl.updateEventInternal(SchedulerServiceImpl.java:799) ~[!/:?]
	... 130 more
```


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
