### PR TITLE
Update Stud.IP User Provider

### DIFF
--- a/modules/userdirectory-studip/src/main/java/org/opencastproject/userdirectory/studip/StudipUserProviderInstance.java
+++ b/modules/userdirectory-studip/src/main/java/org/opencastproject/userdirectory/studip/StudipUserProviderInstance.java
@@ -267,8 +267,9 @@ public class StudipUserProviderInstance implements UserProvider, RoleProvider, C
 
       // Email address
       var email = Objects.toString(userJsonObj.get("email"), null);
+      var name = Objects.toString(userJsonObj.get("fullname"), null);
 
-      User user = new JaxbUser(userName, null, null, email, PROVIDER_NAME, jaxbOrganization, roles);
+      User user = new JaxbUser(userName, null, name, email, PROVIDER_NAME, jaxbOrganization, roles);
 
       cache.put(userName, user);
       logger.debug("Returning user {}", userName);


### PR DESCRIPTION
This patch fixes a number of minor issues in the Stud.IP user provider:

- Errors handled were actually copied over from the Moodle user provider. Changed the code to handle errors from Stud.IP.
- Removed the unnecessary check if roles are `null`. The object `roles` can never be `null`.
- Properly handle non-existing users. In that case, Stud.IP should return `404 Not Found`,
- Add email address to users.
- Fix some logging issues.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
