### PR TITLE
Add Opencast 13.11 release notes

### DIFF
--- a/docs/guides/admin/docs/releasenotes.md
+++ b/docs/guides/admin/docs/releasenotes.md
@@ -1,8 +1,25 @@
 # Opencast 13: Release Notes
 
 
+Opencast 13.11
+--------------
+
+The eleventh maintenance release of Opencast 13.
+
+- Fix static file service exception on non-existing file([#5230](https://github.com/opencast/opencast/pull/5230))
+- Fix Workflow Index Rebuild([#5226](https://github.com/opencast/opencast/pull/5226))
+- Fix NPE when workflow user no longer exists([#5191](https://github.com/opencast/opencast/pull/5191))
+- Fix wrong failedOperation characterers in send email docs WoH and improves Freemaker documentation ([#5177](https://github.com/opencast/opencast/pull/5177))
+- Skip deleting non existent file ([#5171](https://github.com/opencast/opencast/pull/5171))
+- Copy active inputs between CAs if they have the same set of inputs([#5169](https://github.com/opencast/opencast/pull/5169))
+- Fix editing custom actions in the ACL editor([#5164](https://github.com/opencast/opencast/pull/5164))
+
+
+See [changelog](changelog.md) for a comprehensive list of changes.
+
+
 Opencast 13.10
--------------
+--------------
 
 The tenth maintenance release of Opencast 13.
 


### PR DESCRIPTION
This PR will add the Opencast 13.11 release notes. 
The release will probably be on September 14, 2023.

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
