### PR TITLE
Update Opencast Studio to `2023-09-14`

### DIFF
--- a/modules/studio/pom.xml
+++ b/modules/studio/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <opencast.basedir>${project.basedir}/../..</opencast.basedir>
     <checkstyle.skip>false</checkstyle.skip>
-    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2022-08-03/oc-studio-2022-08-03-integrated.tar.gz</opencast.studio.url>
-    <opencast.studio.sha256>ea17a6657fa152805d5f8d78b2368a9ad8a8fc897b4868b6c1fface144315a45</opencast.studio.sha256>
+    <opencast.studio.url>https://github.com/elan-ev/opencast-studio/releases/download/2023-09-14/oc-studio-2023-09-14-integrated.tar.gz</opencast.studio.url>
+    <opencast.studio.sha256>3b1a5ff7b1943866d73a7f19192faaf03151d1a1ff7338192e8040f04236c0d7</opencast.studio.sha256>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
Changelogs:
- https://github.com/elan-ev/opencast-studio/releases/tag/2023-09-14 
- https://github.com/elan-ev/opencast-studio/releases/tag/2023-01-09

Main changes:
- Add shortcuts
- Allow server settings path to be set via `settingsFile` query parameter
- Internal: big project cleanup & switching to Typescript

**Note**: this is *not* the big redesign update! Some people are interested in the `settingsFile` capability and would prefer not to wait for the next major Opencast release (on which the Redesign Update has to wait).

I was a bit hesitant to make this "in between" release as it contains the "big project cleanup", which could introduce bugs. This version here is not as well tested as the current "post redesign" version, unfortunately. That's why I was hesitant. However, I did test this version now again in several scenarios, standalone and integrated. And I haven't found any problems. Still, I would appreciate if others could test this too, ideally in their real deploy environment, ideally before the next 14.x is released.
Also, I just noticed, a client of ours already runs this version in production for a while. So that's a good sign...

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
