### PR TITLE
Extend analyze-mp for tag variables

### DIFF
--- a/docs/guides/admin/docs/releasenotes/analyze-mp-tag-variables
+++ b/docs/guides/admin/docs/releasenotes/analyze-mp-tag-variables
@@ -1,0 +1,2 @@
+The analyze-mediapackage WOH was extended so it will also create variables regarding the existence of elements of a
+certain flavor _and tag_ (example: `captions_source_hastag_archive`). These new variables are not created by default.

--- a/docs/guides/admin/docs/workflowoperationhandlers/analyze-mediapackage-woh.md
+++ b/docs/guides/admin/docs/workflowoperationhandlers/analyze-mediapackage-woh.md
@@ -14,11 +14,11 @@ operations should be executed or skipped.
 Workflow Instance Variables
 ---------------------------
 
-|Name              |Example                        |Description                                                  |
-|------------------|-------------------------------|-------------------------------------------------------------|
-|`*flavor*_exists` |`presenter_source_exists=true` |Whether an element with given flavor is in the mediapackage. |
-|`*flavor*_type`   |`presenter_source_type=Track`  |The type of the element with the given flavor. Possible values are: `Attachment`, `Catalog`, `Track`. |
-
+| Name                    | Example                           | Description                                                                                               |
+|-------------------------|-----------------------------------|-----------------------------------------------------------------------------------------------------------|
+| `*flavor*_exists`       | `presenter_source_exists=true`    | Whether an element with given flavor is in the mediapackage.                                              |
+| `*flavor*_type`         | `presenter_source_type=Track`     | The type of the element with the given flavor. Possible values are: `Attachment`, `Catalog`, `Track`.     |
+| `*flavor*_hastag_*tag*` | `presenter_source_hastag_archive` | Whether an element with given flavor and tag is in the mediapackage (only if `set-tag-variables` is set). |
 
 
 Parameter Table
@@ -28,10 +28,11 @@ If no configuration keys are specified, workflow instance variables will be set 
 
 If no mediapackage element matches a configuration key, no workflow instance variables will be set for that key. For example, the operation will never generate `presentation_work_exists=false`.
 
-|Configuration Key|Example            |Description                                       |
-|-----------------|-------------------|--------------------------------------------------|
-|source-flavors   |`*/work`           |The comma separated list of flavors of the elements we are interested in. |
-|source-tags      |`delivery, 1080p`  |The comma separated list of tags of the elements we are interested in.|
+| Configuration Key | Example           | Description                                                                |
+|-------------------|-------------------|----------------------------------------------------------------------------|
+| source-flavors    | `*/work`          | The comma separated list of flavors of the elements we are interested in.  |
+| source-tags       | `delivery, 1080p` | The comma separated list of tags of the elements we are interested in.     |
+| set-tag-variables | `true`            | Whether to set tag variables (default: false).                             |
 
 
 Operation Example

--- a/modules/analyze-mediapackage-workflowoperation/pom.xml
+++ b/modules/analyze-mediapackage-workflowoperation/pom.xml
@@ -37,16 +37,15 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
 
     <!-- testing -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This extends the analyze-mediapackage WOH so it can also create variables containing whether elements with a specific flavor and tag exist, for example `captions_source_hastag_archive`. This allows this information to be used in workflow execution conditions.

These variables aren't created by default (because there can be a lot of them), but only when `set-tag-variables` is true.