### PR TITLE
Logging of delete snapshot workflow operation

### DIFF
--- a/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerDeleteWorkflowOperationHandler.java
+++ b/modules/asset-manager-workflowoperation/src/main/java/org/opencastproject/workflow/handler/assetmanager/AssetManagerDeleteWorkflowOperationHandler.java
@@ -91,22 +91,19 @@ public class AssetManagerDeleteWorkflowOperationHandler extends AbstractWorkflow
       final long deleted;
 
       if (keepLastSnapshot) {
+        logger.info("Deleting all but latest snapshot of episode {}", mpId);
         deleted = q.delete(DEFAULT_OWNER, q.snapshot())
                 .where(q.mediaPackageId(mpId).and(q.version().isLatest().not())).run();
-        logger.info("Deleting all but latest Snapshot {}", mpId);
       } else {
+        logger.info("Deleting all snapshots of episode {}", mpId);
         deleted = q.delete(DEFAULT_OWNER, q.snapshot())
                 .where(q.mediaPackageId(mpId)).run();
       }
 
-      if (deleted == 0) {
-        logger.info("The asset manager does not contain episode {}", mpId);
-      } else {
-        logger.info("Successfully deleted {} version/s episode {} from the asset manager", deleted, mpId);
-      }
+      logger.info("Successfully deleted {} version/s episode {} from the asset manager", deleted, mpId);
     } catch (Exception e) {
-      logger.warn("Error deleting episode {} from the asset manager: {}", mpId, e);
-      throw new WorkflowOperationException("Unable to delete episode from the asset manager", e);
+      var errorMessage = String.format("Error deleting episode %s from the asset manager", mpId);
+      throw new WorkflowOperationException(errorMessage, e);
     }
     return createResult(mediaPackage, Action.CONTINUE);
   }


### PR DESCRIPTION
This patch fixes a few minor issues of the delete snapshot workflow operation handler which may be confusing right now. For example, having zero snapshots deleted does not mean that there are none if the operation is configured to keep the latest snapshot.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
