### PR TITLE
Don't take snapshot on asset upload before workflow

### DIFF
--- a/docs/guides/admin/docs/releasenotes/no-snapshot-on-asset-upload.txt
+++ b/docs/guides/admin/docs/releasenotes/no-snapshot-on-asset-upload.txt
@@ -1,0 +1,3 @@
+With this release, there will no longer be a snapshot taken to archive new assets uploaded to an existing event _before_
+the workflow is started. Instead, the workflow is expected to take care of this. The community workflow already did
+this, but if you have custom workflows, you might need to make changes to ensure this.

--- a/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
+++ b/modules/index-service/src/main/java/org/opencastproject/index/service/impl/IndexServiceImpl.java
@@ -715,24 +715,7 @@ public class IndexServiceImpl implements IndexService {
   /**
    * Parses the processing information, including the workflowDefinitionId, from the metadataJson and starts the
    * workflow with the passed mediapackage.
-   *
-   * TODO NOTE: This checks for running workflows, then takes a snapshot prior to starting a new workflow. This causes a
-   * potential race condition:
-   *
-   * 1. An existing workflow is running, the add asset workflow cannot start.
-   *
-   * 2. The snapshot(4x) archive(3x) is saved and the new workflow is started.
-   *
-   * 3. Possible race condition: No running workflow, a snapshot is saved but the workflow cannot start because another
-   * workflow has started between the time of checking and starting running.
-   *
-   * 4. If race condition: the Admin UI shows error that the workflow could not start.
-   *
-   * 5. If race condition: The interim snapshot(4x) archive(3x) is updated(4x-3x) by the running workflow's snapshots
-   * and resolves the inconsistency, eventually.
-   *
    * Example of processing json:
-   *
    * ...., "processing": { "workflow": "full", "configuration": { "videoPreview": "false", "trimHold": "false",
    * "captionHold": "false", "archiveOp": "true", "publishEngage": "true", "publishHarvesting": "true" } }, ....
    *


### PR DESCRIPTION
The workflow already takes a snapshot, and otherwise we can't figure out which assets are new in the workflow (which I need later).

This also actually makes the code a bit simpler.