### PR TITLE
Fix Translation Updates

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: upload translation source
       env:
-        CROWDIN_TOKEN: ${{ secret.CROWDIN_TOKEN }}
+        CROWDIN_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
       run: |
         set -o errexit
         update() {


### PR DESCRIPTION
This patch fixes the workflow downloading translation updates from Crowdin and applying them to our codebase. There is a typo in one of the variables causing the workflow to be invalid:

    Invalid workflow file: .github/workflows/update-translations.yml#L41

    The workflow is not valid. .github/workflows/update-translations.yml
    (Line: 41, Col: 24): Unrecognized named-value: 'secret'. Located at
    position 1 within expression: secret.CROWDIN_TOKEN

### Your pull request should…

* [x] have a concise title
* [x] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [x] include migration scripts and documentation, if appropriate
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
