### PR TITLE
Fix NPE when removing a workflow without creator

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -1129,10 +1129,11 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
       }
     }
 
-    User workflowCreator = userDirectoryService.loadUser(workflow.getCreatorName());
+    var creatorName = workflow.getCreatorName();
+    var workflowCreator = creatorName == null ? null : userDirectoryService.loadUser(creatorName);
     boolean authorized = currentUser.hasRole(GLOBAL_ADMIN_ROLE)
             || (currentUser.hasRole(currentOrgAdminRole) && currentOrgId.equals(workflowOrgId))
-            || (workflowCreator != null && currentUser.equals(workflowCreator))
+            || (currentUser.equals(workflowCreator))
             || (authorizationService.hasPermission(mediapackage, action) && currentOrgId.equals(workflowOrgId));
 
     if (!authorized) {


### PR DESCRIPTION
If a workflow has no creator (maybe because the user has been removed), removing a workflow fails with a NullPointerException when Opencast tries loading details of the user `null`.

```
2023-09-05 13:08:19,950 | ERROR | (AbstractScanner$TypedQuartzJob$1:314) - An error occurred while harvesting schedule
com.google.common.util.concurrent.UncheckedExecutionException: java.lang.NullPointerException
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2051) ~[?:?]
        at com.google.common.cache.LocalCache.get(LocalCache.java:3962) ~[?:?]
        at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:3985) ~[?:?]
        at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:4946) ~[?:?]
        at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:4952) ~[?:?]
        at org.opencastproject.userdirectory.UserAndRoleDirectoryServiceImpl.loadUser(UserAndRoleDirectoryServiceImpl.java:265) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.assertPermission(WorkflowServiceImpl.java:1132) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.getWorkflowById(WorkflowServiceImpl.java:446) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.remove(WorkflowServiceImpl.java:928) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.remove(WorkflowServiceImpl.java:914) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowServiceImpl.cleanupWorkflowInstances(WorkflowServiceImpl.java:2125) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowCleanupScanner.scan(WorkflowCleanupScanner.java:203) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.lambda$runInContext$0(SecurityContext.java:68) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:58) ~[?:?]
        at org.opencastproject.security.util.SecurityContext.runInContext(SecurityContext.java:67) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowCleanupScanner$Runner.execute(WorkflowCleanupScanner.java:266) ~[?:?]
        at org.opencastproject.workflow.impl.WorkflowCleanupScanner$Runner.execute(WorkflowCleanupScanner.java:252) ~[?:?]
        at org.opencastproject.kernel.scanner.AbstractScanner$TypedQuartzJob$1.xapply(AbstractScanner.java:311) ~[?:?]
        at org.opencastproject.kernel.scanner.AbstractScanner$TypedQuartzJob$1.xapply(AbstractScanner.java:307) ~[?:?]
        at org.opencastproject.util.data.Function0$X.apply(Function0.java:53) ~[?:?]
        at org.opencastproject.util.NeedleEye.apply(NeedleEye.java:46) ~[?:?]
        at org.opencastproject.kernel.scanner.AbstractScanner$TypedQuartzJob.execute(AbstractScanner.java:297) ~[?:?]
        at org.quartz.core.JobRunShell.run(JobRunShell.java:216) ~[?:?]
        at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:549) ~[?:?]
Caused by: java.lang.NullPointerException
        at org.opencastproject.userdirectory.JpaUserAndRoleProvider.loadUser(JpaUserAndRoleProvider.java:252) ~[?:?]
        at org.opencastproject.userdirectory.UserAndRoleDirectoryServiceImpl.loadUser(UserAndRoleDirectoryServiceImpl.java:310) ~[?:?]
        at org.opencastproject.userdirectory.UserAndRoleDirectoryServiceImpl$1.load(UserAndRoleDirectoryServiceImpl.java:115) ~[?:?]
        at org.opencastproject.userdirectory.UserAndRoleDirectoryServiceImpl$1.load(UserAndRoleDirectoryServiceImpl.java:112) ~[?:?]
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529) ~[?:?]
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278) ~[?:?]
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155) ~[?:?]
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045) ~[?:?]
        ... 23 more
```

This patch fixes the problem.

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
