### PR TITLE
Paella 7: Add Focus Layout for any Flavors

### DIFF
--- a/etc/ui-config/mh_default_org/paella7/config.json
+++ b/etc/ui-config/mh_default_org/paella7/config.json
@@ -234,6 +234,18 @@
             ],
             "tabIndexStart": 40
         },
+        "org.opencast.paella.focusVideoStaticLayout": {
+            "enabled": true,
+            "validContent": [
+                {
+                    "id": "focus-video",
+                    "content": [],
+                    "icon": "present-mode-4.svg",
+                    "title": "Focus"
+                }
+            ],
+            "tabIndexStart": 40
+        },
 
         "/* video formats plugins */": "*********************************************************",
         "es.upv.paella.hlsVideoFormat": {

--- a/modules/engage-paella-player-7/public/default_theme/theme.css
+++ b/modules/engage-paella-player-7/public/default_theme/theme.css
@@ -32,6 +32,14 @@
   /* --video-container-padding: 10px; */
 }
 
+/* dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --video-container-background-color: #000000;
+    --base-video-rect-background-color: #000000;
+  }
+}
+
 
 
 

--- a/modules/engage-paella-player-7/public/default_theme/theme.css
+++ b/modules/engage-paella-player-7/public/default_theme/theme.css
@@ -22,7 +22,7 @@
   --main-bg-gradient: #1F2937;
   /* --main-border-color: rgba(125,125,125,0.4); */
   /* --video-container-background-color: #e4e4e4; */
