### PR TITLE
Fix Workflow Index Rebuild

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -2179,6 +2179,7 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
         int offset = 0;
         String currentMediapackageId;
         String lastMediapackageId = "";
+        var updatedWorkflowRange = new ArrayList<Event>();
         do {
           try {
             workflowIndexData = persistence.getWorkflowIndexData(limit, offset);
@@ -2189,7 +2190,6 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
           if (workflowIndexData.size() > 0) {
             offset += limit;
             logger.debug("Got {} workflows for re-indexing", workflowIndexData.size());
-            var updatedWorkflowRange = new ArrayList<Event>();
 
             for (WorkflowIndexData indexData : workflowIndexData) {
               currentMediapackageId = indexData.getMediaPackageId();


### PR DESCRIPTION
Similar fix as in #5115, except for the Workflow Service this time. Setting the batch size to match the page size isn't enough for this service since only a subset of the items on a page are actually indexed. So let's just carry over the last batch to the next page if it didn't reach the batch size instead of skipping it. (If it's the last page, the last batch is always indexed.)