### PR TITLE
Fix custom roles pattern now working in access policy tab

### DIFF
--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/eventController.js
@@ -220,11 +220,21 @@ angular.module('adminNg.controllers')
 
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
+                $scope.policiesUser.push(policy);
+                // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
+                if ($scope.users.map(user => user.id).indexOf(id) == -1) {
+                  if ($scope.aclCreateDefaults['sanitize']) {
+                    // FixMe: See the FixMe above pertaining to sanitize
+                    data.userRole = $scope.roleUserPrefix + id.replace(/\W/g, '_').toUpperCase();
+                  } else {
+                    data.userRole = $scope.roleUserPrefix + id;
+                  }
+                  $scope.users.push(data);
+                }
               }).catch(function() {
                 policy.userDoesNotExist = id;
+                $scope.policiesUser.push(policy);
               });
-
-              $scope.policiesUser.push(policy);
             }
           });
         },
@@ -522,16 +532,13 @@ angular.module('adminNg.controllers')
         angular.forEach(data, function(newRole) {
           if ($scope.roles.indexOf(newRole) == -1) {
             $scope.roles.unshift(newRole);
-          }
-        });
-      });
-    };
 
-    $scope.getMatchingUsers = function (value) {
-      UsersResource.query({query: value}).$promise.then(function (data) {
-        angular.forEach(data, function(newRole) {
-          if ($scope.roles.indexOf(newRole) == -1) {
-            $scope.roles.unshift(newRole);
+            // So we can have user roles that match custom role patterns
+            if (newRole.startsWith($scope.roleUserPrefix) ) {
+              var user = {};
+              user.userRole = newRole;
+              $scope.users.push(user);
+            }
           }
         });
       });
@@ -705,6 +712,11 @@ angular.module('adminNg.controllers')
       if (!user) {
         return undefined;
       }
+
+      if (!(user.name || user.username) && user.userRole) {
+        return user.userRole;
+      }
+
       var n = user.name ? user.name : user.username;
       var e = user.email ? '<' + user.email + '>' : '';
 

--- a/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/events/controllers/serieController.js
@@ -80,11 +80,21 @@ angular.module('adminNg.controllers')
 
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
+                $scope.policiesUser.push(policy);
+                // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
+                if ($scope.users.map(user => user.id).indexOf(id) == -1) {
+                  if ($scope.aclCreateDefaults['sanitize']) {
+                    // FixMe: See the FixMe above pertaining to sanitize
+                    data.userRole = $scope.roleUserPrefix + id.replace(/\W/g, '_').toUpperCase();
+                  } else {
+                    data.userRole = $scope.roleUserPrefix + id;
+                  }
+                  $scope.users.push(data);
+                }
               }).catch(function() {
                 policy.userDoesNotExist = id;
+                $scope.policiesUser.push(policy);
               });
-
-              $scope.policiesUser.push(policy);
             }
           });
 
@@ -161,6 +171,11 @@ angular.module('adminNg.controllers')
       if (!user) {
         return undefined;
       }
+
+      if (!(user.name || user.username) && user.userRole) {
+        return user.userRole;
+      }
+
       var n = user.name ? user.name : user.username;
       var e = user.email ? '<' + user.email + '>' : '';
 
@@ -209,16 +224,13 @@ angular.module('adminNg.controllers')
         angular.forEach(data, function(newRole) {
           if ($scope.roles.indexOf(newRole) == -1) {
             $scope.roles.unshift(newRole);
-          }
-        });
-      });
-    };
 
