### PR TITLE
Extend Asset Upload Workflow for Captions

### DIFF
--- a/etc/workflows/partial-error.xml
+++ b/etc/workflows/partial-error.xml
@@ -12,7 +12,7 @@
       fail-on-error="false"
       description="Preserve the current recording state">
       <configurations>
-        <configuration key="source-flavors">*/source,dublincore/*,security/*,captions/*</configuration>
+        <configuration key="source-flavors">*/source,dublincore/*,security/*</configuration>
         <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>

--- a/etc/workflows/partial-process-uploaded-captions.xml
+++ b/etc/workflows/partial-process-uploaded-captions.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition xmlns="http://workflow.opencastproject.org">
+  <id>partial-process-uploaded-captions</id>
+  <title>Process uploaded captions</title>
+  <tags/>
+  <description/>
+  <configuration_panel/>
+
+  <operations>
+
+    <!-- create or update captions/prepared -->
+
+    <operation
+      id="tag"
+      description="Remove old captions/prepared">
+      <configurations>
+        <configuration key="source-flavors">captions/prepared</configuration>
+        <configuration key="target-tags">-archive</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      if="${presenter_prepared_exists} OR ${presentation_prepared_exists}"
+      id="clone"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error"
+      description="Create captions/prepared">
+      <configurations>
+        <configuration key="source-flavor">captions/source</configuration>
+        <configuration key="target-flavor">captions/prepared</configuration>
+      </configurations>
+    </operation>
+
+    <!-- cut captions -->
+
+    <operation
+      id="clone"
+      exception-handler-workflow="partial-error"
+      description="Create working copy of the cutting information">
+      <configurations>
+        <configuration key="source-flavor">smil/cutting</configuration>
+        <configuration key="target-flavor">smil/tmp</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="editor"
+      exception-handler-workflow="partial-error"
+      description="Cut the captions">
+      <configurations>
+        <configuration key="source-flavors">captions/source</configuration>
+        <configuration key="smil-flavors">smil/tmp</configuration>
+        <configuration key="target-smil-flavor">smil/tmp</configuration>
+        <configuration key="target-flavor-subtype">delivery</configuration>
+        <configuration key="interactive">false</configuration>
+      </configurations>
+    </operation>
+
+    <!-- tag results -->
+
+    <operation
+      id="tag"
+      description="Tag captions for delivery">
+      <configurations>
+        <configuration key="source-flavors">captions/delivery</configuration>
+	<configuration key="target-tags">-archive,+generator:unknown,+engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="tag"
+      description="Don't publish captions/source">
+      <configurations>
+        <configuration key="source-flavors">captions/source</configuration>
+        <configuration key="target-tags">+exclude-publish</configuration>
+      </configurations>
+    </operation>
+
+  </operations>
+
+</definition>

--- a/etc/workflows/partial-process-uploaded-captions.xml
+++ b/etc/workflows/partial-process-uploaded-captions.xml
@@ -63,7 +63,7 @@
       description="Tag captions for delivery">
       <configurations>
         <configuration key="source-flavors">captions/delivery</configuration>
-	<configuration key="target-tags">-archive,+generator:unknown,+engage-download</configuration>
+        <configuration key="target-tags">-archive,+generator:unknown,+engage-download</configuration>
       </configurations>
     </operation>
 

--- a/etc/workflows/publish-uploaded-assets.xml
+++ b/etc/workflows/publish-uploaded-assets.xml
@@ -27,7 +27,7 @@
       id="tag"
       description="Tag newly uploaded assets for archival">
       <configurations>
-	<configuration key="source-flavors">*/*</configuration>
+        <configuration key="source-flavors">*/*</configuration>
         <configuration key="target-tags">+archive</configuration>
       </configurations>
     </operation>
@@ -59,7 +59,7 @@
       description="Update recording in Opencast Media Module">
       <configurations>
         <configuration key="download-source-flavors">${download-source-flavors},dublincore/*,security/*</configuration>
-	<configuration key="download-source-tags">engage-download,-exclude-publish</configuration>  <!-- exclude necessary bc of download_source_flavors -->
+        <configuration key="download-source-tags">engage-download,-exclude-publish</configuration>  <!-- exclude necessary bc of download_source_flavors -->
         <configuration key="streaming-source-tags">engage-streaming</configuration>
         <configuration key="strategy">merge</configuration>
         <configuration key="check-availability">false</configuration>

--- a/etc/workflows/publish-uploaded-assets.xml
+++ b/etc/workflows/publish-uploaded-assets.xml
@@ -11,45 +11,68 @@
 
   <operations>
 
-    <!-- Apply the default workflow configuration -->
+    <!-- Analyze current state of media package -->
 
     <operation
-      id="defaults"
-      description="Applying default configuration values">
+      id="analyze-mediapackage"
+      description="Set control variables for captions">
       <configurations>
-        <configuration key="publishToEngage">true</configuration>
+        <configuration key="set-tag-variables">true</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Tag new assets for archival -->
+
+    <operation
+      id="tag"
+      description="Tag newly uploaded assets for archival">
+      <configurations>
+	<configuration key="source-flavors">*/*</configuration>
+        <configuration key="target-tags">+archive</configuration>
       </configurations>
     </operation>
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-    <!-- Publish to publication channels                                   -->
+    <!-- Special handling for captions                                     -->
     <!--                                                                   -->
-    <!-- Update the recording metadata in the publication channels.        -->
+    <!-- Creates captions/prepared and captions/delivery.                  -->
+    <!-- Sets the following tags:                                          -->
+    <!--    captions/source     archive, exclude-publish                   -->
+    <!--    captions/prepared   archive                                    -->
+    <!--    captions/delivery   engage-download                            -->
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <operation
+      id="include"
+      if="NOT(${captions_source_hastag_archive})"
+      description="Include special handling for uploaded captions">
+      <configurations>
+        <configuration key="workflow-id">partial-process-uploaded-captions</configuration>
+      </configurations>
+    </operation>
 
     <!-- Publish to engage player -->
 
     <operation
       id="publish-engage"
-      if="${publishToEngage}"
       exception-handler-workflow="partial-error"
       description="Update recording in Opencast Media Module">
       <configurations>
         <configuration key="download-source-flavors">${download-source-flavors},dublincore/*,security/*</configuration>
-        <configuration key="download-source-tags">engage-download</configuration>
+	<configuration key="download-source-tags">engage-download,-exclude-publish</configuration>  <!-- exclude necessary bc of download_source_flavors -->
         <configuration key="streaming-source-tags">engage-streaming</configuration>
         <configuration key="strategy">merge</configuration>
         <configuration key="check-availability">false</configuration>
       </configurations>
     </operation>
 
-    <!-- Archive the current state of the mediapackage -->
+    <!-- Archive uploaded assets -->
 
     <operation
       id="snapshot"
       description="Archiving new assets">
       <configurations>
-        <configuration key="source-flavors">*/*</configuration>
+        <configuration key="source-tags">archive</configuration>
       </configurations>
     </operation>
 


### PR DESCRIPTION
In accordance with the recent changes to subtitles in Opencast, captions need special handling when they're uploaded to an existing event, e.g. they must be cut. This extends the existing workflow to handle this use case.

**Attention:** This change depends on #5243 and #5247 to work and should not be merged separately!

Also contains a minor fix in another workflow.