### PR TITLE
Fix AmberScript transcription failing if video contains no speech

### DIFF
--- a/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
+++ b/modules/transcription-service-amberscript/src/main/java/org/opencastproject/transcription/amberscript/AmberscriptTranscriptionService.java
@@ -132,6 +132,8 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
   private static final String STATUS_DONE = "DONE";
   private static final String STATUS_ERROR = "ERROR";
 
+  private static final String ERROR_NO_SPEECH = "No speech found";
+
   private static final String PROVIDER = "amberscript";
 
   private AssetManager assetManager;
@@ -736,9 +738,11 @@ public class AmberscriptTranscriptionService extends AbstractJobProducer impleme
               logger.debug("Captions job '{}' has not finished yet.", jobId);
               return false;
             case STATUS_ERROR:
-              logger.warn("Captions job '{}' failed.", jobId);
+              var errorMsg = (String) result.get("errorMsg");
               throw new TranscriptionServiceException(
-                      String.format("Captions job '%s' failed: Return Code %d", jobId, code), code);
+                      String.format("Captions job '%s' failed: %s", jobId, errorMsg),
+                      code,
+                      ERROR_NO_SPEECH.equals(errorMsg));
             case STATUS_DONE:
               logger.info("Captions job '{}' has finished.", jobId);
               TranscriptionJobControl jc = database.findByJob(jobId);

--- a/modules/transcription-service-api/src/main/java/org/opencastproject/transcription/api/TranscriptionServiceException.java
+++ b/modules/transcription-service-api/src/main/java/org/opencastproject/transcription/api/TranscriptionServiceException.java
@@ -24,6 +24,7 @@ public class TranscriptionServiceException extends Exception {
   private static final long serialVersionUID = 4196196907868554450L;
 
   private int code;
+  private boolean cancel = false;
 
   public TranscriptionServiceException() {
     super();
@@ -42,7 +43,17 @@ public class TranscriptionServiceException extends Exception {
     this.code = code;
   }
 
+  public TranscriptionServiceException(String message, int code, boolean cancel) {
+    super(message);
+    this.code = code;
+    this.cancel = cancel;
+  }
+
   public int getCode() {
     return this.code;
+  }
+
+  public boolean isCancel() {
+    return cancel;
   }
 }

--- a/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
+++ b/modules/transcription-service-workflowoperation/src/main/java/org/opencastproject/transcription/workflowoperation/AmberscriptAttachTranscriptionOperationHandler.java
@@ -29,6 +29,7 @@ import org.opencastproject.mediapackage.MediaPackageElementFlavor;
 import org.opencastproject.mediapackage.MediaPackageElementParser;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.transcription.api.TranscriptionService;
+import org.opencastproject.transcription.api.TranscriptionServiceException;
 import org.opencastproject.workflow.api.AbstractWorkflowOperationHandler;
 import org.opencastproject.workflow.api.ConfiguredTagsAndFlavors;
 import org.opencastproject.workflow.api.WorkflowInstance;
@@ -128,9 +129,14 @@ public class AmberscriptAttachTranscriptionOperationHandler extends AbstractWork
         convertedTranscription.addTag(tag);
       }
       mediaPackage.add(convertedTranscription);
-      logger.info("Added transcription to the mediapackage {}: {}",
-          mediaPackage.getIdentifier(), convertedTranscription.getURI());
+      logger.info("Added transcription to the media package {}: {}", mediaPackage, convertedTranscription.getURI());
 
+    } catch (TranscriptionServiceException e) {
+      if (e.isCancel()) {
+        logger.warn(e.getMessage());
+        return createResult(mediaPackage, Action.SKIP);
+      }
+      throw new WorkflowOperationException(e);
     } catch (Exception e) {
       throw new WorkflowOperationException(e);
     }


### PR DESCRIPTION
This patch fixes the problem that the AmberScript attach transcription operation fails if a video with no speech got submitted. Instead of failing with a stack trace, the code will now warn about the missing transcript but then simply skip the operation.

This fixes #5192

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