-  --base-video-rect-background-color: #9CA3AF;
+  --base-video-rect-background-color: #e4e4e4;
 
   /* video-container-message */
   /* --video-container-message-bkg: rgba(0, 0, 0, 0.4); */

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.focusVideoStaticLayout.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.focusVideoStaticLayout.js
@@ -1,0 +1,216 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+import {VideoLayout, CanvasButtonPosition, utils} from 'paella-core';
+
+import defaultIconMaximize from '../icons/maximize.svg';
+import defaultIconMinimize from '../icons/minimize.svg';
+
+export default class FocusVideoStaticLayout extends VideoLayout {
+  get identifier() {
+    return 'focus-video-static';
+  }
+
+  get layoutType() {
+    return 'static';
+  }
+
+  async load() {
+    this.player.log.debug('Focus video layout loaded');
+  }
+
+  getValidStreams(streamData) {
+    // Ignore content of streamData
+    return [streamData];
+  }
+
+  getValidContentIds() {
+    // Ignore content of streamData
+    return this.validContentIds;
+  }
+
+  async maximizeVideo(content) {
+    this._focusedContent = content;
+    await this.player.videoContainer.updateLayout();
+  }
+
+  async minimizeVideo() {
+    if (this.player.videoContainer.validContentIds.indexOf('multi-video') === -1) {
+      return;
+    }
+
+    await this.player.videoContainer.setLayout('multi-video');
+  }
+
+  getVideoCanvasButtons(layoutStructure, content, video, videoCanvas) {
+    const buttons = [];
+
+    if (content !== this._focusedContent) {
+      // Maximize
+      buttons.push({
+        icon: this.player.getCustomPluginIcon(this.name, "iconMaximize") || defaultIconMaximize,
+        position: CanvasButtonPosition.LEFT,
+        title: this.player.translate('Maximize video'),
+        ariaLabel: this.player.translate('Maximize video'),
+        name: this.name + ':iconMaximize',
+        click: async () => {
+          await this.maximizeVideo(content);
+        }
+      });
+    } else {
+      // Minimize
+      if (this.player.videoContainer.validContentIds.indexOf('multi-video') !== -1) {
+        buttons.push({
+          icon: this.player.getCustomPluginIcon(this.name, "iconMinimize") || defaultIconMinimize,
+          position: CanvasButtonPosition.LEFT,
+          title: this.player.translate('Minimize video'),
+          ariaLabel: this.player.translate('Minimize video'),
+          name: this.name + ':iconMinimize',
+          click: async () => {
+            await this.minimizeVideo();
+          }
+        });
+      }
+    }
+
+    return buttons;
+  }
+
+  getLayoutStructure(streamData, contendId, mainContent) {
+    // Check for focused content in cookie
+    const cookieContent = utils.getCookie('focusContent');
+    if (cookieContent !== '') {
+      this._focusedContent = cookieContent;
+      utils.setCookie('focusContent', '');
+    }
+
+    // Initially, focus on first stream
+    if (!this._focusedContent) {
+      this._focusedContent = streamData[0].content;
+    }
+
+    const numRightVideos = streamData.length - 1
+    const rightVideoHeight = Math.min(720 / numRightVideos, 180);
+    const rightVideoMaxWidth = rightVideoHeight * 16 / 9;
+
+    const focusVideoWidth = 1280 - rightVideoMaxWidth;
+
+    let videos = [];
+    let rightVideoIndex = 0;
+    streamData.forEach(stream => {
+      let rect;
+      if (stream.content === this._focusedContent) {
+        // Focus video
+        rect = [
+          {
+            aspectRatio: "16/9",
+            width: focusVideoWidth,
+            height: focusVideoWidth * 9 / 16,
+            top: (720 - focusVideoWidth * 9 / 16) / 2,
+            left: 0
+          },
+          {
+            aspectRatio: "16/10",
+            width: focusVideoWidth,
+            height: focusVideoWidth * 10 / 16,
+            top: (720 - focusVideoWidth * 10 / 16) / 2,
+            left: 0
+          },
+          {
+            aspectRatio: "4/3",
+            width: focusVideoWidth,
+            height: focusVideoWidth * 3 / 4,
+            top: (720 - focusVideoWidth * 3 / 4) / 2,
+            left: 0
+          },
+          {
+            aspectRatio: "5/3",
+            width: focusVideoWidth,
+            height: focusVideoWidth * 3 / 5,
+            top: (720 - focusVideoWidth * 3 / 5) / 2,
+            left: 0
+          },
+          {
+            aspectRatio: "5/4",
+            width: focusVideoWidth,
+            height: focusVideoWidth * 4 / 5,
+            top: (720 - focusVideoWidth * 4 / 5) / 2,
+            left: 0
+          }
+        ]
+      } else {
+        // Right minimized Video
+        const rightVideoTop = (720 - rightVideoHeight * numRightVideos) / 2 + rightVideoHeight * rightVideoIndex;
+        rect = [
+          {
+            aspectRatio: "16/9",
+            width: rightVideoHeight * 16 / 9,
+            height: rightVideoHeight,
+            top: rightVideoTop,
+            left: focusVideoWidth
+          },
+          {
+            aspectRatio: "16/10",
+            width: rightVideoHeight * 16 / 10,
+            height: rightVideoHeight,
+            top: rightVideoTop,
+            left: focusVideoWidth + (rightVideoMaxWidth - rightVideoHeight * 16 / 10) / 2
+          },
+          {
+            aspectRatio: "4/3",
+            width: rightVideoHeight * 4 / 3,
+            height: rightVideoHeight,
+            top: rightVideoTop,
+            left: focusVideoWidth + (rightVideoMaxWidth - rightVideoHeight * 4 / 3) / 2
+          },
+          {
+            aspectRatio: "5/3",
+            width: rightVideoHeight * 5 / 3,
+            height: rightVideoHeight,
+            top: rightVideoTop,
+            left: focusVideoWidth + (rightVideoMaxWidth - rightVideoHeight * 5 / 3) / 2
+          },
+          {
+            aspectRatio: "5/4",
+            width: rightVideoHeight * 5 / 4,
+            height: rightVideoHeight,
+            top: rightVideoTop,
+            left: focusVideoWidth + (rightVideoMaxWidth - rightVideoHeight * 5 / 4) / 2
+          }
+        ]
+        rightVideoIndex++;
+      }
+
+      videos.push({
+        content: stream.content,
+        rect: rect,
+        visible: true,
+        layer: 1
+      });
+    });
+
+    return {
+      name: {es: "One focused video"},
+      hidden: false,
+      videos: videos,
+    };
+  }
+}

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.focusVideoStaticLayout.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.focusVideoStaticLayout.js
@@ -60,13 +60,13 @@ export default class FocusVideoStaticLayout extends VideoLayout {
     await this.player.videoContainer.setLayout('multi-video');
   }
 