-    $scope.getMatchingUsers = function (value) {
-      UsersResource.query({query: value}).$promise.then(function (data) {
-        angular.forEach(data, function(newRole) {
-          if ($scope.roles.indexOf(newRole) == -1) {
-            $scope.roles.unshift(newRole);
+            // So we can have user roles that match custom role patterns
+            if (newRole.startsWith($scope.roleUserPrefix) ) {
+              var user = {};
+              user.userRole = newRole;
+              $scope.users.push(user);
+            }
           }
         });
       });

--- a/modules/admin-ui-frontend/app/scripts/modules/users/controllers/aclController.js
+++ b/modules/admin-ui-frontend/app/scripts/modules/users/controllers/aclController.js
@@ -75,11 +75,21 @@ angular.module('adminNg.controllers')
 
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
+                $scope.policiesUser.push(policy);
+                // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
+                if ($scope.users.map(user => user.id).indexOf(id) == -1) {
+                  if ($scope.aclCreateDefaults['sanitize']) {
+                    // FixMe: See the FixMe above pertaining to sanitize
+                    data.userRole = $scope.roleUserPrefix + id.replace(/\W/g, '_').toUpperCase();
+                  } else {
+                    data.userRole = $scope.roleUserPrefix + id;
+                  }
+                  $scope.users.push(data);
+                }
               }).catch(function() {
                 policy.userDoesNotExist = id;
+                $scope.policiesUser.push(policy);
               });
-
-              $scope.policiesUser.push(policy);
             }
           });
 
@@ -143,6 +153,11 @@ angular.module('adminNg.controllers')
       if (!user) {
         return undefined;
       }
+
+      if (!(user.name || user.username) && user.userRole) {
+        return user.userRole;
+      }
+
       var n = user.name ? user.name : user.username;
       var e = user.email ? '<' + user.email + '>' : '';
 
