### PR TITLE
Re-enable Tobira Adopter Tracking

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/shared/resources/adopterStatisticSummaryResource.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/resources/adopterStatisticSummaryResource.js
@@ -32,6 +32,7 @@ angular.module('adminNg.resources')
           var shortenedServices = data['statistics']['hosts'][host]['services'].substring(0, 50) + '[...]';
           data['statistics']['hosts'][host]['services'] = shortenedServices;
         }*/
+        data['statistics']['tobira'] = data['tobira'];
         return {'general': data['general'], 'statistics': data['statistics']};
       }
     }

--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -86,6 +86,12 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.opencastproject</groupId>
+          <artifactId>opencast-tobira</artifactId>
+          <version>13-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/adopter-registration-impl/pom.xml
+++ b/modules/adopter-registration-impl/pom.xml
@@ -86,12 +86,10 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.service.component.annotations</artifactId>
     </dependency>
-      <dependency>
-          <groupId>org.opencastproject</groupId>
-          <artifactId>opencast-tobira</artifactId>
-          <version>13-SNAPSHOT</version>
-          <scope>compile</scope>
-      </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -133,9 +133,9 @@ public class ScheduledDataCollector extends TimerTask {
   /** The security service */
   protected SecurityService securityService;
 
-  protected TobiraRemoteRequester tobiraRemoteRequester;
+  private TobiraRemoteRequester tobiraRemoteRequester;
 
-  protected TrustedHttpClient trustedHttpClient;
+  protected TrustedHttpClient httpClient;
 
 
   //================================================================================
@@ -204,7 +204,7 @@ public class ScheduledDataCollector extends TimerTask {
 
     this.tobiraRemoteRequester = new TobiraRemoteRequester();
     this.tobiraRemoteRequester.setRemoteServiceManager(serviceRegistry);
-    this.tobiraRemoteRequester.setTrustedHttpClient(trustedHttpClient);
+    this.tobiraRemoteRequester.setTrustedHttpClient(httpClient);
 
     Form adopter;
     try {
@@ -444,7 +444,7 @@ public class ScheduledDataCollector extends TimerTask {
 
   @Reference
   public void setTrustedHttpClient(TrustedHttpClient trustedHttpClient) {
-    this.trustedHttpClient = trustedHttpClient;
+    this.httpClient = trustedHttpClient;
   }
 
   private class TobiraRemoteRequester extends RemoteBase {
@@ -454,8 +454,8 @@ public class ScheduledDataCollector extends TimerTask {
     }
 
     public JsonObject getStats() throws IOException {
-      HttpGet get = new HttpGet("/tobira/stats");
-      HttpResponse response = getResponse(get);
+      HttpGet get = new HttpGet("/stats");
+      HttpResponse response = this.getResponse(get);
       try {
         if (response != null) {
           InputStream is = response.getEntity().getContent();
@@ -463,7 +463,7 @@ public class ScheduledDataCollector extends TimerTask {
           return gson.fromJson(json, JsonElement.class).getAsJsonObject();
         }
       } finally {
-        closeConnection(response);
+        this.closeConnection(response);
       }
       return null;
     }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -67,7 +67,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -458,8 +457,7 @@ public class ScheduledDataCollector extends TimerTask {
       HttpResponse response = this.getResponse(get);
       try {
         if (response != null) {
-          InputStream is = response.getEntity().getContent();
-          String json = IOUtils.toString(is, response.getEntity().getContentEncoding().toString());
+          String json = IOUtils.toString(response.getEntity().getContent());
           return gson.fromJson(json, JsonElement.class).getAsJsonObject();
         }
       } finally {

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/ScheduledDataCollector.java
@@ -45,8 +45,11 @@ import org.opencastproject.security.util.SecurityUtil;
 import org.opencastproject.series.api.SeriesService;
 import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.serviceregistry.api.ServiceRegistryException;
+import org.opencastproject.tobira.impl.TobiraEndpoint;
 import org.opencastproject.userdirectory.JpaUserAndRoleProvider;
 import org.opencastproject.userdirectory.JpaUserReferenceProvider;
+
+import com.google.gson.Gson;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Version;
@@ -54,6 +57,8 @@ import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,6 +94,8 @@ public class ScheduledDataCollector extends TimerTask {
   /* How many records to get from the search index at once */
   private static final int SEARCH_ITERATION_SIZE = 100;
 
+  private static final Gson gson = new Gson();
+
   //================================================================================
   // OSGi properties
   //================================================================================
@@ -120,6 +127,8 @@ public class ScheduledDataCollector extends TimerTask {
 
   /** The security service */
   protected SecurityService securityService;
+
+  protected TobiraEndpoint tobiraEndpoint;
 
 
   //================================================================================
@@ -228,8 +237,17 @@ public class ScheduledDataCollector extends TimerTask {
 
       if (adopter.allowsStatistics()) {
         try {
-          String statisticDataAsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
-          sender.sendStatistics(statisticDataAsJson);
+          StatisticData statisticData = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
+          sender.sendStatistics(statisticData.jsonify());
+          if (null != tobiraEndpoint) {
+            String tobiraJson = tobiraEndpoint.getStats().toString();
+            // This is null in the case that Tobira hasn't sent any stats yet.
+            // This could be due to Tobira not existing, or because we've just rebooted.
+            if (null != tobiraJson) {
+              sender.sendTobiraData(
+                  "{ \"statistic_key\": \"" + statisticData.getStatisticKey() + "\", \"data\": " + tobiraJson + " }");
+            }
+          }
           //Note: save the form (unmodified) (again!) to update the dates.  Old dates cause warnings to the user!
           adopterFormService.saveFormData(adopter);
         } catch (Exception e) {
@@ -244,12 +262,14 @@ public class ScheduledDataCollector extends TimerTask {
     String generalJson = collectGeneralData(adopter);
     String statsJson;
     if (adopter.allowsStatistics()) {
-      statsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey());
+      statsJson = collectStatisticData(adopter.getAdopterKey(), adopter.getStatisticKey()).jsonify();
     } else {
       statsJson = "{}";
     }
+    String tobiraJson = gson.toJson(tobiraEndpoint.getStats());
+
     //It's not stupid if it works!
-    return "{ \"general\":" + generalJson + ", \"statistics\":" + statsJson + "}";
+    return "{ \"general\":" + generalJson + ", \"statistics\":" + statsJson + ", \"tobira\":" + tobiraJson + "}";
   }
 
 
@@ -273,7 +293,7 @@ public class ScheduledDataCollector extends TimerTask {
    * @return The statistic data as JSON string.
    * @throws Exception General exception that can occur while gathering data.
    */
-  private String collectStatisticData(String adopterKey, String statisticKey) throws Exception {
+  private StatisticData collectStatisticData(String adopterKey, String statisticKey) throws Exception {
     StatisticData statisticData = new StatisticData(statisticKey);
     statisticData.setAdopterKey(adopterKey);
     serviceRegistry.getHostRegistrations().forEach(host -> {
@@ -342,7 +362,7 @@ public class ScheduledDataCollector extends TimerTask {
       });
     }
     statisticData.setVersion(version);
-    return statisticData.jsonify();
+    return statisticData;
   }
 
 
@@ -408,4 +428,15 @@ public class ScheduledDataCollector extends TimerTask {
     this.organizationDirectoryService = orgDirServ;
   }
 
+  @Reference(
+      cardinality = ReferenceCardinality.OPTIONAL,
+      policy = ReferencePolicy.DYNAMIC,
+      unbind = "unsetTobiraEndpoint")
+  public void setTobiraEndpoint(TobiraEndpoint endpoint) {
+    this.tobiraEndpoint = endpoint;
+  }
+
+  public void unsetTobiraEndpoint(TobiraEndpoint endpoint) {
+    this.tobiraEndpoint = null;
+  }
 }

--- a/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
+++ b/modules/adopter-registration-impl/src/main/java/org/opencastproject/adopter/statistic/Sender.java
@@ -54,6 +54,8 @@ public class Sender {
   private static final String GENERAL_DATA_URL_SUFFIX = "api/1.0/adopter";
   private static final String STATISTIC_URL_SUFFIX = "api/1.0/statistic";
 
+  private static final String TOBIRA_URL_SUFFIX = "api/1.0/tobira";
+
   //================================================================================
   // Constructor
   //================================================================================
@@ -98,6 +100,15 @@ public class Sender {
    */
   public void sendStatistics(String json) throws IOException {
     send(json, STATISTIC_URL_SUFFIX);
+  }
+
+  /**
+   * Executes the 'send' method with the proper REST URL suffix.
+   * @param json The data which shall be sent.
+   * @throws IOException General exception that can occur while sending the data.
+   */
+  public void sendTobiraData(String json) throws IOException {
+    send(json, TOBIRA_URL_SUFFIX);
   }
 
   /**

--- a/modules/tobira/pom.xml
+++ b/modules/tobira/pom.xml
@@ -58,6 +58,18 @@
       <artifactId>opencast-dublincore</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -80,7 +92,8 @@
               *
             </Import-Package>
             <Export-Package>
-              org.opencastproject.tobira;version=${project.version}
+              org.opencastproject.tobira;version=${project.version},
+              org.opencastproject.tobira.impl;version=${project.version}
             </Export-Package>
           </instructions>
         </configuration>

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -35,6 +35,11 @@ import org.opencastproject.util.doc.rest.RestResponse;
 import org.opencastproject.util.doc.rest.RestService;
 import org.opencastproject.workspace.api.Workspace;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import org.apache.commons.io.IOUtils;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -42,13 +47,21 @@ import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
 /**
@@ -98,10 +111,16 @@ public class TobiraEndpoint {
   private static final int VERSION_MINOR = 4;
   private static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR;
 
+  private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+  private static final Gson gson = new Gson();
+
   private SearchService searchService;
   private SeriesService seriesService;
   private AuthorizationService authorizationService;
   private Workspace workspace;
+
+  private JsonObject stats = new JsonObject();
 
   @Activate
   public void activate(BundleContext bundleContext) {
@@ -212,5 +231,37 @@ public class TobiraEndpoint {
   private static Response badRequest(String msg) {
     logger.warn("Bad request to tobira/harvest: {}", msg);
     return Response.status(BAD_REQUEST).entity(msg).build();
+  }
+
+  @POST
+  @Path("/stats")
+  @Consumes(APPLICATION_JSON)
+  @RestQuery(
+      name = "stats",
+      description = "Accepts a json blob of statistical data about Tobira.",
+      restParameters = {},
+      bodyParameter = @RestParameter(description = "The Tobira data blob",
+            isRequired = true,
+            name = "BODY",
+            type = Type.STRING),
+      responses = {
+          @RestResponse(description = "Stats parsed", responseCode = HttpServletResponse.SC_ACCEPTED)
+      },
+      returnDescription = "No data returned, just a 204 on success"
+  )
+  public Response acceptStats(@Context HttpServletRequest request) {
+    try (InputStream is = request.getInputStream()) {
+      String json = IOUtils.toString(is, request.getCharacterEncoding());
+      stats = gson.fromJson(json, JsonElement.class).getAsJsonObject();
+      stats.addProperty("updated", sdf.format(Calendar.getInstance().getTime()));
+    } catch (IOException e) {
+      logger.error("Error parsing Tobira stats blob", e);
+      return Response.status(BAD_REQUEST).build();
+    }
+    return Response.noContent().build();
+  }
+
+  public JsonObject getStats() {
+    return stats;
   }
 }

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -25,9 +25,15 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.opencastproject.util.doc.rest.RestParameter.Type;
 
+import org.opencastproject.job.api.AbstractJobProducer;
+import org.opencastproject.job.api.Job;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
+import org.opencastproject.security.api.OrganizationDirectoryService;
+import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UserDirectoryService;
 import org.opencastproject.series.api.SeriesService;
+import org.opencastproject.serviceregistry.api.ServiceRegistry;
 import org.opencastproject.util.Jsons;
 import org.opencastproject.util.doc.rest.RestParameter;
 import org.opencastproject.util.doc.rest.RestQuery;
@@ -89,7 +95,9 @@ import javax.ws.rs.core.Response;
     immediate = true,
     service = TobiraEndpoint.class
 )
-public class TobiraEndpoint {
+public class TobiraEndpoint extends AbstractJobProducer {
+
+  public static final String JOB_TYPE = "org.opencastproject.tobira";
   private static final Logger logger = LoggerFactory.getLogger(TobiraEndpoint.class);
 
   // Versioning the Tobira API:
@@ -119,8 +127,22 @@ public class TobiraEndpoint {
   private SeriesService seriesService;
   private AuthorizationService authorizationService;
   private Workspace workspace;
+  private OrganizationDirectoryService organizationDirectoryService;
+  private UserDirectoryService userDirectoryService;
+  private ServiceRegistry serviceRegistry;
+
+  private SecurityService securityService;
 
   private JsonObject stats = new JsonObject();
+
+  /**
+   * Creates a new abstract job producer for jobs of the given type.
+   *
+   * @param jobType the job type
+   */
+  public TobiraEndpoint() {
+    super(JOB_TYPE);
+  }
 
   @Activate
   public void activate(BundleContext bundleContext) {
@@ -263,5 +285,48 @@ public class TobiraEndpoint {
 
   public JsonObject getStats() {
     return stats;
+  }
+
+  public void setServiceRegistry(ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @Override
+  protected ServiceRegistry getServiceRegistry() {
+    return serviceRegistry;
+  }
+
+  @Reference
+  public void setSecurityService(SecurityService securityService) {
+    this.securityService = securityService;
+  }
+
+  @Override
+  protected SecurityService getSecurityService() {
+    return securityService;
+  }
+
+  @Reference
+  public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
+    this.userDirectoryService = userDirectoryService;
+  }
+  @Override
+  protected UserDirectoryService getUserDirectoryService() {
+    return userDirectoryService;
+  }
+
+  @Reference
+  public void setOrganizationDirectoryService(OrganizationDirectoryService organizationDirectoryService) {
+    this.organizationDirectoryService = organizationDirectoryService;
+  }
+
+  @Override
+  protected OrganizationDirectoryService getOrganizationDirectoryService() {
+    return organizationDirectoryService;
+  }
+
+  @Override
+  protected String process(Job job) throws Exception {
+    throw new RuntimeException("This should never be called for TobiraEndpoint!");
   }
 }

--- a/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
+++ b/modules/tobira/src/main/java/org/opencastproject/tobira/impl/TobiraEndpoint.java
@@ -283,8 +283,17 @@ public class TobiraEndpoint extends AbstractJobProducer {
     return Response.noContent().build();
   }
 
-  public JsonObject getStats() {
-    return stats;
+  @GET
+  @Path("/stats")
+  @Produces(APPLICATION_JSON)
+  @RestQuery(name = "stats",
+      description = "Returns the stats, if any, pushed from Tobira",
+      returnDescription = "The stats, or an empty object",
+      responses = {
+          @RestResponse(description = "The stats, or an empty object", responseCode = HttpServletResponse.SC_OK)
+      })
+  public Response getStats() {
+    return Response.ok(gson.toJson(stats)).build();
   }
 
   public void setServiceRegistry(ServiceRegistry serviceRegistry) {


### PR DESCRIPTION
This PR reenables Tobira adopter tracking, reverting #5161.  To accomplish this we needed to do a few things:

- Make `TobiraEndpoint` findable from the service registry
- Expose the relevant stats via REST endpoint
- Find `TobiraEndpoint` from the adopter registration code
- Pull the data between the nodes.

In the code then, we:

- Revert the previous PR
- Refactor `RemoteBase` to pull the inter-node service lookup code into its own utility class
- Make `TobiraEndpoint` a `JobProducer` to get it registered in the service registry (and thus findable from another node)
- Use the new `RemoteHostConnector` class to find and query the service, regardless of which node it lives on.

Notably, `TobiraEndpoint` does not produce jobs, and refuses to process any that are created (manually).

### Your pull request should…

* [x] have a concise title
* [ ] ~[close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists~
* [x] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] ~include migration scripts and documentation, if appropriate~
* [x] pass automated tests
* [x] have a clean commit history
* [x] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)