### PR TITLE
Fix static file service exception on non-existing file

### DIFF
--- a/modules/static-file-service-api/src/main/java/org/opencastproject/staticfiles/endpoint/StaticFileRestService.java
+++ b/modules/static-file-service-api/src/main/java/org/opencastproject/staticfiles/endpoint/StaticFileRestService.java
@@ -204,11 +204,8 @@ public class StaticFileRestService {
       final Long length = staticFileService.getContentLength(uuid);
       // It is safe to pass the InputStream without closing it, JAX-RS takes care of that
       return RestUtil.R.ok(file, getMimeType(filename), Option.some(length), Option.some(filename));
-    } catch (NotFoundException e) {
-      throw e;
-    } catch (Exception e) {
-      logger.warn("Unable to retrieve file with uuid {}", uuid, e);
-      return Response.serverError().build();
+    } catch (NotFoundException | IOException e) {
+      return RestUtil.R.notFound();
     }
   }
 

--- a/modules/static-file-service-api/src/test/java/org/opencastproject/staticfiles/endpoint/StaticFileRestServiceTest.java
+++ b/modules/static-file-service-api/src/test/java/org/opencastproject/staticfiles/endpoint/StaticFileRestServiceTest.java
@@ -26,7 +26,6 @@ import static org.easymock.EasyMock.eq;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.Organization;
@@ -260,11 +259,7 @@ public class StaticFileRestServiceTest {
     Response response = staticFileRestService.deleteStaticFile(uuid);
     assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
 
-    try {
-      staticFileRestService.getStaticFile(uuid);
-      fail("NotFoundException must be passed on");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    response = staticFileRestService.getStaticFile(uuid);
+    assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
   }
 }


### PR DESCRIPTION
This patch fixes the problem that the static file service throws an exception when requesting a non existing file instead of returning a proper `404 NOT FOUND` HTTP error code.

This fixes #5189

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
