### PR TITLE
Fix NPE when workflow user no longer exists

### DIFF
--- a/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
+++ b/modules/admin-ui/src/main/java/org/opencastproject/adminui/endpoint/AbstractEventEndpoint.java
@@ -1819,8 +1819,12 @@ public abstract class AbstractEventEndpoint {
           String submitter = instance.getCreatorName();
 
           User user = getUserDirectoryService().loadUser(submitter);
-          String submitterName = user.getName();
-          String submitterEmail = user.getEmail();
+          String submitterName = null;
+          String submitterEmail = null;
+          if (user != null) {
+            submitterName = user.getName();
+            submitterEmail = user.getEmail();
+          }
 
           jsonList.add(obj(f("id", v(instanceId)), f("title", v(instance.getTitle(), Jsons.BLANK)),
                   f("status", v(WORKFLOW_STATUS_TRANSLATION_PREFIX + instance.getState().toString())),


### PR DESCRIPTION
The Admin UI will not load the list of workflows if the workflow user no longer exists. This adds a check and only extracts additional user infos (name, email) if the user was found.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
