### PR TITLE
Skip publications when removing temporary files

### DIFF
--- a/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
+++ b/modules/workflow-service-impl/src/main/java/org/opencastproject/workflow/impl/WorkflowServiceImpl.java
@@ -49,6 +49,7 @@ import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.mediapackage.MediaPackageElement;
 import org.opencastproject.mediapackage.MediaPackageParser;
 import org.opencastproject.mediapackage.MediaPackageSupport;
+import org.opencastproject.mediapackage.Publication;
 import org.opencastproject.metadata.api.MediaPackageMetadata;
 import org.opencastproject.metadata.api.MediaPackageMetadataService;
 import org.opencastproject.metadata.api.MetadataService;
@@ -879,16 +880,20 @@ public class WorkflowServiceImpl extends AbstractIndexProducer implements Workfl
   }
 
   private void removeTempFiles(WorkflowInstance workflowInstance) {
-    logger.info("Removing temporary files for workflow {}", workflowInstance);
+    logger.info("Removing temporary files for workflow {}", workflowInstance.getId());
     MediaPackage mp = workflowInstance.getMediaPackage();
     if (null == mp) {
       logger.warn("Workflow instance {} does not have an media package set", workflowInstance.getId());
       return;
     }
     for (MediaPackageElement elem : mp.getElements()) {
+      // Publications should not link to temporary files and can be skipped
+      if (elem instanceof Publication) {
+        continue;
+      }
       if (null == elem.getURI()) {
-        logger.warn("Mediapackage element {} from the media package {} does not have an URI set",
-                elem.getIdentifier(), mp.getIdentifier().toString());
+        logger.warn("Media package element {} from the media package {} does not have an URI set",
+                elem.getIdentifier(), mp.getIdentifier());
         continue;
       }
       try {


### PR DESCRIPTION
When removing a workflow, Opencast will go through all media package elements to make sure no temporary files remain in the workflow and working file repository. This is unnecessary for publication elements which just link publication locations like a player.

This patch makes sure Opencast skips publications.

This fixes #5235

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