@@ -182,20 +197,17 @@ angular.module('adminNg.controllers')
     };
 
     $scope.getMatchingRoles = function (value) {
-      RolesResource.queryNameOnly({query: value, target:'ACL'}).$promise.then(function (data) {
+      RolesResource.queryNameOnly({query: value, target: 'ACL'}).$promise.then(function (data) {
         angular.forEach(data, function(newRole) {
           if ($scope.roles.indexOf(newRole) == -1) {
             $scope.roles.unshift(newRole);
-          }
-        });
-      });
-    };
 
-    $scope.getMatchingUsers = function (value) {
-      UsersResource.query({query: value}).$promise.then(function (data) {
-        angular.forEach(data, function(newRole) {
-          if ($scope.roles.indexOf(newRole) == -1) {
-            $scope.roles.unshift(newRole);
+            // So we can have user roles that match custom role patterns
+            if (newRole.startsWith($scope.roleUserPrefix) ) {
+              var user = {};
+              user.userRole = newRole;
+              $scope.users.push(user);
+            }
           }
         });
       });

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/acl-details.html
@@ -137,7 +137,7 @@
                                     data-width="'360px'"
                                     ng-model="policy.role"
                                     ng-options="user.userRole as userToStringForDetails(user) for user in users"
-                                    call-on-search="getMatchingUsers"
+                                    call-on-search="getMatchingRoles"
                                     placeholder-text-single="'{{ 'USERS.ACLS.DETAILS.ACCESS.ROLES.LABEL' | translate }}'"
                                     no-results-text="'{{ 'USERS.ACLS.DETAILS.ACCESS.ROLES.EMPTY' | translate }}'"
                                     ></select>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/event-details.html
@@ -624,7 +624,7 @@
                       </tr>
                       </thead>
                       <tbody>
-                      <tr ng-repeat="policy in policiesUser  | filter: userExists">
+                      <tr ng-repeat="policy in policiesUser | filter: userExists">
                         <td ng-show="!transactions.read_only">
                           <select chosen
                                   pre-select-from="users"
@@ -632,7 +632,7 @@
                                   data-width="'360px'"
                                   ng-model="policy.role"
                                   ng-options="user.userRole as userToStringForDetails(user) for user in users"
-                                  call-on-search="getMatchingUsers"
+                                  call-on-search="getMatchingRoles"
                                   placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.USERS.LABEL' | translate }}'"
                                   no-results-text="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.USERS.EMPTY' | translate }}'"
                           ></select>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/modals/series-details.html
@@ -244,7 +244,7 @@
                                     data-width="'360px'"
                                     ng-model="policy.role"
                                     ng-options="user.userRole as userToStringForDetails(user) for user in users"
-                                    call-on-search="getMatchingUsers"
+                                    call-on-search="getMatchingRoles"
                                     placeholder-text-single="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.USERS.LABEL' | translate }}'"
                                     no-results-text="'{{ 'EVENTS.SERIES.DETAILS.ACCESS.USERS.EMPTY' | translate }}'"
                                     ></select>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-acl.html
@@ -109,7 +109,7 @@
                       <tr ng-repeat="policy in wizard.step.ud.policiesUser">
                         <td>
                           <select chosen pre-select-from="users"
-                                         call-on-search="wizard.step.getMatchingUsers"
+                                         call-on-search="wizard.step.getMatchingRoles"
                                          data-width="'360px'"
                                          ng-model="policy.role"
                                          ng-options="user.userRole as wizard.step.userToStringForDetails(user) for user in wizard.step.users"

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-event.html
@@ -573,7 +573,7 @@
                                   data-width="'360px'"
                                   ng-model="policy.role"
                                   ng-options="user.userRole as wizard.step.userToStringForDetails(user) for user in wizard.step.users"
-                                  call-on-search="wizard.step.getMatchingUsers"
+                                  call-on-search="wizard.step.getMatchingRoles"
                                   placeholder-text-single="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.USERS.LABEL' | translate }}'"
                                   no-results-text="'{{ 'EVENTS.EVENTS.DETAILS.ACCESS.USERS.EMPTY' | translate }}'">
                             <option value=""></option>

--- a/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
+++ b/modules/admin-ui-frontend/app/scripts/shared/partials/wizards/new-series.html
@@ -138,7 +138,7 @@
                                   data-width="'360px'"
                                   ng-model="policy.role"
                                   ng-options="user.userRole as wizard.step.userToStringForDetails(user) for user in wizard.step.users"
-                                  call-on-search="wizard.step.getMatchingUsers"
+                                  call-on-search="wizard.step.getMatchingRoles"
                                   data-placeholder=" "
                                   no-results-text="'{{ 'EVENTS.SERIES.NEW.ACCESS.USERS.EMPTY' | translate }}'"
                                   placeholder-text-single="'{{ 'EVENTS.SERIES.NEW.ACCESS.USERS.LABEL' | translate }}'">

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-acl/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-acl/access.js
@@ -102,11 +102,16 @@ angular.module('adminNg.services')
 
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
-              }).catch(function() {
-                // User does not exist, remove associated policy from list
-                var index = me.ud.policiesUser.indexOf(policy);
-                if (index !== -1) {
-                  me.ud.policiesUser.splice(index, 1);
+                me.ud.policiesUser.push(policy);
+                // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
+                if (me.users.map(user => user.id).indexOf(id) == -1) {
+                  if (me.aclCreateDefaults['sanitize']) {
+                    // FixMe: See the FixMe above pertaining to sanitize
+                    data.userRole = me.roleUserPrefix + id.replace(/\W/g, '_').toUpperCase();
+                  } else {
+                    data.userRole = me.roleUserPrefix + id;
+                  }
+                  me.users.push(data);
                 }
               });
 
@@ -127,6 +132,11 @@ angular.module('adminNg.services')
         if (!user) {
           return undefined;
         }
+
+        if (!(user.name || user.username) && user.userRole) {
+          return user.userRole;
+        }
+
         var n = user.name ? user.name : user.username;
         var e = user.email ? '<' + user.email + '>' : '';
 
@@ -227,17 +237,13 @@ angular.module('adminNg.services')
           angular.forEach(data, function(newRole) {
             if (me.roles.indexOf(newRole) == -1) {
               me.roles.unshift(newRole);
-            }
-          });
-          return;
-        });
-      };
 
-      this.getMatchingUsers = function (value) {
-        UsersResource.query({query: value}).$promise.then(function (data) {
-          angular.forEach(data, function(newRole) {
-            if (me.roles.indexOf(newRole) == -1) {
-              me.roles.unshift(newRole);
+              // So we can have user roles that match custom role patterns
+              if (newRole.startsWith(me.roleUserPrefix) ) {
+                var user = {};
+                user.userRole = newRole;
+                me.users.push(user);
+              }
             }
           });
         });

--- a/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
+++ b/modules/admin-ui-frontend/app/scripts/shared/services/wizards/new-event/access.js
@@ -166,6 +166,11 @@ angular.module('adminNg.services')
         if (!user) {
           return undefined;
         }
+
+        if (!(user.name || user.username) && user.userRole) {
+          return user.userRole;
+        }
+
         var n = user.name ? user.name : user.username;
         var e = user.email ? '<' + user.email + '>' : '';
 
@@ -186,16 +191,6 @@ angular.module('adminNg.services')
           return true;
         }
         return !item.includes(me.roleUserPrefix);
