### PR TITLE
Fix Crowdin Sources

### DIFF
--- a/.crowdin.yaml
+++ b/.crowdin.yaml
@@ -17,9 +17,5 @@ files:
     translation: '/modules/engage-paella-player/src/main/paella-opencast/plugins/**/localization/%locale%.json'
 
   -
-    source: '/modules/lti/src/i18n/lang-en_US.json'
-    translation: '/modules/lti/src/i18n/lang-%locale_with_underscore%.json'
-
-  -
     source: '/modules/engage-paella-player-7/src/i18n/en-US.json'
     translation: '/modules/engage-paella-player-7/src/i18n/%locale%.json'


### PR DESCRIPTION
This patch fixes the translation keys uploaded to Crowdin by excluding the ones from the LTI module which are actually the translations of the old admin interface copied during the build process.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