-  getVideoCanvasButtons(layoutStructure, content, video, videoCanvas) {
+  getVideoCanvasButtons(layoutStructure, content) {
     const buttons = [];
 
     if (content !== this._focusedContent) {
       // Maximize
       buttons.push({
-        icon: this.player.getCustomPluginIcon(this.name, "iconMaximize") || defaultIconMaximize,
+        icon: this.player.getCustomPluginIcon(this.name, 'iconMaximize') || defaultIconMaximize,
         position: CanvasButtonPosition.LEFT,
         title: this.player.translate('Maximize video'),
         ariaLabel: this.player.translate('Maximize video'),
@@ -79,7 +79,7 @@ export default class FocusVideoStaticLayout extends VideoLayout {
       // Minimize
       if (this.player.videoContainer.validContentIds.indexOf('multi-video') !== -1) {
         buttons.push({
-          icon: this.player.getCustomPluginIcon(this.name, "iconMinimize") || defaultIconMinimize,
+          icon: this.player.getCustomPluginIcon(this.name, 'iconMinimize') || defaultIconMinimize,
           position: CanvasButtonPosition.LEFT,
           title: this.player.translate('Minimize video'),
           ariaLabel: this.player.translate('Minimize video'),
@@ -94,7 +94,7 @@ export default class FocusVideoStaticLayout extends VideoLayout {
     return buttons;
   }
 
-  getLayoutStructure(streamData, contendId, mainContent) {
+  getLayoutStructure(streamData) {
     // Check for focused content in cookie
     const cookieContent = utils.getCookie('focusContent');
     if (cookieContent !== '') {
@@ -107,7 +107,7 @@ export default class FocusVideoStaticLayout extends VideoLayout {
       this._focusedContent = streamData[0].content;
     }
 
-    const numRightVideos = streamData.length - 1
+    const numRightVideos = streamData.length - 1;
     const rightVideoHeight = Math.min(720 / numRightVideos, 180);
     const rightVideoMaxWidth = rightVideoHeight * 16 / 9;
 
@@ -121,81 +121,81 @@ export default class FocusVideoStaticLayout extends VideoLayout {
         // Focus video
         rect = [
           {
-            aspectRatio: "16/9",
+            aspectRatio: '16/9',
             width: focusVideoWidth,
             height: focusVideoWidth * 9 / 16,
             top: (720 - focusVideoWidth * 9 / 16) / 2,
             left: 0
           },
           {
-            aspectRatio: "16/10",
+            aspectRatio: '16/10',
             width: focusVideoWidth,
             height: focusVideoWidth * 10 / 16,
             top: (720 - focusVideoWidth * 10 / 16) / 2,
             left: 0
           },
           {
-            aspectRatio: "4/3",
+            aspectRatio: '4/3',
             width: focusVideoWidth,
             height: focusVideoWidth * 3 / 4,
             top: (720 - focusVideoWidth * 3 / 4) / 2,
             left: 0
           },
           {
-            aspectRatio: "5/3",
+            aspectRatio: '5/3',
             width: focusVideoWidth,
             height: focusVideoWidth * 3 / 5,
             top: (720 - focusVideoWidth * 3 / 5) / 2,
             left: 0
           },
           {
-            aspectRatio: "5/4",
+            aspectRatio: '5/4',
             width: focusVideoWidth,
             height: focusVideoWidth * 4 / 5,
             top: (720 - focusVideoWidth * 4 / 5) / 2,
             left: 0
           }
-        ]
+        ];
       } else {
         // Right minimized Video
         const rightVideoTop = (720 - rightVideoHeight * numRightVideos) / 2 + rightVideoHeight * rightVideoIndex;
         rect = [
           {
-            aspectRatio: "16/9",
+            aspectRatio: '16/9',
             width: rightVideoHeight * 16 / 9,
             height: rightVideoHeight,
             top: rightVideoTop,
             left: focusVideoWidth
           },
           {
-            aspectRatio: "16/10",
+            aspectRatio: '16/10',
             width: rightVideoHeight * 16 / 10,
             height: rightVideoHeight,
             top: rightVideoTop,
             left: focusVideoWidth + (rightVideoMaxWidth - rightVideoHeight * 16 / 10) / 2
           },
           {
-            aspectRatio: "4/3",
+            aspectRatio: '4/3',
             width: rightVideoHeight * 4 / 3,
             height: rightVideoHeight,
             top: rightVideoTop,
             left: focusVideoWidth + (rightVideoMaxWidth - rightVideoHeight * 4 / 3) / 2
           },
           {
-            aspectRatio: "5/3",
+            aspectRatio: '5/3',
             width: rightVideoHeight * 5 / 3,
             height: rightVideoHeight,
             top: rightVideoTop,
             left: focusVideoWidth + (rightVideoMaxWidth - rightVideoHeight * 5 / 3) / 2
           },
           {
-            aspectRatio: "5/4",
+            aspectRatio: '5/4',
             width: rightVideoHeight * 5 / 4,
             height: rightVideoHeight,
             top: rightVideoTop,
             left: focusVideoWidth + (rightVideoMaxWidth - rightVideoHeight * 5 / 4) / 2
           }
-        ]
+        ];
         rightVideoIndex++;
       }
 
@@ -208,7 +208,7 @@ export default class FocusVideoStaticLayout extends VideoLayout {
     });
 
     return {
-      name: {es: "One focused video"},
+      name: {es: 'One focused video'},
       hidden: false,
       videos: videos,
     };

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.multiVideoDynamicLayout.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.multiVideoDynamicLayout.js
@@ -20,7 +20,7 @@
  */
 
 import {CanvasButtonPosition, VideoLayout, utils} from 'paella-core';
-import defaultIconMaximize from "../icons/maximize.svg";
+import defaultIconMaximize from '../icons/maximize.svg';
 
 export default class MultiVideoDynamicLayout extends VideoLayout {
   get identifier() {
@@ -45,13 +45,13 @@ export default class MultiVideoDynamicLayout extends VideoLayout {
     return this.validContentIds;
   }
 
-  getVideoCanvasButtons(layoutStructure, content, video, videoCanvas) {
+  getVideoCanvasButtons(layoutStructure, content) {
     const buttons = [];
 
     if (this.player.videoContainer.validContentIds.indexOf('focus-video') !== -1) {
       // Maximize
       buttons.push({
-        icon: this.player.getCustomPluginIcon(this.name, "iconMaximize") || defaultIconMaximize,
+        icon: this.player.getCustomPluginIcon(this.name, 'iconMaximize') || defaultIconMaximize,
         position: CanvasButtonPosition.LEFT,
         title: this.player.translate('Maximize video'),
         ariaLabel: this.player.translate('Maximize video'),

--- a/modules/engage-paella-player-7/src/plugins/org.opencast.paella.multiVideoDynamicLayout.js
+++ b/modules/engage-paella-player-7/src/plugins/org.opencast.paella.multiVideoDynamicLayout.js
@@ -19,7 +19,8 @@
  *
  */
 
-import {VideoLayout} from 'paella-core';
+import {CanvasButtonPosition, VideoLayout, utils} from 'paella-core';
+import defaultIconMaximize from "../icons/maximize.svg";
 
 export default class MultiVideoDynamicLayout extends VideoLayout {
   get identifier() {
@@ -42,6 +43,27 @@ export default class MultiVideoDynamicLayout extends VideoLayout {
   getValidContentIds() {
     // Ignore content of streamData
     return this.validContentIds;
+  }
+
+  getVideoCanvasButtons(layoutStructure, content, video, videoCanvas) {
+    const buttons = [];
+
+    if (this.player.videoContainer.validContentIds.indexOf('focus-video') !== -1) {
+      // Maximize
+      buttons.push({
+        icon: this.player.getCustomPluginIcon(this.name, "iconMaximize") || defaultIconMaximize,
+        position: CanvasButtonPosition.LEFT,
+        title: this.player.translate('Maximize video'),
+        ariaLabel: this.player.translate('Maximize video'),
+        name: this.name + ':iconMaximize',
+        click: async () => {
+          utils.setCookie('focusContent', content);
+          await this.player.videoContainer.setLayout('focus-video');
+        }
+      });
+    }
+
+    return buttons;
   }
 
   getLayoutStructure(streamData) {


### PR DESCRIPTION
Adds a new focus layout plugin to paella. It allows any flavor constellations and to maximize a video via button controls. 

Additional changes:
- The video layout background has the same color as the video container

### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)

Close #5258