-      };
-
-      this.userToStringForDetails = function (user) {
-        if (!user) {
-          return undefined;
-        }
-        var n = user.name ? user.name : user.username;
-        var e = user.email ? '<' + user.email + '>' : '';
-
-        return n + ' ' + e;
       };
 
       this.setMetadata = function (metadata) {
@@ -276,9 +271,20 @@ angular.module('adminNg.services')
 
               UserResource.get({ username: id }).$promise.then(function (data) {
                 policy.user = data;
-              });
+                me.ud.policiesUser.push(policy);
+                // Did we get a user not present in Opencast (e.g. LDAP)? Add it to the list!
+                if (me.users.map(user => user.id).indexOf(id) == -1) {
+                  if (me.aclCreateDefaults['sanitize']) {
+                    // FixMe: See the FixMe above pertaining to sanitize
+                    data.userRole = me.roleUserPrefix + id.replace(/\W/g, '_').toUpperCase();
+                  } else {
+                    data.userRole = me.roleUserPrefix + id;
+                  }
+                  me.users.push(data);
+                }
 
-              me.ud.policiesUser.push(policy);
+                me.ud.policiesUser.push(policy);
+              });
             }
           });
         });
@@ -404,16 +410,13 @@ angular.module('adminNg.services')
           angular.forEach(data, function(newRole) {
             if (me.roles.indexOf(newRole) == -1) {
               me.roles.unshift(newRole);
-            }
-          });
-        });
-      };
 
-      this.getMatchingUsers = function (value) {
-        UsersResource.query({query: value}).$promise.then(function (data) {
-          angular.forEach(data, function(newRole) {
-            if (me.roles.indexOf(newRole) == -1) {
-              me.roles.unshift(newRole);
+              // So we can have user roles that match custom role patterns
+              if (newRole.startsWith(me.roleUserPrefix) ) {
+                var user = {};
+                user.userRole = newRole;
+                me.users.push(user);
+              }
             }
           });
         });


### PR DESCRIPTION
Intends to fix #5016.

The issue was that the user part of the access policy tab in the details view in the admin ui would not allow for custom role patterns. With this PR, you should now able to add custom roles in the user part.

Note that you still have to respect your custom role pattern. So if your pattern is something like `ROLE_USER_[A-Z][A-Z0-9]*`, you still have to type the `ROLE_USER_` part. I suppose that could be improved upon, but I decided it's not worth the effort.

Entering a custom role for a user:
![Bildschirmfoto vom 2023-09-29 10-51-40](https://github.com/opencast/opencast/assets/14070005/1cd66fb9-c342-4906-ae6b-9dc1fcc7fee8)
After selecting the custom role. The custom role will show as ROLE, not as a user, until the view is refreshed:
![Bildschirmfoto vom 2023-09-29 10-52-39](https://github.com/opencast/opencast/assets/14070005/e48fd584-ef05-43a4-964f-7418091b07c7)
After saving and refreshing. The view now attempts to get user information for the custom role and display it.
![Bildschirmfoto vom 2023-09-29 10-53-03](https://github.com/opencast/opencast/assets/14070005/c379b4c1-aacb-47b5-9490-ce7886f5bd77)


### Your pull request should…

* [ ] have a concise title
* [ ] [close an accompanying issue](https://help.github.com/en/articles/closing-issues-using-keywords) if one exists
* [ ] [be against the correct branch](https://docs.opencast.org/develop/developer/development-process#acceptance-criteria-for-patches-in-different-versions)
* [ ] include migration scripts and documentation, if appropriate
* [ ] pass automated tests
* [ ] have a clean commit history
* [ ] [have proper commit messages (title and body) for all commits](https://medium.com/@steveamaza/e028865e5791)
