### PR TITLE
Fixed Admin UI redirect after login

### DIFF
--- a/etc/security/mh_default_org.xml
+++ b/etc/security/mh_default_org.xml
@@ -535,8 +535,8 @@
     <property name="securityService" ref="securityService" />
     <property name="welcomePages">
       <map>
-        <entry key="ROLE_ADMIN" value="/admin-ui/index.html" />
-        <entry key="ROLE_ADMIN_UI" value="/admin-ui/index.html" />
+        <entry key="ROLE_ADMIN" value="/index.html" />
+        <entry key="ROLE_ADMIN_UI" value="/index.html" />
         <entry key="*" value="/engage/ui/index.html" /> <!-- Any role not listed explicitly will redirect here -->
       </map>
     </property>


### PR DESCRIPTION
In Opencast 14 the new Admin UI was added as an experimental preview. The opencat administrator should be able to configure, whether the loged in users should be redirected to the new or the previous Admin UI. Due to the issue the users where always redirected to the new Admin UI. This patch fixes it.

You can test this patch by this curl command:
```
curl -s -i -X POST 'http://127.0.0.1:8080/j_spring_security_check' -d 'j_username=admin' -d 'j_password=opencast' | grep Location
```
If the URL path is `/admin-ui/index.html` you will be redirected to the new Admin UI. The URL path `/admin-ng/index.html` will redirect you to the previous Admin UI. Last but not least the URL path `/index.html` will load a page with linked javascript file to redirect the user to the configured Admin UI. The configuration is documented [here](https://docs.opencast.org/r/14.x/admin/#modules/admin-ui/#replacing-the-old-admin-ui).

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
