### PR TITLE
Change default karaf shutdown command

### DIFF
--- a/etc/custom.properties
+++ b/etc/custom.properties
@@ -326,7 +326,7 @@ karaf.shutdown.port.file=${karaf.data}/port
 # Command for shutting down Opencast. If the shutdown port is enabled, Opencast will listen for this command to initiate
 # the shut down procedure.
 # Change this to something secret
-karaf.shutdown.command=3500d4e3-ce93-4ae3-abb4-5e90cef4deb
+karaf.shutdown.command=CHANGE_ME
 
 # Specifies the location of the PID file for Opencast. It is used by the shutdown script to synchronously shut down
 # Opencast as it will wait for the process with the given process id. Removing this will cause the network port to be


### PR DESCRIPTION
The Karaf shutdown command string was set in a string that is not random, but enough random to any who doesn't read carefully can forget easily.

I just changed the string for something more obvious.

* [x] have a concise title
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] pass automated tests
* [x] have a clean commit history
* [x] have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
