### PR TITLE
Update ES index before triggering event handlers from AssetManager

### DIFF
--- a/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
+++ b/modules/asset-manager-impl/src/main/java/org/opencastproject/assetmanager/impl/AssetManagerImpl.java
@@ -438,11 +438,11 @@ public class AssetManagerImpl extends AbstractIndexProducer implements AssetMana
                 mkPropertyName(ace.getRole(), ace.getAction())), Value.mk(ace.isAllow())));
       }
 
+      updateEventInIndex(snapshot);
+
       logger.info("Trigger update handlers for snapshot {}, version {}",
           snapshot.getMediaPackage().getIdentifier(), snapshot.getVersion());
       fireEventHandlers(mkTakeSnapshotMessage(snapshot));
-
-      updateEventInIndex(snapshot);
 
       return snapshot;
     }


### PR DESCRIPTION
The event handler for live events will trigger another snapshot if something in the live publication changed. If we do the Elasticsearch update afterwards, this means the update happens for the new snapshot first, then for the old one, resulting in a lost update. This was broken when this part was changed to be synchronous instead of asynchronous in #3100.
