### PR TITLE
Drop DeleteSnapshot Event Handler

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -912,16 +912,6 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
     return getDatabase().countEvents(organization);
   }
 
-  /**
-   * DeleteSnapshotHandler implementation
-   */
-
-  @Override
-  public void handleDeletedSnapshot(String mpId, VersionImpl version) {
-    logger.info("Firing event handlers for event {}, snapshot {}", mpId, version);
-    fireEventHandlers(AssetManagerItem.deleteSnapshot(mpId, version.value(), new Date()));
-  }
-
   @Override
   public void handleDeletedEpisode(String mpId) {
     logger.info("Firing event handlers for event {}", mpId);

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -161,7 +161,7 @@ import javax.persistence.EntityManagerFactory;
     service = { AssetManager.class, IndexProducer.class }
 )
 public class AssetManagerImpl extends AbstractIndexProducer implements AssetManager,
-        AbstractADeleteQuery.DeleteSnapshotHandler {
+    AbstractADeleteQuery.DeleteEpisodeHandler {
 
   private static final Logger logger = LoggerFactory.getLogger(AssetManagerImpl.class);
 
@@ -1536,7 +1536,7 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
 
   /**
    * Call {@link
-   * org.opencastproject.assetmanager.impl.query.AbstractADeleteQuery#run(AbstractADeleteQuery.DeleteSnapshotHandler)}
+   * org.opencastproject.assetmanager.impl.query.AbstractADeleteQuery#run(AbstractADeleteQuery.DeleteEpisodeHandler)}
    * with a delete handler. Also make sure to propagate the behaviour to subsequent instances.
    */
   private final class ADeleteQueryWithMessaging extends ADeleteQueryDecorator {

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
@@ -90,7 +90,7 @@ public abstract class AbstractADeleteQuery implements ADeleteQuery, DeleteQueryC
     };
   }
 
-  public long run(DeleteEpisodeHandler deleteSnapshotHandler) {
+  public long run(DeleteEpisodeHandler deleteEpisodeHandler) {
     // run query and map the result to records
     final long startTime = System.nanoTime();
     // resolve AST
@@ -115,7 +115,7 @@ public abstract class AbstractADeleteQuery implements ADeleteQuery, DeleteQueryC
       }
     }
     for (String mpId : deletion.deletedEpisodes) {
-      deleteSnapshotHandler.handleDeletedEpisode(mpId);
+      deleteEpisodeHandler.handleDeletedEpisode(mpId);
     }
     final long searchTime = (System.nanoTime() - startTime) / 1000000;
     logger.debug("Complete query ms " + searchTime);

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
@@ -113,7 +113,6 @@ public abstract class AbstractADeleteQuery implements ADeleteQuery, DeleteQueryC
       for (AssetStore as : am.getRemoteAssetStores()) {
         as.delete(deletionSelector);
       }
-      deleteSnapshotHandler.handleDeletedSnapshot(mpId, version);
     }
     for (String mpId : deletion.deletedEpisodes) {
       deleteSnapshotHandler.handleDeletedEpisode(mpId);
@@ -267,14 +266,11 @@ HAVING v = (SELECT count(*)
    * Call {@link #run(DeleteSnapshotHandler)} with a deletion handler to get notified about deletions.
    */
   public interface DeleteSnapshotHandler {
-    void handleDeletedSnapshot(String mpId, VersionImpl version);
 
     void handleDeletedEpisode(String mpId);
   }
 
   public static final DeleteSnapshotHandler NOP_DELETE_SNAPSHOT_HANDLER = new DeleteSnapshotHandler() {
-    @Override public void handleDeletedSnapshot(String mpId, VersionImpl version) {
-    }
 
     @Override public void handleDeletedEpisode(String mpId) {
     }

--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/query/AbstractADeleteQuery.java
@@ -90,7 +90,7 @@ public abstract class AbstractADeleteQuery implements ADeleteQuery, DeleteQueryC
     };
   }
 
-  public long run(DeleteSnapshotHandler deleteSnapshotHandler) {
+  public long run(DeleteEpisodeHandler deleteSnapshotHandler) {
     // run query and map the result to records
     final long startTime = System.nanoTime();
     // resolve AST
@@ -255,7 +255,7 @@ HAVING v = (SELECT count(*)
   }
 
   @Override public long run() {
-    return run(NOP_DELETE_SNAPSHOT_HANDLER);
+    return run(DELETE_EPISODE_HANDLER);
   }
 
   private static String formatQueryName(String name, String subQueryName) {
@@ -263,14 +263,14 @@ HAVING v = (SELECT count(*)
   }
 
   /**
-   * Call {@link #run(DeleteSnapshotHandler)} with a deletion handler to get notified about deletions.
+   * Call {@link #run(DeleteEpisodeHandler)} with a deletion handler to get notified about deletions.
    */
-  public interface DeleteSnapshotHandler {
+  public interface DeleteEpisodeHandler {
 
     void handleDeletedEpisode(String mpId);
   }
 
-  public static final DeleteSnapshotHandler NOP_DELETE_SNAPSHOT_HANDLER = new DeleteSnapshotHandler() {
+  public static final DeleteEpisodeHandler DELETE_EPISODE_HANDLER = new DeleteEpisodeHandler() {
 
     @Override public void handleDeletedEpisode(String mpId) {
     }

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerItemTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerItemTest.java
@@ -27,7 +27,6 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageBuilderFactory;
 import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem;
 import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem.DeleteEpisode;
-import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem.DeleteSnapshot;
 import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem.TakeSnapshot;
 import org.opencastproject.metadata.dublincore.DublinCoreUtil;
 import org.opencastproject.metadata.dublincore.DublinCores;
@@ -64,23 +63,12 @@ public class AssetManagerItemTest {
     final AssetManagerItem deserialized = IoSupport.serializeDeserialize(item);
     assertEquals(item.getDate(), deserialized.getDate());
     assertEquals(item.getType(), deserialized.getType());
-    assertEquals(item.decompose(TakeSnapshot.getMediaPackage, null, null).getIdentifier(),
-            deserialized.decompose(TakeSnapshot.getMediaPackage, null, null).getIdentifier());
-    assertEquals(item.decompose(TakeSnapshot.getAcl, null, null).getEntries(),
-            deserialized.decompose(TakeSnapshot.getAcl, null, null).getEntries());
-    assertTrue(DublinCoreUtil.equals(item.decompose(TakeSnapshot.getEpisodeDublincore, null, null).get(),
-            deserialized.decompose(TakeSnapshot.getEpisodeDublincore, null, null).get()));
-  }
-
-  @Test
-  public void testSerializeDeleteSnapshot() throws Exception {
-    final Date now = new Date();
-    final AssetManagerItem item = AssetManagerItem.deleteSnapshot("id", 0L, now);
-    final AssetManagerItem deserialized = IoSupport.serializeDeserialize(item);
-    assertEquals(item.getDate(), deserialized.getDate());
-    assertEquals(item.getType(), deserialized.getType());
-    assertEquals(item.decompose(null, DeleteSnapshot.getMediaPackageId, null),
-            deserialized.decompose(null, DeleteSnapshot.getMediaPackageId, null));
+    assertEquals(item.decompose(TakeSnapshot.getMediaPackage, null).getIdentifier(),
+            deserialized.decompose(TakeSnapshot.getMediaPackage, null).getIdentifier());
+    assertEquals(item.decompose(TakeSnapshot.getAcl, null).getEntries(),
+            deserialized.decompose(TakeSnapshot.getAcl, null).getEntries());
+    assertTrue(DublinCoreUtil.equals(item.decompose(TakeSnapshot.getEpisodeDublincore, null).get(),
+            deserialized.decompose(TakeSnapshot.getEpisodeDublincore, null).get()));
   }
 
   @Test
@@ -90,7 +78,7 @@ public class AssetManagerItemTest {
     final AssetManagerItem deserialized = IoSupport.serializeDeserialize(item);
     assertEquals(item.getDate(), deserialized.getDate());
     assertEquals(item.getType(), deserialized.getType());
-    assertEquals(item.decompose(null, null, DeleteEpisode.getMediaPackageId),
-            deserialized.decompose(null, null, DeleteEpisode.getMediaPackageId));
+    assertEquals(item.decompose(null, DeleteEpisode.getMediaPackageId),
+            deserialized.decompose(null, DeleteEpisode.getMediaPackageId));
   }
 }

--- a/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerMessagingTest.java
+++ b/modules/asset-manager-impl/src/test/java/org/opencastproject/assetmanager/impl/AssetManagerMessagingTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertThat;
 
 import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem;
 import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem.DeleteEpisode;
-import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem.DeleteSnapshot;
 import org.opencastproject.message.broker.api.assetmanager.AssetManagerItem.TakeSnapshot;
 import org.opencastproject.message.broker.api.update.AssetManagerUpdateHandler;
 
@@ -60,7 +59,7 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
 
   @Test
   public void test1() throws Exception {
-    runTest(1, 1, 1, 1, new Fx<String[]>() {
+    runTest(1, 1, 1, new Fx<String[]>() {
       @Override public void apply(String[] mp) {
         q.delete(OWNER, q.snapshot()).run();
       }
@@ -69,7 +68,7 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
 
   @Test
   public void test2() throws Exception {
-    runTest(2, 1, 1, 1, new Fx<String[]>() {
+    runTest(2, 1, 1, new Fx<String[]>() {
       @Override public void apply(String[] mp) {
         q.delete(OWNER, q.snapshot()).where(q.mediaPackageId(mp[0])).run();
       }
@@ -78,7 +77,7 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
 
   @Test
   public void test3() throws Exception {
-    runTest(3, 2, 2, 1, new Fx<String[]>() {
+    runTest(3, 2, 1, new Fx<String[]>() {
       @Override public void apply(String[] mp) {
         q.delete(OWNER, q.snapshot()).where(q.mediaPackageId(mp[0])).run();
       }
@@ -87,7 +86,7 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
 
   @Test
   public void test4() throws Exception {
-    runTest(3, 2, 1, 0, new Fx<String[]>() {
+    runTest(3, 2, 0, new Fx<String[]>() {
       @Override public void apply(String[] mp) {
         q.delete(OWNER, q.snapshot()).where(q.mediaPackageId(mp[0]).and(q.version().isLatest())).run();
       }
@@ -96,7 +95,7 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
 
   @Test
   public void test5() throws Exception {
-    runTest(3, 2, 2, 0, new Fx<String[]>() {
+    runTest(3, 2, 0, new Fx<String[]>() {
       @Override public void apply(String[] mp) {
         q.delete(OWNER, q.snapshot())
             .where((q.mediaPackageId(mp[0]).or(q.mediaPackageId(mp[1])).and(q.version().isLatest())))
@@ -107,7 +106,7 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
 
   @Test
   public void test6() throws Exception {
-    runTest(3, 2, 3, 0, new Fx<String[]>() {
+    runTest(3, 2, 0, new Fx<String[]>() {
       @Override public void apply(String[] mp) {
         q.delete(OWNER, q.snapshot()).where(q.version().isLatest()).run();
       }
@@ -116,7 +115,7 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
 
   @Test
   public void test7() throws Exception {
-    runTest(3, 2, 6, 3, new Fx<String[]>() {
+    runTest(3, 2, 3, new Fx<String[]>() {
       @Override public void apply(String[] mp) {
         q.delete(OWNER, q.snapshot()).where(p.agent.eq("agent")).run();
       }
@@ -125,7 +124,7 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
 
   @Test
   public void test8() throws Exception {
-    runTest(2, 9, 18, 2, new Fx<String[]>() {
+    runTest(2, 9, 2, new Fx<String[]>() {
       @Override public void apply(String[] mp) {
         q.delete(OWNER, q.snapshot()).where(p.agent.eq("agent")).run();
       }
@@ -136,7 +135,6 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
   private void runTest(
           int mpCount,
           int versionCount,
-          int deleteSnapshotMsgCount,
           int deleteEpisodeMsgCount,
           Fx<String[]> deleteQuery)
           throws Exception {
@@ -145,7 +143,6 @@ public class AssetManagerMessagingTest extends AssetManagerTestBase {
     // expect add messages
     expectObjectMessage(handler1, TakeSnapshot.class, mpCount * versionCount);
     // expect delete messages
-    expectObjectMessage(handler1, DeleteSnapshot.class, deleteSnapshotMsgCount);
     expectObjectMessage(handler1, DeleteEpisode.class, deleteEpisodeMsgCount);
     EasyMock.replay(handler1);
     //

--- a/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/AssetManagerEventUpdateHandler.java
+++ b/modules/live-schedule-impl/src/main/java/org/opencastproject/liveschedule/message/AssetManagerEventUpdateHandler.java
@@ -63,7 +63,7 @@ public class AssetManagerEventUpdateHandler extends UpdateHandler implements Ass
         case Update:
           if (item instanceof TakeSnapshot) { // Check class just in case
             TakeSnapshot snapshotItem = (TakeSnapshot) item;
-            // If no episopde dc, there's nothing to do.
+            // If no episode dc, there's nothing to do.
             if (snapshotItem.getEpisodeDublincore().isNone()) {
               break;
             }

--- a/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/assetmanager/AssetManagerItem.java
+++ b/modules/message-broker-api/src/main/java/org/opencastproject/message/broker/api/assetmanager/AssetManagerItem.java
@@ -72,7 +72,7 @@ public abstract class AssetManagerItem implements MessageItem, Serializable {
   public abstract Type getType();
 
   public abstract <A> A decompose(Fn<? super TakeSnapshot, ? extends A> takeSnapshot,
-          Fn<? super DeleteSnapshot, ? extends A> deleteSnapshot, Fn<? super DeleteEpisode, ? extends A> deleteEpisode);
+          Fn<? super DeleteEpisode, ? extends A> deleteEpisode);
 
   public final Date getDate() {
     return new Date(date);
@@ -109,7 +109,6 @@ public abstract class AssetManagerItem implements MessageItem, Serializable {
 
     @Override
     public <A> A decompose(Fn<? super TakeSnapshot, ? extends A> takeSnapshot,
-            Fn<? super DeleteSnapshot, ? extends A> deleteSnapshot,
             Fn<? super DeleteEpisode, ? extends A> deleteEpisode) {
       return takeSnapshot.apply(this);
     }
@@ -177,44 +176,6 @@ public abstract class AssetManagerItem implements MessageItem, Serializable {
    * ------------------------------------------------------------------------------------------------------------------
    */
 
-  /**
-   * An event for deleting a single version of a media package (aka snapshot).
-   */
-  public static final class DeleteSnapshot extends AssetManagerItem {
-    private static final long serialVersionUID = 4797196156230502250L;
-
-    private final long version;
-
-    private DeleteSnapshot(String mediaPackageId, long version, Date date) {
-      super(mediaPackageId, date);
-      this.version = version;
-    }
-
-    @Override
-    public <A> A decompose(Fn<? super TakeSnapshot, ? extends A> takeSnapshot,
-            Fn<? super DeleteSnapshot, ? extends A> deleteSnapshot,
-            Fn<? super DeleteEpisode, ? extends A> deleteEpisode) {
-      return deleteSnapshot.apply(this);
-    }
-
-    @Override
-    public Type getType() {
-      return Type.Delete;
-    }
-
-    public String getMediaPackageId() {
-      return getId();
-    }
-
-    public static final Fn<DeleteSnapshot, String> getMediaPackageId = new Fn<DeleteSnapshot, String>() {
-      @Override
-      public String apply(DeleteSnapshot a) {
-        return a.getMediaPackageId();
-      }
-    };
-
-  }
-
   /*
    * ------------------------------------------------------------------------------------------------------------------
    */
@@ -231,7 +192,6 @@ public abstract class AssetManagerItem implements MessageItem, Serializable {
 
     @Override
     public <A> A decompose(Fn<? super TakeSnapshot, ? extends A> takeSnapshot,
-            Fn<? super DeleteSnapshot, ? extends A> deleteSnapshot,
             Fn<? super DeleteEpisode, ? extends A> deleteEpisode) {
       return deleteEpisode.apply(this);
     }
@@ -286,19 +246,6 @@ public abstract class AssetManagerItem implements MessageItem, Serializable {
     }
     return new TakeSnapshot(mp.getIdentifier().toString(), MediaPackageParser.getAsXml(mp), dcXml,
             AccessControlParser.toJsonSilent(acl), version, date);
-  }
-
-  /**
-   * @param mediaPackageId
-   *          The unique id of the media package to delete.
-   * @param version
-   *          The episode's version.
-   * @param date
-   *          The modification date.
-   * @return Builds {@link AssetManagerItem} for deleting a snapshot from the asset manager.
-   */
-  public static AssetManagerItem deleteSnapshot(String mediaPackageId, long version, Date date) {
-    return new DeleteSnapshot(mediaPackageId, version, date);
   }
 
   /**


### PR DESCRIPTION
This patch removes the event triggered after deleting a snapshot. This can easily be triggered thousands of times when cleaning up and nothing in Opencast is actually using the event.

This fixes #5173

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
